### PR TITLE
Implement a dedicated range editor widget

### DIFF
--- a/src/qgsquick/qgsquickutils.cpp
+++ b/src/qgsquick/qgsquickutils.cpp
@@ -125,7 +125,8 @@ const QUrl QgsQuickUtils::getThemeIcon( const QString &name )
 const QUrl QgsQuickUtils::getEditorComponentSource( const QString &widgetName )
 {
   QString path( "qgsquick%1.qml" );
-  QStringList supportedWidgets = { QStringLiteral( "textedit" ),
+  QStringList supportedWidgets = { QStringLiteral( "range" ),
+                                   QStringLiteral( "textedit" ),
                                    QStringLiteral( "valuemap" ),
                                    QStringLiteral( "checkbox" ),
                                    QStringLiteral( "externalresource" ),

--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -6,9 +6,14 @@ Item {
   signal valueChanged(var value, bool isNull)
   height: childrenRect.height
 
+  QtObject {
+      id: fieldData
+      property bool isNumeric: field ? field.isNumeric : false
+  }
+
   TextField {
     id: textField
-    height: textArea.height == 0 ? fontMetrics.height + 20 * dp : 0
+    height: fontMetrics.height + 20 * dp
     topPadding: 10 * dp
     bottomPadding: 10 * dp
     visible: height !== 0
@@ -19,7 +24,18 @@ Item {
 
     text: value !== undefined ? value : ''
 
-    inputMethodHints: Qt.ImhNone
+    validator: {
+      if (platformUtilities.fieldType( field ) === 'double')
+      {
+        doubleValidator;
+      }
+      else
+      {
+        intValidator;
+      }
+    }
+
+    inputMethodHints: Qt.ImhFormattedNumbersOnly
 
     background: Rectangle {
       y: textField.height - height - textField.bottomPadding / 2
@@ -33,25 +49,16 @@ Item {
     }
   }
 
-  TextArea {
-    id: textArea
-    height: config['IsMultiline'] === true ? undefined : 0
-    visible: height !== 0
-    anchors.left: parent.left
-    anchors.right: parent.right
-    wrapMode: Text.Wrap
-    font: Theme.defaultFont
-
-    text: value !== undefined ? value : ''
-    textFormat: config['UseHtml'] ? TextEdit.RichText : TextEdit.PlainText
-
-    onEditingFinished: {
-      valueChanged( text, text == '' )
-    }
-  }
-
   FontMetrics {
     id: fontMetrics
     font: textField.font
+  }
+
+  IntValidator {
+    id: intValidator
+  }
+
+  DoubleValidator {
+    id: doubleValidator
   }
 }

--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -114,9 +114,15 @@ Item {
 
   IntValidator {
     id: intValidator
+
+    bottom: from
+    top: to
   }
 
   DoubleValidator {
     id: doubleValidator
+
+    bottom: from
+    top: to
   }
 }

--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -6,17 +6,20 @@ Item {
   signal valueChanged(var value, bool isNull)
   height: childrenRect.height
 
-  QtObject {
-      id: fieldData
-      property bool isNumeric: field ? field.isNumeric : false
-  }
+  id: rangeItem
+  property string widgetStyle: config["Style"] ? config["Style"] : "TextField"
+  property int precision: config["Precision"]
+  property real from: config["Min"]
+  property real to: config["Max"]
+  property real step: config["Step"] ? config["Step"] : 1
+  property string suffix: config["Suffix"] ? config["Suffix"] : ""
 
   TextField {
     id: textField
     height: fontMetrics.height + 20 * dp
     topPadding: 10 * dp
     bottomPadding: 10 * dp
-    visible: height !== 0
+    visible: widgetStyle != "Slider"
     anchors.left: parent.left
     anchors.right: parent.right
     font: Theme.defaultFont
@@ -47,6 +50,61 @@ Item {
     onTextChanged: {
       valueChanged( text, text == '' )
     }
+  }
+
+  Row {
+    id: sliderRow
+    anchors.fill: parent
+    visible: widgetStyle === "Slider"
+
+    Text {
+      id: valueLabel
+      width: sliderRow.width / 4
+      height: fontMetrics.height + 20 * dp
+      elide: Text.ElideRight
+      text: Number( slider.value ).toFixed( rangeItem.precision ).toLocaleString() + rangeItem.suffix
+      verticalAlignment: Text.AlignVCenter
+      horizontalAlignment: Text.AlignLeft
+      font: Theme.defaultFont
+      color: value === undefined || !enabled ? 'gray' : 'black'
+    }
+
+    Slider {
+      id: slider
+      value: rangeItem.parent.value
+      width: sliderRow.width - valueLabel.width
+      height: fontMetrics.height + 20 * dp
+      implicitWidth: width
+      from: rangeItem.from
+      to: rangeItem.to
+      stepSize: rangeItem.step
+
+      onValueChanged: {
+        if (sliderRow.visible) {
+          rangeItem.valueChanged(slider.value, false)
+        }
+      }
+
+      background: Rectangle {
+        x: slider.leftPadding
+        y: slider.topPadding + slider.availableHeight / 2 - height / 2
+        implicitWidth: slider.width
+        implicitHeight: slider.height * 0.1
+        width: slider.availableWidth
+        height: implicitHeight
+        radius: 4 * dp
+        color:  Theme.lightGray
+      }
+    }
+  }
+
+  Rectangle {
+    y: textField.height - height - textField.bottomPadding / 2
+    visible: widgetStyle === "Slider"
+    width: sliderRow.width
+    implicitWidth: 120 * dp
+    height: slider.activeFocus ? 2 * dp : 1 * dp
+    color: slider.activeFocus ? "#4CAF50" : "#C8E6C9"
   }
 
   FontMetrics {

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -22,6 +22,7 @@
         <file>editorwidgets/DateTime.qml</file>
         <file>editorwidgets/ExternalResource.qml</file>
         <file>editorwidgets/TextEdit.qml</file>
+        <file>editorwidgets/Range.qml</file>
         <file>editorwidgets/ValueMap.qml</file>
         <file>editorwidgets/RelationReference.qml</file>
         <file>editorwidgets/RelationEditor.qml</file>


### PR DESCRIPTION
This PR implements a dedicated range editor widget. Other than the benefit of cleaning numeric-specific code away from the text edit widget, the range widget now supports sliders (I was burying the lead here :wink:)

In action:
![Peek 2020-02-09 15-16](https://user-images.githubusercontent.com/1728657/74099512-50ea6d00-4b57-11ea-84a0-d0bb1ee81d12.gif)

In addition, the range widget's integer and double validator will now validate the number being entered to make sure it stays within the min/max numerical values stated in the range widget configuration.