### PR TITLE
Fix map theme combobox out of sync when loading project

### DIFF
--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -170,6 +170,8 @@ QgsProject *LayerTreeModel::project() const
 
 void LayerTreeModel::updateCurrentMapTheme()
 {
+  mMapTheme.clear();
+
   const QgsMapThemeCollection::MapThemeRecord rec = QgsMapThemeCollection::createThemeFromCurrentState( mLayerTreeModel->rootGroup(), mLayerTreeModel );
   const QStringList mapThemes = QgsProject::instance()->mapThemeCollection()->mapThemes();
   for ( const QString &grpName : mapThemes )

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -179,7 +179,7 @@ Controls.Drawer {
             mapThemeComboBox.model = themes
             mapThemeContainer.visible = themes.length > 1
             layerTree.updateCurrentMapTheme()
-            mapThemeComboBox.currentIndex = mapThemeComboBox.find( layerTree.mapTheme )
+            mapThemeComboBox.currentIndex = layerTree.mapTheme != '' ? mapThemeComboBox.find( layerTree.mapTheme ) : -1
             mapThemeContainer.isLoading = false
           }
         }


### PR DESCRIPTION
`LayerTreeModel::updateCurrentMapTheme()` failed to clear the map theme string when checking for a map theme match upon project load, which could lead to an out-of-sync combo box.