### PR TITLE
Evaluate all the field constraints on every change

### DIFF
--- a/src/attributeformmodelbase.cpp
+++ b/src/attributeformmodelbase.cpp
@@ -317,16 +317,13 @@ void AttributeFormModelBase::updateVisibility( int fieldIndex )
   for ( ; constraintIterator != mConstraints.constEnd(); ++constraintIterator )
   {
     QStandardItem* item = constraintIterator.key();
-    if ( item->data( AttributeFormModel::FieldIndex ) == fieldIndex || fieldIndex == -1 )
-    {
-      QgsExpression exp = constraintIterator.value();
-      exp.prepare( &mExpressionContext );
-      bool constraintSatisfied = exp.evaluate( &mExpressionContext ).toBool();
+    QgsExpression exp = constraintIterator.value();
+    exp.prepare( &mExpressionContext );
+    bool constraintSatisfied = exp.evaluate( &mExpressionContext ).toBool();
 
-      if ( constraintSatisfied != item->data( AttributeFormModel::ConstraintValid ).toBool() )
-      {
-        item->setData( constraintSatisfied, AttributeFormModel::ConstraintValid );
-      }
+    if ( constraintSatisfied != item->data( AttributeFormModel::ConstraintValid ).toBool() )
+    {
+      item->setData( constraintSatisfied, AttributeFormModel::ConstraintValid );
     }
 
     if ( !item->data( AttributeFormModel::ConstraintValid ).toBool() )

--- a/src/attributeformmodelbase.cpp
+++ b/src/attributeformmodelbase.cpp
@@ -214,16 +214,15 @@ void AttributeFormModelBase::updateAttributeValue( QStandardItem* item )
   }
 }
 
-void AttributeFormModelBase::flatten( QgsAttributeEditorContainer* container, QStandardItem* parent, const QString& visibilityExpressions, QVector<QStandardItem*>& items )
+void AttributeFormModelBase::flatten( QgsAttributeEditorContainer* container, QStandardItem* parent, const QString& parentVisibilityExpressions, QVector<QStandardItem*>& items )
 {
-  QString visibilityExpression = visibilityExpressions;
-
   Q_FOREACH( QgsAttributeEditorElement* element, container->children() )
   {
     switch ( element->type() )
     {
       case QgsAttributeEditorElement::AeTypeContainer:
       {
+        QString visibilityExpression = parentVisibilityExpressions;
         QgsAttributeEditorContainer* container = static_cast<QgsAttributeEditorContainer*>( element );
         if ( container->visibilityExpression().enabled() )
         {

--- a/src/attributeformmodelbase.h
+++ b/src/attributeformmodelbase.h
@@ -75,7 +75,7 @@ class AttributeFormModelBase : public QStandardItemModel
 
     void updateAttributeValue( QStandardItem* item );
 
-    void flatten( QgsAttributeEditorContainer* container , QStandardItem* parent , const QString& visibilityExpressions, QVector<QStandardItem*>& items );
+    void flatten( QgsAttributeEditorContainer* container , QStandardItem* parent , const QString& parentVisibilityExpressions, QVector<QStandardItem*>& items );
 
     void updateVisibility( int fieldIndex = -1 );
 


### PR DESCRIPTION
On every change of any field ALL constraints had to be evaluated. Because the constraint can depend on different fields. 

This is a fix of https://github.com/opengisch/QField/issues/87

And now it looks like this (constraints on every field is: "EinsS"+"ZweiS"+"DreiS"=100):
![qfield_constraints_fixed](https://user-images.githubusercontent.com/28384354/34937742-2fdc0700-f9e6-11e7-8c47-81668c13bc84.gif)
