### PR TITLE
Fix of remembering wrongly date

### DIFF
--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -52,7 +52,8 @@ Item {
 
         Image {
           source: Style.getThemeIcon("ic_clear_black_18dp")
-          anchors.left: parent.right
+          anchors.right: parent.right
+          anchors.verticalCenter: parent.verticalCenter
           visible: main.currentValue !== undefined && config['allow_null']
 
           MouseArea {

--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -43,8 +43,8 @@ Item {
         anchors.fill: parent
         verticalAlignment: Text.AlignVCenter
 
-        text: value === undefined ||  value === '' ?  qsTr('(no date)') : new Date(value).toLocaleString(Qt.locale(), config['display_format'] )
-        color: value === undefined || value === '' ? 'gray' : 'black'
+        text: value === undefined ?  qsTr('(no date)') : new Date(value).toLocaleString(Qt.locale(), config['display_format'] )
+        color: value === undefined ? 'gray' : 'black'
 
         MouseArea {
           anchors.fill: parent
@@ -57,7 +57,7 @@ Item {
           source: Style.getThemeIcon("ic_clear_black_18dp")
           anchors.right: parent.right
           anchors.verticalCenter: parent.verticalCenter
-          visible: ( value !== undefined || value === '' ) && config['allow_null']
+          visible: ( value !== undefined ) && config['allow_null']
 
           MouseArea {
             anchors.fill: parent

--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -43,6 +43,9 @@ Item {
         anchors.fill: parent
         verticalAlignment: Text.AlignVCenter
 
+        text: value === undefined ||  value === '' ?  qsTr('(no date)') : new Date(value).toLocaleString(Qt.locale(), config['display_format'] )
+        color: value === undefined || value === '' ? 'gray' : 'black'
+
         MouseArea {
           anchors.fill: parent
           onClicked: {
@@ -54,7 +57,7 @@ Item {
           source: Style.getThemeIcon("ic_clear_black_18dp")
           anchors.right: parent.right
           anchors.verticalCenter: parent.verticalCenter
-          visible: main.currentValue !== undefined && config['allow_null']
+          visible: ( value !== undefined || value === '' ) && config['allow_null']
 
           MouseArea {
             anchors.fill: parent
@@ -98,16 +101,6 @@ Item {
 
     onCurrentValueChanged: {
       valueChanged(currentValue, main.currentValue === undefined)
-      if (main.currentValue === undefined)
-      {
-        label.text = qsTr('(no date)')
-        label.color = 'gray'
-      }
-      else
-      {
-        label.color = 'black'
-        label.text = new Date(value).toLocaleString(Qt.locale(), config['display_format'] )
-      }
     }
   }
 }


### PR DESCRIPTION
... and still not saving it. 

Additionally there has been a cross when entering a date that has been unluckily placed exactly on the RememberValue box. So it's placed correctly now, because it's **a clear-cross to erase the date-value (if allowNull)**...
Looks like this:
![datum](https://user-images.githubusercontent.com/28384354/46396608-24ffe180-c6f0-11e8-8e37-a9e2cc54808b.png)

The other thing has been, on "Add Feature" the date of the last edited feature was always displayed - though not saved. So this is fixed now as well.

fix #369
fix #360
fix #319

Would be nice, if you could test that @gnerred @saemiw :slightly_smiling_face: Thanks.