### PR TITLE
On close - wait for second input

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -831,4 +831,28 @@ ApplicationWindow {
       return filePath.split('.').pop() === "qgs"
     }
   }
+
+  property bool alreadyCloseRequested: false
+
+  onClosing: {
+      if( !alreadyCloseRequested )
+      {
+        close.accepted = false
+        alreadyCloseRequested = true
+        displayToast( qsTr( "Press back again to close project and app" ) )
+        closingTimer.start()
+      }
+      else
+      {
+        close.accepted = true
+      }
+  }
+
+  Timer {
+    id: closingTimer
+    interval: 2000
+    onTriggered: {
+        alreadyCloseRequested = false
+    }
+  }
 }


### PR DESCRIPTION
Closing in two steps. when closing the toast appears with the message, that with another closing command (back key) the project will be closed. Regarding #217 that the user does not close it accidentally.

Tested it in the debug mode:
![closeqfield](https://user-images.githubusercontent.com/28384354/35357065-9a014802-0152-11e8-86eb-1519423e5458.gif)

On the app it will be the "back" key... I will test the feeling when apk is created. 
