### PR TITLE
Refactor unzip assets

### DIFF
--- a/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -60,7 +60,6 @@ import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.AssetManager;
-import android.content.res.AssetFileDescriptor;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -196,7 +195,6 @@ public class QFieldActivity extends Activity {
     } else {
       // this is a first run after install or update
       mUnzipTask.execute("assets.zip");
-
     }
   }
 
@@ -246,7 +244,6 @@ public class QFieldActivity extends Activity {
           Log.d(QtTAG, "Exctract zip file asset: "+zipFile);
           InputStream is = getAssets().open(zipFile);
           ZipInputStream zis = new ZipInputStream(new BufferedInputStream(is));
-          //int totalSize = (int) new File(zipFile).length();
           long totalSize = is.available();
           float currentSize = 0;
           float percent = 0;

--- a/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -36,9 +36,12 @@ package ch.opengis.qfield;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.Thread;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -57,6 +60,7 @@ import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.AssetManager;
+import android.content.res.AssetFileDescriptor;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -192,6 +196,7 @@ public class QFieldActivity extends Activity {
     } else {
       // this is a first run after install or update
       mUnzipTask.execute("assets.zip");
+
     }
   }
 
@@ -228,68 +233,57 @@ public class QFieldActivity extends Activity {
   }
 
   private class UnzipTask extends AsyncTask<String, Integer, String> {
-    protected String doInBackground(String... urlString) {
-      extractFolder(urlString[0]);
-      return null;
-    }
-
-    private void extractFolder(String zipFile) {
-      boolean success = false;
-      while (!success) {
-        AssetManager assets = getAssets();
-        int BUFFER = 2048;
-        String newPath = getFilesDir().toString() + "/";
-        InputStream is;
-        ZipInputStream zis;
-
-        try {
-          String filename;
-          is = assets.open(zipFile);
-          double totalSize = is.available();
-          zis = new ZipInputStream(new BufferedInputStream(is));
-          ZipEntry ze;
-          byte[] buffer = new byte[1024];
-          int count;
-
-          success = true;
-          while ((ze = zis.getNextEntry()) != null) {
-            filename = ze.getName();
-
-            // Need to create directories if not exists, or
-            // it will generate an Exception...
-            if (ze.isDirectory()) {
-               File fmd = new File(newPath + filename);
-               fmd.mkdirs();
-               continue;
-            }
-
-            FileOutputStream fout = new FileOutputStream(newPath + filename);
-
-            while ((count = zis.read(buffer)) != -1) {
-                fout.write(buffer, 0, count);
-            }
-
-            fout.close();
-            File outFile = new File(newPath + filename);
-            if (!outFile.exists()) {
-              Log.i(QtTAG, "File could not be created: " + newPath + filename);
-              success = false;
-            }
-            else
-              Log.i(QtTAG, "File unzipped: " + newPath + filename);
-            zis.closeEntry();
-            double currentSize = is.available();
-            double percent = 100 - currentSize / totalSize * 100;
-            Log.i(QtTAG, "Percent:" + percent);
-            publishProgress((int) percent);
+      protected String doInBackground(String... urlString) {
+          try{
+              extractZipFile(urlString[0]);
+          }catch (Exception e){
+              e.printStackTrace();
           }
-        }
-        catch(IOException e)
-        {
-           e.printStackTrace();
-        }
+          return null;
       }
-    }
+
+      private void extractZipFile(String zipFile) throws IOException, InterruptedException{
+          Log.d(QtTAG, "Exctract zip file asset: "+zipFile);
+          InputStream is = getAssets().open(zipFile);
+          ZipInputStream zis = new ZipInputStream(new BufferedInputStream(is));
+          //int totalSize = (int) new File(zipFile).length();
+          long totalSize = is.available();
+          float currentSize = 0;
+          float percent = 0;
+          try {
+              Thread.sleep(2500);
+              ZipEntry ze;
+              int count;
+              byte[] buffer = new byte[8192];
+              while ((ze = zis.getNextEntry()) != null) {
+                  File file = new File(getFilesDir(), ze.getName());
+                  File dir = ze.isDirectory() ? file : file.getParentFile();
+                  if (!dir.isDirectory() && !dir.mkdirs())
+                      throw new FileNotFoundException("Failed to ensure directory: " + dir.getAbsolutePath());
+                  if (ze.isDirectory())
+                      continue;
+                  FileOutputStream fout = new FileOutputStream(file);
+                  try {
+                      while ((count = zis.read(buffer)) != -1)
+                          fout.write(buffer, 0, count);
+                  } finally {
+                      fout.close();
+                  }
+                  currentSize = is.available();
+
+                  // 108 instead of 100 beacuse the is.available() is not accurate on large files and with
+                  // 108 we have a 100% when the unzip is finished
+                  percent = 108 - currentSize / totalSize * 100;
+                  publishProgress((int) percent);
+
+                  Log.d(QtTAG, "File unzipped: " + file.getPath());
+                  Log.d(QtTAG, "Exists: " + file.exists());
+                  Log.d(QtTAG, "Percent: " + percent);
+              }
+          } finally {
+              zis.close();
+          }
+      }
 
     protected void onPreExecute() {
       showDialog(PROGRESS_DIALOG);


### PR DESCRIPTION
- Refactor unzip assets
- Fix unzip progression percent that now goes up to 100% and not only 92%
- Add a sleep before unzip to allow old devices to be ready before files are written