### PR TITLE
Add a configurable antenna height option

### DIFF
--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -11,6 +11,8 @@
 
 set -e
 
+apt update && apt install zip
+
 SOURCE_DIR=/usr/src/qfield
 if [[ -z ${BUILD_FOLDER+x} ]]; then
     BUILD_DIR=${SOURCE_DIR}/build-docker

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -57,7 +57,7 @@ fi
 
 mkdir -p ${BUILD_DIR}/.gradle
 # androiddeployqt needs gradle and downloads it to /root/.gradle. By linking it to the build folder, this will be cached between builds.
-ln -s ${BUILD_DIR}/.gradle /root/.gradle
+ln -sfn ${BUILD_DIR}/.gradle /root/.gradle
 
 pushd ${BUILD_DIR}
 cp ${SOURCE_DIR}/scripts/ci/config.pri ${SOURCE_DIR}/config.pri

--- a/src/qgsquick/CMakeLists.txt
+++ b/src/qgsquick/CMakeLists.txt
@@ -15,7 +15,7 @@ SET(QFIELD_QGSQUICK_HDRS
   qgsquickmaptransform.h
   qgsquickutils.h
 )
-FIND_PACKAGE(Qt5 COMPONENTS Core Gui Xml Widgets Quick REQUIRED)
+FIND_PACKAGE(Qt5 COMPONENTS Core Gui Xml Widgets Quick Positioning REQUIRED)
 
 INCLUDE_DIRECTORIES(SYSTEM
   ${QGIS_INCLUDE_DIR}
@@ -28,6 +28,7 @@ TARGET_LINK_LIBRARIES(qfield_qgsquick
   Qt5::Xml
   Qt5::Widgets
   Qt5::Quick
+  Qt5::Positioning
   ${QGIS_CORE_LIBRARY}
 )
 

--- a/src/qgsquick/qgsquickcoordinatetransformer.cpp
+++ b/src/qgsquick/qgsquickcoordinatetransformer.cpp
@@ -50,6 +50,7 @@ void QgsQuickCoordinateTransformer::setSourcePosition( const QgsPoint &sourcePos
   mSourcePosition = sourcePosition;
 
   emit sourcePositionChanged();
+  emit sourceCoordinateChanged();
   updatePosition();
 }
 
@@ -124,12 +125,31 @@ void QgsQuickCoordinateTransformer::updatePosition()
   emit projectedPositionChanged();
 }
 
+QGeoCoordinate QgsQuickCoordinateTransformer::sourceCoordinate() const
+{
+  return QGeoCoordinate( mSourcePosition.y(), mSourcePosition.x(), mSourcePosition.z() );
+}
+
+void QgsQuickCoordinateTransformer::setSourceCoordinate( const QGeoCoordinate &sourceCoordinate )
+{
+  if ( qgsDoubleNear( sourceCoordinate.latitude(), mSourcePosition.y() )
+       && qgsDoubleNear( sourceCoordinate.longitude(), mSourcePosition.x() )
+       && qgsDoubleNear( sourceCoordinate.altitude(), mSourcePosition.z() )
+     )
+    return;
+
+  mSourcePosition = QgsPoint( sourceCoordinate.longitude(), sourceCoordinate.latitude(), sourceCoordinate.altitude() );
+  emit sourcePositionChanged();
+  emit sourceCoordinateChanged();
+  updatePosition();
+}
+
 qreal QgsQuickCoordinateTransformer::deltaZ() const
 {
   return mDeltaZ;
 }
 
-void QgsQuickCoordinateTransformer::setDeltaZ( const qreal& deltaZ )
+void QgsQuickCoordinateTransformer::setDeltaZ( const qreal &deltaZ )
 {
   if ( qgsDoubleNear( mDeltaZ, deltaZ ) )
     return;

--- a/src/qgsquick/qgsquickcoordinatetransformer.cpp
+++ b/src/qgsquick/qgsquickcoordinatetransformer.cpp
@@ -126,10 +126,11 @@ void QgsQuickCoordinateTransformer::updatePosition()
 
 qreal QgsQuickCoordinateTransformer::deltaZ() const
 {
-    return mDeltaZ;
+  return mDeltaZ;
 }
 
 void QgsQuickCoordinateTransformer::setDeltaZ(const qreal& deltaZ)
 {
-    mDeltaZ = deltaZ;
+  emit deltaZChanged();
+  mDeltaZ = deltaZ;
 }

--- a/src/qgsquick/qgsquickcoordinatetransformer.cpp
+++ b/src/qgsquick/qgsquickcoordinatetransformer.cpp
@@ -119,7 +119,17 @@ void QgsQuickCoordinateTransformer::updatePosition()
   }
 
   mProjectedPosition = QgsPoint( x, y );
-  mProjectedPosition.addZValue( mSourcePosition.z() );
+  mProjectedPosition.addZValue( mSourcePosition.z() + mDeltaZ );
 
   emit projectedPositionChanged();
+}
+
+qreal QgsQuickCoordinateTransformer::deltaZ() const
+{
+    return mDeltaZ;
+}
+
+void QgsQuickCoordinateTransformer::setDeltaZ(const qreal& deltaZ)
+{
+    mDeltaZ = deltaZ;
 }

--- a/src/qgsquick/qgsquickcoordinatetransformer.cpp
+++ b/src/qgsquick/qgsquickcoordinatetransformer.cpp
@@ -119,7 +119,7 @@ void QgsQuickCoordinateTransformer::updatePosition()
   }
 
   mProjectedPosition = QgsPoint( x, y );
-  mProjectedPosition.addZValue( mSourcePosition.z() + mDeltaZ );
+  mProjectedPosition.addZValue( z + mDeltaZ );
 
   emit projectedPositionChanged();
 }

--- a/src/qgsquick/qgsquickcoordinatetransformer.cpp
+++ b/src/qgsquick/qgsquickcoordinatetransformer.cpp
@@ -129,8 +129,11 @@ qreal QgsQuickCoordinateTransformer::deltaZ() const
   return mDeltaZ;
 }
 
-void QgsQuickCoordinateTransformer::setDeltaZ(const qreal& deltaZ)
+void QgsQuickCoordinateTransformer::setDeltaZ( const qreal& deltaZ )
 {
+  if ( qgsDoubleNear( mDeltaZ, deltaZ ) )
+    return;
+
   emit deltaZChanged();
   mDeltaZ = deltaZ;
 }

--- a/src/qgsquick/qgsquickcoordinatetransformer.cpp
+++ b/src/qgsquick/qgsquickcoordinatetransformer.cpp
@@ -119,10 +119,27 @@ void QgsQuickCoordinateTransformer::updatePosition()
     QgsDebugMsg( exp.what() );
   }
 
+  if ( mSkipAltitudeTransformation )
+    z = mSourcePosition.z();
+
   mProjectedPosition = QgsPoint( x, y );
   mProjectedPosition.addZValue( z + mDeltaZ );
 
   emit projectedPositionChanged();
+}
+
+bool QgsQuickCoordinateTransformer::skipAltitudeTransformation() const
+{
+  return mSkipAltitudeTransformation;
+}
+
+void QgsQuickCoordinateTransformer::setSkipAltitudeTransformation( bool skipAltitudeTransformation )
+{
+  if ( mSkipAltitudeTransformation == skipAltitudeTransformation )
+    return;
+
+  mSkipAltitudeTransformation = skipAltitudeTransformation;
+  emit skipAltitudeTransformationChanged();
 }
 
 QGeoCoordinate QgsQuickCoordinateTransformer::sourceCoordinate() const

--- a/src/qgsquick/qgsquickcoordinatetransformer.cpp
+++ b/src/qgsquick/qgsquickcoordinatetransformer.cpp
@@ -134,6 +134,10 @@ void QgsQuickCoordinateTransformer::setDeltaZ( const qreal& deltaZ )
   if ( qgsDoubleNear( mDeltaZ, deltaZ ) )
     return;
 
+  if ( std::isnan( deltaZ ) )
+    mDeltaZ = 0;
+  else
+    mDeltaZ = deltaZ;
+
   emit deltaZChanged();
-  mDeltaZ = deltaZ;
 }

--- a/src/qgsquick/qgsquickcoordinatetransformer.h
+++ b/src/qgsquick/qgsquickcoordinatetransformer.h
@@ -99,7 +99,7 @@ class QgsQuickCoordinateTransformer : public QObject
      * The altitude value of captured coordinates is corrected by the amount of deltaZ.
      * This can be used to correct the altitude with the antenna height for example.
      */
-    void setDeltaZ(const qreal& deltaZ);
+    void setDeltaZ( const qreal& deltaZ );
 
   signals:
     //!\copydoc QgsQuickCoordinateTransformer::projectedPosition
@@ -134,7 +134,7 @@ class QgsQuickCoordinateTransformer : public QObject
      * The altitude value of captured coordinates is corrected by the amount of deltaZ.
      * This can be used to correct the altitude with the antenna height for example.
      */
-    qreal mDeltaZ;
+    qreal mDeltaZ = std::numeric_limits<qreal>::quiet_NaN();
 };
 
 #endif // QGSQUICKCOORDINATETRANSFORMER_H

--- a/src/qgsquick/qgsquickcoordinatetransformer.h
+++ b/src/qgsquick/qgsquickcoordinatetransformer.h
@@ -134,7 +134,7 @@ class QgsQuickCoordinateTransformer : public QObject
      * The altitude value of captured coordinates is corrected by the amount of deltaZ.
      * This can be used to correct the altitude with the antenna height for example.
      */
-    qreal mDeltaZ = std::numeric_limits<qreal>::quiet_NaN();
+    qreal mDeltaZ = 0;
 };
 
 #endif // QGSQUICKCOORDINATETRANSFORMER_H

--- a/src/qgsquick/qgsquickcoordinatetransformer.h
+++ b/src/qgsquick/qgsquickcoordinatetransformer.h
@@ -17,6 +17,7 @@
 #define QGSQUICKCOORDINATETRANSFORMER_H
 
 #include <QObject>
+#include <QGeoCoordinate>
 
 #include <qgspoint.h>
 
@@ -42,6 +43,9 @@ class QgsQuickCoordinateTransformer : public QObject
 
     //! Source position  (in source CRS)
     Q_PROPERTY( QgsPoint sourcePosition READ sourcePosition WRITE setSourcePosition NOTIFY sourcePositionChanged )
+
+    //! Source coordinate for integrating with QtPositioning, alternative to source position
+    Q_PROPERTY( QGeoCoordinate sourceCoordinate READ sourceCoordinate WRITE setSourceCoordinate NOTIFY sourceCoordinateChanged )
 
     //! Destination CRS
     Q_PROPERTY( QgsCoordinateReferenceSystem destinationCrs READ destinationCrs WRITE setDestinationCrs NOTIFY destinationCrsChanged )
@@ -99,7 +103,10 @@ class QgsQuickCoordinateTransformer : public QObject
      * The altitude value of captured coordinates is corrected by the amount of deltaZ.
      * This can be used to correct the altitude with the antenna height for example.
      */
-    void setDeltaZ( const qreal& deltaZ );
+    void setDeltaZ( const qreal &deltaZ );
+
+    QGeoCoordinate sourceCoordinate() const;
+    void setSourceCoordinate( const QGeoCoordinate &sourceCoordinate );
 
   signals:
     //!\copydoc QgsQuickCoordinateTransformer::projectedPosition
@@ -107,6 +114,8 @@ class QgsQuickCoordinateTransformer : public QObject
 
     //!\copydoc QgsQuickCoordinateTransformer::sourcePosition
     void sourcePositionChanged();
+
+    void sourceCoordinateChanged();
 
     //!\copydoc QgsQuickCoordinateTransformer::destinationCrs
     void destinationCrsChanged();

--- a/src/qgsquick/qgsquickcoordinatetransformer.h
+++ b/src/qgsquick/qgsquickcoordinatetransformer.h
@@ -62,6 +62,11 @@ class QgsQuickCoordinateTransformer : public QObject
      */
     Q_PROPERTY( qreal deltaZ READ deltaZ WRITE setDeltaZ NOTIFY deltaZChanged )
 
+    /**
+     * Skips any altitude correction handling during CRS transformation. deltaZ will still be applied.
+     */
+    Q_PROPERTY( bool skipAltitudeTransformation READ skipAltitudeTransformation WRITE setSkipAltitudeTransformation NOTIFY skipAltitudeTransformationChanged )
+
   public:
     //! Creates new coordinate transformer
     explicit QgsQuickCoordinateTransformer( QObject *parent = nullptr );
@@ -108,6 +113,16 @@ class QgsQuickCoordinateTransformer : public QObject
     QGeoCoordinate sourceCoordinate() const;
     void setSourceCoordinate( const QGeoCoordinate &sourceCoordinate );
 
+    /**
+     * Skips any altitude correction handling during CRS transformation. deltaZ will still be applied.
+     */
+    bool skipAltitudeTransformation() const;
+
+    /**
+     * Skips any altitude correction handling during CRS transformation. deltaZ will still be applied.
+     */
+    void setSkipAltitudeTransformation( bool skipAltitudeTransformation );
+
   signals:
     //!\copydoc QgsQuickCoordinateTransformer::projectedPosition
     void projectedPositionChanged();
@@ -132,6 +147,11 @@ class QgsQuickCoordinateTransformer : public QObject
      */
     void deltaZChanged();
 
+    /**
+     * Skips any altitude correction handling during CRS transformation. deltaZ will still be applied.
+     */
+    void skipAltitudeTransformationChanged();
+
   private:
     void updatePosition();
 
@@ -144,6 +164,8 @@ class QgsQuickCoordinateTransformer : public QObject
      * This can be used to correct the altitude with the antenna height for example.
      */
     qreal mDeltaZ = 0;
+
+    bool mSkipAltitudeTransformation = true;
 };
 
 #endif // QGSQUICKCOORDINATETRANSFORMER_H

--- a/src/qgsquick/qgsquickcoordinatetransformer.h
+++ b/src/qgsquick/qgsquickcoordinatetransformer.h
@@ -52,6 +52,12 @@ class QgsQuickCoordinateTransformer : public QObject
     //! Transformation context, can be set from QgsQuickMapSettings::transformContext()
     Q_PROPERTY( QgsCoordinateTransformContext transformContext READ transformContext WRITE setTransformContext NOTIFY transformContextChanged )
 
+    /**
+     * The altitude value of captured coordinates is corrected by the amount of deltaZ.
+     * This can be used to correct the altitude with the antenna height for example.
+     */
+    Q_PROPERTY( qreal deltaZ READ deltaZ WRITE setDeltaZ NOTIFY deltaZChanged )
+
   public:
     //! Creates new coordinate transformer
     explicit QgsQuickCoordinateTransformer( QObject *parent = nullptr );
@@ -83,6 +89,18 @@ class QgsQuickCoordinateTransformer : public QObject
     //!\copydoc QgsQuickCoordinateTransformer::transformContext
     QgsCoordinateTransformContext transformContext() const;
 
+    /**
+     * The altitude value of captured coordinates is corrected by the amount of deltaZ.
+     * This can be used to correct the altitude with the antenna height for example.
+     */
+    qreal deltaZ() const;
+
+    /**
+     * The altitude value of captured coordinates is corrected by the amount of deltaZ.
+     * This can be used to correct the altitude with the antenna height for example.
+     */
+    void setDeltaZ(const qreal& deltaZ);
+
   signals:
     //!\copydoc QgsQuickCoordinateTransformer::projectedPosition
     void projectedPositionChanged();
@@ -99,12 +117,24 @@ class QgsQuickCoordinateTransformer : public QObject
     //!\copydoc QgsQuickCoordinateTransformer::transformContext
     void transformContextChanged();
 
+    /**
+     * The altitude value of captured coordinates is corrected by the amount of deltaZ.
+     * This can be used to correct the altitude with the antenna height for example.
+     */
+    void deltaZChanged();
+
   private:
     void updatePosition();
 
     QgsPoint mProjectedPosition;
     QgsPoint mSourcePosition;
     QgsCoordinateTransform mCoordinateTransform;
+
+    /**
+     * The altitude value of captured coordinates is corrected by the amount of deltaZ.
+     * This can be used to correct the altitude with the antenna height for example.
+     */
+    qreal mDeltaZ;
 };
 
 #endif // QGSQUICKCOORDINATETRANSFORMER_H

--- a/src/qml/MapCanvas.qml
+++ b/src/qml/MapCanvas.qml
@@ -42,7 +42,6 @@ Item {
   function freeze(id) {
     mapCanvasWrapper.__freezecount[id] = true
     mapCanvasWrapper.freeze = true
-    console.log(mapSettings.backgroundColor)
   }
 
   function unfreeze(id) {

--- a/src/qml/PageHeader.qml
+++ b/src/qml/PageHeader.qml
@@ -6,10 +6,13 @@ import "js/style.js" as Style
 
 ToolBar {
   property alias title: titleLabel.text
+  property alias showCancelButton: cancelButton.visible
+
   height: 48 * dp
 
   signal cancel
   signal apply
+  signal finished
 
   anchors {
     top: parent.top
@@ -37,7 +40,11 @@ ToolBar {
 
       iconSource: Style.getThemeIcon( 'ic_check_white_48dp' )
 
-      onClicked: apply()
+      onClicked:
+      {
+        apply()
+        finished()
+      }
     }
 
     Label {
@@ -66,6 +73,7 @@ ToolBar {
 
       onClicked: {
         cancel()
+        finished()
       }
     }
   }

--- a/src/qml/PageHeader.qml
+++ b/src/qml/PageHeader.qml
@@ -1,0 +1,72 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.12
+import "."
+import "js/style.js" as Style
+
+ToolBar {
+  property alias title: titleLabel.text
+  height: 48 * dp
+
+  signal cancel
+  signal apply
+
+  anchors {
+    top: parent.top
+    left: parent.left
+    right: parent.right
+  }
+
+  background: Rectangle {
+    color: '#80CC28'
+  }
+
+  RowLayout {
+    anchors.fill: parent
+    Layout.margins: 0
+
+    Button {
+      id: applayButton
+
+      Layout.alignment: Qt.AlignTop | Qt.AlignLeft
+
+      width: 48*dp
+      height: 48*dp
+      clip: true
+      bgcolor: "#212121"
+
+      iconSource: Style.getThemeIcon( 'ic_check_white_48dp' )
+
+      onClicked: apply()
+    }
+
+    Label {
+      id: titleLabel
+
+      font.pointSize: 14
+      font.bold: true
+      color: "#FFFFFF"
+      elide: Label.ElideRight
+      horizontalAlignment: Qt.AlignHCenter
+      verticalAlignment: Qt.AlignVCenter
+      Layout.fillWidth: true
+    }
+
+    Button {
+      id: cancelButton
+
+      Layout.alignment: Qt.AlignTop | Qt.AlignRight
+
+      width: 48*dp
+      height: 48*dp
+      clip: true
+      bgcolor: "#212121"
+
+      iconSource: Style.getThemeIcon( 'ic_close_white_24dp' )
+
+      onClicked: {
+        cancel()
+      }
+    }
+  }
+}

--- a/src/qml/PageHeader.qml
+++ b/src/qml/PageHeader.qml
@@ -2,7 +2,7 @@ import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
 import "."
-import "js/style.js" as Style
+import Theme 1.0
 
 ToolBar {
   property alias title: titleLabel.text
@@ -21,7 +21,7 @@ ToolBar {
   }
 
   background: Rectangle {
-    color: '#80CC28'
+    color: Theme.mainColor
   }
 
   RowLayout {
@@ -36,9 +36,9 @@ ToolBar {
       width: 48*dp
       height: 48*dp
       clip: true
-      bgcolor: "#212121"
+      bgcolor: Theme.darkGray
 
-      iconSource: Style.getThemeIcon( 'ic_check_white_48dp' )
+      iconSource: Theme.getThemeIcon( 'ic_check_white_48dp' )
 
       onClicked:
       {
@@ -50,9 +50,8 @@ ToolBar {
     Label {
       id: titleLabel
 
-      font.pointSize: 14
-      font.bold: true
-      color: "#FFFFFF"
+      font: Theme.strongFont
+      color: Theme.light
       elide: Label.ElideRight
       horizontalAlignment: Qt.AlignHCenter
       verticalAlignment: Qt.AlignVCenter
@@ -67,9 +66,9 @@ ToolBar {
       width: 48*dp
       height: 48*dp
       clip: true
-      bgcolor: "#212121"
+      bgcolor: Theme.darkGray
 
-      iconSource: Style.getThemeIcon( 'ic_close_white_24dp' )
+      iconSource: Theme.getThemeIcon( 'ic_close_white_24dp' )
 
       onClicked: {
         cancel()

--- a/src/qml/PageHeader.qml
+++ b/src/qml/PageHeader.qml
@@ -6,6 +6,7 @@ import Theme 1.0
 
 ToolBar {
   property alias title: titleLabel.text
+  property alias showApplyButton: applyButton.visible
   property alias showCancelButton: cancelButton.visible
 
   height: 48 * dp
@@ -26,10 +27,11 @@ ToolBar {
 
   RowLayout {
     anchors.fill: parent
+
     Layout.margins: 0
 
     Button {
-      id: applayButton
+      id: applyButton
 
       Layout.alignment: Qt.AlignTop | Qt.AlignLeft
 
@@ -49,7 +51,8 @@ ToolBar {
 
     Label {
       id: titleLabel
-
+      leftPadding: !showApplyButton && showCancelButton ? 48 * dp : 0
+      rightPadding: showApplyButton && !showCancelButton ? 48 * dp : 0
       font: Theme.strongFont
       color: Theme.light
       elide: Label.ElideRight

--- a/src/qml/PositionInformationView.qml
+++ b/src/qml/PositionInformationView.qml
@@ -5,12 +5,14 @@ import QtQuick.Layouts 1.3
 import org.qgis 1.0
 import org.qfield 1.0
 import Utils 1.0
+import Theme 1.0
 
 Rectangle {
   id: positionInformationView
   property PositionSource positionSource
   property alias crs: _ct.destinationCrs
   property double rowHeight: 30*dp
+  property alias antennaHeight: antennaHeightText.value
   border.color: "darkslategrey"
   border.width: 1*dp
   color: "yellow"
@@ -32,7 +34,8 @@ Rectangle {
     rows: parent.width > 800*dp ? 1: 2
     width: parent.width - 2 * parent.border.width
     padding: parent.border.width
-    property double cellWidth: grid.width / ( 3* ( grid.rows === 1 ? 2 : 1 ) )
+    property int extraCells: isNaN( parseFloat( positionInformationView.antennaHeight ) ) ? 0 : 1
+    property double cellWidth: grid.width / ( (3 + extraCells ) * ( grid.rows === 1 ? 2 : 1 ) )
 
     Rectangle {
       id: x
@@ -116,6 +119,35 @@ Rectangle {
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
         text: qsTr( "V. Accuracy" ) + ': ' + ( positionSource.position.verticalAccuracyValid ? positionSource.position.verticalAccuracy.toFixed(3) + " m" : qsTr( "N/A" ) )
+      }
+    }
+
+    Rectangle {
+      height: rowHeight
+      width: grid.cellWidth
+      color: Theme.lightGray
+
+      Text {
+        id: antennaHeightText
+        property double value
+
+        anchors.margins:  10*dp
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.left: parent.left
+        text: qsTr( "Antenna" ) + ': ' + ( !isNaN( parseFloat( value ) ) ? value + " m" : qsTr( "N/A" ) )
+      }
+    }
+
+    Rectangle {
+      height: rowHeight
+      width: grid.cellWidth
+      color: "white"
+
+      Text {
+        anchors.margins:  10*dp
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.left: parent.left
+        text: '' // placeholder for whatever comes up
       }
     }
   }

--- a/src/qml/PositionInformationView.qml
+++ b/src/qml/PositionInformationView.qml
@@ -11,7 +11,7 @@ Rectangle {
   id: positionInformationView
   property TransformedPositionSource positionSource
   property double rowHeight: 30*dp
-  property alias antennaHeight: antennaHeightText.value
+  property double antennaHeight: NaN
   border.color: "darkslategrey"
   border.width: 1*dp
   color: "yellow"
@@ -26,8 +26,7 @@ Rectangle {
     rows: parent.width > 800*dp ? 1: 2
     width: parent.width - 2 * parent.border.width
     padding: parent.border.width
-    property int extraCells: isNaN( parseFloat( positionInformationView.antennaHeight ) ) ? 0 : 1
-    property double cellWidth: grid.width / ( (3 + extraCells ) * ( grid.rows === 1 ? 2 : 1 ) )
+    property double cellWidth: grid.width / ( 3 * ( grid.rows === 1 ? 2 : 1 ) )
 
     Rectangle {
       id: x
@@ -71,7 +70,19 @@ Rectangle {
         anchors.margins:  10*dp
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
-        text: qsTr( "Altitude" ) + ': ' + ( positionSource.position.altitudeValid ? positionSource.position.coordinate.altitude.toFixed(3) : qsTr( "N/A" ) )
+        text: {
+          var altitude
+          if ( positionSource.position.altitudeValid ) {
+            altitude = positionSource.position.coordinate.altitude.toFixed(3)
+            if ( !isNaN( parseFloat( antennaHeight ) ) ) {
+              altitude += (antennaHeight > 0 ? "+" : "") + Math.abs(antennaHeight).toFixed(2)
+            }
+          }
+          else
+            altitude = qsTr( "N/A" )
+          altitude = qsTr( "Altitude" ) + ': ' + altitude
+          return altitude
+        }
       }
     }
 
@@ -111,35 +122,6 @@ Rectangle {
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
         text: qsTr( "V. Accuracy" ) + ': ' + ( positionSource.position.verticalAccuracyValid ? positionSource.position.verticalAccuracy.toFixed(3) + " m" : qsTr( "N/A" ) )
-      }
-    }
-
-    Rectangle {
-      height: rowHeight
-      width: grid.cellWidth
-      color: Theme.lightGray
-
-      Text {
-        id: antennaHeightText
-        property double value
-
-        anchors.margins:  10*dp
-        anchors.verticalCenter: parent.verticalCenter
-        anchors.left: parent.left
-        text: qsTr( "Antenna" ) + ': ' + ( !isNaN( parseFloat( value ) ) ? value + " m" : qsTr( "N/A" ) )
-      }
-    }
-
-    Rectangle {
-      height: rowHeight
-      width: grid.cellWidth
-      color: "white"
-
-      Text {
-        anchors.margins:  10*dp
-        anchors.verticalCenter: parent.verticalCenter
-        anchors.left: parent.left
-        text: '' // placeholder for whatever comes up
       }
     }
   }

--- a/src/qml/PositionInformationView.qml
+++ b/src/qml/PositionInformationView.qml
@@ -9,20 +9,12 @@ import Theme 1.0
 
 Rectangle {
   id: positionInformationView
-  property PositionSource positionSource
-  property alias crs: _ct.destinationCrs
+  property TransformedPositionSource positionSource
   property double rowHeight: 30*dp
   property alias antennaHeight: antennaHeightText.value
   border.color: "darkslategrey"
   border.width: 1*dp
   color: "yellow"
-
-  CoordinateTransformer {
-    id: _ct
-    sourceCrs: CrsFactory.fromEpsgId(4326)
-    sourcePosition: Utils.coordinateToPoint(positionSource.position.coordinate)
-    transformContext: qgisProject.transformContext
-  }
 
   height: grid.rows * positionInformationView.rowHeight + 2 * border.width
   width: parent.width
@@ -48,9 +40,9 @@ Rectangle {
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
 
-        text: crs.isGeographic ?
-                  qsTr( "Lat." ) + ': ' + ( positionSource.position.latitudeValid  ? Number( _ct.projectedPosition.y ).toLocaleString( Qt.locale(), 'f', 3 ) : qsTr( "N/A" ) )
-                : qsTr( "X" )    + ': ' + ( positionSource.position.longitudeValid ? Number( _ct.projectedPosition.x ).toLocaleString( Qt.locale(), 'f', 3 ) : qsTr( "N/A" ) )
+        text: positionSource.destinationCrs.isGeographic ?
+                  qsTr( "Lat." ) + ': ' + ( positionSource.position.latitudeValid  ? Number( positionSource.projectedPosition.y ).toLocaleString( Qt.locale(), 'f', 3 ) : qsTr( "N/A" ) )
+                : qsTr( "X" )    + ': ' + ( positionSource.position.longitudeValid ? Number( positionSource.projectedPosition.x ).toLocaleString( Qt.locale(), 'f', 3 ) : qsTr( "N/A" ) )
       }
     }
 
@@ -63,9 +55,9 @@ Rectangle {
         anchors.margins:  10*dp
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
-        text: crs.isGeographic ?
-                  qsTr( "Lon." ) + ': ' + ( positionSource.position.longitudeValid ? Number( _ct.projectedPosition.x ).toLocaleString( Qt.locale(), 'f', 3 ) : qsTr( "N/A" ) )
-                : qsTr( "Y" )    + ': ' + ( positionSource.position.latitudeValid  ? Number( _ct.projectedPosition.y ).toLocaleString( Qt.locale(), 'f', 3 ) : qsTr( "N/A" ) )
+        text: positionSource.destinationCrs.isGeographic ?
+                  qsTr( "Lon." ) + ': ' + ( positionSource.position.longitudeValid ? Number( positionSource.projectedPosition.x ).toLocaleString( Qt.locale(), 'f', 3 ) : qsTr( "N/A" ) )
+                : qsTr( "Y" )    + ': ' + ( positionSource.position.latitudeValid  ? Number( positionSource.projectedPosition.y ).toLocaleString( Qt.locale(), 'f', 3 ) : qsTr( "N/A" ) )
 
       }
     }

--- a/src/qml/PositionInformationView.qml
+++ b/src/qml/PositionInformationView.qml
@@ -21,9 +21,9 @@ Rectangle {
   Grid {
     id: grid
     flow: GridLayout.TopToBottom
-    rows: parent.width > 800*dp ? 1: 2
+    rows: parent.width > 1000*dp ? 1 : parent.width > 620*dp ? 2 : 3
     width: parent.width
-    property double cellWidth: grid.width / ( 3 * ( grid.rows === 1 ? 2 : 1 ) )
+    property double cellWidth: grid.width / ( 6 / grid.rows )
 
     Rectangle {
       id: x
@@ -35,7 +35,7 @@ Rectangle {
         anchors.margins:  10*dp
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
-        font: Theme.defaultFont
+        font: Theme.tipFont
         text: positionSource.destinationCrs.isGeographic ?
                   qsTr( "Lat." ) + ': ' + ( positionSource.position.latitudeValid  ? Number( positionSource.projectedPosition.y ).toLocaleString( Qt.locale(), 'f', 3 ) : qsTr( "N/A" ) )
                 : qsTr( "X" )    + ': ' + ( positionSource.position.longitudeValid ? Number( positionSource.projectedPosition.x ).toLocaleString( Qt.locale(), 'f', 3 ) : qsTr( "N/A" ) )
@@ -51,7 +51,7 @@ Rectangle {
         anchors.margins:  10*dp
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
-        font: Theme.defaultFont
+        font: Theme.tipFont
         text: positionSource.destinationCrs.isGeographic ?
                   qsTr( "Lon." ) + ': ' + ( positionSource.position.longitudeValid ? Number( positionSource.projectedPosition.x ).toLocaleString( Qt.locale(), 'f', 3 ) : qsTr( "N/A" ) )
                 : qsTr( "Y" )    + ': ' + ( positionSource.position.latitudeValid  ? Number( positionSource.projectedPosition.y ).toLocaleString( Qt.locale(), 'f', 3 ) : qsTr( "N/A" ) )
@@ -68,7 +68,7 @@ Rectangle {
         anchors.margins:  10*dp
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
-        font: Theme.defaultFont
+        font: Theme.tipFont
         text: {
           var altitude
           if ( positionSource.position.altitudeValid ) {
@@ -94,7 +94,7 @@ Rectangle {
         anchors.margins:  10*dp
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
-        font: Theme.defaultFont
+        font: Theme.tipFont
         text: qsTr( "Speed" ) + ': ' + ( positionSource.position.speedValid ? positionSource.position.speed.toFixed(3) + " m/s" : qsTr( "N/A" ) )
       }
     }
@@ -108,7 +108,7 @@ Rectangle {
         anchors.margins:  10*dp
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
-        font: Theme.defaultFont
+        font: Theme.tipFont
         text: qsTr( "H. Accuracy" ) + ': ' + ( positionSource.position.horizontalAccuracyValid ? positionSource.position.horizontalAccuracy.toFixed(3) + " m" : qsTr( "N/A" ) )
       }
     }
@@ -122,7 +122,7 @@ Rectangle {
         anchors.margins:  10*dp
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
-        font: Theme.defaultFont
+        font: Theme.tipFont
         text: qsTr( "V. Accuracy" ) + ': ' + ( positionSource.position.verticalAccuracyValid ? positionSource.position.verticalAccuracy.toFixed(3) + " m" : qsTr( "N/A" ) )
       }
     }

--- a/src/qml/PositionInformationView.qml
+++ b/src/qml/PositionInformationView.qml
@@ -72,9 +72,9 @@ Rectangle {
         text: {
           var altitude
           if ( positionSource.position.altitudeValid ) {
-            altitude = positionSource.position.coordinate.altitude.toFixed(3)
+            altitude = Number( positionSource.projectedPosition.z ).toLocaleString( Qt.locale(), 'f', 3 )
             if ( !isNaN( parseFloat( antennaHeight ) ) ) {
-              altitude += '<font color="#2f2f2f"><i>%1</i></font>'.arg((antennaHeight > 0 ? "+" : "") + Math.abs(antennaHeight).toFixed(2))
+              altitude += '<font color="#2f2f2f"><i>(%1)</i></font>'.arg((antennaHeight > 0 ? "+" : "") + Math.abs(antennaHeight).toFixed(2))
             }
           }
           else

--- a/src/qml/PositionInformationView.qml
+++ b/src/qml/PositionInformationView.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.11
-import QtQuick.Controls 1.4
+import QtQuick.Controls 2.11
 import QtPositioning 5.8
 import QtQuick.Layouts 1.3
 import org.qgis 1.0
@@ -12,8 +12,6 @@ Rectangle {
   property TransformedPositionSource positionSource
   property double rowHeight: 30*dp
   property double antennaHeight: NaN
-  border.color: "darkslategrey"
-  border.width: 1*dp
   color: "yellow"
 
   height: grid.rows * positionInformationView.rowHeight + 2 * border.width
@@ -24,21 +22,20 @@ Rectangle {
     id: grid
     flow: GridLayout.TopToBottom
     rows: parent.width > 800*dp ? 1: 2
-    width: parent.width - 2 * parent.border.width
-    padding: parent.border.width
+    width: parent.width
     property double cellWidth: grid.width / ( 3 * ( grid.rows === 1 ? 2 : 1 ) )
 
     Rectangle {
       id: x
       height: rowHeight
       width: grid.cellWidth
-      color: "#f2f2f2"
+      color: Theme.lightGray
 
       Text {
         anchors.margins:  10*dp
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
-
+        font: Theme.defaultFont
         text: positionSource.destinationCrs.isGeographic ?
                   qsTr( "Lat." ) + ': ' + ( positionSource.position.latitudeValid  ? Number( positionSource.projectedPosition.y ).toLocaleString( Qt.locale(), 'f', 3 ) : qsTr( "N/A" ) )
                 : qsTr( "X" )    + ': ' + ( positionSource.position.longitudeValid ? Number( positionSource.projectedPosition.x ).toLocaleString( Qt.locale(), 'f', 3 ) : qsTr( "N/A" ) )
@@ -54,6 +51,7 @@ Rectangle {
         anchors.margins:  10*dp
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
+        font: Theme.defaultFont
         text: positionSource.destinationCrs.isGeographic ?
                   qsTr( "Lon." ) + ': ' + ( positionSource.position.longitudeValid ? Number( positionSource.projectedPosition.x ).toLocaleString( Qt.locale(), 'f', 3 ) : qsTr( "N/A" ) )
                 : qsTr( "Y" )    + ': ' + ( positionSource.position.latitudeValid  ? Number( positionSource.projectedPosition.y ).toLocaleString( Qt.locale(), 'f', 3 ) : qsTr( "N/A" ) )
@@ -64,18 +62,19 @@ Rectangle {
     Rectangle {
       height: rowHeight
       width: grid.cellWidth
-      color: grid.rows === 2 ? "white" : "#f2f2f2"
+      color: grid.rows === 2 ? "white" : Theme.lightGray
 
       Text {
         anchors.margins:  10*dp
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
+        font: Theme.defaultFont
         text: {
           var altitude
           if ( positionSource.position.altitudeValid ) {
             altitude = positionSource.position.coordinate.altitude.toFixed(3)
             if ( !isNaN( parseFloat( antennaHeight ) ) ) {
-              altitude += (antennaHeight > 0 ? "+" : "") + Math.abs(antennaHeight).toFixed(2)
+              altitude += '<font color="#2f2f2f"><i>%1</i></font>'.arg((antennaHeight > 0 ? "+" : "") + Math.abs(antennaHeight).toFixed(2))
             }
           }
           else
@@ -89,12 +88,13 @@ Rectangle {
     Rectangle {
       height: rowHeight
       width: grid.cellWidth
-      color: grid.rows === 2 ? "#f2f2f2" : "white"
+      color: grid.rows === 2 ? Theme.lightGray : "white"
 
       Text {
         anchors.margins:  10*dp
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
+        font: Theme.defaultFont
         text: qsTr( "Speed" ) + ': ' + ( positionSource.position.speedValid ? positionSource.position.speed.toFixed(3) + " m/s" : qsTr( "N/A" ) )
       }
     }
@@ -102,12 +102,13 @@ Rectangle {
     Rectangle {
       height: rowHeight
       width: grid.cellWidth
-      color: "#f2f2f2"
+      color: Theme.lightGray
 
       Text {
         anchors.margins:  10*dp
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
+        font: Theme.defaultFont
         text: qsTr( "H. Accuracy" ) + ': ' + ( positionSource.position.horizontalAccuracyValid ? positionSource.position.horizontalAccuracy.toFixed(3) + " m" : qsTr( "N/A" ) )
       }
     }
@@ -121,6 +122,7 @@ Rectangle {
         anchors.margins:  10*dp
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
+        font: Theme.defaultFont
         text: qsTr( "V. Accuracy" ) + ': ' + ( positionSource.position.verticalAccuracyValid ? positionSource.position.verticalAccuracy.toFixed(3) + " m" : qsTr( "N/A" ) )
       }
     }

--- a/src/qml/PositionInformationView.qml
+++ b/src/qml/PositionInformationView.qml
@@ -14,7 +14,7 @@ Rectangle {
   property double antennaHeight: NaN
   color: "yellow"
 
-  height: grid.rows * positionInformationView.rowHeight + 2 * border.width
+  height: grid.rows * positionInformationView.rowHeight
   width: parent.width
   anchors.margins: 20
 

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -41,7 +41,7 @@ Popup {
           enabled: antennaHeightActivated.checked
 
           Text {
-            text: qsTr("Antenna Height")
+            text: qsTr("Antenna Height Compensation")
             enabled: antennaHeightActivated.checked
           }
 
@@ -53,6 +53,18 @@ Popup {
 
             inputMethodHints: Qt.ImhFormattedNumbersOnly
             validator: DoubleValidator {}
+          }
+
+          Label {
+            leftPadding: 30 * dp
+            rightPadding: ( 30 + 54 ) * dp
+            bottomPadding: 55 * dp
+            text: qsTr( "Z values which are recorded from a positioning receiver will be corrected by this value. If a value of 1.6 is entered, this will result in a correction of -1.6\u00A0m for each recorded value." )
+            font.pointSize: 12
+            font.italic: true
+
+            wrapMode: Text.WordWrap
+            Layout.fillWidth: true
           }
         }
     }

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -90,7 +90,7 @@ Popup {
         Label {
           leftPadding: 22 * dp
           enabled: antennaHeightActivated.checked
-          text: qsTr( "Z values which are recorded from a positioning receiver will be corrected by this value. If a value of 1.6 is entered, this will result in a correction of -1.6\u00A0m for each recorded value. The value shown in the position information view will be corrected by this value." )
+          text: qsTr( "Z values which are recorded from a positioning receiver will be corrected by this value. If a value of 1.6 is entered, this will result in a correction of -1.6\u00A0m for each recorded value. The value shown in the position information view is already corrected by this value." )
           font: Theme.tipFont
 
           wrapMode: Text.WordWrap

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -1,0 +1,54 @@
+import QtQuick 2.0
+import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.12
+import Qt.labs.settings 1.0
+
+Popup {
+  property alias antennaHeight:  antennaHeightInput.text
+  property alias antennaHeightActivated: antennaHeightActivated.checked
+
+  Settings {
+    property alias antennaHeight: antennaHeightInput.text
+    property alias antennaHeightActivated: antennaHeightActivated.checked
+  }
+
+  Page {
+    anchors.fill: parent
+
+    header: PageHeader {
+      title: qsTr("Positionig Settings")
+    }
+
+    GroupBox {
+        anchors.left: parent.left
+        anchors.right: parent.right
+
+        label: CheckBox {
+          id: antennaHeightActivated
+          text: qsTr("Activate Antenna Height")
+        }
+
+        GridLayout {
+          columns: 2
+          flow: GridLayout.LeftToRight
+          anchors.fill: parent
+          enabled: antennaHeightActivated.checked
+
+          Text {
+            text: qsTr("Antenna Height")
+            enabled: antennaHeightActivated.checked
+          }
+
+          TextField {
+            id: antennaHeightInput
+            enabled: antennaHeightActivated.checked
+
+            Layout.fillWidth: true
+
+            inputMethodHints: Qt.ImhFormattedNumbersOnly
+            validator: DoubleValidator {}
+          }
+        }
+    }
+  }
+}

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -2,6 +2,7 @@ import QtQuick 2.0
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
 import Qt.labs.settings 1.0
+import Theme 1.0
 
 Popup {
   id: popup
@@ -18,6 +19,7 @@ Popup {
 
   Page {
     anchors.fill: parent
+    padding: 20 * dp
 
     header: PageHeader {
       title: qsTr("Positioning Settings")
@@ -34,6 +36,7 @@ Popup {
         label: CheckBox {
           id: antennaHeightActivated
           text: qsTr("Activate Antenna Height Compensation")
+          font: Theme.defaultFont
 
           indicator.height: 16 * dp
           indicator.width: 16 * dp
@@ -50,6 +53,7 @@ Popup {
           Text {
             text: qsTr("Antenna Height")
             enabled: antennaHeightActivated.checked
+            font: Theme.defaultFont
           }
 
           TextField {

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -9,12 +9,14 @@ Popup {
 
   property double antennaHeight: parseFloat(antennaHeightInput.text)
   property alias antennaHeightActivated: antennaHeightActivated.checked
+  property alias skipAltitudeCorrection: skipAltitudeCorrectionSwitch.checked
 
   padding: 0
 
   Settings {
     property alias antennaHeight: antennaHeightInput.text
     property alias antennaHeightActivated: antennaHeightActivated.checked
+    property alias skipAltitudeCorrection: skipAltitudeCorrectionSwitch.checked
   }
 
   Page {
@@ -29,35 +31,31 @@ Popup {
       onFinished: popup.visible = false
     }
 
-    GroupBox {
+    GridLayout {
         anchors.left: parent.left
         anchors.right: parent.right
-        padding: 20 * dp
 
-        label: CheckBox {
-          id: antennaHeightActivated
-          text: qsTr("Activate Antenna Height Compensation")
-          font: Theme.defaultFont
+        columns: 2
+        columnSpacing: 2 * dp
+        rowSpacing: 10 * dp
 
-          indicator.height: 16 * dp
-          indicator.width: 16 * dp
-          icon.height: 16 * dp
-          icon.width: 16 * dp
+        Label {
+            text: qsTr("Activate Antenna Height Compensation")
+            font: Theme.defaultFont
         }
 
-        GridLayout {
-          columns: 2
-          flow: GridLayout.LeftToRight
-          anchors.fill: parent
-          enabled: antennaHeightActivated.checked
+        QfSwitch {
+            id: antennaHeightActivated
+        }
 
-          Text {
+        Label {
             text: qsTr("Antenna Height")
+            leftPadding: 22 * dp
             enabled: antennaHeightActivated.checked
             font: Theme.defaultFont
-          }
+        }
 
-          TextField {
+        TextField {
             id: antennaHeightInput
             enabled: antennaHeightActivated.checked
             text: "0"
@@ -69,17 +67,49 @@ Popup {
 
             inputMethodHints: Qt.ImhFormattedNumbersOnly
             validator: DoubleValidator {}
-          }
+        }
 
-          Label {
+        Label {
             leftPadding: 30 * dp
             rightPadding: 30 * dp
+            enabled: antennaHeightActivated.checked
             text: qsTr( "Z values which are recorded from a positioning receiver will be corrected by this value. If a value of 1.6 is entered, this will result in a correction of -1.6\u00A0m for each recorded value. The value shown in the position information view will be corrected by this value." )
             font: Theme.tipFont
 
             wrapMode: Text.WordWrap
             Layout.fillWidth: true
-          }
+        }
+
+        Item {
+            // empty cell in grid layout
+            width: 1
+        }
+
+        Label {
+            padding: 8 * dp
+            wrapMode: Text.WordWrap
+
+            text: qsTr( "Skip altitude correction" )
+            font: Theme.defaultFont
+
+            MouseArea {
+                anchors.fill: parent
+                onClicked: skipAltitudeCorrectionSwitch.toggle()
+            }
+        }
+
+        QfSwitch {
+            id: skipAltitudeCorrectionSwitch
+        }
+
+        Label {
+            padding: 8 * dp
+            topPadding: 0
+            leftPadding: 22 * dp
+            text: qsTr( "Use the altitude as reported by the positioning interface. Skip any altitude correction that may be implied by the coordinate system transformation." )
+            font: Theme.tipFont
+
+            wrapMode: Text.WordWrap
         }
     }
   }

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -9,6 +9,8 @@ Popup {
   property double antennaHeight: parseFloat(antennaHeightInput.text)
   property alias antennaHeightActivated: antennaHeightActivated.checked
 
+  padding: 0
+
   Settings {
     property alias antennaHeight: antennaHeightInput.text
     property alias antennaHeightActivated: antennaHeightActivated.checked
@@ -18,7 +20,7 @@ Popup {
     anchors.fill: parent
 
     header: PageHeader {
-      title: qsTr("Positionig Settings")
+      title: qsTr("Positioning Settings")
 
       showCancelButton: false
 
@@ -68,8 +70,7 @@ Popup {
             rightPadding: ( 30 + 54 ) * dp
             bottomPadding: 55 * dp
             text: qsTr( "Z values which are recorded from a positioning receiver will be corrected by this value. If a value of 1.6 is entered, this will result in a correction of -1.6\u00A0m for each recorded value." )
-            font.pointSize: 12
-            font.italic: true
+            font: Theme.tipFont
 
             wrapMode: Text.WordWrap
             Layout.fillWidth: true

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -25,6 +25,7 @@ Popup {
     header: PageHeader {
         title: qsTr("Positioning Settings")
 
+        showApplyButton: true
         showCancelButton: false
 
         onFinished: popup.visible = false

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -31,7 +31,12 @@ Popup {
 
         label: CheckBox {
           id: antennaHeightActivated
-          text: qsTr("Activate Antenna Height")
+          text: qsTr("Activate Antenna Height Compensation")
+
+          indicator.height: 16 * dp
+          indicator.width: 16 * dp
+          icon.height: 16 * dp
+          icon.width: 16 * dp
         }
 
         GridLayout {
@@ -41,15 +46,18 @@ Popup {
           enabled: antennaHeightActivated.checked
 
           Text {
-            text: qsTr("Antenna Height Compensation")
+            text: qsTr("Antenna Height")
             enabled: antennaHeightActivated.checked
           }
 
           TextField {
             id: antennaHeightInput
             enabled: antennaHeightActivated.checked
+            text: "0"
 
             Layout.fillWidth: true
+            Layout.preferredHeight: font.height + 20 * dp
+            font: Theme.defaultFont
 
             inputMethodHints: Qt.ImhFormattedNumbersOnly
             validator: DoubleValidator {}

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -74,7 +74,7 @@ Popup {
           Label {
             leftPadding: 30 * dp
             rightPadding: 30 * dp
-            text: qsTr( "Z values which are recorded from a positioning receiver will be corrected by this value. If a value of 1.6 is entered, this will result in a correction of -1.6\u00A0m for each recorded value." )
+            text: qsTr( "Z values which are recorded from a positioning receiver will be corrected by this value. If a value of 1.6 is entered, this will result in a correction of -1.6\u00A0m for each recorded value. The value shown in the position information view will be corrected by this value." )
             font: Theme.tipFont
 
             wrapMode: Text.WordWrap

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -32,6 +32,7 @@ Popup {
     GroupBox {
         anchors.left: parent.left
         anchors.right: parent.right
+        padding: 20 * dp
 
         label: CheckBox {
           id: antennaHeightActivated
@@ -62,6 +63,7 @@ Popup {
             text: "0"
 
             Layout.fillWidth: true
+            Layout.minimumWidth: 60 * dp
             Layout.preferredHeight: font.height + 20 * dp
             font: Theme.defaultFont
 

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -4,6 +4,8 @@ import QtQuick.Layouts 1.12
 import Qt.labs.settings 1.0
 
 Popup {
+  id: popup
+
   property alias antennaHeight:  antennaHeightInput.text
   property alias antennaHeightActivated: antennaHeightActivated.checked
 
@@ -17,6 +19,10 @@ Popup {
 
     header: PageHeader {
       title: qsTr("Positionig Settings")
+
+      showCancelButton: false
+
+      onFinished: popup.visible = false
     }
 
     GroupBox {

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -6,7 +6,7 @@ import Qt.labs.settings 1.0
 Popup {
   id: popup
 
-  property alias antennaHeight:  antennaHeightInput.text
+  property double antennaHeight: parseFloat(antennaHeightInput.text)
   property alias antennaHeightActivated: antennaHeightActivated.checked
 
   Settings {

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -71,8 +71,7 @@ Popup {
 
           Label {
             leftPadding: 30 * dp
-            rightPadding: ( 30 + 54 ) * dp
-            bottomPadding: 55 * dp
+            rightPadding: 30 * dp
             text: qsTr( "Z values which are recorded from a positioning receiver will be corrected by this value. If a value of 1.6 is entered, this will result in a correction of -1.6\u00A0m for each recorded value." )
             font: Theme.tipFont
 

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -51,7 +51,7 @@ Popup {
         rowSpacing: 10 * dp
 
         Label {
-          text: qsTr("Activate Antenna Height Compensation")
+          text: qsTr("Activate antenna height compensation")
           font: Theme.defaultFont
           wrapMode: Text.WordWrap
           Layout.fillWidth: true
@@ -88,8 +88,7 @@ Popup {
         }
 
         Label {
-          leftPadding: 30 * dp
-          rightPadding: 30 * dp
+          leftPadding: 22 * dp
           enabled: antennaHeightActivated.checked
           text: qsTr( "Z values which are recorded from a positioning receiver will be corrected by this value. If a value of 1.6 is entered, this will result in a correction of -1.6\u00A0m for each recorded value. The value shown in the position information view will be corrected by this value." )
           font: Theme.tipFont
@@ -104,7 +103,6 @@ Popup {
         }
 
         Label {
-          padding: 8 * dp
           text: qsTr( "Skip altitude correction" )
           font: Theme.defaultFont
           wrapMode: Text.WordWrap

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -21,96 +21,116 @@ Popup {
 
   Page {
     anchors.fill: parent
-    padding: 20 * dp
 
     header: PageHeader {
-      title: qsTr("Positioning Settings")
+        title: qsTr("Positioning Settings")
 
-      showCancelButton: false
+        showCancelButton: false
 
-      onFinished: popup.visible = false
-    }
+        onFinished: popup.visible = false
+      }
 
-    GridLayout {
-        anchors.left: parent.left
-        anchors.right: parent.right
+
+    ScrollView {
+      padding: 20 * dp
+      ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+      ScrollBar.vertical.policy: ScrollBar.AsNeeded
+      contentWidth: positioningGrid.width
+      contentHeight: positioningGrid.height
+      anchors.fill: parent
+      clip: true
+
+      GridLayout {
+        id: positioningGrid
+        width: parent.parent.width
+        anchors.fill: parent.parent
 
         columns: 2
         columnSpacing: 2 * dp
         rowSpacing: 10 * dp
 
         Label {
-            text: qsTr("Activate Antenna Height Compensation")
-            font: Theme.defaultFont
-        }
+          text: qsTr("Activate Antenna Height Compensation")
+          font: Theme.defaultFont
+          wrapMode: Text.WordWrap
+          Layout.fillWidth: true
 
-        QfSwitch {
-            id: antennaHeightActivated
-        }
-
-        Label {
-            text: qsTr("Antenna Height")
-            leftPadding: 22 * dp
-            enabled: antennaHeightActivated.checked
-            font: Theme.defaultFont
-        }
-
-        TextField {
-            id: antennaHeightInput
-            enabled: antennaHeightActivated.checked
-            text: "0"
-
-            Layout.fillWidth: true
-            Layout.minimumWidth: 60 * dp
-            Layout.preferredHeight: font.height + 20 * dp
-            font: Theme.defaultFont
-
-            inputMethodHints: Qt.ImhFormattedNumbersOnly
-            validator: DoubleValidator {}
-        }
-
-        Label {
-            leftPadding: 30 * dp
-            rightPadding: 30 * dp
-            enabled: antennaHeightActivated.checked
-            text: qsTr( "Z values which are recorded from a positioning receiver will be corrected by this value. If a value of 1.6 is entered, this will result in a correction of -1.6\u00A0m for each recorded value. The value shown in the position information view will be corrected by this value." )
-            font: Theme.tipFont
-
-            wrapMode: Text.WordWrap
-            Layout.fillWidth: true
-        }
-
-        Item {
-            // empty cell in grid layout
-            width: 1
-        }
-
-        Label {
-            padding: 8 * dp
-            wrapMode: Text.WordWrap
-
-            text: qsTr( "Skip altitude correction" )
-            font: Theme.defaultFont
-
-            MouseArea {
-                anchors.fill: parent
-                onClicked: skipAltitudeCorrectionSwitch.toggle()
+          MouseArea {
+            anchors.fill: parent
+            onClicked: antennaHeightActivated.toggle()
             }
         }
 
         QfSwitch {
-            id: skipAltitudeCorrectionSwitch
+          id: antennaHeightActivated
+          Layout.alignment: Qt.AlignTop
         }
 
         Label {
-            padding: 8 * dp
-            topPadding: 0
-            leftPadding: 22 * dp
-            text: qsTr( "Use the altitude as reported by the positioning interface. Skip any altitude correction that may be implied by the coordinate system transformation." )
-            font: Theme.tipFont
-
-            wrapMode: Text.WordWrap
+          text: qsTr("Antenna Height")
+          leftPadding: 22 * dp
+          enabled: antennaHeightActivated.checked
+          font: Theme.defaultFont
         }
+
+        TextField {
+          id: antennaHeightInput
+          enabled: antennaHeightActivated.checked
+          text: "0"
+          width: 60 * dp
+          font: Theme.defaultFont
+          Layout.preferredWidth: 60 * dp
+          Layout.preferredHeight: font.height + 20 * dp
+
+          inputMethodHints: Qt.ImhFormattedNumbersOnly
+          validator: DoubleValidator {}
+        }
+
+        Label {
+          leftPadding: 30 * dp
+          rightPadding: 30 * dp
+          enabled: antennaHeightActivated.checked
+          text: qsTr( "Z values which are recorded from a positioning receiver will be corrected by this value. If a value of 1.6 is entered, this will result in a correction of -1.6\u00A0m for each recorded value. The value shown in the position information view will be corrected by this value." )
+          font: Theme.tipFont
+
+          wrapMode: Text.WordWrap
+          Layout.fillWidth: true
+        }
+
+        Item {
+          // empty cell in grid layout
+          width: 1
+        }
+
+        Label {
+          padding: 8 * dp
+          text: qsTr( "Skip altitude correction" )
+          font: Theme.defaultFont
+          wrapMode: Text.WordWrap
+          Layout.fillWidth: true
+
+          MouseArea {
+            anchors.fill: parent
+            onClicked: skipAltitudeCorrectionSwitch.toggle()
+          }
+        }
+
+        QfSwitch {
+          id: skipAltitudeCorrectionSwitch
+          Layout.alignment: Qt.AlignTop
+        }
+
+        Label {
+          padding: 8 * dp
+          topPadding: 0
+          leftPadding: 22 * dp
+          text: qsTr( "Use the altitude as reported by the positioning interface. Skip any altitude correction that may be implied by the coordinate system transformation." )
+          font: Theme.tipFont
+
+          wrapMode: Text.WordWrap
+          Layout.fillWidth: true
+        }
+      }
     }
   }
 }

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -97,6 +97,7 @@ Page {
 
             QfSwitch {
                 id: showScaleBarCheckBox
+                Layout.alignment: Qt.AlignTop
             }
 
             Label {
@@ -117,6 +118,7 @@ Page {
 
             QfSwitch {
                 id: fullScreenIdentifyViewCheckBox
+                Layout.alignment: Qt.AlignTop
             }
 
             ColumnLayout {
@@ -154,6 +156,7 @@ Page {
 
             QfSwitch {
                 id: locatorKeepScaleCheckBox
+                Layout.alignment: Qt.AlignTop
             }
 
             ColumnLayout {
@@ -191,6 +194,7 @@ Page {
 
             QfSwitch {
                 id: incrementalRenderingCheckBox
+                Layout.alignment: Qt.AlignTop
             }
 
             ColumnLayout {
@@ -228,6 +232,7 @@ Page {
 
             QfSwitch {
                 id: numericalDigitizingInformationCheckBox
+                Layout.alignment: Qt.AlignTop
             }
 
             ColumnLayout {
@@ -265,6 +270,7 @@ Page {
 
             QfSwitch {
                 id: useNativeCameraCheckBox
+                Layout.alignment: Qt.AlignTop
             }
 
 

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -95,39 +95,8 @@ Page {
                 }
             }
 
-            SwitchDelegate {
+            QfSwitch {
                 id: showScaleBarCheckBox
-                Layout.alignment: Qt.AlignTop
-                width: 48 * dp
-                padding: 10 * dp
-                background: Rectangle {
-                    width: 68 * dp
-                    color: transparent
-                }
-                indicator: Rectangle {
-                    implicitWidth: 48 * dp
-                    implicitHeight: 26 * dp
-                    x: parent.leftPadding
-                    y: ( parent.height + parent.topPadding - 6 ) / 2 - height / 2
-                    radius: 13 * dp
-                    color: parent.checked ? Theme.mainColor : Theme.lightGray
-                    border.color: parent.checked ? Theme.mainColor : Theme.lightGray
-
-                    Rectangle {
-                        x: parent.parent.checked ? parent.width - width : 0
-                        width: 26 * dp
-                        height: 26 * dp
-                        radius: 13 * dp
-                        color: parent.parent.down ? Theme.lightGray : Theme.light
-                        border.color: parent.parent.checked ? Theme.mainColor : Theme.lightGray
-                        Behavior on x {
-                            PropertyAnimation {
-                                duration: 150
-                                easing.type: Easing.Linear
-                            }
-                        }
-                    }
-                }
             }
 
             Label {
@@ -146,39 +115,8 @@ Page {
                 }
             }
 
-            SwitchDelegate {
+            QfSwitch {
                 id: fullScreenIdentifyViewCheckBox
-                Layout.alignment: Qt.AlignTop
-                width: 48 * dp
-                padding: 10 * dp
-                background: Rectangle {
-                    width: 68 * dp
-                    color: transparent
-                }
-                indicator: Rectangle {
-                    implicitWidth: 48 * dp
-                    implicitHeight: 26 * dp
-                    x: parent.leftPadding
-                    y: ( parent.height + parent.topPadding - 6 ) / 2 - height / 2
-                    radius: 13 * dp
-                    color: parent.checked ? Theme.mainColor : Theme.lightGray
-                    border.color: parent.checked ? Theme.mainColor : Theme.lightGray
-
-                    Rectangle {
-                        x: parent.parent.checked ? parent.width - width : 0
-                        width: 26 * dp
-                        height: 26 * dp
-                        radius: 13 * dp
-                        color: parent.parent.down ? Theme.lightGray : Theme.light
-                        border.color: parent.parent.checked ? Theme.mainColor : Theme.lightGray
-                        Behavior on x {
-                            PropertyAnimation {
-                                duration: 150
-                                easing.type: Easing.Linear
-                            }
-                        }
-                    }
-                }
             }
 
             ColumnLayout {
@@ -214,39 +152,8 @@ Page {
 
             }
 
-            SwitchDelegate {
+            QfSwitch {
                 id: locatorKeepScaleCheckBox
-                Layout.alignment: Qt.AlignTop
-                width: 48 * dp
-                padding: 10 * dp
-                background: Rectangle {
-                    width: 68 * dp
-                    color: transparent
-                }
-                indicator: Rectangle {
-                    implicitWidth: 48 * dp
-                    implicitHeight: 26 * dp
-                    x: parent.leftPadding
-                    y: ( parent.height + parent.topPadding - 6 ) / 2 - height / 2
-                    radius: 13 * dp
-                    color: parent.checked ? Theme.mainColor : Theme.lightGray
-                    border.color: parent.checked ? Theme.mainColor : Theme.lightGray
-
-                    Rectangle {
-                        x: parent.parent.checked ? parent.width - width : 0
-                        width: 26 * dp
-                        height: 26 * dp
-                        radius: 13 * dp
-                        color: parent.parent.down ? Theme.lightGray : Theme.light
-                        border.color: parent.parent.checked ? Theme.mainColor : Theme.lightGray
-                        Behavior on x {
-                            PropertyAnimation {
-                                duration: 150
-                                easing.type: Easing.Linear
-                            }
-                        }
-                    }
-                }
             }
 
             ColumnLayout {
@@ -282,39 +189,8 @@ Page {
 
             }
 
-            SwitchDelegate {
+            QfSwitch {
                 id: incrementalRenderingCheckBox
-                Layout.alignment: Qt.AlignTop
-                width: 48 * dp
-                padding: 10 * dp
-                background: Rectangle {
-                    width: 68 * dp
-                    color: transparent
-                }
-                indicator: Rectangle {
-                    implicitWidth: 48 * dp
-                    implicitHeight: 26 * dp
-                    x: parent.leftPadding
-                    y: ( parent.height + parent.topPadding - 6 ) / 2 - height / 2
-                    radius: 13 * dp
-                    color: parent.checked ? Theme.mainColor : Theme.lightGray
-                    border.color: parent.checked ? Theme.mainColor : Theme.lightGray
-
-                    Rectangle {
-                        x: parent.parent.checked ? parent.width - width : 0
-                        width: 26 * dp
-                        height: 26 * dp
-                        radius: 13 * dp
-                        color: parent.parent.down ? Theme.lightGray : Theme.light
-                        border.color: parent.parent.checked ? Theme.mainColor : Theme.lightGray
-                        Behavior on x {
-                            PropertyAnimation {
-                                duration: 150
-                                easing.type: Easing.Linear
-                            }
-                        }
-                    }
-                }
             }
 
             ColumnLayout {
@@ -350,39 +226,8 @@ Page {
 
             }
 
-            SwitchDelegate {
+            QfSwitch {
                 id: numericalDigitizingInformationCheckBox
-                Layout.alignment: Qt.AlignTop
-                width: 48 * dp
-                padding: 10 * dp
-                background: Rectangle {
-                    width: 68 * dp
-                    color: transparent
-                }
-                indicator: Rectangle {
-                    implicitWidth: 48 * dp
-                    implicitHeight: 26 * dp
-                    x: parent.leftPadding
-                    y: ( parent.height + parent.topPadding - 6 ) / 2 - height / 2
-                    radius: 13 * dp
-                    color: parent.checked ? Theme.mainColor : Theme.lightGray
-                    border.color: parent.checked ? Theme.mainColor : Theme.lightGray
-
-                    Rectangle {
-                        x: parent.parent.checked ? parent.width - width : 0
-                        width: 26 * dp
-                        height: 26 * dp
-                        radius: 13 * dp
-                        color: parent.parent.down ? Theme.lightGray : Theme.light
-                        border.color: parent.parent.checked ? Theme.mainColor : Theme.lightGray
-                        Behavior on x {
-                            PropertyAnimation {
-                                duration: 150
-                                easing.type: Easing.Linear
-                            }
-                        }
-                    }
-                }
             }
 
             ColumnLayout {
@@ -418,39 +263,8 @@ Page {
 
             }
 
-            SwitchDelegate {
+            QfSwitch {
                 id: useNativeCameraCheckBox
-                Layout.alignment: Qt.AlignTop
-                width: 48 * dp
-                padding: 10 * dp
-                background: Rectangle {
-                    width: 68 * dp
-                    color: transparent
-                }
-                indicator: Rectangle {
-                    implicitWidth: 48 * dp
-                    implicitHeight: 26 * dp
-                    x: parent.leftPadding
-                    y: ( parent.height + parent.topPadding - 6 ) / 2 - height / 2
-                    radius: 13 * dp
-                    color: parent.checked ? Theme.mainColor : Theme.lightGray
-                    border.color: parent.checked ? Theme.mainColor : Theme.lightGray
-
-                    Rectangle {
-                        x: parent.parent.checked ? parent.width - width : 0
-                        width: 26 * dp
-                        height: 26 * dp
-                        radius: 13 * dp
-                        color: parent.parent.down ? Theme.lightGray : Theme.light
-                        border.color: parent.parent.checked ? Theme.mainColor : Theme.lightGray
-                        Behavior on x {
-                            PropertyAnimation {
-                                duration: 150
-                                easing.type: Easing.Linear
-                            }
-                        }
-                    }
-                }
             }
 
 

--- a/src/qml/TransformedPositionSource.qml
+++ b/src/qml/TransformedPositionSource.qml
@@ -14,6 +14,7 @@ PositionSource {
                                                0.0
                                              }
   property alias deltaZ: _ct.deltaZ
+  property alias skipAltitudeTransformation: _ct.skipAltitudeTransformation
 
   property CoordinateTransformer ct: CoordinateTransformer {
     id: _ct

--- a/src/qml/TransformedPositionSource.qml
+++ b/src/qml/TransformedPositionSource.qml
@@ -6,7 +6,6 @@ import Utils 1.0
 
 PositionSource {
   id: positionSource
-
   property alias destinationCrs: _ct.destinationCrs
   property alias projectedPosition: _ct.projectedPosition
   property real projectedHorizontalAccuracy: if (positionSource.position.horizontalAccuracyValid && destinationCrs.mapUnits !== QgsUnitTypes.DistanceUnknownUnit) {
@@ -19,12 +18,14 @@ PositionSource {
   property CoordinateTransformer ct: CoordinateTransformer {
     id: _ct
     sourceCrs: CrsFactory.fromEpsgId(4326)
-    sourcePosition: Utils.coordinateToPoint(_pos.coordinate)
     transformContext: qgisProject.transformContext
-
-    property Position _pos: positionSource.position
   }
-  // TODO:::: remove this block
+
+  onPositionChanged: {
+    _ct.sourcePosition = Utils.coordinateToPoint(position.coordinate)
+  }
+
+// TODO:::: remove this block
   /*
   property Timer tm: Timer {
     interval: 500;
@@ -39,5 +40,5 @@ PositionSource {
     }
   }
   */
-  // END TODO:::: remove this block
+// END TODO:::: remove this block
 }

--- a/src/qml/TransformedPositionSource.qml
+++ b/src/qml/TransformedPositionSource.qml
@@ -14,6 +14,7 @@ PositionSource {
                                              } else {
                                                0.0
                                              }
+  property alias deltaZ: _ct.deltaZ
 
   property CoordinateTransformer ct: CoordinateTransformer {
     id: _ct

--- a/src/qml/imports/Theme/QfSwitch.qml
+++ b/src/qml/imports/Theme/QfSwitch.qml
@@ -1,0 +1,31 @@
+import QtQuick.Controls 2.12
+import QtQuick 2.12
+
+SwitchDelegate {
+    width: 48 * dp
+    padding: 10 * dp
+    indicator: Rectangle {
+        implicitWidth: 48 * dp
+        implicitHeight: 26 * dp
+        x: parent.leftPadding
+        y: ( parent.height + parent.topPadding - 6 ) / 2 - height / 2
+        radius: 13 * dp
+        color: parent.checked ? Theme.mainColor : Theme.lightGray
+        border.color: parent.checked ? Theme.mainColor : Theme.lightGray
+    
+        Rectangle {
+            x: parent.parent.checked ? parent.width - width : 0
+            width: 26 * dp
+            height: 26 * dp
+            radius: 13 * dp
+            color: parent.parent.down ? Theme.lightGray : Theme.light
+            border.color: parent.parent.checked ? Theme.mainColor : Theme.lightGray
+            Behavior on x {
+                PropertyAnimation {
+                    duration: 150
+                    easing.type: Easing.Linear
+                }
+            }
+        }
+    }
+}

--- a/src/qml/imports/Theme/qmldir
+++ b/src/qml/imports/Theme/qmldir
@@ -1,2 +1,3 @@
 module Theme
 singleton Theme 1.0 Theme.qml
+QfSwitch 1.0 QfSwitch.qml

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -143,7 +143,6 @@ ApplicationWindow {
 
     PositionInformationView {
       positionSource: positionSource
-      crs: mapCanvas.mapSettings.destinationCrs
       antennaHeight: positioningSettings.antennaHeightActivated ? positioningSettings.antennaHeight : NaN
     }
   }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -129,6 +129,7 @@ ApplicationWindow {
     active: settings.valueBool( "/QField/Positioning/Active", false )
     destinationCrs: mapCanvas.mapSettings.destinationCrs
     deltaZ: positioningSettings.antennaHeightActivated ? positioningSettings.antennaHeight * -1 : 0
+    skipAltitudeTransformation: positioningSettings.skipAltitudeCorrection
   }
 
   Item {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -865,7 +865,7 @@ ApplicationWindow {
     id: gpsMenu
     title: qsTr( "Positioning Options" )
     font: Theme.defaultFont
-    width: Math.max(200*dp, mainWindow.width/4)
+    width: Math.max(200*dp, mainWindow.width/1.5)
 
     MenuItem {
       text: qsTr( "Enable Positioning" )
@@ -892,14 +892,14 @@ ApplicationWindow {
       }
     }
 
-    MenuSeparator { width: Math.max(200*dp, mainWindow.width/4) }
+    MenuSeparator { width: parent.width }
 
     MenuItem {
-      text: qsTr( "Center current location" )
+      text: qsTr( "Center to Current Location" )
 
       height: 48 * dp
       font: Theme.defaultFont
-      width: Math.max(200*dp, mainWindow.width/4)
+      width: parent.width
       onTriggered: {
         var coord = positionSource.position.coordinate;
         var loc = Qt.point( coord.longitude, coord.latitude );
@@ -907,14 +907,14 @@ ApplicationWindow {
       }
     }
 
-    MenuSeparator { width: Math.max(200*dp, mainWindow.width/4) }
+    MenuSeparator { width: parent.width }
 
     MenuItem {
-      text: qsTr( "Show position information" )
+      text: qsTr( "Show Position Information" )
 
       height: 48 * dp
       font: Theme.defaultFont
-      width: Math.max(200*dp, mainWindow.width/4)
+      width: parent.width
       checkable: true
       checked: settings.valueBool( "/QField/Positioning/ShowInformationView", false )
 
@@ -930,10 +930,10 @@ ApplicationWindow {
     }
 
     MenuItem {
-      text: qsTr( "Configure antenna height" ) // Todo: rename to "Positioning Configuration" when there is more to configure
+      text: qsTr( "Configure Antenna Height" ) // Todo: rename to "Positioning Configuration" when there is more to configure
       height: 48 * dp
       font: Theme.defaultFont
-      width: Math.max(200*dp, mainWindow.width/4)
+      width: parent.width
 
       onTriggered: {
         positioningSettings.visible = true

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -224,10 +224,6 @@ ApplicationWindow {
           currentCoordinate: coordinateLocator.currentCoordinate
           vectorLayer: dashBoard.currentLayer
           crs: mapCanvas.mapSettings.destinationCrs
-
-          onCurrentCoordinateChanged: {
-              console.info( currentCoordinate.x+', '+currentCoordinate.y+', '+currentCoordinate.z )
-          }
         }
 
         anchors.fill: parent

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -921,8 +921,12 @@ ApplicationWindow {
       }
     }
 
-    Controls.MenuItem {
+    MenuItem {
       text: qsTr( "Configure antenna height" ) // Todo: rename to "Positioning Configuration" when there is more to configure
+      height: 48 * dp
+      font: Theme.defaultFont
+      width: Math.max(200*dp, mainWindow.width/4)
+
       onTriggered: {
         positioningSettings.visible = true
       }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -128,6 +128,7 @@ ApplicationWindow {
     id: positionSource
     active: settings.valueBool( "/QField/Positioning/Active", false )
     destinationCrs: mapCanvas.mapSettings.destinationCrs
+    deltaZ: positioningSettings.antennaHeightActivated ? positioningSettings.antennaHeight : 0
   }
 
   Item {
@@ -919,6 +920,13 @@ ApplicationWindow {
         positionInformationView.visible = checked
       }
     }
+
+    Controls.MenuItem {
+      text: qsTr( "Configure antenna height" ) // Todo: rename to "Positioning Configuration" when there is more to configure
+      onTriggered: {
+        positioningSettings.visible = true
+      }
+    }
   }
 
   Button {
@@ -1204,6 +1212,16 @@ ApplicationWindow {
         iface.loadProject( openProjectDialog.fileUrl.toString().slice(7) )
       mainWindow.keyHandler.focus=true
     }
+  }
+
+  PositioningSettings {
+    id: positioningSettings
+    visible: false
+
+    x: 24 * dp
+    y: 24 * dp
+    width: parent.width - 48 * dp
+    height: parent.height - 48 * dp
   }
 
   QFieldSettings {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -132,22 +132,6 @@ ApplicationWindow {
   }
 
   Item {
-    id: positionInformationView
-    anchors.bottom: parent.bottom
-    anchors.left: parent.left
-    anchors.right: parent.right
-    visible: settings.valueBool( "/QField/Positioning/ShowInformationView", false )
-
-    height: childrenRect.height
-    width: parent.width
-
-    PositionInformationView {
-      positionSource: positionSource
-      antennaHeight: positioningSettings.antennaHeightActivated ? positioningSettings.antennaHeight : NaN
-    }
-  }
-
-  Item {
     /*
      * This is the map canvas
      * On top of it are the base map and other items like GPS icon...
@@ -321,6 +305,33 @@ ApplicationWindow {
       selectionColor: "#ff7777"
       width: 5 * dp
     }
+  }
+
+  Item {
+    id: positionInformationView
+    anchors.bottom: parent.bottom
+    anchors.left: parent.left
+    anchors.right: parent.right
+    visible: settings.valueBool( "/QField/Positioning/ShowInformationView", false )
+
+    height: childrenRect.height
+    width: parent.width
+
+    PositionInformationView {
+      id: p
+      positionSource: positionSource
+      antennaHeight: positioningSettings.antennaHeightActivated ? positioningSettings.antennaHeight : NaN
+    }
+  }
+
+  DropShadow {
+    anchors.fill: positionInformationView
+    visible: positionInformationView.visible
+    verticalOffset: -2 * dp
+    radius: 6.0 * dp
+    samples: 17
+    color: "#30000000"
+    source: positionInformationView
   }
 
   /**************************************************

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -128,7 +128,7 @@ ApplicationWindow {
     id: positionSource
     active: settings.valueBool( "/QField/Positioning/Active", false )
     destinationCrs: mapCanvas.mapSettings.destinationCrs
-    deltaZ: positioningSettings.antennaHeightActivated ? positioningSettings.antennaHeight : 0
+    deltaZ: positioningSettings.antennaHeightActivated ? positioningSettings.antennaHeight * -1 : 0
   }
 
   Item {
@@ -144,6 +144,7 @@ ApplicationWindow {
     PositionInformationView {
       positionSource: positionSource
       crs: mapCanvas.mapSettings.destinationCrs
+      antennaHeight: positioningSettings.antennaHeightActivated ? positioningSettings.antennaHeight : NaN
     }
   }
 

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -47,5 +47,7 @@
         <file>LayerLoginDialog.qml</file>
         <file>imports/Theme/Theme.qml</file>
         <file>imports/Theme/qmldir</file>
+        <file>PositioningSettings.qml</file>
+        <file>PageHeader.qml</file>
     </qresource>
 </RCC>

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -46,6 +46,7 @@
         <file>Changelog.qml</file>
         <file>LayerLoginDialog.qml</file>
         <file>imports/Theme/Theme.qml</file>
+        <file>imports/Theme/QfSwitch.qml</file>
         <file>imports/Theme/qmldir</file>
         <file>PositioningSettings.qml</file>
         <file>PageHeader.qml</file>


### PR DESCRIPTION
This can be used to compensate measured Z values for an antenna height.
It can also be abused to compensate for anything else like geoid differences.