### PR TITLE
Fix layer order

### DIFF
--- a/src/core/layertreemapcanvasbridge.cpp
+++ b/src/core/layertreemapcanvasbridge.cpp
@@ -27,8 +27,8 @@
 
 LayerTreeMapCanvasBridge::LayerTreeMapCanvasBridge( LayerTreeModel *model, QgsQuickMapSettings *mapSettings, QObject *parent )
   : QObject( parent )
-  , mModel( model )
   , mRoot( model->layerTree() )
+  , mModel( model )
   , mMapSettings( mapSettings )
   , mPendingCanvasUpdate( false )
   , mHasCustomLayerOrder( false )
@@ -145,68 +145,5 @@ void LayerTreeMapCanvasBridge::mapThemeChanged()
 }
 
 
-bool LayerTreeMapCanvasBridge::findRecordForLayer( QgsMapLayer *layer, const QgsMapThemeCollection::MapThemeRecord &rec, QgsMapThemeCollection::MapThemeLayerRecord &layerRec )
-{
-  Q_FOREACH ( const QgsMapThemeCollection::MapThemeLayerRecord &lr, rec.layerRecords() )
-  {
-    if ( lr.layer() == layer )
-    {
-      layerRec = lr;
-      return true;
-    }
-  }
-  return false;
-}
-
-void LayerTreeMapCanvasBridge::applyThemeToLayer( QgsLayerTreeLayer *nodeLayer, const QgsMapThemeCollection::MapThemeRecord &rec )
-{
-  QgsMapThemeCollection::MapThemeLayerRecord layerRec;
-  bool isVisible = findRecordForLayer( nodeLayer->layer(), rec, layerRec );
-
-  nodeLayer->setItemVisibilityChecked( isVisible );
-
-  if ( !isVisible )
-    return;
-
-  if ( layerRec.usingCurrentStyle )
-  {
-    // apply desired style first
-    nodeLayer->layer()->styleManager()->setCurrentStyle( layerRec.currentStyle );
-  }
-#if 0
-  if ( layerRec.usingLegendItems )
-  {
-    // some nodes are not checked
-    Q_FOREACH ( QgsLayerTreeModelLegendNode *legendNode, model->layerLegendNodes( nodeLayer, true ) )
-    {
-      QString ruleKey = legendNode->data( QgsLayerTreeModelLegendNode::RuleKeyRole ).toString();
-      Qt::CheckState shouldHaveState = layerRec.checkedLegendItems.contains( ruleKey ) ? Qt::Checked : Qt::Unchecked;
-      if ( ( legendNode->flags() & Qt::ItemIsUserCheckable ) &&
-           legendNode->data( Qt::CheckStateRole ).toInt() != shouldHaveState )
-        legendNode->setData( shouldHaveState, Qt::CheckStateRole );
-    }
-  }
-  else
-  {
-    // all nodes should be checked
-    Q_FOREACH ( QgsLayerTreeModelLegendNode *legendNode, model->layerLegendNodes( nodeLayer, true ) )
-    {
-      if ( ( legendNode->flags() & Qt::ItemIsUserCheckable ) &&
-           legendNode->data( Qt::CheckStateRole ).toInt() != Qt::Checked )
-        legendNode->setData( Qt::Checked, Qt::CheckStateRole );
-    }
-  }
-#endif
-}
 
 
-void LayerTreeMapCanvasBridge::applyThemeToGroup( QgsLayerTreeGroup *parent, const QgsMapThemeCollection::MapThemeRecord &rec )
-{
-  Q_FOREACH ( QgsLayerTreeNode *node, parent->children() )
-  {
-    if ( QgsLayerTree::isGroup( node ) )
-      applyThemeToGroup( QgsLayerTree::toGroup( node ), rec );
-    else if ( QgsLayerTree::isLayer( node ) )
-      applyThemeToLayer( QgsLayerTree::toLayer( node ), rec );
-  }
-}

--- a/src/core/layertreemapcanvasbridge.h
+++ b/src/core/layertreemapcanvasbridge.h
@@ -83,10 +83,6 @@ class LayerTreeMapCanvasBridge : public QObject
 
     void deferredSetCanvasLayers();
 
-    static bool findRecordForLayer( QgsMapLayer *layer, const QgsMapThemeCollection::MapThemeRecord &rec, QgsMapThemeCollection::MapThemeLayerRecord &layerRec );
-    static void applyThemeToLayer( QgsLayerTreeLayer *nodeLayer, const QgsMapThemeCollection::MapThemeRecord &rec );
-    static void applyThemeToGroup( QgsLayerTreeGroup *parent, const QgsMapThemeCollection::MapThemeRecord &rec );
-
     QgsLayerTree *mRoot = nullptr;
     LayerTreeModel *mModel = nullptr;
     QgsQuickMapSettings *mMapSettings = nullptr;

--- a/src/core/layertreemapcanvasbridge.h
+++ b/src/core/layertreemapcanvasbridge.h
@@ -51,39 +51,13 @@ class LayerTreeMapCanvasBridge : public QObject
     //! Constructor: does not take ownership of the layer tree nor canvas
     LayerTreeMapCanvasBridge( LayerTreeModel *model, QgsQuickMapSettings *mapSettings, QObject *parent = nullptr );
 
-    void clear();
-
-    QgsLayerTree *layerTree() const
-    {
-      return mModel->layerTree();
-    }
-
-    QgsQuickMapSettings *mapSettings() const
-    {
-      return mMapSettings;
-    }
-
-    bool hasCustomLayerOrder() const
-    {
-      return mHasCustomLayerOrder;
-    }
-    QStringList customLayerOrder() const
-    {
-      return mCustomLayerOrder;
-    }
-
-    QStringList defaultLayerOrder() const;
+    QgsLayerTree *rootGroup() const { return mRoot; }
+    QgsQuickMapSettings *mapSettings() const { return mMapSettings; }
 
     //! if enabled, will automatically set full canvas extent and destination CRS + map units
     //! when first layer(s) are added
-    void setAutoSetupOnFirstLayer( bool enabled )
-    {
-      mAutoSetupOnFirstLayer = enabled;
-    }
-    bool autoSetupOnFirstLayer() const
-    {
-      return mAutoSetupOnFirstLayer;
-    }
+    void setAutoSetupOnFirstLayer( bool enabled ) {  mAutoSetupOnFirstLayer = enabled; }
+    bool autoSetupOnFirstLayer() const    {  return mAutoSetupOnFirstLayer;  }
 
     //! if enabled, will automatically turn on on-the-fly reprojection of layers if a layer
     //! with different source CRS is added
@@ -96,42 +70,26 @@ class LayerTreeMapCanvasBridge : public QObject
       return mAutoEnableCrsTransform;
     }
 
-  public slots:
-    void setHasCustomLayerOrder( bool state );
-    void setCustomLayerOrder( const QStringList &order );
-
     //! force update of canvas layers from the layer tree. Normally this should not be needed to be called.
-    void setCanvasLayers();
-
-    void readProject( const QDomDocument &doc );
-    void writeProject( QDomDocument &doc );
-
-  signals:
-    void hasCustomLayerOrderChanged( bool );
-    void customLayerOrderChanged( const QStringList &order );
-
-  private:
-
-    void defaultLayerOrder( QgsLayerTreeNode *node, QStringList &order ) const;
-
-    void setCanvasLayers( QgsLayerTreeNode *node, QList<QgsMapLayer *> &layers );
-
-    void deferredSetCanvasLayers();
+    Q_INVOKABLE void setCanvasLayers();
 
   private slots:
-    void nodeAddedChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo );
-    void nodeRemovedChildren();
     void nodeVisibilityChanged();
-    void nodeCustomPropertyChanged( QgsLayerTreeNode *node, const QString &key );
     void mapThemeChanged();
 
   private:
+
+    void setCanvasLayers( QgsLayerTreeNode *node, QList<QgsMapLayer *> &canvasLayers, QList<QgsMapLayer *> &allLayers );
+
+    void deferredSetCanvasLayers();
+
     static bool findRecordForLayer( QgsMapLayer *layer, const QgsMapThemeCollection::MapThemeRecord &rec, QgsMapThemeCollection::MapThemeLayerRecord &layerRec );
     static void applyThemeToLayer( QgsLayerTreeLayer *nodeLayer, const QgsMapThemeCollection::MapThemeRecord &rec );
     static void applyThemeToGroup( QgsLayerTreeGroup *parent, const QgsMapThemeCollection::MapThemeRecord &rec );
 
-    LayerTreeModel *mModel;
-    QgsQuickMapSettings *mMapSettings;
+    QgsLayerTree *mRoot = nullptr;
+    LayerTreeModel *mModel = nullptr;
+    QgsQuickMapSettings *mMapSettings = nullptr;
 
     bool mPendingCanvasUpdate;
 
@@ -142,7 +100,7 @@ class LayerTreeMapCanvasBridge : public QObject
     bool mAutoEnableCrsTransform;
 
     bool mHasFirstLayer;
-    bool mNoLayersLoaded;
+    bool mHasLayersLoaded;
 
     QgsCoordinateReferenceSystem mFirstCRS;
 };

--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -170,11 +170,13 @@ QgsProject *LayerTreeModel::project() const
 
 void LayerTreeModel::updateCurrentMapTheme()
 {
-  QgsMapThemeCollection::MapThemeRecord rec = QgsMapThemeCollection::createThemeFromCurrentState( mLayerTreeModel->rootGroup(), mLayerTreeModel );
+  const QgsMapThemeCollection::MapThemeRecord rec = QgsMapThemeCollection::createThemeFromCurrentState( mLayerTreeModel->rootGroup(), mLayerTreeModel );
   const QStringList mapThemes = QgsProject::instance()->mapThemeCollection()->mapThemes();
   for ( const QString &grpName : mapThemes )
   {
-    if ( rec == QgsProject::instance()->mapThemeCollection()->mapThemeState( grpName ) )
+    // only compare layer records as the legend does not offer collapse info for now
+    // TODO check the whole rec equality whenever the layer tree is a tree and not a list anymore
+    if ( rec.validLayerRecords() == QgsProject::instance()->mapThemeCollection()->mapThemeState( grpName ).validLayerRecords() )
     {
       mMapTheme = grpName;
       return;

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -116,8 +116,6 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   connect( mProject, &QgsProject::readProject, this, &QgisMobileapp::onReadProject );
 
   mLayerTreeCanvasBridge = new LayerTreeMapCanvasBridge( mLayerTree, mMapCanvas->mapSettings(), this );
-  connect( mProject, &QgsProject::writeProject, mLayerTreeCanvasBridge, &LayerTreeMapCanvasBridge::writeProject );
-  connect( mProject, &QgsProject::readProject, mLayerTreeCanvasBridge, &LayerTreeMapCanvasBridge::readProject );
   connect( this, &QgisMobileapp::loadProjectStarted, mIface, &AppInterface::loadProjectStarted );
   connect( this, &QgisMobileapp::loadProjectEnded, mIface, &AppInterface::loadProjectEnded );
   QTimer::singleShot( 1, this, &QgisMobileapp::onAfterFirstRendering );


### PR DESCRIPTION
this synchronize QField bridge with the one from QGIS core (see also https://github.com/qgis/QGIS/pull/9050 )
this removes some unused code 
* for custom layer order (moved to core https://github.com/qgis/QGIS/commit/f33aabd90aab071d8b1f8f163e6cbed8869110c3#diff-48da0c3b55429da1f86f5f0d2f4e1f8e)
* for map themes (became useless since dc492ce6acf6a11c5a288605dcd3c249a3669aba)
