### PR TITLE
avoid passing variables in JS

### DIFF
--- a/sdk.conf
+++ b/sdk.conf
@@ -1,1 +1,1 @@
-osgeo4a_version=20200305
+osgeo4a_version=20200318

--- a/src/core/utils/geometryutils.cpp
+++ b/src/core/utils/geometryutils.cpp
@@ -22,15 +22,15 @@
 
 #include "rubberbandmodel.h"
 
-GeometryUtils::GeometryUtils(QObject *parent) : QObject(parent)
+GeometryUtils::GeometryUtils( QObject *parent ) : QObject( parent )
 {
 
 }
 
 
-QgsGeometry GeometryUtils::polygonFromRubberband(RubberbandModel *rubberBandModel, const QgsCoordinateReferenceSystem &crs)
+QgsGeometry GeometryUtils::polygonFromRubberband( RubberbandModel *rubberBandModel, const QgsCoordinateReferenceSystem &crs )
 {
-  QgsPointSequence ring = rubberBandModel->pointSequence(crs, QgsWkbTypes::Point, true);
+  QgsPointSequence ring = rubberBandModel->pointSequence( crs, QgsWkbTypes::Point, true );
   QgsLineString ext( ring );
   std::unique_ptr< QgsPolygon > polygon = qgis::make_unique< QgsPolygon >( );
   polygon->setExteriorRing( ext.clone() );
@@ -38,9 +38,15 @@ QgsGeometry GeometryUtils::polygonFromRubberband(RubberbandModel *rubberBandMode
   return g;
 }
 
-QgsGeometry::OperationResult GeometryUtils::addRingFromRubberBand(QgsVectorLayer* layer, QgsFeatureId fid, RubberbandModel *rubberBandModel)
+QgsGeometry::OperationResult GeometryUtils::addRingFromRubberBand( QgsVectorLayer *layer, QgsFeatureId fid, RubberbandModel *rubberBandModel )
 {
-  QgsPointSequence ring = rubberBandModel->pointSequence(layer->crs(), layer->wkbType(), true);
-  return layer->addRing(ring, &fid);
+  QgsPointSequence ring = rubberBandModel->pointSequence( layer->crs(), layer->wkbType(), true );
+  return layer->addRing( ring, &fid );
+}
+
+QgsGeometry::OperationResult GeometryUtils::splitFeatureFromRubberBand( QgsVectorLayer *layer, RubberbandModel *rubberBandModel )
+{
+  QgsPointSequence line = rubberBandModel->pointSequence( layer->crs(), QgsWkbTypes::Point, false );
+  return layer->splitFeatures( line, true );
 }
 

--- a/src/core/utils/geometryutils.h
+++ b/src/core/utils/geometryutils.h
@@ -27,13 +27,18 @@ class RubberbandModel;
 
 class GeometryUtils : public QObject
 {
-  Q_OBJECT
-public:
-  explicit GeometryUtils(QObject *parent = nullptr);
+    Q_OBJECT
+  public:
+    explicit GeometryUtils( QObject *parent = nullptr );
 
-  static Q_INVOKABLE QgsGeometry polygonFromRubberband(RubberbandModel *rubberBandModel , const QgsCoordinateReferenceSystem &crs);
+    //! Returns a QgsGeometry with a polygon by using the point sequence in the rubberband model.
+    static Q_INVOKABLE QgsGeometry polygonFromRubberband( RubberbandModel *rubberBandModel, const QgsCoordinateReferenceSystem &crs );
 
-  static Q_INVOKABLE QgsGeometry::OperationResult addRingFromRubberBand(QgsVectorLayer* layer, QgsFeatureId fid, RubberbandModel* rubberBandModel );
+    //! Add a ring to a polyon with given \a fid using the ring in the rubberband model.
+    static Q_INVOKABLE QgsGeometry::OperationResult addRingFromRubberBand( QgsVectorLayer *layer, QgsFeatureId fid, RubberbandModel *rubberBandModel );
+
+    //! This will perform a split using the line in the rubberband model. It works with the layer selection if some features are selected.
+    static Q_INVOKABLE QgsGeometry::OperationResult splitFeatureFromRubberBand( QgsVectorLayer *layer, RubberbandModel *rubberBandModel );
 
 };
 

--- a/src/qml/geometry_editors/SplitFeatureToolbar.qml
+++ b/src/qml/geometry_editors/SplitFeatureToolbar.qml
@@ -23,13 +23,23 @@ VisibilityFadingRow {
     onConfirm: {
       // TODO: featureModel.currentLayer.selectByIds([featureModel.feature.id], VectorLayerStatic.SetSelection)
       Utils.selectFeaturesInLayer(featureModel.currentLayer, [featureModel.feature.id], VectorLayerStatic.SetSelection)
-      var line = drawLineToolbar.rubberbandModel.pointSequence(featureModel.currentLayer.crs)
       if (!featureModel.currentLayer.editBuffer())
         featureModel.currentLayer.startEditing()
-      featureModel.currentLayer.splitFeatures(line, true)
-      featureModel.currentLayer.commitChanges()
-      cancel()
-      finished()
+
+      var result = GeometryUtils.splitFeatureFromRubberBand(featureModel.currentLayer, drawLineToolbar.rubberbandModel)
+      if ( result !== QgsGeometryStatic.Success )
+      {
+        displayToast( qsTr( 'Feature could not be split' ) );
+        featureModel.currentLayer.rollBack()
+        cancel()
+        finished()
+      }
+      else
+      {
+        featureModel.currentLayer.commitChanges()
+        cancel()
+        finished()
+      }
     }
   }
 

--- a/src/qml/geometry_editors/SplitFeatureToolbar.qml
+++ b/src/qml/geometry_editors/SplitFeatureToolbar.qml
@@ -40,6 +40,8 @@ VisibilityFadingRow {
         cancel()
         finished()
       }
+
+      featureModel.currentLayer.removeSelection()
     }
   }
 


### PR DESCRIPTION
it is not working anymore with Qt 5.14+

in this case the QgsPointSequence was transformed to a vector, but when sent back to cpp, it's not seen as it should/would/could