### PR TITLE
Improve relation combobox looks

### DIFF
--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -110,13 +110,15 @@ Item {
       // [/hidpi fixes]
     }
 
-    QField.Button {
+    Image {
       id: addButton
-      iconSource: Theme.getThemeIcon( "ic_add_black_48dp" )
-      bgcolor: "white"
-      onClicked: {
-        attributeFormModel.featureModel.resetAttributes()
-        addFeatureForm.active = true
+      source: Theme.getThemeIcon("ic_add_black_48dp")
+      MouseArea {
+        anchors.fill: parent
+        onClicked: {
+            attributeFormModel.featureModel.resetAttributes()
+            addFeatureForm.active = true
+        }
       }
     }
 
@@ -154,6 +156,7 @@ Item {
       y: 24 * dp
       width: parent.width - 48 * dp
       height: parent.height - 48 * dp
+      padding: 0
       modal: true
       focus: true
       closePolicy: Popup.CloseOnEscape

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -111,8 +111,14 @@ Item {
     }
 
     Image {
+      Layout.margins: 4 * dp
+      Layout.preferredWidth: 18 * dp
+      Layout.preferredHeight: 18 * dp
       id: addButton
       source: Theme.getThemeIcon("ic_add_black_48dp")
+      width: 18 * dp
+      height: 18 * dp
+
       MouseArea {
         anchors.fill: parent
         onClicked: {


### PR DESCRIPTION
Stumbled on an ugly situation with the relation combobox (supersized + button with an unwanted white background, as well as a padded popup header, which we got rid of when harmonizing looks). This PR fixes that.