### PR TITLE
Removed quit option in setting

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -538,6 +538,13 @@ ApplicationWindow {
       }
     }
 
+
+    /*
+    We removed this MenuItem part, because usually a mobile app has not the functionality to quit.
+    But we keep the code in case, the concept changes or we need to close the app completely (remove from background)
+    */
+
+    /*
     Controls.MenuSeparator {}
 
     Controls.MenuItem {
@@ -547,6 +554,7 @@ ApplicationWindow {
         Qt.quit()
       }
     }
+    */
   }
 
   Controls.Menu {


### PR DESCRIPTION
Removed this Menu Item part, because usually a mobile app has not the functionality to quit.
When there is a "quit" the user expects something different than when pressing the back key.
