### PR TITLE
Small sized icons in settings

### DIFF
--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick 2.6
 
 import Qt.labs.settings 1.0
 import QtQuick.Controls 2.0
@@ -6,6 +6,8 @@ import QtQuick.Controls 1.4 as Controls
 import QtQuick.Layouts 1.3
 
 import "js/style.js" as Style
+
+import "." as QField
 
 Page {
   signal finished
@@ -59,35 +61,39 @@ Page {
       currentIndex: bar.currentIndex
 
       ColumnLayout {
-        Switch{
+        spacing: 2 * dp
+
+        QField.Switch{
           id: showScaleBarCheckBox
           anchors { left: parent.left; right: parent.right }
           text: qsTr( "Show scalebar" )
         }
 
-        Switch {
+        QField.Switch {
           id: fullScreenIdentifyViewCheckBox
           anchors { left: parent.left; right: parent.right }
           text: qsTr( "Show attribute form in full screen" )
         }
 
-        Switch {
+        QField.Switch {
           id: incrementalRenderingCheckBox
           anchors { left: parent.left; right: parent.right }
           text: qsTr( "Redraw map every 250 ms while rendering" )
         }
 
-        Switch {
+        QField.Switch {
           id: numericalDigitizingInformationCheckBox
           anchors { left: parent.left; right: parent.right }
           text: qsTr( "Show numerical information while digitizing" )
           checked: true
         }
-        Switch {
+
+        QField.Switch {
           id: useNativeCameraCheckBox
           anchors { left: parent.left; right: parent.right }
           text: qsTr( "Use native camera function (unstable on recent Android versions)" )
         }
+
 
 /*
   // To be used in combination with code in main.cpp

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -7,7 +7,7 @@ import QtQuick.Layouts 1.3
 
 import "js/style.js" as Style
 
-import "." as QField
+import "."
 
 Page {
   signal finished
@@ -63,32 +63,32 @@ Page {
       ColumnLayout {
         spacing: 2 * dp
 
-        QField.Switch{
+        Switch{
           id: showScaleBarCheckBox
           anchors { left: parent.left; right: parent.right }
           text: qsTr( "Show scalebar" )
         }
 
-        QField.Switch {
+        Switch {
           id: fullScreenIdentifyViewCheckBox
           anchors { left: parent.left; right: parent.right }
           text: qsTr( "Show attribute form in full screen" )
         }
 
-        QField.Switch {
+        Switch {
           id: incrementalRenderingCheckBox
           anchors { left: parent.left; right: parent.right }
           text: qsTr( "Redraw map every 250 ms while rendering" )
         }
 
-        QField.Switch {
+        Switch {
           id: numericalDigitizingInformationCheckBox
           anchors { left: parent.left; right: parent.right }
           text: qsTr( "Show numerical information while digitizing" )
           checked: true
         }
 
-        QField.Switch {
+        Switch {
           id: useNativeCameraCheckBox
           anchors { left: parent.left; right: parent.right }
           text: qsTr( "Use native camera function (unstable on recent Android versions)" )

--- a/src/qml/Switch.qml
+++ b/src/qml/Switch.qml
@@ -1,0 +1,45 @@
+// [hidpi fixes]
+import QtQuick 2.6
+import QtQuick.Controls 2.0
+
+Item {
+    id: item
+
+    property alias checked: qfieldswitch.checked
+    property alias text: qfieldswitch.text
+
+    height: 48 * dp
+
+    Switch {
+        id: qfieldswitch
+
+        anchors.verticalCenter: parent.verticalCenter
+
+        indicator: Rectangle {
+            implicitHeight: 24 * dp
+            implicitWidth: 48 * dp
+            x: qfieldswitch.leftPadding
+            radius: 12 * dp
+            color: qfieldswitch.checked ? "#B9CCA3" : "#cccccc"
+            anchors.verticalCenter: parent.verticalCenter
+
+            Rectangle {
+                x: qfieldswitch.checked ? parent.width - width : 0
+                width: 24 * dp
+                height: 24 * dp
+                radius: 12 * dp
+                color:  qfieldswitch.checked ? qfieldswitch.down ? "#cccccc" : "#80CC28" : qfieldswitch.down ? "#80CC28" : "#ffffff"
+                border.color: "#cccccc"
+            }
+        }
+
+        contentItem: Text {
+            text: qfieldswitch.text
+            height: 36 * dp
+            font.pointSize: 12
+            verticalAlignment: Text.AlignVCenter
+            leftPadding: qfieldswitch.indicator.width + qfieldswitch.indicator.width / 2
+        }
+    }
+}
+// [/hidpi fixes]

--- a/src/qml/Switch.qml
+++ b/src/qml/Switch.qml
@@ -16,18 +16,18 @@ Item {
         anchors.verticalCenter: parent.verticalCenter
 
         indicator: Rectangle {
-            implicitHeight: 24 * dp
-            implicitWidth: 48 * dp
+            implicitHeight: 18 * dp
+            implicitWidth: 36 * dp
             x: qfieldswitch.leftPadding
-            radius: 12 * dp
+            radius: 9 * dp
             color: qfieldswitch.checked ? "#B9CCA3" : "#cccccc"
             anchors.verticalCenter: parent.verticalCenter
 
             Rectangle {
                 x: qfieldswitch.checked ? parent.width - width : 0
-                width: 24 * dp
-                height: 24 * dp
-                radius: 12 * dp
+                width: 18 * dp
+                height: 18 * dp
+                radius: 9 * dp
                 color:  qfieldswitch.checked ? qfieldswitch.down ? "#cccccc" : "#80CC28" : qfieldswitch.down ? "#80CC28" : "#ffffff"
                 border.color: "#cccccc"
             }

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -32,5 +32,9 @@
         <file>LayerTreeItemProperties.qml</file>
         <file>ui/LayerTreeItemProperties.ui.qml</file>
         <file>QFieldCamera.qml</file>
+        <file>Switch.qml</file>
+    </qresource>
+    <qresource prefix="/">
+        <file>Switch.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Made an own Switch.qml overwriting the Controls.Switch to set the sizes depending on the dpi.
On the Galaxy S6 mobile phone:

![screenshot_20180827-154135](https://user-images.githubusercontent.com/28384354/44663088-c8821600-aa0f-11e8-9bde-4501d69ab831.png)

Fix of: #333