### PR TITLE
Improved digitizing/measurement information strings

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -337,23 +337,29 @@ ApplicationWindow {
 
     text: ( qfieldSettings.numericalDigitizingInformation && stateMachine.state === "digitize" ) || stateMachine.state === 'measure' ?
               '%1%2%3%4'
-                .arg(stateMachine.state === 'digitize' || !digitizingToolbar.isDigitizing ? '<p>%1 / %2</p>'
-                  .arg(coordinateLocator.currentCoordinate.x.toFixed(3))
-                  .arg(coordinateLocator.currentCoordinate.y.toFixed(3))
+                .arg(stateMachine.state === 'digitize' || !digitizingToolbar.isDigitizing ? '<p>%1: %2<br>%3: %4</p>'
+                  .arg(coordinateLocator.mapSettings.destinationCrs.isGeographic ? 'Lon' : 'X')
+                  .arg(coordinateLocator.currentCoordinate.x.toFixed( coordinateLocator.mapSettings.destinationCrs.isGeographic ? 5 : 2 ))
+                  .arg(coordinateLocator.mapSettings.destinationCrs.isGeographic ? 'Lat' : 'Y')
+                  .arg(coordinateLocator.currentCoordinate.y.toFixed( coordinateLocator.mapSettings.destinationCrs.isGeographic ? 5 : 2 ))
                   : '' )
 
-                .arg(digitizingGeometryMeasure.lengthValid ? '<p>%1 %2</p>'
+                .arg(digitizingGeometryMeasure.lengthValid ? '<p>%1: %2%3</p>'
+                  .arg( digitizingGeometryMeasure.segmentLength != digitizingGeometryMeasure.length ? qsTr( 'Segment') : qsTr( 'Length') )
                   .arg(UnitTypes.formatDistance( digitizingGeometryMeasure.segmentLength, 3, digitizingGeometryMeasure.lengthUnits ) )
-                  .arg(digitizingGeometryMeasure.length !== -1 ? '(%1)'.arg(UnitTypes.formatDistance( digitizingGeometryMeasure.length, 3, digitizingGeometryMeasure.lengthUnits ) ) : '' )
+                  .arg(digitizingGeometryMeasure.length !== -1 && digitizingGeometryMeasure.segmentLength != digitizingGeometryMeasure.length ? '<br>%1: %2'.arg( qsTr( 'Length') ).arg(UnitTypes.formatDistance( digitizingGeometryMeasure.length, 3, digitizingGeometryMeasure.lengthUnits ) ) : '' )
                   : '' )
 
-                .arg(digitizingGeometryMeasure.areaValid ? '<p>%1</p>'
+                .arg(digitizingGeometryMeasure.areaValid ? '<p>%1: %2</p>'
+                  .arg( qsTr( 'Area') )
                   .arg(UnitTypes.formatArea( digitizingGeometryMeasure.area, 3, digitizingGeometryMeasure.areaUnits ) )
                   : '' )
 
-                .arg(stateMachine.state === 'measure' && digitizingToolbar.isDigitizing? '<p>%1 / %2</p>'
-                  .arg(coordinateLocator.currentCoordinate.x.toFixed(3))
-                  .arg(coordinateLocator.currentCoordinate.y.toFixed(3))
+                .arg(stateMachine.state === 'measure' && digitizingToolbar.isDigitizing? '<p>%1: %2<br>%3: %4</p>'
+                  .arg(coordinateLocator.mapSettings.destinationCrs.isGeographic ? 'Lon' : 'X')
+                  .arg(coordinateLocator.currentCoordinate.x.toFixed( coordinateLocator.mapSettings.destinationCrs.isGeographic ? 5 : 2 ))
+                  .arg(coordinateLocator.mapSettings.destinationCrs.isGeographic ? 'Lat' : 'Y')
+                  .arg(coordinateLocator.currentCoordinate.y.toFixed( coordinateLocator.mapSettings.destinationCrs.isGeographic ? 5 : 2 ))
                   : '' )
               : ''
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -338,9 +338,9 @@ ApplicationWindow {
     text: ( qfieldSettings.numericalDigitizingInformation && stateMachine.state === "digitize" ) || stateMachine.state === 'measure' ?
               '%1%2%3%4'
                 .arg(stateMachine.state === 'digitize' || !digitizingToolbar.isDigitizing ? '<p>%1: %2<br>%3: %4</p>'
-                  .arg(coordinateLocator.mapSettings.destinationCrs.isGeographic ? 'Lon' : 'X')
+                  .arg(coordinateLocator.mapSettings.destinationCrs.isGeographic ? qsTr( 'Lon' ) : 'X')
                   .arg(coordinateLocator.currentCoordinate.x.toFixed( coordinateLocator.mapSettings.destinationCrs.isGeographic ? 5 : 2 ))
-                  .arg(coordinateLocator.mapSettings.destinationCrs.isGeographic ? 'Lat' : 'Y')
+                  .arg(coordinateLocator.mapSettings.destinationCrs.isGeographic ? qsTr( 'Lat' ) : 'Y')
                   .arg(coordinateLocator.currentCoordinate.y.toFixed( coordinateLocator.mapSettings.destinationCrs.isGeographic ? 5 : 2 ))
                   : '' )
 
@@ -356,9 +356,9 @@ ApplicationWindow {
                   : '' )
 
                 .arg(stateMachine.state === 'measure' && digitizingToolbar.isDigitizing? '<p>%1: %2<br>%3: %4</p>'
-                  .arg(coordinateLocator.mapSettings.destinationCrs.isGeographic ? 'Lon' : 'X')
+                  .arg(coordinateLocator.mapSettings.destinationCrs.isGeographic ? qsTr( 'Lon' ) : 'X')
                   .arg(coordinateLocator.currentCoordinate.x.toFixed( coordinateLocator.mapSettings.destinationCrs.isGeographic ? 5 : 2 ))
-                  .arg(coordinateLocator.mapSettings.destinationCrs.isGeographic ? 'Lat' : 'Y')
+                  .arg(coordinateLocator.mapSettings.destinationCrs.isGeographic ? qsTr( 'Lat' ) : 'Y')
                   .arg(coordinateLocator.currentCoordinate.y.toFixed( coordinateLocator.mapSettings.destinationCrs.isGeographic ? 5 : 2 ))
                   : '' )
               : ''


### PR DESCRIPTION
This PR improves the digitizing / measurement information overlayed onto the canvas. It does so by:
- Adding a keyword for each printed value for a quicker reading/understanding of data shown
- Splitting the coordinates into two lines to avoid text overflowing beyond screen on portrait oriented smartphones
- Use X / Y or Lat / Lon to identify whether coordinates are geometric, or not (a useful visual queue for those who aren't so familiar with GPS programs)
- Add more decimals for lat/lon coordinates, and less for meter (et cie) based units

Here's how it looks like:
![Screenshot from 2019-10-15 16-23-00](https://user-images.githubusercontent.com/1728657/66819416-269def80-ef69-11e9-8ee3-a8a745525df1.png)

![Screenshot from 2019-10-15 16-24-17](https://user-images.githubusercontent.com/1728657/66819426-2a317680-ef69-11e9-80cd-b59febb73459.png)

There's nothing like a long field trip to discover those little tweaks that make a big difference.