### PR TITLE
Do only flush on gpkg or sqlite files 

### DIFF
--- a/src/core/qgsgpkgflusher.cpp
+++ b/src/core/qgsgpkgflusher.cpp
@@ -63,14 +63,14 @@ void QgsGpkgFlusher::onLayersAdded( const QList<QgsMapLayer *> layers )
       QString dataSourceUri = vl->dataProvider()->dataSourceUri();
 
       QString filePath;
-      if( dataSourceUri.contains( QStringLiteral(".sqlite"), Qt::CaseInsensitive) )
+      if ( dataSourceUri.contains( QStringLiteral( ".sqlite" ), Qt::CaseInsensitive ) )
       {
         //sqlite source
-        QRegExp rx(".*dbname='([^']*).*");
-        rx.indexIn(dataSourceUri);
+        QRegExp rx( ".*dbname='([^']*).*" );
+        rx.indexIn( dataSourceUri );
         filePath = rx.capturedTexts()[1];
       }
-      else if( dataSourceUri.contains( QStringLiteral(".gpkg"), Qt::CaseInsensitive ) )
+      else if ( dataSourceUri.contains( QStringLiteral( ".gpkg" ), Qt::CaseInsensitive ) )
       {
         //gpkg source
         filePath = dataSourceUri.left( dataSourceUri.indexOf( '|' ) );

--- a/src/core/qgsgpkgflusher.cpp
+++ b/src/core/qgsgpkgflusher.cpp
@@ -61,7 +61,25 @@ void QgsGpkgFlusher::onLayersAdded( const QList<QgsMapLayer *> layers )
     if ( vl && vl->dataProvider() )
     {
       QString dataSourceUri = vl->dataProvider()->dataSourceUri();
-      QString filePath = dataSourceUri.left( dataSourceUri.indexOf( '|' ) );
+
+      QString filePath;
+      if( dataSourceUri.contains( QStringLiteral(".sqlite"), Qt::CaseInsensitive) )
+      {
+        //sqlite source
+        QRegExp rx(".*dbname='([^']*).*");
+        rx.indexIn(dataSourceUri);
+        filePath = rx.capturedTexts()[1];
+      }
+      else if( dataSourceUri.contains( QStringLiteral(".gpkg"), Qt::CaseInsensitive ) )
+      {
+        //gpkg source
+        filePath = dataSourceUri.left( dataSourceUri.indexOf( '|' ) );
+      }
+      else
+      {
+        //other source (e.g. postgres or shape)
+        continue;
+      }
       QFileInfo fi( filePath );
       if ( fi.isFile() )
       {


### PR DESCRIPTION
and not shp. Because otherwise it would print errors.
![WhatsApp Image 2019-11-18 at 17 21 07](https://user-images.githubusercontent.com/28384354/69070356-4a50cb80-0a28-11ea-81dc-8abdca91faee.jpeg)

@m-kuhn I'm not that familiar with what storage types we need a flush and with what we don't. For example `MBTiles` need it as well, right?