### PR TITLE
Better placement for the canvas rendering busy indicator

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1035,9 +1035,10 @@ ApplicationWindow {
 
   BusyIndicator {
     id: busyIndicator
-    anchors.centerIn: mapCanvas
-    width: 100 * dp
-    height: 100 * dp
+    anchors.left: mainMenuBar.left
+    anchors.top: mainMenuBar.bottom
+    width: 60 * dp
+    height: 60 * dp
     running: mapCanvasMap.isRendering
   }
 


### PR DESCRIPTION
Following the PR improving QField's a busy indicator to have it scale properly, this PR relocates the busy indicator to sit below the main menu button. Reasons include:
- It's less obnoxious, yet still visible
- It prevents busy indicator overlap with the identified features indicator
- It also plays better when panning while digitizing features

Here's how it looks:
![Peek 2019-10-15 11-12](https://user-images.githubusercontent.com/1728657/66799914-3acbf780-ef3d-11e9-9eeb-8ee720747329.gif)
