### PR TITLE
Improve LocationMarker UX by adding on-canvas visual accuracy representation

### DIFF
--- a/src/qgsquick/qgsquickutils.cpp
+++ b/src/qgsquick/qgsquickutils.cpp
@@ -69,6 +69,11 @@ QgsPointXY QgsQuickUtils::transformPoint( const QgsCoordinateReferenceSystem &sr
   return pt;
 }
 
+double QgsQuickUtils::distanceFromUnitToUnitFactor( const QgsUnitTypes::DistanceUnit fromUnit, const QgsUnitTypes::DistanceUnit toUnit )
+{
+  return QgsUnitTypes::fromUnitToUnitFactor( fromUnit, toUnit );
+}
+
 double QgsQuickUtils::screenUnitsToMeters( QgsQuickMapSettings *mapSettings, int baseLengthPixels )
 {
   if ( mapSettings == nullptr ) return 0.0;

--- a/src/qgsquick/qgsquickutils.h
+++ b/src/qgsquick/qgsquickutils.h
@@ -104,6 +104,11 @@ class QgsQuickUtils: public QObject
         const QgsPointXY &srcPoint );
 
     /**
+      * Calculates the conversion factor between the specified distance units.
+      */
+    Q_INVOKABLE static double distanceFromUnitToUnitFactor( const QgsUnitTypes::DistanceUnit fromUnit, const QgsUnitTypes::DistanceUnit toUnit );
+
+    /**
       * Calculates the distance in meter representing baseLengthPixels pixels on the screen based on the current map settings.
       */
     Q_INVOKABLE static double screenUnitsToMeters( QgsQuickMapSettings *mapSettings, int baseLengthPixels );

--- a/src/qml/LocationMarker.qml
+++ b/src/qml/LocationMarker.qml
@@ -5,7 +5,26 @@ Item {
   id: item
 
   property variant location // QgsPointV2
+  property real accuracy
   property MapSettings mapSettings
+
+  Rectangle {
+    id: accuracyMarker
+    property point location
+    property real accuracy
+    visible: accuracy > 0.0
+    width: accuracy
+    height: accuracy
+
+    x: location.x - width/2
+    y: location.y - height/2
+
+    radius: width/2
+
+    color: "#44AD1457"
+    border.color: "#60880E4F"
+    border.width: 0.7 * dp
+  }
 
   Rectangle {
     id: marker
@@ -17,6 +36,9 @@ Item {
     y: location.y - height/2
 
     radius: width/2
+
+    border.color: "#880E4F"
+    border.width: 0.7 * dp
 
     gradient: Gradient  {
       GradientStop  {
@@ -37,18 +59,20 @@ Item {
         }
       }
     }
-    border.color: "#880E4F"
-    border.width: 0.7 * dp
+  }
 
-    Connections {
-      target: mapSettings
-      onExtentChanged: {
-        marker.location = mapSettings.coordinateToScreen( location )
-      }
+  Connections {
+    target: mapSettings
+    onExtentChanged: {
+      marker.location = mapSettings.coordinateToScreen( location )
+      accuracyMarker.location = mapSettings.coordinateToScreen( location )
+      accuracyMarker.accuracy = accuracy / mapSettings.mapUnitsPerPixel
     }
   }
 
   onLocationChanged: {
-    marker.location = mapSettings.coordinateToScreen( location )
+    marker.location = mapSettings.coordinateToScreen( location );
+    accuracyMarker.location = mapSettings.coordinateToScreen( location )
+    accuracyMarker.accuracy = accuracy / mapSettings.mapUnitsPerPixel
   }
 }

--- a/src/qml/TransformedPositionSource.qml
+++ b/src/qml/TransformedPositionSource.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.0
 import QtPositioning 5.3
 import org.qfield 1.0
+import org.qgis 1.0
 import Utils 1.0
 
 PositionSource {
@@ -8,6 +9,11 @@ PositionSource {
 
   property alias destinationCrs: _ct.destinationCrs
   property alias projectedPosition: _ct.projectedPosition
+  property real projectedHorizontalAccuracy: if (positionSource.position.horizontalAccuracyValid && destinationCrs.mapUnits !== QgsUnitTypes.DistanceUnknownUnit) {
+                                               positionSource.position.horizontalAccuracy * Utils.distanceFromUnitToUnitFactor( QgsUnitTypes.DistanceMeters, destinationCrs.mapUnits )
+                                             } else {
+                                               0.0
+                                             }
 
   property CoordinateTransformer ct: CoordinateTransformer {
     id: _ct

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -271,6 +271,7 @@ ApplicationWindow {
       anchors.fill: parent
       visible: positionSource.active
       location: positionSource.projectedPosition
+      accuracy: positionSource.projectedHorizontalAccuracy
     }
 
     /* Rubberband for vertices  */


### PR DESCRIPTION
While field testing QField, I've noticed an unfulfilled expectation: an on-canvas visual representation of my GPS accuracy. It's there on many popular mapping apps (google maps to name one :) ), and can be quite useful to get a quick sense of how accurate data entry will be, and how that accuracy is reflected onto the map (i.e., what overlays within that estimated accuracy area).

This PR implements just that. Here's how it looks:
![image](https://user-images.githubusercontent.com/1728657/71336614-7bb63d00-257a-11ea-8025-ecefb10cf02e.png)
