### PR TITLE
Fix Checkbox

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -255,7 +255,6 @@ Page {
           property var config: ( EditorWidgetConfig || {} )
           property var widget: EditorWidget
           property var field: Field
-          property var fieldType: FieldType
           property var relationId: RelationId
           property var nmRelationId: NmRelationId
           property var constraintValid: ConstraintValid

--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -15,18 +15,14 @@ Item {
 
     property var currentValue: value
     //if the field type is boolean, ignore the configured 'CheckedState' and 'UncheckedState' values and work with true/false always
-    readonly property bool isBool: field.type == 1
+    readonly property bool isBool: field.type == 1 //needs type coercion
 
-    checked: isBool ? value : String(value) === config['CheckedState']
+    checked: isBool ? currentValue !== undefined ? currentValue : false : String(currentValue) === config['CheckedState']
 
     onCheckedChanged: {
+      console.log("isbool "+isBool+" and checked "+checked+" and "+currentValue+" and value "+value);
       valueChanged( isBool ? checked : checked ? config['CheckedState'] : config['UncheckedState'], false )
       forceActiveFocus()
-    }
-
-    // Workaround to get a signal when the value has changed
-    onCurrentValueChanged: {
-      checked = isBool ? currentValue : String(currentValue) === config['CheckedState']
     }
 
     indicator.height: 16 * dp

--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -17,7 +17,15 @@ Item {
     //if the field type is boolean, ignore the configured 'CheckedState' and 'UncheckedState' values and work with true/false always
     readonly property bool isBool: field.type == 1 //needs type coercion
 
-    checked: if( isBool ){ if( currentValue !== undefined ){ currentValue }else{ false } }else{ String(currentValue) === config['CheckedState'] }
+    checked: if( isBool ) {
+                 if( currentValue !== undefined ) {
+                     currentValue
+                 } else {
+                     false
+                 }
+             } else {
+                 String(currentValue) === config['CheckedState']
+             }
 
     onCheckedChanged: {
       valueChanged( isBool ? checked : checked ? config['CheckedState'] : config['UncheckedState'], false )

--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -17,10 +17,9 @@ Item {
     //if the field type is boolean, ignore the configured 'CheckedState' and 'UncheckedState' values and work with true/false always
     readonly property bool isBool: field.type == 1 //needs type coercion
 
-    checked: isBool ? currentValue !== undefined ? currentValue : false : String(currentValue) === config['CheckedState']
+    checked: if( isBool ){ if( currentValue !== undefined ){ currentValue }else{ false } }else{ String(currentValue) === config['CheckedState'] }
 
     onCheckedChanged: {
-      console.log("isbool "+isBool+" and checked "+checked+" and "+currentValue+" and value "+value);
       valueChanged( isBool ? checked : checked ? config['CheckedState'] : config['UncheckedState'], false )
       forceActiveFocus()
     }

--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -17,7 +17,7 @@ Item {
     //if the field type is boolean, ignore the configured 'CheckedState' and 'UncheckedState' values and work with true/false always
     readonly property bool isBool: field.type == 1
 
-    checked: isBool ? value : value === config['CheckedState']
+    checked: isBool ? value : String(value) === config['CheckedState']
 
     onCheckedChanged: {
       valueChanged( isBool ? checked : checked ? config['CheckedState'] : config['UncheckedState'], false )
@@ -26,7 +26,7 @@ Item {
 
     // Workaround to get a signal when the value has changed
     onCurrentValueChanged: {
-      checked = isBool ? currentValue : currentValue === config['CheckedState']
+      checked = isBool ? currentValue : String(currentValue) === config['CheckedState']
     }
 
     indicator.height: 16 * dp


### PR DESCRIPTION
- Because of comparison of the integer value with the value in the config, it did not work. It's fixed with the conversation to string

- The binding of checked has been broken by this workaround function. On creating a new feature with a bool value it did not initiate the checked state correctly