### PR TITLE
update ANDROID_TARGET_ARCH suffix as short time solution

### DIFF
--- a/version.pri
+++ b/version.pri
@@ -8,14 +8,15 @@ CODENAME = 'M...'
 
 VERSION = '$${VERSION_MAJOR}.$${VERSION_MINOR}.$${VERSION_FIX}'
 
+# suffix 1 and 2 are used for the android 5 builds
 ANDROID_VERSION_SUFFIX = 0
 ANDROID_TARGET_ARCH = $$ANDROID_TARGET_ARCH$$
 
 equals ( ANDROID_TARGET_ARCH, 'armeabi-v7a' ) {
-  ANDROID_VERSION_SUFFIX = 1
+  ANDROID_VERSION_SUFFIX = 3
 }
 equals ( ANDROID_TARGET_ARCH, 'x86' ) {
-  ANDROID_VERSION_SUFFIX = 2
+  ANDROID_VERSION_SUFFIX = 4
 }
 
 VERSIONCODE = $$format_number($$format_number($${VERSION_MAJOR}, width=2 zeropad)$$format_number($${VERSION_MINOR}, width=2 zeropad)$$format_number($${VERSION_FIX}, width=2 zeropad)$$format_number($${VERSION_RC}, width=2 zeropad)$$format_number($${ANDROID_VERSION_SUFFIX}))


### PR DESCRIPTION
we might consider changing the versionCode schema
if we keep on shipping multiple apks
see:
https://developer.android.com/google/play/publishing/multiple-apks.html#VersionCodes