### PR TITLE
Fix positioning after activation (#878)

### DIFF
--- a/src/core/androidplatformutilities.cpp
+++ b/src/core/androidplatformutilities.cpp
@@ -194,13 +194,7 @@ bool AndroidPlatformUtilities::checkPositioningPermissions() const
   QtAndroid::PermissionResult r = QtAndroid::checkPermission( "android.permission.ACCESS_COARSE_LOCATION" );
   if ( r == QtAndroid::PermissionResult::Denied )
   {
-    // If there are no permissions available, ask for fine location permissions
-    QtAndroid::requestPermissionsSync( QStringList() << "android.permission.ACCESS_FINE_LOCATION" );
-    r = QtAndroid::checkPermission( "android.permission.ACCESS_FINE_LOCATION" );
-    if ( r == QtAndroid::PermissionResult::Denied )
-    {
-      return false;
-    }
+    return checkAndAcquirePermissions( "android.permission.ACCESS_FINE_LOCATION" );
   }
   return true;
 }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -531,8 +531,6 @@ ApplicationWindow {
           displayToast( qsTr( "No position source available" ) )
       }
 
-      property bool followActive: false
-
       states: [
         State {
 


### PR DESCRIPTION
set the preferredPositioningMethods on position source to receive updated position after the activation of the signal or after giving permission the first time

control activation of positioning over the checked state in the gpsMenu to avoid confusion and binding issues

store in settings if the positioning is activated

use existing functionality