### PR TITLE
Remember values over layers

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -284,6 +284,10 @@ void AttributeFormModelBase::flatten( QgsAttributeEditorContainer* container, QS
       case QgsAttributeEditorElement::AeTypeInvalid:
         // todo
         break;
+
+      case QgsAttributeEditorElement::AeTypeQmlElement:
+        // todo
+        break;
     }
   }
 }

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -38,6 +38,13 @@ class FeatureModel : public QAbstractListModel
     Q_PROPERTY( QString positionSourceName READ positionSourceName WRITE setPositionSourceName NOTIFY positionSourceChanged )
     Q_ENUMS( FeatureRoles )
 
+
+  struct RememberValues
+  {
+      QgsFeature rememberedFeature;
+      QVector<bool> rememberedAttributes;
+  };
+
   public:
     enum FeatureRoles
     {
@@ -126,9 +133,9 @@ class FeatureModel : public QAbstractListModel
     QgsFeature mFeature;
     VertexModel *mVertexModel = nullptr;
     Geometry* mGeometry;
-    QVector<bool> mRememberedAttributes;
     std::unique_ptr<QGeoPositionInfoSource> mPositionSource;
     QString mTempName;
+    QMap<QgsVectorLayer*, RememberValues> mRememberings;
 };
 
 #endif // FEATUREMODEL_H


### PR DESCRIPTION
It's done with a `QMap` storing the rememberAttributes and the last feature.

![rememberlayers](https://user-images.githubusercontent.com/28384354/46729450-a8d44380-cc85-11e8-8859-4dff7bec5c31.gif)

Fix #177 