### PR TITLE
Dashboard navigate/edit toggle improvements

### DIFF
--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -113,8 +113,8 @@ Controls.Pane {
           implicitWidth: 36 * 2 * dp
           x: modeswitch.leftPadding
           radius: 4 * dp
-          color:  "#80CC28"
-          border.color: "white"
+          color:  "#66212121"
+          border.color: "#44FFFFFF"
           anchors.verticalCenter: parent.verticalCenter
           Image {
             height: parent.height
@@ -122,6 +122,7 @@ Controls.Pane {
             anchors.left: parent.left
             anchors.verticalCenter: parent.verticalCenter
             source: Style.getThemeIcon( 'ic_map_white_48dp' )
+            opacity: 0.4
           }
           Image {
             height: parent.height
@@ -129,13 +130,14 @@ Controls.Pane {
             anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
             source: Style.getThemeIcon( 'ic_create_white_24dp' )
+            opacity: 0.4
           }
           Rectangle {
             x: modeswitch.checked ? parent.width - width : 0
             width: 36 * dp
             height: 36 * dp
             radius: 4 * dp
-            color:  "#64B5F6"
+            color:  "#80CC28"
             border.color: "white"
             Image {
               height: parent.height
@@ -144,6 +146,12 @@ Controls.Pane {
               anchors.left:  modeswitch.checked ? undefined : parent.left
               anchors.verticalCenter: parent.verticalCenter
               source:  modeswitch.checked ? Style.getThemeIcon( 'ic_create_white_24dp' ) : Style.getThemeIcon( 'ic_map_white_24dp' )
+            }
+            Behavior on x {
+              PropertyAnimation {
+                duration: 100
+                easing.type: Easing.InQuart
+              }
             }
           }
         }


### PR DESCRIPTION
One thing I had a hard time with when first exploring the map was the dashboard navigation vs. editing toggle. The light blue and light green colors were looking to me like both "activated" colors, and kept confusing whether green meant active or blue meant active.

This PR improves the UI/UX situation by removing the light blue color, and instead use a semi-transparent version of QField's dark gray used elsewhere. I've also made the inactive mode's logo semi-transparent. IMHO, it does a much better job at telling which mode is active.

On top of that, a little toggling animation was added to be more pleasing to the eye:
![Peek 2019-09-28 13-36](https://user-images.githubusercontent.com/1728657/65812733-bb78bd00-e1f5-11e9-83dd-bc4a27f74479.gif)
