### PR TITLE
Save variables in settings by back

### DIFF
--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -142,4 +142,11 @@ Page {
       }
     }
   }
+
+  Keys.onReleased: {
+    if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
+      event.accepted = true
+      variableEditor.apply()
+    }
+  }
 }


### PR DESCRIPTION
Function has been lost on my last GUI implementations.
Saves variables on back event. Other possibility would be the save on every text change, but then there would be a lot more unneeded calls.

Fix: #354