### PR TITLE
Relation editor widget

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
 
 jobs:
   allow_failures:
-    - name: "🍳 Testing"
+#    - name: "🍳 Testing"
   include:
     - stage: test
       name: "🍳 Testing"

--- a/src/core/attributeformmodel.cpp
+++ b/src/core/attributeformmodel.cpp
@@ -63,6 +63,11 @@ void AttributeFormModel::create()
   mSourceModel->create();
 }
 
+void AttributeFormModel::deleteFeature()
+{
+  mSourceModel->deleteFeature();
+}
+
 QVariant AttributeFormModel::attribute( const QString &name )
 {
   return mSourceModel->attribute( name );

--- a/src/core/attributeformmodel.cpp
+++ b/src/core/attributeformmodel.cpp
@@ -26,7 +26,6 @@ AttributeFormModel::AttributeFormModel( QObject *parent )
   connect( mSourceModel, &AttributeFormModelBase::featureModelChanged, this, &AttributeFormModel::featureModelChanged );
   connect( mSourceModel, &AttributeFormModelBase::featureChanged, this, &AttributeFormModel::featureChanged );
   connect( mSourceModel, &AttributeFormModelBase::constraintsValidChanged, this, &AttributeFormModel::constraintsValidChanged );
-  connect( mSourceModel, &AttributeFormModelBase::setRelationFeatureId, this, &AttributeFormModel::setRelationFeatureId );
 }
 
 bool AttributeFormModel::hasTabs() const

--- a/src/core/attributeformmodel.h
+++ b/src/core/attributeformmodel.h
@@ -42,6 +42,7 @@ class AttributeFormModel : public QSortFilterProxyModel
       RememberValue,
       Field,
       RelationId,
+      AssociatedRelationId,
       FieldIndex,
       Group,
       AttributeEditorElement,

--- a/src/core/attributeformmodel.h
+++ b/src/core/attributeformmodel.h
@@ -86,7 +86,6 @@ class AttributeFormModel : public QSortFilterProxyModel
     void hasTabsChanged();
     void featureChanged();
     void constraintsValidChanged();
-    void setRelationFeatureId( QgsFeatureId featureId );
 
   protected:
     virtual bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const override;

--- a/src/core/attributeformmodel.h
+++ b/src/core/attributeformmodel.h
@@ -65,6 +65,7 @@ class AttributeFormModel : public QSortFilterProxyModel
 
     Q_INVOKABLE void save();
     Q_INVOKABLE void create();
+    Q_INVOKABLE void deleteFeature();
     Q_INVOKABLE QVariant attribute( const QString &name );
 
   signals:

--- a/src/core/attributeformmodel.h
+++ b/src/core/attributeformmodel.h
@@ -42,7 +42,7 @@ class AttributeFormModel : public QSortFilterProxyModel
       RememberValue,
       Field,
       RelationId,
-      AssociatedRelationId,
+      NmRelationId,
       FieldIndex,
       Group,
       AttributeEditorElement,

--- a/src/core/attributeformmodel.h
+++ b/src/core/attributeformmodel.h
@@ -62,10 +62,23 @@ class AttributeFormModel : public QSortFilterProxyModel
     void setFeatureModel( FeatureModel *featureModel );
 
     bool constraintsValid() const;
-
+    /**
+     * Save the current (already existing) feature
+     */
     Q_INVOKABLE void save();
+    /**
+     * Create the current (not existing yet) feature
+     */
     Q_INVOKABLE void create();
+    /**
+     * Delete the current feature
+     */
     Q_INVOKABLE void deleteFeature();
+    /**
+     * Get the attribute of the current feature by name
+     * \param name the name of the attribute
+     * \return value of the attribute
+     */
     Q_INVOKABLE QVariant attribute( const QString &name );
 
   signals:

--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -226,7 +226,7 @@ void AttributeFormModelBase::updateAttributeValue( QStandardItem *item )
     QVariant attributeValue = mFeatureModel->feature().attribute( fieldIndex );
     item->setData( attributeValue, AttributeFormModel::AttributeValue );
     //set item visibility to false in case it's a linked attribute
-    //item->setData( !mFeatureModel->data( mFeatureModel->index( fieldIndex ), FeatureModel::LinkedAttribute ).toBool(), AttributeFormModel::CurrentlyVisible );
+    item->setData( !mFeatureModel->data( mFeatureModel->index( fieldIndex ), FeatureModel::LinkedAttribute ).toBool(), AttributeFormModel::CurrentlyVisible );
   }
   else
   {

--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -47,6 +47,7 @@ QHash<int, QByteArray> AttributeFormModelBase::roleNames() const
   roles[AttributeFormModel::RememberValue] = "RememberValue";
   roles[AttributeFormModel::Field] = "Field";
   roles[AttributeFormModel::RelationId] = "RelationId";
+  roles[AttributeFormModel::AssociatedRelationId] = "AssociatedRelationId";
   roles[AttributeFormModel::Group] = "Group";
   roles[AttributeFormModel::ConstraintValid] = "ConstraintValid";
   roles[AttributeFormModel::ConstraintDescription] = "ConstraintDescription";
@@ -307,12 +308,14 @@ void AttributeFormModelBase::flatten( QgsAttributeEditorContainer *container, QS
 
         QStandardItem *item = new QStandardItem();
 
+
         item->setData( relation.name(), AttributeFormModel::Name );
         item->setData( true, AttributeFormModel::AttributeEditable );
         item->setData( true, AttributeFormModel::CurrentlyVisible );
         item->setData( "relation", AttributeFormModel::ElementType );
         item->setData( "RelationEditor", AttributeFormModel::EditorWidget );
         item->setData( relation.id(), AttributeFormModel::RelationId );
+        item->setData( mLayer->editFormConfig().widgetConfig( relation.id() )[ QStringLiteral( "nm-rel" ) ].toString(), AttributeFormModel::AssociatedRelationId );
         item->setData( container->isGroupBox() ? container->name() : QString(), AttributeFormModel::Group );
         item->setData( true, AttributeFormModel::CurrentlyVisible );
         item->setData( true, AttributeFormModel::ConstraintValid );

--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -101,8 +101,6 @@ void AttributeFormModelBase::setFeatureModel( FeatureModel *featureModel )
   {
     disconnect( mFeatureModel, &FeatureModel::currentLayerChanged, this, &AttributeFormModelBase::onLayerChanged );
     disconnect( mFeatureModel, &FeatureModel::featureChanged, this, &AttributeFormModelBase::onFeatureChanged );
-    disconnect( mFeatureModel, &FeatureModel::linkedParentFeatureChanged, this, &AttributeFormModelBase::onFeatureChanged );
-    disconnect( mFeatureModel, &FeatureModel::linkedRelationChanged, this, &AttributeFormModelBase::onFeatureChanged );
     disconnect( mFeatureModel, &FeatureModel::modelReset, this, &AttributeFormModelBase::onFeatureChanged );
   }
 
@@ -110,8 +108,6 @@ void AttributeFormModelBase::setFeatureModel( FeatureModel *featureModel )
 
   connect( mFeatureModel, &FeatureModel::currentLayerChanged, this, &AttributeFormModelBase::onLayerChanged );
   connect( mFeatureModel, &FeatureModel::featureChanged, this, &AttributeFormModelBase::onFeatureChanged );
-  connect( mFeatureModel, &FeatureModel::linkedParentFeatureChanged, this, &AttributeFormModelBase::onFeatureChanged );
-  connect( mFeatureModel, &FeatureModel::linkedRelationChanged, this, &AttributeFormModelBase::onFeatureChanged );
   connect( mFeatureModel, &FeatureModel::modelReset, this, &AttributeFormModelBase::onFeatureChanged );
 
   emit featureModelChanged();
@@ -286,6 +282,7 @@ void AttributeFormModelBase::flatten( QgsAttributeEditorContainer *container, QS
         item->setData( fieldIndex, AttributeFormModel::FieldIndex );
         item->setData( container->isGroupBox() ? container->name() : QString(), AttributeFormModel::Group );
         item->setData( true, AttributeFormModel::CurrentlyVisible );
+
         item->setData( true, AttributeFormModel::ConstraintValid );
         item->setData( field.constraints().constraintDescription(), AttributeFormModel::ConstraintDescription );
 
@@ -318,8 +315,6 @@ void AttributeFormModelBase::flatten( QgsAttributeEditorContainer *container, QS
         item->setData( container->isGroupBox() ? container->name() : QString(), AttributeFormModel::Group );
         item->setData( true, AttributeFormModel::CurrentlyVisible );
         item->setData( true, AttributeFormModel::ConstraintValid );
-
-        updateAttributeValue( item );
 
         items.append( item );
 

--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -47,7 +47,7 @@ QHash<int, QByteArray> AttributeFormModelBase::roleNames() const
   roles[AttributeFormModel::RememberValue] = "RememberValue";
   roles[AttributeFormModel::Field] = "Field";
   roles[AttributeFormModel::RelationId] = "RelationId";
-  roles[AttributeFormModel::AssociatedRelationId] = "AssociatedRelationId";
+  roles[AttributeFormModel::NmRelationId] = "NmRelationId";
   roles[AttributeFormModel::Group] = "Group";
   roles[AttributeFormModel::ConstraintValid] = "ConstraintValid";
   roles[AttributeFormModel::ConstraintDescription] = "ConstraintDescription";
@@ -315,7 +315,7 @@ void AttributeFormModelBase::flatten( QgsAttributeEditorContainer *container, QS
         item->setData( "relation", AttributeFormModel::ElementType );
         item->setData( "RelationEditor", AttributeFormModel::EditorWidget );
         item->setData( relation.id(), AttributeFormModel::RelationId );
-        item->setData( mLayer->editFormConfig().widgetConfig( relation.id() )[ QStringLiteral( "nm-rel" ) ].toString(), AttributeFormModel::AssociatedRelationId );
+        item->setData( mLayer->editFormConfig().widgetConfig( relation.id() )[ QStringLiteral( "nm-rel" ) ].toString(), AttributeFormModel::NmRelationId );
         item->setData( container->isGroupBox() ? container->name() : QString(), AttributeFormModel::Group );
         item->setData( true, AttributeFormModel::CurrentlyVisible );
         item->setData( true, AttributeFormModel::ConstraintValid );

--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -187,8 +187,6 @@ void AttributeFormModelBase::onFeatureChanged()
   }
 
   updateVisibility();
-
-  emit setRelationFeatureId( mFeatureModel->feature().id() );
 }
 
 QgsAttributeEditorContainer *AttributeFormModelBase::generateRootContainer() const
@@ -226,10 +224,6 @@ void AttributeFormModelBase::updateAttributeValue( QStandardItem *item )
     int fieldIndex = item->data( AttributeFormModel::FieldIndex ).toInt();
     QVariant attributeValue = mFeatureModel->feature().attribute( fieldIndex );
     item->setData( attributeValue, AttributeFormModel::AttributeValue );
-  }
-  else if ( item->data( AttributeFormModel::ElementType ) == QStringLiteral("relation") )
-  {
-    item->setData( mFeatureModel->feature().id(), AttributeFormModel::AttributeValue );
   }
   else
   {

--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -205,10 +205,10 @@ QgsAttributeEditorContainer *AttributeFormModelBase::generateRootContainer() con
     }
   }
   //get relations
-  QList<QgsRelation> referencingRelations = QgsProject::instance()->relationManager()->referencedRelations( mLayer );
-  for ( int i = 0; i < referencingRelations.size(); ++i )
+  const QList<QgsRelation> referencingRelations = QgsProject::instance()->relationManager()->referencedRelations( mLayer );
+  for ( const QgsRelation &referencingRelation : referencingRelations )
   {
-      QgsAttributeEditorRelation *relation = new QgsAttributeEditorRelation( referencingRelations.at(i), root );
+      QgsAttributeEditorRelation *relation = new QgsAttributeEditorRelation( referencingRelation, root );
       root->addChildElement( relation );
   }
   return root;
@@ -221,13 +221,13 @@ QgsAttributeEditorContainer *AttributeFormModelBase::invisibleRootContainer() co
 
 void AttributeFormModelBase::updateAttributeValue( QStandardItem *item )
 {
-  if ( item->data( AttributeFormModel::ElementType ) == "field" )
+  if ( item->data( AttributeFormModel::ElementType ) == QStringLiteral("field") )
   {
     int fieldIndex = item->data( AttributeFormModel::FieldIndex ).toInt();
     QVariant attributeValue = mFeatureModel->feature().attribute( fieldIndex );
     item->setData( attributeValue, AttributeFormModel::AttributeValue );
   }
-  else if ( item->data( AttributeFormModel::ElementType ) == "relation" )
+  else if ( item->data( AttributeFormModel::ElementType ) == QStringLiteral("relation") )
   {
     item->setData( mFeatureModel->feature().id(), AttributeFormModel::AttributeValue );
   }

--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -207,8 +207,8 @@ QgsAttributeEditorContainer *AttributeFormModelBase::generateRootContainer() con
   const QList<QgsRelation> referencingRelations = QgsProject::instance()->relationManager()->referencedRelations( mLayer );
   for ( const QgsRelation &referencingRelation : referencingRelations )
   {
-      QgsAttributeEditorRelation *relation = new QgsAttributeEditorRelation( referencingRelation, root );
-      root->addChildElement( relation );
+    QgsAttributeEditorRelation *relation = new QgsAttributeEditorRelation( referencingRelation, root );
+    root->addChildElement( relation );
   }
   return root;
 }
@@ -220,13 +220,13 @@ QgsAttributeEditorContainer *AttributeFormModelBase::invisibleRootContainer() co
 
 void AttributeFormModelBase::updateAttributeValue( QStandardItem *item )
 {
-  if ( item->data( AttributeFormModel::ElementType ) == QStringLiteral("field") )
+  if ( item->data( AttributeFormModel::ElementType ) == QStringLiteral( "field" ) )
   {
     int fieldIndex = item->data( AttributeFormModel::FieldIndex ).toInt();
     QVariant attributeValue = mFeatureModel->feature().attribute( fieldIndex );
     item->setData( attributeValue, AttributeFormModel::AttributeValue );
     //set item visibility to false in case it's a linked attribute
-    item->setData( !mFeatureModel->data( mFeatureModel->index( fieldIndex ) , FeatureModel::LinkedAttribute ).toBool(), AttributeFormModel::CurrentlyVisible );
+    //item->setData( !mFeatureModel->data( mFeatureModel->index( fieldIndex ), FeatureModel::LinkedAttribute ).toBool(), AttributeFormModel::CurrentlyVisible );
   }
   else
   {

--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -101,7 +101,8 @@ void AttributeFormModelBase::setFeatureModel( FeatureModel *featureModel )
   {
     disconnect( mFeatureModel, &FeatureModel::currentLayerChanged, this, &AttributeFormModelBase::onLayerChanged );
     disconnect( mFeatureModel, &FeatureModel::featureChanged, this, &AttributeFormModelBase::onFeatureChanged );
-    disconnect( mFeatureModel, &FeatureModel::referencedFeatureChanged, this, &AttributeFormModelBase::onFeatureChanged );
+    disconnect( mFeatureModel, &FeatureModel::linkedParentFeatureChanged, this, &AttributeFormModelBase::onFeatureChanged );
+    disconnect( mFeatureModel, &FeatureModel::linkedRelationChanged, this, &AttributeFormModelBase::onFeatureChanged );
     disconnect( mFeatureModel, &FeatureModel::modelReset, this, &AttributeFormModelBase::onFeatureChanged );
   }
 
@@ -109,7 +110,8 @@ void AttributeFormModelBase::setFeatureModel( FeatureModel *featureModel )
 
   connect( mFeatureModel, &FeatureModel::currentLayerChanged, this, &AttributeFormModelBase::onLayerChanged );
   connect( mFeatureModel, &FeatureModel::featureChanged, this, &AttributeFormModelBase::onFeatureChanged );
-  connect( mFeatureModel, &FeatureModel::referencedFeatureChanged, this, &AttributeFormModelBase::onFeatureChanged );
+  connect( mFeatureModel, &FeatureModel::linkedParentFeatureChanged, this, &AttributeFormModelBase::onFeatureChanged );
+  connect( mFeatureModel, &FeatureModel::linkedRelationChanged, this, &AttributeFormModelBase::onFeatureChanged );
   connect( mFeatureModel, &FeatureModel::modelReset, this, &AttributeFormModelBase::onFeatureChanged );
 
   emit featureModelChanged();
@@ -226,24 +228,6 @@ void AttributeFormModelBase::updateAttributeValue( QStandardItem *item )
     int fieldIndex = item->data( AttributeFormModel::FieldIndex ).toInt();
     QVariant attributeValue = mFeatureModel->feature().attribute( fieldIndex );
     item->setData( attributeValue, AttributeFormModel::AttributeValue );
-    //overwrite with fixReferencedFeature
-    const QList<QgsRelation> referencedRelations = QgsProject::instance()->relationManager()->referencingRelations( mLayer );
-    for ( const QgsRelation &referencedRelations : referencedRelations )
-    {
-      //dave make loop through fieldPairs
-      if( item->data( AttributeFormModel::Name ) == referencedRelations.fieldPairs().at(0).first )
-      {
-        //dave check if the feature on the correct layer (possibly referencedLayer needed as well)
-        if( mFeatureModel->referencedFeature().isValid() )
-          {
-            if( !mFeatureModel->referencedFeature().attribute( referencedRelations.fieldPairs().at(0).second ).isNull() )
-            {
-              item->setData( mFeatureModel->referencedFeature().attribute( referencedRelations.fieldPairs().at(0).second ), AttributeFormModel::AttributeValue );
-              item->setData( false, AttributeFormModel::CurrentlyVisible);
-              }
-          }
-      }
-    }
   }
   else
   {

--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -224,6 +224,8 @@ void AttributeFormModelBase::updateAttributeValue( QStandardItem *item )
     int fieldIndex = item->data( AttributeFormModel::FieldIndex ).toInt();
     QVariant attributeValue = mFeatureModel->feature().attribute( fieldIndex );
     item->setData( attributeValue, AttributeFormModel::AttributeValue );
+    //set item visibility to false in case it's a linked attribute
+    item->setData( !mFeatureModel->data( mFeatureModel->index( fieldIndex ) , FeatureModel::LinkedAttribute ).toBool(), AttributeFormModel::CurrentlyVisible );
   }
   else
   {
@@ -282,7 +284,6 @@ void AttributeFormModelBase::flatten( QgsAttributeEditorContainer *container, QS
         item->setData( fieldIndex, AttributeFormModel::FieldIndex );
         item->setData( container->isGroupBox() ? container->name() : QString(), AttributeFormModel::Group );
         item->setData( true, AttributeFormModel::CurrentlyVisible );
-
         item->setData( true, AttributeFormModel::ConstraintValid );
         item->setData( field.constraints().constraintDescription(), AttributeFormModel::ConstraintDescription );
 

--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -430,3 +430,8 @@ void AttributeFormModelBase::create()
 {
   mFeatureModel->create();
 }
+
+void AttributeFormModelBase::deleteFeature()
+{
+  mFeatureModel->deleteFeature();
+}

--- a/src/core/attributeformmodelbase.h
+++ b/src/core/attributeformmodelbase.h
@@ -50,6 +50,8 @@ class AttributeFormModelBase : public QStandardItemModel
 
     void create();
 
+    void deleteFeature();
+
     bool constraintsValid() const;
 
     QVariant attribute( const QString &name );

--- a/src/core/attributeformmodelbase.h
+++ b/src/core/attributeformmodelbase.h
@@ -59,7 +59,6 @@ class AttributeFormModelBase : public QStandardItemModel
     void hasTabsChanged();
     void featureChanged();
     void constraintsValidChanged();
-    void setRelationFeatureId( QgsFeatureId featureId );
 
   private slots:
     void onLayerChanged();

--- a/src/core/core.pro
+++ b/src/core/core.pro
@@ -58,7 +58,7 @@ HEADERS += \
     locatormodelsuperbridge.h \
     linepolygonhighlight.h \
     qgsgeometrywrapper.h \
-    valuemapmodel.h\
+    valuemapmodel.h \
     referencingfeaturelistmodel.h
 
 SOURCES += \

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -209,7 +209,10 @@ bool FeatureModel::setData( const QModelIndex &index, const QVariant &value, int
       }
       bool success = mFeature.setAttribute( index.row(), val );
       if ( success )
+      {
         emit dataChanged( index, index, QVector<int>() << role );
+        emit featureChanged();
+      }
       return success;
       break;
     }

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -103,22 +103,22 @@ void FeatureModel::setLinkedFeatureValues()
   const auto fieldPairs = mLinkedRelation.fieldPairs();
   for( QgsRelation::FieldPair fieldPair : fieldPairs )
   {
-    mFeature.setAttribute(mFeature.fieldNameIndex(fieldPair.first), linkedParentFeature().attribute( fieldPair.second ) );
-    mLinkedAttributeIndexes.append( mFeature.fieldNameIndex(fieldPair.first) );
+    mFeature.setAttribute( mFeature.fieldNameIndex( fieldPair.first ), linkedParentFeature().attribute( fieldPair.second ) );
+    mLinkedAttributeIndexes.append( mFeature.fieldNameIndex( fieldPair.first ) );
   }
   endResetModel();
 
   emit featureChanged();
 }
 
-void FeatureModel::setLinkedParentFeature(QgsFeature &feature)
+void FeatureModel::setLinkedParentFeature( const QgsFeature &feature )
 {
-  if( mLinkedParentFeature == feature )
+  if ( mLinkedParentFeature == feature )
     return;
 
   mLinkedParentFeature = feature;
 
-  if( mLinkedRelation.isValid() )
+  if ( mLinkedRelation.isValid() )
     setLinkedFeatureValues();
 }
 
@@ -127,11 +127,11 @@ QgsFeature FeatureModel::linkedParentFeature() const
   return mLinkedParentFeature;
 }
 
-void FeatureModel::setLinkedRelation(QgsRelation &relation)
+void FeatureModel::setLinkedRelation( const QgsRelation &relation )
 {
   mLinkedRelation = relation;
 
-  if( mLinkedParentFeature.isValid() )
+  if ( mLinkedParentFeature.isValid() )
     setLinkedFeatureValues();
 }
 

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -96,6 +96,21 @@ QgsFeature FeatureModel::feature() const
   return mFeature;
 }
 
+void FeatureModel::setReferencedFeature(QgsFeature &referencedFeature)
+{
+  if( mReferencedFeature == referencedFeature )
+    return;
+
+  mReferencedFeature = referencedFeature;
+
+  emit featureChanged();
+}
+
+QgsFeature FeatureModel::referencedFeature() const
+{
+  return mReferencedFeature;
+}
+
 QHash<int, QByteArray> FeatureModel::roleNames() const
 {
   QHash<int, QByteArray> roles = QAbstractListModel::roleNames();

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -57,7 +57,6 @@ void FeatureModel::setCurrentLayer( QgsVectorLayer *layer )
   mLayer = layer;
 
   connect( mLayer, &QgsVectorLayer::destroyed, this, &FeatureModel::removeLayer, Qt::UniqueConnection );
-  connect( mLayer, &QgsVectorLayer::featureAdded, this, &FeatureModel::featureAdded );
 
   if ( mLayer )
   {
@@ -331,6 +330,7 @@ void FeatureModel::create()
     return;
 
   startEditing();
+  connect( mLayer, &QgsVectorLayer::featureAdded, this, &FeatureModel::featureAdded );
   if ( !mLayer->addFeature( mFeature ) )
   {
     QgsMessageLog::logMessage( tr( "Feature could not be added" ), "QField", Qgis::Critical );
@@ -344,6 +344,7 @@ void FeatureModel::create()
     else
       QgsMessageLog::logMessage( tr( "Feature %1 could not be fetched after commit" ).arg( mFeature.id() ), "QField", Qgis::Warning );
   }
+  disconnect( mLayer, &QgsVectorLayer::featureAdded, this, &FeatureModel::featureAdded );
 }
 
 void FeatureModel::deleteFeature()

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -323,11 +323,19 @@ void FeatureModel::create()
     return;
 
   startEditing();
-  if ( !mLayer->addFeature( mFeature ) )
+  if ( !mLayer->dataProvider()->addFeature( mFeature ) )
   {
     QgsMessageLog::logMessage( tr( "Feature could not be added" ), "QField", Qgis::Critical );
   }
-  commit();
+
+  if ( commit() )
+  {
+    QgsFeature feat;
+    if ( mLayer->getFeatures( QgsFeatureRequest().setFilterFid( mFeature.id() ) ).nextFeature( feat ) )
+      setFeature( feat );
+    else
+      QgsMessageLog::logMessage( tr( "Feature %1 could not be fetched after commit" ).arg( mFeature.id() ), "QField", Qgis::Warning );
+  }
 }
 
 bool FeatureModel::commit()

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -96,19 +96,45 @@ QgsFeature FeatureModel::feature() const
   return mFeature;
 }
 
-void FeatureModel::setReferencedFeature(QgsFeature &referencedFeature)
+void FeatureModel::setLinkedFeatureValues()
 {
-  if( mReferencedFeature == referencedFeature )
-    return;
-
-  mReferencedFeature = referencedFeature;
-
-  emit featureChanged();
+  for( QgsRelation::FieldPair fieldPair : mLinkedRelation.fieldPairs() )
+  {
+    mFeature.setAttribute(mFeature.fieldNameIndex(fieldPair.first), linkedParentFeature().attribute( fieldPair.second ) );
+  }
 }
 
-QgsFeature FeatureModel::referencedFeature() const
+void FeatureModel::setLinkedParentFeature(QgsFeature &feature)
 {
-  return mReferencedFeature;
+  if( mLinkedParentFeature == feature )
+    return;
+
+  mLinkedParentFeature = feature;
+
+  if( mLinkedRelation.isValid() )
+    setLinkedFeatureValues();
+
+  emit linkedParentFeatureChanged();
+}
+
+QgsFeature FeatureModel::linkedParentFeature() const
+{
+  return mLinkedParentFeature;
+}
+
+void FeatureModel::setLinkedRelation(QgsRelation &relation)
+{
+  mLinkedRelation = relation;
+
+  if( mLinkedParentFeature.isValid() )
+    setLinkedFeatureValues();
+
+  emit linkedRelationChanged();
+}
+
+QgsRelation FeatureModel::linkedRelation() const
+{
+  return mLinkedRelation;
 }
 
 QHash<int, QByteArray> FeatureModel::roleNames() const

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -100,7 +100,8 @@ void FeatureModel::setLinkedFeatureValues()
 {
   beginResetModel();
   mLinkedAttributeIndexes.clear();
-  for( QgsRelation::FieldPair fieldPair : mLinkedRelation.fieldPairs() )
+  const auto fieldPairs = mLinkedRelation.fieldPairs();
+  for( QgsRelation::FieldPair fieldPair : fieldPairs )
   {
     mFeature.setAttribute(mFeature.fieldNameIndex(fieldPair.first), linkedParentFeature().attribute( fieldPair.second ) );
     mLinkedAttributeIndexes.append( mFeature.fieldNameIndex(fieldPair.first) );

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -103,7 +103,7 @@ void FeatureModel::setLinkedFeatureValues()
   beginResetModel();
   mLinkedAttributeIndexes.clear();
   const auto fieldPairs = mLinkedRelation.fieldPairs();
-  for( QgsRelation::FieldPair fieldPair : fieldPairs )
+  for ( QgsRelation::FieldPair fieldPair : fieldPairs )
   {
     mFeature.setAttribute( mFeature.fieldNameIndex( fieldPair.first ), linkedParentFeature().attribute( fieldPair.second ) );
     mLinkedAttributeIndexes.append( mFeature.fieldNameIndex( fieldPair.first ) );
@@ -211,7 +211,6 @@ bool FeatureModel::setData( const QModelIndex &index, const QVariant &value, int
       if ( success )
       {
         emit dataChanged( index, index, QVector<int>() << role );
-        emit featureChanged();
       }
       return success;
       break;
@@ -332,6 +331,9 @@ void FeatureModel::create()
   {
     QgsMessageLog::logMessage( tr( "Feature could not be added" ), "QField", Qgis::Critical );
   }
+
+  //we have to call this here anyway because the mFeature is probably changed by getting and id
+  emit featureChanged();
 
   if ( commit() )
   {

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -98,10 +98,14 @@ QgsFeature FeatureModel::feature() const
 
 void FeatureModel::setLinkedFeatureValues()
 {
+  beginResetModel();
   for( QgsRelation::FieldPair fieldPair : mLinkedRelation.fieldPairs() )
   {
     mFeature.setAttribute(mFeature.fieldNameIndex(fieldPair.first), linkedParentFeature().attribute( fieldPair.second ) );
   }
+  endResetModel();
+
+  emit featureChanged();
 }
 
 void FeatureModel::setLinkedParentFeature(QgsFeature &feature)
@@ -113,8 +117,6 @@ void FeatureModel::setLinkedParentFeature(QgsFeature &feature)
 
   if( mLinkedRelation.isValid() )
     setLinkedFeatureValues();
-
-  emit linkedParentFeatureChanged();
 }
 
 QgsFeature FeatureModel::linkedParentFeature() const
@@ -128,8 +130,6 @@ void FeatureModel::setLinkedRelation(QgsRelation &relation)
 
   if( mLinkedParentFeature.isValid() )
     setLinkedFeatureValues();
-
-  emit linkedRelationChanged();
 }
 
 QgsRelation FeatureModel::linkedRelation() const

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -275,7 +275,8 @@ void FeatureModel::resetAttributes()
     return;
 
   QgsExpressionContext expressionContext = mLayer->createExpressionContext();
-  expressionContext << ExpressionContextUtils::positionScope( mPositionSource.get() );
+  if ( mPositionSource )
+    expressionContext << ExpressionContextUtils::positionScope( mPositionSource.get() );
   expressionContext.setFeature( mFeature );
 
   QgsFields fields = mLayer->fields();
@@ -283,7 +284,9 @@ void FeatureModel::resetAttributes()
   beginResetModel();
   for ( int i = 0; i < fields.count(); ++i )
   {
-    if ( !mRememberings[mLayer].rememberedAttributes.at( i ) )
+    //if the value does not need to be remembered and it's not prefilled by the linked parent feature
+    if ( !mRememberings[mLayer].rememberedAttributes.at( i ) &&
+         !mLinkedAttributeIndexes.contains( i ) )
     {
       if ( fields.at( i ).defaultValueDefinition().isValid() )
       {

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -99,9 +99,11 @@ QgsFeature FeatureModel::feature() const
 void FeatureModel::setLinkedFeatureValues()
 {
   beginResetModel();
+  mLinkedAttributeIndexes.clear();
   for( QgsRelation::FieldPair fieldPair : mLinkedRelation.fieldPairs() )
   {
     mFeature.setAttribute(mFeature.fieldNameIndex(fieldPair.first), linkedParentFeature().attribute( fieldPair.second ) );
+    mLinkedAttributeIndexes.append( mFeature.fieldNameIndex(fieldPair.first) );
   }
   endResetModel();
 
@@ -144,6 +146,7 @@ QHash<int, QByteArray> FeatureModel::roleNames() const
   roles[AttributeValue] = "AttributeValue";
   roles[Field] = "Field";
   roles[RememberAttribute] = "RememberAttribute";
+  roles[LinkedAttribute] = "LinkedAttribute";
 
   return roles;
 }
@@ -166,19 +169,19 @@ QVariant FeatureModel::data( const QModelIndex &index, int role ) const
   {
     case AttributeName:
       return mLayer->attributeDisplayName( index.row() );
-      break;
 
     case AttributeValue:
       return mFeature.attribute( index.row() );
-      break;
 
     case Field:
       return mLayer->fields().at( index.row() );
-      break;
 
     case RememberAttribute:
       return mRememberings[mLayer].rememberedAttributes.at( index.row() );
-      break;
+
+    case LinkedAttribute:
+      return mLinkedAttributeIndexes.contains( index.row() ) ? true : false;
+
   }
 
   return QVariant();

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -183,7 +183,7 @@ QVariant FeatureModel::data( const QModelIndex &index, int role ) const
       return mRememberings[mLayer].rememberedAttributes.at( index.row() );
 
     case LinkedAttribute:
-      return mLinkedAttributeIndexes.contains( index.row() ) ? true : false;
+      return mLinkedAttributeIndexes.contains( index.row() );
 
   }
 

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -73,10 +73,9 @@ class FeatureModel : public QAbstractListModel
      * the fk fields are evaluated over the linked relation
      */
 
-    void setLinkedFeatureValues();
-    void setLinkedParentFeature( QgsFeature &feature );
+    void setLinkedParentFeature( const QgsFeature &feature );
     QgsFeature linkedParentFeature() const;
-    void setLinkedRelation( QgsRelation &relation );
+    void setLinkedRelation( const QgsRelation &relation );
     QgsRelation linkedRelation() const;
 
     void setCurrentLayer( QgsVectorLayer *layer );
@@ -146,6 +145,7 @@ class FeatureModel : public QAbstractListModel
   private:
     bool commit();
     bool startEditing();
+    void setLinkedFeatureValues();
 
     QgsVectorLayer *mLayer;
     QgsFeature mFeature;

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -31,6 +31,7 @@ class FeatureModel : public QAbstractListModel
 {
     Q_OBJECT
     Q_PROPERTY( QgsFeature feature READ feature WRITE setFeature NOTIFY featureChanged )
+    Q_PROPERTY( QgsFeature referencedFeature READ referencedFeature WRITE setReferencedFeature NOTIFY referencedFeatureChanged )
     //! the vertex model is used to highlight vertices on the map
     Q_PROPERTY( VertexModel *vertexModel READ vertexModel WRITE setVertexModel NOTIFY vertexModelChanged )
     Q_PROPERTY( Geometry *geometry MEMBER mGeometry NOTIFY geometryChanged )
@@ -63,6 +64,9 @@ class FeatureModel : public QAbstractListModel
      * Return the feature wrapped in a QVariant for passing it around in QML
      */
     QgsFeature feature() const;
+
+    void setReferencedFeature( QgsFeature &feature );
+    QgsFeature referencedFeature() const;
 
     void setCurrentLayer( QgsVectorLayer *layer );
     QgsVectorLayer *layer() const;
@@ -119,6 +123,7 @@ class FeatureModel : public QAbstractListModel
 
   signals:
     void featureChanged();
+    void referencedFeatureChanged();
     void vertexModelChanged();
     void geometryChanged();
     void currentLayerChanged();
@@ -132,6 +137,7 @@ class FeatureModel : public QAbstractListModel
 
     QgsVectorLayer *mLayer;
     QgsFeature mFeature;
+    QgsFeature mReferencedFeature;
     VertexModel *mVertexModel = nullptr;
     Geometry *mGeometry;
     std::unique_ptr<QGeoPositionInfoSource> mPositionSource;

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -54,7 +54,8 @@ class FeatureModel : public QAbstractListModel
       AttributeName = Qt::UserRole + 1,
       AttributeValue,
       Field,
-      RememberAttribute
+      RememberAttribute,
+      LinkedAttribute
     };
 
     explicit FeatureModel( QObject *parent = nullptr );
@@ -150,6 +151,7 @@ class FeatureModel : public QAbstractListModel
     QgsFeature mFeature;
     QgsFeature mLinkedParentFeature;
     QgsRelation mLinkedRelation;
+    QList<int> mLinkedAttributeIndexes;
     VertexModel *mVertexModel = nullptr;
     Geometry *mGeometry;
     std::unique_ptr<QGeoPositionInfoSource> mPositionSource;

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -67,8 +67,12 @@ class FeatureModel : public QAbstractListModel
      */
     QgsFeature feature() const;
 
-    void setLinkedFeatureValues();
+    /*
+     * a linked feature is a parent feature of a relation passing it's fk to the created child feature
+     * the fk fields are evaluated over the linked relation
+     */
 
+    void setLinkedFeatureValues();
     void setLinkedParentFeature( QgsFeature &feature );
     QgsFeature linkedParentFeature() const;
     void setLinkedRelation( QgsRelation &relation );

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -68,7 +68,7 @@ class FeatureModel : public QAbstractListModel
      */
     QgsFeature feature() const;
 
-    /*
+    /**
      * a linked feature is a parent feature of a relation passing it's fk to the created child feature
      * the fk fields are evaluated over the linked relation
      */

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -55,7 +55,7 @@ class FeatureModel : public QAbstractListModel
       AttributeValue,
       Field,
       RememberAttribute,
-      LinkedAttribute
+      LinkedAttribute  //! value of this attribute is given by the parent feature and does not to be available for editing in the form
     };
 
     explicit FeatureModel( QObject *parent = nullptr );

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -105,6 +105,11 @@ class FeatureModel : public QAbstractListModel
     Q_INVOKABLE void reset();
     Q_INVOKABLE void create();
 
+    /**
+     * Deletes the current feature from the data source
+     */
+    Q_INVOKABLE void deleteFeature();
+
     Q_INVOKABLE bool suppressFeatureForm() const;
 
     Q_INVOKABLE void resetAttributes();

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -20,6 +20,7 @@
 
 #include <QAbstractListModel>
 #include <QGeoPositionInfoSource>
+#include <qgsrelationmanager.h>
 #include <memory>
 #include <qgsfeature.h>
 
@@ -31,7 +32,8 @@ class FeatureModel : public QAbstractListModel
 {
     Q_OBJECT
     Q_PROPERTY( QgsFeature feature READ feature WRITE setFeature NOTIFY featureChanged )
-    Q_PROPERTY( QgsFeature referencedFeature READ referencedFeature WRITE setReferencedFeature NOTIFY referencedFeatureChanged )
+    Q_PROPERTY( QgsFeature linkedParentFeature READ linkedParentFeature WRITE setLinkedParentFeature NOTIFY linkedParentFeatureChanged )
+    Q_PROPERTY( QgsRelation linkedRelation READ linkedRelation WRITE setLinkedRelation NOTIFY linkedRelationChanged )
     //! the vertex model is used to highlight vertices on the map
     Q_PROPERTY( VertexModel *vertexModel READ vertexModel WRITE setVertexModel NOTIFY vertexModelChanged )
     Q_PROPERTY( Geometry *geometry MEMBER mGeometry NOTIFY geometryChanged )
@@ -65,8 +67,12 @@ class FeatureModel : public QAbstractListModel
      */
     QgsFeature feature() const;
 
-    void setReferencedFeature( QgsFeature &feature );
-    QgsFeature referencedFeature() const;
+    void setLinkedFeatureValues();
+
+    void setLinkedParentFeature( QgsFeature &feature );
+    QgsFeature linkedParentFeature() const;
+    void setLinkedRelation( QgsRelation &relation );
+    QgsRelation linkedRelation() const;
 
     void setCurrentLayer( QgsVectorLayer *layer );
     QgsVectorLayer *layer() const;
@@ -123,7 +129,8 @@ class FeatureModel : public QAbstractListModel
 
   signals:
     void featureChanged();
-    void referencedFeatureChanged();
+    void linkedParentFeatureChanged();
+    void linkedRelationChanged();
     void vertexModelChanged();
     void geometryChanged();
     void currentLayerChanged();
@@ -137,7 +144,8 @@ class FeatureModel : public QAbstractListModel
 
     QgsVectorLayer *mLayer;
     QgsFeature mFeature;
-    QgsFeature mReferencedFeature;
+    QgsFeature mLinkedParentFeature;
+    QgsRelation mLinkedRelation;
     VertexModel *mVertexModel = nullptr;
     Geometry *mGeometry;
     std::unique_ptr<QGeoPositionInfoSource> mPositionSource;

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -167,6 +167,9 @@ class FeatureModel : public QAbstractListModel
 
     void warning( const QString &text );
 
+  private slots:
+    void featureAdded( QgsFeatureId fid );
+
   private:
     bool commit();
     bool startEditing();

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -69,13 +69,33 @@ class FeatureModel : public QAbstractListModel
     QgsFeature feature() const;
 
     /**
-     * a linked feature is a parent feature of a relation passing it's fk to the created child feature
-     * the fk fields are evaluated over the linked relation
+     * A linked feature is a parent feature of a relation passing it's pk(s) to the created child features fk(s)
+     * The fk fields are evaluated over the linked relation.
+     * \param feature
+     * \see linkedParentFeature
      */
-
     void setLinkedParentFeature( const QgsFeature &feature );
+
+    /**
+     * A linked feature is a parent feature of a relation passing it's pk(s) to the created child features fk(s)
+     * \return the parent feature linked to this feature
+     * \see setLinkedParentFeature
+     */
     QgsFeature linkedParentFeature() const;
+
+    /**
+     * The relation connecting this feature to the parent, over which this feature has been loaded (e.g. over relation editor widget)
+     * The relation is userd to evaluate the parents pk(s) and the childs fk(s)
+     * \param relation
+     * \see linkedRelation
+     */
     void setLinkedRelation( const QgsRelation &relation );
+
+    /**
+     * The relation connecting this feature to the parent, over which this feature has been loaded (e.g. over relation editor widget)
+     * \return the relation connecting the parent
+     * \see setLinkedRelation
+     */
     QgsRelation linkedRelation() const;
 
     void setCurrentLayer( QgsVectorLayer *layer );

--- a/src/core/multifeaturelistmodel.cpp
+++ b/src/core/multifeaturelistmodel.cpp
@@ -204,7 +204,6 @@ int MultiFeatureListModel::count() const
 
 void MultiFeatureListModel::deleteFeature( QgsVectorLayer *layer, QgsFeatureId fid )
 {
-  //SHOULD THIS BE DONE IN QGIS INSTEAD?
   //delete child features in case of compositions
   const QList<QgsRelation> referencingRelations = QgsProject::instance()->relationManager()->referencedRelations( layer );
   for ( const QgsRelation &referencingRelation : referencingRelations )

--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -27,7 +27,7 @@ QHash<int, QByteArray> ReferencingFeatureListModel::roleNames() const
 
   roles[DisplayString] = "displayString";
   roles[ReferencingFeature] = "referencingFeature";
-  roles[AssociatedReferencingFeature] = "associatedReferencingFeature";
+  roles[AssociatedReferencedFeature] = "associatedReferencedFeature";
 
   return roles;
 }
@@ -65,7 +65,7 @@ QVariant ReferencingFeatureListModel::data( const QModelIndex &index, int role )
     return mEntries.value( index.row() ).displayString;
   if ( role == ReferencingFeature )
     return mRelation.referencingLayer()->getFeature( mEntries.value( index.row() ).referencingFeatureId );
-  if ( role == AssociatedReferencingFeature )
+  if ( role == AssociatedReferencedFeature )
     return mAssociatedRelation.getReferencedFeature( mRelation.referencingLayer()->getFeature( mEntries.value( index.row() ).referencingFeatureId ) );
   return QVariant();
 }

--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -27,7 +27,7 @@ QHash<int, QByteArray> ReferencingFeatureListModel::roleNames() const
 
   roles[DisplayString] = "displayString";
   roles[ReferencingFeature] = "referencingFeature";
-  roles[AssociatedReferencedFeature] = "associatedReferencedFeature";
+  roles[NmReferencedFeature] = "nmReferencedFeature";
 
   return roles;
 }
@@ -65,8 +65,8 @@ QVariant ReferencingFeatureListModel::data( const QModelIndex &index, int role )
     return mEntries.value( index.row() ).displayString;
   if ( role == ReferencingFeature )
     return mRelation.referencingLayer()->getFeature( mEntries.value( index.row() ).referencingFeatureId );
-  if ( role == AssociatedReferencedFeature )
-    return mAssociatedRelation.getReferencedFeature( mRelation.referencingLayer()->getFeature( mEntries.value( index.row() ).referencingFeatureId ) );
+  if ( role == NmReferencedFeature )
+    return mNmRelation.getReferencedFeature( mRelation.referencingLayer()->getFeature( mEntries.value( index.row() ).referencingFeatureId ) );
   return QVariant();
 }
 
@@ -95,14 +95,14 @@ QgsRelation ReferencingFeatureListModel::relation() const
   return mRelation;
 }
 
-void ReferencingFeatureListModel::setAssociatedRelation( const QgsRelation &relation )
+void ReferencingFeatureListModel::setNmRelation( const QgsRelation &relation )
 {
-  mAssociatedRelation = relation;
+  mNmRelation = relation;
 }
 
-QgsRelation ReferencingFeatureListModel::associatedRelation() const
+QgsRelation ReferencingFeatureListModel::nmRelation() const
 {
-  return mAssociatedRelation;
+  return mNmRelation;
 }
 
 void ReferencingFeatureListModel::setParentPrimariesAvailable( const bool parentPrimariesAvailable )

--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -120,7 +120,7 @@ bool ReferencingFeatureListModel::parentPrimariesAvailable() const
 
 void ReferencingFeatureListModel::reload()
 {
-  if ( !mRelation.isValid() || !mFeature.isValid() )
+  if ( !mRelation.isValid() || !mFeature.isValid() || !checkParentPrimaries() )
     return;
   mEntries.clear();
   QgsFeatureIterator relatedFeaturesIt = mRelation.getRelatedFeatures( mFeature );
@@ -153,7 +153,7 @@ bool ReferencingFeatureListModel::checkParentPrimaries()
   const auto fieldPairs = mRelation.fieldPairs();
   for ( QgsRelation::FieldPair fieldPair : fieldPairs )
   {
-    if( mFeature.attribute( fieldPair.second ).isNull() )
+    if ( mFeature.attribute( fieldPair.second ).isNull() )
       return false;
   }
   return true;

--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -120,7 +120,8 @@ void ReferencingFeatureListModel::updateModel()
 {
   beginResetModel();
 
-  mEntries = mGatherer->entries();
+  if ( mGatherer )
+    mEntries = mGatherer->entries();
 
   endResetModel();
 }

--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -1,3 +1,19 @@
+/***************************************************************************
+  referencingfeaturelistmodel.cpp - ReferencingFeatureListModel
+
+ ---------------------
+ begin                : 1.3.2019
+ copyright            : (C) 2019 by David Signer Kuhn
+ email                : david@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 #include "referencingfeaturelistmodel.h"
 
 ReferencingFeatureListModel::ReferencingFeatureListModel(QObject *parent)
@@ -54,6 +70,9 @@ QVariant ReferencingFeatureListModel::data( const QModelIndex &index, int role )
 
 void ReferencingFeatureListModel::setFeatureId(const QgsFeatureId &featureId)
 {
+  if ( mFeatureId == featureId )
+    return;
+
   mFeatureId = featureId;
   reload();
 }

--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -3,7 +3,7 @@
 
  ---------------------
  begin                : 1.3.2019
- copyright            : (C) 2019 by David Signer Kuhn
+ copyright            : (C) 2019 by David Signer
  email                : david@opengis.ch
  ***************************************************************************
  *                                                                         *
@@ -91,21 +91,6 @@ void ReferencingFeatureListModel::setRelation(const QgsRelation &relation)
 QgsRelation ReferencingFeatureListModel::relation() const
 {
   return mRelation;
-}
-
-AttributeFormModel *ReferencingFeatureListModel::attributeFormModel() const
-{
-  return mAttributeFormModel;
-}
-
-void ReferencingFeatureListModel::setAttributeFormModel( AttributeFormModel *attributeFormModel )
-{
-  mAttributeFormModel = attributeFormModel;
-  connect( mAttributeFormModel, &AttributeFormModel::setRelationFeatureId, this, [this]( QgsFeatureId featureId )
-    {
-      setFeatureId( featureId );
-    }
-  );
 }
 
 void ReferencingFeatureListModel::reload()

--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -16,8 +16,8 @@
 
 #include "referencingfeaturelistmodel.h"
 
-ReferencingFeatureListModel::ReferencingFeatureListModel(QObject *parent)
-  : QStandardItemModel(parent)
+ReferencingFeatureListModel::ReferencingFeatureListModel( QObject *parent )
+  : QAbstractItemModel( parent )
 {
 }
 
@@ -32,7 +32,7 @@ QHash<int, QByteArray> ReferencingFeatureListModel::roleNames() const
   return roles;
 }
 
-QModelIndex ReferencingFeatureListModel::index(int row, int column, const QModelIndex &parent) const
+QModelIndex ReferencingFeatureListModel::index( int row, int column, const QModelIndex &parent ) const
 {
   Q_UNUSED( column )
   Q_UNUSED( parent )
@@ -40,20 +40,20 @@ QModelIndex ReferencingFeatureListModel::index(int row, int column, const QModel
   return createIndex( row, column, 1000 );
 }
 
-QModelIndex ReferencingFeatureListModel::parent(const QModelIndex &index) const
+QModelIndex ReferencingFeatureListModel::parent( const QModelIndex &index ) const
 {
   Q_UNUSED( index )
 
   return QModelIndex();
 }
 
-int ReferencingFeatureListModel::rowCount(const QModelIndex &parent) const
+int ReferencingFeatureListModel::rowCount( const QModelIndex &parent ) const
 {
   Q_UNUSED( parent )
   return mEntries.size();
 }
 
-int ReferencingFeatureListModel::columnCount(const QModelIndex &parent) const
+int ReferencingFeatureListModel::columnCount( const QModelIndex &parent ) const
 {
   Q_UNUSED( parent )
   return 1;
@@ -70,7 +70,7 @@ QVariant ReferencingFeatureListModel::data( const QModelIndex &index, int role )
   return QVariant();
 }
 
-void ReferencingFeatureListModel::setFeature(const QgsFeature &feature)
+void ReferencingFeatureListModel::setFeature( const QgsFeature &feature )
 {
   if ( mFeature == feature )
     return;
@@ -84,7 +84,7 @@ QgsFeature ReferencingFeatureListModel::feature() const
   return mFeature;
 }
 
-void ReferencingFeatureListModel::setRelation(const QgsRelation &relation)
+void ReferencingFeatureListModel::setRelation( const QgsRelation &relation )
 {
   mRelation = relation;
   reload();
@@ -95,7 +95,7 @@ QgsRelation ReferencingFeatureListModel::relation() const
   return mRelation;
 }
 
-void ReferencingFeatureListModel::setAssociatedRelation(const QgsRelation &relation)
+void ReferencingFeatureListModel::setAssociatedRelation( const QgsRelation &relation )
 {
   mAssociatedRelation = relation;
 }
@@ -107,7 +107,7 @@ QgsRelation ReferencingFeatureListModel::associatedRelation() const
 
 void ReferencingFeatureListModel::reload()
 {
-  if( !mRelation.isValid() || !mFeature.isValid() )
+  if ( !mRelation.isValid() || !mFeature.isValid() )
     return;
   mEntries.clear();
   QgsFeatureIterator relatedFeaturesIt = mRelation.getRelatedFeatures( mFeature );
@@ -118,8 +118,8 @@ void ReferencingFeatureListModel::reload()
   QgsFeature childFeature;
   while ( relatedFeaturesIt.nextFeature( childFeature ) )
   {
-   context.setFeature( childFeature );
-   mEntries.append( Entry( expression.evaluate( &context ).toString(), childFeature.id() ) );
+    context.setFeature( childFeature );
+    mEntries.append( Entry( expression.evaluate( &context ).toString(), childFeature.id() ) );
   }
   endResetModel();
 }

--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -154,7 +154,7 @@ bool ReferencingFeatureListModel::checkParentPrimaries()
   const auto fieldPairs = mRelation.fieldPairs();
   for ( QgsRelation::FieldPair fieldPair : fieldPairs )
   {
-    if ( mFeature.attribute( fieldPair.second ).isNull() || mFeature.attribute( fieldPair.second ).toInt() == 0 )
+    if ( mFeature.attribute( fieldPair.second ).isNull() )
       return false;
   }
   return true;

--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -67,7 +67,6 @@ QVariant ReferencingFeatureListModel::data( const QModelIndex &index, int role )
     return mEntries.value( index.row() ).referencingFeatureId;
   if ( role == ReferencingFeature )
     return mRelation.referencingLayer()->getFeature( mEntries.value( index.row() ).referencingFeatureId );
-
   return QVariant();
 }
 

--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -26,7 +26,6 @@ QHash<int, QByteArray> ReferencingFeatureListModel::roleNames() const
   QHash<int, QByteArray> roles = QAbstractItemModel::roleNames();
 
   roles[DisplayString] = "displayString";
-  roles[ReferencingFeatureId] = "referencingFeatureId";
   roles[ReferencingFeature] = "referencingFeature";
 
   return roles;
@@ -63,8 +62,6 @@ QVariant ReferencingFeatureListModel::data( const QModelIndex &index, int role )
 {
   if ( role == DisplayString )
     return mEntries.value( index.row() ).displayString;
-  if ( role == ReferencingFeatureId )
-    return mEntries.value( index.row() ).referencingFeatureId;
   if ( role == ReferencingFeature )
     return mRelation.referencingLayer()->getFeature( mEntries.value( index.row() ).referencingFeatureId );
   return QVariant();

--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -68,18 +68,18 @@ QVariant ReferencingFeatureListModel::data( const QModelIndex &index, int role )
   return QVariant();
 }
 
-void ReferencingFeatureListModel::setFeatureId(const QgsFeatureId &featureId)
+void ReferencingFeatureListModel::setFeature(const QgsFeature &feature)
 {
-  if ( mFeatureId == featureId )
+  if ( mFeature == feature )
     return;
 
-  mFeatureId = featureId;
+  mFeature = feature;
   reload();
 }
 
-QgsFeatureId ReferencingFeatureListModel::featureId() const
+QgsFeature ReferencingFeatureListModel::feature() const
 {
-  return mFeatureId;
+  return mFeature;
 }
 
 void ReferencingFeatureListModel::setRelation(const QgsRelation &relation)
@@ -95,10 +95,10 @@ QgsRelation ReferencingFeatureListModel::relation() const
 
 void ReferencingFeatureListModel::reload()
 {
-  if( !mRelation.isValid() || mFeatureId<0 )
+  if( !mRelation.isValid() || !mFeature.isValid() )
     return;
   mEntries.clear();
-  QgsFeatureIterator relatedFeaturesIt = mRelation.getRelatedFeatures( mRelation.referencedLayer()->getFeature( mFeatureId ) );
+  QgsFeatureIterator relatedFeaturesIt = mRelation.getRelatedFeatures( mFeature );
   QgsExpressionContext context = mRelation.referencingLayer()->createExpressionContext();
   QgsExpression expression( mRelation.referencingLayer()->displayExpression() );
 

--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -161,6 +161,13 @@ void ReferencingFeatureListModel::reload()
     if ( !wasLoading )
       emit isLoadingChanged();
   }
+  else
+  {
+    //clear model entries
+    beginResetModel();
+    mEntries.clear();
+    endResetModel();
+  }
 
   //set the property for parent primaries available status
   setParentPrimariesAvailable( checkParentPrimaries() );

--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -174,6 +174,11 @@ void ReferencingFeatureListModel::deleteFeature( QgsFeatureId referencingFeature
   reload();
 }
 
+bool ReferencingFeatureListModel::isLoading() const
+{
+  return mGatherer;
+}
+
 bool ReferencingFeatureListModel::checkParentPrimaries()
 {
   if ( !mRelation.isValid() || !mFeature.isValid() )

--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -67,6 +67,7 @@ QVariant ReferencingFeatureListModel::data( const QModelIndex &index, int role )
     return mEntries.value( index.row() ).referencingFeature;
   if ( role == NmReferencedFeature )
     return mNmRelation.getReferencedFeature( mEntries.value( index.row() ).referencingFeature );
+  //return mEntries.value( index.row() ).nmReferencedFeature;
   return QVariant();
 }
 

--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -27,6 +27,7 @@ QHash<int, QByteArray> ReferencingFeatureListModel::roleNames() const
 
   roles[DisplayString] = "displayString";
   roles[ReferencingFeature] = "referencingFeature";
+  roles[AssociatedReferencingFeature] = "associatedReferencingFeature";
 
   return roles;
 }
@@ -64,6 +65,8 @@ QVariant ReferencingFeatureListModel::data( const QModelIndex &index, int role )
     return mEntries.value( index.row() ).displayString;
   if ( role == ReferencingFeature )
     return mRelation.referencingLayer()->getFeature( mEntries.value( index.row() ).referencingFeatureId );
+  if ( role == AssociatedReferencingFeature )
+    return mAssociatedRelation.getReferencedFeature( mRelation.referencingLayer()->getFeature( mEntries.value( index.row() ).referencingFeatureId ) );
   return QVariant();
 }
 
@@ -90,6 +93,16 @@ void ReferencingFeatureListModel::setRelation(const QgsRelation &relation)
 QgsRelation ReferencingFeatureListModel::relation() const
 {
   return mRelation;
+}
+
+void ReferencingFeatureListModel::setAssociatedRelation(const QgsRelation &relation)
+{
+  mAssociatedRelation = relation;
+}
+
+QgsRelation ReferencingFeatureListModel::associatedRelation() const
+{
+  return mAssociatedRelation;
 }
 
 void ReferencingFeatureListModel::reload()

--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -26,7 +26,7 @@ QHash<int, QByteArray> ReferencingFeatureListModel::roleNames() const
   QHash<int, QByteArray> roles = QAbstractItemModel::roleNames();
 
   roles[DisplayString] = "displayString";
-  roles[FeatureId] = "featureId";
+  roles[ReferencingFeatureId] = "referencingFeatureId";
 
   return roles;
 }
@@ -62,8 +62,8 @@ QVariant ReferencingFeatureListModel::data( const QModelIndex &index, int role )
 {
   if ( role == DisplayString )
     return mEntries.value( index.row() ).displayString;
-  if ( role == FeatureId )
-    return mEntries.value( index.row() ).featureId;
+  if ( role == ReferencingFeatureId )
+    return mEntries.value( index.row() ).referencingFeatureId;
 
   return QVariant();
 }
@@ -112,10 +112,10 @@ void ReferencingFeatureListModel::reload()
   endResetModel();
 }
 
-void ReferencingFeatureListModel::deleteFeature( QgsFeatureId fid )
+void ReferencingFeatureListModel::deleteFeature( QgsFeatureId referencingFeatureId )
 {
   mRelation.referencingLayer()->startEditing();
-  mRelation.referencingLayer()->deleteFeature( fid );
+  mRelation.referencingLayer()->deleteFeature( referencingFeatureId );
   mRelation.referencingLayer()->commitChanges();
   reload();
 }

--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -27,6 +27,7 @@ QHash<int, QByteArray> ReferencingFeatureListModel::roleNames() const
 
   roles[DisplayString] = "displayString";
   roles[ReferencingFeatureId] = "referencingFeatureId";
+  roles[ReferencingFeature] = "referencingFeature";
 
   return roles;
 }
@@ -64,6 +65,8 @@ QVariant ReferencingFeatureListModel::data( const QModelIndex &index, int role )
     return mEntries.value( index.row() ).displayString;
   if ( role == ReferencingFeatureId )
     return mEntries.value( index.row() ).referencingFeatureId;
+  if ( role == ReferencingFeature )
+    return mRelation.referencingLayer()->getFeature( mEntries.value( index.row() ).referencingFeatureId );
 
   return QVariant();
 }

--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -76,8 +76,6 @@ void ReferencingFeatureListModel::setFeature( const QgsFeature &feature )
     return;
 
   mFeature = feature;
-
-  setParentPrimariesAvailable( checkParentPrimaries() );
   reload();
 }
 
@@ -89,7 +87,6 @@ QgsFeature ReferencingFeatureListModel::feature() const
 void ReferencingFeatureListModel::setRelation( const QgsRelation &relation )
 {
   mRelation = relation;
-  setParentPrimariesAvailable( checkParentPrimaries() );
   reload();
 }
 
@@ -122,6 +119,7 @@ void ReferencingFeatureListModel::reload()
 {
   if ( !mRelation.isValid() || !mFeature.isValid() || !checkParentPrimaries() )
     return;
+
   mEntries.clear();
   QgsFeatureIterator relatedFeaturesIt = mRelation.getRelatedFeatures( mFeature );
   QgsExpressionContext context = mRelation.referencingLayer()->createExpressionContext();
@@ -135,6 +133,9 @@ void ReferencingFeatureListModel::reload()
     mEntries.append( Entry( expression.evaluate( &context ).toString(), childFeature.id() ) );
   }
   endResetModel();
+
+  //set the property for parent primaries available status
+  setParentPrimariesAvailable( checkParentPrimaries() );
 }
 
 void ReferencingFeatureListModel::deleteFeature( QgsFeatureId referencingFeatureId )
@@ -153,7 +154,7 @@ bool ReferencingFeatureListModel::checkParentPrimaries()
   const auto fieldPairs = mRelation.fieldPairs();
   for ( QgsRelation::FieldPair fieldPair : fieldPairs )
   {
-    if ( mFeature.attribute( fieldPair.second ).isNull() )
+    if ( mFeature.attribute( fieldPair.second ).isNull() || mFeature.attribute( fieldPair.second ).toInt() == 0 )
       return false;
   }
   return true;

--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -76,6 +76,8 @@ void ReferencingFeatureListModel::setFeature( const QgsFeature &feature )
     return;
 
   mFeature = feature;
+
+  setParentPrimariesAvailable( checkParentPrimaries() );
   reload();
 }
 
@@ -87,6 +89,7 @@ QgsFeature ReferencingFeatureListModel::feature() const
 void ReferencingFeatureListModel::setRelation( const QgsRelation &relation )
 {
   mRelation = relation;
+  setParentPrimariesAvailable( checkParentPrimaries() );
   reload();
 }
 
@@ -103,6 +106,16 @@ void ReferencingFeatureListModel::setAssociatedRelation( const QgsRelation &rela
 QgsRelation ReferencingFeatureListModel::associatedRelation() const
 {
   return mAssociatedRelation;
+}
+
+void ReferencingFeatureListModel::setParentPrimariesAvailable( const bool parentPrimariesAvailable )
+{
+  mParentPrimariesAvailable = parentPrimariesAvailable;
+}
+
+bool ReferencingFeatureListModel::parentPrimariesAvailable() const
+{
+  return mParentPrimariesAvailable;
 }
 
 void ReferencingFeatureListModel::reload()
@@ -130,4 +143,18 @@ void ReferencingFeatureListModel::deleteFeature( QgsFeatureId referencingFeature
   mRelation.referencingLayer()->deleteFeature( referencingFeatureId );
   mRelation.referencingLayer()->commitChanges();
   reload();
+}
+
+bool ReferencingFeatureListModel::checkParentPrimaries()
+{
+  if ( !mRelation.isValid() || !mFeature.isValid() )
+    return false;
+
+  const auto fieldPairs = mRelation.fieldPairs();
+  for ( QgsRelation::FieldPair fieldPair : fieldPairs )
+  {
+    if( mFeature.attribute( fieldPair.second ).isNull() )
+      return false;
+  }
+  return true;
 }

--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -117,20 +117,25 @@ bool ReferencingFeatureListModel::parentPrimariesAvailable() const
 
 void ReferencingFeatureListModel::reload()
 {
-  if ( !mRelation.isValid() || !mFeature.isValid() || !checkParentPrimaries() )
+  if ( !mRelation.isValid() || !mFeature.isValid() )
     return;
 
-  mEntries.clear();
-  QgsFeatureIterator relatedFeaturesIt = mRelation.getRelatedFeatures( mFeature );
-  QgsExpressionContext context = mRelation.referencingLayer()->createExpressionContext();
-  QgsExpression expression( mRelation.referencingLayer()->displayExpression() );
-
   beginResetModel();
-  QgsFeature childFeature;
-  while ( relatedFeaturesIt.nextFeature( childFeature ) )
+
+  mEntries.clear();
+
+  if ( checkParentPrimaries() )
   {
-    context.setFeature( childFeature );
-    mEntries.append( Entry( expression.evaluate( &context ).toString(), childFeature.id() ) );
+    QgsFeatureIterator relatedFeaturesIt = mRelation.getRelatedFeatures( mFeature );
+    QgsExpressionContext context = mRelation.referencingLayer()->createExpressionContext();
+    QgsExpression expression( mRelation.referencingLayer()->displayExpression() );
+
+    QgsFeature childFeature;
+    while ( relatedFeaturesIt.nextFeature( childFeature ) )
+    {
+      context.setFeature( childFeature );
+      mEntries.append( Entry( expression.evaluate( &context ).toString(), childFeature.id() ) );
+    }
   }
   endResetModel();
 

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -39,7 +39,8 @@ public:
   enum ReferencedFeatureListRoles
   {
     DisplayString = Qt::UserRole,
-    ReferencingFeatureId
+    ReferencingFeatureId,
+    ReferencingFeature
   };
 
   QHash<int, QByteArray> roleNames() const override;
@@ -56,7 +57,7 @@ public:
   void setRelation( const QgsRelation &relation );
   QgsRelation relation() const;
 
-  void reload();
+  Q_INVOKABLE void reload();
   Q_INVOKABLE void deleteFeature( QgsFeatureId referencingFeatureId );
 
 signals:

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -30,7 +30,7 @@ class ReferencingFeatureListModel : public QStandardItemModel
   /**
    * The relation
    */
-  Q_PROPERTY( QgsFeatureId featureId WRITE setFeatureId READ featureId NOTIFY featureIdChanged )
+  Q_PROPERTY( QgsFeature feature WRITE setFeature READ feature NOTIFY featureChanged )
   Q_PROPERTY( QgsRelation relation WRITE setRelation READ relation NOTIFY relationChanged )
 
 public:
@@ -50,8 +50,8 @@ public:
 
   QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
-  void setFeatureId( const QgsFeatureId &featureId );
-  QgsFeatureId featureId () const;
+  void setFeature( const QgsFeature &feature );
+  QgsFeature feature() const;
 
   void setRelation( const QgsRelation &relation );
   QgsRelation relation() const;
@@ -61,7 +61,7 @@ public:
 
 signals:
   void attributeFormModelChanged();
-  void featureIdChanged();
+  void featureChanged();
   void relationChanged();
 
 private:
@@ -80,7 +80,7 @@ private:
 
   QList<Entry> mEntries;
 
-  QgsFeatureId mFeatureId=-1;
+  QgsFeature mFeature;
   QgsRelation mRelation;
 
 };

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -17,6 +17,7 @@
 #define REFERENCINGFEATURELISTMODEL_H
 
 #include <QAbstractItemModel>
+#include <QPair>
 #include "qgsvectorlayer.h"
 #include "attributeformmodel.h"
 

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -51,25 +51,66 @@ class ReferencingFeatureListModel : public QAbstractItemModel
 
     QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
 
+    /**
+     * The parent feature for which this model contains the children
+     * \param feature
+     * \see feature
+     */
     void setFeature( const QgsFeature &feature );
+
+    /**
+     * The parent feature for which this model contains the children
+     * \return the parent feature
+     * \see setFeature
+     */
     QgsFeature feature() const;
 
+    /**
+     * The relation connectiong the parent feature with the children in this model
+     * \param relation
+     * \see relation
+     */
     void setRelation( const QgsRelation &relation );
+
+    /**
+     * The relation connectiong the parent feature with the children in this model
+     * \return relation
+     * \see setRelation
+     */
     QgsRelation relation() const;
 
-    /*
-     * used for nm relations
+    /**
+     * On many-to-many relations this is the second relation connecting the children in the associationtable to their other parent
+     * \param relation The associated relation
+     * \see associatedRelation
      */
     void setAssociatedRelation( const QgsRelation &relation );
+
+    /**
+     * On many-to-many relations this is the second relation connecting the children in the associationtable to their other parent
+     * \return associated relation
+     * \see setAssociatedRelation
+     */
     QgsRelation associatedRelation() const;
 
-    /*
-     * obsolete but I keep it for the moment just in case
+    /**
+     * The status if the pk of the parent feature (this feature) are valid (not null)
+     * \param parentPrimariesAvailable The status if the parent pks are available
+     * \see parentPrimariesAvailable
      */
     void setParentPrimariesAvailable( const bool parentPrimariesAvailable );
+
+    /**
+     * On many-to-many relations this is the second relation connecting the children in the associationtable to their other parent
+     * It's needed to check on opening a form to add a new child
+     * \return parentPrimariesAvailable The status if the parent pks are available
+     * \see setParentPrimariesAvailable
+     */
     bool parentPrimariesAvailable() const;
 
+    //! Reloads the model
     Q_INVOKABLE void reload();
+    //! Deletes a feature regarding the referencing layer and the feature id \param referencingFeatureId of the selected child
     Q_INVOKABLE void deleteFeature( QgsFeatureId referencingFeatureId );
 
   signals:
@@ -100,6 +141,7 @@ class ReferencingFeatureListModel : public QAbstractItemModel
     QgsRelation mAssociatedRelation;
     bool mParentPrimariesAvailable = false;
 
+    //! Checks if the parent pk(s) is not null
     bool checkParentPrimaries();
 };
 

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -31,6 +31,7 @@ class ReferencingFeatureListModel : public QAbstractItemModel
     Q_PROPERTY( QgsFeature feature WRITE setFeature READ feature NOTIFY featureChanged )
     Q_PROPERTY( QgsRelation relation WRITE setRelation READ relation NOTIFY relationChanged )
     Q_PROPERTY( QgsRelation associatedRelation WRITE setAssociatedRelation READ associatedRelation NOTIFY associatedRelationChanged )
+    Q_PROPERTY( bool parentPrimariesAvailable WRITE setParentPrimariesAvailable READ parentPrimariesAvailable NOTIFY parentPrimariesAvailableChanged )
 
   public:
     explicit ReferencingFeatureListModel( QObject *parent = nullptr );
@@ -59,6 +60,9 @@ class ReferencingFeatureListModel : public QAbstractItemModel
     void setAssociatedRelation( const QgsRelation &relation );
     QgsRelation associatedRelation() const;
 
+    void setParentPrimariesAvailable( const bool parentPrimariesAvailable );
+    bool parentPrimariesAvailable() const;
+
     Q_INVOKABLE void reload();
     Q_INVOKABLE void deleteFeature( QgsFeatureId referencingFeatureId );
 
@@ -67,6 +71,7 @@ class ReferencingFeatureListModel : public QAbstractItemModel
     void featureChanged();
     void relationChanged();
     void associatedRelationChanged();
+    void parentPrimariesAvailableChanged();
 
   private:
     struct Entry
@@ -87,7 +92,9 @@ class ReferencingFeatureListModel : public QAbstractItemModel
     QgsFeature mFeature;
     QgsRelation mRelation;
     QgsRelation mAssociatedRelation;
+    bool mParentPrimariesAvailable = false;
 
+    bool checkParentPrimaries();
 };
 
 #endif // REFERENCINGFEATURELISTMODEL_H

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -52,7 +52,6 @@ class ReferencingFeatureListModel : public QAbstractItemModel
     QModelIndex parent( const QModelIndex &index ) const override;
     int rowCount( const QModelIndex &parent = QModelIndex() ) const override;
     int columnCount( const QModelIndex &parent = QModelIndex() ) const override;
-
     QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
 
     /**
@@ -112,9 +111,16 @@ class ReferencingFeatureListModel : public QAbstractItemModel
      */
     bool parentPrimariesAvailable() const;
 
-    //! Reloads the model
+    /**
+     * Reloads the model by starting the reload functionality in the gatherer (seperate thread)
+     * Sets the property parentPrimariesAvailable
+     */
     Q_INVOKABLE void reload();
-    //! Deletes a feature regarding the referencing layer and the feature id \param referencingFeatureId of the selected child
+
+    /**
+     * Deletes a feature regarding the referencing layer and the feature id of the selected child
+     * \param referencingFeatureId id of the selected child
+     */
     Q_INVOKABLE void deleteFeature( QgsFeatureId referencingFeatureId );
 
     /**
@@ -128,8 +134,6 @@ class ReferencingFeatureListModel : public QAbstractItemModel
     void relationChanged();
     void nmRelationChanged();
     void parentPrimariesAvailableChanged();
-
-    //Indicator if the model is currently performing any feature iteration in the background.
     void isLoadingChanged();
 
   private slots:
@@ -155,7 +159,6 @@ class ReferencingFeatureListModel : public QAbstractItemModel
     };
 
     QList<Entry> mEntries;
-
     QgsFeature mFeature;
     QgsRelation mRelation;
     QgsRelation mNmRelation;
@@ -205,7 +208,7 @@ class FeatureGatherer: public QThread
         }
         mEntries.append( ReferencingFeatureListModel::Entry( expression.evaluate( &context ).toString(), childFeature, nmDisplayString, nmFeature ) );
         */
-        //test: sleep(1);
+        //test sleep(1);
         mEntries.append( ReferencingFeatureListModel::Entry( expression.evaluate( &context ).toString(), childFeature ) );
 
         if ( mWasCanceled )
@@ -221,13 +224,11 @@ class FeatureGatherer: public QThread
       mWasCanceled = true;
     }
 
-    //! Returns TRUE if collection was canceled before completion
+    //! \return mWasCanceled true if collection was canceled before completion
     bool wasCanceled() const { return mWasCanceled; }
 
-    QList<ReferencingFeatureListModel::Entry> entries() const
-    {
-      return mEntries;
-    }
+    //! \return mEntries the list of entries
+    QList<ReferencingFeatureListModel::Entry> entries() const { return mEntries; }
 
   signals:
 

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -33,6 +33,7 @@ class ReferencingFeatureListModel : public QStandardItemModel
    */
   Q_PROPERTY( QgsFeature feature WRITE setFeature READ feature NOTIFY featureChanged )
   Q_PROPERTY( QgsRelation relation WRITE setRelation READ relation NOTIFY relationChanged )
+  Q_PROPERTY( QgsRelation associatedRelation WRITE setAssociatedRelation READ associatedRelation NOTIFY associatedRelationChanged )
 
 public:
   explicit ReferencingFeatureListModel(QObject *parent = nullptr);
@@ -40,7 +41,8 @@ public:
   enum ReferencedFeatureListRoles
   {
     DisplayString = Qt::UserRole,
-    ReferencingFeature
+    ReferencingFeature,
+    AssociatedReferencingFeature
   };
 
   QHash<int, QByteArray> roleNames() const override;
@@ -57,6 +59,9 @@ public:
   void setRelation( const QgsRelation &relation );
   QgsRelation relation() const;
 
+  void setAssociatedRelation( const QgsRelation &relation );
+  QgsRelation associatedRelation() const;
+
   Q_INVOKABLE void reload();
   Q_INVOKABLE void deleteFeature( QgsFeatureId referencingFeatureId );
 
@@ -64,6 +69,7 @@ signals:
   void attributeFormModelChanged();
   void featureChanged();
   void relationChanged();
+  void associatedRelationChanged();
 
 private:
   struct Entry
@@ -83,6 +89,7 @@ private:
 
   QgsFeature mFeature;
   QgsRelation mRelation;
+  QgsRelation mAssociatedRelation;
 
 };
 

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -224,10 +224,10 @@ class FeatureGatherer: public QThread
       mWasCanceled = true;
     }
 
-    //! \return mWasCanceled true if collection was canceled before completion
+    //! \returns true if collection was canceled before completion
     bool wasCanceled() const { return mWasCanceled; }
 
-    //! \return mEntries the list of entries
+    //! \returns the list of entries
     QList<ReferencingFeatureListModel::Entry> entries() const { return mEntries; }
 
   signals:

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -35,6 +35,7 @@ class ReferencingFeatureListModel : public QAbstractItemModel
     Q_PROPERTY( QgsRelation relation WRITE setRelation READ relation NOTIFY relationChanged )
     Q_PROPERTY( QgsRelation nmRelation WRITE setNmRelation READ nmRelation NOTIFY nmRelationChanged )
     Q_PROPERTY( bool parentPrimariesAvailable WRITE setParentPrimariesAvailable READ parentPrimariesAvailable NOTIFY parentPrimariesAvailableChanged )
+    Q_PROPERTY( bool isLoading READ isLoading NOTIFY isLoadingChanged )
 
   public:
     explicit ReferencingFeatureListModel( QObject *parent = nullptr );
@@ -116,6 +117,11 @@ class ReferencingFeatureListModel : public QAbstractItemModel
     //! Deletes a feature regarding the referencing layer and the feature id \param referencingFeatureId of the selected child
     Q_INVOKABLE void deleteFeature( QgsFeatureId referencingFeatureId );
 
+    /**
+     * Indicator if the model is currently performing any feature iteration in the background.
+     */
+    bool isLoading() const;
+
   signals:
     void attributeFormModelChanged();
     void featureChanged();
@@ -123,7 +129,7 @@ class ReferencingFeatureListModel : public QAbstractItemModel
     void nmRelationChanged();
     void parentPrimariesAvailableChanged();
 
-    //for loading bar or similar - not used at the moment but i keep it to remember
+    //Indicator if the model is currently performing any feature iteration in the background.
     void isLoadingChanged();
 
   private slots:
@@ -199,7 +205,7 @@ class FeatureGatherer: public QThread
         }
         mEntries.append( ReferencingFeatureListModel::Entry( expression.evaluate( &context ).toString(), childFeature, nmDisplayString, nmFeature ) );
         */
-
+        //test: sleep(1);
         mEntries.append( ReferencingFeatureListModel::Entry( expression.evaluate( &context ).toString(), childFeature ) );
 
         if ( mWasCanceled )

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -39,7 +39,7 @@ public:
   enum ReferencedFeatureListRoles
   {
     DisplayString = Qt::UserRole,
-    FeatureId
+    ReferencingFeatureId
   };
 
   QHash<int, QByteArray> roleNames() const override;
@@ -57,7 +57,7 @@ public:
   QgsRelation relation() const;
 
   void reload();
-  Q_INVOKABLE void deleteFeature( QgsFeatureId fid );
+  Q_INVOKABLE void deleteFeature( QgsFeatureId referencingFeatureId );
 
 signals:
   void attributeFormModelChanged();
@@ -67,15 +67,15 @@ signals:
 private:
   struct Entry
   {
-    Entry( const QString &displayString, const QgsFeatureId &featureId )
+    Entry( const QString &displayString, const QgsFeatureId &referencingFeatureId )
       : displayString( displayString )
-       , featureId(featureId)
+       , referencingFeatureId(referencingFeatureId)
     {}
 
     Entry() = default;
 
     QString displayString;
-    QgsFeatureId featureId;
+    QgsFeatureId referencingFeatureId;
   };
 
   QList<Entry> mEntries;

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -187,6 +187,19 @@ class FeatureGatherer: public QThread
       while ( relatedFeaturesIt.nextFeature( childFeature ) )
       {
         context.setFeature( childFeature );
+
+        /*
+        if( mNmRelation.isValid() )
+        {
+          QgsExpressionContext nmContext = mNmRelation.referencingLayer()->createExpressionContext();
+          QgsExpression nmExpression ( mNmRelation.referencingLayer()->displayExpression() );
+          nmFeature = mNmRelation.getReferencedFeature(childFeature );
+          nmContext.setFeature( nmFeature );
+          nmDisplayString = nmExpression.evaluate( &nmContext ).toString();
+        }
+        mEntries.append( ReferencingFeatureListModel::Entry( expression.evaluate( &context ).toString(), childFeature, nmDisplayString, nmFeature ) );
+        */
+
         mEntries.append( ReferencingFeatureListModel::Entry( expression.evaluate( &context ).toString(), childFeature ) );
 
         if ( mWasCanceled )

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -3,7 +3,7 @@
 
  ---------------------
  begin                : 1.3.2019
- copyright            : (C) 2019 by David Signer Kuhn
+ copyright            : (C) 2019 by David Signer
  email                : david@opengis.ch
  ***************************************************************************
  *                                                                         *
@@ -30,7 +30,6 @@ class ReferencingFeatureListModel : public QStandardItemModel
   /**
    * The relation
    */
-  Q_PROPERTY( AttributeFormModel *attributeFormModel READ attributeFormModel WRITE setAttributeFormModel NOTIFY attributeFormModelChanged )
   Q_PROPERTY( QgsFeatureId featureId WRITE setFeatureId READ featureId NOTIFY featureIdChanged )
   Q_PROPERTY( QgsRelation relation WRITE setRelation READ relation NOTIFY relationChanged )
 
@@ -57,9 +56,6 @@ public:
   void setRelation( const QgsRelation &relation );
   QgsRelation relation() const;
 
-  AttributeFormModel *attributeFormModel() const;
-  void setAttributeFormModel( AttributeFormModel *attributeFormModel );
-
   void reload();
   Q_INVOKABLE void deleteFeature( QgsFeatureId fid );
 
@@ -84,7 +80,6 @@ private:
 
   QList<Entry> mEntries;
 
-  AttributeFormModel *mAttributeFormModel;
   QgsFeatureId mFeatureId=-1;
   QgsRelation mRelation;
 

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -24,72 +24,69 @@
 class QgsVectorLayer;
 class AttributeFormModel;
 
-class ReferencingFeatureListModel : public QStandardItemModel
+class ReferencingFeatureListModel : public QAbstractItemModel
 {
-  Q_OBJECT
+    Q_OBJECT
 
-  /**
-   * The relation
-   */
-  Q_PROPERTY( QgsFeature feature WRITE setFeature READ feature NOTIFY featureChanged )
-  Q_PROPERTY( QgsRelation relation WRITE setRelation READ relation NOTIFY relationChanged )
-  Q_PROPERTY( QgsRelation associatedRelation WRITE setAssociatedRelation READ associatedRelation NOTIFY associatedRelationChanged )
+    Q_PROPERTY( QgsFeature feature WRITE setFeature READ feature NOTIFY featureChanged )
+    Q_PROPERTY( QgsRelation relation WRITE setRelation READ relation NOTIFY relationChanged )
+    Q_PROPERTY( QgsRelation associatedRelation WRITE setAssociatedRelation READ associatedRelation NOTIFY associatedRelationChanged )
 
-public:
-  explicit ReferencingFeatureListModel(QObject *parent = nullptr);
+  public:
+    explicit ReferencingFeatureListModel( QObject *parent = nullptr );
 
-  enum ReferencedFeatureListRoles
-  {
-    DisplayString = Qt::UserRole,
-    ReferencingFeature,
-    AssociatedReferencedFeature
-  };
+    enum ReferencedFeatureListRoles
+    {
+      DisplayString = Qt::UserRole,
+      ReferencingFeature,
+      AssociatedReferencedFeature
+    };
 
-  QHash<int, QByteArray> roleNames() const override;
-  QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
-  QModelIndex parent(const QModelIndex &index) const override;
-  int rowCount(const QModelIndex &parent = QModelIndex()) const override;
-  int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+    QHash<int, QByteArray> roleNames() const override;
+    QModelIndex index( int row, int column, const QModelIndex &parent = QModelIndex() ) const override;
+    QModelIndex parent( const QModelIndex &index ) const override;
+    int rowCount( const QModelIndex &parent = QModelIndex() ) const override;
+    int columnCount( const QModelIndex &parent = QModelIndex() ) const override;
 
-  QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
 
-  void setFeature( const QgsFeature &feature );
-  QgsFeature feature() const;
+    void setFeature( const QgsFeature &feature );
+    QgsFeature feature() const;
 
-  void setRelation( const QgsRelation &relation );
-  QgsRelation relation() const;
+    void setRelation( const QgsRelation &relation );
+    QgsRelation relation() const;
 
-  void setAssociatedRelation( const QgsRelation &relation );
-  QgsRelation associatedRelation() const;
+    void setAssociatedRelation( const QgsRelation &relation );
+    QgsRelation associatedRelation() const;
 
-  Q_INVOKABLE void reload();
-  Q_INVOKABLE void deleteFeature( QgsFeatureId referencingFeatureId );
+    Q_INVOKABLE void reload();
+    Q_INVOKABLE void deleteFeature( QgsFeatureId referencingFeatureId );
 
-signals:
-  void attributeFormModelChanged();
-  void featureChanged();
-  void relationChanged();
-  void associatedRelationChanged();
+  signals:
+    void attributeFormModelChanged();
+    void featureChanged();
+    void relationChanged();
+    void associatedRelationChanged();
 
-private:
-  struct Entry
-  {
-    Entry( const QString &displayString, const QgsFeatureId &referencingFeatureId )
-      : displayString( displayString )
-       , referencingFeatureId(referencingFeatureId)
-    {}
+  private:
+    struct Entry
+    {
+      Entry( const QString &displayString, const QgsFeatureId &referencingFeatureId )
+        : displayString( displayString )
+        , referencingFeatureId( referencingFeatureId )
+      {}
 
-    Entry() = default;
+      Entry() = default;
 
-    QString displayString;
-    QgsFeatureId referencingFeatureId;
-  };
+      QString displayString;
+      QgsFeatureId referencingFeatureId;
+    };
 
-  QList<Entry> mEntries;
+    QList<Entry> mEntries;
 
-  QgsFeature mFeature;
-  QgsRelation mRelation;
-  QgsRelation mAssociatedRelation;
+    QgsFeature mFeature;
+    QgsRelation mRelation;
+    QgsRelation mAssociatedRelation;
 
 };
 

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -30,7 +30,7 @@ class ReferencingFeatureListModel : public QAbstractItemModel
 
     Q_PROPERTY( QgsFeature feature WRITE setFeature READ feature NOTIFY featureChanged )
     Q_PROPERTY( QgsRelation relation WRITE setRelation READ relation NOTIFY relationChanged )
-    Q_PROPERTY( QgsRelation associatedRelation WRITE setAssociatedRelation READ associatedRelation NOTIFY associatedRelationChanged )
+    Q_PROPERTY( QgsRelation nmRelation WRITE setNmRelation READ nmRelation NOTIFY nmRelationChanged )
     Q_PROPERTY( bool parentPrimariesAvailable WRITE setParentPrimariesAvailable READ parentPrimariesAvailable NOTIFY parentPrimariesAvailableChanged )
 
   public:
@@ -40,7 +40,7 @@ class ReferencingFeatureListModel : public QAbstractItemModel
     {
       DisplayString = Qt::UserRole,
       ReferencingFeature,
-      AssociatedReferencedFeature
+      NmReferencedFeature
     };
 
     QHash<int, QByteArray> roleNames() const override;
@@ -82,16 +82,16 @@ class ReferencingFeatureListModel : public QAbstractItemModel
     /**
      * On many-to-many relations this is the second relation connecting the children in the associationtable to their other parent
      * \param relation The associated relation
-     * \see associatedRelation
+     * \see nmRelation
      */
-    void setAssociatedRelation( const QgsRelation &relation );
+    void setNmRelation( const QgsRelation &relation );
 
     /**
      * On many-to-many relations this is the second relation connecting the children in the associationtable to their other parent
      * \return associated relation
-     * \see setAssociatedRelation
+     * \see setNmRelation
      */
-    QgsRelation associatedRelation() const;
+    QgsRelation nmRelation() const;
 
     /**
      * The status if the pk of the parent feature (this feature) are valid (not null)
@@ -101,7 +101,7 @@ class ReferencingFeatureListModel : public QAbstractItemModel
     void setParentPrimariesAvailable( const bool parentPrimariesAvailable );
 
     /**
-     * On many-to-many relations this is the second relation connecting the children in the associationtable to their other parent
+     * The status if the pk of the parent feature (this feature) are valid (not null)
      * It's needed to check on opening a form to add a new child
      * \return parentPrimariesAvailable The status if the parent pks are available
      * \see setParentPrimariesAvailable
@@ -117,7 +117,7 @@ class ReferencingFeatureListModel : public QAbstractItemModel
     void attributeFormModelChanged();
     void featureChanged();
     void relationChanged();
-    void associatedRelationChanged();
+    void nmRelationChanged();
     void parentPrimariesAvailableChanged();
 
   private:
@@ -138,7 +138,7 @@ class ReferencingFeatureListModel : public QAbstractItemModel
 
     QgsFeature mFeature;
     QgsRelation mRelation;
-    QgsRelation mAssociatedRelation;
+    QgsRelation mNmRelation;
     bool mParentPrimariesAvailable = false;
 
     //! Checks if the parent pk(s) is not null

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -40,7 +40,6 @@ public:
   enum ReferencedFeatureListRoles
   {
     DisplayString = Qt::UserRole,
-    ReferencingFeatureId,
     ReferencingFeature
   };
 

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -57,9 +57,15 @@ class ReferencingFeatureListModel : public QAbstractItemModel
     void setRelation( const QgsRelation &relation );
     QgsRelation relation() const;
 
+    /*
+     * used for nm relations
+     */
     void setAssociatedRelation( const QgsRelation &relation );
     QgsRelation associatedRelation() const;
 
+    /*
+     * obsolete but I keep it for the moment just in case
+     */
     void setParentPrimariesAvailable( const bool parentPrimariesAvailable );
     bool parentPrimariesAvailable() const;
 

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -1,3 +1,18 @@
+/***************************************************************************
+  referencingfeaturelistmodel.h - ReferencingFeatureListModel
+
+ ---------------------
+ begin                : 1.3.2019
+ copyright            : (C) 2019 by David Signer Kuhn
+ email                : david@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
 #ifndef REFERENCINGFEATURELISTMODEL_H
 #define REFERENCINGFEATURELISTMODEL_H
 
@@ -15,9 +30,9 @@ class ReferencingFeatureListModel : public QStandardItemModel
   /**
    * The relation
    */
-  Q_PROPERTY( AttributeFormModel *attributeFormModel READ attributeFormModel WRITE setAttributeFormModel )
-  Q_PROPERTY( QgsFeatureId featureId WRITE setFeatureId READ featureId )
-  Q_PROPERTY( QgsRelation relation WRITE setRelation READ relation )
+  Q_PROPERTY( AttributeFormModel *attributeFormModel READ attributeFormModel WRITE setAttributeFormModel NOTIFY attributeFormModelChanged )
+  Q_PROPERTY( QgsFeatureId featureId WRITE setFeatureId READ featureId NOTIFY featureIdChanged )
+  Q_PROPERTY( QgsRelation relation WRITE setRelation READ relation NOTIFY relationChanged )
 
 public:
   explicit ReferencingFeatureListModel(QObject *parent = nullptr);
@@ -47,6 +62,11 @@ public:
 
   void reload();
   Q_INVOKABLE void deleteFeature( QgsFeatureId fid );
+
+signals:
+  void attributeFormModelChanged();
+  void featureIdChanged();
+  void relationChanged();
 
 private:
   struct Entry

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -42,7 +42,7 @@ public:
   {
     DisplayString = Qt::UserRole,
     ReferencingFeature,
-    AssociatedReferencingFeature
+    AssociatedReferencedFeature
   };
 
   QHash<int, QByteArray> roleNames() const override;

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -296,7 +296,7 @@ Page {
       CheckBox {
         id: rememberCheckbox
         checked: RememberValue ? true : false 
-        visible: form.state === "Add" && EditorWidget !== "Hidden"
+        visible: form.state === "Add" && EditorWidget !== "Hidden" && EditorWidget !== 'RelationEditor'
         width: visible ? undefined : 0
 
         anchors { right: parent.right; top: fieldLabel.bottom }

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -239,7 +239,8 @@ Page {
           height: childrenRect.height
           anchors { left: parent.left; right: parent.right }
 
-          enabled: form.state !== "ReadOnly" && !!AttributeEditable
+          enabled: (form.state !== "ReadOnly" || EditorWidget === 'RelationEditor')&& !!AttributeEditable
+          property bool readOnly: form.state === "ReadOnly"
           property var value: AttributeValue
           property var config: ( EditorWidgetConfig || {} )
           property var widget: EditorWidget

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -255,7 +255,7 @@ Page {
           property var field: Field
           property var fieldType: FieldType
           property var relationId: RelationId
-          property var associatedRelationId: AssociatedRelationId
+          property var nmRelationId: NmRelationId
           property var constraintValid: ConstraintValid
           property bool constraintsValid: form.model.constraintsValid
           property var currentFeature: form.model.featureModel.feature

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -346,7 +346,7 @@ Page {
     }
 
     background: Rectangle {
-      color: model.constraintsValid ? "blue" : "orange"
+      color: model.constraintsValid ?  form.state === 'Add' ? "blue" : "#80CC28" : "orange"
     }
 
     RowLayout {
@@ -358,6 +358,7 @@ Page {
 
         Layout.alignment: Qt.AlignTop | Qt.AlignLeft
 
+        visible: form.state === 'Add' || form.state === 'Edit'
         width: 48*dp
         height: 48*dp
         clip: true

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -244,8 +244,6 @@ Page {
         Loader {
           id: attributeEditorLoader
 
-          signal bufferFeature
-
           height: childrenRect.height
           anchors { left: parent.left; right: parent.right }
 
@@ -259,6 +257,7 @@ Page {
           property var relationId: RelationId
           property var associatedRelationId: AssociatedRelationId
           property var constraintValid: ConstraintValid
+          property bool constraintsValid: form.model.constraintsValid
           property var currentFeature: form.model.featureModel.feature
 
           active: widget !== 'Hidden'
@@ -270,10 +269,6 @@ Page {
               console.warn( "Editor widget type '" + EditorWidget + "' not avaliable." )
               source = 'editorwidgets/TextEdit.qml'
             }
-          }
-
-          onBufferFeature: {
-            buffer()
           }
         }
 
@@ -347,6 +342,11 @@ Page {
   }
 
   function buffer() {
+      if( !model.constraintsValid ) {
+          displayToast( "Constraints not valid - cannot buffer" )
+          return false
+      }
+
       aboutToSave() //used the same way like on save
 
       if ( form.state === 'Add' ) {
@@ -364,7 +364,7 @@ Page {
         model.save()
       }
 
-      //evtl. buffered()
+      return true
   }
 
   function cancel() {

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -329,16 +329,20 @@ Page {
 
     if ( form.state === 'Add' ) {
       if( !buffered )
+      {
         model.create()
+      }
       else
+      {
         model.save()
+        buffered = false
+      }
       state = 'Edit'
     }
     else
     {
       model.save()
     }
-
     saved()
   }
 

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -239,7 +239,7 @@ Page {
       Item {
         id: placeholder
         height: childrenRect.height
-        anchors { left: parent.left; right: rememberCheckbox.left; top: constraintDescriptionLabel.bottom }
+        anchors { left: parent.left; right: rememberCheckbox.left; top: constraintDescriptionLabel.bottom; rightMargin: 10 * dp  }
 
         Loader {
           id: attributeEditorLoader

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -19,6 +19,7 @@ Page {
 
   property AttributeFormModel model
   property alias toolbarVisible: toolbar.visible
+  property variant predefinedValue
 
   function reset() {
     master.reset()
@@ -240,7 +241,7 @@ Page {
           anchors { left: parent.left; right: parent.right }
 
           enabled: form.state !== "ReadOnly" && !!AttributeEditable
-          property var value: AttributeValue
+          property var value: Field.name === predefinedValue.name ? predefinedValue.value : AttributeValue
           property var config: ( EditorWidgetConfig || {} )
           property var widget: EditorWidget
           property var field: Field

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -115,9 +115,9 @@ Page {
               // than the parent item and the Flickable is useful
               width: paintedWidth
               text: tabButton.text
-              // color: tabButton.down ? "#17a81a" : "#21be2b"
-              color: !tabButton.enabled ? "#999999" : tabButton.down ||
-                                        tabButton.checked ? "#1B5E20" : "#4CAF50"
+              // color: tabButton.down ? '#17a81a' : '#21be2b'
+              color: !tabButton.enabled ? '999999' : tabButton.down ||
+                                        tabButton.checked ? '#1B5E20' : '#4CAF50'
               font.weight: tabButton.checked ? Font.DemiBold : Font.Normal
 
               horizontalAlignment: Text.AlignHCenter
@@ -158,14 +158,14 @@ Page {
             id: content
             anchors.fill: parent
             clip: true
-            section.property: "Group"
+            section.property: 'Group'
             section.labelPositioning: ViewSection.CurrentLabelAtStart | ViewSection.InlineLabels
             section.delegate: Component {
               // section header: group box name
               Rectangle {
                 width: parent.width
                 height: section === "" ? 0 : 30 * dp
-                color: "lightGray"
+                color: 'lightGray'
 
                 Text {
                   anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
@@ -314,7 +314,7 @@ Page {
   function save() {
     //if this is for some reason not handled before (like when tiping on a map while editing)
     if( !model.constraintsValid ) {
-        displayToast( qsTr( "Constraints not valid - cancel editing") )
+        displayToast( qsTr( 'Constraints not valid - cancel editing') )
         cancel()
         return
     }
@@ -343,7 +343,7 @@ Page {
 
   function buffer() {
       if( !model.constraintsValid ) {
-          displayToast( qsTr("Constraints not valid - cannot buffer") )
+          displayToast( qsTr('Constraints not valid - cannot buffer') )
           return false
       }
 
@@ -395,7 +395,7 @@ Page {
 
     background: Rectangle {
       //testwise have special color for buffered
-      color: model.constraintsValid ?  form.state === 'Add' ? "blue" : "#80CC28" : "orange"
+      color: model.constraintsValid ?  form.state === 'Add' ? 'blue' : '#80CC28' : 'orange'
     }
 
     RowLayout {
@@ -413,13 +413,13 @@ Page {
         clip: true
         bgcolor: "#212121"
 
-        iconSource: Style.getThemeIcon( "ic_check_white_48dp" )
+        iconSource: Style.getThemeIcon( 'ic_check_white_48dp' )
 
         onClicked: {
           if( model.constraintsValid ) {
             save()
           } else {
-            displayToast( qsTr("Constraints not valid") )
+            displayToast( qsTr('Constraints not valid') )
           }
         }
       }
@@ -459,7 +459,7 @@ Page {
         clip: true
         bgcolor: "#212121"
 
-        iconSource: form.state === 'Add' ? Style.getThemeIcon( "ic_delete_forever_white_24dp" ) : Style.getThemeIcon( "ic_close_white_24dp" )
+        iconSource: form.state === 'Add' ? Style.getThemeIcon( 'ic_delete_forever_white_24dp' ) : Style.getThemeIcon( 'ic_close_white_24dp' )
 
         onClicked: {
           Qt.inputMethod.hide()

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -19,6 +19,7 @@ Page {
 
   property AttributeFormModel model
   property alias toolbarVisible: toolbar.visible
+  //! if embedded form called by RelationEditor or RelationReferenceWidget
   property bool embedded: false
 
   function reset() {
@@ -247,6 +248,7 @@ Page {
           height: childrenRect.height
           anchors { left: parent.left; right: parent.right }
 
+          //disable widget if the form is in ReadOnly mode, or if it's an RelationEditor widget in an embedded form
           enabled: (form.state !== 'ReadOnly' || EditorWidget === 'RelationEditor') && !!AttributeEditable
           property bool readOnly: form.state === 'ReadOnly' || embedded && EditorWidget === 'RelationEditor'
           property var value: AttributeValue

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -247,11 +247,8 @@ Page {
           property var fieldType: FieldType
           property var relationId: RelationId
           property var constraintValid: ConstraintValid
-          property var relationEditorModel:  ReferencingFeatureListModel {
-              attributeFormModel: Type === 'relation' ? form.model : undefined
-              relation: qgisProject.relationManager.relation(RelationId)
-              featureId: AttributeValue
-          }
+          property var currentFeatureId: form.model.featureModel.feature.id
+
           active: widget !== 'Hidden'
           source: 'editorwidgets/' + ( widget || 'TextEdit' ) + '.qml'
 

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -349,13 +349,19 @@ Page {
   function buffer(){
       aboutToSave() //used the same way like on save
 
-      if ( form.state === 'Add' && !buffered ) {
-        model.create()
-        buffered = true
+      if ( form.state === 'Add' ) {
+        if( !buffered )
+        {
+          model.create()
+          buffered = true
+        }
+        else
+        {
+          model.save()
+        }
       }
-      else
-      {
-        model.save()
+      else{
+        //not implemented in edit mode
       }
 
       //evtl. buffered()

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -19,6 +19,7 @@ Page {
 
   property AttributeFormModel model
   property alias toolbarVisible: toolbar.visible
+  property bool embedded: false
 
   function reset() {
     master.reset()
@@ -239,8 +240,8 @@ Page {
           height: childrenRect.height
           anchors { left: parent.left; right: parent.right }
 
-          enabled: (form.state !== "ReadOnly" || EditorWidget === 'RelationEditor')&& !!AttributeEditable
-          property bool readOnly: form.state === "ReadOnly"
+          enabled: (form.state !== "ReadOnly" || EditorWidget === 'RelationEditor') && !!AttributeEditable
+          property bool readOnly: form.state === "ReadOnly" || embedded && EditorWidget === 'RelationEditor'
           property var value: AttributeValue
           property var config: ( EditorWidgetConfig || {} )
           property var widget: EditorWidget

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -314,7 +314,7 @@ Page {
   function save() {
     //if this is for some reason not handled before (like when tiping on a map while editing)
     if( !model.constraintsValid ) {
-        displayToast( "Constraints not valid - cancel editing" )
+        displayToast( qsTr( "Constraints not valid - cancel editing") )
         cancel()
         return
     }
@@ -343,7 +343,7 @@ Page {
 
   function buffer() {
       if( !model.constraintsValid ) {
-          displayToast( "Constraints not valid - cannot buffer" )
+          displayToast( qsTr("Constraints not valid - cannot buffer") )
           return false
       }
 
@@ -419,7 +419,7 @@ Page {
           if( model.constraintsValid ) {
             save()
           } else {
-            displayToast( "Constraints not valid" )
+            displayToast( qsTr("Constraints not valid") )
           }
         }
       }

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -327,8 +327,11 @@ Page {
     parent.focus = true
     aboutToSave()
 
-    if ( form.state === 'Add' && !buffered ) {
-      model.create()
+    if ( form.state === 'Add' ) {
+      if( !buffered )
+        model.create()
+      else
+        model.save()
       state = 'Edit'
     }
     else
@@ -343,12 +346,12 @@ Page {
       aboutToSave() //used the same way like on save
 
       if ( form.state === 'Add' && !buffered ) {
-        //model.create()
+        model.create()
         buffered = true
       }
       else
       {
-      //  model.save()
+        model.save()
       }
 
       //evtl. buffered()

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -320,7 +320,7 @@ Page {
     //if this is for some reason not handled before (like when tiping on a map while editing)
     if( !model.constraintsValid ) {
         displayToast( "Constraints not valid - cancel editing" )
-        cancelled()
+        cancel()
         return
     }
 
@@ -346,7 +346,7 @@ Page {
     saved()
   }
 
-  function buffer(){
+  function buffer() {
       aboutToSave() //used the same way like on save
 
       if ( form.state === 'Add' ) {
@@ -361,10 +361,17 @@ Page {
         }
       }
       else{
-        //not implemented in edit mode
+        model.save()
       }
 
       //evtl. buffered()
+  }
+
+  function cancel() {
+    if( buffered )
+      model.deleteFeature()
+    buffered = false
+    cancelled()
   }
 
   Connections {
@@ -456,7 +463,7 @@ Page {
 
         onClicked: {
           Qt.inputMethod.hide()
-          cancelled()
+          cancel()
         }
       }
     }

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -19,7 +19,6 @@ Page {
 
   property AttributeFormModel model
   property alias toolbarVisible: toolbar.visible
-  property variant predefinedValue
 
   function reset() {
     master.reset()
@@ -241,7 +240,7 @@ Page {
           anchors { left: parent.left; right: parent.right }
 
           enabled: form.state !== "ReadOnly" && !!AttributeEditable
-          property var value: Field.name === predefinedValue.name ? predefinedValue.value : AttributeValue
+          property var value: AttributeValue
           property var config: ( EditorWidgetConfig || {} )
           property var widget: EditorWidget
           property var field: Field

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -247,7 +247,7 @@ Page {
           property var fieldType: FieldType
           property var relationId: RelationId
           property var constraintValid: ConstraintValid
-          property var currentFeatureId: form.model.featureModel.feature.id
+          property var currentFeature: form.model.featureModel.feature
 
           active: widget !== 'Hidden'
           source: 'editorwidgets/' + ( widget || 'TextEdit' ) + '.qml'

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -395,7 +395,7 @@ Page {
 
     background: Rectangle {
       //testwise have special color for buffered
-      color: model.constraintsValid ?  form.state === 'Add' ? form.buffered ? "hotpink" : "blue" : "#80CC28" : "orange"
+      color: model.constraintsValid ?  form.state === 'Add' ? "blue" : "#80CC28" : "orange"
     }
 
     RowLayout {

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -247,6 +247,7 @@ Page {
           property var field: Field
           property var fieldType: FieldType
           property var relationId: RelationId
+          property var associatedRelationId: AssociatedRelationId
           property var constraintValid: ConstraintValid
           property var currentFeature: form.model.featureModel.feature
 

--- a/src/qml/OverlayFeatureFormDrawer.qml
+++ b/src/qml/OverlayFeatureFormDrawer.qml
@@ -41,6 +41,7 @@ Drawer {
     model: AttributeFormModel {id: attributeFormModel}
 
     state: "Add"
+    buffered: false
 
     focus: parent.opened
 

--- a/src/qml/OverlayFeatureFormDrawer.qml
+++ b/src/qml/OverlayFeatureFormDrawer.qml
@@ -58,6 +58,7 @@ Drawer {
       displayToast( qsTr( "Changes discarded" ) )
       overlayFeatureForm.isSaved=true //because never changed
       overlayFeatureFormDrawer.close()
+      buffered = false
     }
 
     Keys.onReleased: {

--- a/src/qml/OverlayFeatureFormDrawer.qml
+++ b/src/qml/OverlayFeatureFormDrawer.qml
@@ -58,7 +58,6 @@ Drawer {
       displayToast( qsTr( "Changes discarded" ) )
       overlayFeatureForm.isSaved=true //because never changed
       overlayFeatureFormDrawer.close()
-      buffered = false
     }
 
     Keys.onReleased: {

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -17,7 +17,7 @@ Frame{
     ReferencingFeatureListModel {
         id: relationEditorModel
         relation: qgisProject.relationManager.relation(relationId)
-        featureId: currentFeatureId
+        feature: currentFeature
     }
 
     //the list

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -263,4 +263,12 @@ Rectangle{
         }
       }
     }
+
+    BusyIndicator {
+      id: busyIndicator
+      anchors.centerIn: parent
+      width: 36 * dp
+      height: 36 * dp
+      running: relationEditorModel.isLoading
+    }
 }

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -186,7 +186,8 @@ Frame{
             featureModel: FeatureModel {
               currentLayer: relationEditorModel.relation.referencingLayer
               feature: state === "Edit" ? embeddedFeatureForm.referencingFeature : undefined
-              referencedFeature: relationEditorModel.feature
+              linkedParentFeature: relationEditorModel.feature
+              linkedRelation: relationEditorModel.relation
             }
           }
 

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -186,8 +186,8 @@ Frame{
             featureModel: FeatureModel {
               currentLayer: relationEditorModel.relation.referencingLayer
               feature: state === "Edit" ? embeddedFeatureForm.referencingFeature : undefined
-              linkedParentFeature: relationEditorModel.feature
-              linkedRelation: relationEditorModel.relation
+              linkedParentFeature: state === "Add" ? relationEditorModel.feature : undefined
+              linkedRelation: state === "Add" ? relationEditorModel.relation : undefined
             }
           }
 

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -11,7 +11,7 @@ import org.qfield 1.0
 import org.qgis 1.0
 
 Rectangle{
-    height: referencingFeatureListView.height + itemHeight
+    height: !readOnly ? referencingFeatureListView.height + itemHeight : referencingFeatureListView.height //because no additional addEntry item on readOnly
     property int itemHeight: 24 * dp
 
     border.color: "lightgray"
@@ -47,12 +47,13 @@ Rectangle{
 
       Rectangle{
           anchors.fill: parent
-          color: constraintsValid ? "lightgrey" : "orange"
+          color: "lightgrey"
+          visible: !readOnly
 
           Text {
               visible: !readOnly
               color: "grey"
-              text: !readOnly ? constraintsValid ? qsTr( "Add child feature:" ) : qsTr( "Ensure contraints") : "" //!readOnly && !relationEditorModel.parentPrimariesAvailable ? qsTr( "Save parent feature first..." ) : qsTr( "Add child feature:" )
+              text: !readOnly && !constraintsValid ? qsTr( "Ensure contraints") : ""
               anchors { leftMargin: 10; left: parent.left; right: addButton.left; verticalCenter: parent.verticalCenter }
               font.bold: true
               font.italic: true
@@ -60,7 +61,7 @@ Rectangle{
 
           Row
           {
-            id: editRow
+            id: addButtonRow
             anchors { top: parent.top; right: parent.right }
             height: parent.height
 
@@ -68,8 +69,7 @@ Rectangle{
                 id: addButton
                 width: parent.height
                 height: parent.height
-                visible: !readOnly
-                enabled: !readOnly // !readOnly && relationEditorModel.parentPrimariesAvailable
+                enabled: constraintsValid
 
                 contentItem: Rectangle {
                     anchors.fill: parent
@@ -86,9 +86,16 @@ Rectangle{
 
                 onClicked: {
                   if( buffer() ) {
-                      embeddedFeatureForm.state = "Add"
-                      embeddedFeatureForm.relatedLayer = relationEditorModel.relation.referencingLayer
-                      embeddedFeatureForm.active = true
+                      //this has to be checked after buffering because the primary could be a value that has been created on creating featurer (e.g. fid)
+                      if( relationEditorModel.parentPrimariesAvailable ) {
+                          embeddedFeatureForm.state = "Add"
+                          embeddedFeatureForm.relatedLayer = relationEditorModel.relation.referencingLayer
+                          embeddedFeatureForm.active = true
+                      }
+                      else
+                      {
+                          displayToast(qsTr( "Cannot add child. Parent primary keys are not available." ) )
+                      }
                   }
               }
             }
@@ -129,12 +136,12 @@ Rectangle{
 
           Row
           {
-            id: editRow
+            id: deleteRow
             anchors { top: parent.top; right: parent.right }
             height: listitem.height
 
             ToolButton {
-                id: deleteButton
+                id: deleteButtonRow
                 width: parent.height
                 height: parent.height
                 visible: !readOnly

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -199,35 +199,35 @@ Frame{
         width: parent.width - 48 * dp
         height: parent.width - 48 * dp
         modal: true
-        focus: true
         closePolicy: Popup.CloseOnEscape
 
         FeatureForm {
             model: AttributeFormModel {
-            id: attributeFormModel
+              id: attributeFormModel
 
-            featureModel: FeatureModel {
-              currentLayer: relatedLayer
-              feature: state != "Add" ? embeddedFeatureForm.relatedFeature : undefined
-              linkedParentFeature: relationEditorModel.feature
-              linkedRelation: relationEditorModel.relation
+              featureModel: FeatureModel {
+                currentLayer: relatedLayer
+                feature: state != "Add" ? embeddedFeatureForm.relatedFeature : undefined
+                linkedParentFeature: relationEditorModel.feature
+                linkedRelation: relationEditorModel.relation
+              }
             }
-          }
+            focus: true
 
-          embedded: true
-          toolbarVisible: true
+            embedded: true
+            toolbarVisible: true
 
-          anchors.fill: parent
+            anchors.fill: parent
 
-          state: embeddedFeatureForm.state
+            state: embeddedFeatureForm.state
 
-          onSaved: {
-            popup.close()
-          }
+            onSaved: {
+                popup.close()
+            }
 
-          onCancelled: {
-            popup.close()
-          }
+            onCancelled: {
+                popup.close()
+            }
         }
 
         onClosed: {

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -214,6 +214,7 @@ Frame{
             }
           }
 
+          embedded: true
           toolbarVisible: true
 
           anchors.fill: parent

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -42,37 +42,52 @@ Frame{
 
       focus: true
 
-      Row
-      {
-        id: editRow
-        anchors { top: parent.top; right: parent.right }
-        height: parent.height
+      Rectangle{
+          anchors.fill: parent
+          color: "lightgrey"
 
-        ToolButton {
-            id: addButton
-            width: parent.height
+          Text {
+              visible: !readOnly
+              color: "grey"
+              text: !readOnly && !relationEditorModel.parentPrimariesAvailable ? "Save parent feature first..." : "Add child feature..."
+              anchors { leftMargin: 10; left: parent.left; right: addButton.left; verticalCenter: parent.verticalCenter }
+              font.bold: true
+              font.italic: true
+          }
+
+          Row
+          {
+            id: editRow
+            anchors { top: parent.top; right: parent.right }
             height: parent.height
-            visible: !readOnly
 
-            contentItem: Rectangle {
-                anchors.fill: parent
-                color: "black"
-                Image {
-                  anchors.fill: parent
-                  anchors.margins: 4 * dp
-                  fillMode: Image.PreserveAspectFit
-                  horizontalAlignment: Image.AlignHCenter
-                  verticalAlignment: Image.AlignVCenter
-                  source: Style.getThemeIcon( 'ic_add_white_24dp' )
+            ToolButton {
+                id: addButton
+                width: parent.height
+                height: parent.height
+                visible: !readOnly
+                enabled: !readOnly && relationEditorModel.parentPrimariesAvailable
+
+                contentItem: Rectangle {
+                    anchors.fill: parent
+                    color: parent.enabled ? "black" : "grey"
+                    Image {
+                      anchors.fill: parent
+                      anchors.margins: 4 * dp
+                      fillMode: Image.PreserveAspectFit
+                      horizontalAlignment: Image.AlignHCenter
+                      verticalAlignment: Image.AlignVCenter
+                      source: Style.getThemeIcon( 'ic_add_white_24dp' )
+                    }
+                }
+
+                onClicked: {
+                  embeddedFeatureForm.state = "Add"
+                  embeddedFeatureForm.relatedLayer = relationEditorModel.relation.referencingLayer
+                  embeddedFeatureForm.active = true
                 }
             }
-
-            onClicked: {
-              embeddedFeatureForm.state = "Add"
-              embeddedFeatureForm.relatedLayer = relationEditorModel.relation.referencingLayer
-              embeddedFeatureForm.active = true
-            }
-        }
+          }
       }
     }
 

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -38,7 +38,7 @@ Frame{
     Item {
       id: addEntry
       anchors.top: referencingFeatureListView.bottom
-      height: Math.max( itemHeight, addEntryText.height )
+      height: itemHeight
       width: parent.width
 
       focus: true
@@ -180,13 +180,13 @@ Frame{
         closePolicy: Popup.CloseOnEscape
 
         FeatureForm {
-          predefinedValue: predefinedValue+{'name':'sensor_point_id', 'value':1 } //{'name':relationEditorModel.relation.referencingField, 'value':relationEditorModel.feature.attribute(relationEditorModel.relation.referencedField) }
-          model: AttributeFormModel {
+            model: AttributeFormModel {
             id: attributeFormModel
 
             featureModel: FeatureModel {
               currentLayer: relationEditorModel.relation.referencingLayer
               feature: state === "Edit" ? embeddedFeatureForm.referencingFeature : undefined
+              referencedFeature: relationEditorModel.feature
             }
           }
 

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -10,60 +10,81 @@ import "../js/style.js" as Style
 import org.qfield 1.0
 import org.qgis 1.0
 
-/*
 Frame{
     height: 100
-    width: 400
 
-    ListView {
-        implicitHeight: 400
-        implicitWidth: 100
-        clip: true
-        model: relationEditorModel
-        delegate: RowLayout {
-            focus: true
-            width: parent.width
-            TextField { text: model.featureId + ' - ' + model.displayString }
-        }
-    }
-}
-*/
-Frame{
-    height: 100
-    width: 300
-
-    Component {
-        id: referencingFeatureDelegate
-        Rectangle {
-            id: listitem
-            width: parent.width
-            height: 40
-            border.color: black
-            border.width: 2*dp
-            Column {
-                Text { text: model.featureId + ' - ' + model.displayString }
-            }
-            MouseArea {
-                anchors.fill: parent
-                onClicked: {
-                    //referencingFeatureListView.currentIndex = index
-                    deleteDialog.featureId = model.featureId
-                    deleteDialog.visible = true
-                }
-            }
-        }
-    }
-
+    //the list
     ListView {
         id: referencingFeatureListView
         anchors.fill: parent
         model: relationEditorModel
         delegate: referencingFeatureDelegate
         focus: true
+        clip: true
 
         onCurrentItemChanged: model.featureId + ' selected '+currentIndex
     }
 
+    //list components
+    Component {
+        id: referencingFeatureDelegate
+
+        Item {
+          id: listitem
+          anchors { left: parent.left; right: parent.right }
+
+          focus: true
+
+          height: Math.max( 24*dp, featureText.height )
+
+          Text {
+            id: featureText
+            anchors { leftMargin: 10; left: parent.left; right: deleteButton.left; verticalCenter: parent.verticalCenter }
+            font.bold: true
+            text: { text: model.featureId + ' - ' + model.displayString }
+          }
+
+          MouseArea {
+            anchors.fill: parent
+
+            onClicked: {
+              //open to edit
+            }
+          }
+
+          Row
+          {
+            id: editRow
+            anchors { top: parent.top; right: parent.right }
+
+            Button {
+              id: deleteButton
+
+              width: 24*dp
+              height: 24*dp
+
+              visible: true
+
+              iconSource: Style.getThemeIcon( "ic_delete_forever_white_24dp" )
+
+              onClicked: {
+                  deleteDialog.featureId = model.featureId
+                  deleteDialog.visible = true
+              }
+            }
+          }
+
+          //bottom line
+          Rectangle {
+            anchors.bottom: parent.bottom
+            height: 1
+            color: "lightGray"
+            width: parent.width
+          }
+        }
+    }
+
+    //logical stuff
     MessageDialog {
       id: deleteDialog
 
@@ -85,40 +106,3 @@ Frame{
       }
     }
 }
-
-/*
-
-Item {
-    width: 200; height: 100
-    focus: true
-
-    Component {
-        id: referencingFeatureDelegate
-        Item {
-            id: listitem
-            width: 400; height: 40
-            Column {
-                Text { text: model.featureId + ' - ' + model.displayString }
-            }
-
-            MouseArea{
-
-                anchors.fill: parent
-                onPressed: {
-                    listitem.forceActiveFocus()
-                }
-            }
-        }
-    }
-
-    ListView {
-        id: referencingFeatureListView
-        anchors.fill: parent
-        model: relationEditorModel
-        delegate: referencingFeatureDelegate
-        focus: true
-    }
-
-}
-*/
-

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -53,7 +53,7 @@ Frame{
             id: addButton
             width: parent.height
             height: parent.height
-            visible: true
+            visible: !readOnly
 
             contentItem: Rectangle {
                 anchors.fill: parent
@@ -92,14 +92,15 @@ Frame{
             id: featureText
             anchors { leftMargin: 10; left: parent.left; right: deleteButton.left; verticalCenter: parent.verticalCenter }
             font.bold: true
-            text: { text: model.referencingFeatureId + ' - ' + model.displayString }
+            color: readOnly ? "grey" : "black"
+            text: { text: model.displayString }
           }
 
           MouseArea {
             anchors.fill: parent
 
             onClicked: {
-                embeddedFeatureForm.state = "Edit"
+                embeddedFeatureForm.state = !readOnly ? "Edit" : "ReadOnly"
                 embeddedFeatureForm.referencingFeature = model.referencingFeature
                 embeddedFeatureForm.active = true
             }
@@ -115,7 +116,7 @@ Frame{
                 id: deleteButton
                 width: parent.height
                 height: parent.height
-                visible: true
+                visible: !readOnly
 
                 contentItem: Rectangle {
                     anchors.fill: parent
@@ -205,7 +206,7 @@ Frame{
 
             featureModel: FeatureModel {
               currentLayer: relationEditorModel.relation.referencingLayer
-              feature: state === "Edit" ? embeddedFeatureForm.referencingFeature : undefined
+              feature: state != "Add" ? embeddedFeatureForm.referencingFeature : undefined
               linkedParentFeature: relationEditorModel.feature
               linkedRelation: relationEditorModel.relation
             }

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -69,6 +69,7 @@ Frame{
 
             onClicked: {
               embeddedFeatureForm.state = "Add"
+              embeddedFeatureForm.relatedLayer = relationEditorModel.relation.referencingLayer
               embeddedFeatureForm.active = true
             }
         }
@@ -100,7 +101,8 @@ Frame{
 
             onClicked: {
                 embeddedFeatureForm.state = !readOnly ? "Edit" : "ReadOnly"
-                embeddedFeatureForm.referencingFeature = model.referencingFeature
+                embeddedFeatureForm.relatedFeature = associatedRelationId === "" ? model.referencingFeature : model.associatedReferencedFeature
+                embeddedFeatureForm.relatedLayer = associatedRelationId === "" ? relationEditorModel.relation.referencingLayer : relationEditorModel.associatedRelation.referencedLayer
                 embeddedFeatureForm.active = true
             }
           }
@@ -175,7 +177,8 @@ Frame{
       id: embeddedFeatureForm
 
       property var state
-      property var referencingFeature
+      property var relatedFeature
+      property var relatedLayer
 
       sourceComponent: embeddedFeatureFormComponent
       active: false
@@ -204,8 +207,8 @@ Frame{
             id: attributeFormModel
 
             featureModel: FeatureModel {
-              currentLayer: relationEditorModel.relation.referencingLayer
-              feature: state != "Add" ? embeddedFeatureForm.referencingFeature : undefined
+              currentLayer: relatedLayer
+              feature: state != "Add" ? embeddedFeatureForm.relatedFeature : undefined
               linkedParentFeature: relationEditorModel.feature
               linkedRelation: relationEditorModel.relation
             }

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -14,7 +14,7 @@ Rectangle{
     height: !readOnly ? referencingFeatureListView.height + itemHeight : Math.max( referencingFeatureListView.height, itemHeight) //because no additional addEntry item on readOnly
     property int itemHeight: 32 * dp
 
-    border.color: "lightgray"
+    border.color: 'lightgray'
     border.width: 1 * dp
 
     //the model
@@ -47,13 +47,13 @@ Rectangle{
 
       Rectangle{
           anchors.fill: parent
-          color: "lightgrey"
+          color: 'lightgrey'
           visible: !readOnly
 
           Text {
               visible: !readOnly
-              color: "grey"
-              text: !readOnly && !constraintsValid ? qsTr( "Ensure contraints") : ""
+              color: 'grey'
+              text: !readOnly && !constraintsValid ? qsTr( 'Ensure contraints') : ''
               anchors { leftMargin: 10; left: parent.left; right: addButton.left; verticalCenter: parent.verticalCenter }
               font.bold: true
               font.italic: true
@@ -73,7 +73,7 @@ Rectangle{
 
                 contentItem: Rectangle {
                     anchors.fill: parent
-                    color: parent.enabled ? "black" : "grey"
+                    color: parent.enabled ? 'black' : 'grey'
                     Image {
                       anchors.fill: parent
                       anchors.margins: 4 * dp
@@ -88,13 +88,13 @@ Rectangle{
                   if( buffer() ) {
                       //this has to be checked after buffering because the primary could be a value that has been created on creating featurer (e.g. fid)
                       if( relationEditorModel.parentPrimariesAvailable ) {
-                          embeddedFeatureForm.state = "Add"
+                          embeddedFeatureForm.state = 'Add'
                           embeddedFeatureForm.relatedLayer = relationEditorModel.relation.referencingLayer
                           embeddedFeatureForm.active = true
                       }
                       else
                       {
-                          displayToast(qsTr( "Cannot add child. Parent primary keys are not available." ) )
+                          displayToast(qsTr( 'Cannot add child. Parent primary keys are not available.' ) )
                       }
                   }
               }
@@ -119,7 +119,7 @@ Rectangle{
             id: featureText
             anchors { leftMargin: 10 * dp ; left: parent.left; right: deleteButton.left; verticalCenter: parent.verticalCenter }
             font.bold: true
-            color: readOnly ? "grey" : "black"
+            color: readOnly ? 'grey' : 'black'
             text: { text: model.displayString }
           }
 
@@ -127,9 +127,9 @@ Rectangle{
             anchors.fill: parent
 
             onClicked: {
-                embeddedFeatureForm.state = !readOnly ? "Edit" : "ReadOnly"
-                embeddedFeatureForm.relatedFeature = model.referencingFeature //nm not yet activated: associatedRelationId === "" ? model.referencingFeature : model.associatedReferencedFeature
-                embeddedFeatureForm.relatedLayer = relationEditorModel.relation.referencingLayer //nm not yet activated: associatedRelationId === "" ? relationEditorModel.relation.referencingLayer : relationEditorModel.associatedRelation.referencedLayer
+                embeddedFeatureForm.state = !readOnly ? 'Edit' : 'ReadOnly'
+                embeddedFeatureForm.relatedFeature = model.referencingFeature //nm not yet activated: associatedRelationId === '' ? model.referencingFeature : model.associatedReferencedFeature
+                embeddedFeatureForm.relatedLayer = relationEditorModel.relation.referencingLayer //nm not yet activated: associatedRelationId === '' ? relationEditorModel.relation.referencingLayer : relationEditorModel.associatedRelation.referencedLayer
                 embeddedFeatureForm.active = true
             }
           }
@@ -148,7 +148,7 @@ Rectangle{
 
                 contentItem: Rectangle {
                     anchors.fill: parent
-                    color: "black"
+                    color: 'black'
                     Image {
                       anchors.fill: parent
                       anchors.margins: 4 * dp
@@ -171,7 +171,7 @@ Rectangle{
             id: bottomLine
             anchors.bottom: parent.bottom
             height: 1
-            color: "lightGray"
+            color: 'lightGray'
             width: parent.width
           }
         }
@@ -186,12 +186,12 @@ Rectangle{
 
       visible: false
 
-      title: qsTr( "Delete feature %1 on layer %2" ).arg(referencingFeatureId).arg(layerName)
-      text: qsTr( "Should the feature %1 on layer %2").arg(referencingFeatureId).arg( layerName)
+      title: qsTr( 'Delete feature %1 on layer %2' ).arg(referencingFeatureId).arg(layerName)
+      text: qsTr( 'Should the feature %1 on layer %2').arg(referencingFeatureId).arg( layerName)
       standardButtons: StandardButton.Ok | StandardButton.Cancel
       onAccepted: {
         referencingFeatureListView.model.deleteFeature( referencingFeatureId )
-        console.log("delete feature "+referencingFeatureId)
+        console.log('delete feature '+referencingFeatureId)
         visible = false
       }
       onRejected: {
@@ -234,7 +234,7 @@ Rectangle{
 
               featureModel: FeatureModel {
                 currentLayer: relatedLayer
-                feature: state != "Add" ? embeddedFeatureForm.relatedFeature : undefined
+                feature: state != 'Add' ? embeddedFeatureForm.relatedFeature : undefined
                 linkedParentFeature: relationEditorModel.feature
                 linkedRelation: relationEditorModel.relation
               }

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -19,6 +19,7 @@ Frame{
         relation: qgisProject.relationManager.relation(relationId)
         featureId: currentFeatureId
     }
+
     //the list
     ListView {
         id: referencingFeatureListView
@@ -28,7 +29,7 @@ Frame{
         focus: true
         clip: true
 
-        onCurrentItemChanged: model.featureId + ' selected '+currentIndex
+        onCurrentItemChanged: model.referencingFeatureId + ' selected '+currentIndex
     }
 
     //list components
@@ -47,7 +48,7 @@ Frame{
             id: featureText
             anchors { leftMargin: 10; left: parent.left; right: deleteButton.left; verticalCenter: parent.verticalCenter }
             font.bold: true
-            text: { text: model.featureId + ' - ' + model.displayString }
+            text: { text: model.referencingFeatureId + ' - ' + model.displayString }
           }
 
           MouseArea {
@@ -74,7 +75,7 @@ Frame{
               iconSource: Style.getThemeIcon( "ic_delete_forever_white_24dp" )
 
               onClicked: {
-                  deleteDialog.featureId = model.featureId
+                  deleteDialog.referencingFeatureId = model.referencingFeatureId
                   deleteDialog.visible = true
               }
             }
@@ -94,17 +95,17 @@ Frame{
     MessageDialog {
       id: deleteDialog
 
-      property int featureId
+      property int referencingFeatureId
       property var layerName
 
       visible: false
 
-      title: "Delete feature "+featureId+" on layer "+layerName //translation needed
-      text: "Should the feature "+featureId+" on layer "+layerName+" really be deleted?" //translation needed
+      title: "Delete feature "+referencingFeatureId+" on layer "+layerName //translation needed
+      text: "Should the feature "+referencingFeatureId+" on layer "+layerName+" really be deleted?" //translation needed
       standardButtons: StandardButton.Ok | StandardButton.Cancel
       onAccepted: {
-        referencingFeatureListView.model.deleteFeature( featureId )
-        console.log("delete feature "+featureId)
+        referencingFeatureListView.model.deleteFeature( referencingFeatureId )
+        console.log("delete feature "+referencingFeatureId)
         visible = false
       }
       onRejected: {

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -47,12 +47,12 @@ Rectangle{
 
       Rectangle{
           anchors.fill: parent
-          color: "lightgrey"
+          color: constraintsValid ? "lightgrey" : "orange"
 
           Text {
               visible: !readOnly
               color: "grey"
-              text: !readOnly ? qsTr( "Add child feature:" ) : "" //!readOnly && !relationEditorModel.parentPrimariesAvailable ? qsTr( "Save parent feature first..." ) : qsTr( "Add child feature:" )
+              text: !readOnly ? constraintsValid ? qsTr( "Add child feature:" ) : qsTr( "Ensure contraints") : "" //!readOnly && !relationEditorModel.parentPrimariesAvailable ? qsTr( "Save parent feature first..." ) : qsTr( "Add child feature:" )
               anchors { leftMargin: 10; left: parent.left; right: addButton.left; verticalCenter: parent.verticalCenter }
               font.bold: true
               font.italic: true
@@ -85,10 +85,11 @@ Rectangle{
                 }
 
                 onClicked: {
-                  bufferFeature()
-                  embeddedFeatureForm.state = "Add"
-                  embeddedFeatureForm.relatedLayer = relationEditorModel.relation.referencingLayer
-                  embeddedFeatureForm.active = true
+                  if( buffer() ) {
+                      embeddedFeatureForm.state = "Add"
+                      embeddedFeatureForm.relatedLayer = relationEditorModel.relation.referencingLayer
+                      embeddedFeatureForm.active = true
+                  }
               }
             }
           }

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -18,6 +18,7 @@ Frame{
     ReferencingFeatureListModel {
         id: relationEditorModel
         relation: qgisProject.relationManager.relation(relationId)
+        associatedRelation: qgisProject.relationManager.relation(associatedRelationId)
         feature: currentFeature
     }
 

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -89,7 +89,9 @@ Rectangle{
                       //this has to be checked after buffering because the primary could be a value that has been created on creating featurer (e.g. fid)
                       if( relationEditorModel.parentPrimariesAvailable ) {
                           embeddedFeatureForm.state = 'Add'
-                          embeddedFeatureForm.relatedLayer = relationEditorModel.relation.referencingLayer
+                          embeddedAttributeFormModel.featureModel.linkedParentFeature = relationEditorModel.feature
+                          embeddedAttributeFormModel.featureModel.linkedRelation = relationEditorModel.relation
+                          embeddedAttributeFormModel.featureModel.resetAttributes()
                           embeddedFeatureForm.active = true
                       }
                       else
@@ -117,7 +119,7 @@ Rectangle{
 
           Text {
             id: featureText
-            anchors { leftMargin: 10 * dp ; left: parent.left; right: deleteButton.left; verticalCenter: parent.verticalCenter }
+            anchors { leftMargin: 10 * dp ; left: parent.left; right: deleteButtonRow.left; verticalCenter: parent.verticalCenter }
             font.bold: true
             color: readOnly ? 'grey' : 'black'
             text: { text: model.displayString }
@@ -128,8 +130,9 @@ Rectangle{
 
             onClicked: {
                 embeddedFeatureForm.state = !readOnly ? 'Edit' : 'ReadOnly'
-                embeddedFeatureForm.relatedFeature = model.referencingFeature //nm not yet activated: associatedRelationId === '' ? model.referencingFeature : model.associatedReferencedFeature
-                embeddedFeatureForm.relatedLayer = relationEditorModel.relation.referencingLayer //nm not yet activated: associatedRelationId === '' ? relationEditorModel.relation.referencingLayer : relationEditorModel.associatedRelation.referencedLayer
+                embeddedAttributeFormModel.featureModel.linkedParentFeature = relationEditorModel.feature
+                embeddedAttributeFormModel.featureModel.linkedRelation = relationEditorModel.relation
+                embeddedAttributeFormModel.featureModel.feature = model.referencingFeature
                 embeddedFeatureForm.active = true
             }
           }
@@ -200,12 +203,18 @@ Rectangle{
     }
 
     //the add entry stuff
+    AttributeFormModel {
+      id: embeddedAttributeFormModel
+
+      featureModel: FeatureModel {
+        currentLayer: relationEditorModel.relation.referencingLayer
+      }
+    }
+
     Loader {
       id: embeddedFeatureForm
 
       property var state
-      property var relatedFeature
-      property var relatedLayer
 
       sourceComponent: embeddedFeatureFormComponent
       active: false
@@ -229,16 +238,8 @@ Rectangle{
         closePolicy: Popup.CloseOnEscape
 
         FeatureForm {
-            model: AttributeFormModel {
-              id: attributeFormModel
+            model: embeddedAttributeFormModel
 
-              featureModel: FeatureModel {
-                currentLayer: relatedLayer
-                feature: state != 'Add' ? embeddedFeatureForm.relatedFeature : undefined
-                linkedParentFeature: relationEditorModel.feature
-                linkedRelation: relationEditorModel.relation
-              }
-            }
             focus: true
 
             embedded: true

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -101,8 +101,8 @@ Frame{
 
             onClicked: {
                 embeddedFeatureForm.state = !readOnly ? "Edit" : "ReadOnly"
-                embeddedFeatureForm.relatedFeature = associatedRelationId === "" ? model.referencingFeature : model.associatedReferencedFeature
-                embeddedFeatureForm.relatedLayer = associatedRelationId === "" ? relationEditorModel.relation.referencingLayer : relationEditorModel.associatedRelation.referencedLayer
+                embeddedFeatureForm.relatedFeature = model.referencingFeature //nm not yet activated: associatedRelationId === "" ? model.referencingFeature : model.associatedReferencedFeature
+                embeddedFeatureForm.relatedLayer = relationEditorModel.relation.referencingLayer //nm not yet activated: associatedRelationId === "" ? relationEditorModel.relation.referencingLayer : relationEditorModel.associatedRelation.referencedLayer
                 embeddedFeatureForm.active = true
             }
           }

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -10,9 +10,12 @@ import "../js/style.js" as Style
 import org.qfield 1.0
 import org.qgis 1.0
 
-Frame{
-    height: 200
+Rectangle{
+    height: referencingFeatureListView.height + itemHeight
     property int itemHeight: 24 * dp
+
+    border.color: "lightgray"
+    border.width: 1 * dp
 
     //the model
     ReferencingFeatureListModel {
@@ -25,9 +28,9 @@ Frame{
     //the list
     ListView {
         id: referencingFeatureListView
-        width: parent.width
-        height: parent.height - itemHeight
         model: relationEditorModel
+        width: parent.width
+        height: Math.min( 5 * itemHeight, referencingFeatureListView.count * itemHeight )
         delegate: referencingFeatureDelegate
         focus: true
         clip: true
@@ -49,7 +52,7 @@ Frame{
           Text {
               visible: !readOnly
               color: "grey"
-              text: !readOnly && !relationEditorModel.parentPrimariesAvailable ? "Save parent feature first..." : "Add child feature..."
+              text: !readOnly && !relationEditorModel.parentPrimariesAvailable ? qsTr( "Save parent feature first..." ) : qsTr( "Add child feature:" )
               anchors { leftMargin: 10; left: parent.left; right: addButton.left; verticalCenter: parent.verticalCenter }
               font.bold: true
               font.italic: true

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -13,6 +13,12 @@ import org.qgis 1.0
 Frame{
     height: 200
 
+    //the model
+    ReferencingFeatureListModel {
+        id: relationEditorModel
+        relation: qgisProject.relationManager.relation(relationId)
+        featureId: currentFeatureId
+    }
     //the list
     ListView {
         id: referencingFeatureListView
@@ -97,7 +103,7 @@ Frame{
       text: "Should the feature "+featureId+" on layer "+layerName+" really be deleted?" //translation needed
       standardButtons: StandardButton.Ok | StandardButton.Cancel
       onAccepted: {
-        relationEditorModel.deleteFeature( featureId )
+        referencingFeatureListView.model.deleteFeature( featureId )
         console.log("delete feature "+featureId)
         visible = false
       }

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -136,12 +136,12 @@ Rectangle{
 
           Row
           {
-            id: deleteRow
+            id: deleteButtonRow
             anchors { top: parent.top; right: parent.right }
             height: listitem.height
 
             ToolButton {
-                id: deleteButtonRow
+                id: deleteButton
                 width: parent.height
                 height: parent.height
                 visible: !readOnly

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -43,14 +43,6 @@ Frame{
 
       focus: true
 
-      Text {
-        id: addEntryText
-        anchors { leftMargin: 10; left: parent.left; right: addButton.left; verticalCenter: parent.verticalCenter }
-        font.bold: true
-        color: "gray"
-        text: { text: "Add entry" }
-      }
-
       Row
       {
         id: editRow
@@ -188,6 +180,7 @@ Frame{
         closePolicy: Popup.CloseOnEscape
 
         FeatureForm {
+          predefinedValue: predefinedValue+{'name':'sensor_point_id', 'value':1 } //{'name':relationEditorModel.relation.referencingField, 'value':relationEditorModel.feature.attribute(relationEditorModel.relation.referencedField) }
           model: AttributeFormModel {
             id: attributeFormModel
 
@@ -195,7 +188,6 @@ Frame{
               currentLayer: relationEditorModel.relation.referencingLayer
               feature: state === "Edit" ? embeddedFeatureForm.referencingFeature : undefined
             }
-            //pass the id as FK
           }
 
           toolbarVisible: true

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -11,7 +11,7 @@ import org.qfield 1.0
 import org.qgis 1.0
 
 Frame{
-    height: 100
+    height: 200
 
     //the list
     ListView {

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -12,7 +12,7 @@ import org.qgis 1.0
 
 Frame{
     height: 200
-    property int itemHeight: 24*dp
+    property int itemHeight: 24 * dp
 
     //the model
     ReferencingFeatureListModel {
@@ -49,18 +49,29 @@ Frame{
         anchors { top: parent.top; right: parent.right }
         height: parent.height
 
-        Button {
-          id: addButton
-          width: parent.height
-          height: parent.height
-          visible: true
+        ToolButton {
+            id: addButton
+            width: parent.height
+            height: parent.height
+            visible: true
 
-          iconSource: Style.getThemeIcon( "ic_add_white_24dp" )
+            contentItem: Rectangle {
+                anchors.fill: parent
+                color: "black"
+                Image {
+                  anchors.fill: parent
+                  anchors.margins: 4 * dp
+                  fillMode: Image.PreserveAspectFit
+                  horizontalAlignment: Image.AlignHCenter
+                  verticalAlignment: Image.AlignVCenter
+                  source: Style.getThemeIcon( 'ic_add_white_24dp' )
+                }
+            }
 
-          onClicked: {
-            embeddedFeatureForm.state = "Add"
-            embeddedFeatureForm.active = true
-          }
+            onClicked: {
+              embeddedFeatureForm.state = "Add"
+              embeddedFeatureForm.active = true
+            }
         }
       }
     }
@@ -100,20 +111,29 @@ Frame{
             anchors { top: parent.top; right: parent.right }
             height: listitem.height
 
-            Button {
-              id: deleteButton
+            ToolButton {
+                id: deleteButton
+                width: parent.height
+                height: parent.height
+                visible: true
 
-              width: parent.height
-              height: parent.height
+                contentItem: Rectangle {
+                    anchors.fill: parent
+                    color: "black"
+                    Image {
+                      anchors.fill: parent
+                      anchors.margins: 4 * px
+                      fillMode: Image.PreserveAspectFit
+                      horizontalAlignment: Image.AlignHCenter
+                      verticalAlignment: Image.AlignVCenter
+                      source: Style.getThemeIcon( 'ic_delete_forever_white_24dp' )
+                    }
+                }
 
-              visible: true
-
-              iconSource: Style.getThemeIcon( "ic_delete_forever_white_24dp" )
-
-              onClicked: {
-                  deleteDialog.referencingFeatureId = model.referencingFeatureId
-                  deleteDialog.visible = true
-              }
+                onClicked: {
+                    deleteDialog.referencingFeatureId = model.referencingFeatureId
+                    deleteDialog.visible = true
+                }
             }
           }
 

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -197,7 +197,7 @@ Frame{
         x: 24 * dp
         y: 24 * dp
         width: parent.width - 48 * dp
-        height: parent.width - 48 * dp
+        height: parent.height - 48 * dp
         modal: true
         closePolicy: Popup.CloseOnEscape
 

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -21,7 +21,7 @@ Rectangle{
     ReferencingFeatureListModel {
         id: relationEditorModel
         relation: qgisProject.relationManager.relation(relationId)
-        associatedRelation: qgisProject.relationManager.relation(associatedRelationId)
+        nmRelation: qgisProject.relationManager.relation(nmRelationId)
         feature: currentFeature
     }
 

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -52,7 +52,7 @@ Rectangle{
           Text {
               visible: !readOnly
               color: "grey"
-              text: !readOnly && !relationEditorModel.parentPrimariesAvailable ? qsTr( "Save parent feature first..." ) : qsTr( "Add child feature:" )
+              text: !readOnly ? qsTr( "Add child feature:" ) : "" //!readOnly && !relationEditorModel.parentPrimariesAvailable ? qsTr( "Save parent feature first..." ) : qsTr( "Add child feature:" )
               anchors { leftMargin: 10; left: parent.left; right: addButton.left; verticalCenter: parent.verticalCenter }
               font.bold: true
               font.italic: true
@@ -69,7 +69,7 @@ Rectangle{
                 width: parent.height
                 height: parent.height
                 visible: !readOnly
-                enabled: !readOnly && relationEditorModel.parentPrimariesAvailable
+                enabled: !readOnly // !readOnly && relationEditorModel.parentPrimariesAvailable
 
                 contentItem: Rectangle {
                     anchors.fill: parent
@@ -85,6 +85,7 @@ Rectangle{
                 }
 
                 onClicked: {
+                  bufferFeature()
                   embeddedFeatureForm.state = "Add"
                   embeddedFeatureForm.relatedLayer = relationEditorModel.relation.referencingLayer
                   embeddedFeatureForm.active = true

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -11,8 +11,8 @@ import org.qfield 1.0
 import org.qgis 1.0
 
 Rectangle{
-    height: !readOnly ? referencingFeatureListView.height + itemHeight : referencingFeatureListView.height //because no additional addEntry item on readOnly
-    property int itemHeight: 24 * dp
+    height: !readOnly ? referencingFeatureListView.height + itemHeight : Math.max( referencingFeatureListView.height, itemHeight) //because no additional addEntry item on readOnly
+    property int itemHeight: 32 * dp
 
     border.color: "lightgray"
     border.width: 1 * dp
@@ -117,7 +117,7 @@ Rectangle{
 
           Text {
             id: featureText
-            anchors { leftMargin: 10; left: parent.left; right: deleteButton.left; verticalCenter: parent.verticalCenter }
+            anchors { leftMargin: 10 * dp ; left: parent.left; right: deleteButton.left; verticalCenter: parent.verticalCenter }
             font.bold: true
             color: readOnly ? "grey" : "black"
             text: { text: model.displayString }
@@ -151,7 +151,7 @@ Rectangle{
                     color: "black"
                     Image {
                       anchors.fill: parent
-                      anchors.margins: 4 * px
+                      anchors.margins: 4 * dp
                       fillMode: Image.PreserveAspectFit
                       horizontalAlignment: Image.AlignHCenter
                       verticalAlignment: Image.AlignVCenter

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -159,8 +159,8 @@ Frame{
 
       visible: false
 
-      title: "Delete feature "+referencingFeatureId+" on layer "+layerName //translation needed
-      text: "Should the feature "+referencingFeatureId+" on layer "+layerName+" really be deleted?" //translation needed
+      title: qsTr( "Delete feature %1 on layer %2" ).arg(referencingFeatureId).arg(layerName)
+      text: qsTr( "Should the feature %1 on layer %2").arg(referencingFeatureId).arg( layerName)
       standardButtons: StandardButton.Ok | StandardButton.Cancel
       onAccepted: {
         referencingFeatureListView.model.deleteFeature( referencingFeatureId )

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -186,8 +186,8 @@ Frame{
             featureModel: FeatureModel {
               currentLayer: relationEditorModel.relation.referencingLayer
               feature: state === "Edit" ? embeddedFeatureForm.referencingFeature : undefined
-              linkedParentFeature: state === "Add" ? relationEditorModel.feature : undefined
-              linkedRelation: state === "Add" ? relationEditorModel.relation : undefined
+              linkedParentFeature: relationEditorModel.feature
+              linkedRelation: relationEditorModel.relation
             }
           }
 

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -89,7 +89,7 @@ Rectangle{
                   embeddedFeatureForm.state = "Add"
                   embeddedFeatureForm.relatedLayer = relationEditorModel.relation.referencingLayer
                   embeddedFeatureForm.active = true
-                }
+              }
             }
           }
       }

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -30,8 +30,6 @@ Frame{
         delegate: referencingFeatureDelegate
         focus: true
         clip: true
-
-        onCurrentItemChanged: model.referencingFeatureId + ' selected '+currentIndex
     }
 
     //the add entry "last row"
@@ -132,7 +130,7 @@ Frame{
                 }
 
                 onClicked: {
-                    deleteDialog.referencingFeatureId = model.referencingFeatureId
+                    deleteDialog.referencingFeatureId = model.referencingFeature.id
                     deleteDialog.visible = true
                 }
             }

--- a/src/qml/editorwidgets/RelationReference.qml
+++ b/src/qml/editorwidgets/RelationReference.qml
@@ -125,6 +125,7 @@ Item {
       iconSource: Style.getThemeIcon( "ic_add_black_48dp" )
       bgcolor: "white"
       onClicked: {
+        attributeFormModel.featureModel.resetAttributes()
         addFeatureForm.active = true
       }
     }
@@ -135,6 +136,13 @@ Item {
       text: qsTr( "Invalid relation")
       color: "red"
     }
+  }
+
+  AttributeFormModel {
+   id: attributeFormModel
+   featureModel: FeatureModel {
+       currentLayer: relationReference._relation.referencedLayer
+     }
   }
 
   Loader {
@@ -161,13 +169,7 @@ Item {
       closePolicy: Popup.CloseOnEscape
 
       FeatureForm {
-        model: AttributeFormModel {
-          id: attributeFormModel
-
-          featureModel: FeatureModel {
-            currentLayer: relationReference._relation.referencedLayer
-          }
-        }
+        model: attributeFormModel
 
         anchors.fill: parent
 

--- a/src/qml/editorwidgets/RelationReference.qml
+++ b/src/qml/editorwidgets/RelationReference.qml
@@ -155,7 +155,7 @@ Item {
       x: 24 * dp
       y: 24 * dp
       width: parent.width - 48 * dp
-      height: parent.width - 48 * dp
+      height: parent.height - 48 * dp
       modal: true
       focus: true
       closePolicy: Popup.CloseOnEscape

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -43,7 +43,4 @@
         <file>GeometryHighlighter.qml</file>
         <file>FeatureListSelectionHighlight.qml</file>
     </qresource>
-    <qresource prefix="/">
-        <file>editorwidgets/RelationEditor.qml</file>
-    </qresource>
 </RCC>


### PR DESCRIPTION
# Still in working progress
(only opened to have the apks built)

## Relation Editor Widget basics
- Display relations as widgets
- Pass to the widget the parent feature and the relation id
- Delete child feature
- Delete childs when parent is deleted
- Link parent feature to child - use the parents pk on adding as fk and hide this attribute
- "Buffer" parent when adding child and delete buffered feature on cancel

## Relation Editor Widget n:m
- Pass to the widget the associated relation id

# Stuff to do later
- [x] widget only in edit mode swipable
- [x] fk widget in referencing feature should be invisible () `item->setData( true, AttributeFormModel::CurrentlyVisible )`
- [x] rembember values are not used on adding referencing feature  (neighter it is in RelationReference widget - care for functionality in `FeatureModel::resetAttributes()`
- [x] nested Relations (at the moment read only)
- [x] nm Relation (partly prepared and uncommented by `//nm not yet activated` see #568

# Stuff important to do later
- [x] NULL FKs relates to NULL PKs - not good
- [x] only add child, when there is a pk in parent
- [x] Threading to improve performance
- [x] Delete children when deleted parent
- [x] Datetime Widget broken on forms with relation
- [x] Adding not possible 

## Some additional fixes:
- [x] fix size of embedded form
- [x] improve buttons and colors of embedded forms
- [ ] get widgettype by datatype

## Else
- [ ] Unittests
- [ ] Documentations
