### PR TITLE
Upgrade dashboard to a Drawer to enable edge swipe to open

### DIFF
--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -4,7 +4,7 @@ import QtQuick.Controls 2.4 as Controls
 import QtQuick.Layouts 1.1
 import "js/style.js" as Style
 
-Controls.Pane {
+Controls.Drawer {
   objectName: "dashBoard"
 
   signal showMenu
@@ -14,14 +14,17 @@ Controls.Pane {
   property MapSettings mapSettings
 
   property color mainColor: "#80CC28"
-  padding: 0
 
-  anchors { left: parent.left; bottom: parent.bottom; top: parent.top; }
+  width: Math.min( 300 * dp, mainWindow.width)
+  height: parent.height
+  edge: Qt.LeftEdge
+  dragMargin: 10 * dp
+  padding: 0
 
   property bool preventFromOpening: overlayFeatureFormDrawer.visible
   readonly property bool open: dashBoard.visible && !preventFromOpening
 
-  visible: false
+  position: 0
   focus: visible
   clip: true
 
@@ -29,15 +32,8 @@ Controls.Pane {
     console.warn( "KEY PRESS " + event.key )
     if ( event.key === Qt.Key_Back ||
       event.key === Qt.Key_Escape ) {
-      visible=false
+      close()
       event.accepted = true
-    }
-  }
-
-  Behavior on width {
-    NumberAnimation {
-      duration: 200
-      easing.type: Easing.InOutQuad
     }
   }
 
@@ -62,11 +58,11 @@ Controls.Pane {
 
       Row {
         height: childrenRect.height
-        spacing: 4 * dp
+        spacing: 1 * dp
 
         Controls.ToolButton {
-          height: 48 * dp
-          width: 48 * dp
+          height: 56 * dp
+          width: 56 * dp
 
           contentItem: Rectangle {
             anchors.fill: parent
@@ -76,10 +72,11 @@ Controls.Pane {
               fillMode: Image.Pad
               horizontalAlignment: Image.AlignHCenter
               verticalAlignment: Image.AlignVCenter
-              source: Style.getThemeIcon( 'ic_menu_white_24dp' )
-
+              source: Style.getThemeIcon( 'ic_chevron_left_white_24dp' )
             }
           }
+
+          onClicked: close()
         }
 
         Controls.ToolButton {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -177,6 +177,7 @@ ApplicationWindow {
           identifyTool.identify( Qt.point( mouse.x, mouse.y ) )
         }
       }
+
       Component.onCompleted: platformUtilities.showRateThisApp()
     }
 
@@ -392,7 +393,6 @@ ApplicationWindow {
     id: dashBoard
     allowLayerChange: !digitizingToolbar.isDigitizing
     mapSettings: mapCanvas.mapSettings
-    width: open ? Math.min( 300 * dp, mainWindow.width) : 0
   }
 
   DropShadow {


### PR DESCRIPTION
One major UX issue I had when first testing QField was the absence of a edge swipe gesture to open the dashboard, which has come to be a pretty standard behavior these days.

This PR implements that by upgrading the dashboard to become a drawer. The result is pleasing to the thumb:
![Peek 2019-09-29 13-45](https://user-images.githubusercontent.com/1728657/65828392-a028b300-e2c4-11e9-97a5-c3e4f8d1b4e5.gif)

As the above GIF indicates, this move makes the dashboard modal, whereas once opened, other parts of QField are blocked until the dashboard is closed. IMHO, this is actually a nice change as it insures that there are no overlap between several drawers (identify feature list drawer comes to mind). 

Would anyone object to this new modal behavior?

There *is* a way to make drawers non modal, but AFAIK, you also need to set those drawers as non interactive and that means losing the edge swipe (which brings us back to the UX gap this PR looks at addressing :smile:  )