### PR TITLE
Android 5 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - gem --version
 
 script:
-  - export QFIELD_SDK_VERSION=20190306
+  - export QFIELD_SDK_VERSION=${QFIELD_SDK_VERSION:-20190306}
   - echo "travis_fold:start:docker-pull"
   - docker pull opengisch/qfield-sdk:${QFIELD_SDK_VERSION}
   - echo "travis_fold:end:docker-pull"
@@ -40,14 +40,32 @@ jobs:
         - docker-compose -f .docker/testing/docker-compose-travis.yml run qgis /usr/src/.docker/testing/build-test.sh
       if: type = pull_request OR tag IS present OR branch = master
     - stage: test
-      name: "📱 build ARMv7"
+      name: "📱 Build ARMv7"
       env:
         - ARCH=armv7
       if: type = pull_request OR tag IS present OR branch = master
     - stage: test
-      name: "☎ build X86"
+      name: "📱 Build X86"
       env:
         - ARCH=x86
+      if: type = pull_request OR tag IS present OR branch = master
+    - stage: test
+      name: "☎  Build ARMv7 Android 5"
+      env:
+        - QFIELD_SDK_VERSION=20190128
+        - ARCH=armv7
+        - ANDROID_VERSION=5
+      before_script:
+        - patch -p1 < scripts/ci/android-5.patch
+      if: type = pull_request OR tag IS present OR branch = master
+    - stage: test
+      name: "☎  Build X86"
+      env:
+        - QFIELD_SDK_VERSION=20190128
+        - ANDROID_VERSION=5
+        - ARCH=x86
+      before_script:
+        - patch -p1 < scripts/ci/android-5.patch
       if: type = pull_request OR tag IS present OR branch = master
     - stage: deploy
       name: "🍺 Deploy"

--- a/scripts/ci/android-5.patch
+++ b/scripts/ci/android-5.patch
@@ -1,0 +1,129 @@
+From 0cc8663a08ef211b916abcdfb66c6af74b3442d7 Mon Sep 17 00:00:00 2001
+From: Marco Bernasocchi <marco@opengis.ch>
+Date: Tue, 26 Mar 2019 19:58:25 +0100
+Subject: [PATCH] Patch for Android 5 deployment
+
+---
+ android/AndroidManifest.xml           | 2 +-
+ qfield.pri                            | 2 ++
+ src/core/expressionvariablemodel.cpp  | 1 -
+ src/core/featureslocatorfilter.cpp    | 1 -
+ src/core/identifytool.cpp             | 1 -
+ src/core/multifeaturelistmodel.cpp    | 1 -
+ src/qgsquick/qgsquickmapcanvasmap.cpp | 1 -
+ version.pri                           | 4 ++--
+ 8 files changed, 5 insertions(+), 8 deletions(-)
+
+diff --git a/android/AndroidManifest.xml b/android/AndroidManifest.xml
+index 6e0f0459..541832d6 100644
+--- a/android/AndroidManifest.xml
++++ b/android/AndroidManifest.xml
+@@ -74,7 +74,7 @@
+     <activity android:name="ch.opengis.qfield.QFieldAppRaterActivity" />
+ 
+   </application>
+-  <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="26" />
++  <uses-sdk android:minSdkVersion="21" android:maxSdkVersion="22"  android:targetSdkVersion="26" />
+   <supports-screens android:largeScreens="true" android:normalScreens="true" android:anyDensity="true" android:smallScreens="true"/>
+ 
+   <!-- The permissions are specified manually. This way we do not request the microphone permissions which would be pulled in
+diff --git a/qfield.pri b/qfield.pri
+index bcc732b6..55b03c95 100644
+--- a/qfield.pri
++++ b/qfield.pri
+@@ -12,6 +12,7 @@ android {
+     $${OSGEO4A_STAGE_DIR}/$$ANDROID_TARGET_ARCH$$/include/qgis
+ 
+   ANDROID_EXTRA_LIBS = \
++    $${OSGEO4A_STAGE_DIR}/$$ANDROID_TARGET_ARCH$$/lib/libcrystax.so \
+     $${OSGEO4A_STAGE_DIR}/$$ANDROID_TARGET_ARCH$$/lib/libssl.so \
+     $${OSGEO4A_STAGE_DIR}/$$ANDROID_TARGET_ARCH$$/lib/libcrypto.so \
+     $${OSGEO4A_STAGE_DIR}/$$ANDROID_TARGET_ARCH$$/lib/libexpat.so \
+@@ -49,6 +50,7 @@ android {
+     $$QT_LIBS_DIR/libQt5Sensors.so \
+     $$QT_LIBS_DIR/libQt5Sql.so \
+     $$QT_LIBS_DIR/libQt5Svg.so \
++    $$QT_LIBS_DIR/libQt5SerialPort.so \
+     $$QT_LIBS_DIR/libQt5PrintSupport.so
+ }
+ 
+diff --git a/src/core/expressionvariablemodel.cpp b/src/core/expressionvariablemodel.cpp
+index 31df1232..bdfcc229 100644
+--- a/src/core/expressionvariablemodel.cpp
++++ b/src/core/expressionvariablemodel.cpp
+@@ -16,7 +16,6 @@
+ 
+ #include <expressionvariablemodel.h>
+ #include <qgsexpressioncontext.h>
+-#include <qgsexpressioncontextutils.h>
+ 
+ 
+ #include <QSettings>
+diff --git a/src/core/featureslocatorfilter.cpp b/src/core/featureslocatorfilter.cpp
+index d5b65c03..0a2f4ea5 100644
+--- a/src/core/featureslocatorfilter.cpp
++++ b/src/core/featureslocatorfilter.cpp
+@@ -23,7 +23,6 @@
+ #include <qgsvectorlayer.h>
+ #include <qgsmaplayermodel.h>
+ #include <qgsfeedback.h>
+-#include <qgsexpressioncontextutils.h>
+ 
+ #include "locatormodelsuperbridge.h"
+ #include "qgsquickmapsettings.h"
+diff --git a/src/core/identifytool.cpp b/src/core/identifytool.cpp
+index d87cc8f5..2ab70fcb 100644
+--- a/src/core/identifytool.cpp
++++ b/src/core/identifytool.cpp
+@@ -21,7 +21,6 @@
+ #include <qgsvectorlayer.h>
+ #include <qgsproject.h>
+ #include <qgsrenderer.h>
+-#include <qgsexpressioncontextutils.h>
+ 
+ IdentifyTool::IdentifyTool( QObject *parent )
+   : QObject( parent )
+diff --git a/src/core/multifeaturelistmodel.cpp b/src/core/multifeaturelistmodel.cpp
+index d53bdd2d..8869625d 100644
+--- a/src/core/multifeaturelistmodel.cpp
++++ b/src/core/multifeaturelistmodel.cpp
+@@ -20,7 +20,6 @@
+ #include <qgsproject.h>
+ #include <qgsgeometry.h>
+ #include <qgscoordinatereferencesystem.h>
+-#include <qgsexpressioncontextutils.h>
+ #include <qgsrelationmanager.h>
+ 
+ #include "multifeaturelistmodel.h"
+diff --git a/src/qgsquick/qgsquickmapcanvasmap.cpp b/src/qgsquick/qgsquickmapcanvasmap.cpp
+index 4d807c2a..8e680fb6 100644
+--- a/src/qgsquick/qgsquickmapcanvasmap.cpp
++++ b/src/qgsquick/qgsquickmapcanvasmap.cpp
+@@ -22,7 +22,6 @@
+ #include <qgspallabeling.h>
+ #include <qgsproject.h>
+ #include <qgsvectorlayer.h>
+-#include <qgsexpressioncontextutils.h>
+ #include <qgis.h>
+ 
+ #include "qgsquickmapcanvasmap.h"
+diff --git a/version.pri b/version.pri
+index de58df09..4179f690 100644
+--- a/version.pri
++++ b/version.pri
+@@ -13,10 +13,10 @@ ANDROID_VERSION_SUFFIX = 0
+ ANDROID_TARGET_ARCH = $$ANDROID_TARGET_ARCH$$
+ 
+ equals ( ANDROID_TARGET_ARCH, 'armeabi-v7a' ) {
+-  ANDROID_VERSION_SUFFIX = 3
++  ANDROID_VERSION_SUFFIX = 1
+ }
+ equals ( ANDROID_TARGET_ARCH, 'x86' ) {
+-  ANDROID_VERSION_SUFFIX = 4
++  ANDROID_VERSION_SUFFIX = 2
+ }
+ 
+ VERSIONCODE = $$format_number($$format_number($${VERSION_MAJOR}, width=2 zeropad)$$format_number($${VERSION_MINOR}, width=2 zeropad)$$format_number($${VERSION_FIX}, width=2 zeropad)$$format_number($${VERSION_RC}, width=2 zeropad)$$format_number($${ANDROID_VERSION_SUFFIX}))
+-- 
+2.21.0
+

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,22 +6,24 @@ source scripts/travis_env.sh
 if [[ ${TRAVIS_SECURE_ENV_VARS} = true ]]; then
   if [ ${TRAVIS_PULL_REQUEST} != false ]; then
     echo -e "\e[31mDeploying app to pull request\e[0m"
-    curl -u m-kuhn:${GITHUB_API_TOKEN} -X POST --data '{"body": "Uploaded test apks for [armv7](https://download.opengis.ch/qfield/ci-builds/qfield-dev-'${UPLOAD_ARTIFACT_ID}'-'${TRAVIS_COMMIT}'-armv7.apk) and [x86](https://download.opengis.ch/qfield/ci-builds/qfield-dev-'${UPLOAD_ARTIFACT_ID}'-'${TRAVIS_COMMIT}'-x86.apk)"}' https://api.github.com/repos/opengisch/QField/issues/${TRAVIS_PULL_REQUEST}/comments
+    curl -u m-kuhn:${GITHUB_API_TOKEN} -X POST --data '{"body": "Uploaded test apks for [armv7](https://download.opengis.ch/qfield/ci-builds/qfield-dev-'${UPLOAD_ARTIFACT_ID}'-'${TRAVIS_COMMIT}'-armv7-X.apk) and [x86](https://download.opengis.ch/qfield/ci-builds/qfield-dev-'${UPLOAD_ARTIFACT_ID}'-'${TRAVIS_COMMIT}'-x86-X.apk) (Android 5: [armv7](https://download.opengis.ch/qfield/ci-builds/qfield-dev-'${UPLOAD_ARTIFACT_ID}'-'${TRAVIS_COMMIT}'-armv7-5.apk) and [x86](https://download.opengis.ch/qfield/ci-builds/qfield-dev-'${UPLOAD_ARTIFACT_ID}'-'${TRAVIS_COMMIT}'-x86-5.apk))"}' https://api.github.com/repos/opengisch/QField/issues/${TRAVIS_PULL_REQUEST}/comments
   elif [[ -n ${TRAVIS_TAG} ]]; then
     echo -e "\e[93;1mStarting to deploy a new release\e[0m"
     openssl aes-256-cbc -K $encrypted_play_upload_key -iv $encrypted_play_upload_iv -in .ci/play_developer.p12.enc -out .ci/play_developer.p12 -d
     echo -e "\e[93m * Collecting apks to upload...\e[0m"
-    curl -L -s -S -o /tmp/qfield-${TRAVIS_TAG}-armv7.apk https://download.opengis.ch/qfield/ci-builds/qfield-dev-${UPLOAD_ARTIFACT_ID}-${TRAVIS_COMMIT}-armv7.apk
-    curl -L -s -S -o /tmp/qfield-${TRAVIS_TAG}-x86.apk https://download.opengis.ch/qfield/ci-builds/qfield-dev-${UPLOAD_ARTIFACT_ID}-${TRAVIS_COMMIT}-x86.apk
+    curl -L -s -S -o /tmp/qfield-${TRAVIS_TAG}-armv7-X.apk https://download.opengis.ch/qfield/ci-builds/qfield-dev-${UPLOAD_ARTIFACT_ID}-${TRAVIS_COMMIT}-armv7-X.apk
+    curl -L -s -S -o /tmp/qfield-${TRAVIS_TAG}-x86-X.apk https://download.opengis.ch/qfield/ci-builds/qfield-dev-${UPLOAD_ARTIFACT_ID}-${TRAVIS_COMMIT}-x86-X.apk
+    curl -L -s -S -o /tmp/qfield-${TRAVIS_TAG}-armv7-5.apk https://download.opengis.ch/qfield/ci-builds/qfield-dev-${UPLOAD_ARTIFACT_ID}-${TRAVIS_COMMIT}-armv7-5.apk
+    curl -L -s -S -o /tmp/qfield-${TRAVIS_TAG}-x86-5.apk https://download.opengis.ch/qfield/ci-builds/qfield-dev-${UPLOAD_ARTIFACT_ID}-${TRAVIS_COMMIT}-x86-5.apk
 
     echo -e "\e[93m * Deploying app to github release...\e[0m"
-    ./scripts/release-upload.py --release=${TRAVIS_TAG} --oauth-token=${GITHUB_API_TOKEN} /tmp/qfield-${TRAVIS_TAG}-armv7.apk /tmp/qfield-${TRAVIS_TAG}-x86.apk
+    ./scripts/release-upload.py --release=${TRAVIS_TAG} --oauth-token=${GITHUB_API_TOKEN} /tmp/qfield-${TRAVIS_TAG}-armv7-X.apk /tmp/qfield-${TRAVIS_TAG}-x86-X.apk /tmp/qfield-${TRAVIS_TAG}-x86-5.apk /tmp/qfield-${TRAVIS_TAG}-x86-5.apk
 
     echo -e "\e[93m * Deploying app to google play (beta)...\e[0m"
-    ./scripts/basic_upload_apks_service_account.py ch.opengis.qfield /tmp/qfield-${TRAVIS_TAG}-armv7.apk ch.opengis.qfield /tmp/qfield-${TRAVIS_TAG}-x86.apk
+    ./scripts/basic_upload_apks_service_account.py ch.opengis.qfield /tmp/qfield-${TRAVIS_TAG}-armv7-5.apk ch.opengis.qfield /tmp/qfield-${TRAVIS_TAG}-x86-5.apk /tmp/qfield-${TRAVIS_TAG}-armv7-X.apk ch.opengis.qfield /tmp/qfield-${TRAVIS_TAG}-x86-X.apk
 
   elif [[ ${TRAVIS_BRANCH} = master ]]; then
     # we are on a standard commit on master branch
-    curl -u m-kuhn:${GITHUB_API_TOKEN} -X POST --data '{"body": "Uploaded test apks for [armv7](https://download.opengis.ch/qfield/ci-builds/qfield-dev-'${UPLOAD_ARTIFACT_ID}'-'${TRAVIS_COMMIT}'-armv7.apk) and [x86](https://download.opengis.ch/qfield/ci-builds/qfield-dev-'${UPLOAD_ARTIFACT_ID}'-'${TRAVIS_COMMIT}'-x86.apk)"}' https://api.github.com/repos/opengisch/QField/commits/${TRAVIS_COMMIT}/comments
+    curl -u m-kuhn:${GITHUB_API_TOKEN} -X POST --data '{"body": "Uploaded test apks for [armv7](https://download.opengis.ch/qfield/ci-builds/qfield-dev-'${UPLOAD_ARTIFACT_ID}'-'${TRAVIS_COMMIT}'-armv7-X.apk) and [x86](https://download.opengis.ch/qfield/ci-builds/qfield-dev-'${UPLOAD_ARTIFACT_ID}'-'${TRAVIS_COMMIT}'-x86-X.apk) (Android 5 versions [armv7](https://download.opengis.ch/qfield/ci-builds/qfield-dev-'${UPLOAD_ARTIFACT_ID}'-'${TRAVIS_COMMIT}'-armv7-5.apk) and [x86](https://download.opengis.ch/qfield/ci-builds/qfield-dev-'${UPLOAD_ARTIFACT_ID}'-'${TRAVIS_COMMIT}'-x86-5.apk) "}' https://api.github.com/repos/opengisch/QField/commits/${TRAVIS_COMMIT}/comments
   fi
 fi

--- a/scripts/upload-artifacts.sh
+++ b/scripts/upload-artifacts.sh
@@ -9,11 +9,11 @@ set -e
 if [[ "${TRAVIS_SECURE_ENV_VARS}" = "true" ]];
 then
   echo -e "\e[31mAbout to upload build artifacts\e[0m"
-  sudo mv build-${ARCH}/out/build/outputs/apk/release/out-release-signed.apk /tmp/qfield-dev-${UPLOAD_ARTIFACT_ID}-${TRAVIS_COMMIT}-${ARCH}.apk
+  sudo mv build-${ARCH}/out/build/outputs/apk/release/out-release-signed.apk /tmp/qfield-dev-${UPLOAD_ARTIFACT_ID}-${TRAVIS_COMMIT}-${ARCH}-${ANDROID_VERSION:-X}.apk
   openssl aes-256-cbc -K $encrypted_dev_upload_key -iv $encrypted_dev_upload_iv -in .ci/id_rsa.enc -out .ci/id_rsa -d
   chmod 400 .ci/id_rsa
-  scp -i .ci/id_rsa -o "StrictHostKeyChecking no" /tmp/qfield-dev-${UPLOAD_ARTIFACT_ID}-${TRAVIS_COMMIT}-${ARCH}.apk ${DEV_UPLOAD_USER}@${DEV_UPLOAD_HOST}:~/download.opengis.ch/qfield/ci-builds
-  echo -e "\e[31Uploaded to https://download.opengis.ch/qfield/ci-builds/qfield-dev-${UPLOAD_ARTIFACT_ID}-${TRAVIS_COMMIT}-${ARCH}.apk \e[0m"
+  scp -i .ci/id_rsa -o "StrictHostKeyChecking no" /tmp/qfield-dev-${UPLOAD_ARTIFACT_ID}-${TRAVIS_COMMIT}-${ARCH}-${ANDROID_VERSION:-X}.apk ${DEV_UPLOAD_USER}@${DEV_UPLOAD_HOST}:~/download.opengis.ch/qfield/ci-builds
+  echo -e "\e[31Uploaded to https://download.opengis.ch/qfield/ci-builds/qfield-dev-${UPLOAD_ARTIFACT_ID}-${TRAVIS_COMMIT}-${ARCH}-${ANDROID_VERSION:-X}.apk \e[0m"
 else
   echo -e "Not uploading artifacts ..."
   if [ "${TRAVIS_SECURE_ENV_VARS}" != "true" ];


### PR DESCRIPTION
Directly build Android 5 versions from the same travis infrastructure as anything else.
This applies a patch to use the old SDK.

Note: This does not actually solve our Android 5 issues, it just automates the workaround.

Mid-term we will still have to either retire Android 5 or find a sustainable way of deploying openssl to Android 5.