### PR TITLE
adapt deploy scripts to stable/master branches

### DIFF
--- a/scripts/ci/travis_build.sh
+++ b/scripts/ci/travis_build.sh
@@ -30,9 +30,9 @@ elif [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
   export APP_ICON="qfield-testlogo.svg"
   export APP_VERSION=""
   export APP_VERSION_CODE=${COMMIT_COUNT_SINCE_v140}${ARCH_NUMBER}
-  export APP_VERSION_STR="${LAST_TAG}-dev${COMMIT_COUNT} (${CURRENT_COMMIT})"
+  export APP_VERSION_STR="${LAST_TAG}-dev${COMMIT_COUNT_SINCE_LAST_TAG} (${CURRENT_COMMIT})"
 
-  echo "Commit number: ${COMMIT_COUNT_SINCE_v140}"
+  echo "Commit number: ${COMMIT_COUNT_SINCE_LAST_TAG}"
   echo "Arch number: ${ARCH_NUMBER}"
 
 else

--- a/scripts/ci/travis_build.sh
+++ b/scripts/ci/travis_build.sh
@@ -30,7 +30,7 @@ elif [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
   export APP_ICON="qfield-testlogo.svg"
   export APP_VERSION=""
   export APP_VERSION_CODE=${COMMIT_COUNT_SINCE_v140}${ARCH_NUMBER}
-  export APP_VERSION_STR="${LAST_TAG}-dev${COMMIT_COUNT_SINCE_LAST_TAG} (${CURRENT_COMMIT})"
+  export APP_VERSION_STR="${LAST_TAG}-dev${COMMIT_COUNT_SINCE_LAST_TAG} (commit ${CURRENT_COMMIT})"
 
   echo "Commit number: ${COMMIT_COUNT_SINCE_LAST_TAG}"
   echo "Arch number: ${ARCH_NUMBER}"

--- a/scripts/ci/travis_build.sh
+++ b/scripts/ci/travis_build.sh
@@ -37,11 +37,15 @@ elif [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
 
 else
   echo "Building pull request beta"
+  # use a date for the version code since it's the most working solution
+  # to switch from a PR to another without needing to uninstall
+  # (as long as you always install a more recent version)
+  CUR_DATE=$(date +%Y%j%H%M)
   export APP_NAME="QField Beta ${TRAVIS_PULL_REQUEST}"
   export PKG_NAME="qfield_beta"
   export APP_ICON="qfield-testlogo.svg"
   export APP_VERSION=""
-  export APP_VERSION_CODE="1"
+  export APP_VERSION_CODE=${CUR_DATE:4:7}
   export APP_VERSION_STR="PR${TRAVIS_PULL_REQUEST}"
 fi
 

--- a/scripts/ci/travis_build.sh
+++ b/scripts/ci/travis_build.sh
@@ -37,15 +37,11 @@ elif [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
 
 else
   echo "Building pull request beta"
-  # use a date for the version code since it's the most working solution
-  # to switch from a PR to another without needing to uninstall
-  # (as long as you always install a more recent version)
-  CUR_DATE=$(date +%Y%j%H%M)
   export APP_NAME="QField Beta ${TRAVIS_PULL_REQUEST}"
   export PKG_NAME="qfield_beta"
   export APP_ICON="qfield-testlogo.svg"
   export APP_VERSION=""
-  export APP_VERSION_CODE=${CUR_DATE:4:7}
+  export APP_VERSION_CODE="1"
   export APP_VERSION_STR="PR${TRAVIS_PULL_REQUEST}"
 fi
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -33,13 +33,10 @@ if [[ ${TRAVIS_SECURE_ENV_VARS} = true ]]; then
     for ARCH in "${ARCHS[@]}"
     do
       ASSET_PATH=/tmp/qfield-${TRAVIS_TAG}-${ARCH}.apk
-
       echo -e "\e[93m * Collecting apks to upload...\e[0m"
       fetch_asset ${ARCH} ${ASSET_PATH}
-
       echo -e "\e[93m * Deploying app to github release...\e[0m"
       ./scripts/upload_release_asset.py ${ASSET_PATH} ${TRAVIS_TAG}
-
       ASSETS="${ASSETS} ${ASSET_PATH}"
     done
 
@@ -49,19 +46,19 @@ if [[ ${TRAVIS_SECURE_ENV_VARS} = true ]]; then
 
   elif [[ ${TRAVIS_BRANCH} = master ]] || [[ ${TRAVIS_BRANCH} = stable ]]; then
     # we are on a standard commit on master or stable branch
+    # write comment
     echo "${BODY}" | curl -u m-kuhn:${GITHUB_API_TOKEN} -X POST --data $@- https://api.github.com/repos/opengisch/QField/commits/${TRAVIS_COMMIT}/comments
-
-    ASSETS=""
-    for ARCH in "${ARCHS[@]}"
-    do
-      echo -e "\e[93m * Collecting apks to upload...\e[0m"
-      ASSET_PATH=/tmp/qfield-dev-${ARCH}.apk
-      fetch_asset ${ARCH} ${ASSET_PATH}
-      ASSETS="${ASSETS} ${ASSET_PATH}"
-    done
 
     # only master builds are pushed to play store
     if [[ ${TRAVIS_BRANCH} = master ]]; then
+      ASSETS=""
+      for ARCH in "${ARCHS[@]}"
+      do
+        echo -e "\e[93m * Collecting apks to upload...\e[0m"
+        ASSET_PATH=/tmp/qfield-dev-${ARCH}.apk
+        fetch_asset ${ARCH} ${ASSET_PATH}
+        ASSETS="${ASSETS} ${ASSET_PATH}"
+      done
       openssl aes-256-cbc -K $encrypted_play_upload_key -iv $encrypted_play_upload_iv -in .ci/play_developer.p12.enc -out .ci/play_developer.p12 -d
       echo -e "\e[93m * Deploying app to google play (release version)...\e[0m"
       RELEASE_URL="https://github.com/opengisch/QField/commit/${TRAVIS_COMMIT}"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -24,8 +24,8 @@ if [[ ${TRAVIS_SECURE_ENV_VARS} = true ]]; then
     echo -e "\e[31mDeploying app to pull request\e[0m"
     echo "${BODY}" | curl -u m-kuhn:${GITHUB_API_TOKEN} -X POST --data @- https://api.github.com/repos/opengisch/QField/issues/${TRAVIS_PULL_REQUEST}/comments
 
-  elif [[ -n ${TRAVIS_TAG} ]]; then
-    # we are on a standard commit on master branch => push to ALPHA
+  elif [[ -n ${TRAVIS_TAG} ]] && [[ ${TRAVIS_BRANCH} = stable ]]; then
+    # we are on a tag and on stable branch
     echo -e "\e[93;1mStarting to deploy a new release\e[0m"
     openssl aes-256-cbc -K $encrypted_play_upload_key -iv $encrypted_play_upload_iv -in .ci/play_developer.p12.enc -out .ci/play_developer.p12 -d
 
@@ -47,10 +47,9 @@ if [[ ${TRAVIS_SECURE_ENV_VARS} = true ]]; then
     echo -e "\e[93m * Deploying app to google play (release version)...\e[0m"
     ./scripts/basic_upload_apks_service_account.py ch.opengis.qfield internal ${RELEASE_URL} ${ASSETS}
 
-  elif [[ ${TRAVIS_BRANCH} = master ]]; then
-    # we on a tag and master => push to BETA
+  elif [[ ${TRAVIS_BRANCH} = master ]] || [[ ${TRAVIS_BRANCH} = stable ]]; then
+    # we are on a standard commit on master or stable branch
     echo "${BODY}" | curl -u m-kuhn:${GITHUB_API_TOKEN} -X POST --data $@- https://api.github.com/repos/opengisch/QField/commits/${TRAVIS_COMMIT}/comments
-    openssl aes-256-cbc -K $encrypted_play_upload_key -iv $encrypted_play_upload_iv -in .ci/play_developer.p12.enc -out .ci/play_developer.p12 -d
 
     ASSETS=""
     for ARCH in "${ARCHS[@]}"
@@ -61,8 +60,12 @@ if [[ ${TRAVIS_SECURE_ENV_VARS} = true ]]; then
       ASSETS="${ASSETS} ${ASSET_PATH}"
     done
 
-    echo -e "\e[93m * Deploying app to google play (release version)...\e[0m"
-    RELEASE_URL="https://github.com/opengisch/QField/commit/${TRAVIS_COMMIT}"
-    ./scripts/basic_upload_apks_service_account.py ch.opengis.qfield_dev beta ${RELEASE_URL} ${ASSETS}
+    # only master builds are pushed to play store
+    if [[ ${TRAVIS_BRANCH} = master ]]; then
+      openssl aes-256-cbc -K $encrypted_play_upload_key -iv $encrypted_play_upload_iv -in .ci/play_developer.p12.enc -out .ci/play_developer.p12 -d
+      echo -e "\e[93m * Deploying app to google play (release version)...\e[0m"
+      RELEASE_URL="https://github.com/opengisch/QField/commit/${TRAVIS_COMMIT}"
+      ./scripts/basic_upload_apks_service_account.py ch.opengis.qfield_dev beta ${RELEASE_URL} ${ASSETS}
+    fi
   fi
 fi

--- a/src/qml/About.qml
+++ b/src/qml/About.qml
@@ -28,7 +28,7 @@ Item {
       color: Theme.light
       font: Theme.strongFont
       wrapMode: Text.WordWrap
-      text: qsTr( "QField Version: %1 (%2)").arg( version ).arg( versionCode )
+      text: qsTr( "QField Version: %1 (code: %2)").arg( version ).arg( versionCode )
     }
     Label {
       Layout.alignment: Qt.AlignCenter


### PR DESCRIPTION
we will build APKs for master and stable but only master ones are pushed to play store

also increase version code for PR builds so we won't need to uninstall all the time before installing new APK