### PR TITLE
Camera: Only display buttons on edit mode

### DIFF
--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -56,6 +56,7 @@ Item {
     anchors.bottom: parent.bottom
 
     bgcolor: "transparent"
+    visible: !readOnly
 
     onClicked: {
       if ( settings.valueBool("useNativeCamera", true) ) {
@@ -78,6 +79,7 @@ Item {
     anchors.bottom: parent.bottom
 
     bgcolor: "transparent"
+    visible: !readOnly
 
     onClicked: {
         __pictureSource = platformUtilities.getGalleryPicture(qgisProject.homePath + '/DCIM')


### PR DESCRIPTION
When edit is **_not_** toggled.

Before:
![readonly1](https://user-images.githubusercontent.com/28384354/73629777-6f7ece80-4654-11ea-81d5-c49fd5d62624.png)
Now:
![readonly2](https://user-images.githubusercontent.com/28384354/73629776-6ee63800-4654-11ea-9389-975d755478e8.png)