### PR TITLE
Improve scale bar widget

### DIFF
--- a/src/qml/ScaleBar.qml
+++ b/src/qml/ScaleBar.qml
@@ -41,10 +41,21 @@ Item {
 
   Text {
     id: label
+    anchors.bottomMargin: 4 * dp
     anchors.bottom: mainLine.top
     anchors.horizontalCenter: mainLine.horizontalCenter
-    font.pointSize: 12 * dp
+    anchors.left: undefined // The value will be set to mainLine.left is the label is wider than the mainLine
+    font.pointSize: 12
     color: "darkslategrey"
+
+    states: State {
+        name: "narrow"; when: label.width > mainLine.width
+        AnchorChanges {
+            target: label
+            anchors.horizontalCenter: undefined
+            anchors.left: mainLine.left
+        }
+    }
 
     text: if (vars.units === QgsUnitTypes.DistanceMeters && vars.adjustedMagnitude >= 1000 ) {
             vars.adjustedMagnitude/1000 + ' ' + UnitTypes.toAbbreviatedString( QgsUnitTypes.DistanceKilometers )


### PR DESCRIPTION
- Better font size on highdpi screen
- Add a small margin between text and ticks
- Most importantly, avoid the text overflowing beyond screen

Regarding the text overflowing beyond screen, this is what it looked like:
![Peek 2019-09-26 17-17_bad](https://user-images.githubusercontent.com/1728657/65680691-ada22b00-e081-11e9-816c-cddda841b614.gif)

With the PR, things look much nicer:
![Peek 2019-09-26 17-17](https://user-images.githubusercontent.com/1728657/65680708-b430a280-e081-11e9-9ffc-11e7d440a307.gif)
