### PR TITLE
Evaluate all the field constraints on every change

### DIFF
--- a/src/attributeformmodelbase.cpp
+++ b/src/attributeformmodelbase.cpp
@@ -318,16 +318,13 @@ void AttributeFormModelBase::updateVisibility( int fieldIndex )
   for ( ; constraintIterator != mConstraints.constEnd(); ++constraintIterator )
   {
     QStandardItem* item = constraintIterator.key();
-    if ( item->data( AttributeFormModel::FieldIndex ) == fieldIndex || fieldIndex == -1 )
-    {
-      QgsExpression exp = constraintIterator.value();
-      exp.prepare( &mExpressionContext );
-      bool constraintSatisfied = exp.evaluate( &mExpressionContext ).toBool();
+    QgsExpression exp = constraintIterator.value();
+    exp.prepare( &mExpressionContext );
+    bool constraintSatisfied = exp.evaluate( &mExpressionContext ).toBool();
 
-      if ( constraintSatisfied != item->data( AttributeFormModel::ConstraintValid ).toBool() )
-      {
-        item->setData( constraintSatisfied, AttributeFormModel::ConstraintValid );
-      }
+    if ( constraintSatisfied != item->data( AttributeFormModel::ConstraintValid ).toBool() )
+    {
+      item->setData( constraintSatisfied, AttributeFormModel::ConstraintValid );
     }
 
     if ( !item->data( AttributeFormModel::ConstraintValid ).toBool() )


### PR DESCRIPTION
On every change of any field ALL constraints had to be evaluated. because the constraint can depend on different fields. So I removed the check to evaluate only on the current field.

It's a fix for #87 

It looks now like this (Contraint is: "EinsS"+"ZweiS"+"DreiS"=100)
![qfield_constraints_fixed](https://user-images.githubusercontent.com/28384354/34938283-0d087ab8-f9e8-11e7-9dd0-70606c26e729.gif)
