### PR TITLE
Add day when it sets time back

### DIFF
--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -187,6 +187,8 @@ Item {
               newDate.setMinutes(0)
               newDate.setSeconds(0)
               newDate.setMilliseconds(0)
+              // because this sets us back one day we add one day
+              newDate.setDate(newDate.getDate()+1)
 
               if ( main.isDateTimeType )
               {

--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -183,12 +183,6 @@ Item {
             onClicked: {
               // weird, selectedDate seems to be set at time 12:00:00
               var newDate = calendar.selectedDate
-              newDate.setHours(0)
-              newDate.setMinutes(0)
-              newDate.setSeconds(0)
-              newDate.setMilliseconds(0)
-              // because this sets us back one day we add one day
-              newDate.setDate(newDate.getDate()+1)
 
               if ( main.isDateTimeType )
               {


### PR DESCRIPTION
When we selected a day, it stored one day before. This because the time is set to 0:00:00.
Now with adding a day we have the correct date.

Not sure if this is the correct way to solve the issue. What do you think @3nids ?