### PR TITLE
GPS and digitize toolbars improvements

### DIFF
--- a/src/qml/DigitizingToolbar.qml
+++ b/src/qml/DigitizingToolbar.qml
@@ -16,23 +16,11 @@ VisibilityFadingRow {
   signal confirm
 
   Button {
-    id: removeVertexButton
-    iconSource: Style.getThemeIcon( "ic_remove_white_24dp" )
-    visible: rubberbandModel.vertexCount > 1
-    round: true
-    bgcolor: "#616161"
-
-    onClicked: {
-      vertexRemoved()
-    }
-  }
-
-  Button {
     id: cancelButton
     iconSource: Style.getThemeIcon( "ic_clear_white_24dp" )
     visible: rubberbandModel.vertexCount > 1
     round: true
-    bgcolor: "#616161"
+    bgcolor: "#900000"
 
     onClicked: {
       cancel()
@@ -61,7 +49,7 @@ VisibilityFadingRow {
       }
     }
     round: true
-    bgcolor: "#FFD600"
+    bgcolor: "#80cc28"
 
     onClicked: {
       // remove editing vertex for lines and polygons
@@ -71,12 +59,24 @@ VisibilityFadingRow {
   }
 
   Button {
+    id: removeVertexButton
+    iconSource: Style.getThemeIcon( "ic_remove_white_24dp" )
+    visible: rubberbandModel.vertexCount > 1
+    round: true
+    bgcolor: "#212121"
+
+    onClicked: {
+      vertexRemoved()
+    }
+  }
+
+  Button {
     id: addVertexButton
     iconSource: {
         Style.getThemeIcon( "ic_add_white_24dp" )
     }
     round: true
-    bgcolor: stateMachine.state === 'measure' ? "#000000": Number( rubberbandModel.geometryType ) === QgsWkbTypes.PointGeometry ? "#FFD600" : "#2E7D32"
+    bgcolor: stateMachine.state === 'measure' ? "#000000": Number( rubberbandModel.geometryType ) === QgsWkbTypes.PointGeometry ? "#80cc28" : "#212121"
 
     onClicked: {
       if ( Number( rubberbandModel.geometryType ) === QgsWkbTypes.PointGeometry ||

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -490,6 +490,7 @@ ApplicationWindow {
       id: gpsLinkButton
       visible: gpsButton.state == "On" && ( stateMachine.state === "digitize" || stateMachine.state === 'measure' )
       round: true
+      bgcolor: "#212121"
       checkable: true
 
       iconSource: linkActive ? Style.getThemeIcon( "ic_gps_link_activated_white_24dp" ) : Style.getThemeIcon( "ic_gps_link_white_24dp" )
@@ -514,7 +515,7 @@ ApplicationWindow {
           PropertyChanges {
             target: gpsButton
             iconSource: Style.getThemeIcon( "ic_location_disabled_white_24dp" )
-            bgcolor: "#AA999999"
+            bgcolor: "#88212121"
           }
         },
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -480,11 +480,24 @@ ApplicationWindow {
 
   Column {
     id: mainToolBar
-    anchors.left: dashBoard.right
-    anchors.leftMargin: 4 * dp
-    anchors.top: mainMenuBar.bottom
-    anchors.topMargin: 4 * dp
+    anchors.right: mapCanvas.right
+    anchors.rightMargin: 4 * dp
+    anchors.bottom: mapCanvas.bottom
+    anchors.bottomMargin: digitizingToolbar.height + 4 * dp
     spacing: 4 * dp
+
+    Button {
+      id: gpsLinkButton
+      visible: gpsButton.state == "On" && ( stateMachine.state === "digitize" || stateMachine.state === 'measure' )
+      round: true
+      checkable: true
+
+      iconSource: linkActive ? Style.getThemeIcon( "ic_gps_link_activated_white_24dp" ) : Style.getThemeIcon( "ic_gps_link_white_24dp" )
+
+      readonly property bool linkActive: gpsButton.state == "On" && checked
+
+      onClicked: gpsLinkButton.checked = !gpsLinkButton.checked
+    }
 
     Button {
       id: gpsButton
@@ -501,7 +514,7 @@ ApplicationWindow {
           PropertyChanges {
             target: gpsButton
             iconSource: Style.getThemeIcon( "ic_location_disabled_white_24dp" )
-            bgcolor: "lightgrey"
+            bgcolor: "#AA999999"
           }
         },
 
@@ -509,8 +522,9 @@ ApplicationWindow {
           name: "On"
           PropertyChanges {
             target: gpsButton
-            bgcolor: "#64B5F6"
             iconSource: positionSource.position.latitudeValid ? Style.getThemeIcon( "ic_my_location_white_24dp" ) : Style.getThemeIcon( "ic_gps_not_fixed_white_24dp" )
+            bgcolor: "#64B5F6"
+            opacity:1
           }
         }
       ]
@@ -563,19 +577,6 @@ ApplicationWindow {
             break;
         }
       }
-    }
-
-    Button {
-      id: gpsLinkButton
-      visible: gpsButton.state == "On" && ( stateMachine.state === "digitize" || stateMachine.state === 'measure' )
-      round: true
-      checkable: true
-
-      iconSource: linkActive ? Style.getThemeIcon( "ic_gps_link_activated_white_24dp" ) : Style.getThemeIcon( "ic_gps_link_white_24dp" )
-
-      readonly property bool linkActive: gpsButton.state == "On" && checked
-
-      onClicked: gpsLinkButton.checked = !gpsLinkButton.checked
     }
   }
 


### PR DESCRIPTION
Here's a before vs. PR shot first:
![image](https://user-images.githubusercontent.com/1728657/65755428-4649b100-e13d-11e9-8b9c-10d1926b372e.png)

On the GPS toolbar front, biggest change here is the relocation of the toolbar to sit at the bottom right corner of the screen. This is favorable for a couple of reasons:
- It'll likely come as a more 'natural' position for most users since a large number of mapping apps places the button in that area;
- More importantly, the GPS toolbar has strong relation to digitizing, it therefore makes sense to have it close to the digitizing toolbar;
- In its former position, below the hamburger menu button, it felt odd to see it moving when the dashboard expanded while the hamburger button didn't;
- On narrow screens, with the dashboard expanded, the GPS button was going beyond the right edge of the screen.

The commit also changes the background color of the enable/disable GPS button to be semi-transparent, which allows for map content to still be visible when the GPS isn't active.

On the digitizing toolbar front, the buttons were re-ordered so that the vertex addition (+) and
removal (-) buttons sit next to each other. This felt like a much more natural location, and reduces the confusion between the vertex removal and the cancel buttons. 

To further help distinguishing the vertex removal vs the cancel buttons, the latter is now colored in red. It should help giving more visual guidance to new users, and just provide a better visual indicator overall.

I've also changed the green color to match the QField green, and killed the overly bright orange/yellow color. The idea here is to ultimately settle on a limited color palette.

Finally, the green color is now attached to save feature button instead of the vertex addition button, the latter still green for point layers but for polygon and line layers will share the same dark gray as its sister vertex removal (-) button.
for line and polygon layers