### PR TITLE
Remove embedded feature form in the Relation Editor

### DIFF
--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -91,11 +91,23 @@ Rectangle{
                   if( buffer() ) {
                       //this has to be checked after buffering because the primary could be a value that has been created on creating featurer (e.g. fid)
                       if( relationEditorModel.parentPrimariesAvailable ) {
+                          /*
+                          // Removed part:
                           embeddedPopup.state = 'Add'
                           embeddedPopup.currentLayer = relationEditorModel.relation.referencingLayer
                           embeddedPopup.linkedParentFeature = relationEditorModel.feature
                           embeddedPopup.linkedRelation = relationEditorModel.relation
                           embeddedPopup.open()
+                          // End of removed part.
+                          */
+                          //Temporary part
+                          embeddedFeatureForm.state = 'Add'
+                          embeddedAttributeFormModel.featureModel.currentLayer = relationEditorModel.relation.referencingLayer
+                          embeddedAttributeFormModel.featureModel.linkedParentFeature = relationEditorModel.feature
+                          embeddedAttributeFormModel.featureModel.linkedRelation = relationEditorModel.relation
+                          embeddedAttributeFormModel.featureModel.resetAttributes()
+                          embeddedFeatureForm.active = true
+                          //Temporary part
                       }
                       else
                       {
@@ -132,12 +144,24 @@ Rectangle{
             anchors.fill: parent
 
             onClicked: {
+                /*
+                // Removed part:
                 embeddedPopup.state = !readOnly ? 'Edit' : 'ReadOnly'
                 embeddedPopup.currentLayer = nmRelationId ?  relationEditorModel.nmRelation.referencedLayer : relationEditorModel.relation.referencingLayer
                 embeddedPopup.linkedRelation = relationEditorModel.relation
                 embeddedPopup.linkedParentFeature = relationEditorModel.feature
                 embeddedPopup.feature = nmRelationId ? model.nmReferencedFeature : model.referencingFeature
                 embeddedPopup.open()
+                // End of removed part.
+                */
+                //Temporary part
+                embeddedFeatureForm.state = !readOnly ? 'Edit' : 'ReadOnly'
+                embeddedAttributeFormModel.featureModel.currentLayer = nmRelationId ?  relationEditorModel.nmRelation.referencedLayer : relationEditorModel.relation.referencingLayer
+                embeddedAttributeFormModel.featureModel.linkedRelation = relationEditorModel.relation
+                embeddedAttributeFormModel.featureModel.linkedParentFeature = relationEditorModel.feature
+                embeddedAttributeFormModel.featureModel.feature = nmRelationId ? model.nmReferencedFeature : model.referencingFeature
+                embeddedFeatureForm.active = true
+                //End of temporary part
             }
           }
 
@@ -215,14 +239,6 @@ Rectangle{
 
     }
 
-    EmbeddedFeatureForm{
-        id: embeddedPopup
-
-        onFeatureSaved: {
-            relationEditorModel.reload()
-        }
-    }
-
     BusyIndicator {
       id: busyIndicator
       anchors.centerIn: parent
@@ -230,4 +246,86 @@ Rectangle{
       height: 36 * dp
       running: relationEditorModel.isLoading
     }
+
+    /*
+    * Temporary implementation of the feature form (until there is no trouble with EmbeddedFeatureForm anymore) since we assume crash cause in the embedded feature form.
+    */
+
+    /*
+    // Removed part:
+    EmbeddedFeatureForm{
+        id: embeddedPopup
+
+        onFeatureSaved: {
+            relationEditorModel.reload()
+        }
+    }
+    // End of removed part.
+    */
+
+    //Temporary part
+
+    //the add entry stuff
+    AttributeFormModel {
+      id: embeddedAttributeFormModel
+      featureModel: FeatureModel {
+        id: embeddedFeatureModel
+      }
+    }
+
+    Loader {
+      id: embeddedFeatureForm
+
+      property var state
+
+      sourceComponent: embeddedFeatureFormComponent
+      active: false
+      onLoaded: {
+        item.open()
+      }
+    }
+
+    Component {
+      id: embeddedFeatureFormComponent
+
+      Popup {
+        id: popup
+        parent: ApplicationWindow.overlay
+
+        x: 24 * dp
+        y: 24 * dp
+        padding: 0
+        width: parent.width - 48 * dp
+        height: parent.height - 48 * dp
+        modal: true
+        closePolicy: Popup.CloseOnEscape
+
+        FeatureForm {
+            model: embeddedAttributeFormModel
+
+            focus: true
+
+            embedded: true
+            toolbarVisible: true
+
+            anchors.fill: parent
+
+            state: embeddedFeatureForm.state
+
+            onSaved: {
+                popup.close()
+            }
+
+            onCancelled: {
+                popup.close()
+            }
+        }
+
+        onClosed: {
+          embeddedFeatureForm.active = false
+          relationEditorModel.reload()
+        }
+      }
+    }
+    //End of temporary part
 }


### PR DESCRIPTION
and implement it directly in the widget. But kept the original implementation to bring it back as soon as we found out the reason for the assumed crash.