### PR TITLE
Allow entering decimals in all double fields

### DIFF
--- a/src/platformutilities.cpp
+++ b/src/platformutilities.cpp
@@ -63,3 +63,8 @@ void PlatformUtilities::open( const QString& data, const QString& type )
   Q_UNUSED( type )
 }
 
+QString PlatformUtilities::fieldType( const QgsField &field ) const
+{
+  return QVariant( field.type() ).typeName();
+}
+

--- a/src/platformutilities.h
+++ b/src/platformutilities.h
@@ -20,6 +20,7 @@
 #define PLATFORMUTILITIES_H
 
 #include <QObject>
+#include <qgsfield.h>
 #include "picturesource.h"
 
 class PlatformUtilities : public QObject
@@ -47,5 +48,10 @@ class PlatformUtilities : public QObject
 
     Q_INVOKABLE virtual void open( const QString& data, const QString& type );
 
+    /**
+     * Returns the QVariant typeName of a field.
+     * This is a stable identifier (compared to the provider field name).
+     */
+    Q_INVOKABLE QString fieldType( const QgsField& field ) const;
 };
 #endif // PLATFORMUTILITIES_H

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -18,7 +18,19 @@ Item {
 
     text: value || ''
 
-    inputMethodHints: field.isNumeric || widget == 'Range' ? platformUtilities.fieldType( field ) === 'double' ? Qt.ImhFormattedNumbersOnly : Qt.ImhDigitsOnly : Qt.ImhNone
+    validator: {
+      if (field.isNumeric || widget == 'Range') {
+        if (platformUtilities.fieldType( field ) === 'double')
+          doubleValidator;
+        else
+          intValidator;
+      }
+      else {
+        null;
+      }
+    }
+
+    inputMethodHints: field.isNumeric || widget == 'Range' ? Qt.ImhFormattedNumbersOnly : Qt.ImhNone
 
     background: Rectangle {
       y: textField.height - height - textField.bottomPadding / 2
@@ -50,5 +62,13 @@ Item {
   FontMetrics {
     id: fontMetrics
     font: textField.font
+  }
+
+  IntValidator {
+    id: intValidator
+  }
+
+  DoubleValidator {
+    id: doubleValidator
   }
 }

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -18,7 +18,7 @@ Item {
 
     text: value || ''
 
-    inputMethodHints: field.isNumeric || widget == 'Range' ? field.precision === 0 ? Qt.ImhDigitsOnly : Qt.ImhFormattedNumbersOnly : Qt.ImhNone
+    inputMethodHints: field.isNumeric || widget == 'Range' ? platformUtilities.fieldType( field ) === 'double' ? Qt.ImhFormattedNumbersOnly : Qt.ImhDigitsOnly : Qt.ImhNone
 
     background: Rectangle {
       y: textField.height - height - textField.bottomPadding / 2


### PR DESCRIPTION
The new approach is based on the field type. The previous approach relied on precision which was reported differently, in particular ogr and spatialite would happily return 0 precision for double values.

Fix #197