### PR TITLE
multilevel visibilityexpressions concatinate

### DIFF
--- a/src/attributeformmodelbase.cpp
+++ b/src/attributeformmodelbase.cpp
@@ -214,16 +214,15 @@ void AttributeFormModelBase::updateAttributeValue( QStandardItem* item )
   }
 }
 
-void AttributeFormModelBase::flatten( QgsAttributeEditorContainer* container, QStandardItem* parent, const QString& visibilityExpressions, QVector<QStandardItem*>& items )
+void AttributeFormModelBase::flatten( QgsAttributeEditorContainer* container, QStandardItem* parent, const QString& parentVisibilityExpressions, QVector<QStandardItem*>& items )
 {
-  QString visibilityExpression = visibilityExpressions;
-
   Q_FOREACH( QgsAttributeEditorElement* element, container->children() )
   {
     switch ( element->type() )
     {
       case QgsAttributeEditorElement::AeTypeContainer:
       {
+        QString visibilityExpression = parentVisibilityExpressions;
         QgsAttributeEditorContainer* container = static_cast<QgsAttributeEditorContainer*>( element );
         if ( container->visibilityExpression().enabled() )
         {

--- a/src/attributeformmodelbase.h
+++ b/src/attributeformmodelbase.h
@@ -75,7 +75,7 @@ class AttributeFormModelBase : public QStandardItemModel
 
     void updateAttributeValue( QStandardItem* item );
 
-    void flatten( QgsAttributeEditorContainer* container , QStandardItem* parent , const QString& visibilityExpressions, QVector<QStandardItem*>& items );
+    void flatten( QgsAttributeEditorContainer* container , QStandardItem* parent , const QString& parentVisibilityExpressions, QVector<QStandardItem*>& items );
 
     void updateVisibility( int fieldIndex = -1 );
 


### PR DESCRIPTION
instead of concatinating all visibilityexpression of the same level in attributeform what leaded misbehaviour

Fix #125