### PR TITLE
Not using strict comparison operators in js

### DIFF
--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -13,7 +13,7 @@ Item {
   CheckBox {
     property var currentValue: value
 
-    checked: value === config['CheckedState']
+    checked: value == config['CheckedState']
 
     onCheckedChanged: {
       valueChanged( checked ? config['CheckedState'] : config['UncheckedState'], false )
@@ -22,7 +22,7 @@ Item {
 
     // Workaround to get a signal when the value has changed
     onCurrentValueChanged: {
-      checked = currentValue === config['CheckedState']
+      checked = currentValue == config['CheckedState']
     }
   }
 }


### PR DESCRIPTION
Because the value can be int or string - the config-states are strings.
To avoid problems with int values we cannot use strict comparison operators to get the checked value.

Fix #118