### PR TITLE
Set QSettings format to NativeFormat

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,8 +46,10 @@ int main( int argc, char ** argv )
     QGuiApplication::setAttribute( Qt::AA_EnableHighDpiScaling );
   delete dummyApp;
 #endif
+
   QgsApplication app( argc, argv, true );
   QSettings settings;
+
   app.setThemeName( settings.value( "/Themes", "default" ).toString() );
 
   // load providers
@@ -59,6 +61,9 @@ int main( int argc, char ** argv )
   app.setPrefixPath( CMAKE_INSTALL_PREFIX, true );
 #endif
   app.initQgis();
+
+  //set NativeFormat for settings
+  QSettings::setDefaultFormat( QSettings::NativeFormat );
 
   // Set up the QSettings environment must be done after qapp is created
   QCoreApplication::setOrganizationName( "OPENGIS.ch" );


### PR DESCRIPTION
Then Qt handles the whole background with path, prefix and conf-file.

Issue was, that the settings haven't been stored and read. This leaded to the issue, that the project cannot be opened automatically again on reactivate QField from standby mode. With the NativeFormat instead of IniFormat it says in the [QSettings](http://doc.qt.io/qt-5/qsettings.html) specification.

> On Unix, NativeFormat and IniFormat mean the same thing, except that the file extension is different (.conf for NativeFormat, .ini for IniFormat).

And with NativeFormat there is no problem with the prefix path and so the issue #254 should be fixed.
