### PR TITLE
[search] Fix crash when all layer features locator searching against …

### DIFF
--- a/src/core/featureslocatorfilter.cpp
+++ b/src/core/featureslocatorfilter.cpp
@@ -55,7 +55,7 @@ void FeaturesLocatorFilter::prepare( const QString &string, const QgsLocatorCont
   for ( auto it = layers.constBegin(); it != layers.constEnd(); ++it )
   {
     QgsVectorLayer *layer = qobject_cast< QgsVectorLayer *>( it.value() );
-    if ( !layer || !layer->flags().testFlag( QgsMapLayer::Searchable ) )
+    if ( !layer || !layer->dataProvider() || !layer->flags().testFlag( QgsMapLayer::Searchable ) )
       continue;
 
     QgsExpression expression( layer->displayExpression() );


### PR DESCRIPTION
…an invalid layer

cherry-picked from https://github.com/qgis/QGIS/commit/aef6cd417be8d22a05a3b44181f0c6d3c7fd4e77