### PR TITLE
Showcase range widget's slider mode in bee demos

### DIFF
--- a/resources/demo_projects/advanced_bee_farming.qgs
+++ b/resources/demo_projects/advanced_bee_farming.qgs
@@ -990,11 +990,12 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="Range">
                   <config>
                     <Option type="Map">
-                      <Option type="QString" name="AllowNull" value="1"/>
-                      <Option type="QString" name="Max" value="10"/>
-                      <Option type="QString" name="Min" value="1"/>
-                      <Option type="QString" name="Step" value="1"/>
-                      <Option type="QString" name="Style" value="SpinBox"/>
+                      <Option value="true" type="bool" name="AllowNull"/>
+                      <Option value="10" type="int" name="Max"/>
+                      <Option value="1" type="int" name="Min"/>
+                      <Option value="0" type="int" name="Precision"/>
+                      <Option value="1" type="int" name="Step"/>
+                      <Option value="Slider" type="QString" name="Style"/>
                     </Option>
                   </config>
                 </editWidget>
@@ -1384,7 +1385,7 @@ def my_form_open(dialog, layer, feature):
                       <Option type="QString" name="Max" value="10"/>
                       <Option type="QString" name="Min" value="1"/>
                       <Option type="QString" name="Step" value="1"/>
-                      <Option type="QString" name="Style" value="SpinBox"/>
+                      <Option type="QString" name="Style" value="Slider"/>
                     </Option>
                   </config>
                 </editWidget>
@@ -2037,7 +2038,7 @@ def my_form_open(dialog, layer, feature):
                 <Option type="int" name="Min" value="1"/>
                 <Option type="int" name="Precision" value="0"/>
                 <Option type="int" name="Step" value="1"/>
-                <Option type="QString" name="Style" value="SpinBox"/>
+                <Option type="QString" name="Style" value="Slider"/>
               </Option>
             </config>
           </editWidget>

--- a/resources/demo_projects/simple_bee_farming.qgs
+++ b/resources/demo_projects/simple_bee_farming.qgs
@@ -562,7 +562,7 @@
                       <Option type="QString" value="10" name="Max"/>
                       <Option type="QString" value="1" name="Min"/>
                       <Option type="QString" value="1" name="Step"/>
-                      <Option type="QString" value="SpinBox" name="Style"/>
+                      <Option type="QString" value="Slider" name="Style"/>
                     </Option>
                   </config>
                 </editWidget>
@@ -964,7 +964,7 @@ def my_form_open(dialog, layer, feature):
                       <Option type="QString" value="10" name="Max"/>
                       <Option type="QString" value="1" name="Min"/>
                       <Option type="QString" value="1" name="Step"/>
-                      <Option type="QString" value="SpinBox" name="Style"/>
+                      <Option type="QString" value="Slider" name="Style"/>
                     </Option>
                   </config>
                 </editWidget>
@@ -1630,7 +1630,7 @@ def my_form_open(dialog, layer, feature):
                 <Option type="int" value="1" name="Min"/>
                 <Option type="int" value="0" name="Precision"/>
                 <Option type="int" value="1" name="Step"/>
-                <Option type="QString" value="SpinBox" name="Style"/>
+                <Option type="QString" value="Slider" name="Style"/>
               </Option>
             </config>
           </editWidget>


### PR DESCRIPTION
Because it deserves exposure and promotion, let's use sliders in the QField demo projects:
![Screenshot from 2020-02-12 15-37-51](https://user-images.githubusercontent.com/1728657/74317825-a66c8700-4dae-11ea-9d95-f6992dc1b5fe.png)
