### PR TITLE
changed URL to submodule repositories

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "test/QGIS-Sampledata"]
 	path = test/QGIS-Sampledata
-	url = git@github.com:opengisch/QGIS-Sampledata.git
+	url = https://github.com/opengisch/QGIS-Sampledata.git
 [submodule "3rdparty/tessellate"]
 	path = 3rdparty/tessellate
-	url = git@github.com:opengisch/tessellate.git
+	url = https://github.com/opengisch/tessellate.git


### PR DESCRIPTION
Using public https:// instead of private git@ enables everyone to clone --recursive / submodule update. Even if they have configured a public key for github but don't have that key registered to the submodules.
Previously, "git submodule update" would try to authenticate with my public key and deny access.