### PR TITLE
correctly convert date/time format to respect field and display formats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - gem --version
 
 script:
-  - export QFIELD_SDK_VERSION=20190123
+  - export QFIELD_SDK_VERSION=20190128
   - echo "travis_fold:start:docker-pull"
   - docker pull opengisch/qfield-sdk:${QFIELD_SDK_VERSION}
   - echo "travis_fold:end:docker-pull"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,21 +27,27 @@ script:
   - ./scripts/upload-artifacts.sh
 
 jobs:
+  allow_failures:
+    - testing
   include:
     - stage: test
+      name: testing
       script:
         - echo "travis_fold:start:build\n$(tput bold)Build QField $(tput sgr0)"
         - docker-compose -f .docker/testing/docker-compose-travis.yml run qgis /usr/src/.docker/testing/build-test.sh
       if: type = pull_request OR tag IS present OR branch = master
     - stage: test
+      name: build ARMv7
       env:
         - ARCH=armv7
       if: type = pull_request OR tag IS present OR branch = master
     - stage: test
+      name: build X86
       env:
         - ARCH=x86
       if: type = pull_request OR tag IS present OR branch = master
     - stage: deploy
+      name: "Deploy 🍺"
       if: type = pull_request OR tag IS present OR branch = master
       script:
         - pip install pyopenssl

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
 
 jobs:
   allow_failures:
-    - testing
+    - name: testing
   include:
     - stage: test
       name: testing
@@ -58,3 +58,6 @@ jobs:
       install:
         pip install -r requirements.txt
       script: ./scripts/ci/update-translations.sh
+
+matrix:
+  fast_finish: true 

--- a/src/core/attributeformmodel.h
+++ b/src/core/attributeformmodel.h
@@ -26,7 +26,7 @@ class AttributeFormModel : public QSortFilterProxyModel
 {
     Q_OBJECT
 
-    Q_PROPERTY( FeatureModel* featureModel READ featureModel WRITE setFeatureModel NOTIFY featureModelChanged )
+    Q_PROPERTY( FeatureModel *featureModel READ featureModel WRITE setFeatureModel NOTIFY featureModelChanged )
     Q_PROPERTY( bool hasTabs READ hasTabs WRITE setHasTabs NOTIFY hasTabsChanged )
     Q_PROPERTY( bool constraintsValid READ constraintsValid NOTIFY constraintsValidChanged )
 
@@ -41,6 +41,7 @@ class AttributeFormModel : public QSortFilterProxyModel
       EditorWidgetConfig,
       RememberValue,
       Field,
+      FieldType,
       FieldIndex,
       Group,
       AttributeEditorElement,
@@ -51,19 +52,19 @@ class AttributeFormModel : public QSortFilterProxyModel
 
     Q_ENUM( FeatureRoles )
 
-    AttributeFormModel( QObject* parent = nullptr );
+    AttributeFormModel( QObject *parent = nullptr );
 
     bool hasTabs() const;
     void setHasTabs( bool hasTabs );
 
-    FeatureModel* featureModel() const;
-    void setFeatureModel( FeatureModel* featureModel );
+    FeatureModel *featureModel() const;
+    void setFeatureModel( FeatureModel *featureModel );
 
     bool constraintsValid() const;
 
     Q_INVOKABLE void save();
     Q_INVOKABLE void create();
-    Q_INVOKABLE QVariant attribute( const QString& name );
+    Q_INVOKABLE QVariant attribute( const QString &name );
 
   signals:
     void featureModelChanged();
@@ -72,10 +73,10 @@ class AttributeFormModel : public QSortFilterProxyModel
     void constraintsValidChanged();
 
   protected:
-    virtual bool filterAcceptsRow( int source_row, const QModelIndex& source_parent ) const override;
+    virtual bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const override;
 
   private:
-    AttributeFormModelBase* mSourceModel;
+    AttributeFormModelBase *mSourceModel;
 };
 
 #endif // ATTRIBUTEFORMMODEL_H

--- a/src/core/attributeformmodel.h
+++ b/src/core/attributeformmodel.h
@@ -41,7 +41,6 @@ class AttributeFormModel : public QSortFilterProxyModel
       EditorWidgetConfig,
       RememberValue,
       Field,
-      FieldType,
       FieldIndex,
       Group,
       AttributeEditorElement,

--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -262,8 +262,7 @@ void AttributeFormModelBase::flatten( QgsAttributeEditorContainer *container, QS
         item->setData( setup.type(), AttributeFormModel::EditorWidget );
         item->setData( setup.config(), AttributeFormModel::EditorWidgetConfig );
         item->setData( mFeatureModel->rememberedAttributes().at( fieldIndex ) ? Qt::Checked : Qt::Unchecked, AttributeFormModel::RememberValue );
-        item->setData( field, AttributeFormModel::Field );
-        item->setData( static_cast<int>( field.type() ), AttributeFormModel::FieldType );
+        item->setData( QgsField( field ), AttributeFormModel::Field );
         item->setData( "field", AttributeFormModel::ElementType );
         item->setData( fieldIndex, AttributeFormModel::FieldIndex );
         item->setData( container->isGroupBox() ? container->name() : QString(), AttributeFormModel::Group );

--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -44,6 +44,7 @@ QHash<int, QByteArray> AttributeFormModelBase::roleNames() const
   roles[AttributeFormModel::EditorWidgetConfig] = "EditorWidgetConfig";
   roles[AttributeFormModel::RememberValue] = "RememberValue";
   roles[AttributeFormModel::Field] = "Field";
+  roles[AttributeFormModel::FieldType] = "FieldType";
   roles[AttributeFormModel::Group] = "Group";
   roles[AttributeFormModel::ConstraintValid] = "ConstraintValid";
   roles[AttributeFormModel::ConstraintDescription] = "ConstraintDescription";
@@ -261,7 +262,8 @@ void AttributeFormModelBase::flatten( QgsAttributeEditorContainer *container, QS
         item->setData( setup.type(), AttributeFormModel::EditorWidget );
         item->setData( setup.config(), AttributeFormModel::EditorWidgetConfig );
         item->setData( mFeatureModel->rememberedAttributes().at( fieldIndex ) ? Qt::Checked : Qt::Unchecked, AttributeFormModel::RememberValue );
-        item->setData( mLayer->fields().at( fieldIndex ), AttributeFormModel::Field );
+        item->setData( field, AttributeFormModel::Field );
+        item->setData( static_cast<int>( field.type() ), AttributeFormModel::FieldType );
         item->setData( "field", AttributeFormModel::ElementType );
         item->setData( fieldIndex, AttributeFormModel::FieldIndex );
         item->setData( container->isGroupBox() ? container->name() : QString(), AttributeFormModel::Group );

--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -44,7 +44,6 @@ QHash<int, QByteArray> AttributeFormModelBase::roleNames() const
   roles[AttributeFormModel::EditorWidgetConfig] = "EditorWidgetConfig";
   roles[AttributeFormModel::RememberValue] = "RememberValue";
   roles[AttributeFormModel::Field] = "Field";
-  roles[AttributeFormModel::FieldType] = "FieldType";
   roles[AttributeFormModel::Group] = "Group";
   roles[AttributeFormModel::ConstraintValid] = "ConstraintValid";
   roles[AttributeFormModel::ConstraintDescription] = "ConstraintDescription";

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -22,7 +22,7 @@
 #include <qgsmessagelog.h>
 #include <qgsvectorlayer.h>
 #include <QGeoPositionInfoSource>
-#include <QDebug>
+
 
 FeatureModel::FeatureModel( QObject *parent )
   : QAbstractListModel( parent )
@@ -128,7 +128,6 @@ QVariant FeatureModel::data( const QModelIndex& index, int role ) const
       break;
 
     case AttributeValue:
-      qDebug() << mFeature.attribute( index.row() );
       return mFeature.attribute( index.row() );
       break;
 

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -128,6 +128,7 @@ QVariant FeatureModel::data( const QModelIndex& index, int role ) const
       break;
 
     case AttributeValue:
+      qDebug() << mFeature.attribute( index.row() );
       return mFeature.attribute( index.row() );
       break;
 

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -44,6 +44,7 @@
 #include <qgslayoutpagecollection.h>
 #include <qgslocator.h>
 #include <qgslocatormodel.h>
+#include <qgsfield.h>
 
 #include "qgsquickmapsettings.h"
 #include "qgsquickmapcanvasmap.h"
@@ -146,6 +147,7 @@ void QgisMobileapp::initDeclarative()
   qRegisterMetaType<QgsUnitTypes::DistanceUnit>( "QgsUnitTypes::DistanceUnit" );
   qRegisterMetaType<QgsUnitTypes::AreaUnit>( "QgsUnitTypes::AreaUnit" );
   qRegisterMetaType<QgsRelation>( "QgsRelation" );
+  qRegisterMetaType<QgsField>( "QgsField" );
 
   qmlRegisterUncreatableType<QgsProject>( "org.qgis", 1, 0, "Project", "" );
   qmlRegisterUncreatableType<QgsCoordinateReferenceSystem>( "org.qgis", 1, 0, "CoordinateReferenceSystem", "" );

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -45,6 +45,7 @@
 #include <qgslocator.h>
 #include <qgslocatormodel.h>
 #include <qgsfield.h>
+#include <qgsfieldconstraints.h>
 
 #include "qgsquickmapsettings.h"
 #include "qgsquickmapcanvasmap.h"
@@ -148,6 +149,9 @@ void QgisMobileapp::initDeclarative()
   qRegisterMetaType<QgsUnitTypes::AreaUnit>( "QgsUnitTypes::AreaUnit" );
   qRegisterMetaType<QgsRelation>( "QgsRelation" );
   qRegisterMetaType<QgsField>( "QgsField" );
+  qRegisterMetaType<QVariant::Type>( "QVariant::Type" );
+  qRegisterMetaType<QgsDefaultValue>( "QgsDefaultValue" );
+  qRegisterMetaType<QgsFieldConstraints>( "QgsFieldConstraints" );
 
   qmlRegisterUncreatableType<QgsProject>( "org.qgis", 1, 0, "Project", "" );
   qmlRegisterUncreatableType<QgsCoordinateReferenceSystem>( "org.qgis", 1, 0, "CoordinateReferenceSystem", "" );

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -130,5 +130,9 @@ class QgisMobileapp : public QQmlApplicationEngine
 Q_DECLARE_METATYPE( QgsWkbTypes::GeometryType )
 Q_DECLARE_METATYPE( QgsFeatureId )
 Q_DECLARE_METATYPE( QgsAttributes )
+Q_DECLARE_METATYPE( QVariant::Type )
+Q_DECLARE_METATYPE( QgsDefaultValue )
+Q_DECLARE_METATYPE( QgsFieldConstraints )
+
 
 #endif // QGISMOBILEAPP_H

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -131,7 +131,6 @@ Q_DECLARE_METATYPE( QgsWkbTypes::GeometryType )
 Q_DECLARE_METATYPE( QgsFeatureId )
 Q_DECLARE_METATYPE( QgsAttributes )
 Q_DECLARE_METATYPE( QVariant::Type )
-Q_DECLARE_METATYPE( QgsDefaultValue )
 Q_DECLARE_METATYPE( QgsFieldConstraints )
 
 

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -241,6 +241,7 @@ Page {
           property var config: EditorWidgetConfig
           property var widget: EditorWidget
           property var field: Field
+          property var fieldType: FieldType
           property var constraintValid: ConstraintValid
 
           active: widget !== 'Hidden'

--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -27,7 +27,7 @@ Item {
   ColumnLayout {
     id: main
     property var isDateTimeType: field.type === Qt.DateTime || field.type === Qt.Date || field.type === Qt.Time
-    property var currentValue: isDateTimeType? value : Qt.formatDateTime(value, config['field_format'])
+    property var currentValue: isDateTimeType ? value : Qt.formatDateTime(value, config['field_format'])
 
     anchors { right: parent.right; left: parent.left }
 
@@ -55,15 +55,15 @@ Item {
 
         // this is a bit difficult to auto generate input mask out of date/time format using regex
         // mainly because number of caracters is variable (e.g. "d": the day as number without a leading zero)
-        // not saying impossible, but keep it for next regex challenge or at least not the day before vacation
+        // not saying impossible, but let's keep it for next regex challenge
         inputMask:      if (config['display_format'] === "yyyy-MM-dd" ) { "9999-99-99;_" }
-                   else if (config['display_format'] === "yyyy.MM.dd" ) { "9999.99.09;_" }
-                   else if (config['display_format'] === "yyyy-MM-dd HH:mm:ss" ) { "9999-99-09 99:99:99;_" }
+                   else if (config['display_format'] === "yyyy.MM.dd" ) { "9999.99.99;_" }
+                   else if (config['display_format'] === "yyyy-MM-dd HH:mm:ss" ) { "9999-99-99 99:99:99;_" }
                    else if (config['display_format'] === "HH:mm:ss" ) { "99:99:99;_" }
                    else if (config['display_format'] === "HH:mm" ) { "99:99;_" }
                    else { "" }
 
-        text: if ( main.currentValue === undefined )
+        text: if ( value === undefined )
               {
                 qsTr('(no date)')
               }
@@ -71,16 +71,16 @@ Item {
               {
                 if ( main.isDateTimeType )
                 {
-                  Qt.formatDateTime(main.currentValue, config['display_format'])
+                  Qt.formatDateTime(value, config['display_format'])
                 }
                 else
                 {
-                  var date = Date.fromLocaleString(Qt.locale(), main.currentValue, config['field_format'])
+                  var date = Date.fromLocaleString(Qt.locale(), value, config['field_format'])
                   Qt.formatDateTime(date, config['display_format'])
                 }
               }
 
-        color: main.currentValue === undefined ? 'gray' : 'black'
+        color: value === undefined ? 'gray' : 'black'
 
         MouseArea {
           enabled: config['calendar_popup']
@@ -91,18 +91,14 @@ Item {
         }
 
         onTextEdited: {
-          var date = Date.fromLocaleString(Qt.locale(), label.text, config['display_format'])
-          if ( date.toLocaleString() !== "" )
+          var newDate = Date.fromLocaleString(Qt.locale(), label.text, config['display_format'])
+          if ( newDate.toLocaleString() !== "" )
           {
-            if ( main.isDateTimeType )
+            if ( !main.isDateTimeType )
             {
-              main.currentValue = date
+              newDate = Qt.formatDateTime(newDate, config['field_format'])
             }
-            else
-            {
-              main.currentValue = Qt.formatDateTime(date, config['field_format'])
-            }
-            valueChanged(main.currentValue, main.currentValue === undefined)
+            valueChanged(newDate, newDate === undefined)
           }
           else
           {
@@ -128,12 +124,13 @@ Item {
           source: Style.getThemeIcon("ic_clear_black_18dp")
           anchors.right: parent.right
           anchors.verticalCenter: parent.verticalCenter
-          visible: ( main.currentValue !== undefined ) && config['allow_null']
+          visible: ( value !== undefined ) && config['allow_null']
 
           MouseArea {
             anchors.fill: parent
             onClicked: {
-              main.currentValue = undefined
+              valueChanged(undefined, true)
+              //main.currentValue = undefined
             }
           }
         }
@@ -150,7 +147,7 @@ Item {
       ColumnLayout {
         Controls.Calendar {
           id: calendar
-          selectedDate: main.currentValue
+          selectedDate: main.isDateTimeType ? main.currentValue : Date.fromLocaleString(Qt.locale(), main.currentValue, config['field_format'])
           weekNumbersVisible: true
           focus: false
 

--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -4,6 +4,7 @@ import QtQuick.Controls 1.4 as Controls
 import QtQuick.Layouts 1.1
 import "../js/style.js" as Style
 
+
 /*
   Config:
   * field_format
@@ -26,7 +27,7 @@ Item {
 
   ColumnLayout {
     id: main
-    property bool isDateTimeType: field.type === Qt.DateTime || field.type === Qt.Date || field.type === Qt.Time
+    property bool isDateTimeType: field.isDateOrTime
     property var currentValue: isDateTimeType ? value : Qt.formatDateTime(value, config['field_format'])
 
     anchors { right: parent.right; left: parent.left }
@@ -142,6 +143,7 @@ Item {
       closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
       parent: ApplicationWindow.overlay
 
+      // TODO: fixme no signal when date is clicked on current
       ColumnLayout {
         Controls.Calendar {
           id: calendar
@@ -151,25 +153,6 @@ Item {
           function resetDate() {
             selectedDate = main.currentValue ? main.isDateTimeType ? main.currentValue : Date.fromLocaleString(Qt.locale(), main.currentValue, config['field_format']) : new Date()
           }
-
-          onSelectedDateChanged: {
-            // weird, selectedDate seems to be set at time 12:00:00
-            var newDate = selectedDate
-//            newDate.setHours(0)
-//            newDate.setMinutes(0)
-//            newDate.setSeconds(0)
-//            newDate.setMilliseconds(0)
-
-            if ( main.isDateTimeType )
-            {
-              valueChanged(newDate, newDate === undefined)
-            }
-            else
-            {
-              var textDate = Qt.formatDateTime(newDate, config['field_format'])
-              valueChanged(textDate, textDate === undefined)
-            }
-          }
         }
 
         RowLayout {
@@ -177,7 +160,26 @@ Item {
             text: qsTr( "Ok" )
             Layout.fillWidth: true
 
-            onClicked: popup.close()
+            onClicked: {
+              // weird, selectedDate seems to be set at time 12:00:00
+              var newDate = calendar.selectedDate
+              newDate.setHours(0)
+              newDate.setMinutes(0)
+              newDate.setSeconds(0)
+              newDate.setMilliseconds(0)
+
+              if ( main.isDateTimeType )
+              {
+                valueChanged(newDate, newDate === undefined)
+              }
+              else
+              {
+                var textDate = Qt.formatDateTime(newDate, config['field_format'])
+                valueChanged(textDate, textDate === undefined)
+              }
+
+              popup.close()
+            }
           }
         }
       }

--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -1,16 +1,22 @@
-import QtQuick 2.0
-import QtQuick.Controls 2.0
+import QtQuick 2.11
+import QtQuick.Controls 2.4
 import QtQuick.Controls 1.4 as Controls
 import QtQuick.Layouts 1.1
 import "../js/style.js" as Style
 
 /*
+  Config:
   * field_format
   * display_format
   * calendar_popup
   * allow_null
- */
 
+  If the calendar_popup is enabled, no direct editing is possible in the TextField.
+  If not, it will try to match the display_format with the best possible InputMask.
+  A Date/Time object (Date in QML) is used even with text field as source (not DateTime)
+  to allow a full flexibility of field and display formats.
+
+ */
 
 Item {
   signal valueChanged(var value, bool isNull)
@@ -37,21 +43,64 @@ Item {
         radius: 2
       }
 
-      Label {
+      TextField {
         id: label
 
         anchors.fill: parent
         verticalAlignment: Text.AlignVCenter
         font.pointSize: 16
 
-        text: value === undefined ?  qsTr('(no date)') : new Date(value).toLocaleString(Qt.locale(), config['display_format'] )
+        inputMethodHints: Qt.ImhDigitsOnly
+
+        // this is a bit difficult to auto generate input mask out of date/time format using regex
+        // mainly because number of caracters is variable (e.g. "d": the day as number without a leading zero)
+        // not saying impossible, but keep it for next regex challenge or at least not the day before vacation
+        inputMask:      if (config['display_format'] === "yyyy-MM-dd" ) { "9999-09-09;_" }
+                   else if (config['display_format'] === "yyyy.MM.dd" ) { "9999.09.09;_" }
+                   else if (config['display_format'] === "yyyy-MM-dd HH:mm:ss" ) { "9999-09-09 09:09:00;_" }
+                   else if (config['display_format'] === "HH:mm:ss" ) { "09:09:00;_" }
+                   else if (config['display_format'] === "HH:mm" ) { "09:09;_" }
+                   else { "" }
+
+        text: if ( value === undefined )
+              {
+                qsTr('(no date)')
+              }
+              else
+              {
+                if ( value instanceof Date )
+                {
+                  Qt.formatDateTime(value, config['display_format'])
+                }
+                else
+                {
+                  var date = Date.fromLocaleString(Qt.locale(), value, config['field_format'])
+                  Qt.formatDateTime(date, config['display_format'])
+                }
+              }
+
         color: value === undefined ? 'gray' : 'black'
 
         MouseArea {
+          enabled: config['calendar_popup']
           anchors.fill: parent
           onClicked: {
             popup.open()
           }
+        }
+
+        onActiveFocusChanged: {
+            if (activeFocus) {
+              var mytext = label.text
+              var cur = label.cursorPosition
+              while ( cur > 0 )
+              {
+                if (!mytext.charAt(cur-1).match("[0-9]") )
+                  break
+                cur--
+              }
+              label.cursorPosition = cur
+            }
         }
 
         Image {
@@ -85,7 +134,14 @@ Item {
           focus: false
 
           onSelectedDateChanged: {
-            main.currentValue = selectedDate
+            if ( main.currentValue instanceof Date )
+            {
+              main.currentValue = selectedDate
+            }
+            else
+            {
+              main.currentValue = Qt.formatDateTime(selectedDate, config['field_format'])
+            }
           }
         }
 


### PR DESCRIPTION
these formats are defined in QGIS and can differ from each other
more over, the type of value from the field can be either a date or a string

by correctly constructing a date/time object when getting/setting the value from
the widget, the same behavior than in QGIS is allowed

also:
* do not open calendar when option is not checked in QGIS project
* define inputMask whenever easily possible

fix #9
fix #215
fix #371 

supersedes #404 