### PR TITLE
Fix project canvas background color not respected

### DIFF
--- a/src/qgsquick/qgsquickmapsettings.cpp
+++ b/src/qgsquick/qgsquickmapsettings.cpp
@@ -248,7 +248,11 @@ QColor QgsQuickMapSettings::backgroundColor() const
   return mMapSettings.backgroundColor();
 }
 
-void QgsQuickMapSettings::setBackgroundColor( QColor &color )
+void QgsQuickMapSettings::setBackgroundColor( const QColor &color )
 {
+  if ( mMapSettings.backgroundColor() == color )
+    return;
+
   mMapSettings.setBackgroundColor( color );
+  emit backgroundColorChanged();
 }

--- a/src/qgsquick/qgsquickmapsettings.cpp
+++ b/src/qgsquick/qgsquickmapsettings.cpp
@@ -204,6 +204,14 @@ emit layersChanged();
 
 void QgsQuickMapSettings::onReadProject( const QDomDocument &doc )
 {
+  if ( mProject )
+  {
+    int red = mProject->readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/CanvasColorRedPart" ), 255 );
+    int green = mProject->readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/CanvasColorGreenPart" ), 255 );
+    int blue = mProject->readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/CanvasColorBluePart" ), 255 );
+    mMapSettings.setBackgroundColor( QColor( red, green, blue ) );
+  }
+
   QDomNodeList nodes = doc.elementsByTagName( "mapcanvas" );
   if ( nodes.count() )
   {
@@ -233,4 +241,14 @@ void QgsQuickMapSettings::setRotation( double rotation )
 {
   if ( !qgsDoubleNear( rotation, 0 ) )
     QgsMessageLog::logMessage( tr( "Map Canvas rotation is not supported. Resetting from %1 to 0." ).arg( rotation ) );
+}
+
+QColor QgsQuickMapSettings::backgroundColor() const
+{
+  return mMapSettings.backgroundColor();
+}
+
+void QgsQuickMapSettings::setBackgroundColor( QColor &color )
+{
+  mMapSettings.setBackgroundColor( color );
 }

--- a/src/qgsquick/qgsquickmapsettings.h
+++ b/src/qgsquick/qgsquickmapsettings.h
@@ -74,6 +74,13 @@ class QgsQuickMapSettings : public QObject
     Q_PROPERTY( double rotation READ rotation WRITE setRotation NOTIFY rotationChanged )
 
     /**
+     * The background color used to render the map
+     * 
+     * The value is set to the project's bacckground color setting on QgsProject::readProject
+     */
+    Q_PROPERTY( QColor backgroundColor READ backgroundColor WRITE setBackgroundColor NOTIFY backgroundColorChanged )
+
+    /**
      * The size of the resulting map image
      *
      * Automatically loaded from project on QgsProject::readProject
@@ -167,7 +174,7 @@ class QgsQuickMapSettings : public QObject
     QColor backgroundColor() const;
 
     //! \copydoc QgsQuickMapSettings::setBackgroundColor
-    void setBackgroundColor( QColor &color );
+    void setBackgroundColor( const QColor &color );
 
     //! \copydoc QgsMapSettings::outputSize()
     QSize outputSize() const;
@@ -208,6 +215,9 @@ class QgsQuickMapSettings : public QObject
 
     //! \copydoc QgsQuickMapSettings::rotation
     void rotationChanged();
+
+    //! \copydoc QgsQuickMapSettings::backgroundColor
+    void backgroundColorChanged();
 
     //! \copydoc QgsQuickMapSettings::visibleExtent
     void visibleExtentChanged();

--- a/src/qgsquick/qgsquickmapsettings.h
+++ b/src/qgsquick/qgsquickmapsettings.h
@@ -173,7 +173,7 @@ class QgsQuickMapSettings : public QObject
     //! \copydoc QgsQuickMapSettings::backgroundColor
     QColor backgroundColor() const;
 
-    //! \copydoc QgsQuickMapSettings::setBackgroundColor
+    //! \copydoc QgsQuickMapSettings::backgroundColor
     void setBackgroundColor( const QColor &color );
 
     //! \copydoc QgsMapSettings::outputSize()

--- a/src/qgsquick/qgsquickmapsettings.h
+++ b/src/qgsquick/qgsquickmapsettings.h
@@ -163,6 +163,12 @@ class QgsQuickMapSettings : public QObject
     //! \copydoc QgsQuickMapSettings::rotation
     void setRotation( double rotation );
 
+    //! \copydoc QgsQuickMapSettings::backgroundColor
+    QColor backgroundColor() const;
+
+    //! \copydoc QgsQuickMapSettings::setBackgroundColor
+    void setBackgroundColor( QColor &color );
+
     //! \copydoc QgsMapSettings::outputSize()
     QSize outputSize() const;
 

--- a/src/qml/MapCanvas.qml
+++ b/src/qml/MapCanvas.qml
@@ -42,6 +42,7 @@ Item {
   function freeze(id) {
     mapCanvasWrapper.__freezecount[id] = true
     mapCanvasWrapper.freeze = true
+    console.log(mapSettings.backgroundColor)
   }
 
   function unfreeze(id) {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -144,6 +144,7 @@ ApplicationWindow {
      * On top of it are the base map and other items like GPS icon...
      */
     id: mapCanvas
+    clip: true
 
     /* Initialize a MapSettings object. This will contain information about
      * the current canvas extent. It is shared between the base map and all

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -160,6 +160,12 @@ ApplicationWindow {
     anchors.right: parent.right
     anchors.bottom: positionInformationView.visible ? positionInformationView.top : parent.bottom
 
+    Rectangle {
+      id: mapCanvasBackground
+      anchors.fill: parent
+      color: mapSettings.backgroundColor
+    }
+
     /* The base map */
     MapCanvas {
       id: mapCanvasMap
@@ -932,6 +938,7 @@ ApplicationWindow {
       onLoadProjectEnded: {
         busyMessage.visible = false
         openProjectDialog.folder = qgisProject.homePath
+        mapCanvasBackground.color = mapCanvas.mapSettings.backgroundColor
       }
     }
   }


### PR DESCRIPTION
Title says it all; QField would always draw the canvas with a white background, irrespective of what was set by the opened project. This PR fixes this issue. 

Previously (broken) vs. PR:
![image](https://user-images.githubusercontent.com/1728657/65829279-e7677180-e2cd-11e9-811a-f4f661c32f9e.png)
