### PR TITLE
Update to Qt 5.12.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - gem --version
 
 script:
-  - export QFIELD_SDK_VERSION=20190128
+  - export QFIELD_SDK_VERSION=20190217
   - echo "travis_fold:start:docker-pull"
   - docker pull opengisch/qfield-sdk:${QFIELD_SDK_VERSION}
   - echo "travis_fold:end:docker-pull"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - gem --version
 
 script:
-  - export QFIELD_SDK_VERSION=20190218
+  - export QFIELD_SDK_VERSION=20190219
   - echo "travis_fold:start:docker-pull"
   - docker pull opengisch/qfield-sdk:${QFIELD_SDK_VERSION}
   - echo "travis_fold:end:docker-pull"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - gem --version
 
 script:
-  - export QFIELD_SDK_VERSION=20190219
+  - export QFIELD_SDK_VERSION=20190220
   - echo "travis_fold:start:docker-pull"
   - docker pull opengisch/qfield-sdk:${QFIELD_SDK_VERSION}
   - echo "travis_fold:end:docker-pull"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - gem --version
 
 script:
-  - export QFIELD_SDK_VERSION=20190217
+  - export QFIELD_SDK_VERSION=20190218
   - echo "travis_fold:start:docker-pull"
   - docker pull opengisch/qfield-sdk:${QFIELD_SDK_VERSION}
   - echo "travis_fold:end:docker-pull"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - gem --version
 
 script:
-  - export QFIELD_SDK_VERSION=20190220
+  - export QFIELD_SDK_VERSION=20190221
   - echo "travis_fold:start:docker-pull"
   - docker pull opengisch/qfield-sdk:${QFIELD_SDK_VERSION}
   - echo "travis_fold:end:docker-pull"

--- a/qfield.pri
+++ b/qfield.pri
@@ -12,7 +12,6 @@ android {
     $${OSGEO4A_STAGE_DIR}/$$ANDROID_TARGET_ARCH$$/include/qgis
 
   ANDROID_EXTRA_LIBS = \
-    $${OSGEO4A_STAGE_DIR}/$$ANDROID_TARGET_ARCH$$/lib/libcrystax.so \
     $${OSGEO4A_STAGE_DIR}/$$ANDROID_TARGET_ARCH$$/lib/libexpat.so \
     $${OSGEO4A_STAGE_DIR}/$$ANDROID_TARGET_ARCH$$/lib/libgeos.so \
     $${OSGEO4A_STAGE_DIR}/$$ANDROID_TARGET_ARCH$$/lib/libgeos_c.so \

--- a/qfield.pri
+++ b/qfield.pri
@@ -49,7 +49,6 @@ android {
     $$QT_LIBS_DIR/libQt5Sensors.so \
     $$QT_LIBS_DIR/libQt5Sql.so \
     $$QT_LIBS_DIR/libQt5Svg.so \
-    $$QT_LIBS_DIR/libQt5SerialPort.so \
     $$QT_LIBS_DIR/libQt5PrintSupport.so
 }
 

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -20,7 +20,6 @@ if [[ -z ${ARCH+x} ]]; then
 fi
 INSTALL_DIR=${BUILD_DIR}/out
 QT_ANDROID=${QT_ANDROID_BASE}/android_${ARCH}
-export QMAKESPEC=android-clang
 
 set -e
 

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -20,6 +20,7 @@ if [[ -z ${ARCH+x} ]]; then
 fi
 INSTALL_DIR=${BUILD_DIR}/out
 QT_ANDROID=${QT_ANDROID_BASE}/android_${ARCH}
+export QMAKESPEC=android-clang
 
 set -e
 

--- a/src/core/expressionvariablemodel.cpp
+++ b/src/core/expressionvariablemodel.cpp
@@ -14,8 +14,11 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "expressionvariablemodel.h"
-#include "qgsexpressioncontext.h"
+#include <expressionvariablemodel.h>
+#include <qgsexpressioncontext.h>
+#include <qgsexpressioncontextutils.h>
+
+
 #include <QSettings>
 #include <QDebug>
 

--- a/src/core/featureslocatorfilter.cpp
+++ b/src/core/featureslocatorfilter.cpp
@@ -23,6 +23,7 @@
 #include <qgsvectorlayer.h>
 #include <qgsmaplayermodel.h>
 #include <qgsfeedback.h>
+#include <qgsexpressioncontextutils.h>
 
 #include "locatormodelsuperbridge.h"
 #include "qgsquickmapsettings.h"

--- a/src/core/identifytool.cpp
+++ b/src/core/identifytool.cpp
@@ -21,6 +21,7 @@
 #include <qgsvectorlayer.h>
 #include <qgsproject.h>
 #include <qgsrenderer.h>
+#include <qgsexpressioncontextutils.h>
 
 IdentifyTool::IdentifyTool( QObject *parent )
   : QObject( parent )

--- a/src/core/multifeaturelistmodel.cpp
+++ b/src/core/multifeaturelistmodel.cpp
@@ -20,6 +20,7 @@
 #include <qgsproject.h>
 #include <qgsgeometry.h>
 #include <qgscoordinatereferencesystem.h>
+#include <qgsexpressioncontextutils.h>
 
 #include "multifeaturelistmodel.h"
 

--- a/src/qgsquick/qgsquickmapcanvasmap.cpp
+++ b/src/qgsquick/qgsquickmapcanvasmap.cpp
@@ -22,7 +22,7 @@
 #include <qgspallabeling.h>
 #include <qgsproject.h>
 #include <qgsvectorlayer.h>
-#include <qgsexpressioncontextutils.h>
+#include <qgsexpressioncontext.h>
 #include "qgis.h"
 
 #include "qgsquickmapcanvasmap.h"

--- a/src/qgsquick/qgsquickmapcanvasmap.cpp
+++ b/src/qgsquick/qgsquickmapcanvasmap.cpp
@@ -22,7 +22,7 @@
 #include <qgspallabeling.h>
 #include <qgsproject.h>
 #include <qgsvectorlayer.h>
-#include <qgsexpressioncontext.h>
+#include <qgsexpressioncontextutils.h>
 #include "qgis.h"
 
 #include "qgsquickmapcanvasmap.h"

--- a/src/qgsquick/qgsquickmapcanvasmap.cpp
+++ b/src/qgsquick/qgsquickmapcanvasmap.cpp
@@ -22,6 +22,7 @@
 #include <qgspallabeling.h>
 #include <qgsproject.h>
 #include <qgsvectorlayer.h>
+#include <qgsexpressioncontextutils.h>
 #include "qgis.h"
 
 #include "qgsquickmapcanvasmap.h"


### PR DESCRIPTION
And a shiny new build chain without crystax

 - [x] libssl.so still has a versioned filename, trying [this](https://stackoverflow.com/questions/24204366/how-to-build-openssl-as-unversioned-shared-lib-for-android) now
 - [x] libpq.so crashes on Android <8