### PR TITLE
Value map field widget improvements

### DIFF
--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -19,6 +19,7 @@ Item {
     anchors.left: parent.left
     anchors.right: parent.right
     font.pointSize: 14
+    color: value === undefined || !enabled ? 'gray' : 'black'
 
     text: value !== undefined ? value : ''
 

--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -64,19 +64,22 @@ Item {
     // [hidpi fixes]
     delegate: ItemDelegate {
       width: comboBox.width
-      height: 36 * dp
+      height: fontMetrics.height + 20 * dp
       text: model.value
       font.weight: comboBox.currentIndex === index ? Font.DemiBold : Font.Normal
-      font.pointSize: 12
+      font.pointSize: 14
       highlighted: comboBox.highlightedIndex == index
     }
 
     contentItem: Text {
-      height: 36 * dp
+      id: textLabel
+      height: fontMetrics.height + 20 * dp
       text: comboBox.displayText
+      font.pointSize: 14
       horizontalAlignment: Text.AlignLeft
       verticalAlignment: Text.AlignVCenter
       elide: Text.ElideRight
+      color: value === undefined || !enabled ? 'gray' : 'black'
     }
 
     background: Item {
@@ -84,9 +87,17 @@ Item {
       implicitHeight: 36 * dp
 
       Rectangle {
+        y: textLabel.height - 8 * dp
+        width: comboBox.width
+        height: comboBox.activeFocus ? 2 * dp : 1 * dp
+        color: comboBox.activeFocus ? "#4CAF50" : "#C8E6C9"
+      }
+
+      Rectangle {
+        visible: enabled
         anchors.fill: parent
         id: backgroundRect
-        border.color: comboBox.pressed ? "#17a81a" : "#21be2b"
+        border.color: comboBox.pressed ? "#4CAF50" : "#C8E6C9"
         border.width: comboBox.visualFocus ? 2 : 1
         color: "#dddddd"
         radius: 2


### PR DESCRIPTION
This mirrors effort applied to the calendar widget in PR #627 , whereas when a combobox field widget isn't enabled (i.e. when it is in read mode) the looks match that of a disabled text field. This allows for a much cleaner reading of all fields:
![Peek 2019-09-29 18-00](https://user-images.githubusercontent.com/1728657/65831428-6f0bab00-e2e3-11e9-92ec-a62f6959baf7.gif)

When the field is enabled, visual indicators showing the field is a combo box is re-activated.