### PR TITLE
Checkbox widget with boolean fields

### DIFF
--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -12,17 +12,18 @@ Item {
 
   CheckBox {
     property var currentValue: value
+    property bool isBool: value === true || value === false
 
-    checked: value == config['CheckedState']
+    checked: isBool ? value : value === config['CheckedState']
 
     onCheckedChanged: {
-      valueChanged( checked ? config['CheckedState'] : config['UncheckedState'], false )
+      valueChanged( isBool ? checked : checked ? config['CheckedState'] : config['UncheckedState'], false )
       forceActiveFocus()
     }
 
     // Workaround to get a signal when the value has changed
     onCurrentValueChanged: {
-      checked = currentValue == config['CheckedState']
+      checked = isBool ? currentValue : currentValue === config['CheckedState']
     }
 
     indicator.height: 16 * dp

--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -12,7 +12,8 @@ Item {
 
   CheckBox {
     property var currentValue: value
-    property bool isBool: value === true || value === false
+    //if the field type is boolean, ignore the configured 'CheckedState' and 'UncheckedState' values and work with true/false always
+    property bool isBool: field.type == 1
 
     checked: isBool ? value : value === config['CheckedState']
 

--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -13,7 +13,7 @@ Item {
   CheckBox {
     property var currentValue: value
     //if the field type is boolean, ignore the configured 'CheckedState' and 'UncheckedState' values and work with true/false always
-    property bool isBool: field.type == 1
+    readonly property bool isBool: field.type == 1
 
     checked: isBool ? value : value === config['CheckedState']
 


### PR DESCRIPTION
Checkbox has been not working for Boolean fields (only for other fields used as checkbox) I believe this issue existed since we used QGIS 3.0.

Because since then the widget needs to decide if the value is a boolean or we use a representing value.
This is done in the QGIS widget here: https://github.com/qgis/QGIS/blob/master/src/gui/editorwidgets/qgscheckboxwidgetwrapper.cpp#L29-L35

I did it now in the Checkbox widget here as well. 

Since I guess I'm not able to request a type in QML I did it like this. Another possibility would be to request the value over the model, but probably that would be an overkill as well. What do you think  @m-kuhn ?