### PR TITLE
Do not running the identify tool when double tapping on map canvas

### DIFF
--- a/src/qml/MapCanvas.qml
+++ b/src/qml/MapCanvas.qml
@@ -87,6 +87,7 @@ Item {
       anchors.fill : parent
 
       onDoubleClicked: {
+        clickedTimer.stop()
         var center = Qt.point( mouse.x, mouse.y )
         mapCanvasWrapper.zoom( center, 0.8 )
         // mapCanvasWrapper.pan( pinch.center, pinch.previousCenter )
@@ -103,7 +104,12 @@ Item {
           var distance = Math.abs( mouse.x - __initialPosition.x ) + Math.abs( mouse.y - __initialPosition.y )
 
           if ( distance < 5 * dp)
-            mapArea.clicked( mouse )
+          {
+            if (!clickedTimer.running) {
+              props.mouse = mouse
+              clickedTimer.restart()
+            }
+          }
         }
       }
 
@@ -132,11 +138,22 @@ Item {
       }
 
       Timer {
+        id: clickedTimer
+        interval: 250
+        onTriggered: mapArea.clicked( props.mouse )
+      }
+
+      Timer {
         id: unfreezePanTimer
         interval: 500;
         running: false;
         repeat: false
         onTriggered: unfreeze('pan')
+      }
+
+      QtObject {
+        id: props
+        property var mouse
       }
     }
   }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -162,23 +162,23 @@ ApplicationWindow {
 
     /* The base map */
     MapCanvas {
+
       id: mapCanvasMap
       incrementalRendering: qfieldSettings.incrementalRendering
 
       anchors.fill: parent
 
       onClicked: {
-        if (locatorItem.searching)
-        {
-          locatorItem.searching = false
-        }
-        else if( !overlayFeatureFormDrawer.visible )
-        {
-          identifyTool.identify( Qt.point( mouse.x, mouse.y ) )
-        }
+          if (locatorItem.searching) {
+              locatorItem.searching = false
+          } else if( !overlayFeatureFormDrawer.visible ) {
+              identifyTool.identify( Qt.point( parent.mouseX, parent.mouseY ) )
+          }
       }
+
       Component.onCompleted: platformUtilities.showRateThisApp()
     }
+
 
   /**************************************************
    * Position markers


### PR DESCRIPTION
Here's one huge UX issue fixed: when double tapping on the screen, QField used to both zoom into the canvas (good, standard UX on smartphones and tablets) _as well as_ launching the identify too (bad).

This PR insures that the identify tool is only launched on single tap onto the screen.