### PR TITLE
Fix focus issues

### DIFF
--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -22,10 +22,9 @@ Controls.Drawer {
   padding: 0
 
   property bool preventFromOpening: overlayFeatureFormDrawer.visible
-  readonly property bool open: dashBoard.visible && !preventFromOpening
 
   position: 0
-  focus: visible
+  focus: opened
   clip: true
 
   Keys.onReleased: {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -94,7 +94,6 @@ ApplicationWindow {
         name: 'measure'
         PropertyChanges { target: identifyTool; deactivated: true }
         PropertyChanges { target: mainWindow; currentRubberband: measuringRubberband }
-        PropertyChanges { target: dashBoard; visible: false }
         PropertyChanges { target: featureForm; state: "Hidden" }
       }
     ]
@@ -424,8 +423,8 @@ ApplicationWindow {
       id: menuButton
       round: true
       iconSource: Theme.getThemeIcon( "ic_menu_white_24dp" )
-      onClicked: dashBoard.visible = !dashBoard.visible
-      bgcolor: dashBoard.visible ? Theme.mainColor : Theme.darkGray
+      onClicked: dashBoard.opened ? dashBoard.close() : dashBoard.open()
+      bgcolor: dashBoard.opened ? Theme.mainColor : Theme.darkGray
       anchors.left: mainMenuBar.left
       anchors.leftMargin: 4 * dp
       anchors.top: mainMenuBar.top
@@ -702,7 +701,7 @@ ApplicationWindow {
       leftPadding: 10 * dp
 
       onTriggered: {
-        dashBoard.visible = false
+        dashBoard.close()
         qfieldSettings.visible = true
         highlighted = false
       }
@@ -717,7 +716,7 @@ ApplicationWindow {
       leftPadding: 10 * dp
 
       onTriggered: {
-        dashBoard.visible = false
+        dashBoard.close()
         aboutDialog.visible = true
         highlighted = false
       }
@@ -732,7 +731,7 @@ ApplicationWindow {
       leftPadding: 10 * dp
 
       onTriggered: {
-        dashBoard.visible = false
+        dashBoard.close()
         messageLog.visible = true
         highlighted = false
       }
@@ -749,6 +748,7 @@ ApplicationWindow {
       leftPadding: 10 * dp
 
       onTriggered: {
+        dashBoard.close()
         changeMode( 'measure' )
         highlighted = false
       }


### PR DESCRIPTION
@m-kuhn , looking into the focus issue reported by @Emic37 , I found out one source of broken focus state happens when closing the updated dashboard popup menu in an area that'll also close the dashboard itself.

One way to fix this is to force the focus onto the desired control whenever we can. This PR does that. It's a pretty important fix.