### PR TITLE
Correct DistanceUnit in Scalebar

### DIFF
--- a/src/mapsettings.cpp
+++ b/src/mapsettings.cpp
@@ -148,6 +148,11 @@ void MapSettings::setLayers( const QList<QgsMapLayer *> &layers )
   emit layersChanged();
 }
 
+QString MapSettings::abbreviatedStringOfDistanceUnit() const
+{
+  return QgsUnitTypes::toAbbreviatedString( mMapSettings.destinationCrs().mapUnits() );
+}
+
 #if 0
 void MapSettings::setMapTheme( QgsProject* project, const QString& mapThemeName )
 {

--- a/src/mapsettings.cpp
+++ b/src/mapsettings.cpp
@@ -27,6 +27,7 @@ MapSettings::MapSettings( QObject *parent )
 {
   // Connect signals for derived values
   connect( this, &MapSettings::destinationCrsChanged, this, &MapSettings::mapUnitsPerPixelChanged );
+  connect( this, &MapSettings::destinationCrsChanged, this, &MapSettings::abbreviatedStringOfDistanceUnitChanged );
   connect( this, &MapSettings::extentChanged, this, &MapSettings::mapUnitsPerPixelChanged );
   connect( this, &MapSettings::outputSizeChanged, this, &MapSettings::mapUnitsPerPixelChanged );
   connect( this, &MapSettings::extentChanged, this, &MapSettings::visibleExtentChanged );

--- a/src/mapsettings.h
+++ b/src/mapsettings.h
@@ -78,7 +78,7 @@ class MapSettings : public QObject
     /**
       * The string of the QgsUnitTypes::DistanceUnits CRS of destination coordinate reference system.
       */
-    Q_PROPERTY( QString abbreviatedStringOfDistanceUnit READ abbreviatedStringOfDistanceUnit )
+    Q_PROPERTY( QString abbreviatedStringOfDistanceUnit READ abbreviatedStringOfDistanceUnit NOTIFY abbreviatedStringOfDistanceUnitChanged )
 
     /**
      * Set list of layers for map rendering. The layers must be registered in QgsProject.
@@ -197,6 +197,9 @@ class MapSettings : public QObject
 
     //! \copydoc MapSettings::layers
     void layersChanged();
+
+    //! for recalculating the abbreviatedString when destinationCrs changed
+    void abbreviatedStringOfDistanceUnitChanged();
 
   private slots:
 

--- a/src/mapsettings.h
+++ b/src/mapsettings.h
@@ -76,6 +76,11 @@ class MapSettings : public QObject
     Q_PROPERTY( QgsCoordinateReferenceSystem destinationCrs READ destinationCrs WRITE setDestinationCrs NOTIFY destinationCrsChanged )
 
     /**
+      * The string of the QgsUnitTypes::DistanceUnits CRS of destination coordinate reference system.
+      */
+    Q_PROPERTY( QString abbreviatedStringOfDistanceUnit READ abbreviatedStringOfDistanceUnit )
+
+    /**
      * Set list of layers for map rendering. The layers must be registered in QgsProject.
      * The layers are stored in the reverse order of how they are rendered (layer with index 0 will be on top)
      *
@@ -162,6 +167,11 @@ class MapSettings : public QObject
 
     //! \copydoc QgsMapSettings::setLayers()
     void setLayers( const QList<QgsMapLayer *> &layers );
+
+    /**
+     * The string of the QgsUnitTypes::DistanceUnits CRS of destination coordinate reference system.
+     */
+    QString abbreviatedStringOfDistanceUnit() const;
 
   signals:
     //! \copydoc MapSettings::extent

--- a/src/qml/ScaleBar.qml
+++ b/src/qml/ScaleBar.qml
@@ -22,7 +22,7 @@ Row {
 
       property int factor: 2
       property int xindex: index
-      property string labelText: vars.adjustedMagnitude * factor + ' ' + UnitTypes.toAbbreviatedString(mapSettings.destinationCrs.mapUnits)
+      property string labelText: vars.adjustedMagnitude * factor + ' ' + mapSettings.abbreviatedStringOfDistanceUnit
     }
   }
 


### PR DESCRIPTION
Fix of #273 

But I request for feedback if it's solved at the correct place.

### Problem

Originally it would call in `scalebar.qml`:
```
UnitTypes.toAbbreviatedString(mapSettings.destinationCrs.mapUnits)
```

But because QML cannot handle the enumeration types it just passes 0 as integer.

So it does not call `QString toAbbreviatedString( QgsUnitTypes::DistanceUnit unit )` but `QString toAbbreviatedString( QgsUnitTypes::LayoutUnit unit )` instead.

### Solution
The Function to return the string is implemented in c++.

Is `mapsettings.cpp` the correct place, or should I create a `scalebar.cpp`?
Or is it even possible to make kind of typecast in QML to call the correct function?

Edit:
My problem is that only the `QgsUnitTypes` is registered where I can use the enumeration values (e.g. `QgsUnitTypes.DistanceMeters`. But not the enum Type `QgsUnitTypes::DistanceUnit`