### PR TITLE
Fix positioning after activation

### DIFF
--- a/src/core/androidplatformutilities.cpp
+++ b/src/core/androidplatformutilities.cpp
@@ -206,13 +206,7 @@ bool AndroidPlatformUtilities::checkPositioningPermissions() const
   QtAndroid::PermissionResult r = QtAndroid::checkPermission( "android.permission.ACCESS_COARSE_LOCATION" );
   if ( r == QtAndroid::PermissionResult::Denied )
   {
-    // If there are no permissions available, ask for fine location permissions
-    QtAndroid::requestPermissionsSync( QStringList() << "android.permission.ACCESS_FINE_LOCATION" );
-    r = QtAndroid::checkPermission( "android.permission.ACCESS_FINE_LOCATION" );
-    if ( r == QtAndroid::PermissionResult::Denied )
-    {
-      return false;
-    }
+    return checkAndAcquirePermissions( "android.permission.ACCESS_FINE_LOCATION" );
   }
   return true;
 }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -288,7 +288,7 @@ ApplicationWindow {
       id: locationMarker
       mapSettings: mapCanvas.mapSettings
       anchors.fill: parent
-      visible: positionSource.active
+      visible: positionSource.active && positionSource.position.latitudeValid
       location: positionSource.projectedPosition
       accuracy: positionSource.projectedHorizontalAccuracy
       direction: positionSource.position.directionValid ? positionSource.position.direction : -1
@@ -529,6 +529,11 @@ ApplicationWindow {
 
       bgcolor: "#64B5F6"
 
+      onIconSourceChanged: {
+        if( state === "On" && !positionSource.position.latitudeValid )
+          displayToast( qsTr( "No position source available" ) )
+      }
+
       property bool followActive: false
 
       states: [
@@ -559,8 +564,7 @@ ApplicationWindow {
         {
           if ( !positionSource.active )
           {
-            positionSource.active = true;
-            displayToast( qsTr( "Activating positioning service" ) )
+            gpsMenu.gpsActivated = true
           }
           else
           {
@@ -578,8 +582,7 @@ ApplicationWindow {
             }
             else
             {
-              positionSource.active = true
-              displayToast( qsTr( "Activating positioning service" ) )
+              gpsMenu.gpsActivated = true
             }
           }
         }
@@ -852,29 +855,38 @@ ApplicationWindow {
     title: qsTr( "Positioning Options" )
     font: Theme.defaultFont
     width: Math.max(200*dp, mainWindow.width/1.5)
+    property alias gpsActivated: positioningItem.checked
 
     MenuItem {
+      id: positioningItem
       text: qsTr( "Enable Positioning" )
 
       height: 48 * dp
       font: Theme.defaultFont
       width: parent.width
       checkable: true
-      checked: positionSource.active
+      checked: settings.valueBool("/QField/Positioning/Active", false )
       indicator.height: 20 * dp
       indicator.width: 20 * dp
       indicator.implicitHeight: 24 * dp
       indicator.implicitWidth: 24 * dp
 
       onCheckedChanged: {
-        if ( checked && platformUtilities.checkPositioningPermissions() ) {
-          positionSource.active = checked
+        if ( checked ) {
+          if( platformUtilities.checkPositioningPermissions() ) {
+            positionSource.preferredPositioningMethods = PositionSource.AllPositioningMethods
+            positionSource.active = true
+            displayToast( qsTr( "Activating positioning service" ) )
+          }else{
+            displayToast( qsTr( "QField has no permissions to use positioning." ) )
+            //deactivate again
+            checked = false
+          }
         }
         else {
-          displayToast( qsTr( "QField has no permissions to use positioning." ) )
           positionSource.active = false
         }
-
+        settings.setValue("/QField/Positioning/Active", checked )
       }
     }
 


### PR DESCRIPTION
After the activation of the positioning (setting first time) the position updates, means the marker does not stay anymore in the top left corner until the next restart.

By setting the `preferredPositioningMethods` this works. Not really sure about what Qt Positioning does in the background but I think it's because if it starts without any positioning methods that work it does not retry with them. On setting them it tries it again.

The activation is now done over the checked state of the gpsMenu. This to avoid confusion with the binding. 

The settings are stored now to be reused after next restart.