### PR TITLE
Close featurelist (featureform) drawer on opening new project

### DIFF
--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -394,6 +394,12 @@ Rectangle {
     target: iface
 
     onLoadProjectEnded: {
+        if( state != "FeatureList" ) {
+          if( featureListToolBar.state === "Edit"){
+            featureListToolBar.cancel()
+          }
+          state = "FeatureList"
+        }
         state = "Hidden"
     }
   }

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -389,7 +389,8 @@ Rectangle {
     }
   }
 
-  //if project changed we should hide drawer - it makes a pedal back not to effect any issues (except resetting the featuremodel because it possibly changed meanwhile)
+  //if project changed we should hide drawer in case it's still open with old values
+  //it pedals back, "simulates" a cancel without touching anything, but does not reset the model
   Connections {
     target: iface
 

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -389,14 +389,15 @@ Rectangle {
     }
   }
 
-  //if project changed we should hide drawer
+  //if project changed we should hide drawer - it makes a pedal back not to effect any issues (except resetting the featuremodel because it possibly changed meanwhile)
   Connections {
     target: iface
 
     onLoadProjectEnded: {
         if( state != "FeatureList" ) {
           if( featureListToolBar.state === "Edit"){
-            featureListToolBar.cancel()
+              featureForm.state = "FeatureForm"
+              displayToast( qsTr( "Changes discarded" ) )
           }
           state = "FeatureList"
         }

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -38,7 +38,6 @@ Rectangle {
 
   width: props.isVisible ? qfieldSettings.fullScreenIdentifyView || parent.width<300*dp ? parent.width : Math.min(Math.max(200*dp, parent.width/3), parent.width) : 0
 
-
   states: [
     State {
       name: "Hidden"
@@ -387,6 +386,15 @@ Rectangle {
     }
     onRejected: {
       visible = false
+    }
+  }
+
+  //if project changed we should hide drawer
+  Connections {
+    target: iface
+
+    onLoadProjectEnded: {
+        state = "Hidden"
     }
   }
 }


### PR DESCRIPTION
Be aware, if you are in the middle of editing a feature, this edits are lost. There is a error message in the log.
![image](https://user-images.githubusercontent.com/28384354/54987554-16b2c400-4fb5-11e9-95d3-6c86d621172a.png)
But IMO this is not a bad way of work. In case someone opens a project during editing a feature I guess he doesn't need to save that. And he get's informed as well...