### PR TITLE
A couple of GPS / digitize buttons improvements

### DIFF
--- a/src/qml/DigitizingToolbar.qml
+++ b/src/qml/DigitizingToolbar.qml
@@ -30,7 +30,7 @@ VisibilityFadingRow {
   Button {
     id: confirmButton
     iconSource: {
-      Theme.getThemeIcon( "ic_save_white_24dp" )
+      Theme.getThemeIcon( "ic_check_white_48dp" )
     }
     visible: {
       if ( Number( rubberbandModel ? rubberbandModel.geometryType : 0 ) === 0 || stateMachine.state === 'measure' )

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -510,8 +510,8 @@ ApplicationWindow {
     id: mainToolBar
     anchors.right: mapCanvas.right
     anchors.rightMargin: 4 * dp
-    anchors.bottom: mapCanvas.bottom
-    anchors.bottomMargin: digitizingToolbar.height + 4 * dp
+    anchors.bottom: digitizingToolbar.stateVisible ? digitizingToolbar.top : mapCanvas.bottom
+    anchors.bottomMargin: 4 * dp
     spacing: 4 * dp
 
     Button {


### PR DESCRIPTION
Popular demand is overruling my "muscle memory" argument, seems most people are happier seeing the GPS anchored to the bottom right side of the screen when the measurement / digitizing toolbar isn't active. It actually has grown on me, and I think it's likely the best behavior here:
![Peek 2019-12-27 16-10](https://user-images.githubusercontent.com/1728657/71511251-38cecf00-28c4-11ea-81f5-2c0b33becac7.gif)

I've also gotten rid of the floppy disk icon in favor of a check icon in the digitizing toolbar (seen in the GIF above), matches what we've established elsewhere (e.g. the page header).