### PR TITLE
Try to fix tiny-tiny busy indicator

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -910,7 +910,7 @@ ApplicationWindow {
     opacity: 0.5
     visible: false
 
-    Controls.BusyIndicator {
+    BusyIndicator {
       id: busyMessageIndicator
       anchors.centerIn: parent
       running: true
@@ -941,11 +941,11 @@ ApplicationWindow {
     }
   }
 
-  Controls.BusyIndicator {
+  BusyIndicator {
     id: busyIndicator
     anchors.centerIn: mapCanvas
-    width: 36 * dp
-    height: 36 * dp
+    width: 100 * dp
+    height: 100 * dp
     running: mapCanvasMap.isRendering
   }
 


### PR DESCRIPTION
On my phone, the busy indicator (crucial feedback to users when remote content like XYZ tiles is being fetched) is tiny, _tiny. In fact, I thought it was simply missing.

This PR tries to fix the tiny size by using the controls 2.4 element (instead of 1.X), and enlarge the indicator to take more of the screen. 