### PR TITLE
Move osgeo4a version to txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - gem --version
 
 script:
-  - export QFIELD_SDK_VERSION=20191107
+  - export QFIELD_SDK_VERSION=$(awk -F "=" '/osgeo4a_version/{print $2}' sdk.conf)
   - echo "travis_fold:start:docker-pull"
   - docker pull opengisch/qfield-sdk:${QFIELD_SDK_VERSION}
   - echo "travis_fold:end:docker-pull"

--- a/sdk.conf
+++ b/sdk.conf
@@ -1,0 +1,1 @@
+osgeo4a_version=20191107


### PR DESCRIPTION
Separate the currently used osgeo4a version from .travis.yml