### PR TITLE
Focusstack implementation

### DIFF
--- a/src/focusstack.cpp
+++ b/src/focusstack.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
-  focusstack.cpp - %{Cpp:License:ClassName}
+  focusstack.cpp
 
  ---------------------
  begin                : 11.4.2018
@@ -15,25 +15,13 @@
  ***************************************************************************/
 #include "focusstack.h"
 
-#include <QDebug>
-
-FocusStack::FocusStack( QObject* parent )
-  : QObject( parent ),
-  QList<QQuickItem*>()
-{
-
-}
-
 void FocusStack::addFocusTaker( QQuickItem *item )
 {
-  qDebug() << "Add focus taker item " << item->objectName();
   connect( item, &QQuickItem::activeFocusChanged, this, &FocusStack::itemFocusChanged );
 }
 
 void FocusStack::itemFocusChanged( bool itemActiveFocus )
 {
-  qDebug() << "Item " << sender()->objectName() << " changed focus to " << itemActiveFocus;
-
   if( itemActiveFocus )
   {
     setFocused( qobject_cast<QQuickItem*>( sender() ) );
@@ -46,33 +34,18 @@ void FocusStack::itemFocusChanged( bool itemActiveFocus )
 
 void FocusStack::setFocused( QQuickItem* item  )
 {
-  qDebug() << "Set item focused: " << item->objectName();
-
-  removeAll( item );
-  qDebug() << "Size of focusstack after remove: " << size();
-  append( item );
-  qDebug() << "Size of focusstack after append: " << size();
+  mStackList.removeAll( item );
+  mStackList.append( item );
 }
 
 void FocusStack::setUnfocused( QQuickItem* item  )
 {
-  qDebug() << "Unset item focused: " << item->objectName();
-
   if( !item->isVisible() )
   {
-
-    qDebug() << "Size of stacklist before remove: " << size();
-    removeAll( item );
-    qDebug() << "Size of stacklist after remove: " << size();
-    if( !isEmpty() )
+    mStackList.removeAll( item );
+    if( !mStackList.isEmpty() )
     {
-      last()->forceActiveFocus();
-      qDebug() << "Forced focus to: " << last()->objectName();
+      mStackList.last()->forceActiveFocus();
     }
   }
-  else
-  {
-    qDebug() << "Size of focusstack after doing nothing: " << size();
-  }
-
 }

--- a/src/focusstack.cpp
+++ b/src/focusstack.cpp
@@ -1,0 +1,78 @@
+/***************************************************************************
+  focusstack.cpp - %{Cpp:License:ClassName}
+
+ ---------------------
+ begin                : 11.4.2018
+ copyright            : (C) 2018 by david
+ email                : david at opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "focusstack.h"
+
+#include <QDebug>
+
+FocusStack::FocusStack( QObject* parent )
+  : QObject( parent ),
+  QList<QQuickItem*>()
+{
+
+}
+
+void FocusStack::addFocusTaker( QQuickItem *item )
+{
+  qDebug() << "Add focus taker item " << item->objectName();
+  connect( item, &QQuickItem::activeFocusChanged, this, &FocusStack::itemFocusChanged );
+}
+
+void FocusStack::itemFocusChanged( bool itemActiveFocus )
+{
+  qDebug() << "Item " << sender()->objectName() << " changed focus to " << itemActiveFocus;
+
+  if( itemActiveFocus )
+  {
+    setFocused( qobject_cast<QQuickItem*>( sender() ) );
+  }
+  else
+  {
+    setUnfocused( qobject_cast<QQuickItem*>( sender() ) );
+  }
+}
+
+void FocusStack::setFocused( QQuickItem* item  )
+{
+  qDebug() << "Set item focused: " << item->objectName();
+
+  removeAll( item );
+  qDebug() << "Size of focusstack after remove: " << size();
+  append( item );
+  qDebug() << "Size of focusstack after append: " << size();
+}
+
+void FocusStack::setUnfocused( QQuickItem* item  )
+{
+  qDebug() << "Unset item focused: " << item->objectName();
+
+  if( !item->isVisible() )
+  {
+
+    qDebug() << "Size of stacklist before remove: " << size();
+    removeAll( item );
+    qDebug() << "Size of stacklist after remove: " << size();
+    if( !isEmpty() )
+    {
+      last()->forceActiveFocus();
+      qDebug() << "Forced focus to: " << last()->objectName();
+    }
+  }
+  else
+  {
+    qDebug() << "Size of focusstack after doing nothing: " << size();
+  }
+
+}

--- a/src/focusstack.h
+++ b/src/focusstack.h
@@ -1,0 +1,40 @@
+/***************************************************************************
+  focusstack.h - %{Cpp:License:ClassName}
+
+ ---------------------
+ begin                : 11.4.2018
+ copyright            : (C) 2018 by david
+ email                : david at opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef FOCUSSTACK_H
+#define FOCUSSTACK_H
+
+#include <QList>
+#include <QtQuick/QQuickItem>
+
+class FocusStack : public QObject, public QList<QQuickItem*>
+{
+  Q_OBJECT
+
+  public:
+    explicit FocusStack( QObject* parent = 0 );
+
+    Q_INVOKABLE void addFocusTaker( QQuickItem* item );
+
+  private slots:
+    void itemFocusChanged( bool itemActiveFocus );
+
+  private:
+    void setFocused( QQuickItem* item );
+    void setUnfocused( QQuickItem* item );
+};
+
+#endif // FOCUSSTACK_H
+

--- a/src/focusstack.h
+++ b/src/focusstack.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-  focusstack.h - %{Cpp:License:ClassName}
+  focusstack.h
 
  ---------------------
  begin                : 11.4.2018
@@ -19,19 +19,18 @@
 #include <QList>
 #include <QtQuick/QQuickItem>
 
-class FocusStack : public QObject, public QList<QQuickItem*>
+class FocusStack : public QObject
 {
   Q_OBJECT
 
   public:
-    explicit FocusStack( QObject* parent = 0 );
-
     Q_INVOKABLE void addFocusTaker( QQuickItem* item );
 
   private slots:
     void itemFocusChanged( bool itemActiveFocus );
 
   private:
+    QList<QQuickItem*> mStackList;
     void setFocused( QQuickItem* item );
     void setUnfocused( QQuickItem* item );
 };

--- a/src/qgismobileapp.cpp
+++ b/src/qgismobileapp.cpp
@@ -157,6 +157,7 @@ void QgisMobileapp::initDeclarative()
   qmlRegisterType<SnappingUtils>( "org.qfield", 1, 0, "SnappingUtils" );
   qmlRegisterType<DistanceArea>( "org.qfield", 1, 0, "DistanceArea" );
   qmlRegisterType<CoordinateTransformer>( "org.qfield", 1, 0, "CoordinateTransformer" );
+  qmlRegisterType<FocusStack>( "org.qfield", 1, 0, "FocusStack" );
 
   qmlRegisterUncreatableType<AppInterface>( "org.qgis", 1, 0, "QgisInterface", "QgisInterface is only provided by the environment and cannot be created ad-hoc" );
   qmlRegisterUncreatableType<Settings>( "org.qgis", 1, 0, "Settings", "" );

--- a/src/qgismobileapp.h
+++ b/src/qgismobileapp.h
@@ -28,6 +28,7 @@
 // QGIS mobile includes
 #include "multifeaturelistmodel.h"
 #include "settings.h"
+#include "focusstack.h"
 
 #include "platformutilities.h"
 #if defined(Q_OS_ANDROID)

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -243,6 +243,7 @@ Rectangle {
     focus: true
 
     visible: !globalFeaturesList.shown
+
   }
 
   NavigationBar {
@@ -277,7 +278,10 @@ Rectangle {
   Keys.onReleased: {
     if ( event.key === Qt.Key_Back ||
         event.key === Qt.Key_Escape ) {
-      state = "Hidden"
+      if( state != "FeatureList" )
+        state = "FeatureList"
+      else
+        state = "Hidden"
       event.accepted = true
     }
   }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -670,17 +670,16 @@ ApplicationWindow {
 
     Component.onCompleted: focusstack.addFocusTaker( this )
 
-    /*
+    //this is that the focus is set by selecting the empty space
     MouseArea {
+      enabled: parent.state!="FeatureFormEdit"
       anchors.fill: parent
       propagateComposedEvents: true
       onClicked: {
-        if (state != "Hidden" )
-          forceActiveFocus()
-        mouse.accepted = false;
+        parent.focus=true
+        mouse.accepted=false
       }
     }
-    */
   }
 
   FeatureForm {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -670,12 +670,12 @@ ApplicationWindow {
 
     Component.onCompleted: focusstack.addFocusTaker( this )
 
-    //this is that the focus is set by selecting the empty space
+    //that the focus is set by selecting the empty space
     MouseArea {
-      enabled: parent.state!="FeatureFormEdit"
       anchors.fill: parent
       propagateComposedEvents: true
-      onClicked: {
+      //onPressed because onClicked shall be handled in underlying MouseArea
+      onPressed: {
         parent.focus=true
         mouse.accepted=false
       }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -34,10 +34,17 @@ ApplicationWindow {
   minimumWidth: 600
   minimumHeight: 400
 
+  FocusStack{
+      id: focusstack
+  }
+
   //this keyHandler is because otherwise the back-key is not handled in the mainWindow. Probably this could be solved cuter.
 
   Item {
     id: keyHandler
+    objectName: "keyHandler"
+
+    visible: true
     focus: true
 
     Keys.onReleased: {
@@ -48,6 +55,8 @@ ApplicationWindow {
         event.accepted = true
       }
     }
+
+    Component.onCompleted: focusstack.addFocusTaker( this )
   }
 
   Item {
@@ -282,6 +291,7 @@ ApplicationWindow {
 
   DashBoard {
     id: dashBoard
+    objectName: "dashBoard"
 
     anchors { left: parent.left; bottom: parent.bottom; top: parent.top; }
 
@@ -290,6 +300,7 @@ ApplicationWindow {
 
     width: open ? 300 * dp : 0
     visible: false
+    focus: visible
     clip: true
 
     allowLayerChange: !digitizingToolbar.isDigitizing
@@ -299,7 +310,7 @@ ApplicationWindow {
       console.warn( "KEY PRESS " + event.key )
       if ( event.key === Qt.Key_Back ||
         event.key === Qt.Key_Escape ) {
-        mainWindow.close();
+        visible=false
         event.accepted = true
       }
     }
@@ -318,6 +329,8 @@ ApplicationWindow {
       if ( currentLayer.readOnly && stateMachine.state == "digitize" )
         displayToast( qsTr( "The layer %1 is read only." ).arg( currentLayer.name ) )
     }
+
+    Component.onCompleted: focusstack.addFocusTaker( this )
   }
 
   DropShadow {
@@ -634,7 +647,11 @@ ApplicationWindow {
   /* The feature form */
   FeatureListForm {
     id: featureForm
+    objectName: "featureForm"
     mapSettings: mapCanvas.mapSettings
+
+    visible: state != "Hidden"
+    focus: visible
 
     anchors { right: parent.right; top: parent.top; bottom: parent.bottom }
     border { color: "lightGray"; width: 1 }
@@ -650,6 +667,20 @@ ApplicationWindow {
     selectionColor: "#ff7777"
 
     onShowMessage: displayToast(message)
+
+    Component.onCompleted: focusstack.addFocusTaker( this )
+
+    /*
+    MouseArea {
+      anchors.fill: parent
+      propagateComposedEvents: true
+      onClicked: {
+        if (state != "Hidden" )
+          forceActiveFocus()
+        mouse.accepted = false;
+      }
+    }
+    */
   }
 
   FeatureForm {
@@ -665,6 +696,7 @@ ApplicationWindow {
     state: "Add"
 
     visible: false
+    focus: visible
 
     onSaved: {
       visible = false
@@ -674,6 +706,15 @@ ApplicationWindow {
         digitizingRubberband.model.reset()
         visible = false
     }
+
+    Keys.onReleased: {
+      if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
+        visible = false
+        event.accepted = true
+      }
+    }
+
+    Component.onCompleted: focusstack.addFocusTaker( this )
   }
 
   function displayToast( message ) {
@@ -739,6 +780,8 @@ ApplicationWindow {
         visible = false
       }
     }
+
+    Component.onCompleted: focusstack.addFocusTaker( this )
   }
 
   BadLayerItem {
@@ -773,6 +816,8 @@ ApplicationWindow {
         visible = false
       }
     }
+
+    Component.onCompleted: focusstack.addFocusTaker( this )
   }
 
   FileDialog {
@@ -807,6 +852,8 @@ ApplicationWindow {
         visible = false
       }
     }
+
+    Component.onCompleted: focusstack.addFocusTaker( this )
   }
 
   WelcomeScreen {
@@ -853,7 +900,6 @@ ApplicationWindow {
     Timer {
       id: toastTimer
       interval: 3000
-      onTriggered: { toast.opacity = 0 }
     }
   }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -899,6 +899,7 @@ ApplicationWindow {
     Timer {
       id: toastTimer
       interval: 3000
+      onTriggered: { toast.opacity = 0 }
     }
   }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -674,6 +674,8 @@ ApplicationWindow {
     MouseArea {
       anchors.fill: parent
       propagateComposedEvents: true
+      enabled: !parent.activeFocus
+
       //onPressed because onClicked shall be handled in underlying MouseArea
       onPressed: {
         parent.focus=true

--- a/src/src.pro
+++ b/src/src.pro
@@ -54,7 +54,8 @@ HEADERS += \
     featurelistmodel.h \
     distancearea.h \
     coordinatetransformer.h \
-    expressioncontextutils.h
+    expressioncontextutils.h \
+    focusstack.h
 
 SOURCES += \
     appinterface.cpp \
@@ -93,7 +94,8 @@ SOURCES += \
     featurelistmodel.cpp \
     distancearea.cpp \
     coordinatetransformer.cpp \
-    expressioncontextutils.cpp
+    expressioncontextutils.cpp \
+    focusstack.cpp
 
 INCLUDEPATH += ../3rdparty/tessellate
 LIBS += ../3rdparty/tessellate/libtessellate.a


### PR DESCRIPTION
The focusstack is a QList() implementation that handles the items requesting a focus in a stack.

On creation the items "register" by `focusstack.addFocusTaker( this ))`

When an item looses the focus because another one get's it, it's still in the stack.
In case the item looses the focus because it's closed (by "back" key), it removes itself from the stack and forces the focus to the last item in the stack. Looks like this (dashboard on the left, featureform on the right, keyhandler is the mainlevel):
![focusstack_handlinggeneral](https://user-images.githubusercontent.com/28384354/38816087-a2deab1c-4195-11e8-8dcf-3b8ad1948e1e.gif)
(Without the display messages of course)

Additionally if the featureform is open and the user presses "back" key, not the feature-sidebar closes like before, but it goes back to the list of features. This is changed, because I belief this is what a user expects. See the demonstration:
![focusstack_handlingfeaturelist](https://user-images.githubusercontent.com/28384354/38816360-38a6b360-4196-11e8-8f98-0d6e6754afd8.gif)

Still an open issue is that you cannot select the featurelist by clicking on it. This should be solved with the mouse area in `FeatureListForm`, but there is the problem that you cannot select a widget anymore. so it's commented out. I'm still working on this one.