### PR TITLE
On a portrait oriented screen, use the bottom part of the screen to display the feature (list) form drawer

### DIFF
--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -1,5 +1,5 @@
 /***************************************************************************
-                            FeatureForm.qml
+                            FeatureListForm.qml
                               -------------------
               begin                : 10.12.2014
               copyright            : (C) 2014 by Matthias Kuhn
@@ -36,7 +36,24 @@ Rectangle {
   signal showMessage(string message)
   signal editGeometry
 
-  width: props.isVisible ? qfieldSettings.fullScreenIdentifyView || parent.width<300*dp ? parent.width : Math.min(Math.max(200*dp, parent.width/3), parent.width) : 0
+  width: {
+      if (props.isVisible) {
+          if (qfieldSettings.fullScreenIdentifyView || parent.width < parent.height || parent.width < 300 * dp) {
+              parent.width
+          } else {
+              Math.min(Math.max( 200 * dp, parent.width / 3), parent.width)
+          }
+      } else { 0 }
+  }
+  height: {
+     if (props.isVisible) {
+         if (qfieldSettings.fullScreenIdentifyView || parent.width > parent.height) {
+             parent.height
+         } else {
+             Math.min(Math.max( 200 * dp, parent.height / 2 ), parent.height)
+         }
+     } else { 0 }
+  }
 
   states: [
     State {
@@ -121,7 +138,7 @@ Rectangle {
     anchors.top: featureListToolBar.bottom
     anchors.left: parent.left
     anchors.right: parent.right
-    height: parent.height - featureListToolBar.height
+    anchors.bottom: parent.bottom
 
     property bool shown: false
 
@@ -326,6 +343,21 @@ Rectangle {
 
   Behavior on width {
     PropertyAnimation {
+      duration: parent.width > parent.height ? 250 : 0
+      easing.type: Easing.InQuart
+
+      onRunningChanged: {
+        if ( running )
+          mapCanvasMap.freeze('formresize')
+        else
+          mapCanvasMap.unfreeze('formresize')
+      }
+    }
+  }
+
+  Behavior on height {
+    PropertyAnimation {
+      duration: parent.width < parent.height ? 250 : 0
       easing.type: Easing.InQuart
 
       onRunningChanged: {

--- a/src/qml/OverlayFeatureFormDrawer.qml
+++ b/src/qml/OverlayFeatureFormDrawer.qml
@@ -8,8 +8,23 @@ Drawer {
   property alias featureModel: overlayFeatureForm.featureModel
   property alias state: overlayFeatureForm.state
   property alias featureForm: overlayFeatureForm
-  height: parent.height
-  edge: Qt.RightEdge
+
+  edge: parent.width < parent.height ? Qt.BottomEdge : Qt.RightEdge
+  width: {
+      if (qfieldSettings.fullScreenIdentifyView || parent.width < parent.height || parent.width < 300 * dp) {
+          parent.width
+      } else {
+          Math.min(Math.max( 200 * dp, parent.width / 3), parent.width)
+      }
+  }
+  height: {
+     if (qfieldSettings.fullScreenIdentifyView || parent.width > parent.height) {
+         parent.height
+     } else {
+         Math.min(Math.max( 200 * dp, parent.height / 2 ), parent.height)
+     }
+  }
+
   interactive: overlayFeatureForm.model.constraintsValid
   dragMargin: 0
   Keys.enabled: true

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -369,8 +369,8 @@ ApplicationWindow {
 
   DropShadow {
     anchors.fill: featureForm
-    horizontalOffset: -2 * dp
-    verticalOffset: 0
+    horizontalOffset: mainWindow.width >= mainWindow.height ? -2 * dp : 0
+    verticalOffset: mainWindow.width < mainWindow.height ? -2 * dp : 0
     radius: 6.0 * dp
     samples: 17
     color: "#80000000"
@@ -884,7 +884,6 @@ ApplicationWindow {
   OverlayFeatureFormDrawer {
     id: overlayFeatureFormDrawer
     featureModel: digitizingFeature
-    width: qfieldSettings.fullScreenIdentifyView || mainWindow.width<300*dp? mainWindow.width : Math.min(Math.max(200*dp, mainWindow.width/3), mainWindow.width)
   }
 
   Keys.onReleased: {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -833,7 +833,7 @@ ApplicationWindow {
     visible: state != "Hidden"
     focus: visible
 
-    anchors { right: parent.right; top: parent.top; bottom: parent.bottom }
+    anchors { right: parent.right; bottom: parent.bottom }
     border { color: "lightGray"; width: 1 }
     allowEdit: stateMachine.state === "digitize"
 


### PR DESCRIPTION
On my smartphone, browsing features while the screen is in portrait mode isn't ideal (the navigation bar's widgets are overlapping each other, the form itself is too narrow, etc.):
![image](https://user-images.githubusercontent.com/1728657/65676445-200f0d00-e07a-11e9-9479-a119acea783e.png)

This PR implements an alternative drawer position for portrait oriented screens, which opens at the bottom of the screen:
![Peek 2019-09-26 16-20](https://user-images.githubusercontent.com/1728657/65676499-37e69100-e07a-11e9-8a6a-269046d43315.gif)

It's a nice UX win for smartphone users too as it insures  widgets are more easily reached by reducing the distance between thumb and widgets.