### PR TITLE
Use version number from tag

### DIFF
--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -23,6 +23,7 @@ QT_ANDROID=${QT_ANDROID_BASE}/android_${ARCH}
 
 set -e
 
+# Replace the version number in version.pri with the one from the TRAVIS_TAG which is being built
 if [[ -n ${TRAVIS_TAG} ]];
 then
   sed -i "s/VERSION_MAJOR = .*/VERSION_MAJOR = $(echo "${TRAVIS_TAG}" | cut -f 2 -d '-' | cut -f 1 -d '.')/g" ${SOURCE_DIR}/version.pri

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -23,6 +23,13 @@ QT_ANDROID=${QT_ANDROID_BASE}/android_${ARCH}
 
 set -e
 
+if [[ -n ${TRAVIS_TAG} ]];
+then
+  sed -i "s/VERSION_MAJOR = .*/VERSION_MAJOR = $(echo "${TRAVIS_TAG}" | cut -f 2 -d '-' | cut -f 1 -d '.')/g" ${SOURCE_DIR}/version.pri
+  sed -i "s/VERSION_MINOR = .*/VERSION_MINOR = $(echo "${TRAVIS_TAG}" | cut -f 2 -d '.')/g" ${SOURCE_DIR}/version.pri
+  sed -i "s/VERSION_FIX = .*/VERSION_FIX = $(echo "${TRAVIS_TAG}" | cut -f 3 -d '.')/g" ${SOURCE_DIR}/version.pri
+fi
+
 mkdir -p ${BUILD_DIR}/.gradle
 # androiddeployqt needs gradle and downloads it to /root/.gradle. By linking it to the build folder, this will be cached between builds.
 ln -s ${BUILD_DIR}/.gradle /root/.gradle


### PR DESCRIPTION
Fix #352

@signedav after this pull request it should finally be possible to release with a single click from the release page.

This will replace the version with the information from the git tag (assuming it to be formatted `release-MAJOR.MINOR.FIX`)
One open question is what to put into the version.pri on the repository, would it be ok to tag dev-versions as 0.0.0? Or will that somehow complicate installing test releases on the device?