### PR TITLE
Nicer Log Visualization with timestamp

### DIFF
--- a/src/core/messagelogmodel.cpp
+++ b/src/core/messagelogmodel.cpp
@@ -31,6 +31,7 @@ QHash<int, QByteArray> MessageLogModel::roleNames() const
   roles[MessageRole]  = "Message";
   roles[MessageTagRole] = "MessageTag";
   roles[MessageLevelRole] = "MessageLevel";
+  roles[MessageDateTimeRole] = "MessageDateTime";
 
   return roles;
 }
@@ -52,6 +53,8 @@ QVariant MessageLogModel::data( const QModelIndex &index, int role ) const
     return mMessages.at( index.row() ).tag;
   else if ( role == MessageLevelRole )
     return mMessages.at( index.row() ).level;
+  else if ( role == MessageDateTimeRole )
+    return mMessages.at( index.row() ).datetime;
 
   return QVariant();
 }

--- a/src/core/messagelogmodel.h
+++ b/src/core/messagelogmodel.h
@@ -17,6 +17,7 @@
 #define MESSAGELOGMODEL_H
 
 #include <QAbstractListModel>
+#include <QDateTime>
 #include <qgsmessagelog.h>
 
 /**
@@ -34,11 +35,13 @@ class MessageLogModel : public QAbstractListModel
 
       LogMessage( const QString &tag, const QString &message, Qgis::MessageLevel level )
       {
+        this->datetime = QDateTime::currentDateTime().toString( QStringLiteral( "yyyy-MM-dd hh:mm:ss:zzz" ) );
         this->tag = tag;
         this->message = message;
         this->level = level;
       }
 
+      QString datetime;
       QString tag;
       QString message;
       Qgis::MessageLevel level;
@@ -48,7 +51,8 @@ class MessageLogModel : public QAbstractListModel
     {
       MessageRole = Qt::UserRole,
       MessageTagRole,
-      MessageLevelRole
+      MessageLevelRole,
+      MessageDateTimeRole
     };
 
   public:

--- a/src/qml/MessageLog.qml
+++ b/src/qml/MessageLog.qml
@@ -9,32 +9,32 @@ Item {
   id: item
   anchors.fill: parent
 
-  Rectangle {
-    color: "white"
-    anchors.fill: parent
-  }
-
   ListView {
     id: table
     anchors.fill: parent
 
-    delegate: Column {
-      Text {
-        text: MessageTag
-        font.bold: true
-      }
-
-      Text {
-        text: Message
-        wrapMode: Text.WordWrap
-      }
-
-      Rectangle {
-        color: "gray"
-        height: 1*dp
-      }
+    delegate:
+        Rectangle {
+         color: index % 2 == 0 ? 'lightgrey' : 'white'
+         width: parent.width
+         height: line.height
+         Row {
+             id: line
+             spacing: 40 * dp
+             Text {
+               text: MessageDateTime
+             }
+             Text {
+               text: MessageTag || '-'
+               font.bold: true
+             }
+             Text {
+                text: Message
+                wrapMode: Text.WordWrap
+             }
+       }
+     }
     }
-  }
 
   MouseArea {
     anchors.fill: parent

--- a/src/qml/MessageLog.qml
+++ b/src/qml/MessageLog.qml
@@ -18,34 +18,37 @@ Item {
     id: table
     anchors.fill: parent
 
-    delegate:
+    delegate: Rectangle {
+      color: index % 2 == 0 ? 'lightgrey' : 'white'
+      width: parent.width
+      height: line.height
+      Row {
+        id: line
+        spacing: 10 * dp
+        Text {
+          id: datetext
+          text: MessageDateTime
+        }
         Rectangle {
-         color: index % 2 == 0 ? 'lightgrey' : 'white'
-         width: parent.width
-         height: line.height
-         Row {
-             id: line
-             spacing: 40 * dp
-             Text {
-               id: datetext
-               width: content.width
-               text: MessageDateTime
-             }
-             Text {
-               id: tagtext
-               width: Math.max( content.width, parent.width / 6 )
-               text: MessageTag
-               font.bold: true
-             }
-             Text {
-                id: messagetext
-                width: parent.width - datetext.width - tagtext.width
-                text: Message
-                wrapMode: Text.WordWrap
-             }
-       }
-     }
+          id: separator
+          color: index % 2 == 0 ? 'white' : 'lightgrey'
+          height: parent.height
+          width: 5 * dp
+        }
+        Text {
+          id: tagtext
+          text: MessageTag
+          font.bold: true
+        }
+        Text {
+          id: messagetext
+          width: table.width - datetext.width - tagtext.width - separator.width
+          text: Message
+          wrapMode: Text.WordWrap
+        }
+      }
     }
+  }
 
   MouseArea {
     anchors.fill: parent

--- a/src/qml/MessageLog.qml
+++ b/src/qml/MessageLog.qml
@@ -9,6 +9,11 @@ Item {
   id: item
   anchors.fill: parent
 
+  Rectangle {
+    color: 'lightgrey'
+    anchors.fill: parent
+  }
+
   ListView {
     id: table
     anchors.fill: parent
@@ -22,13 +27,19 @@ Item {
              id: line
              spacing: 40 * dp
              Text {
+               id: datetext
+               width: content.width
                text: MessageDateTime
              }
              Text {
-               text: MessageTag || '-'
+               id: tagtext
+               width: Math.max( content.width, parent.width / 6 )
+               text: MessageTag
                font.bold: true
              }
              Text {
+                id: messagetext
+                width: parent.width - datetext.width - tagtext.width
                 text: Message
                 wrapMode: Text.WordWrap
              }


### PR DESCRIPTION
I did that because I needed it to debug the WFS/WMS stuff, to have a better log visualization.
Because it's not a life without timestamps :-)

Looks now like this. If you agree we can take the changes:
 
![Screenshot from 2019-09-02 08-18-13](https://user-images.githubusercontent.com/28384354/64094068-c6f1d900-cd5a-11e9-905e-0abd0564f215.png)
