### PR TITLE
Enable native camera on default

### DIFF
--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -257,7 +257,7 @@ Page {
                     padding: 8 * dp
                     topPadding: 0
                     leftPadding: 22 * dp
-                    text: qsTr( "Warning: native camera function is unstable on recent Android versions." )
+                    text: qsTr( "If enabled, the user can choose the system camera app to use." )
                     font: Theme.tipFont
 
                     wrapMode: Text.WordWrap
@@ -270,6 +270,7 @@ Page {
 
             QfSwitch {
                 id: useNativeCameraCheckBox
+                checked: true
                 Layout.alignment: Qt.AlignTop
             }
 


### PR DESCRIPTION
And to go back to the handcrafted stuck-in-Madeira-with-fish-and-bananas-QML-cam you have to disable it. 

I did not change the setting that disabled is native cam and enabled banana cam. It's still like before, just with default on. 

And changed the description...