### PR TITLE
Use QgsMapRendererJob::cancelWithoutBlocking

### DIFF
--- a/src/qgsquickmapcanvasmap.cpp
+++ b/src/qgsquickmapcanvasmap.cpp
@@ -365,9 +365,7 @@ void QgsQuickMapCanvasMap::stopRendering()
     disconnect( mJob, &QgsMapRendererJob::renderingLayersFinished, this, &QgsQuickMapCanvasMap::renderJobUpdated );
     disconnect( mJob, &QgsMapRendererJob::finished, this, &QgsQuickMapCanvasMap::renderJobFinished );
 
-    // Destroy job in separate worker thread, killing an iterator may take some time
-    // and reduce responsiveness
-    mZombieJobs.addFuture( QtConcurrent::run( this, &QgsQuickMapCanvasMap::destroyJob, mJob ) );
+    mJob->cancelWithoutBlocking();
     mJob = nullptr;
   }
 }

--- a/src/qgsquickmapcanvasmap.h
+++ b/src/qgsquickmapcanvasmap.h
@@ -139,7 +139,6 @@ class QgsQuickMapCanvasMap : public QQuickItem
     bool mDirty;
     bool mFreeze;
     QList<QMetaObject::Connection> mLayerConnections;
-    QFutureSynchronizer<void> mZombieJobs;
     QTimer mMapUpdateTimer;
     int mMapUpdateInterval;
     bool mIncrementalRendering;


### PR DESCRIPTION
the internal previous approach caused crashes when called too quickly (during navigation).