### PR TITLE
Add/Drop Z value based on dataprovider

### DIFF
--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -22,13 +22,13 @@ QgsGeometry Geometry::asQgsGeometry() const
   {
     case QgsWkbTypes::PointGeometry:
     {
-      geom = new QgsPoint( mRubberbandModel->currentPoint(  mVectorLayer->crs() ) );
+      geom = new QgsPoint( mRubberbandModel->currentPoint(  mVectorLayer->crs(), mVectorLayer->wkbType() ) );
       break;
     }
     case QgsWkbTypes::LineGeometry:
     {
       QgsLineString* line = new QgsLineString();
-      line->setPoints( mRubberbandModel->pointSequence( mVectorLayer->crs() ) );
+      line->setPoints( mRubberbandModel->pointSequence( mVectorLayer->crs(), mVectorLayer->wkbType() ) );
       geom = line;
       break;
     }
@@ -36,7 +36,7 @@ QgsGeometry Geometry::asQgsGeometry() const
     {
       QgsPolygon* polygon = new QgsPolygon();
       QgsLineString* ring = new QgsLineString();
-      ring->setPoints( mRubberbandModel->pointSequence( mVectorLayer->crs() ) );
+      ring->setPoints( mRubberbandModel->pointSequence( mVectorLayer->crs(), mVectorLayer->wkbType() ) );
       polygon->setExteriorRing( ring );
       geom = polygon;
       break;

--- a/src/rubberbandmodel.cpp
+++ b/src/rubberbandmodel.cpp
@@ -51,7 +51,7 @@ QVector<QgsPoint> RubberbandModel::flatVertices() const
   return points;
 }
 
-QgsPointSequence RubberbandModel::pointSequence( const QgsCoordinateReferenceSystem& crs ) const
+QgsPointSequence RubberbandModel::pointSequence( const QgsCoordinateReferenceSystem& crs, QgsWkbTypes::Type wkbType ) const
 {
   QgsPointSequence sequence;
 
@@ -60,7 +60,8 @@ QgsPointSequence RubberbandModel::pointSequence( const QgsCoordinateReferenceSys
   Q_FOREACH( const QgsPoint& pt, mPointList )
   {
     QgsPoint p2( ct.transform( pt.x(), pt.y() ) );
-    p2.setZ( pt.z() );
+    if ( QgsWkbTypes::hasZ( wkbType ) )
+      p2.setZ( pt.z() );
     sequence.append( p2 );
   }
 
@@ -132,7 +133,7 @@ void RubberbandModel::setCurrentCoordinateIndex( int currentCoordinateIndex )
   emit currentCoordinateChanged();
 }
 
-QgsPoint RubberbandModel::currentPoint( const QgsCoordinateReferenceSystem& crs ) const
+QgsPoint RubberbandModel::currentPoint( const QgsCoordinateReferenceSystem& crs, QgsWkbTypes::Type wkbType ) const
 {
   QgsCoordinateTransform ct( mCrs, crs );
 
@@ -144,7 +145,7 @@ QgsPoint RubberbandModel::currentPoint( const QgsCoordinateReferenceSystem& crs 
   ct.transformInPlace( x, y, z );
 
   QgsPoint resultPt( x, y );
-  if ( QgsWkbTypes::hasZ( currentPt.wkbType() ) )
+  if ( QgsWkbTypes::hasZ( currentPt.wkbType() ) && QgsWkbTypes::hasZ( wkbType ) )
     resultPt.addZValue( z );
 
   return resultPt;

--- a/src/rubberbandmodel.h
+++ b/src/rubberbandmodel.h
@@ -59,7 +59,7 @@ class RubberbandModel : public QObject
      *
      * By default coordinates will be returned unprojected.
      */
-    QgsPointSequence pointSequence( const QgsCoordinateReferenceSystem& crs = QgsCoordinateReferenceSystem() ) const;
+    QgsPointSequence pointSequence( const QgsCoordinateReferenceSystem& crs = QgsCoordinateReferenceSystem(), QgsWkbTypes::Type wkbType = QgsWkbTypes::PointZ ) const;
 
     QVector<QgsPointXY> flatPointSequence( const QgsCoordinateReferenceSystem& crs = QgsCoordinateReferenceSystem() ) const;
 
@@ -72,7 +72,7 @@ class RubberbandModel : public QObject
     int currentCoordinateIndex() const;
     void setCurrentCoordinateIndex( int currentCoordinateIndex );
 
-    QgsPoint currentPoint( const QgsCoordinateReferenceSystem& crs = QgsCoordinateReferenceSystem() ) const;
+    QgsPoint currentPoint( const QgsCoordinateReferenceSystem& crs = QgsCoordinateReferenceSystem(), QgsWkbTypes::Type wkbType = QgsWkbTypes::PointZ ) const;
 
     QgsPoint currentCoordinate() const;
     void setCurrentCoordinate( const QgsPoint& currentCoordinate );


### PR DESCRIPTION
Apparently some dataproviders will refuse to save anything at all when they only have X/Y data and are provided with X,Y,Z data. Looking at you, spatialite.

Fix #233
Fix #146
Fix #135