### PR TITLE
Fix overlapping search and notification buttons

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -813,8 +813,9 @@ ApplicationWindow {
     visible: messageLog.unreadMessages
 
     anchors.right: mapCanvas.right
-    anchors.top: parent.top
-    anchors.margins: 4 * dp
+    anchors.top: locatorItem.bottom
+    anchors.topMargin: 10 * dp
+    anchors.rightMargin: 15 * dp
     width: 36 * dp
     height: 36 * dp
 


### PR DESCRIPTION
Simple one:
![Screenshot from 2019-09-27 16-34-12](https://user-images.githubusercontent.com/1728657/65759236-ad1e9880-e144-11e9-8790-b4788cd8008f.png)
