### PR TITLE
Photo path improvements and camera fixes

### DIFF
--- a/src/platformutilities.cpp
+++ b/src/platformutilities.cpp
@@ -51,6 +51,12 @@ bool PlatformUtilities::rmFile( const QString &filename ) const
   return file.remove( filename );
 }
 
+bool PlatformUtilities::renameFile( const QString &filename, const QString &newname ) const
+{
+  QFile file ( filename );
+  return file.rename( newname );
+}
+
 PictureSource* PlatformUtilities::getPicture( const QString& prefix )
 {
   Q_UNUSED( prefix )

--- a/src/platformutilities.h
+++ b/src/platformutilities.h
@@ -38,6 +38,7 @@ class PlatformUtilities : public QObject
     virtual QString qgsProject() const;
     Q_INVOKABLE bool createDir( const QString &path, const QString &dirname ) const;
     Q_INVOKABLE bool rmFile( const QString &filename ) const;
+    Q_INVOKABLE bool renameFile( const QString &filename, const QString &newname ) const;
 
     /**
      * Get a picture and copy it to the requested prefix

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -240,7 +240,6 @@ Page {
           property var widget: EditorWidget
           property var field: Field
           property var constraintValid: ConstraintValid
-          property bool featureUseNativeCamera: useNativeCamera
 
           active: widget !== 'Hidden'
           source: 'editorwidgets/' + widget + '.qml'

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -30,7 +30,7 @@ Item {
         if ( settings.value("useNativeCamera", false) )
           'file://' + qgisProject.homePath + '/' + currentValue
         else
-          'file://' + currentValue
+          'file://' + qgisProject.homePath + '/' + currentValue
       } else {
         Style.getThemeIcon("ic_photo_notavailable_white_48dp")
       }
@@ -98,7 +98,10 @@ Item {
         visible: true
 
         onFinished: {
-          valueChanged(path, false)
+          var timestamp = (new Date()).toISOString().replace(/[^0-9]/g, "")
+          var filename = timestamp+'.jpg';
+          platformUtilities.renameFile( path, qgisProject.homePath +'/DCIM/' + filename)
+          valueChanged('DCIM/' + filename, false)
           campopup.close()
         }
         onCanceled: {

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -27,10 +27,7 @@ Item {
       if (image.status === Image.Error) {
         Style.getThemeIcon("ic_broken_image_black_24dp")
       } else if (currentValue) {
-        if ( settings.value("useNativeCamera", false) )
-          'file://' + qgisProject.homePath + '/' + currentValue
-        else
-          'file://' + qgisProject.homePath + '/' + currentValue
+        'file://' + qgisProject.homePath + '/' + currentValue
       } else {
         Style.getThemeIcon("ic_photo_notavailable_white_48dp")
       }

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -24,22 +24,23 @@ Item {
     fillMode: Image.PreserveAspectFit
 
     source: {
-      if (image.status === Image.Error)
+      if (image.status === Image.Error) {
         Style.getThemeIcon("ic_broken_image_black_24dp")
-      else if (currentValue)
-        if ( featureUseNativeCamera )
+      } else if (currentValue) {
+        if ( settings.value("useNativeCamera", false) )
           'file://' + qgisProject.homePath + '/' + currentValue
         else
           'file://' + currentValue
-      else
+      } else {
         Style.getThemeIcon("ic_photo_notavailable_white_48dp")
+      }
     }
 
     MouseArea {
       anchors.fill: parent
 
       onClicked: {
-        if (currentValue && featureUseNativeCamera)
+        if (currentValue && settings.value("useNativeCamera", false))
           platformUtilities.open(image.source, "image/*");
       }
     }
@@ -56,11 +57,12 @@ Item {
     bgcolor: "transparent"
 
     onClicked: {
-      if (featureUseNativeCamera)
+      if ( settings.valueBool("useNativeCamera", false) ) {
         __pictureSource = platformUtilities.getPicture(qgisProject.homePath + '/DCIM')
-      else
+      } else {
         platformUtilities.createDir( qgisProject.homePath, 'DCIM' )
         camloader.active = true
+      }
     }
 
     iconSource: Style.getThemeIcon("ic_camera_alt_border_24dp")

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -655,8 +655,6 @@ ApplicationWindow {
   FeatureForm {
     id: overlayFeatureForm
 
-    property bool useNativeCamera: qfieldSettings.useNativeCamera
-
     anchors { right: parent.right; top: parent.top; bottom: parent.bottom }
     width: qfieldSettings.fullScreenIdentifyView ? parent.width : parent.width / 3
 


### PR DESCRIPTION
1. Photos are now named in the format YYYYMMDDHHmmSSsss.jpg and in the relative path DCIM/<imagename> Fix #256 

2. The settings for the native camera are read directly and are not looped over featureforms.

3. Fix of small bug when using native camera that in the background the new camera implementation appeared.