### PR TITLE
avoid overlap of busy indicator and search icon

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -795,7 +795,7 @@ ApplicationWindow {
 
   Controls.BusyIndicator {
     id: busyIndicator
-    anchors { right: alertIcon.left; top: parent.top }
+    anchors.centerIn: mapCanvas
     width: 36 * dp
     height: 36 * dp
     running: mapCanvasMap.isRendering


### PR DESCRIPTION
move the busy indicator to the center of the map
it is not that much obtrusive

![image](https://user-images.githubusercontent.com/127259/51497426-161d6780-1d91-11e9-9d5d-8f566a91eb59.png)
