### PR TITLE
Care about legend nodes

### DIFF
--- a/src/layertreemodel.cpp
+++ b/src/layertreemodel.cpp
@@ -90,7 +90,8 @@ QVariant LayerTreeModel::data( const QModelIndex& index, int role ) const
 
     case Visible:
     {
-      if ( QgsLayerTreeModelLegendNode *sym = mLayerTreeModel->index2legendNode( mapToSource( index ) ) )
+      QgsLayerTreeModelLegendNode *sym = mLayerTreeModel->index2legendNode( mapToSource( index ) );
+      if ( sym )
       {
         return sym->data( Qt::CheckStateRole ).toBool();
       }
@@ -109,12 +110,10 @@ bool LayerTreeModel::setData(const QModelIndex& index, const QVariant& value, in
 {
   if ( role == Visible )
   {
-    if ( QgsLayerTreeModelLegendNode *sym = mLayerTreeModel->index2legendNode( mapToSource( index ) ) )
+    QgsLayerTreeModelLegendNode *sym = mLayerTreeModel->index2legendNode( mapToSource( index ) );
+    if ( sym )
     {
-      QVariant checked = Qt::Unchecked;
-      if( value.toBool() )
-        checked=Qt::Checked;
-
+      QVariant checked = value.toBool() ? Qt::Checked : Qt::Unchecked;
       sym->setData( checked, Qt::CheckStateRole );
     }
     else

--- a/src/layertreemodel.cpp
+++ b/src/layertreemodel.cpp
@@ -90,10 +90,16 @@ QVariant LayerTreeModel::data( const QModelIndex& index, int role ) const
 
     case Visible:
     {
-      QgsLayerTreeNode* node = mLayerTreeModel->index2node( mapToSource( index ) );
-      return node->isVisible();
+      if ( QgsLayerTreeModelLegendNode *sym = mLayerTreeModel->index2legendNode( mapToSource( index ) ) )
+      {
+        return sym->data( Qt::CheckStateRole ).toBool();
+      }
+      else
+      {
+        QgsLayerTreeNode* node = mLayerTreeModel->index2node( mapToSource( index ) );
+        return node->isVisible();
+      }
     }
-
     default:
       return QSortFilterProxyModel::data( index, role );
   }
@@ -103,8 +109,19 @@ bool LayerTreeModel::setData(const QModelIndex& index, const QVariant& value, in
 {
   if ( role == Visible )
   {
-    QgsLayerTreeNode* node = mLayerTreeModel->index2node( mapToSource( index ) );
-    node->setItemVisibilityCheckedRecursive( value.toBool() );
+    if ( QgsLayerTreeModelLegendNode *sym = mLayerTreeModel->index2legendNode( mapToSource( index ) ) )
+    {
+      QVariant checked = Qt::Unchecked;
+      if( value.toBool() )
+        checked=Qt::Checked;
+
+      sym->setData( checked, Qt::CheckStateRole );
+    }
+    else
+    {
+      QgsLayerTreeNode* node = mLayerTreeModel->index2node( mapToSource( index ) );
+      node->setItemVisibilityCheckedRecursive( value.toBool() );
+    }
     return true;
   }
   return false;


### PR DESCRIPTION
Functionality to set to visible / invisible and get the visible status for legend nodes - means in categorized etc. layers.

This avoids the crash and is a fix for #199 and mentioning in #181 and let's us display the subcategory as well. And set them visible and invisible like on QGIS.

![image](https://user-images.githubusercontent.com/28384354/35325973-99d1b6c6-00f5-11e8-809d-4409e2eaa2dc.png)
