### PR TITLE
fix crash when switching layer

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -91,7 +91,7 @@ Page {
         }
 
         Repeater {
-          model: form.model
+          model: form.model && form.model.hasTabs ? form.model : 0
 
           TabButton {
             id: tabButton


### PR DESCRIPTION
a crash was hapenning when switching between layers having tabbed and non-tabbbed attribute form
there was a count mismatch between swipe view and tab bar

fixes #474
fixes #477 

kudos to @m-kuhn for digging into this nasty crash
and thanks to reporters with sample projects!