### PR TITLE
Do not clear model on not deactivating identify tool

### DIFF
--- a/src/core/identifytool.cpp
+++ b/src/core/identifytool.cpp
@@ -165,7 +165,8 @@ void IdentifyTool::setModel( MultiFeatureListModel *model )
 
 void IdentifyTool::setDeactivated( bool deactivated )
 {
-  mModel->clear();
+  if ( deactivated )
+    mModel->clear();
   mDeactivated = deactivated;
 }
 


### PR DESCRIPTION
On state change (e.g. navigate to edit) the model of the identify tool has been cleared. That's why QField crashed, when it still wanted to continue with this model data (e.g. zoom to feature or edit geometry).
![crash_zoom](https://user-images.githubusercontent.com/28384354/58480405-95b1ad80-815a-11e9-8a7c-9e0242e1c8a6.gif)

Since this happens on state change:
```
State {
        name: "digitize"
        PropertyChanges { target: identifyTool; deactivated: false }
        [...]
```
First commit avoids the clear if `deactivated` is `false`. Then it's working like that:
![nocrash](https://user-images.githubusercontent.com/28384354/58480511-cc87c380-815a-11e9-9cb9-aae219bacb58.gif)

Still you can see that the edit button is enabled in navigate-mode but edit geometry is not. I set it now to invisible, so it's the same for both. I think it's better understandable for a user when it's like that. But I'm not sure, if @m-kuhn agrees.

Another possibility would be that both keys are visible, but then we would need to change the edit-tools that they work in the navigate mode or the digitize mode would need to be enforced. This would be an additional implementation.