### PR TITLE
Not Null and Unique Constraints

### DIFF
--- a/resources/demo_projects/advanced_bee_farming.qgs
+++ b/resources/demo_projects/advanced_bee_farming.qgs
@@ -1,73 +1,73 @@
-<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="3.10.1-A Coruña" projectname="Advanced Bee Farming Demo">
-  <homePath path=""/>
+<qgis projectname="Advanced Bee Farming Demo" saveUser="david" saveUserFull="David" version="3.13.0-Master">
+  <homePath path=""></homePath>
   <title>Advanced Bee Farming Demo</title>
-  <autotransaction active="0"/>
-  <evaluateDefaultValues active="0"/>
-  <trust active="0"/>
+  <autotransaction active="0"></autotransaction>
+  <evaluateDefaultValues active="0"></evaluateDefaultValues>
+  <trust active="0"></trust>
   <projectCrs>
     <spatialrefsys>
-      <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+      <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
+      <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
       <srsid>3857</srsid>
       <srid>3857</srid>
       <authid>EPSG:3857</authid>
       <description>WGS 84 / Pseudo-Mercator</description>
       <projectionacronym>merc</projectionacronym>
-      <ellipsoidacronym></ellipsoidacronym>
+      <ellipsoidacronym>WGS84</ellipsoidacronym>
       <geographicflag>false</geographicflag>
     </spatialrefsys>
   </projectCrs>
   <layer-tree-group>
-    <customproperties/>
-    <layer-tree-layer id="apiary_27954fba_aad8_4336_8b19_23afed462c51" name="Apiary" expanded="1" checked="Qt::Checked" source="./bees.gpkg|layername=apiary" providerKey="ogr">
+    <customproperties></customproperties>
+    <layer-tree-layer checked="Qt::Checked" expanded="1" id="apiary_27954fba_aad8_4336_8b19_23afed462c51" name="Apiary" providerKey="ogr" source="./bees.gpkg|layername=apiary">
       <customproperties>
-        <property key="expandedLegendNodes" value="{2c8997f2-a415-45d2-bd98-2c0898cb3118}"/>
-        <property key="showFeatureCount" value="1"/>
+        <property key="expandedLegendNodes" value="{2c8997f2-a415-45d2-bd98-2c0898cb3118}"></property>
+        <property key="showFeatureCount" value="1"></property>
       </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" name="Fields" expanded="0" checked="Qt::Checked" source="./bees.gpkg|layername=area" providerKey="ogr">
+    <layer-tree-layer checked="Qt::Checked" expanded="0" id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" name="Fields" providerKey="ogr" source="./bees.gpkg|layername=area">
       <customproperties>
-        <property key="expandedLegendNodes"/>
-        <property key="showFeatureCount" value="0"/>
+        <property key="expandedLegendNodes"></property>
+        <property key="showFeatureCount" value="0"></property>
       </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer id="countries_a5e8d4da_f5b9_48ce_9909_c3760e271a9e" name="Countries" expanded="1" checked="Qt::Unchecked" source="./basemaps/countries.gpkg|layername=countries" providerKey="ogr">
+    <layer-tree-layer checked="Qt::Unchecked" expanded="1" id="countries_a5e8d4da_f5b9_48ce_9909_c3760e271a9e" name="Countries" providerKey="ogr" source="./basemaps/countries.gpkg|layername=countries">
       <customproperties>
-        <property key="expandedLegendNodes"/>
+        <property key="expandedLegendNodes"></property>
       </customproperties>
     </layer-tree-layer>
-    <layer-tree-group mutually-exclusive="1" mutually-exclusive-child="1" name="Basemap" expanded="0" checked="Qt::Checked">
-      <customproperties/>
-      <layer-tree-layer id="OpenStreetMap_442da2b8_ea6a_4114_a4f4_e472a9f7d8b9" name="Online OpenStreetMap" expanded="0" checked="Qt::Unchecked" source="crs=EPSG:3857&amp;format&amp;type=xyz&amp;url=http://a.tile.openstreetmap.org/%7Bz%7D/%7Bx%7D/%7By%7D.png&amp;zmax=19&amp;zmin=0" providerKey="wms">
-        <customproperties/>
+    <layer-tree-group checked="Qt::Checked" expanded="0" mutually-exclusive="1" mutually-exclusive-child="1" name="Basemap">
+      <customproperties></customproperties>
+      <layer-tree-layer checked="Qt::Unchecked" expanded="0" id="OpenStreetMap_442da2b8_ea6a_4114_a4f4_e472a9f7d8b9" name="Online OpenStreetMap" providerKey="wms" source="crs=EPSG:3857&amp;format&amp;type=xyz&amp;url=http://a.tile.openstreetmap.org/%7Bz%7D/%7Bx%7D/%7By%7D.png&amp;zmax=19&amp;zmin=0">
+        <customproperties></customproperties>
       </layer-tree-layer>
-      <layer-tree-group name="Offline local osm" expanded="0" checked="Qt::Checked">
-        <customproperties/>
-        <layer-tree-layer id="lines_3691e21a_d6eb_4d63_a8f5_d5ada1aca9b8" name="lines" expanded="0" checked="Qt::Checked" source="./basemaps/laax.gpkg|layername=lines" providerKey="ogr">
+      <layer-tree-group checked="Qt::Checked" expanded="0" name="Offline local osm">
+        <customproperties></customproperties>
+        <layer-tree-layer checked="Qt::Checked" expanded="0" id="lines_3691e21a_d6eb_4d63_a8f5_d5ada1aca9b8" name="lines" providerKey="ogr" source="./basemaps/laax.gpkg|layername=lines">
           <customproperties>
-            <property key="expandedLegendNodes"/>
-            <property key="showFeatureCount" value="0"/>
+            <property key="expandedLegendNodes"></property>
+            <property key="showFeatureCount" value="0"></property>
           </customproperties>
         </layer-tree-layer>
-        <layer-tree-layer id="buildings_3bd3a9b3_9f70_44bd_9390_807f598c2835" name="buildings" expanded="0" checked="Qt::Checked" source="./basemaps/laax.gpkg|layername=buildings" providerKey="ogr">
+        <layer-tree-layer checked="Qt::Checked" expanded="0" id="buildings_3bd3a9b3_9f70_44bd_9390_807f598c2835" name="buildings" providerKey="ogr" source="./basemaps/laax.gpkg|layername=buildings">
           <customproperties>
-            <property key="expandedLegendNodes"/>
+            <property key="expandedLegendNodes"></property>
           </customproperties>
         </layer-tree-layer>
-        <layer-tree-layer id="landscape_b275e43a_b9f2_4087_b31a_c5793005d343" name="landscape" expanded="0" checked="Qt::Checked" source="./basemaps/laax.gpkg|layername=landscape" providerKey="ogr">
+        <layer-tree-layer checked="Qt::Checked" expanded="0" id="landscape_b275e43a_b9f2_4087_b31a_c5793005d343" name="landscape" providerKey="ogr" source="./basemaps/laax.gpkg|layername=landscape">
           <customproperties>
-            <property key="expandedLegendNodes"/>
+            <property key="expandedLegendNodes"></property>
           </customproperties>
         </layer-tree-layer>
       </layer-tree-group>
     </layer-tree-group>
-    <layer-tree-group name="Tables" expanded="0" checked="Qt::Checked">
-      <customproperties/>
-      <layer-tree-layer id="Reviews_c8ab909e_4686_45c7_affe_08141059dfd0" name="Apiary_Reviews" expanded="1" checked="Qt::Unchecked" source="./bees.gpkg|layername=Reviews" providerKey="ogr">
-        <customproperties/>
+    <layer-tree-group checked="Qt::Checked" expanded="0" name="Tables">
+      <customproperties></customproperties>
+      <layer-tree-layer checked="Qt::Unchecked" expanded="1" id="Reviews_c8ab909e_4686_45c7_affe_08141059dfd0" name="Apiary_Reviews" providerKey="ogr" source="./bees.gpkg|layername=Reviews">
+        <customproperties></customproperties>
       </layer-tree-layer>
-      <layer-tree-layer id="Pollen_Consumption_9dac944e_6937_4617_928b_0daaf97303e9" name="Pollen_Consumption" expanded="1" checked="Qt::Unchecked" source="./bees.gpkg|layername=Pollen_Consumption" providerKey="ogr">
-        <customproperties/>
+      <layer-tree-layer checked="Qt::Unchecked" expanded="1" id="Pollen_Consumption_9dac944e_6937_4617_928b_0daaf97303e9" name="Pollen_Consumption" providerKey="ogr" source="./bees.gpkg|layername=Pollen_Consumption">
+        <customproperties></customproperties>
       </layer-tree-layer>
     </layer-tree-group>
     <custom-order enabled="0">
@@ -80,28 +80,28 @@
       <item>apiary_27954fba_aad8_4336_8b19_23afed462c51</item>
     </custom-order>
   </layer-tree-group>
-  <snapping-settings enabled="0" type="1" intersection-snapping="0" mode="3" tolerance="0" unit="2">
+  <snapping-settings enabled="0" intersection-snapping="0" mode="3" tolerance="0" type="1" unit="2">
     <individual-layer-settings>
-      <layer-setting enabled="0" type="1" id="buildings_3bd3a9b3_9f70_44bd_9390_807f598c2835" units="1" tolerance="12"/>
-      <layer-setting enabled="0" type="1" id="lines_3691e21a_d6eb_4d63_a8f5_d5ada1aca9b8" units="1" tolerance="12"/>
-      <layer-setting enabled="0" type="1" id="apiary_27954fba_aad8_4336_8b19_23afed462c51" units="1" tolerance="12"/>
-      <layer-setting enabled="0" type="1" id="landscape_b275e43a_b9f2_4087_b31a_c5793005d343" units="1" tolerance="12"/>
-      <layer-setting enabled="0" type="1" id="countries_a5e8d4da_f5b9_48ce_9909_c3760e271a9e" units="1" tolerance="12"/>
-      <layer-setting enabled="0" type="1" id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" units="1" tolerance="12"/>
+      <layer-setting enabled="0" id="buildings_3bd3a9b3_9f70_44bd_9390_807f598c2835" tolerance="12" type="1" units="1"></layer-setting>
+      <layer-setting enabled="0" id="landscape_b275e43a_b9f2_4087_b31a_c5793005d343" tolerance="12" type="1" units="1"></layer-setting>
+      <layer-setting enabled="0" id="apiary_27954fba_aad8_4336_8b19_23afed462c51" tolerance="12" type="1" units="1"></layer-setting>
+      <layer-setting enabled="0" id="lines_3691e21a_d6eb_4d63_a8f5_d5ada1aca9b8" tolerance="12" type="1" units="1"></layer-setting>
+      <layer-setting enabled="0" id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" tolerance="12" type="1" units="1"></layer-setting>
+      <layer-setting enabled="0" id="countries_a5e8d4da_f5b9_48ce_9909_c3760e271a9e" tolerance="12" type="1" units="1"></layer-setting>
     </individual-layer-settings>
   </snapping-settings>
   <relations>
-    <relation strength="Composition" id="Pollen_Con_apiary_id_apiary_279_fid" name="consume_on_fields" referencedLayer="apiary_27954fba_aad8_4336_8b19_23afed462c51" referencingLayer="Pollen_Consumption_9dac944e_6937_4617_928b_0daaf97303e9">
-      <fieldRef referencedField="fid" referencingField="apiary_id"/>
+    <relation id="Pollen_Con_apiary_id_apiary_279_fid" name="consume_on_fields" referencedLayer="apiary_27954fba_aad8_4336_8b19_23afed462c51" referencingLayer="Pollen_Consumption_9dac944e_6937_4617_928b_0daaf97303e9" strength="Composition">
+      <fieldRef referencedField="fid" referencingField="apiary_id"></fieldRef>
     </relation>
-    <relation strength="Composition" id="Pollen_Con_field_id_ogr_dbname_fid" name="consumed_by_apiaries" referencedLayer="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" referencingLayer="Pollen_Consumption_9dac944e_6937_4617_928b_0daaf97303e9">
-      <fieldRef referencedField="fid" referencingField="field_id"/>
+    <relation id="Pollen_Con_field_id_ogr_dbname_fid" name="consumed_by_apiaries" referencedLayer="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" referencingLayer="Pollen_Consumption_9dac944e_6937_4617_928b_0daaf97303e9" strength="Composition">
+      <fieldRef referencedField="fid" referencingField="field_id"></fieldRef>
     </relation>
-    <relation strength="Composition" id="Reviews_c8_apiary_id_apiary_279_fid" name="review_apiary" referencedLayer="apiary_27954fba_aad8_4336_8b19_23afed462c51" referencingLayer="Reviews_c8ab909e_4686_45c7_affe_08141059dfd0">
-      <fieldRef referencedField="fid" referencingField="apiary_id"/>
+    <relation id="Reviews_c8_apiary_id_apiary_279_fid" name="review_apiary" referencedLayer="apiary_27954fba_aad8_4336_8b19_23afed462c51" referencingLayer="Reviews_c8ab909e_4686_45c7_affe_08141059dfd0" strength="Composition">
+      <fieldRef referencedField="fid" referencingField="apiary_id"></fieldRef>
     </relation>
-    <relation strength="Association" id="apiary_279_area_id_ogr_dbname_fid" name="apiary_area" referencedLayer="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" referencingLayer="apiary_27954fba_aad8_4336_8b19_23afed462c51">
-      <fieldRef referencedField="fid" referencingField="area_id"/>
+    <relation id="apiary_279_area_id_ogr_dbname_fid" name="apiary_area" referencedLayer="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" referencingLayer="apiary_27954fba_aad8_4336_8b19_23afed462c51" strength="Association">
+      <fieldRef referencedField="fid" referencingField="area_id"></fieldRef>
     </relation>
   </relations>
   <mapcanvas annotationsVisible="1" name="theMapCanvas">
@@ -115,77 +115,76 @@
     <rotation>0</rotation>
     <destinationsrs>
       <spatialrefsys>
-        <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+        <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
+        <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
         <srsid>3857</srsid>
         <srid>3857</srid>
         <authid>EPSG:3857</authid>
         <description>WGS 84 / Pseudo-Mercator</description>
         <projectionacronym>merc</projectionacronym>
-        <ellipsoidacronym></ellipsoidacronym>
+        <ellipsoidacronym>WGS84</ellipsoidacronym>
         <geographicflag>false</geographicflag>
       </spatialrefsys>
     </destinationsrs>
     <rendermaptile>0</rendermaptile>
-    <expressionContextScope/>
+    <expressionContextScope></expressionContextScope>
   </mapcanvas>
-  <projectModels/>
   <legend updateDrawingOrder="true">
-    <legendlayer name="Apiary" checked="Qt::Checked" open="true" drawingOrder="-1" showFeatureCount="1">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile layerid="apiary_27954fba_aad8_4336_8b19_23afed462c51" visible="1" isInOverview="0"/>
+    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="Apiary" open="true" showFeatureCount="1">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile isInOverview="0" layerid="apiary_27954fba_aad8_4336_8b19_23afed462c51" visible="1"></legendlayerfile>
       </filegroup>
     </legendlayer>
-    <legendlayer name="Fields" checked="Qt::Checked" open="false" drawingOrder="-1" showFeatureCount="0">
-      <filegroup open="false" hidden="false">
-        <legendlayerfile layerid="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" visible="1" isInOverview="0"/>
+    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="Fields" open="false" showFeatureCount="0">
+      <filegroup hidden="false" open="false">
+        <legendlayerfile isInOverview="0" layerid="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" visible="1"></legendlayerfile>
       </filegroup>
     </legendlayer>
-    <legendlayer name="Countries" checked="Qt::Unchecked" open="true" drawingOrder="-1" showFeatureCount="0">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile layerid="countries_a5e8d4da_f5b9_48ce_9909_c3760e271a9e" visible="0" isInOverview="0"/>
+    <legendlayer checked="Qt::Unchecked" drawingOrder="-1" name="Countries" open="true" showFeatureCount="0">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile isInOverview="0" layerid="countries_a5e8d4da_f5b9_48ce_9909_c3760e271a9e" visible="0"></legendlayerfile>
       </filegroup>
     </legendlayer>
-    <legendgroup name="Basemap" checked="Qt::Checked" open="false">
-      <legendlayer name="Online OpenStreetMap" checked="Qt::Unchecked" open="false" drawingOrder="-1" showFeatureCount="0">
-        <filegroup open="false" hidden="false">
-          <legendlayerfile layerid="OpenStreetMap_442da2b8_ea6a_4114_a4f4_e472a9f7d8b9" visible="0" isInOverview="0"/>
+    <legendgroup checked="Qt::Checked" name="Basemap" open="false">
+      <legendlayer checked="Qt::Unchecked" drawingOrder="-1" name="Online OpenStreetMap" open="false" showFeatureCount="0">
+        <filegroup hidden="false" open="false">
+          <legendlayerfile isInOverview="0" layerid="OpenStreetMap_442da2b8_ea6a_4114_a4f4_e472a9f7d8b9" visible="0"></legendlayerfile>
         </filegroup>
       </legendlayer>
-      <legendgroup name="Offline local osm" checked="Qt::Checked" open="false">
-        <legendlayer name="lines" checked="Qt::Checked" open="false" drawingOrder="-1" showFeatureCount="0">
-          <filegroup open="false" hidden="false">
-            <legendlayerfile layerid="lines_3691e21a_d6eb_4d63_a8f5_d5ada1aca9b8" visible="1" isInOverview="0"/>
+      <legendgroup checked="Qt::Checked" name="Offline local osm" open="false">
+        <legendlayer checked="Qt::Checked" drawingOrder="-1" name="lines" open="false" showFeatureCount="0">
+          <filegroup hidden="false" open="false">
+            <legendlayerfile isInOverview="0" layerid="lines_3691e21a_d6eb_4d63_a8f5_d5ada1aca9b8" visible="1"></legendlayerfile>
           </filegroup>
         </legendlayer>
-        <legendlayer name="buildings" checked="Qt::Checked" open="false" drawingOrder="-1" showFeatureCount="0">
-          <filegroup open="false" hidden="false">
-            <legendlayerfile layerid="buildings_3bd3a9b3_9f70_44bd_9390_807f598c2835" visible="1" isInOverview="0"/>
+        <legendlayer checked="Qt::Checked" drawingOrder="-1" name="buildings" open="false" showFeatureCount="0">
+          <filegroup hidden="false" open="false">
+            <legendlayerfile isInOverview="0" layerid="buildings_3bd3a9b3_9f70_44bd_9390_807f598c2835" visible="1"></legendlayerfile>
           </filegroup>
         </legendlayer>
-        <legendlayer name="landscape" checked="Qt::Checked" open="false" drawingOrder="-1" showFeatureCount="0">
-          <filegroup open="false" hidden="false">
-            <legendlayerfile layerid="landscape_b275e43a_b9f2_4087_b31a_c5793005d343" visible="1" isInOverview="0"/>
+        <legendlayer checked="Qt::Checked" drawingOrder="-1" name="landscape" open="false" showFeatureCount="0">
+          <filegroup hidden="false" open="false">
+            <legendlayerfile isInOverview="0" layerid="landscape_b275e43a_b9f2_4087_b31a_c5793005d343" visible="1"></legendlayerfile>
           </filegroup>
         </legendlayer>
       </legendgroup>
     </legendgroup>
-    <legendgroup name="Tables" checked="Qt::Checked" open="false">
-      <legendlayer name="Apiary_Reviews" checked="Qt::Unchecked" open="true" drawingOrder="-1" showFeatureCount="0">
-        <filegroup open="true" hidden="false">
-          <legendlayerfile layerid="Reviews_c8ab909e_4686_45c7_affe_08141059dfd0" visible="0" isInOverview="0"/>
+    <legendgroup checked="Qt::Checked" name="Tables" open="false">
+      <legendlayer checked="Qt::Unchecked" drawingOrder="-1" name="Apiary_Reviews" open="true" showFeatureCount="0">
+        <filegroup hidden="false" open="true">
+          <legendlayerfile isInOverview="0" layerid="Reviews_c8ab909e_4686_45c7_affe_08141059dfd0" visible="0"></legendlayerfile>
         </filegroup>
       </legendlayer>
-      <legendlayer name="Pollen_Consumption" checked="Qt::Unchecked" open="true" drawingOrder="-1" showFeatureCount="0">
-        <filegroup open="true" hidden="false">
-          <legendlayerfile layerid="Pollen_Consumption_9dac944e_6937_4617_928b_0daaf97303e9" visible="0" isInOverview="0"/>
+      <legendlayer checked="Qt::Unchecked" drawingOrder="-1" name="Pollen_Consumption" open="true" showFeatureCount="0">
+        <filegroup hidden="false" open="true">
+          <legendlayerfile isInOverview="0" layerid="Pollen_Consumption_9dac944e_6937_4617_928b_0daaf97303e9" visible="0"></legendlayerfile>
         </filegroup>
       </legendlayer>
     </legendgroup>
   </legend>
-  <mapViewDocks/>
-  <mapViewDocks3D/>
+  <mapViewDocks></mapViewDocks>
   <projectlayers>
-    <maplayer hasScaleBasedVisibilityFlag="0" autoRefreshEnabled="0" refreshOnNotifyEnabled="0" maxScale="0" autoRefreshTime="0" type="raster" styleCategories="AllStyleCategories" refreshOnNotifyMessage="" minScale="1e+08">
+    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" maxScale="0" minScale="1e+8" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" type="raster">
       <extent>
         <xmin>-20037508.34278924390673637</xmin>
         <ymin>-20037508.34278925508260727</ymin>
@@ -200,13 +199,14 @@
       <layername>Online OpenStreetMap</layername>
       <srs>
         <spatialrefsys>
-          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+          <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
+          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
           <srsid>3857</srsid>
           <srid>3857</srid>
           <authid>EPSG:3857</authid>
           <description>WGS 84 / Pseudo-Mercator</description>
           <projectionacronym>merc</projectionacronym>
-          <ellipsoidacronym></ellipsoidacronym>
+          <ellipsoidacronym>WGS84</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -217,11 +217,118 @@
         <type></type>
         <title></title>
         <abstract></abstract>
-        <links/>
+        <links></links>
         <fees></fees>
         <encoding></encoding>
         <crs>
           <spatialrefsys>
+            <wkt></wkt>
+            <proj4></proj4>
+            <srsid>0</srsid>
+            <srid>0</srid>
+            <authid></authid>
+            <description></description>
+            <projectionacronym></projectionacronym>
+            <ellipsoidacronym></ellipsoidacronym>
+            <geographicflag>true</geographicflag>
+          </spatialrefsys>
+        </crs>
+        <extent></extent>
+      </resourceMetadata>
+      <provider>wms</provider>
+      <noData>
+        <noDataList bandNo="1" useSrcNoData="0"></noDataList>
+      </noData>
+      <temporal enabled="0" fetchMode="0" mode="0" source="0">
+        <fixedRange>
+          <start></start>
+          <end></end>
+        </fixedRange>
+        <fixedReferenceRange>
+          <start></start>
+          <end></end>
+        </fixedReferenceRange>
+        <normalRange>
+          <start></start>
+          <end></end>
+        </normalRange>
+        <referenceRange>
+          <start></start>
+          <end></end>
+        </referenceRange>
+      </temporal>
+      <map-layer-style-manager current="default">
+        <map-layer-style name="default"></map-layer-style>
+      </map-layer-style-manager>
+      <flags>
+        <Identifiable>0</Identifiable>
+        <Removable>1</Removable>
+        <Searchable>0</Searchable>
+      </flags>
+      <customproperties>
+        <property key="QFieldSync/action" value="no_action"></property>
+        <property key="identify/format" value="Undefined"></property>
+      </customproperties>
+      <pipe>
+        <rasterrenderer alphaBand="-1" band="1" nodataColor="" opacity="1" type="singlebandcolordata">
+          <rasterTransparency></rasterTransparency>
+          <minMaxOrigin>
+            <limits>None</limits>
+            <extent>WholeRaster</extent>
+            <statAccuracy>Estimated</statAccuracy>
+            <cumulativeCutLower>0.02</cumulativeCutLower>
+            <cumulativeCutUpper>0.98</cumulativeCutUpper>
+            <stdDevFactor>2</stdDevFactor>
+          </minMaxOrigin>
+        </rasterrenderer>
+        <brightnesscontrast brightness="0" contrast="0"></brightnesscontrast>
+        <huesaturation colorizeBlue="128" colorizeGreen="128" colorizeOn="0" colorizeRed="255" colorizeStrength="100" grayscaleMode="0" saturation="0"></huesaturation>
+        <rasterresampler maxOversampling="2"></rasterresampler>
+      </pipe>
+      <blendMode>0</blendMode>
+    </maplayer>
+    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" geometry="No geometry" hasScaleBasedVisibilityFlag="0" maxScale="0" minScale="1e+8" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" type="vector" wkbType="NoGeometry">
+      <id>Pollen_Consumption_9dac944e_6937_4617_928b_0daaf97303e9</id>
+      <datasource>./bees.gpkg|layername=Pollen_Consumption</datasource>
+      <keywordList>
+        <value></value>
+      </keywordList>
+      <layername>Pollen_Consumption</layername>
+      <srs>
+        <spatialrefsys>
+          <wkt></wkt>
+          <proj4></proj4>
+          <srsid>0</srsid>
+          <srid>0</srid>
+          <authid></authid>
+          <description></description>
+          <projectionacronym></projectionacronym>
+          <ellipsoidacronym></ellipsoidacronym>
+          <geographicflag>false</geographicflag>
+        </spatialrefsys>
+      </srs>
+      <resourceMetadata>
+        <identifier></identifier>
+        <parentidentifier></parentidentifier>
+        <language></language>
+        <type>dataset</type>
+        <title></title>
+        <abstract></abstract>
+        <contact>
+          <name></name>
+          <organization></organization>
+          <position></position>
+          <voice></voice>
+          <fax></fax>
+          <email></email>
+          <role></role>
+        </contact>
+        <links></links>
+        <fees></fees>
+        <encoding></encoding>
+        <crs>
+          <spatialrefsys>
+            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -232,94 +339,8 @@
             <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
-        <extent/>
-      </resourceMetadata>
-      <provider>wms</provider>
-      <noData>
-        <noDataList useSrcNoData="0" bandNo="1"/>
-      </noData>
-      <map-layer-style-manager current="default">
-        <map-layer-style name="default"/>
-      </map-layer-style-manager>
-      <flags>
-        <Identifiable>0</Identifiable>
-        <Removable>1</Removable>
-        <Searchable>0</Searchable>
-      </flags>
-      <customproperties>
-        <property key="QFieldSync/action" value="no_action"/>
-        <property key="identify/format" value="Undefined"/>
-      </customproperties>
-      <pipe>
-        <rasterrenderer type="singlebandcolordata" opacity="1" band="1" alphaBand="-1">
-          <rasterTransparency/>
-          <minMaxOrigin>
-            <limits>None</limits>
-            <extent>WholeRaster</extent>
-            <statAccuracy>Estimated</statAccuracy>
-            <cumulativeCutLower>0.02</cumulativeCutLower>
-            <cumulativeCutUpper>0.98</cumulativeCutUpper>
-            <stdDevFactor>2</stdDevFactor>
-          </minMaxOrigin>
-        </rasterrenderer>
-        <brightnesscontrast brightness="0" contrast="0"/>
-        <huesaturation colorizeOn="0" colorizeGreen="128" grayscaleMode="0" colorizeBlue="128" colorizeStrength="100" saturation="0" colorizeRed="255"/>
-        <rasterresampler maxOversampling="2"/>
-      </pipe>
-      <blendMode>0</blendMode>
-    </maplayer>
-    <maplayer hasScaleBasedVisibilityFlag="0" autoRefreshEnabled="0" refreshOnNotifyEnabled="0" maxScale="0" autoRefreshTime="0" readOnly="0" type="vector" styleCategories="AllStyleCategories" geometry="No geometry" wkbType="NoGeometry" refreshOnNotifyMessage="" minScale="1e+08">
-      <id>Pollen_Consumption_9dac944e_6937_4617_928b_0daaf97303e9</id>
-      <datasource>./bees.gpkg|layername=Pollen_Consumption</datasource>
-      <keywordList>
-        <value></value>
-      </keywordList>
-      <layername>Pollen_Consumption</layername>
-      <srs>
-        <spatialrefsys>
-          <proj4></proj4>
-          <srsid>0</srsid>
-          <srid>0</srid>
-          <authid></authid>
-          <description></description>
-          <projectionacronym></projectionacronym>
-          <ellipsoidacronym></ellipsoidacronym>
-          <geographicflag>true</geographicflag>
-        </spatialrefsys>
-      </srs>
-      <resourceMetadata>
-        <identifier></identifier>
-        <parentidentifier></parentidentifier>
-        <language></language>
-        <type>dataset</type>
-        <title></title>
-        <abstract></abstract>
-        <contact>
-          <name></name>
-          <organization></organization>
-          <position></position>
-          <voice></voice>
-          <fax></fax>
-          <email></email>
-          <role></role>
-        </contact>
-        <links/>
-        <fees></fees>
-        <encoding></encoding>
-        <crs>
-          <spatialrefsys>
-            <proj4></proj4>
-            <srsid>0</srsid>
-            <srid>0</srid>
-            <authid></authid>
-            <description></description>
-            <projectionacronym></projectionacronym>
-            <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
-          </spatialrefsys>
-        </crs>
         <extent>
-          <spatial maxx="0" maxz="0" dimensions="2" minx="0" minz="0" crs="" maxy="0" miny="0"/>
+          <spatial crs="" dimensions="2" maxx="0" maxy="0" maxz="0" minx="0" miny="0" minz="0"></spatial>
           <temporal>
             <period>
               <start></start>
@@ -329,37 +350,51 @@
         </extent>
       </resourceMetadata>
       <provider encoding="UTF-8">ogr</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <legend type="default-vector"/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <legend type="default-vector"></legend>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"/>
+        <map-layer-style name="default"></map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
+      <auxiliaryLayer></auxiliaryLayer>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
       </flags>
       <customproperties>
-        <property key="dualview/previewExpressions" value="&quot;fid&quot;"/>
-        <property key="embeddedWidgets/count" value="0"/>
-        <property key="variableNames"/>
-        <property key="variableValues"/>
+        <property key="dualview/previewExpressions">
+          <value>percentage || ' % ' || attribute( get_feature( 'Fields', 'fid', "field_id"), 'plant_species' )  || ' [' || attribute( get_feature( 'Fields', 'fid', "field_id"), 'fid' ) || ']'
+
+
+</value>
+        </property>
+        <property key="embeddedWidgets/count" value="0"></property>
+        <property key="variableNames"></property>
+        <property key="variableValues"></property>
       </customproperties>
       <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-        <activeChecks/>
-        <checkConfiguration/>
+        <activeChecks></activeChecks>
+        <checkConfiguration></checkConfiguration>
       </geometryOptions>
+      <referencedLayers>
+        <relation dataSource="./bees.gpkg|layername=apiary" id="Pollen_Con_apiary_id_apiary_279_fid" layerId="apiary_27954fba_aad8_4336_8b19_23afed462c51" layerName="Apiary" name="consume_on_fields" providerKey="ogr" strength="1">
+          <fieldPair referenced="fid" referencing="apiary_id"></fieldPair>
+        </relation>
+        <relation dataSource="./bees.gpkg|layername=area" id="Pollen_Con_field_id_ogr_dbname_fid" layerId="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" layerName="Fields" name="consumed_by_apiaries" providerKey="ogr" strength="1">
+          <fieldPair referenced="fid" referencing="field_id"></fieldPair>
+        </relation>
+      </referencedLayers>
+      <referencingLayers></referencingLayers>
       <fieldConfiguration>
         <field name="fid">
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="bool" name="IsMultiline" value="false"/>
-                <Option type="bool" name="UseHtml" value="false"/>
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -368,14 +403,14 @@
           <editWidget type="RelationReference">
             <config>
               <Option type="Map">
-                <Option type="bool" name="AllowAddFeatures" value="false"/>
-                <Option type="bool" name="AllowNULL" value="false"/>
-                <Option type="bool" name="MapIdentification" value="false"/>
-                <Option type="bool" name="OrderByValue" value="false"/>
-                <Option type="bool" name="ReadOnly" value="false"/>
-                <Option type="QString" name="Relation" value="Pollen_Con_apiary_id_apiary_279_fid"/>
-                <Option type="bool" name="ShowForm" value="false"/>
-                <Option type="bool" name="ShowOpenFormButton" value="true"/>
+                <Option name="AllowAddFeatures" type="bool" value="false"></Option>
+                <Option name="AllowNULL" type="bool" value="false"></Option>
+                <Option name="MapIdentification" type="bool" value="false"></Option>
+                <Option name="OrderByValue" type="bool" value="false"></Option>
+                <Option name="ReadOnly" type="bool" value="false"></Option>
+                <Option name="Relation" type="QString" value="Pollen_Con_apiary_id_apiary_279_fid"></Option>
+                <Option name="ShowForm" type="bool" value="false"></Option>
+                <Option name="ShowOpenFormButton" type="bool" value="true"></Option>
               </Option>
             </config>
           </editWidget>
@@ -384,14 +419,14 @@
           <editWidget type="RelationReference">
             <config>
               <Option type="Map">
-                <Option type="bool" name="AllowAddFeatures" value="false"/>
-                <Option type="bool" name="AllowNULL" value="false"/>
-                <Option type="bool" name="MapIdentification" value="false"/>
-                <Option type="bool" name="OrderByValue" value="false"/>
-                <Option type="bool" name="ReadOnly" value="false"/>
-                <Option type="QString" name="Relation" value="Pollen_Con_field_id_ogr_dbname_fid"/>
-                <Option type="bool" name="ShowForm" value="false"/>
-                <Option type="bool" name="ShowOpenFormButton" value="true"/>
+                <Option name="AllowAddFeatures" type="bool" value="false"></Option>
+                <Option name="AllowNULL" type="bool" value="false"></Option>
+                <Option name="MapIdentification" type="bool" value="false"></Option>
+                <Option name="OrderByValue" type="bool" value="false"></Option>
+                <Option name="ReadOnly" type="bool" value="false"></Option>
+                <Option name="Relation" type="QString" value="Pollen_Con_field_id_ogr_dbname_fid"></Option>
+                <Option name="ShowForm" type="bool" value="false"></Option>
+                <Option name="ShowOpenFormButton" type="bool" value="true"></Option>
               </Option>
             </config>
           </editWidget>
@@ -400,66 +435,66 @@
           <editWidget type="Range">
             <config>
               <Option type="Map">
-                <Option type="bool" name="AllowNull" value="true"/>
-                <Option type="int" name="Max" value="2147483647"/>
-                <Option type="int" name="Min" value="-2147483648"/>
-                <Option type="int" name="Precision" value="0"/>
-                <Option type="int" name="Step" value="1"/>
-                <Option type="QString" name="Style" value="SpinBox"/>
+                <Option name="AllowNull" type="bool" value="true"></Option>
+                <Option name="Max" type="int" value="2147483647"></Option>
+                <Option name="Min" type="int" value="-2147483648"></Option>
+                <Option name="Precision" type="int" value="0"></Option>
+                <Option name="Step" type="int" value="1"></Option>
+                <Option name="Style" type="QString" value="SpinBox"></Option>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" field="fid" index="0"/>
-        <alias name="" field="apiary_id" index="1"/>
-        <alias name="" field="field_id" index="2"/>
-        <alias name="" field="percentage" index="3"/>
+        <alias field="fid" index="0" name=""></alias>
+        <alias field="apiary_id" index="1" name=""></alias>
+        <alias field="field_id" index="2" name=""></alias>
+        <alias field="percentage" index="3" name=""></alias>
       </aliases>
-      <excludeAttributesWMS/>
-      <excludeAttributesWFS/>
+      <excludeAttributesWMS></excludeAttributesWMS>
+      <excludeAttributesWFS></excludeAttributesWFS>
       <defaults>
-        <default applyOnUpdate="0" field="fid" expression=""/>
-        <default applyOnUpdate="0" field="apiary_id" expression=""/>
-        <default applyOnUpdate="0" field="field_id" expression=""/>
-        <default applyOnUpdate="0" field="percentage" expression=""/>
+        <default applyOnUpdate="0" expression="" field="fid"></default>
+        <default applyOnUpdate="0" expression="" field="apiary_id"></default>
+        <default applyOnUpdate="0" expression="" field="field_id"></default>
+        <default applyOnUpdate="0" expression="" field="percentage"></default>
       </defaults>
       <constraints>
-        <constraint notnull_strength="1" constraints="3" field="fid" unique_strength="1" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="apiary_id" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="field_id" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="percentage" unique_strength="0" exp_strength="0"/>
+        <constraint constraints="3" exp_strength="0" field="fid" notnull_strength="1" unique_strength="1"></constraint>
+        <constraint constraints="0" exp_strength="0" field="apiary_id" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="field_id" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="percentage" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint field="fid" desc="" exp=""/>
-        <constraint field="apiary_id" desc="" exp=""/>
-        <constraint field="field_id" desc="" exp=""/>
-        <constraint field="percentage" desc="" exp=""/>
+        <constraint desc="" exp="" field="fid"></constraint>
+        <constraint desc="" exp="" field="apiary_id"></constraint>
+        <constraint desc="" exp="" field="field_id"></constraint>
+        <constraint desc="" exp="" field="percentage"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
       </attributeactions>
-      <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column type="field" name="fid" width="-1" hidden="0"/>
-          <column type="field" name="apiary_id" width="-1" hidden="0"/>
-          <column type="field" name="field_id" width="-1" hidden="0"/>
-          <column type="field" name="percentage" width="-1" hidden="0"/>
-          <column type="actions" width="-1" hidden="1"/>
+          <column hidden="0" name="fid" type="field" width="-1"></column>
+          <column hidden="0" name="apiary_id" type="field" width="-1"></column>
+          <column hidden="0" name="field_id" type="field" width="-1"></column>
+          <column hidden="0" name="percentage" type="field" width="-1"></column>
+          <column hidden="1" type="actions" width="-1"></column>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1"></editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath></editforminitfilepath>
-      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+      <editforminitcode># -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -475,34 +510,34 @@ from qgis.PyQt.QtWidgets import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-]]></editforminitcode>
+</editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>tablayout</editorlayout>
       <attributeEditorForm>
-        <attributeEditorField name="apiary_id" showLabel="1" index="1"/>
-        <attributeEditorField name="field_id" showLabel="1" index="2"/>
-        <attributeEditorField name="percentage" showLabel="1" index="3"/>
+        <attributeEditorField index="1" name="apiary_id" showLabel="1"></attributeEditorField>
+        <attributeEditorField index="2" name="field_id" showLabel="1"></attributeEditorField>
+        <attributeEditorField index="3" name="percentage" showLabel="1"></attributeEditorField>
       </attributeEditorForm>
       <editable>
-        <field name="apiary_id" editable="1"/>
-        <field name="fid" editable="1"/>
-        <field name="field_id" editable="1"/>
-        <field name="percentage" editable="1"/>
+        <field editable="1" name="apiary_id"></field>
+        <field editable="1" name="fid"></field>
+        <field editable="1" name="field_id"></field>
+        <field editable="1" name="percentage"></field>
       </editable>
       <labelOnTop>
-        <field labelOnTop="0" name="apiary_id"/>
-        <field labelOnTop="0" name="fid"/>
-        <field labelOnTop="0" name="field_id"/>
-        <field labelOnTop="0" name="percentage"/>
+        <field labelOnTop="0" name="apiary_id"></field>
+        <field labelOnTop="0" name="fid"></field>
+        <field labelOnTop="0" name="field_id"></field>
+        <field labelOnTop="0" name="percentage"></field>
       </labelOnTop>
-      <widgets/>
+      <widgets></widgets>
       <previewExpression>percentage || ' % ' || attribute( get_feature( 'Fields', 'fid', "field_id"), 'plant_species' )  || ' [' || attribute( get_feature( 'Fields', 'fid', "field_id"), 'fid' ) || ']'
 
 
 </previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer hasScaleBasedVisibilityFlag="0" autoRefreshEnabled="0" refreshOnNotifyEnabled="0" maxScale="0" autoRefreshTime="0" readOnly="0" type="vector" styleCategories="AllStyleCategories" geometry="No geometry" wkbType="NoGeometry" refreshOnNotifyMessage="" minScale="1e+08">
+    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" geometry="No geometry" hasScaleBasedVisibilityFlag="0" maxScale="0" minScale="1e+8" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" type="vector" wkbType="NoGeometry">
       <id>Reviews_c8ab909e_4686_45c7_affe_08141059dfd0</id>
       <datasource>./bees.gpkg|layername=Reviews</datasource>
       <keywordList>
@@ -511,6 +546,7 @@ def my_form_open(dialog, layer, feature):
       <layername>Apiary_Reviews</layername>
       <srs>
         <spatialrefsys>
+          <wkt></wkt>
           <proj4></proj4>
           <srsid>0</srsid>
           <srid>0</srid>
@@ -518,7 +554,7 @@ def my_form_open(dialog, layer, feature):
           <description></description>
           <projectionacronym></projectionacronym>
           <ellipsoidacronym></ellipsoidacronym>
-          <geographicflag>true</geographicflag>
+          <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
       <resourceMetadata>
@@ -537,11 +573,12 @@ def my_form_open(dialog, layer, feature):
           <email></email>
           <role></role>
         </contact>
-        <links/>
+        <links></links>
         <fees></fees>
         <encoding></encoding>
         <crs>
           <spatialrefsys>
+            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -549,11 +586,11 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
+            <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial maxx="0" maxz="0" dimensions="2" minx="0" minz="0" crs="" maxy="0" miny="0"/>
+          <spatial crs="" dimensions="2" maxx="0" maxy="0" maxz="0" minx="0" miny="0" minz="0"></spatial>
           <temporal>
             <period>
               <start></start>
@@ -563,37 +600,43 @@ def my_form_open(dialog, layer, feature):
         </extent>
       </resourceMetadata>
       <provider encoding="UTF-8">ogr</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <legend type="default-vector"/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <legend type="default-vector"></legend>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"/>
+        <map-layer-style name="default"></map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
+      <auxiliaryLayer></auxiliaryLayer>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
       </flags>
       <customproperties>
-        <property key="dualview/previewExpressions" value="&quot;review_date&quot; || ' by '  || &quot;reviewer&quot;"/>
-        <property key="embeddedWidgets/count" value="0"/>
-        <property key="variableNames"/>
-        <property key="variableValues"/>
+        <property key="dualview/previewExpressions" value="&quot;review_date&quot; || ' by '  || &quot;reviewer&quot;"></property>
+        <property key="embeddedWidgets/count" value="0"></property>
+        <property key="variableNames"></property>
+        <property key="variableValues"></property>
       </customproperties>
       <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-        <activeChecks/>
-        <checkConfiguration/>
+        <activeChecks></activeChecks>
+        <checkConfiguration></checkConfiguration>
       </geometryOptions>
+      <referencedLayers>
+        <relation dataSource="./bees.gpkg|layername=apiary" id="Reviews_c8_apiary_id_apiary_279_fid" layerId="apiary_27954fba_aad8_4336_8b19_23afed462c51" layerName="Apiary" name="review_apiary" providerKey="ogr" strength="1">
+          <fieldPair referenced="fid" referencing="apiary_id"></fieldPair>
+        </relation>
+      </referencedLayers>
+      <referencingLayers></referencingLayers>
       <fieldConfiguration>
         <field name="fid">
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="bool" name="IsMultiline" value="false"/>
-                <Option type="bool" name="UseHtml" value="false"/>
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -602,8 +645,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="bool" name="IsMultiline" value="false"/>
-                <Option type="bool" name="UseHtml" value="false"/>
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -612,11 +655,11 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="DateTime">
             <config>
               <Option type="Map">
-                <Option type="bool" name="allow_null" value="true"/>
-                <Option type="bool" name="calendar_popup" value="true"/>
-                <Option type="QString" name="display_format" value="yyyy-MM-dd"/>
-                <Option type="QString" name="field_format" value="yyyy-MM-dd"/>
-                <Option type="bool" name="field_iso_format" value="false"/>
+                <Option name="allow_null" type="bool" value="true"></Option>
+                <Option name="calendar_popup" type="bool" value="true"></Option>
+                <Option name="display_format" type="QString" value="yyyy-MM-dd"></Option>
+                <Option name="field_format" type="QString" value="yyyy-MM-dd"></Option>
+                <Option name="field_iso_format" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -625,66 +668,66 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="Range">
             <config>
               <Option type="Map">
-                <Option type="bool" name="AllowNull" value="true"/>
-                <Option type="int" name="Max" value="2147483647"/>
-                <Option type="int" name="Min" value="-2147483648"/>
-                <Option type="int" name="Precision" value="0"/>
-                <Option type="int" name="Step" value="1"/>
-                <Option type="QString" name="Style" value="SpinBox"/>
+                <Option name="AllowNull" type="bool" value="true"></Option>
+                <Option name="Max" type="int" value="2147483647"></Option>
+                <Option name="Min" type="int" value="-2147483648"></Option>
+                <Option name="Precision" type="int" value="0"></Option>
+                <Option name="Step" type="int" value="1"></Option>
+                <Option name="Style" type="QString" value="SpinBox"></Option>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" field="fid" index="0"/>
-        <alias name="Reviewer" field="reviewer" index="1"/>
-        <alias name="Date of Review" field="review_date" index="2"/>
-        <alias name="" field="apiary_id" index="3"/>
+        <alias field="fid" index="0" name=""></alias>
+        <alias field="reviewer" index="1" name="Reviewer"></alias>
+        <alias field="review_date" index="2" name="Date of Review"></alias>
+        <alias field="apiary_id" index="3" name=""></alias>
       </aliases>
-      <excludeAttributesWMS/>
-      <excludeAttributesWFS/>
+      <excludeAttributesWMS></excludeAttributesWMS>
+      <excludeAttributesWFS></excludeAttributesWFS>
       <defaults>
-        <default applyOnUpdate="0" field="fid" expression=""/>
-        <default applyOnUpdate="0" field="reviewer" expression=""/>
-        <default applyOnUpdate="0" field="review_date" expression=""/>
-        <default applyOnUpdate="0" field="apiary_id" expression=""/>
+        <default applyOnUpdate="0" expression="" field="fid"></default>
+        <default applyOnUpdate="0" expression="" field="reviewer"></default>
+        <default applyOnUpdate="0" expression="" field="review_date"></default>
+        <default applyOnUpdate="0" expression="" field="apiary_id"></default>
       </defaults>
       <constraints>
-        <constraint notnull_strength="1" constraints="3" field="fid" unique_strength="1" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="reviewer" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="review_date" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="apiary_id" unique_strength="0" exp_strength="0"/>
+        <constraint constraints="3" exp_strength="0" field="fid" notnull_strength="1" unique_strength="1"></constraint>
+        <constraint constraints="0" exp_strength="0" field="reviewer" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="review_date" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="apiary_id" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint field="fid" desc="" exp=""/>
-        <constraint field="reviewer" desc="" exp=""/>
-        <constraint field="review_date" desc="" exp=""/>
-        <constraint field="apiary_id" desc="" exp=""/>
+        <constraint desc="" exp="" field="fid"></constraint>
+        <constraint desc="" exp="" field="reviewer"></constraint>
+        <constraint desc="" exp="" field="review_date"></constraint>
+        <constraint desc="" exp="" field="apiary_id"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
       </attributeactions>
-      <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column type="field" name="fid" width="-1" hidden="0"/>
-          <column type="field" name="reviewer" width="201" hidden="0"/>
-          <column type="field" name="review_date" width="200" hidden="0"/>
-          <column type="field" name="apiary_id" width="223" hidden="0"/>
-          <column type="actions" width="-1" hidden="1"/>
+          <column hidden="0" name="fid" type="field" width="-1"></column>
+          <column hidden="0" name="reviewer" type="field" width="201"></column>
+          <column hidden="0" name="review_date" type="field" width="200"></column>
+          <column hidden="0" name="apiary_id" type="field" width="223"></column>
+          <column hidden="1" type="actions" width="-1"></column>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1"></editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath></editforminitfilepath>
-      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+      <editforminitcode># -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -700,36 +743,36 @@ from qgis.PyQt.QtWidgets import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-]]></editforminitcode>
+</editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>tablayout</editorlayout>
       <attributeEditorForm>
-        <attributeEditorField name="reviewer" showLabel="1" index="1"/>
-        <attributeEditorField name="review_date" showLabel="1" index="2"/>
-        <attributeEditorField name="apiary_id" showLabel="1" index="3"/>
+        <attributeEditorField index="1" name="reviewer" showLabel="1"></attributeEditorField>
+        <attributeEditorField index="2" name="review_date" showLabel="1"></attributeEditorField>
+        <attributeEditorField index="3" name="apiary_id" showLabel="1"></attributeEditorField>
       </attributeEditorForm>
       <editable>
-        <field name="apiary_id" editable="1"/>
-        <field name="fid" editable="1"/>
-        <field name="review_date" editable="1"/>
-        <field name="reviewer" editable="1"/>
+        <field editable="1" name="apiary_id"></field>
+        <field editable="1" name="fid"></field>
+        <field editable="1" name="review_date"></field>
+        <field editable="1" name="reviewer"></field>
       </editable>
       <labelOnTop>
-        <field labelOnTop="0" name="apiary_id"/>
-        <field labelOnTop="0" name="fid"/>
-        <field labelOnTop="0" name="review_date"/>
-        <field labelOnTop="0" name="reviewer"/>
+        <field labelOnTop="0" name="apiary_id"></field>
+        <field labelOnTop="0" name="fid"></field>
+        <field labelOnTop="0" name="review_date"></field>
+        <field labelOnTop="0" name="reviewer"></field>
       </labelOnTop>
-      <widgets/>
+      <widgets></widgets>
       <previewExpression>"review_date" || ' by '  || "reviewer"</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer styleCategories="AllStyleCategories" autoRefreshEnabled="0" autoRefreshTime="0" geometry="Point" refreshOnNotifyMessage="" simplifyAlgorithm="0" wkbType="Point" refreshOnNotifyEnabled="0" simplifyDrawingHints="0" minScale="0" readOnly="0" type="vector" simplifyMaxScale="1" maxScale="0" simplifyLocal="1" simplifyDrawingTol="1" labelsEnabled="1" hasScaleBasedVisibilityFlag="0">
+    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" geometry="Point" hasScaleBasedVisibilityFlag="0" labelsEnabled="1" maxScale="0" minScale="0" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="0" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" type="vector" wkbType="Point">
       <extent>
-        <xmin>1029520</xmin>
-        <ymin>5910540</ymin>
-        <xmax>1031390</xmax>
-        <ymax>5911980</ymax>
+        <xmin>1029518.875</xmin>
+        <ymin>5910544</ymin>
+        <xmax>1031392.6875</xmax>
+        <ymax>5911983</ymax>
       </extent>
       <id>apiary_27954fba_aad8_4336_8b19_23afed462c51</id>
       <datasource>./bees.gpkg|layername=apiary</datasource>
@@ -739,13 +782,14 @@ def my_form_open(dialog, layer, feature):
       <layername>Apiary</layername>
       <srs>
         <spatialrefsys>
-          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+          <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
+          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
           <srsid>3857</srsid>
           <srid>3857</srid>
           <authid>EPSG:3857</authid>
           <description>WGS 84 / Pseudo-Mercator</description>
           <projectionacronym>merc</projectionacronym>
-          <ellipsoidacronym></ellipsoidacronym>
+          <ellipsoidacronym>WGS84</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -765,11 +809,12 @@ def my_form_open(dialog, layer, feature):
           <email></email>
           <role></role>
         </contact>
-        <links/>
+        <links></links>
         <fees></fees>
         <encoding></encoding>
         <crs>
           <spatialrefsys>
+            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -777,11 +822,11 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
+            <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial maxx="0" maxz="0" dimensions="2" minx="0" minz="0" crs="" maxy="0" miny="0"/>
+          <spatial crs="" dimensions="2" maxx="0" maxy="0" maxz="0" minx="0" miny="0" minz="0"></spatial>
           <temporal>
             <period>
               <start></start>
@@ -791,141 +836,141 @@ def my_form_open(dialog, layer, feature):
         </extent>
       </resourceMetadata>
       <provider encoding="UTF-8">ogr</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <legend type="default-vector"/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <legend type="default-vector"></legend>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="Species">
         <map-layer-style name="Diseases">
-          <qgis hasScaleBasedVisibilityFlag="0" maxScale="0" simplifyMaxScale="1" readOnly="0" version="3.4.4-Madeira" styleCategories="AllStyleCategories" simplifyDrawingTol="1" simplifyDrawingHints="0" simplifyAlgorithm="0" simplifyLocal="1" labelsEnabled="0" minScale="0">
+          <qgis hasScaleBasedVisibilityFlag="0" labelsEnabled="0" maxScale="0" minScale="0" readOnly="0" simplifyAlgorithm="0" simplifyDrawingHints="0" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" version="3.4.4-Madeira">
             <flags>
               <Identifiable>1</Identifiable>
               <Removable>1</Removable>
               <Searchable>1</Searchable>
             </flags>
-            <renderer-v2 enableorderby="0" type="RuleRenderer" symbollevels="0" forceraster="0">
+            <renderer-v2 enableorderby="0" forceraster="0" symbollevels="0" type="RuleRenderer">
               <rules key="{4157b923-0ac3-4ea0-ba49-d157faf5f0b9}">
-                <rule key="{9b02c077-cf2f-43ca-b6f1-f92c5f4ec2b7}" symbol="0" filter="ELSE" label="No disease information"/>
-                <rule key="{2c8997f2-a415-45d2-bd98-2c0898cb3118}" filter=" &quot;disease&quot; is not NULL" label="Diseases">
-                  <rule key="{00cac068-dfab-4de1-b717-90ccb04e7578}" symbol="1" filter="&quot;disease&quot; in(false, 'f')" label="good"/>
-                  <rule key="{b28ddc2f-8fe3-4b1b-a95f-24a6d59c38c7}" symbol="2" filter="&quot;disease&quot; in (true, 't') and &quot;kind_of_disease&quot; != 'AFB'" label="ok"/>
-                  <rule key="{c38c7fee-fcf0-4c65-832e-65626d4abae7}" symbol="3" filter="&quot;disease&quot;  in (true, 't') and &quot;kind_of_disease&quot; = 'AFB'" label="not ok"/>
+                <rule filter="ELSE" key="{9b02c077-cf2f-43ca-b6f1-f92c5f4ec2b7}" label="No disease information" symbol="0"></rule>
+                <rule filter=" &quot;disease&quot; is not NULL" key="{2c8997f2-a415-45d2-bd98-2c0898cb3118}" label="Diseases">
+                  <rule filter="&quot;disease&quot; in(false, 'f')" key="{00cac068-dfab-4de1-b717-90ccb04e7578}" label="good" symbol="1"></rule>
+                  <rule filter="&quot;disease&quot; in (true, 't') and &quot;kind_of_disease&quot; != 'AFB'" key="{b28ddc2f-8fe3-4b1b-a95f-24a6d59c38c7}" label="ok" symbol="2"></rule>
+                  <rule filter="&quot;disease&quot;  in (true, 't') and &quot;kind_of_disease&quot; = 'AFB'" key="{c38c7fee-fcf0-4c65-832e-65626d4abae7}" label="not ok" symbol="3"></rule>
                 </rule>
               </rules>
               <symbols>
-                <symbol type="marker" alpha="1" force_rhr="0" clip_to_extent="1" name="0">
-                  <layer enabled="1" locked="0" class="SimpleMarker" pass="0">
-                    <prop v="0" k="angle"/>
-                    <prop v="255,255,255,255" k="color"/>
-                    <prop v="1" k="horizontal_anchor_point"/>
-                    <prop v="miter" k="joinstyle"/>
-                    <prop v="hexagon" k="name"/>
-                    <prop v="0,0" k="offset"/>
-                    <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-                    <prop v="MM" k="offset_unit"/>
-                    <prop v="250,139,57,255" k="outline_color"/>
-                    <prop v="solid" k="outline_style"/>
-                    <prop v="1" k="outline_width"/>
-                    <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-                    <prop v="MM" k="outline_width_unit"/>
-                    <prop v="diameter" k="scale_method"/>
-                    <prop v="6.8" k="size"/>
-                    <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-                    <prop v="MM" k="size_unit"/>
-                    <prop v="1" k="vertical_anchor_point"/>
+                <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="0" type="marker">
+                  <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                    <prop k="angle" v="0"></prop>
+                    <prop k="color" v="255,255,255,255"></prop>
+                    <prop k="horizontal_anchor_point" v="1"></prop>
+                    <prop k="joinstyle" v="miter"></prop>
+                    <prop k="name" v="hexagon"></prop>
+                    <prop k="offset" v="0,0"></prop>
+                    <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="offset_unit" v="MM"></prop>
+                    <prop k="outline_color" v="250,139,57,255"></prop>
+                    <prop k="outline_style" v="solid"></prop>
+                    <prop k="outline_width" v="1"></prop>
+                    <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="outline_width_unit" v="MM"></prop>
+                    <prop k="scale_method" v="diameter"></prop>
+                    <prop k="size" v="6.8"></prop>
+                    <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="size_unit" v="MM"></prop>
+                    <prop k="vertical_anchor_point" v="1"></prop>
                     <data_defined_properties>
                       <Option type="Map">
-                        <Option type="QString" name="name" value=""/>
-                        <Option name="properties"/>
-                        <Option type="QString" name="type" value="collection"/>
+                        <Option name="name" type="QString" value=""></Option>
+                        <Option name="properties"></Option>
+                        <Option name="type" type="QString" value="collection"></Option>
                       </Option>
                     </data_defined_properties>
                   </layer>
                 </symbol>
-                <symbol type="marker" alpha="1" force_rhr="0" clip_to_extent="1" name="1">
-                  <layer enabled="1" locked="0" class="SimpleMarker" pass="0">
-                    <prop v="0" k="angle"/>
-                    <prop v="190,255,185,255" k="color"/>
-                    <prop v="1" k="horizontal_anchor_point"/>
-                    <prop v="miter" k="joinstyle"/>
-                    <prop v="hexagon" k="name"/>
-                    <prop v="0,0" k="offset"/>
-                    <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-                    <prop v="MM" k="offset_unit"/>
-                    <prop v="250,139,57,255" k="outline_color"/>
-                    <prop v="solid" k="outline_style"/>
-                    <prop v="1" k="outline_width"/>
-                    <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-                    <prop v="MM" k="outline_width_unit"/>
-                    <prop v="diameter" k="scale_method"/>
-                    <prop v="6.8" k="size"/>
-                    <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-                    <prop v="MM" k="size_unit"/>
-                    <prop v="1" k="vertical_anchor_point"/>
+                <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="1" type="marker">
+                  <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                    <prop k="angle" v="0"></prop>
+                    <prop k="color" v="190,255,185,255"></prop>
+                    <prop k="horizontal_anchor_point" v="1"></prop>
+                    <prop k="joinstyle" v="miter"></prop>
+                    <prop k="name" v="hexagon"></prop>
+                    <prop k="offset" v="0,0"></prop>
+                    <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="offset_unit" v="MM"></prop>
+                    <prop k="outline_color" v="250,139,57,255"></prop>
+                    <prop k="outline_style" v="solid"></prop>
+                    <prop k="outline_width" v="1"></prop>
+                    <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="outline_width_unit" v="MM"></prop>
+                    <prop k="scale_method" v="diameter"></prop>
+                    <prop k="size" v="6.8"></prop>
+                    <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="size_unit" v="MM"></prop>
+                    <prop k="vertical_anchor_point" v="1"></prop>
                     <data_defined_properties>
                       <Option type="Map">
-                        <Option type="QString" name="name" value=""/>
-                        <Option name="properties"/>
-                        <Option type="QString" name="type" value="collection"/>
+                        <Option name="name" type="QString" value=""></Option>
+                        <Option name="properties"></Option>
+                        <Option name="type" type="QString" value="collection"></Option>
                       </Option>
                     </data_defined_properties>
                   </layer>
                 </symbol>
-                <symbol type="marker" alpha="1" force_rhr="0" clip_to_extent="1" name="2">
-                  <layer enabled="1" locked="0" class="SimpleMarker" pass="0">
-                    <prop v="0" k="angle"/>
-                    <prop v="250,176,124,255" k="color"/>
-                    <prop v="1" k="horizontal_anchor_point"/>
-                    <prop v="miter" k="joinstyle"/>
-                    <prop v="hexagon" k="name"/>
-                    <prop v="0,0" k="offset"/>
-                    <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-                    <prop v="MM" k="offset_unit"/>
-                    <prop v="250,139,57,255" k="outline_color"/>
-                    <prop v="solid" k="outline_style"/>
-                    <prop v="1" k="outline_width"/>
-                    <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-                    <prop v="MM" k="outline_width_unit"/>
-                    <prop v="diameter" k="scale_method"/>
-                    <prop v="6.8" k="size"/>
-                    <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-                    <prop v="MM" k="size_unit"/>
-                    <prop v="1" k="vertical_anchor_point"/>
+                <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="2" type="marker">
+                  <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                    <prop k="angle" v="0"></prop>
+                    <prop k="color" v="250,176,124,255"></prop>
+                    <prop k="horizontal_anchor_point" v="1"></prop>
+                    <prop k="joinstyle" v="miter"></prop>
+                    <prop k="name" v="hexagon"></prop>
+                    <prop k="offset" v="0,0"></prop>
+                    <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="offset_unit" v="MM"></prop>
+                    <prop k="outline_color" v="250,139,57,255"></prop>
+                    <prop k="outline_style" v="solid"></prop>
+                    <prop k="outline_width" v="1"></prop>
+                    <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="outline_width_unit" v="MM"></prop>
+                    <prop k="scale_method" v="diameter"></prop>
+                    <prop k="size" v="6.8"></prop>
+                    <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="size_unit" v="MM"></prop>
+                    <prop k="vertical_anchor_point" v="1"></prop>
                     <data_defined_properties>
                       <Option type="Map">
-                        <Option type="QString" name="name" value=""/>
-                        <Option name="properties"/>
-                        <Option type="QString" name="type" value="collection"/>
+                        <Option name="name" type="QString" value=""></Option>
+                        <Option name="properties"></Option>
+                        <Option name="type" type="QString" value="collection"></Option>
                       </Option>
                     </data_defined_properties>
                   </layer>
                 </symbol>
-                <symbol type="marker" alpha="1" force_rhr="0" clip_to_extent="1" name="3">
-                  <layer enabled="1" locked="0" class="SimpleMarker" pass="0">
-                    <prop v="0" k="angle"/>
-                    <prop v="227,117,119,255" k="color"/>
-                    <prop v="1" k="horizontal_anchor_point"/>
-                    <prop v="miter" k="joinstyle"/>
-                    <prop v="hexagon" k="name"/>
-                    <prop v="0,0" k="offset"/>
-                    <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-                    <prop v="MM" k="offset_unit"/>
-                    <prop v="250,139,57,255" k="outline_color"/>
-                    <prop v="solid" k="outline_style"/>
-                    <prop v="1" k="outline_width"/>
-                    <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-                    <prop v="MM" k="outline_width_unit"/>
-                    <prop v="diameter" k="scale_method"/>
-                    <prop v="6.8" k="size"/>
-                    <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-                    <prop v="MM" k="size_unit"/>
-                    <prop v="1" k="vertical_anchor_point"/>
+                <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="3" type="marker">
+                  <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                    <prop k="angle" v="0"></prop>
+                    <prop k="color" v="227,117,119,255"></prop>
+                    <prop k="horizontal_anchor_point" v="1"></prop>
+                    <prop k="joinstyle" v="miter"></prop>
+                    <prop k="name" v="hexagon"></prop>
+                    <prop k="offset" v="0,0"></prop>
+                    <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="offset_unit" v="MM"></prop>
+                    <prop k="outline_color" v="250,139,57,255"></prop>
+                    <prop k="outline_style" v="solid"></prop>
+                    <prop k="outline_width" v="1"></prop>
+                    <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="outline_width_unit" v="MM"></prop>
+                    <prop k="scale_method" v="diameter"></prop>
+                    <prop k="size" v="6.8"></prop>
+                    <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="size_unit" v="MM"></prop>
+                    <prop k="vertical_anchor_point" v="1"></prop>
                     <data_defined_properties>
                       <Option type="Map">
-                        <Option type="QString" name="name" value=""/>
-                        <Option name="properties"/>
-                        <Option type="QString" name="type" value="collection"/>
+                        <Option name="name" type="QString" value=""></Option>
+                        <Option name="properties"></Option>
+                        <Option name="type" type="QString" value="collection"></Option>
                       </Option>
                     </data_defined_properties>
                   </layer>
@@ -933,56 +978,56 @@ def my_form_open(dialog, layer, feature):
               </symbols>
             </renderer-v2>
             <customproperties>
-              <property key="embeddedWidgets/count" value="0"/>
-              <property key="isOfflineEditable" value="true"/>
-              <property key="remoteProvider" value="postgres"/>
-              <property key="remoteSource" value="dbname='demo' host=lizmapdemo.opengis.ch port=5432 user='editor1' password='editor1' sslmode=disable key='id' srid=2056 type=Point table=&quot;citybees&quot;.&quot;apiary&quot; (geom) sql="/>
-              <property key="variableNames"/>
-              <property key="variableValues"/>
+              <property key="embeddedWidgets/count" value="0"></property>
+              <property key="isOfflineEditable" value="true"></property>
+              <property key="remoteProvider" value="postgres"></property>
+              <property key="remoteSource" value="dbname='demo' host=lizmapdemo.opengis.ch port=5432 user='editor1' password='editor1' sslmode=disable key='id' srid=2056 type=Point table=&quot;citybees&quot;.&quot;apiary&quot; (geom) sql="></property>
+              <property key="variableNames"></property>
+              <property key="variableValues"></property>
             </customproperties>
             <blendMode>0</blendMode>
             <featureBlendMode>0</featureBlendMode>
             <layerOpacity>1</layerOpacity>
-            <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
-              <DiagramCategory labelPlacementMethod="XHeight" minScaleDenominator="0" penAlpha="255" diagramOrientation="Up" penColor="#000000" scaleBasedVisibility="0" rotationOffset="0" maxScaleDenominator="1e+8" sizeScale="3x:0,0,0,0,0,0" barWidth="5" lineSizeType="MM" backgroundColor="#ffffff" scaleDependency="Area" width="15" minimumSize="0" lineSizeScale="3x:0,0,0,0,0,0" sizeType="MM" backgroundAlpha="255" height="15" enabled="0" penWidth="0" opacity="1">
-                <fontProperties style="" description="Cantarell,11,-1,5,50,0,0,0,0,0"/>
-                <attribute color="#000000" field="" label=""/>
+            <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+              <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+8" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="0" scaleBasedVisibility="0" scaleDependency="Area" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" width="15">
+                <fontProperties description="Cantarell,11,-1,5,50,0,0,0,0,0" style=""></fontProperties>
+                <attribute color="#000000" field="" label=""></attribute>
               </DiagramCategory>
             </SingleCategoryDiagramRenderer>
-            <DiagramLayerSettings linePlacementFlags="2" dist="0" priority="0" zIndex="0" placement="0" obstacle="0" showAll="1">
+            <DiagramLayerSettings dist="0" linePlacementFlags="2" obstacle="0" placement="0" priority="0" showAll="1" zIndex="0">
               <properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option type="Map" name="properties">
-                    <Option type="Map" name="positionX">
-                      <Option type="bool" name="active" value="true"/>
-                      <Option type="QString" name="field" value="id"/>
-                      <Option type="int" name="type" value="2"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties" type="Map">
+                    <Option name="positionX" type="Map">
+                      <Option name="active" type="bool" value="true"></Option>
+                      <Option name="field" type="QString" value="id"></Option>
+                      <Option name="type" type="int" value="2"></Option>
                     </Option>
-                    <Option type="Map" name="positionY">
-                      <Option type="bool" name="active" value="true"/>
-                      <Option type="QString" name="field" value="id"/>
-                      <Option type="int" name="type" value="2"/>
+                    <Option name="positionY" type="Map">
+                      <Option name="active" type="bool" value="true"></Option>
+                      <Option name="field" type="QString" value="id"></Option>
+                      <Option name="type" type="int" value="2"></Option>
                     </Option>
-                    <Option type="Map" name="show">
-                      <Option type="bool" name="active" value="true"/>
-                      <Option type="QString" name="field" value="id"/>
-                      <Option type="int" name="type" value="2"/>
+                    <Option name="show" type="Map">
+                      <Option name="active" type="bool" value="true"></Option>
+                      <Option name="field" type="QString" value="id"></Option>
+                      <Option name="type" type="int" value="2"></Option>
                     </Option>
                   </Option>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </properties>
             </DiagramLayerSettings>
             <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-              <activeChecks/>
-              <checkConfiguration/>
+              <activeChecks></activeChecks>
+              <checkConfiguration></checkConfiguration>
             </geometryOptions>
             <fieldConfiguration>
               <field name="fid">
                 <editWidget type="TextEdit">
                   <config>
-                    <Option/>
+                    <Option></Option>
                   </config>
                 </editWidget>
               </field>
@@ -990,12 +1035,12 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="Range">
                   <config>
                     <Option type="Map">
-                      <Option value="true" type="bool" name="AllowNull"/>
-                      <Option value="10" type="int" name="Max"/>
-                      <Option value="1" type="int" name="Min"/>
-                      <Option value="0" type="int" name="Precision"/>
-                      <Option value="1" type="int" name="Step"/>
-                      <Option value="Slider" type="QString" name="Style"/>
+                      <Option name="AllowNull" type="bool" value="true"></Option>
+                      <Option name="Max" type="int" value="10"></Option>
+                      <Option name="Min" type="int" value="1"></Option>
+                      <Option name="Precision" type="int" value="0"></Option>
+                      <Option name="Step" type="int" value="1"></Option>
+                      <Option name="Style" type="QString" value="Slider"></Option>
                     </Option>
                   </config>
                 </editWidget>
@@ -1004,10 +1049,10 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="ValueMap">
                   <config>
                     <Option type="Map">
-                      <Option type="Map" name="map">
-                        <Option type="QString" name="Buckfast bee" value="Apis Mellifera"/>
-                        <Option type="QString" name="Carniolan honey bee" value="Apis Mellifera Carnica"/>
-                        <Option type="QString" name="European honey bee" value="Apis Mellifera Mellifera"/>
+                      <Option name="map" type="Map">
+                        <Option name="Buckfast bee" type="QString" value="Apis Mellifera"></Option>
+                        <Option name="Carniolan honey bee" type="QString" value="Apis Mellifera Carnica"></Option>
+                        <Option name="European honey bee" type="QString" value="Apis Mellifera Mellifera"></Option>
                       </Option>
                     </Option>
                   </config>
@@ -1017,10 +1062,10 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="ValueMap">
                   <config>
                     <Option type="Map">
-                      <Option type="Map" name="map">
-                        <Option type="QString" name="1000 - 10000" value="10000"/>
-                        <Option type="QString" name="&lt; 1000" value="1000"/>
-                        <Option type="QString" name="> 10000" value="100000"/>
+                      <Option name="map" type="Map">
+                        <Option name="1000 - 10000" type="QString" value="10000"></Option>
+                        <Option name="&lt; 1000" type="QString" value="1000"></Option>
+                        <Option name="> 10000" type="QString" value="100000"></Option>
                       </Option>
                     </Option>
                   </config>
@@ -1030,8 +1075,8 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="TextEdit">
                   <config>
                     <Option type="Map">
-                      <Option type="QString" name="IsMultiline" value="0"/>
-                      <Option type="QString" name="UseHtml" value="0"/>
+                      <Option name="IsMultiline" type="QString" value="0"></Option>
+                      <Option name="UseHtml" type="QString" value="0"></Option>
                     </Option>
                   </config>
                 </editWidget>
@@ -1040,19 +1085,19 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="ExternalResource">
                   <config>
                     <Option type="Map">
-                      <Option type="int" name="DocumentViewer" value="1"/>
-                      <Option type="int" name="DocumentViewerHeight" value="0"/>
-                      <Option type="int" name="DocumentViewerWidth" value="0"/>
-                      <Option type="bool" name="FileWidget" value="true"/>
-                      <Option type="bool" name="FileWidgetButton" value="true"/>
-                      <Option type="QString" name="FileWidgetFilter" value=""/>
-                      <Option type="Map" name="PropertyCollection">
-                        <Option type="QString" name="name" value=""/>
-                        <Option type="invalid" name="properties"/>
-                        <Option type="QString" name="type" value="collection"/>
+                      <Option name="DocumentViewer" type="int" value="1"></Option>
+                      <Option name="DocumentViewerHeight" type="int" value="0"></Option>
+                      <Option name="DocumentViewerWidth" type="int" value="0"></Option>
+                      <Option name="FileWidget" type="bool" value="true"></Option>
+                      <Option name="FileWidgetButton" type="bool" value="true"></Option>
+                      <Option name="FileWidgetFilter" type="QString" value=""></Option>
+                      <Option name="PropertyCollection" type="Map">
+                        <Option name="name" type="QString" value=""></Option>
+                        <Option name="properties" type="invalid"></Option>
+                        <Option name="type" type="QString" value="collection"></Option>
                       </Option>
-                      <Option type="int" name="RelativeStorage" value="1"/>
-                      <Option type="int" name="StorageMode" value="0"/>
+                      <Option name="RelativeStorage" type="int" value="1"></Option>
+                      <Option name="StorageMode" type="int" value="0"></Option>
                     </Option>
                   </config>
                 </editWidget>
@@ -1061,8 +1106,8 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="CheckBox">
                   <config>
                     <Option type="Map">
-                      <Option type="QString" name="CheckedState" value="t"/>
-                      <Option type="QString" name="UncheckedState" value="f"/>
+                      <Option name="CheckedState" type="QString" value="t"></Option>
+                      <Option name="UncheckedState" type="QString" value="f"></Option>
                     </Option>
                   </config>
                 </editWidget>
@@ -1071,9 +1116,9 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="ValueMap">
                   <config>
                     <Option type="Map">
-                      <Option type="Map" name="map">
-                        <Option type="QString" name="American Foulbreed" value="AFB"/>
-                        <Option type="QString" name="European Foulbreed" value="EFB"/>
+                      <Option name="map" type="Map">
+                        <Option name="American Foulbreed" type="QString" value="AFB"></Option>
+                        <Option name="European Foulbreed" type="QString" value="EFB"></Option>
                       </Option>
                     </Option>
                   </config>
@@ -1083,10 +1128,10 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="DateTime">
                   <config>
                     <Option type="Map">
-                      <Option type="QString" name="allow_null" value="0"/>
-                      <Option type="QString" name="calendar_popup" value="0"/>
-                      <Option type="QString" name="display_format" value="yyyy-MM-dd"/>
-                      <Option type="QString" name="field_format" value="yyyy-MM-dd"/>
+                      <Option name="allow_null" type="QString" value="0"></Option>
+                      <Option name="calendar_popup" type="QString" value="0"></Option>
+                      <Option name="display_format" type="QString" value="yyyy-MM-dd"></Option>
+                      <Option name="field_format" type="QString" value="yyyy-MM-dd"></Option>
                     </Option>
                   </config>
                 </editWidget>
@@ -1095,8 +1140,8 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="TextEdit">
                   <config>
                     <Option type="Map">
-                      <Option type="QString" name="IsMultiline" value="0"/>
-                      <Option type="QString" name="UseHtml" value="0"/>
+                      <Option name="IsMultiline" type="QString" value="0"></Option>
+                      <Option name="UseHtml" type="QString" value="0"></Option>
                     </Option>
                   </config>
                 </editWidget>
@@ -1105,11 +1150,11 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="Range">
                   <config>
                     <Option type="Map">
-                      <Option type="QString" name="AllowNull" value="1"/>
-                      <Option type="QString" name="Max" value="100"/>
-                      <Option type="QString" name="Min" value="0"/>
-                      <Option type="QString" name="Step" value="5"/>
-                      <Option type="QString" name="Style" value="SpinBox"/>
+                      <Option name="AllowNull" type="QString" value="1"></Option>
+                      <Option name="Max" type="QString" value="100"></Option>
+                      <Option name="Min" type="QString" value="0"></Option>
+                      <Option name="Step" type="QString" value="5"></Option>
+                      <Option name="Style" type="QString" value="SpinBox"></Option>
                     </Option>
                   </config>
                 </editWidget>
@@ -1118,112 +1163,112 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="RelationReference">
                   <config>
                     <Option type="Map">
-                      <Option type="bool" name="AllowAddFeatures" value="false"/>
-                      <Option type="bool" name="AllowNULL" value="true"/>
-                      <Option type="bool" name="MapIdentification" value="true"/>
-                      <Option type="bool" name="OrderByValue" value="false"/>
-                      <Option type="bool" name="ReadOnly" value="false"/>
-                      <Option type="QString" name="Relation" value="apiary_036bee2c_a341_4b84_b25c_1bea7c01e9c2_area_id_area_60ff9e18_ea5b_4814_a227_157fe79ce94c_id"/>
-                      <Option type="bool" name="ShowForm" value="false"/>
-                      <Option type="bool" name="ShowOpenFormButton" value="true"/>
+                      <Option name="AllowAddFeatures" type="bool" value="false"></Option>
+                      <Option name="AllowNULL" type="bool" value="true"></Option>
+                      <Option name="MapIdentification" type="bool" value="true"></Option>
+                      <Option name="OrderByValue" type="bool" value="false"></Option>
+                      <Option name="ReadOnly" type="bool" value="false"></Option>
+                      <Option name="Relation" type="QString" value="apiary_036bee2c_a341_4b84_b25c_1bea7c01e9c2_area_id_area_60ff9e18_ea5b_4814_a227_157fe79ce94c_id"></Option>
+                      <Option name="ShowForm" type="bool" value="false"></Option>
+                      <Option name="ShowOpenFormButton" type="bool" value="true"></Option>
                     </Option>
                   </config>
                 </editWidget>
               </field>
             </fieldConfiguration>
             <aliases>
-              <alias name="" field="fid" index="0"/>
-              <alias name="Number of Boxes" field="nbr_of_boxes" index="1"/>
-              <alias name="Species of Bees" field="bee_species" index="2"/>
-              <alias name="Amount of Bees" field="bee_amount" index="3"/>
-              <alias name="Beekeeper" field="beekeeper" index="4"/>
-              <alias name="Photo" field="picture" index="5"/>
-              <alias name="Infected" field="disease" index="6"/>
-              <alias name="Kind of Disease" field="kind_of_disease" index="7"/>
-              <alias name="Date of Review" field="review_date" index="8"/>
-              <alias name="Reviewer" field="reviewer" index="9"/>
-              <alias name="Yearly Harvest (kg)" field="average_harvest" index="10"/>
-              <alias name="Area mostly used" field="area_id" index="11"/>
+              <alias field="fid" index="0" name=""></alias>
+              <alias field="nbr_of_boxes" index="1" name="Number of Boxes"></alias>
+              <alias field="bee_species" index="2" name="Species of Bees"></alias>
+              <alias field="bee_amount" index="3" name="Amount of Bees"></alias>
+              <alias field="beekeeper" index="4" name="Beekeeper"></alias>
+              <alias field="picture" index="5" name="Photo"></alias>
+              <alias field="disease" index="6" name="Infected"></alias>
+              <alias field="kind_of_disease" index="7" name="Kind of Disease"></alias>
+              <alias field="review_date" index="8" name="Date of Review"></alias>
+              <alias field="reviewer" index="9" name="Reviewer"></alias>
+              <alias field="average_harvest" index="10" name="Yearly Harvest (kg)"></alias>
+              <alias field="area_id" index="11" name="Area mostly used"></alias>
             </aliases>
-            <excludeAttributesWMS/>
-            <excludeAttributesWFS/>
+            <excludeAttributesWMS></excludeAttributesWMS>
+            <excludeAttributesWFS></excludeAttributesWFS>
             <defaults>
-              <default applyOnUpdate="0" field="fid" expression=""/>
-              <default applyOnUpdate="0" field="nbr_of_boxes" expression=""/>
-              <default applyOnUpdate="0" field="bee_species" expression=""/>
-              <default applyOnUpdate="0" field="bee_amount" expression=""/>
-              <default applyOnUpdate="0" field="beekeeper" expression=""/>
-              <default applyOnUpdate="0" field="picture" expression=""/>
-              <default applyOnUpdate="0" field="disease" expression=""/>
-              <default applyOnUpdate="0" field="kind_of_disease" expression=""/>
-              <default applyOnUpdate="0" field="review_date" expression=""/>
-              <default applyOnUpdate="0" field="reviewer" expression=""/>
-              <default applyOnUpdate="0" field="average_harvest" expression=""/>
-              <default applyOnUpdate="0" field="area_id" expression=""/>
+              <default applyOnUpdate="0" expression="" field="fid"></default>
+              <default applyOnUpdate="0" expression="" field="nbr_of_boxes"></default>
+              <default applyOnUpdate="0" expression="" field="bee_species"></default>
+              <default applyOnUpdate="0" expression="" field="bee_amount"></default>
+              <default applyOnUpdate="0" expression="" field="beekeeper"></default>
+              <default applyOnUpdate="0" expression="" field="picture"></default>
+              <default applyOnUpdate="0" expression="" field="disease"></default>
+              <default applyOnUpdate="0" expression="" field="kind_of_disease"></default>
+              <default applyOnUpdate="0" expression="" field="review_date"></default>
+              <default applyOnUpdate="0" expression="" field="reviewer"></default>
+              <default applyOnUpdate="0" expression="" field="average_harvest"></default>
+              <default applyOnUpdate="0" expression="" field="area_id"></default>
             </defaults>
             <constraints>
-              <constraint notnull_strength="1" constraints="3" field="fid" unique_strength="1" exp_strength="0"/>
-              <constraint notnull_strength="1" constraints="1" field="nbr_of_boxes" unique_strength="0" exp_strength="0"/>
-              <constraint notnull_strength="0" constraints="0" field="bee_species" unique_strength="0" exp_strength="0"/>
-              <constraint notnull_strength="0" constraints="0" field="bee_amount" unique_strength="0" exp_strength="0"/>
-              <constraint notnull_strength="0" constraints="0" field="beekeeper" unique_strength="0" exp_strength="0"/>
-              <constraint notnull_strength="0" constraints="0" field="picture" unique_strength="0" exp_strength="0"/>
-              <constraint notnull_strength="0" constraints="0" field="disease" unique_strength="0" exp_strength="0"/>
-              <constraint notnull_strength="0" constraints="0" field="kind_of_disease" unique_strength="0" exp_strength="0"/>
-              <constraint notnull_strength="0" constraints="0" field="review_date" unique_strength="0" exp_strength="0"/>
-              <constraint notnull_strength="0" constraints="0" field="reviewer" unique_strength="0" exp_strength="0"/>
-              <constraint notnull_strength="0" constraints="0" field="average_harvest" unique_strength="0" exp_strength="0"/>
-              <constraint notnull_strength="0" constraints="0" field="area_id" unique_strength="0" exp_strength="0"/>
+              <constraint constraints="3" exp_strength="0" field="fid" notnull_strength="1" unique_strength="1"></constraint>
+              <constraint constraints="1" exp_strength="0" field="nbr_of_boxes" notnull_strength="1" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="bee_species" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="bee_amount" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="beekeeper" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="picture" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="disease" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="kind_of_disease" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="review_date" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="reviewer" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="average_harvest" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="area_id" notnull_strength="0" unique_strength="0"></constraint>
             </constraints>
             <constraintExpressions>
-              <constraint field="fid" desc="" exp=""/>
-              <constraint field="nbr_of_boxes" desc="" exp=""/>
-              <constraint field="bee_species" desc="" exp=""/>
-              <constraint field="bee_amount" desc="" exp=""/>
-              <constraint field="beekeeper" desc="" exp=""/>
-              <constraint field="picture" desc="" exp=""/>
-              <constraint field="disease" desc="" exp=""/>
-              <constraint field="kind_of_disease" desc="" exp=""/>
-              <constraint field="review_date" desc="" exp=""/>
-              <constraint field="reviewer" desc="" exp=""/>
-              <constraint field="average_harvest" desc="" exp=""/>
-              <constraint field="area_id" desc="" exp=""/>
+              <constraint desc="" exp="" field="fid"></constraint>
+              <constraint desc="" exp="" field="nbr_of_boxes"></constraint>
+              <constraint desc="" exp="" field="bee_species"></constraint>
+              <constraint desc="" exp="" field="bee_amount"></constraint>
+              <constraint desc="" exp="" field="beekeeper"></constraint>
+              <constraint desc="" exp="" field="picture"></constraint>
+              <constraint desc="" exp="" field="disease"></constraint>
+              <constraint desc="" exp="" field="kind_of_disease"></constraint>
+              <constraint desc="" exp="" field="review_date"></constraint>
+              <constraint desc="" exp="" field="reviewer"></constraint>
+              <constraint desc="" exp="" field="average_harvest"></constraint>
+              <constraint desc="" exp="" field="area_id"></constraint>
             </constraintExpressions>
-            <expressionfields/>
+            <expressionfields></expressionfields>
             <attributeactions>
-              <defaultAction key="Canvas" value="{82c96019-8b22-4c5d-a9b4-6d1a68e63e02}"/>
-              <actionsetting isEnabledOnlyWhenEditable="0" capture="0" type="0" icon="" shortTitle="" notificationMessage="" name="" id="{82c96019-8b22-4c5d-a9b4-6d1a68e63e02}" action="">
-                <actionScope id="Field"/>
-                <actionScope id="Canvas"/>
-                <actionScope id="Feature"/>
+              <defaultAction key="Canvas" value="{82c96019-8b22-4c5d-a9b4-6d1a68e63e02}"></defaultAction>
+              <actionsetting action="" capture="0" icon="" id="{82c96019-8b22-4c5d-a9b4-6d1a68e63e02}" isEnabledOnlyWhenEditable="0" name="" notificationMessage="" shortTitle="" type="0">
+                <actionScope id="Field"></actionScope>
+                <actionScope id="Canvas"></actionScope>
+                <actionScope id="Feature"></actionScope>
               </actionsetting>
             </attributeactions>
-            <attributetableconfig sortOrder="0" sortExpression="" actionWidgetStyle="dropDown">
+            <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
               <columns>
-                <column type="field" name="nbr_of_boxes" width="165" hidden="0"/>
-                <column type="field" name="bee_species" width="164" hidden="0"/>
-                <column type="field" name="bee_amount" width="192" hidden="0"/>
-                <column type="field" name="beekeeper" width="-1" hidden="0"/>
-                <column type="field" name="picture" width="-1" hidden="0"/>
-                <column type="field" name="disease" width="-1" hidden="0"/>
-                <column type="field" name="kind_of_disease" width="188" hidden="0"/>
-                <column type="field" name="review_date" width="-1" hidden="0"/>
-                <column type="field" name="reviewer" width="-1" hidden="0"/>
-                <column type="actions" width="-1" hidden="1"/>
-                <column type="field" name="average_harvest" width="161" hidden="0"/>
-                <column type="field" name="area_id" width="-1" hidden="0"/>
-                <column type="field" name="fid" width="-1" hidden="0"/>
+                <column hidden="0" name="nbr_of_boxes" type="field" width="165"></column>
+                <column hidden="0" name="bee_species" type="field" width="164"></column>
+                <column hidden="0" name="bee_amount" type="field" width="192"></column>
+                <column hidden="0" name="beekeeper" type="field" width="-1"></column>
+                <column hidden="0" name="picture" type="field" width="-1"></column>
+                <column hidden="0" name="disease" type="field" width="-1"></column>
+                <column hidden="0" name="kind_of_disease" type="field" width="188"></column>
+                <column hidden="0" name="review_date" type="field" width="-1"></column>
+                <column hidden="0" name="reviewer" type="field" width="-1"></column>
+                <column hidden="1" type="actions" width="-1"></column>
+                <column hidden="0" name="average_harvest" type="field" width="161"></column>
+                <column hidden="0" name="area_id" type="field" width="-1"></column>
+                <column hidden="0" name="fid" type="field" width="-1"></column>
               </columns>
             </attributetableconfig>
             <conditionalstyles>
-              <rowstyles/>
-              <fieldstyles/>
+              <rowstyles></rowstyles>
+              <fieldstyles></fieldstyles>
             </conditionalstyles>
             <editform tolerant="1">/run/user/1000/gvfs/mtp:host=SAMSUNG_SAMSUNG_Android_1cc5ab8c12047ece/Phone/qfield/workshop_foss4g2018</editform>
-            <editforminit/>
+            <editforminit></editforminit>
             <editforminitcodesource>0</editforminitcodesource>
             <editforminitfilepath>/run/user/1000/gvfs/mtp:host=SAMSUNG_SAMSUNG_Android_1cc5ab8c12047ece/Phone/qfield/demo_proj_citybees_218</editforminitfilepath>
-            <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+            <editforminitcode># -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -1239,141 +1284,141 @@ from qgis.PyQt.QtWidgets import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-]]></editforminitcode>
+</editforminitcode>
             <featformsuppress>0</featformsuppress>
             <editorlayout>tablayout</editorlayout>
             <attributeEditorForm>
-              <attributeEditorContainer name="General" visibilityExpressionEnabled="0" groupBox="0" showLabel="1" columnCount="1" visibilityExpression="">
-                <attributeEditorField name="nbr_of_boxes" showLabel="1" index="1"/>
-                <attributeEditorField name="bee_species" showLabel="1" index="2"/>
-                <attributeEditorField name="bee_amount" showLabel="1" index="3"/>
-                <attributeEditorField name="beekeeper" showLabel="1" index="4"/>
-                <attributeEditorField name="average_harvest" showLabel="1" index="10"/>
+              <attributeEditorContainer columnCount="1" groupBox="0" name="General" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+                <attributeEditorField index="1" name="nbr_of_boxes" showLabel="1"></attributeEditorField>
+                <attributeEditorField index="2" name="bee_species" showLabel="1"></attributeEditorField>
+                <attributeEditorField index="3" name="bee_amount" showLabel="1"></attributeEditorField>
+                <attributeEditorField index="4" name="beekeeper" showLabel="1"></attributeEditorField>
+                <attributeEditorField index="10" name="average_harvest" showLabel="1"></attributeEditorField>
               </attributeEditorContainer>
-              <attributeEditorContainer name="Picture" visibilityExpressionEnabled="0" groupBox="0" showLabel="1" columnCount="1" visibilityExpression="">
-                <attributeEditorField name="picture" showLabel="1" index="5"/>
+              <attributeEditorContainer columnCount="1" groupBox="0" name="Picture" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+                <attributeEditorField index="5" name="picture" showLabel="1"></attributeEditorField>
               </attributeEditorContainer>
-              <attributeEditorContainer name="Issues" visibilityExpressionEnabled="0" groupBox="0" showLabel="1" columnCount="1" visibilityExpression="">
-                <attributeEditorField name="disease" showLabel="1" index="6"/>
-                <attributeEditorContainer name="Disease" visibilityExpressionEnabled="1" groupBox="1" showLabel="1" columnCount="1" visibilityExpression="disease in ('t', true, 1)">
-                  <attributeEditorField name="kind_of_disease" showLabel="1" index="7"/>
+              <attributeEditorContainer columnCount="1" groupBox="0" name="Issues" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+                <attributeEditorField index="6" name="disease" showLabel="1"></attributeEditorField>
+                <attributeEditorContainer columnCount="1" groupBox="1" name="Disease" showLabel="1" visibilityExpression="disease in ('t', true, 1)" visibilityExpressionEnabled="1">
+                  <attributeEditorField index="7" name="kind_of_disease" showLabel="1"></attributeEditorField>
                 </attributeEditorContainer>
               </attributeEditorContainer>
-              <attributeEditorContainer name="Review" visibilityExpressionEnabled="0" groupBox="0" showLabel="1" columnCount="1" visibilityExpression="">
-                <attributeEditorField name="review_date" showLabel="1" index="8"/>
-                <attributeEditorField name="reviewer" showLabel="1" index="9"/>
+              <attributeEditorContainer columnCount="1" groupBox="0" name="Review" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+                <attributeEditorField index="8" name="review_date" showLabel="1"></attributeEditorField>
+                <attributeEditorField index="9" name="reviewer" showLabel="1"></attributeEditorField>
               </attributeEditorContainer>
-              <attributeEditorContainer name="Area" visibilityExpressionEnabled="0" groupBox="0" showLabel="1" columnCount="1" visibilityExpression="">
-                <attributeEditorField name="area_id" showLabel="1" index="11"/>
+              <attributeEditorContainer columnCount="1" groupBox="0" name="Area" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+                <attributeEditorField index="11" name="area_id" showLabel="1"></attributeEditorField>
               </attributeEditorContainer>
             </attributeEditorForm>
             <editable>
-              <field name="area_id" editable="1"/>
-              <field name="average_harvest" editable="1"/>
-              <field name="bee_amount" editable="1"/>
-              <field name="bee_species" editable="1"/>
-              <field name="beekeeper" editable="1"/>
-              <field name="disease" editable="1"/>
-              <field name="fid" editable="1"/>
-              <field name="id" editable="1"/>
-              <field name="kind_of_disease" editable="1"/>
-              <field name="nbr_of_boxes" editable="1"/>
-              <field name="picture" editable="1"/>
-              <field name="review_date" editable="1"/>
-              <field name="reviewer" editable="1"/>
+              <field editable="1" name="area_id"></field>
+              <field editable="1" name="average_harvest"></field>
+              <field editable="1" name="bee_amount"></field>
+              <field editable="1" name="bee_species"></field>
+              <field editable="1" name="beekeeper"></field>
+              <field editable="1" name="disease"></field>
+              <field editable="1" name="fid"></field>
+              <field editable="1" name="id"></field>
+              <field editable="1" name="kind_of_disease"></field>
+              <field editable="1" name="nbr_of_boxes"></field>
+              <field editable="1" name="picture"></field>
+              <field editable="1" name="review_date"></field>
+              <field editable="1" name="reviewer"></field>
             </editable>
             <labelOnTop>
-              <field labelOnTop="0" name="area_id"/>
-              <field labelOnTop="0" name="average_harvest"/>
-              <field labelOnTop="0" name="bee_amount"/>
-              <field labelOnTop="0" name="bee_species"/>
-              <field labelOnTop="0" name="beekeeper"/>
-              <field labelOnTop="0" name="disease"/>
-              <field labelOnTop="0" name="fid"/>
-              <field labelOnTop="0" name="id"/>
-              <field labelOnTop="0" name="kind_of_disease"/>
-              <field labelOnTop="0" name="nbr_of_boxes"/>
-              <field labelOnTop="0" name="picture"/>
-              <field labelOnTop="0" name="review_date"/>
-              <field labelOnTop="0" name="reviewer"/>
+              <field labelOnTop="0" name="area_id"></field>
+              <field labelOnTop="0" name="average_harvest"></field>
+              <field labelOnTop="0" name="bee_amount"></field>
+              <field labelOnTop="0" name="bee_species"></field>
+              <field labelOnTop="0" name="beekeeper"></field>
+              <field labelOnTop="0" name="disease"></field>
+              <field labelOnTop="0" name="fid"></field>
+              <field labelOnTop="0" name="id"></field>
+              <field labelOnTop="0" name="kind_of_disease"></field>
+              <field labelOnTop="0" name="nbr_of_boxes"></field>
+              <field labelOnTop="0" name="picture"></field>
+              <field labelOnTop="0" name="review_date"></field>
+              <field labelOnTop="0" name="reviewer"></field>
             </labelOnTop>
             <widgets>
               <widget name="ref_apiary_apiary_id_apiary2018_id">
-                <config/>
+                <config></config>
               </widget>
             </widgets>
             <previewExpression>beekeeper+' - '+bee_species</previewExpression>
-            <mapTip/>
+            <mapTip></mapTip>
             <layerGeometryType>0</layerGeometryType>
           </qgis>
         </map-layer-style>
         <map-layer-style name="Heatmap">
-          <qgis hasScaleBasedVisibilityFlag="0" maxScale="0" simplifyMaxScale="1" readOnly="0" version="3.4.4-Madeira" styleCategories="AllStyleCategories" simplifyDrawingTol="1" simplifyDrawingHints="0" simplifyAlgorithm="0" simplifyLocal="1" labelsEnabled="0" minScale="0">
+          <qgis hasScaleBasedVisibilityFlag="0" labelsEnabled="0" maxScale="0" minScale="0" readOnly="0" simplifyAlgorithm="0" simplifyDrawingHints="0" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" version="3.4.4-Madeira">
             <flags>
               <Identifiable>1</Identifiable>
               <Removable>1</Removable>
               <Searchable>1</Searchable>
             </flags>
-            <renderer-v2 max_value="0" enableorderby="0" type="heatmapRenderer" radius="10" weight_expression="" quality="3" forceraster="0" radius_unit="0" radius_map_unit_scale="3x:0,0,0,0,0,0">
-              <colorramp type="gradient" name="[source]">
-                <prop v="255,245,240,0" k="color1"/>
-                <prop v="103,0,13,255" k="color2"/>
-                <prop v="0" k="discrete"/>
-                <prop v="gradient" k="rampType"/>
-                <prop v="0.13;254,224,210,255:0.26;252,187,161,255:0.39;252,146,114,255:0.52;251,106,74,255:0.65;239,59,44,255:0.78;203,24,29,255:0.9;165,15,21,255" k="stops"/>
+            <renderer-v2 enableorderby="0" forceraster="0" max_value="0" quality="3" radius="10" radius_map_unit_scale="3x:0,0,0,0,0,0" radius_unit="0" type="heatmapRenderer" weight_expression="">
+              <colorramp name="[source]" type="gradient">
+                <prop k="color1" v="255,245,240,0"></prop>
+                <prop k="color2" v="103,0,13,255"></prop>
+                <prop k="discrete" v="0"></prop>
+                <prop k="rampType" v="gradient"></prop>
+                <prop k="stops" v="0.13;254,224,210,255:0.26;252,187,161,255:0.39;252,146,114,255:0.52;251,106,74,255:0.65;239,59,44,255:0.78;203,24,29,255:0.9;165,15,21,255"></prop>
               </colorramp>
             </renderer-v2>
             <customproperties>
-              <property key="embeddedWidgets/count" value="0"/>
-              <property key="isOfflineEditable" value="true"/>
-              <property key="remoteProvider" value="postgres"/>
-              <property key="remoteSource" value="dbname='demo' host=lizmapdemo.opengis.ch port=5432 user='editor1' password='editor1' sslmode=disable key='id' srid=2056 type=Point table=&quot;citybees&quot;.&quot;apiary&quot; (geom) sql="/>
-              <property key="variableNames"/>
-              <property key="variableValues"/>
+              <property key="embeddedWidgets/count" value="0"></property>
+              <property key="isOfflineEditable" value="true"></property>
+              <property key="remoteProvider" value="postgres"></property>
+              <property key="remoteSource" value="dbname='demo' host=lizmapdemo.opengis.ch port=5432 user='editor1' password='editor1' sslmode=disable key='id' srid=2056 type=Point table=&quot;citybees&quot;.&quot;apiary&quot; (geom) sql="></property>
+              <property key="variableNames"></property>
+              <property key="variableValues"></property>
             </customproperties>
             <blendMode>6</blendMode>
             <featureBlendMode>0</featureBlendMode>
             <layerOpacity>0.8</layerOpacity>
-            <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
-              <DiagramCategory labelPlacementMethod="XHeight" minScaleDenominator="0" penAlpha="255" diagramOrientation="Up" penColor="#000000" scaleBasedVisibility="0" rotationOffset="0" maxScaleDenominator="1e+8" sizeScale="3x:0,0,0,0,0,0" barWidth="5" lineSizeType="MM" backgroundColor="#ffffff" scaleDependency="Area" width="15" minimumSize="0" lineSizeScale="3x:0,0,0,0,0,0" sizeType="MM" backgroundAlpha="255" height="15" enabled="0" penWidth="0" opacity="1">
-                <fontProperties style="" description="Cantarell,11,-1,5,50,0,0,0,0,0"/>
-                <attribute color="#000000" field="" label=""/>
+            <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+              <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+8" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="0" scaleBasedVisibility="0" scaleDependency="Area" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" width="15">
+                <fontProperties description="Cantarell,11,-1,5,50,0,0,0,0,0" style=""></fontProperties>
+                <attribute color="#000000" field="" label=""></attribute>
               </DiagramCategory>
             </SingleCategoryDiagramRenderer>
-            <DiagramLayerSettings linePlacementFlags="2" dist="0" priority="0" zIndex="0" placement="0" obstacle="0" showAll="1">
+            <DiagramLayerSettings dist="0" linePlacementFlags="2" obstacle="0" placement="0" priority="0" showAll="1" zIndex="0">
               <properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option type="Map" name="properties">
-                    <Option type="Map" name="positionX">
-                      <Option type="bool" name="active" value="true"/>
-                      <Option type="QString" name="field" value="id"/>
-                      <Option type="int" name="type" value="2"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties" type="Map">
+                    <Option name="positionX" type="Map">
+                      <Option name="active" type="bool" value="true"></Option>
+                      <Option name="field" type="QString" value="id"></Option>
+                      <Option name="type" type="int" value="2"></Option>
                     </Option>
-                    <Option type="Map" name="positionY">
-                      <Option type="bool" name="active" value="true"/>
-                      <Option type="QString" name="field" value="id"/>
-                      <Option type="int" name="type" value="2"/>
+                    <Option name="positionY" type="Map">
+                      <Option name="active" type="bool" value="true"></Option>
+                      <Option name="field" type="QString" value="id"></Option>
+                      <Option name="type" type="int" value="2"></Option>
                     </Option>
-                    <Option type="Map" name="show">
-                      <Option type="bool" name="active" value="true"/>
-                      <Option type="QString" name="field" value="id"/>
-                      <Option type="int" name="type" value="2"/>
+                    <Option name="show" type="Map">
+                      <Option name="active" type="bool" value="true"></Option>
+                      <Option name="field" type="QString" value="id"></Option>
+                      <Option name="type" type="int" value="2"></Option>
                     </Option>
                   </Option>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </properties>
             </DiagramLayerSettings>
             <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-              <activeChecks/>
-              <checkConfiguration/>
+              <activeChecks></activeChecks>
+              <checkConfiguration></checkConfiguration>
             </geometryOptions>
             <fieldConfiguration>
               <field name="fid">
                 <editWidget type="TextEdit">
                   <config>
-                    <Option/>
+                    <Option></Option>
                   </config>
                 </editWidget>
               </field>
@@ -1381,11 +1426,11 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="Range">
                   <config>
                     <Option type="Map">
-                      <Option type="QString" name="AllowNull" value="1"/>
-                      <Option type="QString" name="Max" value="10"/>
-                      <Option type="QString" name="Min" value="1"/>
-                      <Option type="QString" name="Step" value="1"/>
-                      <Option type="QString" name="Style" value="Slider"/>
+                      <Option name="AllowNull" type="QString" value="1"></Option>
+                      <Option name="Max" type="QString" value="10"></Option>
+                      <Option name="Min" type="QString" value="1"></Option>
+                      <Option name="Step" type="QString" value="1"></Option>
+                      <Option name="Style" type="QString" value="Slider"></Option>
                     </Option>
                   </config>
                 </editWidget>
@@ -1394,10 +1439,10 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="ValueMap">
                   <config>
                     <Option type="Map">
-                      <Option type="Map" name="map">
-                        <Option type="QString" name="Buckfast bee" value="Apis Mellifera"/>
-                        <Option type="QString" name="Carniolan honey bee" value="Apis Mellifera Carnica"/>
-                        <Option type="QString" name="European honey bee" value="Apis Mellifera Mellifera"/>
+                      <Option name="map" type="Map">
+                        <Option name="Buckfast bee" type="QString" value="Apis Mellifera"></Option>
+                        <Option name="Carniolan honey bee" type="QString" value="Apis Mellifera Carnica"></Option>
+                        <Option name="European honey bee" type="QString" value="Apis Mellifera Mellifera"></Option>
                       </Option>
                     </Option>
                   </config>
@@ -1407,10 +1452,10 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="ValueMap">
                   <config>
                     <Option type="Map">
-                      <Option type="Map" name="map">
-                        <Option type="QString" name="1000 - 10000" value="10000"/>
-                        <Option type="QString" name="&lt; 1000" value="1000"/>
-                        <Option type="QString" name="> 10000" value="100000"/>
+                      <Option name="map" type="Map">
+                        <Option name="1000 - 10000" type="QString" value="10000"></Option>
+                        <Option name="&lt; 1000" type="QString" value="1000"></Option>
+                        <Option name="> 10000" type="QString" value="100000"></Option>
                       </Option>
                     </Option>
                   </config>
@@ -1420,8 +1465,8 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="TextEdit">
                   <config>
                     <Option type="Map">
-                      <Option type="QString" name="IsMultiline" value="0"/>
-                      <Option type="QString" name="UseHtml" value="0"/>
+                      <Option name="IsMultiline" type="QString" value="0"></Option>
+                      <Option name="UseHtml" type="QString" value="0"></Option>
                     </Option>
                   </config>
                 </editWidget>
@@ -1430,19 +1475,19 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="ExternalResource">
                   <config>
                     <Option type="Map">
-                      <Option type="int" name="DocumentViewer" value="1"/>
-                      <Option type="int" name="DocumentViewerHeight" value="0"/>
-                      <Option type="int" name="DocumentViewerWidth" value="0"/>
-                      <Option type="bool" name="FileWidget" value="true"/>
-                      <Option type="bool" name="FileWidgetButton" value="true"/>
-                      <Option type="QString" name="FileWidgetFilter" value=""/>
-                      <Option type="Map" name="PropertyCollection">
-                        <Option type="QString" name="name" value=""/>
-                        <Option type="invalid" name="properties"/>
-                        <Option type="QString" name="type" value="collection"/>
+                      <Option name="DocumentViewer" type="int" value="1"></Option>
+                      <Option name="DocumentViewerHeight" type="int" value="0"></Option>
+                      <Option name="DocumentViewerWidth" type="int" value="0"></Option>
+                      <Option name="FileWidget" type="bool" value="true"></Option>
+                      <Option name="FileWidgetButton" type="bool" value="true"></Option>
+                      <Option name="FileWidgetFilter" type="QString" value=""></Option>
+                      <Option name="PropertyCollection" type="Map">
+                        <Option name="name" type="QString" value=""></Option>
+                        <Option name="properties" type="invalid"></Option>
+                        <Option name="type" type="QString" value="collection"></Option>
                       </Option>
-                      <Option type="int" name="RelativeStorage" value="1"/>
-                      <Option type="int" name="StorageMode" value="0"/>
+                      <Option name="RelativeStorage" type="int" value="1"></Option>
+                      <Option name="StorageMode" type="int" value="0"></Option>
                     </Option>
                   </config>
                 </editWidget>
@@ -1451,8 +1496,8 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="CheckBox">
                   <config>
                     <Option type="Map">
-                      <Option type="QString" name="CheckedState" value="t"/>
-                      <Option type="QString" name="UncheckedState" value="f"/>
+                      <Option name="CheckedState" type="QString" value="t"></Option>
+                      <Option name="UncheckedState" type="QString" value="f"></Option>
                     </Option>
                   </config>
                 </editWidget>
@@ -1461,9 +1506,9 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="ValueMap">
                   <config>
                     <Option type="Map">
-                      <Option type="Map" name="map">
-                        <Option type="QString" name="American Foulbreed" value="AFB"/>
-                        <Option type="QString" name="European Foulbreed" value="EFB"/>
+                      <Option name="map" type="Map">
+                        <Option name="American Foulbreed" type="QString" value="AFB"></Option>
+                        <Option name="European Foulbreed" type="QString" value="EFB"></Option>
                       </Option>
                     </Option>
                   </config>
@@ -1473,10 +1518,10 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="DateTime">
                   <config>
                     <Option type="Map">
-                      <Option type="QString" name="allow_null" value="0"/>
-                      <Option type="QString" name="calendar_popup" value="0"/>
-                      <Option type="QString" name="display_format" value="yyyy-MM-dd"/>
-                      <Option type="QString" name="field_format" value="yyyy-MM-dd"/>
+                      <Option name="allow_null" type="QString" value="0"></Option>
+                      <Option name="calendar_popup" type="QString" value="0"></Option>
+                      <Option name="display_format" type="QString" value="yyyy-MM-dd"></Option>
+                      <Option name="field_format" type="QString" value="yyyy-MM-dd"></Option>
                     </Option>
                   </config>
                 </editWidget>
@@ -1485,8 +1530,8 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="TextEdit">
                   <config>
                     <Option type="Map">
-                      <Option type="QString" name="IsMultiline" value="0"/>
-                      <Option type="QString" name="UseHtml" value="0"/>
+                      <Option name="IsMultiline" type="QString" value="0"></Option>
+                      <Option name="UseHtml" type="QString" value="0"></Option>
                     </Option>
                   </config>
                 </editWidget>
@@ -1495,11 +1540,11 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="Range">
                   <config>
                     <Option type="Map">
-                      <Option type="QString" name="AllowNull" value="1"/>
-                      <Option type="QString" name="Max" value="100"/>
-                      <Option type="QString" name="Min" value="0"/>
-                      <Option type="QString" name="Step" value="5"/>
-                      <Option type="QString" name="Style" value="SpinBox"/>
+                      <Option name="AllowNull" type="QString" value="1"></Option>
+                      <Option name="Max" type="QString" value="100"></Option>
+                      <Option name="Min" type="QString" value="0"></Option>
+                      <Option name="Step" type="QString" value="5"></Option>
+                      <Option name="Style" type="QString" value="SpinBox"></Option>
                     </Option>
                   </config>
                 </editWidget>
@@ -1508,112 +1553,112 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="RelationReference">
                   <config>
                     <Option type="Map">
-                      <Option type="bool" name="AllowAddFeatures" value="false"/>
-                      <Option type="bool" name="AllowNULL" value="true"/>
-                      <Option type="bool" name="MapIdentification" value="true"/>
-                      <Option type="bool" name="OrderByValue" value="false"/>
-                      <Option type="bool" name="ReadOnly" value="false"/>
-                      <Option type="QString" name="Relation" value="apiary_036bee2c_a341_4b84_b25c_1bea7c01e9c2_area_id_area_60ff9e18_ea5b_4814_a227_157fe79ce94c_id"/>
-                      <Option type="bool" name="ShowForm" value="false"/>
-                      <Option type="bool" name="ShowOpenFormButton" value="true"/>
+                      <Option name="AllowAddFeatures" type="bool" value="false"></Option>
+                      <Option name="AllowNULL" type="bool" value="true"></Option>
+                      <Option name="MapIdentification" type="bool" value="true"></Option>
+                      <Option name="OrderByValue" type="bool" value="false"></Option>
+                      <Option name="ReadOnly" type="bool" value="false"></Option>
+                      <Option name="Relation" type="QString" value="apiary_036bee2c_a341_4b84_b25c_1bea7c01e9c2_area_id_area_60ff9e18_ea5b_4814_a227_157fe79ce94c_id"></Option>
+                      <Option name="ShowForm" type="bool" value="false"></Option>
+                      <Option name="ShowOpenFormButton" type="bool" value="true"></Option>
                     </Option>
                   </config>
                 </editWidget>
               </field>
             </fieldConfiguration>
             <aliases>
-              <alias name="" field="fid" index="0"/>
-              <alias name="Number of Boxes" field="nbr_of_boxes" index="1"/>
-              <alias name="Species of Bees" field="bee_species" index="2"/>
-              <alias name="Amount of Bees" field="bee_amount" index="3"/>
-              <alias name="Beekeeper" field="beekeeper" index="4"/>
-              <alias name="Photo" field="picture" index="5"/>
-              <alias name="Infected" field="disease" index="6"/>
-              <alias name="Kind of Disease" field="kind_of_disease" index="7"/>
-              <alias name="Date of Review" field="review_date" index="8"/>
-              <alias name="Reviewer" field="reviewer" index="9"/>
-              <alias name="Yearly Harvest (kg)" field="average_harvest" index="10"/>
-              <alias name="Area mostly used" field="area_id" index="11"/>
+              <alias field="fid" index="0" name=""></alias>
+              <alias field="nbr_of_boxes" index="1" name="Number of Boxes"></alias>
+              <alias field="bee_species" index="2" name="Species of Bees"></alias>
+              <alias field="bee_amount" index="3" name="Amount of Bees"></alias>
+              <alias field="beekeeper" index="4" name="Beekeeper"></alias>
+              <alias field="picture" index="5" name="Photo"></alias>
+              <alias field="disease" index="6" name="Infected"></alias>
+              <alias field="kind_of_disease" index="7" name="Kind of Disease"></alias>
+              <alias field="review_date" index="8" name="Date of Review"></alias>
+              <alias field="reviewer" index="9" name="Reviewer"></alias>
+              <alias field="average_harvest" index="10" name="Yearly Harvest (kg)"></alias>
+              <alias field="area_id" index="11" name="Area mostly used"></alias>
             </aliases>
-            <excludeAttributesWMS/>
-            <excludeAttributesWFS/>
+            <excludeAttributesWMS></excludeAttributesWMS>
+            <excludeAttributesWFS></excludeAttributesWFS>
             <defaults>
-              <default applyOnUpdate="0" field="fid" expression=""/>
-              <default applyOnUpdate="0" field="nbr_of_boxes" expression=""/>
-              <default applyOnUpdate="0" field="bee_species" expression=""/>
-              <default applyOnUpdate="0" field="bee_amount" expression=""/>
-              <default applyOnUpdate="0" field="beekeeper" expression=""/>
-              <default applyOnUpdate="0" field="picture" expression=""/>
-              <default applyOnUpdate="0" field="disease" expression=""/>
-              <default applyOnUpdate="0" field="kind_of_disease" expression=""/>
-              <default applyOnUpdate="0" field="review_date" expression=""/>
-              <default applyOnUpdate="0" field="reviewer" expression=""/>
-              <default applyOnUpdate="0" field="average_harvest" expression=""/>
-              <default applyOnUpdate="0" field="area_id" expression=""/>
+              <default applyOnUpdate="0" expression="" field="fid"></default>
+              <default applyOnUpdate="0" expression="" field="nbr_of_boxes"></default>
+              <default applyOnUpdate="0" expression="" field="bee_species"></default>
+              <default applyOnUpdate="0" expression="" field="bee_amount"></default>
+              <default applyOnUpdate="0" expression="" field="beekeeper"></default>
+              <default applyOnUpdate="0" expression="" field="picture"></default>
+              <default applyOnUpdate="0" expression="" field="disease"></default>
+              <default applyOnUpdate="0" expression="" field="kind_of_disease"></default>
+              <default applyOnUpdate="0" expression="" field="review_date"></default>
+              <default applyOnUpdate="0" expression="" field="reviewer"></default>
+              <default applyOnUpdate="0" expression="" field="average_harvest"></default>
+              <default applyOnUpdate="0" expression="" field="area_id"></default>
             </defaults>
             <constraints>
-              <constraint notnull_strength="1" constraints="3" field="fid" unique_strength="1" exp_strength="0"/>
-              <constraint notnull_strength="1" constraints="1" field="nbr_of_boxes" unique_strength="0" exp_strength="0"/>
-              <constraint notnull_strength="0" constraints="0" field="bee_species" unique_strength="0" exp_strength="0"/>
-              <constraint notnull_strength="0" constraints="0" field="bee_amount" unique_strength="0" exp_strength="0"/>
-              <constraint notnull_strength="0" constraints="0" field="beekeeper" unique_strength="0" exp_strength="0"/>
-              <constraint notnull_strength="0" constraints="0" field="picture" unique_strength="0" exp_strength="0"/>
-              <constraint notnull_strength="0" constraints="0" field="disease" unique_strength="0" exp_strength="0"/>
-              <constraint notnull_strength="0" constraints="0" field="kind_of_disease" unique_strength="0" exp_strength="0"/>
-              <constraint notnull_strength="0" constraints="0" field="review_date" unique_strength="0" exp_strength="0"/>
-              <constraint notnull_strength="0" constraints="0" field="reviewer" unique_strength="0" exp_strength="0"/>
-              <constraint notnull_strength="0" constraints="0" field="average_harvest" unique_strength="0" exp_strength="0"/>
-              <constraint notnull_strength="0" constraints="0" field="area_id" unique_strength="0" exp_strength="0"/>
+              <constraint constraints="3" exp_strength="0" field="fid" notnull_strength="1" unique_strength="1"></constraint>
+              <constraint constraints="1" exp_strength="0" field="nbr_of_boxes" notnull_strength="1" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="bee_species" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="bee_amount" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="beekeeper" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="picture" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="disease" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="kind_of_disease" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="review_date" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="reviewer" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="average_harvest" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="area_id" notnull_strength="0" unique_strength="0"></constraint>
             </constraints>
             <constraintExpressions>
-              <constraint field="fid" desc="" exp=""/>
-              <constraint field="nbr_of_boxes" desc="" exp=""/>
-              <constraint field="bee_species" desc="" exp=""/>
-              <constraint field="bee_amount" desc="" exp=""/>
-              <constraint field="beekeeper" desc="" exp=""/>
-              <constraint field="picture" desc="" exp=""/>
-              <constraint field="disease" desc="" exp=""/>
-              <constraint field="kind_of_disease" desc="" exp=""/>
-              <constraint field="review_date" desc="" exp=""/>
-              <constraint field="reviewer" desc="" exp=""/>
-              <constraint field="average_harvest" desc="" exp=""/>
-              <constraint field="area_id" desc="" exp=""/>
+              <constraint desc="" exp="" field="fid"></constraint>
+              <constraint desc="" exp="" field="nbr_of_boxes"></constraint>
+              <constraint desc="" exp="" field="bee_species"></constraint>
+              <constraint desc="" exp="" field="bee_amount"></constraint>
+              <constraint desc="" exp="" field="beekeeper"></constraint>
+              <constraint desc="" exp="" field="picture"></constraint>
+              <constraint desc="" exp="" field="disease"></constraint>
+              <constraint desc="" exp="" field="kind_of_disease"></constraint>
+              <constraint desc="" exp="" field="review_date"></constraint>
+              <constraint desc="" exp="" field="reviewer"></constraint>
+              <constraint desc="" exp="" field="average_harvest"></constraint>
+              <constraint desc="" exp="" field="area_id"></constraint>
             </constraintExpressions>
-            <expressionfields/>
+            <expressionfields></expressionfields>
             <attributeactions>
-              <defaultAction key="Canvas" value="{083d0585-5cd8-41d2-8ece-4ee5023fa9a4}"/>
-              <actionsetting isEnabledOnlyWhenEditable="0" capture="0" type="0" icon="" shortTitle="" notificationMessage="" name="" id="{083d0585-5cd8-41d2-8ece-4ee5023fa9a4}" action="">
-                <actionScope id="Field"/>
-                <actionScope id="Canvas"/>
-                <actionScope id="Feature"/>
+              <defaultAction key="Canvas" value="{083d0585-5cd8-41d2-8ece-4ee5023fa9a4}"></defaultAction>
+              <actionsetting action="" capture="0" icon="" id="{083d0585-5cd8-41d2-8ece-4ee5023fa9a4}" isEnabledOnlyWhenEditable="0" name="" notificationMessage="" shortTitle="" type="0">
+                <actionScope id="Field"></actionScope>
+                <actionScope id="Canvas"></actionScope>
+                <actionScope id="Feature"></actionScope>
               </actionsetting>
             </attributeactions>
-            <attributetableconfig sortOrder="0" sortExpression="" actionWidgetStyle="dropDown">
+            <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
               <columns>
-                <column type="field" name="nbr_of_boxes" width="165" hidden="0"/>
-                <column type="field" name="bee_species" width="164" hidden="0"/>
-                <column type="field" name="bee_amount" width="192" hidden="0"/>
-                <column type="field" name="beekeeper" width="-1" hidden="0"/>
-                <column type="field" name="picture" width="-1" hidden="0"/>
-                <column type="field" name="disease" width="-1" hidden="0"/>
-                <column type="field" name="kind_of_disease" width="188" hidden="0"/>
-                <column type="field" name="review_date" width="-1" hidden="0"/>
-                <column type="field" name="reviewer" width="-1" hidden="0"/>
-                <column type="actions" width="-1" hidden="1"/>
-                <column type="field" name="average_harvest" width="161" hidden="0"/>
-                <column type="field" name="area_id" width="-1" hidden="0"/>
-                <column type="field" name="fid" width="-1" hidden="0"/>
+                <column hidden="0" name="nbr_of_boxes" type="field" width="165"></column>
+                <column hidden="0" name="bee_species" type="field" width="164"></column>
+                <column hidden="0" name="bee_amount" type="field" width="192"></column>
+                <column hidden="0" name="beekeeper" type="field" width="-1"></column>
+                <column hidden="0" name="picture" type="field" width="-1"></column>
+                <column hidden="0" name="disease" type="field" width="-1"></column>
+                <column hidden="0" name="kind_of_disease" type="field" width="188"></column>
+                <column hidden="0" name="review_date" type="field" width="-1"></column>
+                <column hidden="0" name="reviewer" type="field" width="-1"></column>
+                <column hidden="1" type="actions" width="-1"></column>
+                <column hidden="0" name="average_harvest" type="field" width="161"></column>
+                <column hidden="0" name="area_id" type="field" width="-1"></column>
+                <column hidden="0" name="fid" type="field" width="-1"></column>
               </columns>
             </attributetableconfig>
             <conditionalstyles>
-              <rowstyles/>
-              <fieldstyles/>
+              <rowstyles></rowstyles>
+              <fieldstyles></fieldstyles>
             </conditionalstyles>
             <editform tolerant="1">/run/user/1000/gvfs/mtp:host=SAMSUNG_SAMSUNG_Android_1cc5ab8c12047ece/Phone/qfield/workshop_foss4g2018</editform>
-            <editforminit/>
+            <editforminit></editforminit>
             <editforminitcodesource>0</editforminitcodesource>
             <editforminitfilepath>/run/user/1000/gvfs/mtp:host=SAMSUNG_SAMSUNG_Android_1cc5ab8c12047ece/Phone/qfield/demo_proj_citybees_218</editforminitfilepath>
-            <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+            <editforminitcode># -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -1629,296 +1674,296 @@ from qgis.PyQt.QtWidgets import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-]]></editforminitcode>
+</editforminitcode>
             <featformsuppress>0</featformsuppress>
             <editorlayout>tablayout</editorlayout>
             <attributeEditorForm>
-              <attributeEditorContainer name="General" visibilityExpressionEnabled="0" groupBox="0" showLabel="1" columnCount="1" visibilityExpression="">
-                <attributeEditorField name="nbr_of_boxes" showLabel="1" index="1"/>
-                <attributeEditorField name="bee_species" showLabel="1" index="2"/>
-                <attributeEditorField name="bee_amount" showLabel="1" index="3"/>
-                <attributeEditorField name="beekeeper" showLabel="1" index="4"/>
-                <attributeEditorField name="average_harvest" showLabel="1" index="10"/>
+              <attributeEditorContainer columnCount="1" groupBox="0" name="General" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+                <attributeEditorField index="1" name="nbr_of_boxes" showLabel="1"></attributeEditorField>
+                <attributeEditorField index="2" name="bee_species" showLabel="1"></attributeEditorField>
+                <attributeEditorField index="3" name="bee_amount" showLabel="1"></attributeEditorField>
+                <attributeEditorField index="4" name="beekeeper" showLabel="1"></attributeEditorField>
+                <attributeEditorField index="10" name="average_harvest" showLabel="1"></attributeEditorField>
               </attributeEditorContainer>
-              <attributeEditorContainer name="Picture" visibilityExpressionEnabled="0" groupBox="0" showLabel="1" columnCount="1" visibilityExpression="">
-                <attributeEditorField name="picture" showLabel="1" index="5"/>
+              <attributeEditorContainer columnCount="1" groupBox="0" name="Picture" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+                <attributeEditorField index="5" name="picture" showLabel="1"></attributeEditorField>
               </attributeEditorContainer>
-              <attributeEditorContainer name="Issues" visibilityExpressionEnabled="0" groupBox="0" showLabel="1" columnCount="1" visibilityExpression="">
-                <attributeEditorField name="disease" showLabel="1" index="6"/>
-                <attributeEditorContainer name="Disease" visibilityExpressionEnabled="1" groupBox="1" showLabel="1" columnCount="1" visibilityExpression="disease in ('t', true, 1)">
-                  <attributeEditorField name="kind_of_disease" showLabel="1" index="7"/>
+              <attributeEditorContainer columnCount="1" groupBox="0" name="Issues" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+                <attributeEditorField index="6" name="disease" showLabel="1"></attributeEditorField>
+                <attributeEditorContainer columnCount="1" groupBox="1" name="Disease" showLabel="1" visibilityExpression="disease in ('t', true, 1)" visibilityExpressionEnabled="1">
+                  <attributeEditorField index="7" name="kind_of_disease" showLabel="1"></attributeEditorField>
                 </attributeEditorContainer>
               </attributeEditorContainer>
-              <attributeEditorContainer name="Review" visibilityExpressionEnabled="0" groupBox="0" showLabel="1" columnCount="1" visibilityExpression="">
-                <attributeEditorField name="review_date" showLabel="1" index="8"/>
-                <attributeEditorField name="reviewer" showLabel="1" index="9"/>
+              <attributeEditorContainer columnCount="1" groupBox="0" name="Review" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+                <attributeEditorField index="8" name="review_date" showLabel="1"></attributeEditorField>
+                <attributeEditorField index="9" name="reviewer" showLabel="1"></attributeEditorField>
               </attributeEditorContainer>
-              <attributeEditorContainer name="Area" visibilityExpressionEnabled="0" groupBox="0" showLabel="1" columnCount="1" visibilityExpression="">
-                <attributeEditorField name="area_id" showLabel="1" index="11"/>
+              <attributeEditorContainer columnCount="1" groupBox="0" name="Area" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+                <attributeEditorField index="11" name="area_id" showLabel="1"></attributeEditorField>
               </attributeEditorContainer>
             </attributeEditorForm>
             <editable>
-              <field name="area_id" editable="1"/>
-              <field name="average_harvest" editable="1"/>
-              <field name="bee_amount" editable="1"/>
-              <field name="bee_species" editable="1"/>
-              <field name="beekeeper" editable="1"/>
-              <field name="disease" editable="1"/>
-              <field name="fid" editable="1"/>
-              <field name="id" editable="1"/>
-              <field name="kind_of_disease" editable="1"/>
-              <field name="nbr_of_boxes" editable="1"/>
-              <field name="picture" editable="1"/>
-              <field name="review_date" editable="1"/>
-              <field name="reviewer" editable="1"/>
+              <field editable="1" name="area_id"></field>
+              <field editable="1" name="average_harvest"></field>
+              <field editable="1" name="bee_amount"></field>
+              <field editable="1" name="bee_species"></field>
+              <field editable="1" name="beekeeper"></field>
+              <field editable="1" name="disease"></field>
+              <field editable="1" name="fid"></field>
+              <field editable="1" name="id"></field>
+              <field editable="1" name="kind_of_disease"></field>
+              <field editable="1" name="nbr_of_boxes"></field>
+              <field editable="1" name="picture"></field>
+              <field editable="1" name="review_date"></field>
+              <field editable="1" name="reviewer"></field>
             </editable>
             <labelOnTop>
-              <field labelOnTop="0" name="area_id"/>
-              <field labelOnTop="0" name="average_harvest"/>
-              <field labelOnTop="0" name="bee_amount"/>
-              <field labelOnTop="0" name="bee_species"/>
-              <field labelOnTop="0" name="beekeeper"/>
-              <field labelOnTop="0" name="disease"/>
-              <field labelOnTop="0" name="fid"/>
-              <field labelOnTop="0" name="id"/>
-              <field labelOnTop="0" name="kind_of_disease"/>
-              <field labelOnTop="0" name="nbr_of_boxes"/>
-              <field labelOnTop="0" name="picture"/>
-              <field labelOnTop="0" name="review_date"/>
-              <field labelOnTop="0" name="reviewer"/>
+              <field labelOnTop="0" name="area_id"></field>
+              <field labelOnTop="0" name="average_harvest"></field>
+              <field labelOnTop="0" name="bee_amount"></field>
+              <field labelOnTop="0" name="bee_species"></field>
+              <field labelOnTop="0" name="beekeeper"></field>
+              <field labelOnTop="0" name="disease"></field>
+              <field labelOnTop="0" name="fid"></field>
+              <field labelOnTop="0" name="id"></field>
+              <field labelOnTop="0" name="kind_of_disease"></field>
+              <field labelOnTop="0" name="nbr_of_boxes"></field>
+              <field labelOnTop="0" name="picture"></field>
+              <field labelOnTop="0" name="review_date"></field>
+              <field labelOnTop="0" name="reviewer"></field>
             </labelOnTop>
             <widgets>
               <widget name="ref_apiary_apiary_id_apiary2018_id">
-                <config/>
+                <config></config>
               </widget>
             </widgets>
             <previewExpression>beekeeper+' - '+bee_species</previewExpression>
-            <mapTip/>
+            <mapTip></mapTip>
             <layerGeometryType>0</layerGeometryType>
           </qgis>
         </map-layer-style>
-        <map-layer-style name="Species"/>
+        <map-layer-style name="Species"></map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
+      <auxiliaryLayer></auxiliaryLayer>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
       </flags>
-      <renderer-v2 enableorderby="0" type="pointCluster" toleranceUnit="MM" toleranceUnitScale="3x:0,0,0,0,0,0" forceraster="0" tolerance="15">
-        <renderer-v2 attr="bee_species" enableorderby="0" type="categorizedSymbol" symbollevels="0" forceraster="0">
+      <renderer-v2 enableorderby="0" forceraster="0" tolerance="15" toleranceUnit="MM" toleranceUnitScale="3x:0,0,0,0,0,0" type="pointCluster">
+        <renderer-v2 attr="bee_species" enableorderby="0" forceraster="0" symbollevels="0" type="categorizedSymbol">
           <categories>
-            <category symbol="0" render="true" value="Apis Mellifera Mellifera" label="European honey bee"/>
-            <category symbol="1" render="true" value="Apis Mellifera" label="Buckfast bee"/>
-            <category symbol="2" render="true" value="Apis Mellifera Carnica" label="Carniolan honey bee"/>
+            <category label="European honey bee" render="true" symbol="0" value="Apis Mellifera Mellifera"></category>
+            <category label="Buckfast bee" render="true" symbol="1" value="Apis Mellifera"></category>
+            <category label="Carniolan honey bee" render="true" symbol="2" value="Apis Mellifera Carnica"></category>
           </categories>
           <symbols>
-            <symbol type="marker" alpha="1" clip_to_extent="1" force_rhr="0" name="0">
-              <layer enabled="1" locked="0" class="SimpleMarker" pass="0">
-                <prop v="0" k="angle"/>
-                <prop v="154,150,84,255" k="color"/>
-                <prop v="1" k="horizontal_anchor_point"/>
-                <prop v="miter" k="joinstyle"/>
-                <prop v="hexagon" k="name"/>
-                <prop v="0,0" k="offset"/>
-                <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-                <prop v="MM" k="offset_unit"/>
-                <prop v="250,139,57,255" k="outline_color"/>
-                <prop v="solid" k="outline_style"/>
-                <prop v="1" k="outline_width"/>
-                <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-                <prop v="MM" k="outline_width_unit"/>
-                <prop v="diameter" k="scale_method"/>
-                <prop v="6.8" k="size"/>
-                <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-                <prop v="MM" k="size_unit"/>
-                <prop v="1" k="vertical_anchor_point"/>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="0" type="marker">
+              <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                <prop k="angle" v="0"></prop>
+                <prop k="color" v="154,150,84,255"></prop>
+                <prop k="horizontal_anchor_point" v="1"></prop>
+                <prop k="joinstyle" v="miter"></prop>
+                <prop k="name" v="hexagon"></prop>
+                <prop k="offset" v="0,0"></prop>
+                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="offset_unit" v="MM"></prop>
+                <prop k="outline_color" v="250,139,57,255"></prop>
+                <prop k="outline_style" v="solid"></prop>
+                <prop k="outline_width" v="1"></prop>
+                <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="outline_width_unit" v="MM"></prop>
+                <prop k="scale_method" v="diameter"></prop>
+                <prop k="size" v="6.8"></prop>
+                <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="size_unit" v="MM"></prop>
+                <prop k="vertical_anchor_point" v="1"></prop>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option type="QString" name="name" value=""/>
-                    <Option name="properties"/>
-                    <Option type="QString" name="type" value="collection"/>
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
                   </Option>
                 </data_defined_properties>
               </layer>
             </symbol>
-            <symbol type="marker" alpha="1" clip_to_extent="1" force_rhr="0" name="1">
-              <layer enabled="1" locked="0" class="SimpleMarker" pass="0">
-                <prop v="0" k="angle"/>
-                <prop v="112,142,166,255" k="color"/>
-                <prop v="1" k="horizontal_anchor_point"/>
-                <prop v="miter" k="joinstyle"/>
-                <prop v="hexagon" k="name"/>
-                <prop v="0,0" k="offset"/>
-                <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-                <prop v="MM" k="offset_unit"/>
-                <prop v="250,139,57,255" k="outline_color"/>
-                <prop v="solid" k="outline_style"/>
-                <prop v="1" k="outline_width"/>
-                <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-                <prop v="MM" k="outline_width_unit"/>
-                <prop v="diameter" k="scale_method"/>
-                <prop v="6.8" k="size"/>
-                <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-                <prop v="MM" k="size_unit"/>
-                <prop v="1" k="vertical_anchor_point"/>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="1" type="marker">
+              <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                <prop k="angle" v="0"></prop>
+                <prop k="color" v="112,142,166,255"></prop>
+                <prop k="horizontal_anchor_point" v="1"></prop>
+                <prop k="joinstyle" v="miter"></prop>
+                <prop k="name" v="hexagon"></prop>
+                <prop k="offset" v="0,0"></prop>
+                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="offset_unit" v="MM"></prop>
+                <prop k="outline_color" v="250,139,57,255"></prop>
+                <prop k="outline_style" v="solid"></prop>
+                <prop k="outline_width" v="1"></prop>
+                <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="outline_width_unit" v="MM"></prop>
+                <prop k="scale_method" v="diameter"></prop>
+                <prop k="size" v="6.8"></prop>
+                <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="size_unit" v="MM"></prop>
+                <prop k="vertical_anchor_point" v="1"></prop>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option type="QString" name="name" value=""/>
-                    <Option name="properties"/>
-                    <Option type="QString" name="type" value="collection"/>
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
                   </Option>
                 </data_defined_properties>
               </layer>
             </symbol>
-            <symbol type="marker" alpha="1" clip_to_extent="1" force_rhr="0" name="2">
-              <layer enabled="1" locked="0" class="SimpleMarker" pass="0">
-                <prop v="0" k="angle"/>
-                <prop v="79,94,69,255" k="color"/>
-                <prop v="1" k="horizontal_anchor_point"/>
-                <prop v="miter" k="joinstyle"/>
-                <prop v="hexagon" k="name"/>
-                <prop v="0,0" k="offset"/>
-                <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-                <prop v="MM" k="offset_unit"/>
-                <prop v="250,139,57,255" k="outline_color"/>
-                <prop v="solid" k="outline_style"/>
-                <prop v="1" k="outline_width"/>
-                <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-                <prop v="MM" k="outline_width_unit"/>
-                <prop v="diameter" k="scale_method"/>
-                <prop v="6.8" k="size"/>
-                <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-                <prop v="MM" k="size_unit"/>
-                <prop v="1" k="vertical_anchor_point"/>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="2" type="marker">
+              <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                <prop k="angle" v="0"></prop>
+                <prop k="color" v="79,94,69,255"></prop>
+                <prop k="horizontal_anchor_point" v="1"></prop>
+                <prop k="joinstyle" v="miter"></prop>
+                <prop k="name" v="hexagon"></prop>
+                <prop k="offset" v="0,0"></prop>
+                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="offset_unit" v="MM"></prop>
+                <prop k="outline_color" v="250,139,57,255"></prop>
+                <prop k="outline_style" v="solid"></prop>
+                <prop k="outline_width" v="1"></prop>
+                <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="outline_width_unit" v="MM"></prop>
+                <prop k="scale_method" v="diameter"></prop>
+                <prop k="size" v="6.8"></prop>
+                <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="size_unit" v="MM"></prop>
+                <prop k="vertical_anchor_point" v="1"></prop>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option type="QString" name="name" value=""/>
-                    <Option name="properties"/>
-                    <Option type="QString" name="type" value="collection"/>
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
                   </Option>
                 </data_defined_properties>
               </layer>
             </symbol>
           </symbols>
           <source-symbol>
-            <symbol type="marker" alpha="1" clip_to_extent="1" force_rhr="0" name="0">
-              <layer enabled="1" locked="0" class="SimpleMarker" pass="0">
-                <prop v="0" k="angle"/>
-                <prop v="255,255,255,255" k="color"/>
-                <prop v="1" k="horizontal_anchor_point"/>
-                <prop v="miter" k="joinstyle"/>
-                <prop v="hexagon" k="name"/>
-                <prop v="0,0" k="offset"/>
-                <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-                <prop v="MM" k="offset_unit"/>
-                <prop v="250,139,57,255" k="outline_color"/>
-                <prop v="solid" k="outline_style"/>
-                <prop v="1" k="outline_width"/>
-                <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-                <prop v="MM" k="outline_width_unit"/>
-                <prop v="diameter" k="scale_method"/>
-                <prop v="8.8" k="size"/>
-                <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-                <prop v="MM" k="size_unit"/>
-                <prop v="1" k="vertical_anchor_point"/>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="0" type="marker">
+              <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                <prop k="angle" v="0"></prop>
+                <prop k="color" v="255,255,255,255"></prop>
+                <prop k="horizontal_anchor_point" v="1"></prop>
+                <prop k="joinstyle" v="miter"></prop>
+                <prop k="name" v="hexagon"></prop>
+                <prop k="offset" v="0,0"></prop>
+                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="offset_unit" v="MM"></prop>
+                <prop k="outline_color" v="250,139,57,255"></prop>
+                <prop k="outline_style" v="solid"></prop>
+                <prop k="outline_width" v="1"></prop>
+                <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="outline_width_unit" v="MM"></prop>
+                <prop k="scale_method" v="diameter"></prop>
+                <prop k="size" v="8.8"></prop>
+                <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="size_unit" v="MM"></prop>
+                <prop k="vertical_anchor_point" v="1"></prop>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option type="QString" name="name" value=""/>
-                    <Option name="properties"/>
-                    <Option type="QString" name="type" value="collection"/>
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
                   </Option>
                 </data_defined_properties>
               </layer>
-              <layer enabled="1" locked="0" class="SimpleMarker" pass="0">
-                <prop v="0" k="angle"/>
-                <prop v="250,176,124,255" k="color"/>
-                <prop v="1" k="horizontal_anchor_point"/>
-                <prop v="bevel" k="joinstyle"/>
-                <prop v="hexagon" k="name"/>
-                <prop v="0,0" k="offset"/>
-                <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-                <prop v="MM" k="offset_unit"/>
-                <prop v="250,176,124,255" k="outline_color"/>
-                <prop v="solid" k="outline_style"/>
-                <prop v="0.2" k="outline_width"/>
-                <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-                <prop v="MM" k="outline_width_unit"/>
-                <prop v="diameter" k="scale_method"/>
-                <prop v="3.6" k="size"/>
-                <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-                <prop v="MM" k="size_unit"/>
-                <prop v="1" k="vertical_anchor_point"/>
+              <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                <prop k="angle" v="0"></prop>
+                <prop k="color" v="250,176,124,255"></prop>
+                <prop k="horizontal_anchor_point" v="1"></prop>
+                <prop k="joinstyle" v="bevel"></prop>
+                <prop k="name" v="hexagon"></prop>
+                <prop k="offset" v="0,0"></prop>
+                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="offset_unit" v="MM"></prop>
+                <prop k="outline_color" v="250,176,124,255"></prop>
+                <prop k="outline_style" v="solid"></prop>
+                <prop k="outline_width" v="0.2"></prop>
+                <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="outline_width_unit" v="MM"></prop>
+                <prop k="scale_method" v="diameter"></prop>
+                <prop k="size" v="3.6"></prop>
+                <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="size_unit" v="MM"></prop>
+                <prop k="vertical_anchor_point" v="1"></prop>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option type="QString" name="name" value=""/>
-                    <Option name="properties"/>
-                    <Option type="QString" name="type" value="collection"/>
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
                   </Option>
                 </data_defined_properties>
               </layer>
             </symbol>
           </source-symbol>
-          <rotation/>
-          <sizescale/>
+          <rotation></rotation>
+          <sizescale></sizescale>
         </renderer-v2>
-        <symbol type="marker" alpha="1" clip_to_extent="1" force_rhr="0" name="centerSymbol">
-          <layer enabled="1" locked="0" class="SimpleMarker" pass="0">
-            <prop v="0" k="angle"/>
-            <prop v="255,255,255,255" k="color"/>
-            <prop v="1" k="horizontal_anchor_point"/>
-            <prop v="miter" k="joinstyle"/>
-            <prop v="hexagon" k="name"/>
-            <prop v="0,0" k="offset"/>
-            <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="250,139,57,255" k="outline_color"/>
-            <prop v="solid" k="outline_style"/>
-            <prop v="1" k="outline_width"/>
-            <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-            <prop v="MM" k="outline_width_unit"/>
-            <prop v="diameter" k="scale_method"/>
-            <prop v="10.8" k="size"/>
-            <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-            <prop v="MM" k="size_unit"/>
-            <prop v="1" k="vertical_anchor_point"/>
+        <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="centerSymbol" type="marker">
+          <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+            <prop k="angle" v="0"></prop>
+            <prop k="color" v="255,255,255,255"></prop>
+            <prop k="horizontal_anchor_point" v="1"></prop>
+            <prop k="joinstyle" v="miter"></prop>
+            <prop k="name" v="hexagon"></prop>
+            <prop k="offset" v="0,0"></prop>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+            <prop k="offset_unit" v="MM"></prop>
+            <prop k="outline_color" v="250,139,57,255"></prop>
+            <prop k="outline_style" v="solid"></prop>
+            <prop k="outline_width" v="1"></prop>
+            <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+            <prop k="outline_width_unit" v="MM"></prop>
+            <prop k="scale_method" v="diameter"></prop>
+            <prop k="size" v="10.8"></prop>
+            <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+            <prop k="size_unit" v="MM"></prop>
+            <prop k="vertical_anchor_point" v="1"></prop>
             <data_defined_properties>
               <Option type="Map">
-                <Option type="QString" name="name" value=""/>
-                <Option name="properties"/>
-                <Option type="QString" name="type" value="collection"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
           </layer>
-          <layer enabled="1" locked="0" class="FontMarker" pass="0">
-            <prop v="0" k="angle"/>
-            <prop v="A" k="chr"/>
-            <prop v="250,176,124,255" k="color"/>
-            <prop v="Cantarell" k="font"/>
-            <prop v="1" k="horizontal_anchor_point"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="0,-1.20000000000000218" k="offset"/>
-            <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="35,35,35,255" k="outline_color"/>
-            <prop v="0" k="outline_width"/>
-            <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-            <prop v="MM" k="outline_width_unit"/>
-            <prop v="6" k="size"/>
-            <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-            <prop v="MM" k="size_unit"/>
-            <prop v="1" k="vertical_anchor_point"/>
+          <layer class="FontMarker" enabled="1" locked="0" pass="0">
+            <prop k="angle" v="0"></prop>
+            <prop k="chr" v="A"></prop>
+            <prop k="color" v="250,176,124,255"></prop>
+            <prop k="font" v="Cantarell"></prop>
+            <prop k="horizontal_anchor_point" v="1"></prop>
+            <prop k="joinstyle" v="bevel"></prop>
+            <prop k="offset" v="0,-1.20000000000000218"></prop>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+            <prop k="offset_unit" v="MM"></prop>
+            <prop k="outline_color" v="35,35,35,255"></prop>
+            <prop k="outline_width" v="0"></prop>
+            <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+            <prop k="outline_width_unit" v="MM"></prop>
+            <prop k="size" v="6"></prop>
+            <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+            <prop k="size_unit" v="MM"></prop>
+            <prop k="vertical_anchor_point" v="1"></prop>
             <data_defined_properties>
               <Option type="Map">
-                <Option type="QString" name="name" value=""/>
-                <Option type="Map" name="properties">
-                  <Option type="Map" name="char">
-                    <Option type="bool" name="active" value="true"/>
-                    <Option type="QString" name="expression" value="@cluster_size"/>
-                    <Option type="int" name="type" value="3"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties" type="Map">
+                  <Option name="char" type="Map">
+                    <Option name="active" type="bool" value="true"></Option>
+                    <Option name="expression" type="QString" value="@cluster_size"></Option>
+                    <Option name="type" type="int" value="3"></Option>
                   </Option>
                 </Option>
-                <Option type="QString" name="type" value="collection"/>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
           </layer>
@@ -1926,106 +1971,180 @@ def my_form_open(dialog, layer, feature):
       </renderer-v2>
       <labeling type="simple">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fieldName="concat(&quot;bee_amount&quot; ,  ' (' || nbr_of_boxes || ' boxes)' )" fontLetterSpacing="0" blendMode="0" fontSize="12" fontItalic="0" fontStrikeout="0" fontWordSpacing="0" isExpression="1" fontKerning="1" useSubstitutions="0" multilineHeight="1" namedStyle="Regular" fontCapitals="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontFamily="Sans Serif" textColor="0,0,0,255" fontSizeUnit="Point" fontUnderline="0" textOrientation="horizontal">
-            <text-buffer bufferNoFill="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1" bufferBlendMode="0" bufferSizeUnits="MM" bufferJoinStyle="128" bufferDraw="0" bufferColor="255,255,255,255" bufferOpacity="1"/>
-            <background shapeOffsetUnit="MM" shapeBorderWidthUnit="MM" shapeOffsetY="0" shapeBorderWidth="0" shapeType="0" shapeRadiiX="0" shapeDraw="0" shapeBlendMode="0" shapeOpacity="1" shapeFillColor="255,255,255,255" shapeRotationType="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRotation="0" shapeRadiiY="0" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255" shapeJoinStyle="64" shapeSizeUnit="MM" shapeSizeType="0" shapeSVGFile="" shapeSizeY="0" shapeSizeX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-            <shadow shadowRadiusUnit="MM" shadowOffsetUnit="MM" shadowOpacity="0.7" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowUnder="0" shadowOffsetDist="1" shadowColor="0,0,0,255" shadowScale="100" shadowOffsetAngle="135" shadowOffsetGlobal="1" shadowDraw="0" shadowRadius="1.5" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowBlendMode="6"/>
+          <text-style blendMode="0" fieldName="concat(&quot;bee_amount&quot; ,  ' (' || nbr_of_boxes || ' boxes)' )" fontCapitals="0" fontFamily="Sans Serif" fontItalic="0" fontKerning="1" fontLetterSpacing="0" fontSize="12" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontStrikeout="0" fontUnderline="0" fontWeight="50" fontWordSpacing="0" isExpression="1" multilineHeight="1" namedStyle="Normal" previewBkgrdColor="255,255,255,255" textColor="0,0,0,255" textOpacity="1" textOrientation="horizontal" useSubstitutions="0">
+            <text-buffer bufferBlendMode="0" bufferColor="255,255,255,255" bufferDraw="0" bufferJoinStyle="128" bufferNoFill="1" bufferOpacity="1" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM"></text-buffer>
+            <text-mask maskEnabled="0" maskJoinStyle="128" maskOpacity="1" maskSize="0" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSizeUnits="MM" maskType="0" maskedSymbolLayers=""></text-mask>
+            <background shapeBlendMode="0" shapeBorderColor="128,128,128,255" shapeBorderWidth="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeDraw="0" shapeFillColor="255,255,255,255" shapeJoinStyle="64" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeOffsetY="0" shapeOpacity="1" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiUnit="MM" shapeRadiiX="0" shapeRadiiY="0" shapeRotation="0" shapeRotationType="0" shapeSVGFile="" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeSizeUnit="MM" shapeSizeX="0" shapeSizeY="0" shapeType="0">
+              <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="markerSymbol" type="marker">
+                <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                  <prop k="angle" v="0"></prop>
+                  <prop k="color" v="229,182,54,255"></prop>
+                  <prop k="horizontal_anchor_point" v="1"></prop>
+                  <prop k="joinstyle" v="bevel"></prop>
+                  <prop k="name" v="circle"></prop>
+                  <prop k="offset" v="0,0"></prop>
+                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="offset_unit" v="MM"></prop>
+                  <prop k="outline_color" v="35,35,35,255"></prop>
+                  <prop k="outline_style" v="solid"></prop>
+                  <prop k="outline_width" v="0"></prop>
+                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="outline_width_unit" v="MM"></prop>
+                  <prop k="scale_method" v="diameter"></prop>
+                  <prop k="size" v="2"></prop>
+                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="size_unit" v="MM"></prop>
+                  <prop k="vertical_anchor_point" v="1"></prop>
+                  <data_defined_properties>
+                    <Option type="Map">
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
+                    </Option>
+                  </data_defined_properties>
+                </layer>
+              </symbol>
+            </background>
+            <shadow shadowBlendMode="6" shadowColor="0,0,0,255" shadowDraw="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowOpacity="0.7" shadowRadius="1.5" shadowRadiusAlphaOnly="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowUnder="0"></shadow>
             <dd_properties>
               <Option type="Map">
-                <Option type="QString" name="name" value=""/>
-                <Option name="properties"/>
-                <Option type="QString" name="type" value="collection"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </dd_properties>
-            <substitutions/>
+            <substitutions></substitutions>
           </text-style>
-          <text-format leftDirectionSymbol="&lt;" useMaxLineLengthForAutoWrap="1" formatNumbers="0" decimals="3" rightDirectionSymbol=">" placeDirectionSymbol="0" reverseDirectionSymbol="0" plussign="0" wrapChar="" multilineAlign="3" addDirectionSymbol="0" autoWrapLength="0"/>
-          <placement quadOffset="4" repeatDistance="0" centroidInside="0" maxCurvedCharAngleOut="-25" centroidWhole="0" rotationAngle="0" priority="5" repeatDistanceUnits="MM" xOffset="0" placement="0" offsetType="0" geometryGeneratorType="PointGeometry" placementFlags="10" distMapUnitScale="3x:0,0,0,0,0,0" geometryGenerator="" dist="4.5" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" fitInPolygonOnly="0" maxCurvedCharAngleIn="25" overrunDistanceUnit="MM" geometryGeneratorEnabled="0" yOffset="0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" overrunDistance="0" offsetUnits="MM" preserveRotation="1" distUnits="MM" layerType="UnknownGeometry"/>
-          <rendering fontLimitPixelSize="0" obstacleType="0" labelPerPart="0" upsidedownLabels="0" obstacleFactor="1" obstacle="1" limitNumLabels="0" fontMaxPixelSize="10000" scaleMin="0" zIndex="0" minFeatureSize="0" displayAll="0" maxNumLabels="2000" scaleVisibility="1" fontMinPixelSize="3" drawLabels="1" scaleMax="2500" mergeLines="0"/>
+          <text-format addDirectionSymbol="0" autoWrapLength="0" decimals="3" formatNumbers="0" leftDirectionSymbol="&lt;" multilineAlign="3" placeDirectionSymbol="0" plussign="0" reverseDirectionSymbol="0" rightDirectionSymbol=">" useMaxLineLengthForAutoWrap="1" wrapChar=""></text-format>
+          <placement centroidInside="0" centroidWhole="0" dist="4.5" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" fitInPolygonOnly="0" geometryGenerator="" geometryGeneratorEnabled="0" geometryGeneratorType="PointGeometry" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" layerType="PointGeometry" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" offsetType="0" offsetUnits="MM" overrunDistance="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" placement="0" placementFlags="10" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" preserveRotation="1" priority="5" quadOffset="4" repeatDistance="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" rotationAngle="0" xOffset="0" yOffset="0"></placement>
+          <rendering displayAll="0" drawLabels="1" fontLimitPixelSize="0" fontMaxPixelSize="10000" fontMinPixelSize="3" labelPerPart="0" limitNumLabels="0" maxNumLabels="2000" mergeLines="0" minFeatureSize="0" obstacle="1" obstacleFactor="1" obstacleType="0" scaleMax="2500" scaleMin="0" scaleVisibility="1" upsidedownLabels="0" zIndex="0"></rendering>
           <dd_properties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
-              <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option type="QString" name="anchorPoint" value="pole_of_inaccessibility"/>
-              <Option type="Map" name="ddProperties">
-                <Option type="QString" name="name" value=""/>
-                <Option name="properties"/>
-                <Option type="QString" name="type" value="collection"/>
+              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility"></Option>
+              <Option name="ddProperties" type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
-              <Option type="bool" name="drawToAllParts" value="false"/>
-              <Option type="QString" name="enabled" value="0"/>
-              <Option type="QString" name="lineSymbol" value="&lt;symbol type=&quot;line&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; force_rhr=&quot;0&quot; name=&quot;symbol&quot;>&lt;layer enabled=&quot;1&quot; locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot;>&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/>&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/>&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/>&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/>&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/>&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/>&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; name=&quot;name&quot; value=&quot;&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;type&quot; value=&quot;collection&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>"/>
-              <Option type="double" name="minLength" value="0"/>
-              <Option type="QString" name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0"/>
-              <Option type="QString" name="minLengthUnit" value="MM"/>
-              <Option type="double" name="offsetFromAnchor" value="0"/>
-              <Option type="QString" name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0"/>
-              <Option type="QString" name="offsetFromAnchorUnit" value="MM"/>
-              <Option type="double" name="offsetFromLabel" value="0"/>
-              <Option type="QString" name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0"/>
-              <Option type="QString" name="offsetFromLabelUnit" value="MM"/>
+              <Option name="drawToAllParts" type="bool" value="false"></Option>
+              <Option name="enabled" type="QString" value="0"></Option>
+              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior"></Option>
+              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; type=&quot;line&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; force_rhr=&quot;0&quot;>&lt;layer enabled=&quot;1&quot; pass=&quot;0&quot; locked=&quot;0&quot; class=&quot;SimpleLine&quot;>&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/>&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/>&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/>&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/>&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/>&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/>&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>"></Option>
+              <Option name="minLength" type="double" value="0"></Option>
+              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="minLengthUnit" type="QString" value="MM"></Option>
+              <Option name="offsetFromAnchor" type="double" value="0"></Option>
+              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="offsetFromAnchorUnit" type="QString" value="MM"></Option>
+              <Option name="offsetFromLabel" type="double" value="0"></Option>
+              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="offsetFromLabelUnit" type="QString" value="MM"></Option>
             </Option>
           </callout>
         </settings>
       </labeling>
       <customproperties>
-        <property key="QFieldSync/action" value="offline"/>
-        <property key="dualview/previewExpressions" value="concat( &quot;beekeeper&quot;,  ' - ' ||  represent_value( &quot;bee_species&quot; ) )"/>
-        <property key="embeddedWidgets/count" value="0"/>
-        <property key="isOfflineEditable" value="true"/>
-        <property key="remoteProvider" value="postgres"/>
-        <property key="remoteSource" value="dbname='demo' host=lizmapdemo.opengis.ch port=5432 user='editor1' password='editor1' sslmode=disable key='id' srid=2056 type=Point table=&quot;citybees&quot;.&quot;apiary&quot; (geom) sql="/>
-        <property key="variableNames"/>
-        <property key="variableValues"/>
+        <property key="QFieldSync/action" value="offline"></property>
+        <property key="dualview/previewExpressions" value="concat( &quot;beekeeper&quot;,  ' - ' ||  represent_value( &quot;bee_species&quot; ) )"></property>
+        <property key="embeddedWidgets/count" value="0"></property>
+        <property key="isOfflineEditable" value="true"></property>
+        <property key="remoteProvider" value="postgres"></property>
+        <property key="remoteSource" value="dbname='demo' host=lizmapdemo.opengis.ch port=5432 user='editor1' password='editor1' sslmode=disable key='id' srid=2056 type=Point table=&quot;citybees&quot;.&quot;apiary&quot; (geom) sql="></property>
+        <property key="variableNames"></property>
+        <property key="variableValues"></property>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
-        <DiagramCategory labelPlacementMethod="XHeight" minScaleDenominator="0" penAlpha="255" diagramOrientation="Up" penColor="#000000" scaleBasedVisibility="0" rotationOffset="0" maxScaleDenominator="1e+08" sizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" barWidth="5" backgroundColor="#ffffff" width="15" scaleDependency="Area" minimumSize="0" lineSizeScale="3x:0,0,0,0,0,0" sizeType="MM" backgroundAlpha="255" height="15" enabled="0" penWidth="0" opacity="1">
-          <fontProperties style="" description="Cantarell,11,-1,5,50,0,0,0,0,0"/>
-          <attribute color="#000000" field="" label=""/>
+      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="1" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+8" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="0" scaleBasedVisibility="0" scaleDependency="Area" showAxis="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="0" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
+          <fontProperties description="Cantarell,11,-1,5,50,0,0,0,0,0" style=""></fontProperties>
+          <attribute color="#000000" field="" label=""></attribute>
+          <axisSymbol>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" type="line">
+              <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+                <prop k="capstyle" v="square"></prop>
+                <prop k="customdash" v="5;2"></prop>
+                <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="customdash_unit" v="MM"></prop>
+                <prop k="draw_inside_polygon" v="0"></prop>
+                <prop k="joinstyle" v="bevel"></prop>
+                <prop k="line_color" v="35,35,35,255"></prop>
+                <prop k="line_style" v="solid"></prop>
+                <prop k="line_width" v="0.26"></prop>
+                <prop k="line_width_unit" v="MM"></prop>
+                <prop k="offset" v="0"></prop>
+                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="offset_unit" v="MM"></prop>
+                <prop k="ring_filter" v="0"></prop>
+                <prop k="use_custom_dash" v="0"></prop>
+                <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings linePlacementFlags="2" dist="0" priority="0" zIndex="0" placement="0" obstacle="0" showAll="1">
+      <DiagramLayerSettings dist="0" linePlacementFlags="2" obstacle="0" placement="0" priority="0" showAll="1" zIndex="0">
         <properties>
           <Option type="Map">
-            <Option type="QString" name="name" value=""/>
-            <Option type="Map" name="properties">
-              <Option type="Map" name="positionX">
-                <Option type="bool" name="active" value="true"/>
-                <Option type="QString" name="field" value="id"/>
-                <Option type="int" name="type" value="2"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties" type="Map">
+              <Option name="positionX" type="Map">
+                <Option name="active" type="bool" value="true"></Option>
+                <Option name="field" type="QString" value="id"></Option>
+                <Option name="type" type="int" value="2"></Option>
               </Option>
-              <Option type="Map" name="positionY">
-                <Option type="bool" name="active" value="true"/>
-                <Option type="QString" name="field" value="id"/>
-                <Option type="int" name="type" value="2"/>
+              <Option name="positionY" type="Map">
+                <Option name="active" type="bool" value="true"></Option>
+                <Option name="field" type="QString" value="id"></Option>
+                <Option name="type" type="int" value="2"></Option>
               </Option>
-              <Option type="Map" name="show">
-                <Option type="bool" name="active" value="true"/>
-                <Option type="QString" name="field" value="id"/>
-                <Option type="int" name="type" value="2"/>
+              <Option name="show" type="Map">
+                <Option name="active" type="bool" value="true"></Option>
+                <Option name="field" type="QString" value="id"></Option>
+                <Option name="type" type="int" value="2"></Option>
               </Option>
             </Option>
-            <Option type="QString" name="type" value="collection"/>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </properties>
       </DiagramLayerSettings>
       <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-        <activeChecks/>
-        <checkConfiguration/>
+        <activeChecks></activeChecks>
+        <checkConfiguration></checkConfiguration>
       </geometryOptions>
+      <referencedLayers>
+        <relation dataSource="./bees.gpkg|layername=area" id="apiary_279_area_id_ogr_dbname_fid" layerId="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" layerName="Fields" name="apiary_area" providerKey="ogr" strength="0">
+          <fieldPair referenced="fid" referencing="area_id"></fieldPair>
+        </relation>
+      </referencedLayers>
+      <referencingLayers>
+        <relation dataSource="./bees.gpkg|layername=Pollen_Consumption" id="Pollen_Con_apiary_id_apiary_279_fid" layerId="Pollen_Consumption_9dac944e_6937_4617_928b_0daaf97303e9" layerName="Pollen_Consumption" name="consume_on_fields" providerKey="ogr" strength="1">
+          <fieldPair referenced="fid" referencing="apiary_id"></fieldPair>
+        </relation>
+        <relation dataSource="./bees.gpkg|layername=Reviews" id="Reviews_c8_apiary_id_apiary_279_fid" layerId="Reviews_c8ab909e_4686_45c7_affe_08141059dfd0" layerName="Apiary_Reviews" name="review_apiary" providerKey="ogr" strength="1">
+          <fieldPair referenced="fid" referencing="apiary_id"></fieldPair>
+        </relation>
+      </referencingLayers>
       <fieldConfiguration>
         <field name="fid">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
@@ -2033,12 +2152,12 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="Range">
             <config>
               <Option type="Map">
-                <Option type="bool" name="AllowNull" value="true"/>
-                <Option type="int" name="Max" value="10"/>
-                <Option type="int" name="Min" value="1"/>
-                <Option type="int" name="Precision" value="0"/>
-                <Option type="int" name="Step" value="1"/>
-                <Option type="QString" name="Style" value="Slider"/>
+                <Option name="AllowNull" type="bool" value="true"></Option>
+                <Option name="Max" type="int" value="10"></Option>
+                <Option name="Min" type="int" value="1"></Option>
+                <Option name="Precision" type="int" value="0"></Option>
+                <Option name="Step" type="int" value="1"></Option>
+                <Option name="Style" type="QString" value="Slider"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2047,15 +2166,15 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="ValueMap">
             <config>
               <Option type="Map">
-                <Option type="List" name="map">
+                <Option name="map" type="List">
                   <Option type="Map">
-                    <Option type="QString" name="Buckfast bee" value="Apis Mellifera"/>
+                    <Option name="Buckfast bee" type="QString" value="Apis Mellifera"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option type="QString" name="Carniolan honey bee" value="Apis Mellifera Carnica"/>
+                    <Option name="Carniolan honey bee" type="QString" value="Apis Mellifera Carnica"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option type="QString" name="European honey bee" value="Apis Mellifera Mellifera"/>
+                    <Option name="European honey bee" type="QString" value="Apis Mellifera Mellifera"></Option>
                   </Option>
                 </Option>
               </Option>
@@ -2066,10 +2185,16 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="ValueMap">
             <config>
               <Option type="Map">
-                <Option type="Map" name="map">
-                  <Option type="QString" name="1000 - 10000" value="10000"/>
-                  <Option type="QString" name="&lt; 1000" value="1000"/>
-                  <Option type="QString" name="> 10000" value="100000"/>
+                <Option name="map" type="List">
+                  <Option type="Map">
+                    <Option name="1000 - 10000" type="QString" value="10000"></Option>
+                  </Option>
+                  <Option type="Map">
+                    <Option name="&lt; 1000" type="QString" value="1000"></Option>
+                  </Option>
+                  <Option type="Map">
+                    <Option name="> 10000" type="QString" value="100000"></Option>
+                  </Option>
                 </Option>
               </Option>
             </config>
@@ -2079,8 +2204,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="bool" name="IsMultiline" value="false"/>
-                <Option type="bool" name="UseHtml" value="false"/>
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2089,19 +2214,19 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="ExternalResource">
             <config>
               <Option type="Map">
-                <Option type="int" name="DocumentViewer" value="1"/>
-                <Option type="int" name="DocumentViewerHeight" value="0"/>
-                <Option type="int" name="DocumentViewerWidth" value="0"/>
-                <Option type="bool" name="FileWidget" value="true"/>
-                <Option type="bool" name="FileWidgetButton" value="true"/>
-                <Option type="QString" name="FileWidgetFilter" value=""/>
-                <Option type="Map" name="PropertyCollection">
-                  <Option type="QString" name="name" value=""/>
-                  <Option type="invalid" name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                <Option name="DocumentViewer" type="int" value="1"></Option>
+                <Option name="DocumentViewerHeight" type="int" value="0"></Option>
+                <Option name="DocumentViewerWidth" type="int" value="0"></Option>
+                <Option name="FileWidget" type="bool" value="true"></Option>
+                <Option name="FileWidgetButton" type="bool" value="true"></Option>
+                <Option name="FileWidgetFilter" type="QString" value=""></Option>
+                <Option name="PropertyCollection" type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties" type="invalid"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
-                <Option type="int" name="RelativeStorage" value="1"/>
-                <Option type="int" name="StorageMode" value="0"/>
+                <Option name="RelativeStorage" type="int" value="1"></Option>
+                <Option name="StorageMode" type="int" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2110,8 +2235,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="CheckBox">
             <config>
               <Option type="Map">
-                <Option type="QString" name="CheckedState" value="t"/>
-                <Option type="QString" name="UncheckedState" value="f"/>
+                <Option name="CheckedState" type="QString" value="t"></Option>
+                <Option name="UncheckedState" type="QString" value="f"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2120,12 +2245,12 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="ValueMap">
             <config>
               <Option type="Map">
-                <Option type="List" name="map">
+                <Option name="map" type="List">
                   <Option type="Map">
-                    <Option type="QString" name="American Foulbreed" value="AFB"/>
+                    <Option name="American Foulbreed" type="QString" value="AFB"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option type="QString" name="European Foulbreed" value="EFB"/>
+                    <Option name="European Foulbreed" type="QString" value="EFB"></Option>
                   </Option>
                 </Option>
               </Option>
@@ -2136,12 +2261,12 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="Range">
             <config>
               <Option type="Map">
-                <Option type="bool" name="AllowNull" value="true"/>
-                <Option type="int" name="Max" value="1000"/>
-                <Option type="int" name="Min" value="0"/>
-                <Option type="int" name="Precision" value="0"/>
-                <Option type="int" name="Step" value="5"/>
-                <Option type="QString" name="Style" value="SpinBox"/>
+                <Option name="AllowNull" type="bool" value="true"></Option>
+                <Option name="Max" type="int" value="1000"></Option>
+                <Option name="Min" type="int" value="0"></Option>
+                <Option name="Precision" type="int" value="0"></Option>
+                <Option name="Step" type="int" value="5"></Option>
+                <Option name="Style" type="QString" value="SpinBox"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2150,103 +2275,103 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="RelationReference">
             <config>
               <Option type="Map">
-                <Option type="bool" name="AllowAddFeatures" value="false"/>
-                <Option type="bool" name="AllowNULL" value="true"/>
-                <Option type="bool" name="MapIdentification" value="true"/>
-                <Option type="bool" name="OrderByValue" value="false"/>
-                <Option type="bool" name="ReadOnly" value="false"/>
-                <Option type="QString" name="Relation" value="apiary_279_area_id_ogr_dbname_fid"/>
-                <Option type="bool" name="ShowForm" value="false"/>
-                <Option type="bool" name="ShowOpenFormButton" value="true"/>
+                <Option name="AllowAddFeatures" type="bool" value="false"></Option>
+                <Option name="AllowNULL" type="bool" value="true"></Option>
+                <Option name="MapIdentification" type="bool" value="true"></Option>
+                <Option name="OrderByValue" type="bool" value="false"></Option>
+                <Option name="ReadOnly" type="bool" value="false"></Option>
+                <Option name="Relation" type="QString" value="apiary_279_area_id_ogr_dbname_fid"></Option>
+                <Option name="ShowForm" type="bool" value="false"></Option>
+                <Option name="ShowOpenFormButton" type="bool" value="true"></Option>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" field="fid" index="0"/>
-        <alias name="Number of Boxes" field="nbr_of_boxes" index="1"/>
-        <alias name="Species of Bees" field="bee_species" index="2"/>
-        <alias name="Amount of Bees" field="bee_amount" index="3"/>
-        <alias name="Beekeeper" field="beekeeper" index="4"/>
-        <alias name="Photo" field="picture" index="5"/>
-        <alias name="Infected" field="disease" index="6"/>
-        <alias name="Kind of Disease" field="kind_of_disease" index="7"/>
-        <alias name="Yearly Harvest (kg)" field="average_harvest" index="8"/>
-        <alias name="Area mostly used" field="area_id" index="9"/>
+        <alias field="fid" index="0" name=""></alias>
+        <alias field="nbr_of_boxes" index="1" name="Number of Boxes"></alias>
+        <alias field="bee_species" index="2" name="Species of Bees"></alias>
+        <alias field="bee_amount" index="3" name="Amount of Bees"></alias>
+        <alias field="beekeeper" index="4" name="Beekeeper"></alias>
+        <alias field="picture" index="5" name="Photo"></alias>
+        <alias field="disease" index="6" name="Infected"></alias>
+        <alias field="kind_of_disease" index="7" name="Kind of Disease"></alias>
+        <alias field="average_harvest" index="8" name="Yearly Harvest (kg)"></alias>
+        <alias field="area_id" index="9" name="Area mostly used"></alias>
       </aliases>
-      <excludeAttributesWMS/>
-      <excludeAttributesWFS/>
+      <excludeAttributesWMS></excludeAttributesWMS>
+      <excludeAttributesWFS></excludeAttributesWFS>
       <defaults>
-        <default applyOnUpdate="0" field="fid" expression=""/>
-        <default applyOnUpdate="0" field="nbr_of_boxes" expression=""/>
-        <default applyOnUpdate="0" field="bee_species" expression=""/>
-        <default applyOnUpdate="0" field="bee_amount" expression=""/>
-        <default applyOnUpdate="0" field="beekeeper" expression=""/>
-        <default applyOnUpdate="0" field="picture" expression=""/>
-        <default applyOnUpdate="0" field="disease" expression=""/>
-        <default applyOnUpdate="0" field="kind_of_disease" expression=""/>
-        <default applyOnUpdate="0" field="average_harvest" expression=""/>
-        <default applyOnUpdate="0" field="area_id" expression=""/>
+        <default applyOnUpdate="0" expression="" field="fid"></default>
+        <default applyOnUpdate="0" expression="" field="nbr_of_boxes"></default>
+        <default applyOnUpdate="0" expression="" field="bee_species"></default>
+        <default applyOnUpdate="0" expression="" field="bee_amount"></default>
+        <default applyOnUpdate="0" expression="" field="beekeeper"></default>
+        <default applyOnUpdate="0" expression="" field="picture"></default>
+        <default applyOnUpdate="0" expression="" field="disease"></default>
+        <default applyOnUpdate="0" expression="" field="kind_of_disease"></default>
+        <default applyOnUpdate="0" expression="" field="average_harvest"></default>
+        <default applyOnUpdate="0" expression="" field="area_id"></default>
       </defaults>
       <constraints>
-        <constraint notnull_strength="1" constraints="3" field="fid" unique_strength="1" exp_strength="0"/>
-        <constraint notnull_strength="1" constraints="5" field="nbr_of_boxes" unique_strength="0" exp_strength="1"/>
-        <constraint notnull_strength="1" constraints="5" field="bee_species" unique_strength="0" exp_strength="1"/>
-        <constraint notnull_strength="0" constraints="0" field="bee_amount" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="1" constraints="5" field="beekeeper" unique_strength="0" exp_strength="1"/>
-        <constraint notnull_strength="0" constraints="0" field="picture" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="disease" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="kind_of_disease" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="average_harvest" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="area_id" unique_strength="0" exp_strength="0"/>
+        <constraint constraints="3" exp_strength="0" field="fid" notnull_strength="1" unique_strength="1"></constraint>
+        <constraint constraints="5" exp_strength="1" field="nbr_of_boxes" notnull_strength="1" unique_strength="0"></constraint>
+        <constraint constraints="1" exp_strength="0" field="bee_species" notnull_strength="1" unique_strength="0"></constraint>
+        <constraint constraints="1" exp_strength="0" field="bee_amount" notnull_strength="2" unique_strength="0"></constraint>
+        <constraint constraints="5" exp_strength="1" field="beekeeper" notnull_strength="1" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="picture" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="disease" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="kind_of_disease" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="average_harvest" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="area_id" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint field="fid" desc="" exp=""/>
-        <constraint field="nbr_of_boxes" desc="must be between 1 and 10" exp="1 &lt;= nbr_of_boxes and nbr_of_boxes &lt;= 10"/>
-        <constraint field="bee_species" desc="cannot be empty" exp="&quot;bee_species&quot;"/>
-        <constraint field="bee_amount" desc="" exp=""/>
-        <constraint field="beekeeper" desc="at least 2 letters" exp="length(beekeeper)>1"/>
-        <constraint field="picture" desc="" exp=""/>
-        <constraint field="disease" desc="" exp=""/>
-        <constraint field="kind_of_disease" desc="" exp=""/>
-        <constraint field="average_harvest" desc="" exp=""/>
-        <constraint field="area_id" desc="" exp=""/>
+        <constraint desc="" exp="" field="fid"></constraint>
+        <constraint desc="must be between 1 and 10" exp="1 &lt;= nbr_of_boxes and nbr_of_boxes &lt;= 10" field="nbr_of_boxes"></constraint>
+        <constraint desc="" exp="" field="bee_species"></constraint>
+        <constraint desc="" exp="" field="bee_amount"></constraint>
+        <constraint desc="at least 2 letters" exp="length(beekeeper)>1" field="beekeeper"></constraint>
+        <constraint desc="" exp="" field="picture"></constraint>
+        <constraint desc="" exp="" field="disease"></constraint>
+        <constraint desc="" exp="" field="kind_of_disease"></constraint>
+        <constraint desc="" exp="" field="average_harvest"></constraint>
+        <constraint desc="" exp="" field="area_id"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction key="Canvas" value="{9c6cab86-7710-48f6-a961-0273bcaaeca9}"/>
-        <actionsetting capture="0" isEnabledOnlyWhenEditable="0" type="0" icon="" shortTitle="" notificationMessage="" name="" id="{9c6cab86-7710-48f6-a961-0273bcaaeca9}" action="">
-          <actionScope id="Canvas"/>
-          <actionScope id="Feature"/>
-          <actionScope id="Field"/>
+        <defaultAction key="Canvas" value="{7781df3b-1acf-428b-b221-40b757361964}"></defaultAction>
+        <actionsetting action="" capture="0" icon="" id="{7781df3b-1acf-428b-b221-40b757361964}" isEnabledOnlyWhenEditable="0" name="" notificationMessage="" shortTitle="" type="0">
+          <actionScope id="Field"></actionScope>
+          <actionScope id="Canvas"></actionScope>
+          <actionScope id="Feature"></actionScope>
         </actionsetting>
       </attributeactions>
-      <attributetableconfig sortExpression="&quot;fid&quot;" sortOrder="0" actionWidgetStyle="dropDown">
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="&quot;fid&quot;" sortOrder="0">
         <columns>
-          <column type="field" name="nbr_of_boxes" width="165" hidden="0"/>
-          <column type="field" name="bee_species" width="164" hidden="0"/>
-          <column type="field" name="bee_amount" width="192" hidden="0"/>
-          <column type="field" name="beekeeper" width="203" hidden="0"/>
-          <column type="field" name="picture" width="-1" hidden="0"/>
-          <column type="field" name="disease" width="-1" hidden="0"/>
-          <column type="field" name="kind_of_disease" width="188" hidden="0"/>
-          <column type="actions" width="-1" hidden="1"/>
-          <column type="field" name="average_harvest" width="161" hidden="0"/>
-          <column type="field" name="area_id" width="150" hidden="0"/>
-          <column type="field" name="fid" width="-1" hidden="0"/>
+          <column hidden="0" name="nbr_of_boxes" type="field" width="165"></column>
+          <column hidden="0" name="bee_species" type="field" width="164"></column>
+          <column hidden="0" name="bee_amount" type="field" width="192"></column>
+          <column hidden="0" name="beekeeper" type="field" width="203"></column>
+          <column hidden="0" name="picture" type="field" width="-1"></column>
+          <column hidden="0" name="disease" type="field" width="-1"></column>
+          <column hidden="0" name="kind_of_disease" type="field" width="188"></column>
+          <column hidden="1" type="actions" width="-1"></column>
+          <column hidden="0" name="average_harvest" type="field" width="161"></column>
+          <column hidden="0" name="area_id" type="field" width="150"></column>
+          <column hidden="0" name="fid" type="field" width="-1"></column>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1">../../../OPENGIS.ch-CLOUD/public/qfield_workshop_odense/qfield_workshop_odense</editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath>../../../OPENGIS.ch-CLOUD/public/qfield_workshop_odense/demo_proj_citybees_218</editforminitfilepath>
-      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+      <editforminitcode># -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -2262,87 +2387,89 @@ from qgis.PyQt.QtWidgets import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-]]></editforminitcode>
+</editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>tablayout</editorlayout>
       <attributeEditorForm>
-        <attributeEditorContainer name="General" visibilityExpressionEnabled="0" groupBox="0" showLabel="1" columnCount="1" visibilityExpression="">
-          <attributeEditorField name="nbr_of_boxes" showLabel="1" index="1"/>
-          <attributeEditorField name="bee_species" showLabel="1" index="2"/>
-          <attributeEditorField name="bee_amount" showLabel="1" index="3"/>
-          <attributeEditorField name="beekeeper" showLabel="1" index="4"/>
-          <attributeEditorField name="average_harvest" showLabel="1" index="8"/>
+        <attributeEditorContainer columnCount="1" groupBox="0" name="General" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+          <attributeEditorField index="1" name="nbr_of_boxes" showLabel="1"></attributeEditorField>
+          <attributeEditorField index="2" name="bee_species" showLabel="1"></attributeEditorField>
+          <attributeEditorField index="3" name="bee_amount" showLabel="1"></attributeEditorField>
+          <attributeEditorField index="4" name="beekeeper" showLabel="1"></attributeEditorField>
+          <attributeEditorField index="8" name="average_harvest" showLabel="1"></attributeEditorField>
         </attributeEditorContainer>
-        <attributeEditorContainer name="Picture" visibilityExpressionEnabled="0" groupBox="0" showLabel="1" columnCount="1" visibilityExpression="">
-          <attributeEditorField name="picture" showLabel="1" index="5"/>
+        <attributeEditorContainer columnCount="1" groupBox="0" name="Picture" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+          <attributeEditorField index="5" name="picture" showLabel="1"></attributeEditorField>
         </attributeEditorContainer>
-        <attributeEditorContainer name="Issues" visibilityExpressionEnabled="0" groupBox="0" showLabel="1" columnCount="1" visibilityExpression="">
-          <attributeEditorField name="disease" showLabel="1" index="6"/>
-          <attributeEditorContainer name="" visibilityExpressionEnabled="1" groupBox="1" showLabel="0" columnCount="1" visibilityExpression="disease in ('t', true, 1)">
-            <attributeEditorField name="kind_of_disease" showLabel="1" index="7"/>
+        <attributeEditorContainer columnCount="1" groupBox="0" name="Issues" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+          <attributeEditorField index="6" name="disease" showLabel="1"></attributeEditorField>
+          <attributeEditorContainer columnCount="1" groupBox="1" name="" showLabel="0" visibilityExpression="disease in ('t', true, 1)" visibilityExpressionEnabled="1">
+            <attributeEditorField index="7" name="kind_of_disease" showLabel="1"></attributeEditorField>
           </attributeEditorContainer>
         </attributeEditorContainer>
-        <attributeEditorContainer name="Review" visibilityExpressionEnabled="0" groupBox="0" showLabel="1" columnCount="1" visibilityExpression="">
-          <attributeEditorRelation showUnlinkButton="1" name="Reviews_c8_apiary_id_apiary_279_fid" showLabel="1" showLinkButton="1" relation="Reviews_c8_apiary_id_apiary_279_fid"/>
+        <attributeEditorContainer columnCount="1" groupBox="0" name="Review" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+          <attributeEditorRelation name="Reviews_c8_apiary_id_apiary_279_fid" relation="Reviews_c8_apiary_id_apiary_279_fid" showLabel="1" showLinkButton="1" showSaveChildEditsButton="1" showUnlinkButton="1"></attributeEditorRelation>
         </attributeEditorContainer>
-        <attributeEditorContainer name="Consumption" visibilityExpressionEnabled="0" groupBox="0" showLabel="1" columnCount="1" visibilityExpression="">
-          <attributeEditorRelation showUnlinkButton="1" name="Pollen_Con_apiary_id_apiary_279_fid" showLabel="1" showLinkButton="1" relation="Pollen_Con_apiary_id_apiary_279_fid"/>
+        <attributeEditorContainer columnCount="1" groupBox="0" name="Consumption" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+          <attributeEditorRelation name="Pollen_Con_apiary_id_apiary_279_fid" relation="Pollen_Con_apiary_id_apiary_279_fid" showLabel="1" showLinkButton="1" showSaveChildEditsButton="1" showUnlinkButton="1"></attributeEditorRelation>
         </attributeEditorContainer>
       </attributeEditorForm>
       <editable>
-        <field name="area_id" editable="1"/>
-        <field name="average_harvest" editable="1"/>
-        <field name="bee_amount" editable="1"/>
-        <field name="bee_species" editable="1"/>
-        <field name="beekeeper" editable="1"/>
-        <field name="disease" editable="1"/>
-        <field name="fid" editable="1"/>
-        <field name="id" editable="1"/>
-        <field name="kind_of_disease" editable="1"/>
-        <field name="nbr_of_boxes" editable="1"/>
-        <field name="picture" editable="1"/>
-        <field name="review_date" editable="1"/>
-        <field name="reviewer" editable="1"/>
+        <field editable="1" name="area_id"></field>
+        <field editable="1" name="average_harvest"></field>
+        <field editable="1" name="bee_amount"></field>
+        <field editable="1" name="bee_species"></field>
+        <field editable="1" name="beekeeper"></field>
+        <field editable="1" name="disease"></field>
+        <field editable="1" name="fid"></field>
+        <field editable="1" name="id"></field>
+        <field editable="1" name="kind_of_disease"></field>
+        <field editable="1" name="nbr_of_boxes"></field>
+        <field editable="1" name="picture"></field>
+        <field editable="1" name="review_date"></field>
+        <field editable="1" name="reviewer"></field>
       </editable>
       <labelOnTop>
-        <field labelOnTop="0" name="area_id"/>
-        <field labelOnTop="0" name="average_harvest"/>
-        <field labelOnTop="0" name="bee_amount"/>
-        <field labelOnTop="0" name="bee_species"/>
-        <field labelOnTop="0" name="beekeeper"/>
-        <field labelOnTop="0" name="disease"/>
-        <field labelOnTop="0" name="fid"/>
-        <field labelOnTop="0" name="id"/>
-        <field labelOnTop="0" name="kind_of_disease"/>
-        <field labelOnTop="0" name="nbr_of_boxes"/>
-        <field labelOnTop="0" name="picture"/>
-        <field labelOnTop="0" name="review_date"/>
-        <field labelOnTop="0" name="reviewer"/>
+        <field labelOnTop="0" name="area_id"></field>
+        <field labelOnTop="0" name="average_harvest"></field>
+        <field labelOnTop="0" name="bee_amount"></field>
+        <field labelOnTop="0" name="bee_species"></field>
+        <field labelOnTop="0" name="beekeeper"></field>
+        <field labelOnTop="0" name="disease"></field>
+        <field labelOnTop="0" name="fid"></field>
+        <field labelOnTop="0" name="id"></field>
+        <field labelOnTop="0" name="kind_of_disease"></field>
+        <field labelOnTop="0" name="nbr_of_boxes"></field>
+        <field labelOnTop="0" name="picture"></field>
+        <field labelOnTop="0" name="review_date"></field>
+        <field labelOnTop="0" name="reviewer"></field>
       </labelOnTop>
       <widgets>
         <widget name="Pollen_Con_apiary_id_apiary_279_fid">
           <config type="Map">
-            <Option type="QString" name="nm-rel" value=""/>
+            <Option name="force-suppress-popup" type="bool" value="false"></Option>
+            <Option name="nm-rel" type="QString" value=""></Option>
           </config>
         </widget>
         <widget name="Reviews_c8_apiary_id_apiary_279_fid">
           <config type="Map">
-            <Option type="QString" name="nm-rel" value=""/>
+            <Option name="force-suppress-popup" type="bool" value="false"></Option>
+            <Option name="nm-rel" type="QString" value=""></Option>
           </config>
         </widget>
         <widget name="ref_apiary_apiary_id_apiary2018_id">
-          <config/>
+          <config></config>
         </widget>
       </widgets>
       <previewExpression>concat( "beekeeper",  ' - ' ||  represent_value( "bee_species" ) )</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer styleCategories="AllStyleCategories" autoRefreshEnabled="0" autoRefreshTime="0" geometry="Polygon" refreshOnNotifyMessage="" simplifyAlgorithm="0" wkbType="MultiPolygon" refreshOnNotifyEnabled="0" simplifyDrawingHints="1" minScale="10001" readOnly="1" type="vector" simplifyMaxScale="1" maxScale="1000" simplifyLocal="1" simplifyDrawingTol="1" labelsEnabled="1" hasScaleBasedVisibilityFlag="1">
+    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" geometry="Polygon" hasScaleBasedVisibilityFlag="1" labelsEnabled="1" maxScale="1000" minScale="10001" readOnly="1" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" type="vector" wkbType="MultiPolygon">
       <extent>
-        <xmin>1026380</xmin>
-        <ymin>5907620</ymin>
-        <xmax>1036740</xmax>
-        <ymax>5916960</ymax>
+        <xmin>1026381.1875</xmin>
+        <ymin>5907615.5</ymin>
+        <xmax>1036736.625</xmax>
+        <ymax>5916963</ymax>
       </extent>
       <id>buildings_3bd3a9b3_9f70_44bd_9390_807f598c2835</id>
       <datasource>./basemaps/laax.gpkg|layername=buildings</datasource>
@@ -2352,13 +2479,14 @@ def my_form_open(dialog, layer, feature):
       <layername>buildings</layername>
       <srs>
         <spatialrefsys>
-          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+          <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
+          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
           <srsid>3857</srsid>
           <srid>3857</srid>
           <authid>EPSG:3857</authid>
           <description>WGS 84 / Pseudo-Mercator</description>
           <projectionacronym>merc</projectionacronym>
-          <ellipsoidacronym></ellipsoidacronym>
+          <ellipsoidacronym>WGS84</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -2378,11 +2506,12 @@ def my_form_open(dialog, layer, feature):
           <email></email>
           <role></role>
         </contact>
-        <links/>
+        <links></links>
         <fees></fees>
         <encoding></encoding>
         <crs>
           <spatialrefsys>
+            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -2390,11 +2519,11 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
+            <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial maxx="0" maxz="0" dimensions="2" minx="0" minz="0" crs="" maxy="0" miny="0"/>
+          <spatial crs="" dimensions="2" maxx="0" maxy="0" maxz="0" minx="0" miny="0" minz="0"></spatial>
           <temporal>
             <period>
               <start></start>
@@ -2404,112 +2533,112 @@ def my_form_open(dialog, layer, feature):
         </extent>
       </resourceMetadata>
       <provider encoding="UTF-8">ogr</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <legend type="default-vector"/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <legend type="default-vector"></legend>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"/>
+        <map-layer-style name="default"></map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
+      <auxiliaryLayer></auxiliaryLayer>
       <flags>
         <Identifiable>0</Identifiable>
         <Removable>1</Removable>
         <Searchable>0</Searchable>
       </flags>
-      <renderer-v2 enableorderby="0" type="RuleRenderer" symbollevels="0" forceraster="0">
+      <renderer-v2 enableorderby="0" forceraster="0" symbollevels="0" type="RuleRenderer">
         <rules key="{97f0d72b-7526-4e4a-9590-ba6aeff295a0}">
-          <rule key="{15f12a17-dfc1-4645-a12b-2be6fa855a59}" symbol="0" label="Building"/>
-          <rule key="{189e90f8-0122-4134-bee7-5626c6b44f9c}" symbol="1" scalemaxdenom="5000" label="Shadow 1"/>
-          <rule key="{b93d2b01-7223-4d7e-bb6e-9c485384c85b}" symbol="2" scalemaxdenom="5000" label="Shadow 2"/>
-          <rule key="{28cb84eb-40ca-41b5-8932-96d9050f1218}" symbol="3" scalemaxdenom="5000" label="Shadow 3"/>
+          <rule key="{15f12a17-dfc1-4645-a12b-2be6fa855a59}" label="Building" symbol="0"></rule>
+          <rule key="{189e90f8-0122-4134-bee7-5626c6b44f9c}" label="Shadow 1" scalemaxdenom="5000" symbol="1"></rule>
+          <rule key="{b93d2b01-7223-4d7e-bb6e-9c485384c85b}" label="Shadow 2" scalemaxdenom="5000" symbol="2"></rule>
+          <rule key="{28cb84eb-40ca-41b5-8932-96d9050f1218}" label="Shadow 3" scalemaxdenom="5000" symbol="3"></rule>
         </rules>
         <symbols>
-          <symbol type="fill" alpha="1" clip_to_extent="1" force_rhr="0" name="0">
-            <layer enabled="1" locked="0" class="SimpleFill" pass="3">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="230,222,211,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="213,206,197,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.2" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="0" type="fill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="3">
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="color" v="230,222,211,255"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="offset" v="0,0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="outline_color" v="213,206,197,255"></prop>
+              <prop k="outline_style" v="solid"></prop>
+              <prop k="outline_width" v="0.2"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
+              <prop k="style" v="solid"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol type="fill" alpha="1" clip_to_extent="1" force_rhr="0" name="1">
-            <layer enabled="1" locked="0" class="SimpleFill" pass="2">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="194,189,181,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0.5,0.5" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MapUnit" k="offset_unit"/>
-              <prop v="0,0,0,255" k="outline_color"/>
-              <prop v="no" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="1" type="fill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="2">
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="color" v="194,189,181,255"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="offset" v="0.5,0.5"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MapUnit"></prop>
+              <prop k="outline_color" v="0,0,0,255"></prop>
+              <prop k="outline_style" v="no"></prop>
+              <prop k="outline_width" v="0.26"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
+              <prop k="style" v="solid"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol type="fill" alpha="0.741176" clip_to_extent="1" force_rhr="0" name="2">
-            <layer enabled="1" locked="0" class="SimpleFill" pass="1">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="194,189,181,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="2,2" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MapUnit" k="offset_unit"/>
-              <prop v="0,0,0,255" k="outline_color"/>
-              <prop v="no" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+          <symbol alpha="0.741176" clip_to_extent="1" force_rhr="0" name="2" type="fill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="1">
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="color" v="194,189,181,255"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="offset" v="2,2"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MapUnit"></prop>
+              <prop k="outline_color" v="0,0,0,255"></prop>
+              <prop k="outline_style" v="no"></prop>
+              <prop k="outline_width" v="0.26"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
+              <prop k="style" v="solid"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol type="fill" alpha="0.494118" clip_to_extent="1" force_rhr="0" name="3">
-            <layer enabled="1" locked="0" class="SimpleFill" pass="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="194,189,181,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="3.5,3.5" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MapUnit" k="offset_unit"/>
-              <prop v="0,0,0,255" k="outline_color"/>
-              <prop v="no" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+          <symbol alpha="0.494118" clip_to_extent="1" force_rhr="0" name="3" type="fill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="color" v="194,189,181,255"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="offset" v="3.5,3.5"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MapUnit"></prop>
+              <prop k="outline_color" v="0,0,0,255"></prop>
+              <prop k="outline_style" v="no"></prop>
+              <prop k="outline_width" v="0.26"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
+              <prop k="style" v="solid"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -2518,87 +2647,120 @@ def my_form_open(dialog, layer, feature):
       </renderer-v2>
       <labeling type="simple">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fieldName="name" fontLetterSpacing="0" blendMode="0" fontSize="8.5" fontItalic="0" fontStrikeout="0" fontWordSpacing="0" isExpression="0" fontKerning="1" useSubstitutions="0" multilineHeight="1" namedStyle="Regular" fontCapitals="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontFamily="Sans Serif" textColor="98,98,98,255" fontSizeUnit="MapUnit" fontUnderline="0" textOrientation="horizontal">
-            <text-buffer bufferNoFill="0" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="0.6" bufferBlendMode="0" bufferSizeUnits="MM" bufferJoinStyle="128" bufferDraw="1" bufferColor="255,255,255,255" bufferOpacity="0.7"/>
-            <background shapeOffsetUnit="MM" shapeBorderWidthUnit="MM" shapeOffsetY="0" shapeBorderWidth="0" shapeType="0" shapeRadiiX="0" shapeDraw="0" shapeBlendMode="0" shapeOpacity="1" shapeFillColor="255,255,255,255" shapeRotationType="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRotation="0" shapeRadiiY="0" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255" shapeJoinStyle="64" shapeSizeUnit="MM" shapeSizeType="0" shapeSVGFile="" shapeSizeY="0" shapeSizeX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-            <shadow shadowRadiusUnit="MM" shadowOffsetUnit="MM" shadowOpacity="0.7" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowUnder="0" shadowOffsetDist="1" shadowColor="0,0,0,255" shadowScale="100" shadowOffsetAngle="135" shadowOffsetGlobal="1" shadowDraw="0" shadowRadius="1.5" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowBlendMode="6"/>
+          <text-style blendMode="0" fieldName="name" fontCapitals="0" fontFamily="Sans Serif" fontItalic="0" fontKerning="1" fontLetterSpacing="0" fontSize="8.5" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="MapUnit" fontStrikeout="0" fontUnderline="0" fontWeight="50" fontWordSpacing="0" isExpression="0" multilineHeight="1" namedStyle="Regular" previewBkgrdColor="255,255,255,255" textColor="98,98,98,255" textOpacity="1" textOrientation="horizontal" useSubstitutions="0">
+            <text-buffer bufferBlendMode="0" bufferColor="255,255,255,255" bufferDraw="1" bufferJoinStyle="128" bufferNoFill="0" bufferOpacity="0.7" bufferSize="0.6" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM"></text-buffer>
+            <text-mask maskEnabled="0" maskJoinStyle="128" maskOpacity="1" maskSize="0" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSizeUnits="MM" maskType="0" maskedSymbolLayers=""></text-mask>
+            <background shapeBlendMode="0" shapeBorderColor="128,128,128,255" shapeBorderWidth="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeDraw="0" shapeFillColor="255,255,255,255" shapeJoinStyle="64" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeOffsetY="0" shapeOpacity="1" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiUnit="MM" shapeRadiiX="0" shapeRadiiY="0" shapeRotation="0" shapeRotationType="0" shapeSVGFile="" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeSizeUnit="MM" shapeSizeX="0" shapeSizeY="0" shapeType="0"></background>
+            <shadow shadowBlendMode="6" shadowColor="0,0,0,255" shadowDraw="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowOpacity="0.7" shadowRadius="1.5" shadowRadiusAlphaOnly="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowUnder="0"></shadow>
             <dd_properties>
               <Option type="Map">
-                <Option type="QString" name="name" value=""/>
-                <Option name="properties"/>
-                <Option type="QString" name="type" value="collection"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </dd_properties>
-            <substitutions/>
+            <substitutions></substitutions>
           </text-style>
-          <text-format leftDirectionSymbol="&lt;" useMaxLineLengthForAutoWrap="1" formatNumbers="0" decimals="3" rightDirectionSymbol=">" placeDirectionSymbol="0" reverseDirectionSymbol="0" plussign="0" wrapChar=" " multilineAlign="1" addDirectionSymbol="0" autoWrapLength="0"/>
-          <placement quadOffset="4" repeatDistance="0" centroidInside="0" maxCurvedCharAngleOut="-20" centroidWhole="0" rotationAngle="0" priority="0" repeatDistanceUnits="MM" xOffset="0" placement="1" offsetType="0" geometryGeneratorType="PointGeometry" placementFlags="0" distMapUnitScale="3x:0,0,0,0,0,0" geometryGenerator="" dist="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" fitInPolygonOnly="0" maxCurvedCharAngleIn="20" overrunDistanceUnit="MM" geometryGeneratorEnabled="0" yOffset="0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" overrunDistance="0" offsetUnits="MM" preserveRotation="1" distUnits="MM" layerType="UnknownGeometry"/>
-          <rendering fontLimitPixelSize="0" obstacleType="0" labelPerPart="0" upsidedownLabels="0" obstacleFactor="1" obstacle="1" limitNumLabels="0" fontMaxPixelSize="10000" scaleMin="1" zIndex="0" minFeatureSize="8" displayAll="0" maxNumLabels="500" scaleVisibility="1" fontMinPixelSize="3" drawLabels="1" scaleMax="5000" mergeLines="0"/>
+          <text-format addDirectionSymbol="0" autoWrapLength="0" decimals="3" formatNumbers="0" leftDirectionSymbol="&lt;" multilineAlign="1" placeDirectionSymbol="0" plussign="0" reverseDirectionSymbol="0" rightDirectionSymbol=">" useMaxLineLengthForAutoWrap="1" wrapChar=" "></text-format>
+          <placement centroidInside="0" centroidWhole="0" dist="0" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" fitInPolygonOnly="0" geometryGenerator="" geometryGeneratorEnabled="0" geometryGeneratorType="PointGeometry" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" layerType="UnknownGeometry" maxCurvedCharAngleIn="20" maxCurvedCharAngleOut="-20" offsetType="0" offsetUnits="MM" overrunDistance="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" placement="1" placementFlags="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" preserveRotation="1" priority="0" quadOffset="4" repeatDistance="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" rotationAngle="0" xOffset="0" yOffset="0"></placement>
+          <rendering displayAll="0" drawLabels="1" fontLimitPixelSize="0" fontMaxPixelSize="10000" fontMinPixelSize="3" labelPerPart="0" limitNumLabels="0" maxNumLabels="500" mergeLines="0" minFeatureSize="8" obstacle="1" obstacleFactor="1" obstacleType="0" scaleMax="5000" scaleMin="1" scaleVisibility="1" upsidedownLabels="0" zIndex="0"></rendering>
           <dd_properties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
-              <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option type="QString" name="anchorPoint" value="pole_of_inaccessibility"/>
-              <Option type="Map" name="ddProperties">
-                <Option type="QString" name="name" value=""/>
-                <Option name="properties"/>
-                <Option type="QString" name="type" value="collection"/>
+              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility"></Option>
+              <Option name="ddProperties" type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
-              <Option type="bool" name="drawToAllParts" value="false"/>
-              <Option type="QString" name="enabled" value="0"/>
-              <Option type="QString" name="lineSymbol" value="&lt;symbol type=&quot;line&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; force_rhr=&quot;0&quot; name=&quot;symbol&quot;>&lt;layer enabled=&quot;1&quot; locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot;>&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/>&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/>&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/>&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/>&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/>&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/>&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; name=&quot;name&quot; value=&quot;&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;type&quot; value=&quot;collection&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>"/>
-              <Option type="double" name="minLength" value="0"/>
-              <Option type="QString" name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0"/>
-              <Option type="QString" name="minLengthUnit" value="MM"/>
-              <Option type="double" name="offsetFromAnchor" value="0"/>
-              <Option type="QString" name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0"/>
-              <Option type="QString" name="offsetFromAnchorUnit" value="MM"/>
-              <Option type="double" name="offsetFromLabel" value="0"/>
-              <Option type="QString" name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0"/>
-              <Option type="QString" name="offsetFromLabelUnit" value="MM"/>
+              <Option name="drawToAllParts" type="bool" value="false"></Option>
+              <Option name="enabled" type="QString" value="0"></Option>
+              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior"></Option>
+              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; type=&quot;line&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; force_rhr=&quot;0&quot;>&lt;layer enabled=&quot;1&quot; pass=&quot;0&quot; locked=&quot;0&quot; class=&quot;SimpleLine&quot;>&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/>&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/>&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/>&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/>&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/>&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/>&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>"></Option>
+              <Option name="minLength" type="double" value="0"></Option>
+              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="minLengthUnit" type="QString" value="MM"></Option>
+              <Option name="offsetFromAnchor" type="double" value="0"></Option>
+              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="offsetFromAnchorUnit" type="QString" value="MM"></Option>
+              <Option name="offsetFromLabel" type="double" value="0"></Option>
+              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="offsetFromLabelUnit" type="QString" value="MM"></Option>
             </Option>
           </callout>
         </settings>
       </labeling>
       <customproperties>
-        <property key="embeddedWidgets/count" value="0"/>
-        <property key="variableNames"/>
-        <property key="variableValues"/>
+        <property key="embeddedWidgets/count" value="0"></property>
+        <property key="variableNames"></property>
+        <property key="variableValues"></property>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
-        <DiagramCategory labelPlacementMethod="XHeight" minScaleDenominator="1000" penAlpha="255" diagramOrientation="Up" penColor="#000000" scaleBasedVisibility="0" rotationOffset="270" maxScaleDenominator="1e+08" sizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" barWidth="5" backgroundColor="#ffffff" width="15" scaleDependency="Area" minimumSize="0" lineSizeScale="3x:0,0,0,0,0,0" sizeType="MM" backgroundAlpha="255" height="15" enabled="0" penWidth="0" opacity="1">
-          <fontProperties style="" description="Cantarell,11,-1,5,50,0,0,0,0,0"/>
-          <attribute color="#000000" field="" label=""/>
+      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="1" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+8" minScaleDenominator="1000" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" showAxis="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="0" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
+          <fontProperties description="Cantarell,11,-1,5,50,0,0,0,0,0" style=""></fontProperties>
+          <attribute color="#000000" field="" label=""></attribute>
+          <axisSymbol>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" type="line">
+              <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+                <prop k="capstyle" v="square"></prop>
+                <prop k="customdash" v="5;2"></prop>
+                <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="customdash_unit" v="MM"></prop>
+                <prop k="draw_inside_polygon" v="0"></prop>
+                <prop k="joinstyle" v="bevel"></prop>
+                <prop k="line_color" v="35,35,35,255"></prop>
+                <prop k="line_style" v="solid"></prop>
+                <prop k="line_width" v="0.26"></prop>
+                <prop k="line_width_unit" v="MM"></prop>
+                <prop k="offset" v="0"></prop>
+                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="offset_unit" v="MM"></prop>
+                <prop k="ring_filter" v="0"></prop>
+                <prop k="use_custom_dash" v="0"></prop>
+                <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings linePlacementFlags="18" dist="0" priority="0" zIndex="0" placement="1" obstacle="0" showAll="1">
+      <DiagramLayerSettings dist="0" linePlacementFlags="18" obstacle="0" placement="1" priority="0" showAll="1" zIndex="0">
         <properties>
           <Option type="Map">
-            <Option type="QString" name="name" value=""/>
-            <Option name="properties"/>
-            <Option type="QString" name="type" value="collection"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </properties>
       </DiagramLayerSettings>
       <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-        <activeChecks/>
-        <checkConfiguration/>
+        <activeChecks></activeChecks>
+        <checkConfiguration></checkConfiguration>
       </geometryOptions>
+      <referencedLayers></referencedLayers>
+      <referencingLayers></referencingLayers>
       <fieldConfiguration>
         <field name="fid">
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2607,8 +2769,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2617,8 +2779,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2627,8 +2789,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2637,8 +2799,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2647,8 +2809,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2657,8 +2819,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2667,8 +2829,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2677,8 +2839,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2687,8 +2849,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2697,8 +2859,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2707,8 +2869,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2717,8 +2879,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2727,8 +2889,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2737,8 +2899,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2747,8 +2909,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2757,8 +2919,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2767,8 +2929,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2777,8 +2939,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2787,8 +2949,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2797,8 +2959,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2807,8 +2969,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2817,8 +2979,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2827,8 +2989,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2837,8 +2999,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2847,8 +3009,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2857,177 +3019,177 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" field="fid" index="0"/>
-        <alias name="" field="osm_id" index="1"/>
-        <alias name="" field="osm_way_id" index="2"/>
-        <alias name="" field="name" index="3"/>
-        <alias name="" field="type" index="4"/>
-        <alias name="" field="aeroway" index="5"/>
-        <alias name="" field="amenity" index="6"/>
-        <alias name="" field="admin_level" index="7"/>
-        <alias name="" field="barrier" index="8"/>
-        <alias name="" field="boundary" index="9"/>
-        <alias name="" field="building" index="10"/>
-        <alias name="" field="craft" index="11"/>
-        <alias name="" field="geological" index="12"/>
-        <alias name="" field="historic" index="13"/>
-        <alias name="" field="land_area" index="14"/>
-        <alias name="" field="landuse" index="15"/>
-        <alias name="" field="leisure" index="16"/>
-        <alias name="" field="man_made" index="17"/>
-        <alias name="" field="military" index="18"/>
-        <alias name="" field="natural" index="19"/>
-        <alias name="" field="office" index="20"/>
-        <alias name="" field="place" index="21"/>
-        <alias name="" field="shop" index="22"/>
-        <alias name="" field="sport" index="23"/>
-        <alias name="" field="tourism" index="24"/>
-        <alias name="" field="other_tags" index="25"/>
-        <alias name="" field="orig_ogc_fid" index="26"/>
+        <alias field="fid" index="0" name=""></alias>
+        <alias field="osm_id" index="1" name=""></alias>
+        <alias field="osm_way_id" index="2" name=""></alias>
+        <alias field="name" index="3" name=""></alias>
+        <alias field="type" index="4" name=""></alias>
+        <alias field="aeroway" index="5" name=""></alias>
+        <alias field="amenity" index="6" name=""></alias>
+        <alias field="admin_level" index="7" name=""></alias>
+        <alias field="barrier" index="8" name=""></alias>
+        <alias field="boundary" index="9" name=""></alias>
+        <alias field="building" index="10" name=""></alias>
+        <alias field="craft" index="11" name=""></alias>
+        <alias field="geological" index="12" name=""></alias>
+        <alias field="historic" index="13" name=""></alias>
+        <alias field="land_area" index="14" name=""></alias>
+        <alias field="landuse" index="15" name=""></alias>
+        <alias field="leisure" index="16" name=""></alias>
+        <alias field="man_made" index="17" name=""></alias>
+        <alias field="military" index="18" name=""></alias>
+        <alias field="natural" index="19" name=""></alias>
+        <alias field="office" index="20" name=""></alias>
+        <alias field="place" index="21" name=""></alias>
+        <alias field="shop" index="22" name=""></alias>
+        <alias field="sport" index="23" name=""></alias>
+        <alias field="tourism" index="24" name=""></alias>
+        <alias field="other_tags" index="25" name=""></alias>
+        <alias field="orig_ogc_fid" index="26" name=""></alias>
       </aliases>
-      <excludeAttributesWMS/>
-      <excludeAttributesWFS/>
+      <excludeAttributesWMS></excludeAttributesWMS>
+      <excludeAttributesWFS></excludeAttributesWFS>
       <defaults>
-        <default applyOnUpdate="0" field="fid" expression=""/>
-        <default applyOnUpdate="0" field="osm_id" expression=""/>
-        <default applyOnUpdate="0" field="osm_way_id" expression=""/>
-        <default applyOnUpdate="0" field="name" expression=""/>
-        <default applyOnUpdate="0" field="type" expression=""/>
-        <default applyOnUpdate="0" field="aeroway" expression=""/>
-        <default applyOnUpdate="0" field="amenity" expression=""/>
-        <default applyOnUpdate="0" field="admin_level" expression=""/>
-        <default applyOnUpdate="0" field="barrier" expression=""/>
-        <default applyOnUpdate="0" field="boundary" expression=""/>
-        <default applyOnUpdate="0" field="building" expression=""/>
-        <default applyOnUpdate="0" field="craft" expression=""/>
-        <default applyOnUpdate="0" field="geological" expression=""/>
-        <default applyOnUpdate="0" field="historic" expression=""/>
-        <default applyOnUpdate="0" field="land_area" expression=""/>
-        <default applyOnUpdate="0" field="landuse" expression=""/>
-        <default applyOnUpdate="0" field="leisure" expression=""/>
-        <default applyOnUpdate="0" field="man_made" expression=""/>
-        <default applyOnUpdate="0" field="military" expression=""/>
-        <default applyOnUpdate="0" field="natural" expression=""/>
-        <default applyOnUpdate="0" field="office" expression=""/>
-        <default applyOnUpdate="0" field="place" expression=""/>
-        <default applyOnUpdate="0" field="shop" expression=""/>
-        <default applyOnUpdate="0" field="sport" expression=""/>
-        <default applyOnUpdate="0" field="tourism" expression=""/>
-        <default applyOnUpdate="0" field="other_tags" expression=""/>
-        <default applyOnUpdate="0" field="orig_ogc_fid" expression=""/>
+        <default applyOnUpdate="0" expression="" field="fid"></default>
+        <default applyOnUpdate="0" expression="" field="osm_id"></default>
+        <default applyOnUpdate="0" expression="" field="osm_way_id"></default>
+        <default applyOnUpdate="0" expression="" field="name"></default>
+        <default applyOnUpdate="0" expression="" field="type"></default>
+        <default applyOnUpdate="0" expression="" field="aeroway"></default>
+        <default applyOnUpdate="0" expression="" field="amenity"></default>
+        <default applyOnUpdate="0" expression="" field="admin_level"></default>
+        <default applyOnUpdate="0" expression="" field="barrier"></default>
+        <default applyOnUpdate="0" expression="" field="boundary"></default>
+        <default applyOnUpdate="0" expression="" field="building"></default>
+        <default applyOnUpdate="0" expression="" field="craft"></default>
+        <default applyOnUpdate="0" expression="" field="geological"></default>
+        <default applyOnUpdate="0" expression="" field="historic"></default>
+        <default applyOnUpdate="0" expression="" field="land_area"></default>
+        <default applyOnUpdate="0" expression="" field="landuse"></default>
+        <default applyOnUpdate="0" expression="" field="leisure"></default>
+        <default applyOnUpdate="0" expression="" field="man_made"></default>
+        <default applyOnUpdate="0" expression="" field="military"></default>
+        <default applyOnUpdate="0" expression="" field="natural"></default>
+        <default applyOnUpdate="0" expression="" field="office"></default>
+        <default applyOnUpdate="0" expression="" field="place"></default>
+        <default applyOnUpdate="0" expression="" field="shop"></default>
+        <default applyOnUpdate="0" expression="" field="sport"></default>
+        <default applyOnUpdate="0" expression="" field="tourism"></default>
+        <default applyOnUpdate="0" expression="" field="other_tags"></default>
+        <default applyOnUpdate="0" expression="" field="orig_ogc_fid"></default>
       </defaults>
       <constraints>
-        <constraint notnull_strength="1" constraints="3" field="fid" unique_strength="1" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="osm_id" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="osm_way_id" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="name" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="type" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="aeroway" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="amenity" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="admin_level" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="barrier" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="boundary" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="building" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="craft" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="geological" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="historic" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="land_area" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="landuse" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="leisure" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="man_made" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="military" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="natural" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="office" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="place" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="shop" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="sport" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="tourism" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="other_tags" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="orig_ogc_fid" unique_strength="0" exp_strength="0"/>
+        <constraint constraints="3" exp_strength="0" field="fid" notnull_strength="1" unique_strength="1"></constraint>
+        <constraint constraints="0" exp_strength="0" field="osm_id" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="osm_way_id" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="name" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="type" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="aeroway" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="amenity" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="admin_level" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="barrier" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="boundary" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="building" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="craft" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="geological" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="historic" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="land_area" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="landuse" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="leisure" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="man_made" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="military" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="natural" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="office" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="place" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="shop" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="sport" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="tourism" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="other_tags" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="orig_ogc_fid" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint field="fid" desc="" exp=""/>
-        <constraint field="osm_id" desc="" exp=""/>
-        <constraint field="osm_way_id" desc="" exp=""/>
-        <constraint field="name" desc="" exp=""/>
-        <constraint field="type" desc="" exp=""/>
-        <constraint field="aeroway" desc="" exp=""/>
-        <constraint field="amenity" desc="" exp=""/>
-        <constraint field="admin_level" desc="" exp=""/>
-        <constraint field="barrier" desc="" exp=""/>
-        <constraint field="boundary" desc="" exp=""/>
-        <constraint field="building" desc="" exp=""/>
-        <constraint field="craft" desc="" exp=""/>
-        <constraint field="geological" desc="" exp=""/>
-        <constraint field="historic" desc="" exp=""/>
-        <constraint field="land_area" desc="" exp=""/>
-        <constraint field="landuse" desc="" exp=""/>
-        <constraint field="leisure" desc="" exp=""/>
-        <constraint field="man_made" desc="" exp=""/>
-        <constraint field="military" desc="" exp=""/>
-        <constraint field="natural" desc="" exp=""/>
-        <constraint field="office" desc="" exp=""/>
-        <constraint field="place" desc="" exp=""/>
-        <constraint field="shop" desc="" exp=""/>
-        <constraint field="sport" desc="" exp=""/>
-        <constraint field="tourism" desc="" exp=""/>
-        <constraint field="other_tags" desc="" exp=""/>
-        <constraint field="orig_ogc_fid" desc="" exp=""/>
+        <constraint desc="" exp="" field="fid"></constraint>
+        <constraint desc="" exp="" field="osm_id"></constraint>
+        <constraint desc="" exp="" field="osm_way_id"></constraint>
+        <constraint desc="" exp="" field="name"></constraint>
+        <constraint desc="" exp="" field="type"></constraint>
+        <constraint desc="" exp="" field="aeroway"></constraint>
+        <constraint desc="" exp="" field="amenity"></constraint>
+        <constraint desc="" exp="" field="admin_level"></constraint>
+        <constraint desc="" exp="" field="barrier"></constraint>
+        <constraint desc="" exp="" field="boundary"></constraint>
+        <constraint desc="" exp="" field="building"></constraint>
+        <constraint desc="" exp="" field="craft"></constraint>
+        <constraint desc="" exp="" field="geological"></constraint>
+        <constraint desc="" exp="" field="historic"></constraint>
+        <constraint desc="" exp="" field="land_area"></constraint>
+        <constraint desc="" exp="" field="landuse"></constraint>
+        <constraint desc="" exp="" field="leisure"></constraint>
+        <constraint desc="" exp="" field="man_made"></constraint>
+        <constraint desc="" exp="" field="military"></constraint>
+        <constraint desc="" exp="" field="natural"></constraint>
+        <constraint desc="" exp="" field="office"></constraint>
+        <constraint desc="" exp="" field="place"></constraint>
+        <constraint desc="" exp="" field="shop"></constraint>
+        <constraint desc="" exp="" field="sport"></constraint>
+        <constraint desc="" exp="" field="tourism"></constraint>
+        <constraint desc="" exp="" field="other_tags"></constraint>
+        <constraint desc="" exp="" field="orig_ogc_fid"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
       </attributeactions>
-      <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column type="field" name="osm_id" width="-1" hidden="0"/>
-          <column type="field" name="name" width="-1" hidden="0"/>
-          <column type="field" name="type" width="-1" hidden="0"/>
-          <column type="actions" width="-1" hidden="1"/>
-          <column type="field" name="fid" width="-1" hidden="0"/>
-          <column type="field" name="osm_way_id" width="-1" hidden="0"/>
-          <column type="field" name="aeroway" width="-1" hidden="0"/>
-          <column type="field" name="amenity" width="-1" hidden="0"/>
-          <column type="field" name="admin_level" width="-1" hidden="0"/>
-          <column type="field" name="barrier" width="-1" hidden="0"/>
-          <column type="field" name="boundary" width="-1" hidden="0"/>
-          <column type="field" name="building" width="-1" hidden="0"/>
-          <column type="field" name="craft" width="-1" hidden="0"/>
-          <column type="field" name="geological" width="-1" hidden="0"/>
-          <column type="field" name="historic" width="-1" hidden="0"/>
-          <column type="field" name="land_area" width="-1" hidden="0"/>
-          <column type="field" name="landuse" width="-1" hidden="0"/>
-          <column type="field" name="leisure" width="-1" hidden="0"/>
-          <column type="field" name="man_made" width="-1" hidden="0"/>
-          <column type="field" name="military" width="-1" hidden="0"/>
-          <column type="field" name="natural" width="-1" hidden="0"/>
-          <column type="field" name="office" width="-1" hidden="0"/>
-          <column type="field" name="place" width="-1" hidden="0"/>
-          <column type="field" name="shop" width="-1" hidden="0"/>
-          <column type="field" name="sport" width="-1" hidden="0"/>
-          <column type="field" name="tourism" width="-1" hidden="0"/>
-          <column type="field" name="other_tags" width="-1" hidden="0"/>
-          <column type="field" name="orig_ogc_fid" width="-1" hidden="0"/>
+          <column hidden="0" name="osm_id" type="field" width="-1"></column>
+          <column hidden="0" name="name" type="field" width="-1"></column>
+          <column hidden="0" name="type" type="field" width="-1"></column>
+          <column hidden="1" type="actions" width="-1"></column>
+          <column hidden="0" name="fid" type="field" width="-1"></column>
+          <column hidden="0" name="osm_way_id" type="field" width="-1"></column>
+          <column hidden="0" name="aeroway" type="field" width="-1"></column>
+          <column hidden="0" name="amenity" type="field" width="-1"></column>
+          <column hidden="0" name="admin_level" type="field" width="-1"></column>
+          <column hidden="0" name="barrier" type="field" width="-1"></column>
+          <column hidden="0" name="boundary" type="field" width="-1"></column>
+          <column hidden="0" name="building" type="field" width="-1"></column>
+          <column hidden="0" name="craft" type="field" width="-1"></column>
+          <column hidden="0" name="geological" type="field" width="-1"></column>
+          <column hidden="0" name="historic" type="field" width="-1"></column>
+          <column hidden="0" name="land_area" type="field" width="-1"></column>
+          <column hidden="0" name="landuse" type="field" width="-1"></column>
+          <column hidden="0" name="leisure" type="field" width="-1"></column>
+          <column hidden="0" name="man_made" type="field" width="-1"></column>
+          <column hidden="0" name="military" type="field" width="-1"></column>
+          <column hidden="0" name="natural" type="field" width="-1"></column>
+          <column hidden="0" name="office" type="field" width="-1"></column>
+          <column hidden="0" name="place" type="field" width="-1"></column>
+          <column hidden="0" name="shop" type="field" width="-1"></column>
+          <column hidden="0" name="sport" type="field" width="-1"></column>
+          <column hidden="0" name="tourism" type="field" width="-1"></column>
+          <column hidden="0" name="other_tags" type="field" width="-1"></column>
+          <column hidden="0" name="orig_ogc_fid" type="field" width="-1"></column>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1"></editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath>/david/doc/teaching/QField_Workshop/citybees</editforminitfilepath>
-      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+      <editforminitcode># -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -3043,77 +3205,77 @@ from qgis.PyQt.QtWidgets import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-]]></editforminitcode>
+</editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <editable>
-        <field name="admin_level" editable="1"/>
-        <field name="aeroway" editable="1"/>
-        <field name="amenity" editable="1"/>
-        <field name="barrier" editable="1"/>
-        <field name="boundary" editable="1"/>
-        <field name="building" editable="1"/>
-        <field name="craft" editable="1"/>
-        <field name="fid" editable="1"/>
-        <field name="geological" editable="1"/>
-        <field name="historic" editable="1"/>
-        <field name="land_area" editable="1"/>
-        <field name="landuse" editable="1"/>
-        <field name="leisure" editable="1"/>
-        <field name="man_made" editable="1"/>
-        <field name="military" editable="1"/>
-        <field name="name" editable="1"/>
-        <field name="natural" editable="1"/>
-        <field name="office" editable="1"/>
-        <field name="orig_ogc_fid" editable="1"/>
-        <field name="osm_id" editable="1"/>
-        <field name="osm_way_id" editable="1"/>
-        <field name="other_tags" editable="1"/>
-        <field name="place" editable="1"/>
-        <field name="shop" editable="1"/>
-        <field name="sport" editable="1"/>
-        <field name="tourism" editable="1"/>
-        <field name="type" editable="1"/>
+        <field editable="1" name="admin_level"></field>
+        <field editable="1" name="aeroway"></field>
+        <field editable="1" name="amenity"></field>
+        <field editable="1" name="barrier"></field>
+        <field editable="1" name="boundary"></field>
+        <field editable="1" name="building"></field>
+        <field editable="1" name="craft"></field>
+        <field editable="1" name="fid"></field>
+        <field editable="1" name="geological"></field>
+        <field editable="1" name="historic"></field>
+        <field editable="1" name="land_area"></field>
+        <field editable="1" name="landuse"></field>
+        <field editable="1" name="leisure"></field>
+        <field editable="1" name="man_made"></field>
+        <field editable="1" name="military"></field>
+        <field editable="1" name="name"></field>
+        <field editable="1" name="natural"></field>
+        <field editable="1" name="office"></field>
+        <field editable="1" name="orig_ogc_fid"></field>
+        <field editable="1" name="osm_id"></field>
+        <field editable="1" name="osm_way_id"></field>
+        <field editable="1" name="other_tags"></field>
+        <field editable="1" name="place"></field>
+        <field editable="1" name="shop"></field>
+        <field editable="1" name="sport"></field>
+        <field editable="1" name="tourism"></field>
+        <field editable="1" name="type"></field>
       </editable>
       <labelOnTop>
-        <field labelOnTop="0" name="admin_level"/>
-        <field labelOnTop="0" name="aeroway"/>
-        <field labelOnTop="0" name="amenity"/>
-        <field labelOnTop="0" name="barrier"/>
-        <field labelOnTop="0" name="boundary"/>
-        <field labelOnTop="0" name="building"/>
-        <field labelOnTop="0" name="craft"/>
-        <field labelOnTop="0" name="fid"/>
-        <field labelOnTop="0" name="geological"/>
-        <field labelOnTop="0" name="historic"/>
-        <field labelOnTop="0" name="land_area"/>
-        <field labelOnTop="0" name="landuse"/>
-        <field labelOnTop="0" name="leisure"/>
-        <field labelOnTop="0" name="man_made"/>
-        <field labelOnTop="0" name="military"/>
-        <field labelOnTop="0" name="name"/>
-        <field labelOnTop="0" name="natural"/>
-        <field labelOnTop="0" name="office"/>
-        <field labelOnTop="0" name="orig_ogc_fid"/>
-        <field labelOnTop="0" name="osm_id"/>
-        <field labelOnTop="0" name="osm_way_id"/>
-        <field labelOnTop="0" name="other_tags"/>
-        <field labelOnTop="0" name="place"/>
-        <field labelOnTop="0" name="shop"/>
-        <field labelOnTop="0" name="sport"/>
-        <field labelOnTop="0" name="tourism"/>
-        <field labelOnTop="0" name="type"/>
+        <field labelOnTop="0" name="admin_level"></field>
+        <field labelOnTop="0" name="aeroway"></field>
+        <field labelOnTop="0" name="amenity"></field>
+        <field labelOnTop="0" name="barrier"></field>
+        <field labelOnTop="0" name="boundary"></field>
+        <field labelOnTop="0" name="building"></field>
+        <field labelOnTop="0" name="craft"></field>
+        <field labelOnTop="0" name="fid"></field>
+        <field labelOnTop="0" name="geological"></field>
+        <field labelOnTop="0" name="historic"></field>
+        <field labelOnTop="0" name="land_area"></field>
+        <field labelOnTop="0" name="landuse"></field>
+        <field labelOnTop="0" name="leisure"></field>
+        <field labelOnTop="0" name="man_made"></field>
+        <field labelOnTop="0" name="military"></field>
+        <field labelOnTop="0" name="name"></field>
+        <field labelOnTop="0" name="natural"></field>
+        <field labelOnTop="0" name="office"></field>
+        <field labelOnTop="0" name="orig_ogc_fid"></field>
+        <field labelOnTop="0" name="osm_id"></field>
+        <field labelOnTop="0" name="osm_way_id"></field>
+        <field labelOnTop="0" name="other_tags"></field>
+        <field labelOnTop="0" name="place"></field>
+        <field labelOnTop="0" name="shop"></field>
+        <field labelOnTop="0" name="sport"></field>
+        <field labelOnTop="0" name="tourism"></field>
+        <field labelOnTop="0" name="type"></field>
       </labelOnTop>
-      <widgets/>
+      <widgets></widgets>
       <previewExpression>name</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer styleCategories="AllStyleCategories" autoRefreshEnabled="0" autoRefreshTime="0" geometry="Polygon" refreshOnNotifyMessage="" simplifyAlgorithm="0" wkbType="MultiPolygon" refreshOnNotifyEnabled="0" simplifyDrawingHints="1" minScale="1e+08" readOnly="0" type="vector" simplifyMaxScale="1" maxScale="0" simplifyLocal="1" simplifyDrawingTol="1" labelsEnabled="1" hasScaleBasedVisibilityFlag="0">
+    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" geometry="Polygon" hasScaleBasedVisibilityFlag="0" labelsEnabled="1" maxScale="0" minScale="100000000" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" type="vector" wkbType="MultiPolygon">
       <extent>
         <xmin>-180</xmin>
         <ymin>-90</ymin>
-        <xmax>180</xmax>
-        <ymax>83.63410000000000366</ymax>
+        <xmax>180.0000152587890625</xmax>
+        <ymax>83.63410186767578125</ymax>
       </extent>
       <id>countries_a5e8d4da_f5b9_48ce_9909_c3760e271a9e</id>
       <datasource>./basemaps/countries.gpkg|layername=countries</datasource>
@@ -3123,6 +3285,7 @@ def my_form_open(dialog, layer, feature):
       <layername>Countries</layername>
       <srs>
         <spatialrefsys>
+          <wkt>GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]</wkt>
           <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
           <srsid>3452</srsid>
           <srid>4326</srid>
@@ -3149,11 +3312,12 @@ def my_form_open(dialog, layer, feature):
           <email></email>
           <role></role>
         </contact>
-        <links/>
+        <links></links>
         <fees></fees>
         <encoding></encoding>
         <crs>
           <spatialrefsys>
+            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -3161,11 +3325,11 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
+            <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial maxx="0" maxz="0" dimensions="2" minx="0" minz="0" crs="" maxy="0" miny="0"/>
+          <spatial crs="" dimensions="2" maxx="0" maxy="0" maxz="0" minx="0" miny="0" minz="0"></spatial>
           <temporal>
             <period>
               <start></start>
@@ -3175,948 +3339,981 @@ def my_form_open(dialog, layer, feature):
         </extent>
       </resourceMetadata>
       <provider encoding="UTF-8">ogr</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <legend type="default-vector"/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <legend type="default-vector"></legend>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"/>
+        <map-layer-style name="default"></map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
+      <auxiliaryLayer></auxiliaryLayer>
       <flags>
         <Identifiable>0</Identifiable>
         <Removable>1</Removable>
         <Searchable>0</Searchable>
       </flags>
-      <renderer-v2 enableorderby="0" type="singleSymbol" symbollevels="0" forceraster="0">
+      <renderer-v2 enableorderby="0" forceraster="0" symbollevels="0" type="singleSymbol">
         <symbols>
-          <symbol type="fill" alpha="1" clip_to_extent="1" force_rhr="0" name="0">
-            <layer enabled="1" locked="0" class="SimpleFill" pass="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="247,247,247,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="82,82,82,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="no" k="style"/>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="0" type="fill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="color" v="247,247,247,255"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="offset" v="0,0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="outline_color" v="82,82,82,255"></prop>
+              <prop k="outline_style" v="solid"></prop>
+              <prop k="outline_width" v="0.26"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
+              <prop k="style" v="no"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </symbols>
-        <rotation/>
-        <sizescale/>
+        <rotation></rotation>
+        <sizescale></sizescale>
       </renderer-v2>
       <labeling type="simple">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fieldName="NAME" fontLetterSpacing="0" blendMode="0" fontSize="10" fontItalic="0" fontStrikeout="0" fontWordSpacing="0" isExpression="0" fontKerning="1" useSubstitutions="0" multilineHeight="1" namedStyle="Regular" fontCapitals="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontFamily="Sans Serif" textColor="0,0,0,255" fontSizeUnit="Point" fontUnderline="0" textOrientation="horizontal">
-            <text-buffer bufferNoFill="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1" bufferBlendMode="0" bufferSizeUnits="MM" bufferJoinStyle="128" bufferDraw="0" bufferColor="255,255,255,255" bufferOpacity="1"/>
-            <background shapeOffsetUnit="MM" shapeBorderWidthUnit="MM" shapeOffsetY="0" shapeBorderWidth="0" shapeType="0" shapeRadiiX="0" shapeDraw="0" shapeBlendMode="0" shapeOpacity="1" shapeFillColor="255,255,255,255" shapeRotationType="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRotation="0" shapeRadiiY="0" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255" shapeJoinStyle="64" shapeSizeUnit="MM" shapeSizeType="0" shapeSVGFile="" shapeSizeY="0" shapeSizeX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-            <shadow shadowRadiusUnit="MM" shadowOffsetUnit="MM" shadowOpacity="0.7" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowUnder="0" shadowOffsetDist="1" shadowColor="0,0,0,255" shadowScale="100" shadowOffsetAngle="135" shadowOffsetGlobal="1" shadowDraw="0" shadowRadius="1.5" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowBlendMode="6"/>
+          <text-style blendMode="0" fieldName="NAME" fontCapitals="0" fontFamily="Sans Serif" fontItalic="0" fontKerning="1" fontLetterSpacing="0" fontSize="10" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontStrikeout="0" fontUnderline="0" fontWeight="50" fontWordSpacing="0" isExpression="0" multilineHeight="1" namedStyle="Regular" previewBkgrdColor="255,255,255,255" textColor="0,0,0,255" textOpacity="1" textOrientation="horizontal" useSubstitutions="0">
+            <text-buffer bufferBlendMode="0" bufferColor="255,255,255,255" bufferDraw="0" bufferJoinStyle="128" bufferNoFill="1" bufferOpacity="1" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM"></text-buffer>
+            <text-mask maskEnabled="0" maskJoinStyle="128" maskOpacity="1" maskSize="0" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSizeUnits="MM" maskType="0" maskedSymbolLayers=""></text-mask>
+            <background shapeBlendMode="0" shapeBorderColor="128,128,128,255" shapeBorderWidth="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeDraw="0" shapeFillColor="255,255,255,255" shapeJoinStyle="64" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeOffsetY="0" shapeOpacity="1" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiUnit="MM" shapeRadiiX="0" shapeRadiiY="0" shapeRotation="0" shapeRotationType="0" shapeSVGFile="" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeSizeUnit="MM" shapeSizeX="0" shapeSizeY="0" shapeType="0"></background>
+            <shadow shadowBlendMode="6" shadowColor="0,0,0,255" shadowDraw="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowOpacity="0.7" shadowRadius="1.5" shadowRadiusAlphaOnly="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowUnder="0"></shadow>
             <dd_properties>
               <Option type="Map">
-                <Option type="QString" name="name" value=""/>
-                <Option name="properties"/>
-                <Option type="QString" name="type" value="collection"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </dd_properties>
-            <substitutions/>
+            <substitutions></substitutions>
           </text-style>
-          <text-format leftDirectionSymbol="&lt;" useMaxLineLengthForAutoWrap="1" formatNumbers="0" decimals="3" rightDirectionSymbol=">" placeDirectionSymbol="0" reverseDirectionSymbol="0" plussign="0" wrapChar="" multilineAlign="4294967295" addDirectionSymbol="0" autoWrapLength="0"/>
-          <placement quadOffset="4" repeatDistance="0" centroidInside="1" maxCurvedCharAngleOut="-25" centroidWhole="0" rotationAngle="0" priority="5" repeatDistanceUnits="MM" xOffset="0" placement="0" offsetType="0" geometryGeneratorType="PointGeometry" placementFlags="10" distMapUnitScale="3x:0,0,0,0,0,0" geometryGenerator="" dist="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" fitInPolygonOnly="0" maxCurvedCharAngleIn="25" overrunDistanceUnit="MM" geometryGeneratorEnabled="0" yOffset="0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" overrunDistance="0" offsetUnits="MM" preserveRotation="1" distUnits="MM" layerType="UnknownGeometry"/>
-          <rendering fontLimitPixelSize="0" obstacleType="0" labelPerPart="0" upsidedownLabels="0" obstacleFactor="1" obstacle="1" limitNumLabels="0" fontMaxPixelSize="10000" scaleMin="0" zIndex="0" minFeatureSize="0" displayAll="0" maxNumLabels="2000" scaleVisibility="0" fontMinPixelSize="3" drawLabels="0" scaleMax="0" mergeLines="0"/>
+          <text-format addDirectionSymbol="0" autoWrapLength="0" decimals="3" formatNumbers="0" leftDirectionSymbol="&lt;" multilineAlign="4294967295" placeDirectionSymbol="0" plussign="0" reverseDirectionSymbol="0" rightDirectionSymbol=">" useMaxLineLengthForAutoWrap="1" wrapChar=""></text-format>
+          <placement centroidInside="1" centroidWhole="0" dist="0" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" fitInPolygonOnly="0" geometryGenerator="" geometryGeneratorEnabled="0" geometryGeneratorType="PointGeometry" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" layerType="UnknownGeometry" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" offsetType="0" offsetUnits="MM" overrunDistance="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" placement="0" placementFlags="10" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" preserveRotation="1" priority="5" quadOffset="4" repeatDistance="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" rotationAngle="0" xOffset="0" yOffset="0"></placement>
+          <rendering displayAll="0" drawLabels="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" fontMinPixelSize="3" labelPerPart="0" limitNumLabels="0" maxNumLabels="2000" mergeLines="0" minFeatureSize="0" obstacle="1" obstacleFactor="1" obstacleType="0" scaleMax="0" scaleMin="0" scaleVisibility="0" upsidedownLabels="0" zIndex="0"></rendering>
           <dd_properties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
-              <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option type="QString" name="anchorPoint" value="pole_of_inaccessibility"/>
-              <Option type="Map" name="ddProperties">
-                <Option type="QString" name="name" value=""/>
-                <Option name="properties"/>
-                <Option type="QString" name="type" value="collection"/>
+              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility"></Option>
+              <Option name="ddProperties" type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
-              <Option type="bool" name="drawToAllParts" value="false"/>
-              <Option type="QString" name="enabled" value="0"/>
-              <Option type="QString" name="lineSymbol" value="&lt;symbol type=&quot;line&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; force_rhr=&quot;0&quot; name=&quot;symbol&quot;>&lt;layer enabled=&quot;1&quot; locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot;>&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/>&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/>&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/>&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/>&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/>&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/>&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; name=&quot;name&quot; value=&quot;&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;type&quot; value=&quot;collection&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>"/>
-              <Option type="double" name="minLength" value="0"/>
-              <Option type="QString" name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0"/>
-              <Option type="QString" name="minLengthUnit" value="MM"/>
-              <Option type="double" name="offsetFromAnchor" value="0"/>
-              <Option type="QString" name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0"/>
-              <Option type="QString" name="offsetFromAnchorUnit" value="MM"/>
-              <Option type="double" name="offsetFromLabel" value="0"/>
-              <Option type="QString" name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0"/>
-              <Option type="QString" name="offsetFromLabelUnit" value="MM"/>
+              <Option name="drawToAllParts" type="bool" value="false"></Option>
+              <Option name="enabled" type="QString" value="0"></Option>
+              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior"></Option>
+              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; type=&quot;line&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; force_rhr=&quot;0&quot;>&lt;layer enabled=&quot;1&quot; pass=&quot;0&quot; locked=&quot;0&quot; class=&quot;SimpleLine&quot;>&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/>&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/>&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/>&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/>&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/>&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/>&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>"></Option>
+              <Option name="minLength" type="double" value="0"></Option>
+              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="minLengthUnit" type="QString" value="MM"></Option>
+              <Option name="offsetFromAnchor" type="double" value="0"></Option>
+              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="offsetFromAnchorUnit" type="QString" value="MM"></Option>
+              <Option name="offsetFromLabel" type="double" value="0"></Option>
+              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="offsetFromLabelUnit" type="QString" value="MM"></Option>
             </Option>
           </callout>
         </settings>
       </labeling>
       <customproperties>
-        <property key="dualview/previewExpressions" value="fid"/>
-        <property key="embeddedWidgets/count" value="0"/>
-        <property key="variableNames"/>
-        <property key="variableValues"/>
+        <property key="dualview/previewExpressions" value="fid"></property>
+        <property key="embeddedWidgets/count" value="0"></property>
+        <property key="variableNames"></property>
+        <property key="variableValues"></property>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
-        <DiagramCategory labelPlacementMethod="XHeight" minScaleDenominator="0" penAlpha="255" diagramOrientation="Up" penColor="#000000" scaleBasedVisibility="0" rotationOffset="270" maxScaleDenominator="1e+08" sizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" barWidth="5" backgroundColor="#ffffff" width="15" scaleDependency="Area" minimumSize="0" lineSizeScale="3x:0,0,0,0,0,0" sizeType="MM" backgroundAlpha="255" height="15" enabled="0" penWidth="0" opacity="1">
-          <fontProperties style="" description="Ubuntu,11,-1,5,50,0,0,0,0,0"/>
-          <attribute color="#000000" field="" label=""/>
+      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="1" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+8" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" showAxis="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="0" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
+          <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""></fontProperties>
+          <attribute color="#000000" field="" label=""></attribute>
+          <axisSymbol>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" type="line">
+              <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+                <prop k="capstyle" v="square"></prop>
+                <prop k="customdash" v="5;2"></prop>
+                <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="customdash_unit" v="MM"></prop>
+                <prop k="draw_inside_polygon" v="0"></prop>
+                <prop k="joinstyle" v="bevel"></prop>
+                <prop k="line_color" v="35,35,35,255"></prop>
+                <prop k="line_style" v="solid"></prop>
+                <prop k="line_width" v="0.26"></prop>
+                <prop k="line_width_unit" v="MM"></prop>
+                <prop k="offset" v="0"></prop>
+                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="offset_unit" v="MM"></prop>
+                <prop k="ring_filter" v="0"></prop>
+                <prop k="use_custom_dash" v="0"></prop>
+                <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings linePlacementFlags="18" dist="0" priority="0" zIndex="0" placement="1" obstacle="0" showAll="1">
+      <DiagramLayerSettings dist="0" linePlacementFlags="18" obstacle="0" placement="1" priority="0" showAll="1" zIndex="0">
         <properties>
           <Option type="Map">
-            <Option type="QString" name="name" value=""/>
-            <Option name="properties"/>
-            <Option type="QString" name="type" value="collection"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </properties>
       </DiagramLayerSettings>
       <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-        <activeChecks/>
-        <checkConfiguration/>
+        <activeChecks></activeChecks>
+        <checkConfiguration></checkConfiguration>
       </geometryOptions>
+      <referencedLayers></referencedLayers>
+      <referencingLayers></referencingLayers>
       <fieldConfiguration>
         <field name="fid">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="scalerank">
           <editWidget type="Range">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="featurecla">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="LABELRANK">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="SOVEREIGNT">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="SOV_A3">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="ADM0_DIF">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="LEVEL">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="TYPE">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="ADMIN">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="ADM0_A3">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="GEOU_DIF">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="GEOUNIT">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="GU_A3">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="SU_DIF">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="SUBUNIT">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="SU_A3">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="BRK_DIFF">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="NAME">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="NAME_LONG">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="BRK_A3">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="BRK_NAME">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="BRK_GROUP">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="ABBREV">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="POSTAL">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="FORMAL_EN">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="FORMAL_FR">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="NOTE_ADM0">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="NOTE_BRK">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="NAME_SORT">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="NAME_ALT">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="MAPCOLOR7">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="MAPCOLOR8">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="MAPCOLOR9">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="MAPCOLOR13">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="POP_EST">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="GDP_MD_EST">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="POP_YEAR">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="LASTCENSUS">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="GDP_YEAR">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="ECONOMY">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="INCOME_GRP">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="WIKIPEDIA">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="FIPS_10_">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="ISO_A2">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="ISO_A3">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="ISO_N3">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="UN_A3">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="WB_A2">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="WB_A3">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="WOE_ID">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="WOE_ID_EH">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="WOE_NOTE">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="ADM0_A3_IS">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="ADM0_A3_US">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="ADM0_A3_UN">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="ADM0_A3_WB">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="CONTINENT">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="REGION_UN">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="SUBREGION">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="REGION_WB">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="NAME_LEN">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="LONG_LEN">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="ABBREV_LEN">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="TINY">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="HOMEPART">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" field="fid" index="0"/>
-        <alias name="" field="scalerank" index="1"/>
-        <alias name="" field="featurecla" index="2"/>
-        <alias name="" field="LABELRANK" index="3"/>
-        <alias name="" field="SOVEREIGNT" index="4"/>
-        <alias name="" field="SOV_A3" index="5"/>
-        <alias name="" field="ADM0_DIF" index="6"/>
-        <alias name="" field="LEVEL" index="7"/>
-        <alias name="" field="TYPE" index="8"/>
-        <alias name="" field="ADMIN" index="9"/>
-        <alias name="" field="ADM0_A3" index="10"/>
-        <alias name="" field="GEOU_DIF" index="11"/>
-        <alias name="" field="GEOUNIT" index="12"/>
-        <alias name="" field="GU_A3" index="13"/>
-        <alias name="" field="SU_DIF" index="14"/>
-        <alias name="" field="SUBUNIT" index="15"/>
-        <alias name="" field="SU_A3" index="16"/>
-        <alias name="" field="BRK_DIFF" index="17"/>
-        <alias name="" field="NAME" index="18"/>
-        <alias name="" field="NAME_LONG" index="19"/>
-        <alias name="" field="BRK_A3" index="20"/>
-        <alias name="" field="BRK_NAME" index="21"/>
-        <alias name="" field="BRK_GROUP" index="22"/>
-        <alias name="" field="ABBREV" index="23"/>
-        <alias name="" field="POSTAL" index="24"/>
-        <alias name="" field="FORMAL_EN" index="25"/>
-        <alias name="" field="FORMAL_FR" index="26"/>
-        <alias name="" field="NOTE_ADM0" index="27"/>
-        <alias name="" field="NOTE_BRK" index="28"/>
-        <alias name="" field="NAME_SORT" index="29"/>
-        <alias name="" field="NAME_ALT" index="30"/>
-        <alias name="" field="MAPCOLOR7" index="31"/>
-        <alias name="" field="MAPCOLOR8" index="32"/>
-        <alias name="" field="MAPCOLOR9" index="33"/>
-        <alias name="" field="MAPCOLOR13" index="34"/>
-        <alias name="" field="POP_EST" index="35"/>
-        <alias name="" field="GDP_MD_EST" index="36"/>
-        <alias name="" field="POP_YEAR" index="37"/>
-        <alias name="" field="LASTCENSUS" index="38"/>
-        <alias name="" field="GDP_YEAR" index="39"/>
-        <alias name="" field="ECONOMY" index="40"/>
-        <alias name="" field="INCOME_GRP" index="41"/>
-        <alias name="" field="WIKIPEDIA" index="42"/>
-        <alias name="" field="FIPS_10_" index="43"/>
-        <alias name="" field="ISO_A2" index="44"/>
-        <alias name="" field="ISO_A3" index="45"/>
-        <alias name="" field="ISO_N3" index="46"/>
-        <alias name="" field="UN_A3" index="47"/>
-        <alias name="" field="WB_A2" index="48"/>
-        <alias name="" field="WB_A3" index="49"/>
-        <alias name="" field="WOE_ID" index="50"/>
-        <alias name="" field="WOE_ID_EH" index="51"/>
-        <alias name="" field="WOE_NOTE" index="52"/>
-        <alias name="" field="ADM0_A3_IS" index="53"/>
-        <alias name="" field="ADM0_A3_US" index="54"/>
-        <alias name="" field="ADM0_A3_UN" index="55"/>
-        <alias name="" field="ADM0_A3_WB" index="56"/>
-        <alias name="" field="CONTINENT" index="57"/>
-        <alias name="" field="REGION_UN" index="58"/>
-        <alias name="" field="SUBREGION" index="59"/>
-        <alias name="" field="REGION_WB" index="60"/>
-        <alias name="" field="NAME_LEN" index="61"/>
-        <alias name="" field="LONG_LEN" index="62"/>
-        <alias name="" field="ABBREV_LEN" index="63"/>
-        <alias name="" field="TINY" index="64"/>
-        <alias name="" field="HOMEPART" index="65"/>
+        <alias field="fid" index="0" name=""></alias>
+        <alias field="scalerank" index="1" name=""></alias>
+        <alias field="featurecla" index="2" name=""></alias>
+        <alias field="LABELRANK" index="3" name=""></alias>
+        <alias field="SOVEREIGNT" index="4" name=""></alias>
+        <alias field="SOV_A3" index="5" name=""></alias>
+        <alias field="ADM0_DIF" index="6" name=""></alias>
+        <alias field="LEVEL" index="7" name=""></alias>
+        <alias field="TYPE" index="8" name=""></alias>
+        <alias field="ADMIN" index="9" name=""></alias>
+        <alias field="ADM0_A3" index="10" name=""></alias>
+        <alias field="GEOU_DIF" index="11" name=""></alias>
+        <alias field="GEOUNIT" index="12" name=""></alias>
+        <alias field="GU_A3" index="13" name=""></alias>
+        <alias field="SU_DIF" index="14" name=""></alias>
+        <alias field="SUBUNIT" index="15" name=""></alias>
+        <alias field="SU_A3" index="16" name=""></alias>
+        <alias field="BRK_DIFF" index="17" name=""></alias>
+        <alias field="NAME" index="18" name=""></alias>
+        <alias field="NAME_LONG" index="19" name=""></alias>
+        <alias field="BRK_A3" index="20" name=""></alias>
+        <alias field="BRK_NAME" index="21" name=""></alias>
+        <alias field="BRK_GROUP" index="22" name=""></alias>
+        <alias field="ABBREV" index="23" name=""></alias>
+        <alias field="POSTAL" index="24" name=""></alias>
+        <alias field="FORMAL_EN" index="25" name=""></alias>
+        <alias field="FORMAL_FR" index="26" name=""></alias>
+        <alias field="NOTE_ADM0" index="27" name=""></alias>
+        <alias field="NOTE_BRK" index="28" name=""></alias>
+        <alias field="NAME_SORT" index="29" name=""></alias>
+        <alias field="NAME_ALT" index="30" name=""></alias>
+        <alias field="MAPCOLOR7" index="31" name=""></alias>
+        <alias field="MAPCOLOR8" index="32" name=""></alias>
+        <alias field="MAPCOLOR9" index="33" name=""></alias>
+        <alias field="MAPCOLOR13" index="34" name=""></alias>
+        <alias field="POP_EST" index="35" name=""></alias>
+        <alias field="GDP_MD_EST" index="36" name=""></alias>
+        <alias field="POP_YEAR" index="37" name=""></alias>
+        <alias field="LASTCENSUS" index="38" name=""></alias>
+        <alias field="GDP_YEAR" index="39" name=""></alias>
+        <alias field="ECONOMY" index="40" name=""></alias>
+        <alias field="INCOME_GRP" index="41" name=""></alias>
+        <alias field="WIKIPEDIA" index="42" name=""></alias>
+        <alias field="FIPS_10_" index="43" name=""></alias>
+        <alias field="ISO_A2" index="44" name=""></alias>
+        <alias field="ISO_A3" index="45" name=""></alias>
+        <alias field="ISO_N3" index="46" name=""></alias>
+        <alias field="UN_A3" index="47" name=""></alias>
+        <alias field="WB_A2" index="48" name=""></alias>
+        <alias field="WB_A3" index="49" name=""></alias>
+        <alias field="WOE_ID" index="50" name=""></alias>
+        <alias field="WOE_ID_EH" index="51" name=""></alias>
+        <alias field="WOE_NOTE" index="52" name=""></alias>
+        <alias field="ADM0_A3_IS" index="53" name=""></alias>
+        <alias field="ADM0_A3_US" index="54" name=""></alias>
+        <alias field="ADM0_A3_UN" index="55" name=""></alias>
+        <alias field="ADM0_A3_WB" index="56" name=""></alias>
+        <alias field="CONTINENT" index="57" name=""></alias>
+        <alias field="REGION_UN" index="58" name=""></alias>
+        <alias field="SUBREGION" index="59" name=""></alias>
+        <alias field="REGION_WB" index="60" name=""></alias>
+        <alias field="NAME_LEN" index="61" name=""></alias>
+        <alias field="LONG_LEN" index="62" name=""></alias>
+        <alias field="ABBREV_LEN" index="63" name=""></alias>
+        <alias field="TINY" index="64" name=""></alias>
+        <alias field="HOMEPART" index="65" name=""></alias>
       </aliases>
-      <excludeAttributesWMS/>
-      <excludeAttributesWFS/>
+      <excludeAttributesWMS></excludeAttributesWMS>
+      <excludeAttributesWFS></excludeAttributesWFS>
       <defaults>
-        <default applyOnUpdate="0" field="fid" expression=""/>
-        <default applyOnUpdate="0" field="scalerank" expression=""/>
-        <default applyOnUpdate="0" field="featurecla" expression=""/>
-        <default applyOnUpdate="0" field="LABELRANK" expression=""/>
-        <default applyOnUpdate="0" field="SOVEREIGNT" expression=""/>
-        <default applyOnUpdate="0" field="SOV_A3" expression=""/>
-        <default applyOnUpdate="0" field="ADM0_DIF" expression=""/>
-        <default applyOnUpdate="0" field="LEVEL" expression=""/>
-        <default applyOnUpdate="0" field="TYPE" expression=""/>
-        <default applyOnUpdate="0" field="ADMIN" expression=""/>
-        <default applyOnUpdate="0" field="ADM0_A3" expression=""/>
-        <default applyOnUpdate="0" field="GEOU_DIF" expression=""/>
-        <default applyOnUpdate="0" field="GEOUNIT" expression=""/>
-        <default applyOnUpdate="0" field="GU_A3" expression=""/>
-        <default applyOnUpdate="0" field="SU_DIF" expression=""/>
-        <default applyOnUpdate="0" field="SUBUNIT" expression=""/>
-        <default applyOnUpdate="0" field="SU_A3" expression=""/>
-        <default applyOnUpdate="0" field="BRK_DIFF" expression=""/>
-        <default applyOnUpdate="0" field="NAME" expression=""/>
-        <default applyOnUpdate="0" field="NAME_LONG" expression=""/>
-        <default applyOnUpdate="0" field="BRK_A3" expression=""/>
-        <default applyOnUpdate="0" field="BRK_NAME" expression=""/>
-        <default applyOnUpdate="0" field="BRK_GROUP" expression=""/>
-        <default applyOnUpdate="0" field="ABBREV" expression=""/>
-        <default applyOnUpdate="0" field="POSTAL" expression=""/>
-        <default applyOnUpdate="0" field="FORMAL_EN" expression=""/>
-        <default applyOnUpdate="0" field="FORMAL_FR" expression=""/>
-        <default applyOnUpdate="0" field="NOTE_ADM0" expression=""/>
-        <default applyOnUpdate="0" field="NOTE_BRK" expression=""/>
-        <default applyOnUpdate="0" field="NAME_SORT" expression=""/>
-        <default applyOnUpdate="0" field="NAME_ALT" expression=""/>
-        <default applyOnUpdate="0" field="MAPCOLOR7" expression=""/>
-        <default applyOnUpdate="0" field="MAPCOLOR8" expression=""/>
-        <default applyOnUpdate="0" field="MAPCOLOR9" expression=""/>
-        <default applyOnUpdate="0" field="MAPCOLOR13" expression=""/>
-        <default applyOnUpdate="0" field="POP_EST" expression=""/>
-        <default applyOnUpdate="0" field="GDP_MD_EST" expression=""/>
-        <default applyOnUpdate="0" field="POP_YEAR" expression=""/>
-        <default applyOnUpdate="0" field="LASTCENSUS" expression=""/>
-        <default applyOnUpdate="0" field="GDP_YEAR" expression=""/>
-        <default applyOnUpdate="0" field="ECONOMY" expression=""/>
-        <default applyOnUpdate="0" field="INCOME_GRP" expression=""/>
-        <default applyOnUpdate="0" field="WIKIPEDIA" expression=""/>
-        <default applyOnUpdate="0" field="FIPS_10_" expression=""/>
-        <default applyOnUpdate="0" field="ISO_A2" expression=""/>
-        <default applyOnUpdate="0" field="ISO_A3" expression=""/>
-        <default applyOnUpdate="0" field="ISO_N3" expression=""/>
-        <default applyOnUpdate="0" field="UN_A3" expression=""/>
-        <default applyOnUpdate="0" field="WB_A2" expression=""/>
-        <default applyOnUpdate="0" field="WB_A3" expression=""/>
-        <default applyOnUpdate="0" field="WOE_ID" expression=""/>
-        <default applyOnUpdate="0" field="WOE_ID_EH" expression=""/>
-        <default applyOnUpdate="0" field="WOE_NOTE" expression=""/>
-        <default applyOnUpdate="0" field="ADM0_A3_IS" expression=""/>
-        <default applyOnUpdate="0" field="ADM0_A3_US" expression=""/>
-        <default applyOnUpdate="0" field="ADM0_A3_UN" expression=""/>
-        <default applyOnUpdate="0" field="ADM0_A3_WB" expression=""/>
-        <default applyOnUpdate="0" field="CONTINENT" expression=""/>
-        <default applyOnUpdate="0" field="REGION_UN" expression=""/>
-        <default applyOnUpdate="0" field="SUBREGION" expression=""/>
-        <default applyOnUpdate="0" field="REGION_WB" expression=""/>
-        <default applyOnUpdate="0" field="NAME_LEN" expression=""/>
-        <default applyOnUpdate="0" field="LONG_LEN" expression=""/>
-        <default applyOnUpdate="0" field="ABBREV_LEN" expression=""/>
-        <default applyOnUpdate="0" field="TINY" expression=""/>
-        <default applyOnUpdate="0" field="HOMEPART" expression=""/>
+        <default applyOnUpdate="0" expression="" field="fid"></default>
+        <default applyOnUpdate="0" expression="" field="scalerank"></default>
+        <default applyOnUpdate="0" expression="" field="featurecla"></default>
+        <default applyOnUpdate="0" expression="" field="LABELRANK"></default>
+        <default applyOnUpdate="0" expression="" field="SOVEREIGNT"></default>
+        <default applyOnUpdate="0" expression="" field="SOV_A3"></default>
+        <default applyOnUpdate="0" expression="" field="ADM0_DIF"></default>
+        <default applyOnUpdate="0" expression="" field="LEVEL"></default>
+        <default applyOnUpdate="0" expression="" field="TYPE"></default>
+        <default applyOnUpdate="0" expression="" field="ADMIN"></default>
+        <default applyOnUpdate="0" expression="" field="ADM0_A3"></default>
+        <default applyOnUpdate="0" expression="" field="GEOU_DIF"></default>
+        <default applyOnUpdate="0" expression="" field="GEOUNIT"></default>
+        <default applyOnUpdate="0" expression="" field="GU_A3"></default>
+        <default applyOnUpdate="0" expression="" field="SU_DIF"></default>
+        <default applyOnUpdate="0" expression="" field="SUBUNIT"></default>
+        <default applyOnUpdate="0" expression="" field="SU_A3"></default>
+        <default applyOnUpdate="0" expression="" field="BRK_DIFF"></default>
+        <default applyOnUpdate="0" expression="" field="NAME"></default>
+        <default applyOnUpdate="0" expression="" field="NAME_LONG"></default>
+        <default applyOnUpdate="0" expression="" field="BRK_A3"></default>
+        <default applyOnUpdate="0" expression="" field="BRK_NAME"></default>
+        <default applyOnUpdate="0" expression="" field="BRK_GROUP"></default>
+        <default applyOnUpdate="0" expression="" field="ABBREV"></default>
+        <default applyOnUpdate="0" expression="" field="POSTAL"></default>
+        <default applyOnUpdate="0" expression="" field="FORMAL_EN"></default>
+        <default applyOnUpdate="0" expression="" field="FORMAL_FR"></default>
+        <default applyOnUpdate="0" expression="" field="NOTE_ADM0"></default>
+        <default applyOnUpdate="0" expression="" field="NOTE_BRK"></default>
+        <default applyOnUpdate="0" expression="" field="NAME_SORT"></default>
+        <default applyOnUpdate="0" expression="" field="NAME_ALT"></default>
+        <default applyOnUpdate="0" expression="" field="MAPCOLOR7"></default>
+        <default applyOnUpdate="0" expression="" field="MAPCOLOR8"></default>
+        <default applyOnUpdate="0" expression="" field="MAPCOLOR9"></default>
+        <default applyOnUpdate="0" expression="" field="MAPCOLOR13"></default>
+        <default applyOnUpdate="0" expression="" field="POP_EST"></default>
+        <default applyOnUpdate="0" expression="" field="GDP_MD_EST"></default>
+        <default applyOnUpdate="0" expression="" field="POP_YEAR"></default>
+        <default applyOnUpdate="0" expression="" field="LASTCENSUS"></default>
+        <default applyOnUpdate="0" expression="" field="GDP_YEAR"></default>
+        <default applyOnUpdate="0" expression="" field="ECONOMY"></default>
+        <default applyOnUpdate="0" expression="" field="INCOME_GRP"></default>
+        <default applyOnUpdate="0" expression="" field="WIKIPEDIA"></default>
+        <default applyOnUpdate="0" expression="" field="FIPS_10_"></default>
+        <default applyOnUpdate="0" expression="" field="ISO_A2"></default>
+        <default applyOnUpdate="0" expression="" field="ISO_A3"></default>
+        <default applyOnUpdate="0" expression="" field="ISO_N3"></default>
+        <default applyOnUpdate="0" expression="" field="UN_A3"></default>
+        <default applyOnUpdate="0" expression="" field="WB_A2"></default>
+        <default applyOnUpdate="0" expression="" field="WB_A3"></default>
+        <default applyOnUpdate="0" expression="" field="WOE_ID"></default>
+        <default applyOnUpdate="0" expression="" field="WOE_ID_EH"></default>
+        <default applyOnUpdate="0" expression="" field="WOE_NOTE"></default>
+        <default applyOnUpdate="0" expression="" field="ADM0_A3_IS"></default>
+        <default applyOnUpdate="0" expression="" field="ADM0_A3_US"></default>
+        <default applyOnUpdate="0" expression="" field="ADM0_A3_UN"></default>
+        <default applyOnUpdate="0" expression="" field="ADM0_A3_WB"></default>
+        <default applyOnUpdate="0" expression="" field="CONTINENT"></default>
+        <default applyOnUpdate="0" expression="" field="REGION_UN"></default>
+        <default applyOnUpdate="0" expression="" field="SUBREGION"></default>
+        <default applyOnUpdate="0" expression="" field="REGION_WB"></default>
+        <default applyOnUpdate="0" expression="" field="NAME_LEN"></default>
+        <default applyOnUpdate="0" expression="" field="LONG_LEN"></default>
+        <default applyOnUpdate="0" expression="" field="ABBREV_LEN"></default>
+        <default applyOnUpdate="0" expression="" field="TINY"></default>
+        <default applyOnUpdate="0" expression="" field="HOMEPART"></default>
       </defaults>
       <constraints>
-        <constraint notnull_strength="1" constraints="3" field="fid" unique_strength="1" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="scalerank" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="featurecla" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="LABELRANK" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="SOVEREIGNT" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="SOV_A3" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="ADM0_DIF" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="LEVEL" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="TYPE" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="ADMIN" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="ADM0_A3" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="GEOU_DIF" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="GEOUNIT" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="GU_A3" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="SU_DIF" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="SUBUNIT" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="SU_A3" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="BRK_DIFF" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="NAME" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="NAME_LONG" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="BRK_A3" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="BRK_NAME" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="BRK_GROUP" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="ABBREV" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="POSTAL" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="FORMAL_EN" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="FORMAL_FR" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="NOTE_ADM0" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="NOTE_BRK" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="NAME_SORT" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="NAME_ALT" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="MAPCOLOR7" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="MAPCOLOR8" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="MAPCOLOR9" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="MAPCOLOR13" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="POP_EST" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="GDP_MD_EST" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="POP_YEAR" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="LASTCENSUS" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="GDP_YEAR" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="ECONOMY" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="INCOME_GRP" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="WIKIPEDIA" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="FIPS_10_" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="ISO_A2" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="ISO_A3" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="ISO_N3" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="UN_A3" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="WB_A2" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="WB_A3" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="WOE_ID" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="WOE_ID_EH" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="WOE_NOTE" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="ADM0_A3_IS" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="ADM0_A3_US" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="ADM0_A3_UN" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="ADM0_A3_WB" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="CONTINENT" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="REGION_UN" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="SUBREGION" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="REGION_WB" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="NAME_LEN" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="LONG_LEN" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="ABBREV_LEN" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="TINY" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="HOMEPART" unique_strength="0" exp_strength="0"/>
+        <constraint constraints="3" exp_strength="0" field="fid" notnull_strength="1" unique_strength="1"></constraint>
+        <constraint constraints="0" exp_strength="0" field="scalerank" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="featurecla" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="LABELRANK" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="SOVEREIGNT" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="SOV_A3" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ADM0_DIF" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="LEVEL" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="TYPE" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ADMIN" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ADM0_A3" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="GEOU_DIF" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="GEOUNIT" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="GU_A3" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="SU_DIF" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="SUBUNIT" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="SU_A3" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="BRK_DIFF" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="NAME" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="NAME_LONG" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="BRK_A3" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="BRK_NAME" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="BRK_GROUP" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ABBREV" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="POSTAL" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="FORMAL_EN" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="FORMAL_FR" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="NOTE_ADM0" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="NOTE_BRK" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="NAME_SORT" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="NAME_ALT" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="MAPCOLOR7" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="MAPCOLOR8" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="MAPCOLOR9" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="MAPCOLOR13" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="POP_EST" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="GDP_MD_EST" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="POP_YEAR" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="LASTCENSUS" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="GDP_YEAR" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ECONOMY" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="INCOME_GRP" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="WIKIPEDIA" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="FIPS_10_" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ISO_A2" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ISO_A3" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ISO_N3" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="UN_A3" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="WB_A2" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="WB_A3" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="WOE_ID" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="WOE_ID_EH" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="WOE_NOTE" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ADM0_A3_IS" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ADM0_A3_US" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ADM0_A3_UN" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ADM0_A3_WB" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="CONTINENT" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="REGION_UN" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="SUBREGION" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="REGION_WB" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="NAME_LEN" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="LONG_LEN" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ABBREV_LEN" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="TINY" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="HOMEPART" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint field="fid" desc="" exp=""/>
-        <constraint field="scalerank" desc="" exp=""/>
-        <constraint field="featurecla" desc="" exp=""/>
-        <constraint field="LABELRANK" desc="" exp=""/>
-        <constraint field="SOVEREIGNT" desc="" exp=""/>
-        <constraint field="SOV_A3" desc="" exp=""/>
-        <constraint field="ADM0_DIF" desc="" exp=""/>
-        <constraint field="LEVEL" desc="" exp=""/>
-        <constraint field="TYPE" desc="" exp=""/>
-        <constraint field="ADMIN" desc="" exp=""/>
-        <constraint field="ADM0_A3" desc="" exp=""/>
-        <constraint field="GEOU_DIF" desc="" exp=""/>
-        <constraint field="GEOUNIT" desc="" exp=""/>
-        <constraint field="GU_A3" desc="" exp=""/>
-        <constraint field="SU_DIF" desc="" exp=""/>
-        <constraint field="SUBUNIT" desc="" exp=""/>
-        <constraint field="SU_A3" desc="" exp=""/>
-        <constraint field="BRK_DIFF" desc="" exp=""/>
-        <constraint field="NAME" desc="" exp=""/>
-        <constraint field="NAME_LONG" desc="" exp=""/>
-        <constraint field="BRK_A3" desc="" exp=""/>
-        <constraint field="BRK_NAME" desc="" exp=""/>
-        <constraint field="BRK_GROUP" desc="" exp=""/>
-        <constraint field="ABBREV" desc="" exp=""/>
-        <constraint field="POSTAL" desc="" exp=""/>
-        <constraint field="FORMAL_EN" desc="" exp=""/>
-        <constraint field="FORMAL_FR" desc="" exp=""/>
-        <constraint field="NOTE_ADM0" desc="" exp=""/>
-        <constraint field="NOTE_BRK" desc="" exp=""/>
-        <constraint field="NAME_SORT" desc="" exp=""/>
-        <constraint field="NAME_ALT" desc="" exp=""/>
-        <constraint field="MAPCOLOR7" desc="" exp=""/>
-        <constraint field="MAPCOLOR8" desc="" exp=""/>
-        <constraint field="MAPCOLOR9" desc="" exp=""/>
-        <constraint field="MAPCOLOR13" desc="" exp=""/>
-        <constraint field="POP_EST" desc="" exp=""/>
-        <constraint field="GDP_MD_EST" desc="" exp=""/>
-        <constraint field="POP_YEAR" desc="" exp=""/>
-        <constraint field="LASTCENSUS" desc="" exp=""/>
-        <constraint field="GDP_YEAR" desc="" exp=""/>
-        <constraint field="ECONOMY" desc="" exp=""/>
-        <constraint field="INCOME_GRP" desc="" exp=""/>
-        <constraint field="WIKIPEDIA" desc="" exp=""/>
-        <constraint field="FIPS_10_" desc="" exp=""/>
-        <constraint field="ISO_A2" desc="" exp=""/>
-        <constraint field="ISO_A3" desc="" exp=""/>
-        <constraint field="ISO_N3" desc="" exp=""/>
-        <constraint field="UN_A3" desc="" exp=""/>
-        <constraint field="WB_A2" desc="" exp=""/>
-        <constraint field="WB_A3" desc="" exp=""/>
-        <constraint field="WOE_ID" desc="" exp=""/>
-        <constraint field="WOE_ID_EH" desc="" exp=""/>
-        <constraint field="WOE_NOTE" desc="" exp=""/>
-        <constraint field="ADM0_A3_IS" desc="" exp=""/>
-        <constraint field="ADM0_A3_US" desc="" exp=""/>
-        <constraint field="ADM0_A3_UN" desc="" exp=""/>
-        <constraint field="ADM0_A3_WB" desc="" exp=""/>
-        <constraint field="CONTINENT" desc="" exp=""/>
-        <constraint field="REGION_UN" desc="" exp=""/>
-        <constraint field="SUBREGION" desc="" exp=""/>
-        <constraint field="REGION_WB" desc="" exp=""/>
-        <constraint field="NAME_LEN" desc="" exp=""/>
-        <constraint field="LONG_LEN" desc="" exp=""/>
-        <constraint field="ABBREV_LEN" desc="" exp=""/>
-        <constraint field="TINY" desc="" exp=""/>
-        <constraint field="HOMEPART" desc="" exp=""/>
+        <constraint desc="" exp="" field="fid"></constraint>
+        <constraint desc="" exp="" field="scalerank"></constraint>
+        <constraint desc="" exp="" field="featurecla"></constraint>
+        <constraint desc="" exp="" field="LABELRANK"></constraint>
+        <constraint desc="" exp="" field="SOVEREIGNT"></constraint>
+        <constraint desc="" exp="" field="SOV_A3"></constraint>
+        <constraint desc="" exp="" field="ADM0_DIF"></constraint>
+        <constraint desc="" exp="" field="LEVEL"></constraint>
+        <constraint desc="" exp="" field="TYPE"></constraint>
+        <constraint desc="" exp="" field="ADMIN"></constraint>
+        <constraint desc="" exp="" field="ADM0_A3"></constraint>
+        <constraint desc="" exp="" field="GEOU_DIF"></constraint>
+        <constraint desc="" exp="" field="GEOUNIT"></constraint>
+        <constraint desc="" exp="" field="GU_A3"></constraint>
+        <constraint desc="" exp="" field="SU_DIF"></constraint>
+        <constraint desc="" exp="" field="SUBUNIT"></constraint>
+        <constraint desc="" exp="" field="SU_A3"></constraint>
+        <constraint desc="" exp="" field="BRK_DIFF"></constraint>
+        <constraint desc="" exp="" field="NAME"></constraint>
+        <constraint desc="" exp="" field="NAME_LONG"></constraint>
+        <constraint desc="" exp="" field="BRK_A3"></constraint>
+        <constraint desc="" exp="" field="BRK_NAME"></constraint>
+        <constraint desc="" exp="" field="BRK_GROUP"></constraint>
+        <constraint desc="" exp="" field="ABBREV"></constraint>
+        <constraint desc="" exp="" field="POSTAL"></constraint>
+        <constraint desc="" exp="" field="FORMAL_EN"></constraint>
+        <constraint desc="" exp="" field="FORMAL_FR"></constraint>
+        <constraint desc="" exp="" field="NOTE_ADM0"></constraint>
+        <constraint desc="" exp="" field="NOTE_BRK"></constraint>
+        <constraint desc="" exp="" field="NAME_SORT"></constraint>
+        <constraint desc="" exp="" field="NAME_ALT"></constraint>
+        <constraint desc="" exp="" field="MAPCOLOR7"></constraint>
+        <constraint desc="" exp="" field="MAPCOLOR8"></constraint>
+        <constraint desc="" exp="" field="MAPCOLOR9"></constraint>
+        <constraint desc="" exp="" field="MAPCOLOR13"></constraint>
+        <constraint desc="" exp="" field="POP_EST"></constraint>
+        <constraint desc="" exp="" field="GDP_MD_EST"></constraint>
+        <constraint desc="" exp="" field="POP_YEAR"></constraint>
+        <constraint desc="" exp="" field="LASTCENSUS"></constraint>
+        <constraint desc="" exp="" field="GDP_YEAR"></constraint>
+        <constraint desc="" exp="" field="ECONOMY"></constraint>
+        <constraint desc="" exp="" field="INCOME_GRP"></constraint>
+        <constraint desc="" exp="" field="WIKIPEDIA"></constraint>
+        <constraint desc="" exp="" field="FIPS_10_"></constraint>
+        <constraint desc="" exp="" field="ISO_A2"></constraint>
+        <constraint desc="" exp="" field="ISO_A3"></constraint>
+        <constraint desc="" exp="" field="ISO_N3"></constraint>
+        <constraint desc="" exp="" field="UN_A3"></constraint>
+        <constraint desc="" exp="" field="WB_A2"></constraint>
+        <constraint desc="" exp="" field="WB_A3"></constraint>
+        <constraint desc="" exp="" field="WOE_ID"></constraint>
+        <constraint desc="" exp="" field="WOE_ID_EH"></constraint>
+        <constraint desc="" exp="" field="WOE_NOTE"></constraint>
+        <constraint desc="" exp="" field="ADM0_A3_IS"></constraint>
+        <constraint desc="" exp="" field="ADM0_A3_US"></constraint>
+        <constraint desc="" exp="" field="ADM0_A3_UN"></constraint>
+        <constraint desc="" exp="" field="ADM0_A3_WB"></constraint>
+        <constraint desc="" exp="" field="CONTINENT"></constraint>
+        <constraint desc="" exp="" field="REGION_UN"></constraint>
+        <constraint desc="" exp="" field="SUBREGION"></constraint>
+        <constraint desc="" exp="" field="REGION_WB"></constraint>
+        <constraint desc="" exp="" field="NAME_LEN"></constraint>
+        <constraint desc="" exp="" field="LONG_LEN"></constraint>
+        <constraint desc="" exp="" field="ABBREV_LEN"></constraint>
+        <constraint desc="" exp="" field="TINY"></constraint>
+        <constraint desc="" exp="" field="HOMEPART"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
       </attributeactions>
-      <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column type="field" name="fid" width="-1" hidden="0"/>
-          <column type="field" name="NAME" width="-1" hidden="0"/>
-          <column type="actions" width="-1" hidden="1"/>
-          <column type="field" name="scalerank" width="-1" hidden="0"/>
-          <column type="field" name="featurecla" width="-1" hidden="0"/>
-          <column type="field" name="LABELRANK" width="-1" hidden="0"/>
-          <column type="field" name="SOVEREIGNT" width="-1" hidden="0"/>
-          <column type="field" name="SOV_A3" width="-1" hidden="0"/>
-          <column type="field" name="ADM0_DIF" width="-1" hidden="0"/>
-          <column type="field" name="LEVEL" width="-1" hidden="0"/>
-          <column type="field" name="TYPE" width="-1" hidden="0"/>
-          <column type="field" name="ADMIN" width="-1" hidden="0"/>
-          <column type="field" name="ADM0_A3" width="-1" hidden="0"/>
-          <column type="field" name="GEOU_DIF" width="-1" hidden="0"/>
-          <column type="field" name="GEOUNIT" width="-1" hidden="0"/>
-          <column type="field" name="GU_A3" width="-1" hidden="0"/>
-          <column type="field" name="SU_DIF" width="-1" hidden="0"/>
-          <column type="field" name="SUBUNIT" width="-1" hidden="0"/>
-          <column type="field" name="SU_A3" width="-1" hidden="0"/>
-          <column type="field" name="BRK_DIFF" width="-1" hidden="0"/>
-          <column type="field" name="NAME_LONG" width="-1" hidden="0"/>
-          <column type="field" name="BRK_A3" width="-1" hidden="0"/>
-          <column type="field" name="BRK_NAME" width="-1" hidden="0"/>
-          <column type="field" name="BRK_GROUP" width="-1" hidden="0"/>
-          <column type="field" name="ABBREV" width="-1" hidden="0"/>
-          <column type="field" name="POSTAL" width="-1" hidden="0"/>
-          <column type="field" name="FORMAL_EN" width="-1" hidden="0"/>
-          <column type="field" name="FORMAL_FR" width="-1" hidden="0"/>
-          <column type="field" name="NOTE_ADM0" width="-1" hidden="0"/>
-          <column type="field" name="NOTE_BRK" width="-1" hidden="0"/>
-          <column type="field" name="NAME_SORT" width="-1" hidden="0"/>
-          <column type="field" name="NAME_ALT" width="-1" hidden="0"/>
-          <column type="field" name="MAPCOLOR7" width="-1" hidden="0"/>
-          <column type="field" name="MAPCOLOR8" width="-1" hidden="0"/>
-          <column type="field" name="MAPCOLOR9" width="-1" hidden="0"/>
-          <column type="field" name="MAPCOLOR13" width="-1" hidden="0"/>
-          <column type="field" name="POP_EST" width="-1" hidden="0"/>
-          <column type="field" name="GDP_MD_EST" width="-1" hidden="0"/>
-          <column type="field" name="POP_YEAR" width="-1" hidden="0"/>
-          <column type="field" name="LASTCENSUS" width="-1" hidden="0"/>
-          <column type="field" name="GDP_YEAR" width="-1" hidden="0"/>
-          <column type="field" name="ECONOMY" width="-1" hidden="0"/>
-          <column type="field" name="INCOME_GRP" width="-1" hidden="0"/>
-          <column type="field" name="WIKIPEDIA" width="-1" hidden="0"/>
-          <column type="field" name="FIPS_10_" width="-1" hidden="0"/>
-          <column type="field" name="ISO_A2" width="-1" hidden="0"/>
-          <column type="field" name="ISO_A3" width="-1" hidden="0"/>
-          <column type="field" name="ISO_N3" width="-1" hidden="0"/>
-          <column type="field" name="UN_A3" width="-1" hidden="0"/>
-          <column type="field" name="WB_A2" width="-1" hidden="0"/>
-          <column type="field" name="WB_A3" width="-1" hidden="0"/>
-          <column type="field" name="WOE_ID" width="-1" hidden="0"/>
-          <column type="field" name="WOE_ID_EH" width="-1" hidden="0"/>
-          <column type="field" name="WOE_NOTE" width="-1" hidden="0"/>
-          <column type="field" name="ADM0_A3_IS" width="-1" hidden="0"/>
-          <column type="field" name="ADM0_A3_US" width="-1" hidden="0"/>
-          <column type="field" name="ADM0_A3_UN" width="-1" hidden="0"/>
-          <column type="field" name="ADM0_A3_WB" width="-1" hidden="0"/>
-          <column type="field" name="CONTINENT" width="-1" hidden="0"/>
-          <column type="field" name="REGION_UN" width="-1" hidden="0"/>
-          <column type="field" name="SUBREGION" width="-1" hidden="0"/>
-          <column type="field" name="REGION_WB" width="-1" hidden="0"/>
-          <column type="field" name="NAME_LEN" width="-1" hidden="0"/>
-          <column type="field" name="LONG_LEN" width="-1" hidden="0"/>
-          <column type="field" name="ABBREV_LEN" width="-1" hidden="0"/>
-          <column type="field" name="TINY" width="-1" hidden="0"/>
-          <column type="field" name="HOMEPART" width="-1" hidden="0"/>
+          <column hidden="0" name="fid" type="field" width="-1"></column>
+          <column hidden="0" name="NAME" type="field" width="-1"></column>
+          <column hidden="1" type="actions" width="-1"></column>
+          <column hidden="0" name="scalerank" type="field" width="-1"></column>
+          <column hidden="0" name="featurecla" type="field" width="-1"></column>
+          <column hidden="0" name="LABELRANK" type="field" width="-1"></column>
+          <column hidden="0" name="SOVEREIGNT" type="field" width="-1"></column>
+          <column hidden="0" name="SOV_A3" type="field" width="-1"></column>
+          <column hidden="0" name="ADM0_DIF" type="field" width="-1"></column>
+          <column hidden="0" name="LEVEL" type="field" width="-1"></column>
+          <column hidden="0" name="TYPE" type="field" width="-1"></column>
+          <column hidden="0" name="ADMIN" type="field" width="-1"></column>
+          <column hidden="0" name="ADM0_A3" type="field" width="-1"></column>
+          <column hidden="0" name="GEOU_DIF" type="field" width="-1"></column>
+          <column hidden="0" name="GEOUNIT" type="field" width="-1"></column>
+          <column hidden="0" name="GU_A3" type="field" width="-1"></column>
+          <column hidden="0" name="SU_DIF" type="field" width="-1"></column>
+          <column hidden="0" name="SUBUNIT" type="field" width="-1"></column>
+          <column hidden="0" name="SU_A3" type="field" width="-1"></column>
+          <column hidden="0" name="BRK_DIFF" type="field" width="-1"></column>
+          <column hidden="0" name="NAME_LONG" type="field" width="-1"></column>
+          <column hidden="0" name="BRK_A3" type="field" width="-1"></column>
+          <column hidden="0" name="BRK_NAME" type="field" width="-1"></column>
+          <column hidden="0" name="BRK_GROUP" type="field" width="-1"></column>
+          <column hidden="0" name="ABBREV" type="field" width="-1"></column>
+          <column hidden="0" name="POSTAL" type="field" width="-1"></column>
+          <column hidden="0" name="FORMAL_EN" type="field" width="-1"></column>
+          <column hidden="0" name="FORMAL_FR" type="field" width="-1"></column>
+          <column hidden="0" name="NOTE_ADM0" type="field" width="-1"></column>
+          <column hidden="0" name="NOTE_BRK" type="field" width="-1"></column>
+          <column hidden="0" name="NAME_SORT" type="field" width="-1"></column>
+          <column hidden="0" name="NAME_ALT" type="field" width="-1"></column>
+          <column hidden="0" name="MAPCOLOR7" type="field" width="-1"></column>
+          <column hidden="0" name="MAPCOLOR8" type="field" width="-1"></column>
+          <column hidden="0" name="MAPCOLOR9" type="field" width="-1"></column>
+          <column hidden="0" name="MAPCOLOR13" type="field" width="-1"></column>
+          <column hidden="0" name="POP_EST" type="field" width="-1"></column>
+          <column hidden="0" name="GDP_MD_EST" type="field" width="-1"></column>
+          <column hidden="0" name="POP_YEAR" type="field" width="-1"></column>
+          <column hidden="0" name="LASTCENSUS" type="field" width="-1"></column>
+          <column hidden="0" name="GDP_YEAR" type="field" width="-1"></column>
+          <column hidden="0" name="ECONOMY" type="field" width="-1"></column>
+          <column hidden="0" name="INCOME_GRP" type="field" width="-1"></column>
+          <column hidden="0" name="WIKIPEDIA" type="field" width="-1"></column>
+          <column hidden="0" name="FIPS_10_" type="field" width="-1"></column>
+          <column hidden="0" name="ISO_A2" type="field" width="-1"></column>
+          <column hidden="0" name="ISO_A3" type="field" width="-1"></column>
+          <column hidden="0" name="ISO_N3" type="field" width="-1"></column>
+          <column hidden="0" name="UN_A3" type="field" width="-1"></column>
+          <column hidden="0" name="WB_A2" type="field" width="-1"></column>
+          <column hidden="0" name="WB_A3" type="field" width="-1"></column>
+          <column hidden="0" name="WOE_ID" type="field" width="-1"></column>
+          <column hidden="0" name="WOE_ID_EH" type="field" width="-1"></column>
+          <column hidden="0" name="WOE_NOTE" type="field" width="-1"></column>
+          <column hidden="0" name="ADM0_A3_IS" type="field" width="-1"></column>
+          <column hidden="0" name="ADM0_A3_US" type="field" width="-1"></column>
+          <column hidden="0" name="ADM0_A3_UN" type="field" width="-1"></column>
+          <column hidden="0" name="ADM0_A3_WB" type="field" width="-1"></column>
+          <column hidden="0" name="CONTINENT" type="field" width="-1"></column>
+          <column hidden="0" name="REGION_UN" type="field" width="-1"></column>
+          <column hidden="0" name="SUBREGION" type="field" width="-1"></column>
+          <column hidden="0" name="REGION_WB" type="field" width="-1"></column>
+          <column hidden="0" name="NAME_LEN" type="field" width="-1"></column>
+          <column hidden="0" name="LONG_LEN" type="field" width="-1"></column>
+          <column hidden="0" name="ABBREV_LEN" type="field" width="-1"></column>
+          <column hidden="0" name="TINY" type="field" width="-1"></column>
+          <column hidden="0" name="HOMEPART" type="field" width="-1"></column>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1"></editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath></editforminitfilepath>
-      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+      <editforminitcode># -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -4132,155 +4329,155 @@ from qgis.PyQt.QtWidgets import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-]]></editforminitcode>
+</editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <editable>
-        <field name="ABBREV" editable="1"/>
-        <field name="ABBREV_LEN" editable="1"/>
-        <field name="ADM0_A3" editable="1"/>
-        <field name="ADM0_A3_IS" editable="1"/>
-        <field name="ADM0_A3_UN" editable="1"/>
-        <field name="ADM0_A3_US" editable="1"/>
-        <field name="ADM0_A3_WB" editable="1"/>
-        <field name="ADM0_DIF" editable="1"/>
-        <field name="ADMIN" editable="1"/>
-        <field name="BRK_A3" editable="1"/>
-        <field name="BRK_DIFF" editable="1"/>
-        <field name="BRK_GROUP" editable="1"/>
-        <field name="BRK_NAME" editable="1"/>
-        <field name="CONTINENT" editable="1"/>
-        <field name="ECONOMY" editable="1"/>
-        <field name="FIPS_10_" editable="1"/>
-        <field name="FORMAL_EN" editable="1"/>
-        <field name="FORMAL_FR" editable="1"/>
-        <field name="GDP_MD_EST" editable="1"/>
-        <field name="GDP_YEAR" editable="1"/>
-        <field name="GEOUNIT" editable="1"/>
-        <field name="GEOU_DIF" editable="1"/>
-        <field name="GU_A3" editable="1"/>
-        <field name="HOMEPART" editable="1"/>
-        <field name="INCOME_GRP" editable="1"/>
-        <field name="ISO_A2" editable="1"/>
-        <field name="ISO_A3" editable="1"/>
-        <field name="ISO_N3" editable="1"/>
-        <field name="LABELRANK" editable="1"/>
-        <field name="LASTCENSUS" editable="1"/>
-        <field name="LEVEL" editable="1"/>
-        <field name="LONG_LEN" editable="1"/>
-        <field name="MAPCOLOR13" editable="1"/>
-        <field name="MAPCOLOR7" editable="1"/>
-        <field name="MAPCOLOR8" editable="1"/>
-        <field name="MAPCOLOR9" editable="1"/>
-        <field name="NAME" editable="1"/>
-        <field name="NAME_ALT" editable="1"/>
-        <field name="NAME_LEN" editable="1"/>
-        <field name="NAME_LONG" editable="1"/>
-        <field name="NAME_SORT" editable="1"/>
-        <field name="NOTE_ADM0" editable="1"/>
-        <field name="NOTE_BRK" editable="1"/>
-        <field name="POP_EST" editable="1"/>
-        <field name="POP_YEAR" editable="1"/>
-        <field name="POSTAL" editable="1"/>
-        <field name="REGION_UN" editable="1"/>
-        <field name="REGION_WB" editable="1"/>
-        <field name="SOVEREIGNT" editable="1"/>
-        <field name="SOV_A3" editable="1"/>
-        <field name="SUBREGION" editable="1"/>
-        <field name="SUBUNIT" editable="1"/>
-        <field name="SU_A3" editable="1"/>
-        <field name="SU_DIF" editable="1"/>
-        <field name="TINY" editable="1"/>
-        <field name="TYPE" editable="1"/>
-        <field name="UN_A3" editable="1"/>
-        <field name="WB_A2" editable="1"/>
-        <field name="WB_A3" editable="1"/>
-        <field name="WIKIPEDIA" editable="1"/>
-        <field name="WOE_ID" editable="1"/>
-        <field name="WOE_ID_EH" editable="1"/>
-        <field name="WOE_NOTE" editable="1"/>
-        <field name="featurecla" editable="1"/>
-        <field name="fid" editable="1"/>
-        <field name="scalerank" editable="1"/>
+        <field editable="1" name="ABBREV"></field>
+        <field editable="1" name="ABBREV_LEN"></field>
+        <field editable="1" name="ADM0_A3"></field>
+        <field editable="1" name="ADM0_A3_IS"></field>
+        <field editable="1" name="ADM0_A3_UN"></field>
+        <field editable="1" name="ADM0_A3_US"></field>
+        <field editable="1" name="ADM0_A3_WB"></field>
+        <field editable="1" name="ADM0_DIF"></field>
+        <field editable="1" name="ADMIN"></field>
+        <field editable="1" name="BRK_A3"></field>
+        <field editable="1" name="BRK_DIFF"></field>
+        <field editable="1" name="BRK_GROUP"></field>
+        <field editable="1" name="BRK_NAME"></field>
+        <field editable="1" name="CONTINENT"></field>
+        <field editable="1" name="ECONOMY"></field>
+        <field editable="1" name="FIPS_10_"></field>
+        <field editable="1" name="FORMAL_EN"></field>
+        <field editable="1" name="FORMAL_FR"></field>
+        <field editable="1" name="GDP_MD_EST"></field>
+        <field editable="1" name="GDP_YEAR"></field>
+        <field editable="1" name="GEOUNIT"></field>
+        <field editable="1" name="GEOU_DIF"></field>
+        <field editable="1" name="GU_A3"></field>
+        <field editable="1" name="HOMEPART"></field>
+        <field editable="1" name="INCOME_GRP"></field>
+        <field editable="1" name="ISO_A2"></field>
+        <field editable="1" name="ISO_A3"></field>
+        <field editable="1" name="ISO_N3"></field>
+        <field editable="1" name="LABELRANK"></field>
+        <field editable="1" name="LASTCENSUS"></field>
+        <field editable="1" name="LEVEL"></field>
+        <field editable="1" name="LONG_LEN"></field>
+        <field editable="1" name="MAPCOLOR13"></field>
+        <field editable="1" name="MAPCOLOR7"></field>
+        <field editable="1" name="MAPCOLOR8"></field>
+        <field editable="1" name="MAPCOLOR9"></field>
+        <field editable="1" name="NAME"></field>
+        <field editable="1" name="NAME_ALT"></field>
+        <field editable="1" name="NAME_LEN"></field>
+        <field editable="1" name="NAME_LONG"></field>
+        <field editable="1" name="NAME_SORT"></field>
+        <field editable="1" name="NOTE_ADM0"></field>
+        <field editable="1" name="NOTE_BRK"></field>
+        <field editable="1" name="POP_EST"></field>
+        <field editable="1" name="POP_YEAR"></field>
+        <field editable="1" name="POSTAL"></field>
+        <field editable="1" name="REGION_UN"></field>
+        <field editable="1" name="REGION_WB"></field>
+        <field editable="1" name="SOVEREIGNT"></field>
+        <field editable="1" name="SOV_A3"></field>
+        <field editable="1" name="SUBREGION"></field>
+        <field editable="1" name="SUBUNIT"></field>
+        <field editable="1" name="SU_A3"></field>
+        <field editable="1" name="SU_DIF"></field>
+        <field editable="1" name="TINY"></field>
+        <field editable="1" name="TYPE"></field>
+        <field editable="1" name="UN_A3"></field>
+        <field editable="1" name="WB_A2"></field>
+        <field editable="1" name="WB_A3"></field>
+        <field editable="1" name="WIKIPEDIA"></field>
+        <field editable="1" name="WOE_ID"></field>
+        <field editable="1" name="WOE_ID_EH"></field>
+        <field editable="1" name="WOE_NOTE"></field>
+        <field editable="1" name="featurecla"></field>
+        <field editable="1" name="fid"></field>
+        <field editable="1" name="scalerank"></field>
       </editable>
       <labelOnTop>
-        <field labelOnTop="0" name="ABBREV"/>
-        <field labelOnTop="0" name="ABBREV_LEN"/>
-        <field labelOnTop="0" name="ADM0_A3"/>
-        <field labelOnTop="0" name="ADM0_A3_IS"/>
-        <field labelOnTop="0" name="ADM0_A3_UN"/>
-        <field labelOnTop="0" name="ADM0_A3_US"/>
-        <field labelOnTop="0" name="ADM0_A3_WB"/>
-        <field labelOnTop="0" name="ADM0_DIF"/>
-        <field labelOnTop="0" name="ADMIN"/>
-        <field labelOnTop="0" name="BRK_A3"/>
-        <field labelOnTop="0" name="BRK_DIFF"/>
-        <field labelOnTop="0" name="BRK_GROUP"/>
-        <field labelOnTop="0" name="BRK_NAME"/>
-        <field labelOnTop="0" name="CONTINENT"/>
-        <field labelOnTop="0" name="ECONOMY"/>
-        <field labelOnTop="0" name="FIPS_10_"/>
-        <field labelOnTop="0" name="FORMAL_EN"/>
-        <field labelOnTop="0" name="FORMAL_FR"/>
-        <field labelOnTop="0" name="GDP_MD_EST"/>
-        <field labelOnTop="0" name="GDP_YEAR"/>
-        <field labelOnTop="0" name="GEOUNIT"/>
-        <field labelOnTop="0" name="GEOU_DIF"/>
-        <field labelOnTop="0" name="GU_A3"/>
-        <field labelOnTop="0" name="HOMEPART"/>
-        <field labelOnTop="0" name="INCOME_GRP"/>
-        <field labelOnTop="0" name="ISO_A2"/>
-        <field labelOnTop="0" name="ISO_A3"/>
-        <field labelOnTop="0" name="ISO_N3"/>
-        <field labelOnTop="0" name="LABELRANK"/>
-        <field labelOnTop="0" name="LASTCENSUS"/>
-        <field labelOnTop="0" name="LEVEL"/>
-        <field labelOnTop="0" name="LONG_LEN"/>
-        <field labelOnTop="0" name="MAPCOLOR13"/>
-        <field labelOnTop="0" name="MAPCOLOR7"/>
-        <field labelOnTop="0" name="MAPCOLOR8"/>
-        <field labelOnTop="0" name="MAPCOLOR9"/>
-        <field labelOnTop="0" name="NAME"/>
-        <field labelOnTop="0" name="NAME_ALT"/>
-        <field labelOnTop="0" name="NAME_LEN"/>
-        <field labelOnTop="0" name="NAME_LONG"/>
-        <field labelOnTop="0" name="NAME_SORT"/>
-        <field labelOnTop="0" name="NOTE_ADM0"/>
-        <field labelOnTop="0" name="NOTE_BRK"/>
-        <field labelOnTop="0" name="POP_EST"/>
-        <field labelOnTop="0" name="POP_YEAR"/>
-        <field labelOnTop="0" name="POSTAL"/>
-        <field labelOnTop="0" name="REGION_UN"/>
-        <field labelOnTop="0" name="REGION_WB"/>
-        <field labelOnTop="0" name="SOVEREIGNT"/>
-        <field labelOnTop="0" name="SOV_A3"/>
-        <field labelOnTop="0" name="SUBREGION"/>
-        <field labelOnTop="0" name="SUBUNIT"/>
-        <field labelOnTop="0" name="SU_A3"/>
-        <field labelOnTop="0" name="SU_DIF"/>
-        <field labelOnTop="0" name="TINY"/>
-        <field labelOnTop="0" name="TYPE"/>
-        <field labelOnTop="0" name="UN_A3"/>
-        <field labelOnTop="0" name="WB_A2"/>
-        <field labelOnTop="0" name="WB_A3"/>
-        <field labelOnTop="0" name="WIKIPEDIA"/>
-        <field labelOnTop="0" name="WOE_ID"/>
-        <field labelOnTop="0" name="WOE_ID_EH"/>
-        <field labelOnTop="0" name="WOE_NOTE"/>
-        <field labelOnTop="0" name="featurecla"/>
-        <field labelOnTop="0" name="fid"/>
-        <field labelOnTop="0" name="scalerank"/>
+        <field labelOnTop="0" name="ABBREV"></field>
+        <field labelOnTop="0" name="ABBREV_LEN"></field>
+        <field labelOnTop="0" name="ADM0_A3"></field>
+        <field labelOnTop="0" name="ADM0_A3_IS"></field>
+        <field labelOnTop="0" name="ADM0_A3_UN"></field>
+        <field labelOnTop="0" name="ADM0_A3_US"></field>
+        <field labelOnTop="0" name="ADM0_A3_WB"></field>
+        <field labelOnTop="0" name="ADM0_DIF"></field>
+        <field labelOnTop="0" name="ADMIN"></field>
+        <field labelOnTop="0" name="BRK_A3"></field>
+        <field labelOnTop="0" name="BRK_DIFF"></field>
+        <field labelOnTop="0" name="BRK_GROUP"></field>
+        <field labelOnTop="0" name="BRK_NAME"></field>
+        <field labelOnTop="0" name="CONTINENT"></field>
+        <field labelOnTop="0" name="ECONOMY"></field>
+        <field labelOnTop="0" name="FIPS_10_"></field>
+        <field labelOnTop="0" name="FORMAL_EN"></field>
+        <field labelOnTop="0" name="FORMAL_FR"></field>
+        <field labelOnTop="0" name="GDP_MD_EST"></field>
+        <field labelOnTop="0" name="GDP_YEAR"></field>
+        <field labelOnTop="0" name="GEOUNIT"></field>
+        <field labelOnTop="0" name="GEOU_DIF"></field>
+        <field labelOnTop="0" name="GU_A3"></field>
+        <field labelOnTop="0" name="HOMEPART"></field>
+        <field labelOnTop="0" name="INCOME_GRP"></field>
+        <field labelOnTop="0" name="ISO_A2"></field>
+        <field labelOnTop="0" name="ISO_A3"></field>
+        <field labelOnTop="0" name="ISO_N3"></field>
+        <field labelOnTop="0" name="LABELRANK"></field>
+        <field labelOnTop="0" name="LASTCENSUS"></field>
+        <field labelOnTop="0" name="LEVEL"></field>
+        <field labelOnTop="0" name="LONG_LEN"></field>
+        <field labelOnTop="0" name="MAPCOLOR13"></field>
+        <field labelOnTop="0" name="MAPCOLOR7"></field>
+        <field labelOnTop="0" name="MAPCOLOR8"></field>
+        <field labelOnTop="0" name="MAPCOLOR9"></field>
+        <field labelOnTop="0" name="NAME"></field>
+        <field labelOnTop="0" name="NAME_ALT"></field>
+        <field labelOnTop="0" name="NAME_LEN"></field>
+        <field labelOnTop="0" name="NAME_LONG"></field>
+        <field labelOnTop="0" name="NAME_SORT"></field>
+        <field labelOnTop="0" name="NOTE_ADM0"></field>
+        <field labelOnTop="0" name="NOTE_BRK"></field>
+        <field labelOnTop="0" name="POP_EST"></field>
+        <field labelOnTop="0" name="POP_YEAR"></field>
+        <field labelOnTop="0" name="POSTAL"></field>
+        <field labelOnTop="0" name="REGION_UN"></field>
+        <field labelOnTop="0" name="REGION_WB"></field>
+        <field labelOnTop="0" name="SOVEREIGNT"></field>
+        <field labelOnTop="0" name="SOV_A3"></field>
+        <field labelOnTop="0" name="SUBREGION"></field>
+        <field labelOnTop="0" name="SUBUNIT"></field>
+        <field labelOnTop="0" name="SU_A3"></field>
+        <field labelOnTop="0" name="SU_DIF"></field>
+        <field labelOnTop="0" name="TINY"></field>
+        <field labelOnTop="0" name="TYPE"></field>
+        <field labelOnTop="0" name="UN_A3"></field>
+        <field labelOnTop="0" name="WB_A2"></field>
+        <field labelOnTop="0" name="WB_A3"></field>
+        <field labelOnTop="0" name="WIKIPEDIA"></field>
+        <field labelOnTop="0" name="WOE_ID"></field>
+        <field labelOnTop="0" name="WOE_ID_EH"></field>
+        <field labelOnTop="0" name="WOE_NOTE"></field>
+        <field labelOnTop="0" name="featurecla"></field>
+        <field labelOnTop="0" name="fid"></field>
+        <field labelOnTop="0" name="scalerank"></field>
       </labelOnTop>
-      <widgets/>
+      <widgets></widgets>
       <previewExpression>concat( "NAME" , '  (' || "ISO_A2" || ')' )</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer styleCategories="AllStyleCategories" autoRefreshEnabled="0" autoRefreshTime="0" geometry="Polygon" refreshOnNotifyMessage="" simplifyAlgorithm="0" wkbType="MultiPolygon" refreshOnNotifyEnabled="0" simplifyDrawingHints="1" minScale="1e+08" readOnly="1" type="vector" simplifyMaxScale="1" maxScale="0" simplifyLocal="1" simplifyDrawingTol="1" labelsEnabled="0" hasScaleBasedVisibilityFlag="0">
+    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" geometry="Polygon" hasScaleBasedVisibilityFlag="0" labelsEnabled="0" maxScale="0" minScale="100000000" readOnly="1" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" type="vector" wkbType="MultiPolygon">
       <extent>
-        <xmin>1022800</xmin>
-        <ymin>5855480</ymin>
-        <xmax>1061040</xmax>
-        <ymax>5920510</ymax>
+        <xmin>1022797.1875</xmin>
+        <ymin>5855478</ymin>
+        <xmax>1061041.875</xmax>
+        <ymax>5920515</ymax>
       </extent>
       <id>landscape_b275e43a_b9f2_4087_b31a_c5793005d343</id>
       <datasource>./basemaps/laax.gpkg|layername=landscape</datasource>
@@ -4290,13 +4487,14 @@ def my_form_open(dialog, layer, feature):
       <layername>landscape</layername>
       <srs>
         <spatialrefsys>
-          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+          <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
+          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
           <srsid>3857</srsid>
           <srid>3857</srid>
           <authid>EPSG:3857</authid>
           <description>WGS 84 / Pseudo-Mercator</description>
           <projectionacronym>merc</projectionacronym>
-          <ellipsoidacronym></ellipsoidacronym>
+          <ellipsoidacronym>WGS84</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -4307,11 +4505,12 @@ def my_form_open(dialog, layer, feature):
         <type></type>
         <title></title>
         <abstract></abstract>
-        <links/>
+        <links></links>
         <fees></fees>
         <encoding></encoding>
         <crs>
           <spatialrefsys>
+            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -4319,123 +4518,123 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
+            <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
-        <extent/>
+        <extent></extent>
       </resourceMetadata>
       <provider encoding="UTF-8">ogr</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <legend type="default-vector"/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <legend type="default-vector"></legend>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"/>
+        <map-layer-style name="default"></map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
+      <auxiliaryLayer></auxiliaryLayer>
       <flags>
         <Identifiable>0</Identifiable>
         <Removable>1</Removable>
         <Searchable>0</Searchable>
       </flags>
-      <renderer-v2 enableorderby="0" type="RuleRenderer" symbollevels="0" forceraster="0">
+      <renderer-v2 enableorderby="0" forceraster="0" symbollevels="0" type="RuleRenderer">
         <rules key="{7260d5ed-010a-41ed-a7fb-94583dfb4927}">
-          <rule key="{08be5fc4-5283-403e-8b9e-96a8132fa353}" symbol="0" filter="&quot;natural&quot; is not null OR &quot;landuse&quot; is not null OR &quot;leisure&quot; is not null" label="nature"/>
-          <rule key="{24f05b7a-969c-40bb-88cb-a7cbd53e27aa}" symbol="1" filter=" &quot;landuse&quot; = 'residential' " label="residential"/>
-          <rule key="{143c3f72-6f99-42bd-a969-f088bcbc1190}" symbol="2" filter="&quot;natural&quot; = 'water' or &quot;other_tags&quot; LIKE '%water%'" label="water"/>
-          <rule key="{ae5108a9-1d87-45e5-909b-76ff045b59fa}" symbol="3" filter=" &quot;aeroway&quot; is not null or &quot;landuse&quot; = 'industrial'" label="industrial"/>
+          <rule filter="&quot;natural&quot; is not null OR &quot;landuse&quot; is not null OR &quot;leisure&quot; is not null" key="{08be5fc4-5283-403e-8b9e-96a8132fa353}" label="nature" symbol="0"></rule>
+          <rule filter=" &quot;landuse&quot; = 'residential' " key="{24f05b7a-969c-40bb-88cb-a7cbd53e27aa}" label="residential" symbol="1"></rule>
+          <rule filter="&quot;natural&quot; = 'water' or &quot;other_tags&quot; LIKE '%water%'" key="{143c3f72-6f99-42bd-a969-f088bcbc1190}" label="water" symbol="2"></rule>
+          <rule filter=" &quot;aeroway&quot; is not null or &quot;landuse&quot; = 'industrial'" key="{ae5108a9-1d87-45e5-909b-76ff045b59fa}" label="industrial" symbol="3"></rule>
         </rules>
         <symbols>
-          <symbol type="fill" alpha="1" clip_to_extent="1" force_rhr="0" name="0">
-            <layer enabled="1" locked="0" class="SimpleFill" pass="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="191,223,160,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="128,152,72,0" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="0" type="fill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="color" v="191,223,160,255"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="offset" v="0,0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="outline_color" v="128,152,72,0"></prop>
+              <prop k="outline_style" v="solid"></prop>
+              <prop k="outline_width" v="0.26"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
+              <prop k="style" v="solid"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol type="fill" alpha="1" clip_to_extent="1" force_rhr="0" name="1">
-            <layer enabled="1" locked="0" class="SimpleFill" pass="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="253,225,191,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0,0,0,0" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="1" type="fill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="color" v="253,225,191,255"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="offset" v="0,0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="outline_color" v="0,0,0,0"></prop>
+              <prop k="outline_style" v="solid"></prop>
+              <prop k="outline_width" v="0.26"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
+              <prop k="style" v="solid"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol type="fill" alpha="1" clip_to_extent="1" force_rhr="0" name="2">
-            <layer enabled="1" locked="0" class="ShapeburstFill" pass="0">
-              <prop v="0" k="blur_radius"/>
-              <prop v="122,189,234,255" k="color"/>
-              <prop v="49,165,223,255" k="color1"/>
-              <prop v="0,213,255,255" k="color2"/>
-              <prop v="0" k="color_type"/>
-              <prop v="0" k="discrete"/>
-              <prop v="3x:0,0,0,0,0,0" k="distance_map_unit_scale"/>
-              <prop v="MM" k="distance_unit"/>
-              <prop v="173,197,212,255" k="gradient_color2"/>
-              <prop v="0" k="ignore_rings"/>
-              <prop v="5" k="max_distance"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="gradient" k="rampType"/>
-              <prop v="1" k="use_whole_shape"/>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="2" type="fill">
+            <layer class="ShapeburstFill" enabled="1" locked="0" pass="0">
+              <prop k="blur_radius" v="0"></prop>
+              <prop k="color" v="122,189,234,255"></prop>
+              <prop k="color1" v="49,165,223,255"></prop>
+              <prop k="color2" v="0,213,255,255"></prop>
+              <prop k="color_type" v="0"></prop>
+              <prop k="discrete" v="0"></prop>
+              <prop k="distance_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_unit" v="MM"></prop>
+              <prop k="gradient_color2" v="173,197,212,255"></prop>
+              <prop k="ignore_rings" v="0"></prop>
+              <prop k="max_distance" v="5"></prop>
+              <prop k="offset" v="0,0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="rampType" v="gradient"></prop>
+              <prop k="use_whole_shape" v="1"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol type="fill" alpha="1" clip_to_extent="1" force_rhr="0" name="3">
-            <layer enabled="1" locked="0" class="SimpleFill" pass="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="175,175,175,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0,0,0,0" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="3" type="fill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="color" v="175,175,175,255"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="offset" v="0,0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="outline_color" v="0,0,0,0"></prop>
+              <prop k="outline_style" v="solid"></prop>
+              <prop k="outline_width" v="0.26"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
+              <prop k="style" v="solid"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -4443,39 +4642,70 @@ def my_form_open(dialog, layer, feature):
         </symbols>
       </renderer-v2>
       <customproperties>
-        <property key="embeddedWidgets/count" value="0"/>
-        <property key="variableNames"/>
-        <property key="variableValues"/>
+        <property key="embeddedWidgets/count" value="0"></property>
+        <property key="variableNames"></property>
+        <property key="variableValues"></property>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
-        <DiagramCategory labelPlacementMethod="XHeight" minScaleDenominator="0" penAlpha="255" diagramOrientation="Up" penColor="#000000" scaleBasedVisibility="0" rotationOffset="270" maxScaleDenominator="1e+08" sizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" barWidth="5" backgroundColor="#ffffff" width="15" scaleDependency="Area" minimumSize="0" lineSizeScale="3x:0,0,0,0,0,0" sizeType="MM" backgroundAlpha="255" height="15" enabled="0" penWidth="0" opacity="1">
-          <fontProperties style="" description="Cantarell,11,-1,5,50,0,0,0,0,0"/>
-          <attribute color="#000000" field="" label=""/>
+      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="1" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+8" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" showAxis="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="0" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
+          <fontProperties description="Cantarell,11,-1,5,50,0,0,0,0,0" style=""></fontProperties>
+          <attribute color="#000000" field="" label=""></attribute>
+          <axisSymbol>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" type="line">
+              <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+                <prop k="capstyle" v="square"></prop>
+                <prop k="customdash" v="5;2"></prop>
+                <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="customdash_unit" v="MM"></prop>
+                <prop k="draw_inside_polygon" v="0"></prop>
+                <prop k="joinstyle" v="bevel"></prop>
+                <prop k="line_color" v="35,35,35,255"></prop>
+                <prop k="line_style" v="solid"></prop>
+                <prop k="line_width" v="0.26"></prop>
+                <prop k="line_width_unit" v="MM"></prop>
+                <prop k="offset" v="0"></prop>
+                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="offset_unit" v="MM"></prop>
+                <prop k="ring_filter" v="0"></prop>
+                <prop k="use_custom_dash" v="0"></prop>
+                <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings linePlacementFlags="18" dist="0" priority="0" zIndex="0" placement="1" obstacle="0" showAll="1">
+      <DiagramLayerSettings dist="0" linePlacementFlags="18" obstacle="0" placement="1" priority="0" showAll="1" zIndex="0">
         <properties>
           <Option type="Map">
-            <Option type="QString" name="name" value=""/>
-            <Option name="properties"/>
-            <Option type="QString" name="type" value="collection"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </properties>
       </DiagramLayerSettings>
       <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-        <activeChecks/>
-        <checkConfiguration/>
+        <activeChecks></activeChecks>
+        <checkConfiguration></checkConfiguration>
       </geometryOptions>
+      <referencedLayers></referencedLayers>
+      <referencingLayers></referencingLayers>
       <fieldConfiguration>
         <field name="fid">
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -4484,8 +4714,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -4494,8 +4724,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -4504,8 +4734,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -4514,8 +4744,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -4524,8 +4754,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -4534,8 +4764,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -4544,8 +4774,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -4554,8 +4784,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -4564,8 +4794,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -4574,8 +4804,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -4584,8 +4814,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -4594,8 +4824,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -4604,8 +4834,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -4614,8 +4844,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -4624,8 +4854,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -4634,8 +4864,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -4644,8 +4874,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -4654,8 +4884,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -4664,8 +4894,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -4674,8 +4904,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -4684,8 +4914,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -4694,8 +4924,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -4704,8 +4934,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -4714,8 +4944,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -4724,8 +4954,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -4734,177 +4964,177 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" field="fid" index="0"/>
-        <alias name="" field="osm_id" index="1"/>
-        <alias name="" field="osm_way_id" index="2"/>
-        <alias name="" field="name" index="3"/>
-        <alias name="" field="type" index="4"/>
-        <alias name="" field="aeroway" index="5"/>
-        <alias name="" field="amenity" index="6"/>
-        <alias name="" field="admin_level" index="7"/>
-        <alias name="" field="barrier" index="8"/>
-        <alias name="" field="boundary" index="9"/>
-        <alias name="" field="building" index="10"/>
-        <alias name="" field="craft" index="11"/>
-        <alias name="" field="geological" index="12"/>
-        <alias name="" field="historic" index="13"/>
-        <alias name="" field="land_area" index="14"/>
-        <alias name="" field="landuse" index="15"/>
-        <alias name="" field="leisure" index="16"/>
-        <alias name="" field="man_made" index="17"/>
-        <alias name="" field="military" index="18"/>
-        <alias name="" field="natural" index="19"/>
-        <alias name="" field="office" index="20"/>
-        <alias name="" field="place" index="21"/>
-        <alias name="" field="shop" index="22"/>
-        <alias name="" field="sport" index="23"/>
-        <alias name="" field="tourism" index="24"/>
-        <alias name="" field="other_tags" index="25"/>
-        <alias name="" field="orig_ogc_fid" index="26"/>
+        <alias field="fid" index="0" name=""></alias>
+        <alias field="osm_id" index="1" name=""></alias>
+        <alias field="osm_way_id" index="2" name=""></alias>
+        <alias field="name" index="3" name=""></alias>
+        <alias field="type" index="4" name=""></alias>
+        <alias field="aeroway" index="5" name=""></alias>
+        <alias field="amenity" index="6" name=""></alias>
+        <alias field="admin_level" index="7" name=""></alias>
+        <alias field="barrier" index="8" name=""></alias>
+        <alias field="boundary" index="9" name=""></alias>
+        <alias field="building" index="10" name=""></alias>
+        <alias field="craft" index="11" name=""></alias>
+        <alias field="geological" index="12" name=""></alias>
+        <alias field="historic" index="13" name=""></alias>
+        <alias field="land_area" index="14" name=""></alias>
+        <alias field="landuse" index="15" name=""></alias>
+        <alias field="leisure" index="16" name=""></alias>
+        <alias field="man_made" index="17" name=""></alias>
+        <alias field="military" index="18" name=""></alias>
+        <alias field="natural" index="19" name=""></alias>
+        <alias field="office" index="20" name=""></alias>
+        <alias field="place" index="21" name=""></alias>
+        <alias field="shop" index="22" name=""></alias>
+        <alias field="sport" index="23" name=""></alias>
+        <alias field="tourism" index="24" name=""></alias>
+        <alias field="other_tags" index="25" name=""></alias>
+        <alias field="orig_ogc_fid" index="26" name=""></alias>
       </aliases>
-      <excludeAttributesWMS/>
-      <excludeAttributesWFS/>
+      <excludeAttributesWMS></excludeAttributesWMS>
+      <excludeAttributesWFS></excludeAttributesWFS>
       <defaults>
-        <default applyOnUpdate="0" field="fid" expression=""/>
-        <default applyOnUpdate="0" field="osm_id" expression=""/>
-        <default applyOnUpdate="0" field="osm_way_id" expression=""/>
-        <default applyOnUpdate="0" field="name" expression=""/>
-        <default applyOnUpdate="0" field="type" expression=""/>
-        <default applyOnUpdate="0" field="aeroway" expression=""/>
-        <default applyOnUpdate="0" field="amenity" expression=""/>
-        <default applyOnUpdate="0" field="admin_level" expression=""/>
-        <default applyOnUpdate="0" field="barrier" expression=""/>
-        <default applyOnUpdate="0" field="boundary" expression=""/>
-        <default applyOnUpdate="0" field="building" expression=""/>
-        <default applyOnUpdate="0" field="craft" expression=""/>
-        <default applyOnUpdate="0" field="geological" expression=""/>
-        <default applyOnUpdate="0" field="historic" expression=""/>
-        <default applyOnUpdate="0" field="land_area" expression=""/>
-        <default applyOnUpdate="0" field="landuse" expression=""/>
-        <default applyOnUpdate="0" field="leisure" expression=""/>
-        <default applyOnUpdate="0" field="man_made" expression=""/>
-        <default applyOnUpdate="0" field="military" expression=""/>
-        <default applyOnUpdate="0" field="natural" expression=""/>
-        <default applyOnUpdate="0" field="office" expression=""/>
-        <default applyOnUpdate="0" field="place" expression=""/>
-        <default applyOnUpdate="0" field="shop" expression=""/>
-        <default applyOnUpdate="0" field="sport" expression=""/>
-        <default applyOnUpdate="0" field="tourism" expression=""/>
-        <default applyOnUpdate="0" field="other_tags" expression=""/>
-        <default applyOnUpdate="0" field="orig_ogc_fid" expression=""/>
+        <default applyOnUpdate="0" expression="" field="fid"></default>
+        <default applyOnUpdate="0" expression="" field="osm_id"></default>
+        <default applyOnUpdate="0" expression="" field="osm_way_id"></default>
+        <default applyOnUpdate="0" expression="" field="name"></default>
+        <default applyOnUpdate="0" expression="" field="type"></default>
+        <default applyOnUpdate="0" expression="" field="aeroway"></default>
+        <default applyOnUpdate="0" expression="" field="amenity"></default>
+        <default applyOnUpdate="0" expression="" field="admin_level"></default>
+        <default applyOnUpdate="0" expression="" field="barrier"></default>
+        <default applyOnUpdate="0" expression="" field="boundary"></default>
+        <default applyOnUpdate="0" expression="" field="building"></default>
+        <default applyOnUpdate="0" expression="" field="craft"></default>
+        <default applyOnUpdate="0" expression="" field="geological"></default>
+        <default applyOnUpdate="0" expression="" field="historic"></default>
+        <default applyOnUpdate="0" expression="" field="land_area"></default>
+        <default applyOnUpdate="0" expression="" field="landuse"></default>
+        <default applyOnUpdate="0" expression="" field="leisure"></default>
+        <default applyOnUpdate="0" expression="" field="man_made"></default>
+        <default applyOnUpdate="0" expression="" field="military"></default>
+        <default applyOnUpdate="0" expression="" field="natural"></default>
+        <default applyOnUpdate="0" expression="" field="office"></default>
+        <default applyOnUpdate="0" expression="" field="place"></default>
+        <default applyOnUpdate="0" expression="" field="shop"></default>
+        <default applyOnUpdate="0" expression="" field="sport"></default>
+        <default applyOnUpdate="0" expression="" field="tourism"></default>
+        <default applyOnUpdate="0" expression="" field="other_tags"></default>
+        <default applyOnUpdate="0" expression="" field="orig_ogc_fid"></default>
       </defaults>
       <constraints>
-        <constraint notnull_strength="1" constraints="3" field="fid" unique_strength="1" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="osm_id" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="osm_way_id" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="name" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="type" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="aeroway" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="amenity" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="admin_level" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="barrier" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="boundary" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="building" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="craft" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="geological" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="historic" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="land_area" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="landuse" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="leisure" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="man_made" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="military" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="natural" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="office" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="place" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="shop" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="sport" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="tourism" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="other_tags" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="orig_ogc_fid" unique_strength="0" exp_strength="0"/>
+        <constraint constraints="3" exp_strength="0" field="fid" notnull_strength="1" unique_strength="1"></constraint>
+        <constraint constraints="0" exp_strength="0" field="osm_id" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="osm_way_id" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="name" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="type" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="aeroway" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="amenity" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="admin_level" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="barrier" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="boundary" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="building" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="craft" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="geological" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="historic" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="land_area" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="landuse" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="leisure" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="man_made" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="military" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="natural" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="office" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="place" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="shop" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="sport" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="tourism" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="other_tags" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="orig_ogc_fid" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint field="fid" desc="" exp=""/>
-        <constraint field="osm_id" desc="" exp=""/>
-        <constraint field="osm_way_id" desc="" exp=""/>
-        <constraint field="name" desc="" exp=""/>
-        <constraint field="type" desc="" exp=""/>
-        <constraint field="aeroway" desc="" exp=""/>
-        <constraint field="amenity" desc="" exp=""/>
-        <constraint field="admin_level" desc="" exp=""/>
-        <constraint field="barrier" desc="" exp=""/>
-        <constraint field="boundary" desc="" exp=""/>
-        <constraint field="building" desc="" exp=""/>
-        <constraint field="craft" desc="" exp=""/>
-        <constraint field="geological" desc="" exp=""/>
-        <constraint field="historic" desc="" exp=""/>
-        <constraint field="land_area" desc="" exp=""/>
-        <constraint field="landuse" desc="" exp=""/>
-        <constraint field="leisure" desc="" exp=""/>
-        <constraint field="man_made" desc="" exp=""/>
-        <constraint field="military" desc="" exp=""/>
-        <constraint field="natural" desc="" exp=""/>
-        <constraint field="office" desc="" exp=""/>
-        <constraint field="place" desc="" exp=""/>
-        <constraint field="shop" desc="" exp=""/>
-        <constraint field="sport" desc="" exp=""/>
-        <constraint field="tourism" desc="" exp=""/>
-        <constraint field="other_tags" desc="" exp=""/>
-        <constraint field="orig_ogc_fid" desc="" exp=""/>
+        <constraint desc="" exp="" field="fid"></constraint>
+        <constraint desc="" exp="" field="osm_id"></constraint>
+        <constraint desc="" exp="" field="osm_way_id"></constraint>
+        <constraint desc="" exp="" field="name"></constraint>
+        <constraint desc="" exp="" field="type"></constraint>
+        <constraint desc="" exp="" field="aeroway"></constraint>
+        <constraint desc="" exp="" field="amenity"></constraint>
+        <constraint desc="" exp="" field="admin_level"></constraint>
+        <constraint desc="" exp="" field="barrier"></constraint>
+        <constraint desc="" exp="" field="boundary"></constraint>
+        <constraint desc="" exp="" field="building"></constraint>
+        <constraint desc="" exp="" field="craft"></constraint>
+        <constraint desc="" exp="" field="geological"></constraint>
+        <constraint desc="" exp="" field="historic"></constraint>
+        <constraint desc="" exp="" field="land_area"></constraint>
+        <constraint desc="" exp="" field="landuse"></constraint>
+        <constraint desc="" exp="" field="leisure"></constraint>
+        <constraint desc="" exp="" field="man_made"></constraint>
+        <constraint desc="" exp="" field="military"></constraint>
+        <constraint desc="" exp="" field="natural"></constraint>
+        <constraint desc="" exp="" field="office"></constraint>
+        <constraint desc="" exp="" field="place"></constraint>
+        <constraint desc="" exp="" field="shop"></constraint>
+        <constraint desc="" exp="" field="sport"></constraint>
+        <constraint desc="" exp="" field="tourism"></constraint>
+        <constraint desc="" exp="" field="other_tags"></constraint>
+        <constraint desc="" exp="" field="orig_ogc_fid"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
       </attributeactions>
-      <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column type="field" name="fid" width="-1" hidden="0"/>
-          <column type="field" name="osm_id" width="-1" hidden="0"/>
-          <column type="field" name="osm_way_id" width="-1" hidden="0"/>
-          <column type="field" name="name" width="-1" hidden="0"/>
-          <column type="field" name="type" width="-1" hidden="0"/>
-          <column type="field" name="aeroway" width="-1" hidden="0"/>
-          <column type="field" name="amenity" width="-1" hidden="0"/>
-          <column type="field" name="admin_level" width="-1" hidden="0"/>
-          <column type="field" name="barrier" width="-1" hidden="0"/>
-          <column type="field" name="boundary" width="-1" hidden="0"/>
-          <column type="field" name="building" width="-1" hidden="0"/>
-          <column type="field" name="craft" width="-1" hidden="0"/>
-          <column type="field" name="geological" width="-1" hidden="0"/>
-          <column type="field" name="historic" width="-1" hidden="0"/>
-          <column type="field" name="land_area" width="-1" hidden="0"/>
-          <column type="field" name="landuse" width="-1" hidden="0"/>
-          <column type="field" name="leisure" width="-1" hidden="0"/>
-          <column type="field" name="man_made" width="-1" hidden="0"/>
-          <column type="field" name="military" width="-1" hidden="0"/>
-          <column type="field" name="natural" width="-1" hidden="0"/>
-          <column type="field" name="office" width="-1" hidden="0"/>
-          <column type="field" name="place" width="-1" hidden="0"/>
-          <column type="field" name="shop" width="-1" hidden="0"/>
-          <column type="field" name="sport" width="-1" hidden="0"/>
-          <column type="field" name="tourism" width="-1" hidden="0"/>
-          <column type="field" name="other_tags" width="-1" hidden="0"/>
-          <column type="actions" width="-1" hidden="1"/>
-          <column type="field" name="orig_ogc_fid" width="-1" hidden="0"/>
+          <column hidden="0" name="fid" type="field" width="-1"></column>
+          <column hidden="0" name="osm_id" type="field" width="-1"></column>
+          <column hidden="0" name="osm_way_id" type="field" width="-1"></column>
+          <column hidden="0" name="name" type="field" width="-1"></column>
+          <column hidden="0" name="type" type="field" width="-1"></column>
+          <column hidden="0" name="aeroway" type="field" width="-1"></column>
+          <column hidden="0" name="amenity" type="field" width="-1"></column>
+          <column hidden="0" name="admin_level" type="field" width="-1"></column>
+          <column hidden="0" name="barrier" type="field" width="-1"></column>
+          <column hidden="0" name="boundary" type="field" width="-1"></column>
+          <column hidden="0" name="building" type="field" width="-1"></column>
+          <column hidden="0" name="craft" type="field" width="-1"></column>
+          <column hidden="0" name="geological" type="field" width="-1"></column>
+          <column hidden="0" name="historic" type="field" width="-1"></column>
+          <column hidden="0" name="land_area" type="field" width="-1"></column>
+          <column hidden="0" name="landuse" type="field" width="-1"></column>
+          <column hidden="0" name="leisure" type="field" width="-1"></column>
+          <column hidden="0" name="man_made" type="field" width="-1"></column>
+          <column hidden="0" name="military" type="field" width="-1"></column>
+          <column hidden="0" name="natural" type="field" width="-1"></column>
+          <column hidden="0" name="office" type="field" width="-1"></column>
+          <column hidden="0" name="place" type="field" width="-1"></column>
+          <column hidden="0" name="shop" type="field" width="-1"></column>
+          <column hidden="0" name="sport" type="field" width="-1"></column>
+          <column hidden="0" name="tourism" type="field" width="-1"></column>
+          <column hidden="0" name="other_tags" type="field" width="-1"></column>
+          <column hidden="1" type="actions" width="-1"></column>
+          <column hidden="0" name="orig_ogc_fid" type="field" width="-1"></column>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1"></editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath>/david/doc/teaching/QField_Workshop/citybees</editforminitfilepath>
-      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+      <editforminitcode># -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -4920,77 +5150,77 @@ from qgis.PyQt.QtWidgets import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-]]></editforminitcode>
+</editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <editable>
-        <field name="admin_level" editable="1"/>
-        <field name="aeroway" editable="1"/>
-        <field name="amenity" editable="1"/>
-        <field name="barrier" editable="1"/>
-        <field name="boundary" editable="1"/>
-        <field name="building" editable="1"/>
-        <field name="craft" editable="1"/>
-        <field name="fid" editable="1"/>
-        <field name="geological" editable="1"/>
-        <field name="historic" editable="1"/>
-        <field name="land_area" editable="1"/>
-        <field name="landuse" editable="1"/>
-        <field name="leisure" editable="1"/>
-        <field name="man_made" editable="1"/>
-        <field name="military" editable="1"/>
-        <field name="name" editable="1"/>
-        <field name="natural" editable="1"/>
-        <field name="office" editable="1"/>
-        <field name="orig_ogc_fid" editable="1"/>
-        <field name="osm_id" editable="1"/>
-        <field name="osm_way_id" editable="1"/>
-        <field name="other_tags" editable="1"/>
-        <field name="place" editable="1"/>
-        <field name="shop" editable="1"/>
-        <field name="sport" editable="1"/>
-        <field name="tourism" editable="1"/>
-        <field name="type" editable="1"/>
+        <field editable="1" name="admin_level"></field>
+        <field editable="1" name="aeroway"></field>
+        <field editable="1" name="amenity"></field>
+        <field editable="1" name="barrier"></field>
+        <field editable="1" name="boundary"></field>
+        <field editable="1" name="building"></field>
+        <field editable="1" name="craft"></field>
+        <field editable="1" name="fid"></field>
+        <field editable="1" name="geological"></field>
+        <field editable="1" name="historic"></field>
+        <field editable="1" name="land_area"></field>
+        <field editable="1" name="landuse"></field>
+        <field editable="1" name="leisure"></field>
+        <field editable="1" name="man_made"></field>
+        <field editable="1" name="military"></field>
+        <field editable="1" name="name"></field>
+        <field editable="1" name="natural"></field>
+        <field editable="1" name="office"></field>
+        <field editable="1" name="orig_ogc_fid"></field>
+        <field editable="1" name="osm_id"></field>
+        <field editable="1" name="osm_way_id"></field>
+        <field editable="1" name="other_tags"></field>
+        <field editable="1" name="place"></field>
+        <field editable="1" name="shop"></field>
+        <field editable="1" name="sport"></field>
+        <field editable="1" name="tourism"></field>
+        <field editable="1" name="type"></field>
       </editable>
       <labelOnTop>
-        <field labelOnTop="0" name="admin_level"/>
-        <field labelOnTop="0" name="aeroway"/>
-        <field labelOnTop="0" name="amenity"/>
-        <field labelOnTop="0" name="barrier"/>
-        <field labelOnTop="0" name="boundary"/>
-        <field labelOnTop="0" name="building"/>
-        <field labelOnTop="0" name="craft"/>
-        <field labelOnTop="0" name="fid"/>
-        <field labelOnTop="0" name="geological"/>
-        <field labelOnTop="0" name="historic"/>
-        <field labelOnTop="0" name="land_area"/>
-        <field labelOnTop="0" name="landuse"/>
-        <field labelOnTop="0" name="leisure"/>
-        <field labelOnTop="0" name="man_made"/>
-        <field labelOnTop="0" name="military"/>
-        <field labelOnTop="0" name="name"/>
-        <field labelOnTop="0" name="natural"/>
-        <field labelOnTop="0" name="office"/>
-        <field labelOnTop="0" name="orig_ogc_fid"/>
-        <field labelOnTop="0" name="osm_id"/>
-        <field labelOnTop="0" name="osm_way_id"/>
-        <field labelOnTop="0" name="other_tags"/>
-        <field labelOnTop="0" name="place"/>
-        <field labelOnTop="0" name="shop"/>
-        <field labelOnTop="0" name="sport"/>
-        <field labelOnTop="0" name="tourism"/>
-        <field labelOnTop="0" name="type"/>
+        <field labelOnTop="0" name="admin_level"></field>
+        <field labelOnTop="0" name="aeroway"></field>
+        <field labelOnTop="0" name="amenity"></field>
+        <field labelOnTop="0" name="barrier"></field>
+        <field labelOnTop="0" name="boundary"></field>
+        <field labelOnTop="0" name="building"></field>
+        <field labelOnTop="0" name="craft"></field>
+        <field labelOnTop="0" name="fid"></field>
+        <field labelOnTop="0" name="geological"></field>
+        <field labelOnTop="0" name="historic"></field>
+        <field labelOnTop="0" name="land_area"></field>
+        <field labelOnTop="0" name="landuse"></field>
+        <field labelOnTop="0" name="leisure"></field>
+        <field labelOnTop="0" name="man_made"></field>
+        <field labelOnTop="0" name="military"></field>
+        <field labelOnTop="0" name="name"></field>
+        <field labelOnTop="0" name="natural"></field>
+        <field labelOnTop="0" name="office"></field>
+        <field labelOnTop="0" name="orig_ogc_fid"></field>
+        <field labelOnTop="0" name="osm_id"></field>
+        <field labelOnTop="0" name="osm_way_id"></field>
+        <field labelOnTop="0" name="other_tags"></field>
+        <field labelOnTop="0" name="place"></field>
+        <field labelOnTop="0" name="shop"></field>
+        <field labelOnTop="0" name="sport"></field>
+        <field labelOnTop="0" name="tourism"></field>
+        <field labelOnTop="0" name="type"></field>
       </labelOnTop>
-      <widgets/>
-      <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
+      <widgets></widgets>
+      <previewExpression>COALESCE( "name", '&lt;NULL&gt;' )</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer styleCategories="AllStyleCategories" autoRefreshEnabled="0" autoRefreshTime="0" geometry="Line" refreshOnNotifyMessage="" simplifyAlgorithm="0" wkbType="LineString" refreshOnNotifyEnabled="0" simplifyDrawingHints="1" minScale="0" readOnly="1" type="vector" simplifyMaxScale="1" maxScale="0" simplifyLocal="1" simplifyDrawingTol="1" labelsEnabled="0" hasScaleBasedVisibilityFlag="0">
+    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" geometry="Line" hasScaleBasedVisibilityFlag="0" labelsEnabled="0" maxScale="0" minScale="0" readOnly="1" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" type="vector" wkbType="LineString">
       <extent>
-        <xmin>1024930</xmin>
-        <ymin>5905780</ymin>
-        <xmax>1038050</xmax>
-        <ymax>5919520</ymax>
+        <xmin>1024927.75</xmin>
+        <ymin>5905779.5</ymin>
+        <xmax>1038055</xmax>
+        <ymax>5919519</ymax>
       </extent>
       <id>lines_3691e21a_d6eb_4d63_a8f5_d5ada1aca9b8</id>
       <datasource>./basemaps/laax.gpkg|layername=lines</datasource>
@@ -5000,13 +5230,14 @@ def my_form_open(dialog, layer, feature):
       <layername>lines</layername>
       <srs>
         <spatialrefsys>
-          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+          <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
+          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
           <srsid>3857</srsid>
           <srid>3857</srid>
           <authid>EPSG:3857</authid>
           <description>WGS 84 / Pseudo-Mercator</description>
           <projectionacronym>merc</projectionacronym>
-          <ellipsoidacronym></ellipsoidacronym>
+          <ellipsoidacronym>WGS84</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -5017,11 +5248,12 @@ def my_form_open(dialog, layer, feature):
         <type></type>
         <title></title>
         <abstract></abstract>
-        <links/>
+        <links></links>
         <fees></fees>
         <encoding></encoding>
         <crs>
           <spatialrefsys>
+            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -5029,517 +5261,517 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
+            <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
-        <extent/>
+        <extent></extent>
       </resourceMetadata>
       <provider encoding="UTF-8">ogr</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <legend type="default-vector"/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <legend type="default-vector"></legend>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"/>
+        <map-layer-style name="default"></map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
+      <auxiliaryLayer></auxiliaryLayer>
       <flags>
         <Identifiable>0</Identifiable>
         <Removable>1</Removable>
         <Searchable>0</Searchable>
       </flags>
-      <renderer-v2 enableorderby="0" type="RuleRenderer" symbollevels="0" forceraster="0">
+      <renderer-v2 enableorderby="0" forceraster="0" symbollevels="0" type="RuleRenderer">
         <rules key="{0d36de44-6814-4fea-a48c-d678277f9bd4}">
-          <rule key="{f1926d8e-6ccf-40d0-a1b2-aadaeb0e4ac4}" filter="&quot;highway&quot; is not null" label="roads">
-            <rule key="{8ef7a743-8700-4afe-9018-fc3dbcb8fe50}" filter="&quot;highway&quot; = 'motorway' " label="motorway">
-              <rule key="{c6cbaf95-2947-4da4-b098-d1c33b31654a}" symbol="0" filter="&quot;other_tags&quot; like '%&quot;layer&quot;=>&quot;-%' = 0" label="motorway"/>
-              <rule key="{e0fcf762-24dc-4be8-9a70-0ce423f800dd}" symbol="1" filter="&quot;other_tags&quot; like '%&quot;layer&quot;=>&quot;-%' = 1" label="tunnel"/>
+          <rule filter="&quot;highway&quot; is not null" key="{f1926d8e-6ccf-40d0-a1b2-aadaeb0e4ac4}" label="roads">
+            <rule filter="&quot;highway&quot; = 'motorway' " key="{8ef7a743-8700-4afe-9018-fc3dbcb8fe50}" label="motorway">
+              <rule filter="&quot;other_tags&quot; like '%&quot;layer&quot;=>&quot;-%' = 0" key="{c6cbaf95-2947-4da4-b098-d1c33b31654a}" label="motorway" symbol="0"></rule>
+              <rule filter="&quot;other_tags&quot; like '%&quot;layer&quot;=>&quot;-%' = 1" key="{e0fcf762-24dc-4be8-9a70-0ce423f800dd}" label="tunnel" symbol="1"></rule>
             </rule>
-            <rule key="{460cf940-02d3-46c1-8af3-d81902e55292}" filter="&quot;highway&quot; IN ( 'motorway_link','trunk','primary')" label="trunk &amp; primary">
-              <rule key="{be0a9363-979f-44b5-9833-9039fc2c8554}" symbol="2" filter="&quot;other_tags&quot; like '%&quot;layer&quot;=>&quot;-%' = 0" label="trunk &amp; primary"/>
-              <rule key="{144c24ee-f792-4030-bc85-01d5dd5099f1}" symbol="3" filter="&quot;other_tags&quot; like '%&quot;layer&quot;=>&quot;-%' = 1" label="tunnel"/>
+            <rule filter="&quot;highway&quot; IN ( 'motorway_link','trunk','primary')" key="{460cf940-02d3-46c1-8af3-d81902e55292}" label="trunk &amp; primary">
+              <rule filter="&quot;other_tags&quot; like '%&quot;layer&quot;=>&quot;-%' = 0" key="{be0a9363-979f-44b5-9833-9039fc2c8554}" label="trunk &amp; primary" symbol="2"></rule>
+              <rule filter="&quot;other_tags&quot; like '%&quot;layer&quot;=>&quot;-%' = 1" key="{144c24ee-f792-4030-bc85-01d5dd5099f1}" label="tunnel" symbol="3"></rule>
             </rule>
-            <rule key="{79dfc622-0af0-480a-b30e-bab186370428}" symbol="4" filter="&quot;highway&quot; IN ( 'trunk_link','primary_link','secondary','secondary_link','road','tertiary','tertiary_link')" label="roads"/>
-            <rule scalemindenom="1" key="{66a14f73-bc31-4103-8560-0db9e17d7fb7}" symbol="5" scalemaxdenom="1000" filter="&quot;highway&quot; is not null" label="minor roads"/>
-            <rule scalemindenom="1000" key="{73f736c6-ce27-41de-8d1a-e156a03ead91}" symbol="6" scalemaxdenom="50000" filter="&quot;highway&quot; is not null" label="minor roads"/>
+            <rule filter="&quot;highway&quot; IN ( 'trunk_link','primary_link','secondary','secondary_link','road','tertiary','tertiary_link')" key="{79dfc622-0af0-480a-b30e-bab186370428}" label="roads" symbol="4"></rule>
+            <rule filter="&quot;highway&quot; is not null" key="{66a14f73-bc31-4103-8560-0db9e17d7fb7}" label="minor roads" scalemaxdenom="1000" scalemindenom="1" symbol="5"></rule>
+            <rule filter="&quot;highway&quot; is not null" key="{73f736c6-ce27-41de-8d1a-e156a03ead91}" label="minor roads" scalemaxdenom="50000" scalemindenom="1000" symbol="6"></rule>
           </rule>
-          <rule key="{fda0c98a-1143-4220-899c-eafc75601a6f}" symbol="7" filter="&quot;other_tags&quot; LIKE '%&quot;rail&quot;%' or &quot;other_tags&quot; LIKE '%&quot;railway&quot;%'" label="rails"/>
-          <rule key="{f3082c5b-c4d0-4e58-8dba-ee4c9d2d6ef5}" filter="&quot;waterway&quot; = 'river'" label="river">
-            <rule key="{2ea395c2-750f-4578-8764-4725bf71c7dc}" symbol="8" scalemaxdenom="125000" label="river"/>
-            <rule scalemindenom="125000" key="{fde5ded2-bf93-48f2-aa0c-5c717be6ae08}" symbol="9" label="river"/>
+          <rule filter="&quot;other_tags&quot; LIKE '%&quot;rail&quot;%' or &quot;other_tags&quot; LIKE '%&quot;railway&quot;%'" key="{fda0c98a-1143-4220-899c-eafc75601a6f}" label="rails" symbol="7"></rule>
+          <rule filter="&quot;waterway&quot; = 'river'" key="{f3082c5b-c4d0-4e58-8dba-ee4c9d2d6ef5}" label="river">
+            <rule key="{2ea395c2-750f-4578-8764-4725bf71c7dc}" label="river" scalemaxdenom="125000" symbol="8"></rule>
+            <rule key="{fde5ded2-bf93-48f2-aa0c-5c717be6ae08}" label="river" scalemindenom="125000" symbol="9"></rule>
           </rule>
         </rules>
         <symbols>
-          <symbol type="line" alpha="1" clip_to_extent="1" force_rhr="0" name="0">
-            <layer enabled="1" locked="0" class="SimpleLine" pass="3">
-              <prop v="square" k="capstyle"/>
-              <prop v="5;2" k="customdash"/>
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-              <prop v="MM" k="customdash_unit"/>
-              <prop v="0" k="draw_inside_polygon"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="143,143,143,255" k="line_color"/>
-              <prop v="solid" k="line_style"/>
-              <prop v="1" k="line_width"/>
-              <prop v="MM" k="line_width_unit"/>
-              <prop v="0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0" k="ring_filter"/>
-              <prop v="0" k="use_custom_dash"/>
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="0" type="line">
+            <layer class="SimpleLine" enabled="1" locked="0" pass="3">
+              <prop k="capstyle" v="square"></prop>
+              <prop k="customdash" v="5;2"></prop>
+              <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="customdash_unit" v="MM"></prop>
+              <prop k="draw_inside_polygon" v="0"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="line_color" v="143,143,143,255"></prop>
+              <prop k="line_style" v="solid"></prop>
+              <prop k="line_width" v="1"></prop>
+              <prop k="line_width_unit" v="MM"></prop>
+              <prop k="offset" v="0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="ring_filter" v="0"></prop>
+              <prop k="use_custom_dash" v="0"></prop>
+              <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer enabled="1" locked="0" class="SimpleLine" pass="4">
-              <prop v="square" k="capstyle"/>
-              <prop v="5;2" k="customdash"/>
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-              <prop v="MM" k="customdash_unit"/>
-              <prop v="0" k="draw_inside_polygon"/>
-              <prop v="round" k="joinstyle"/>
-              <prop v="251,145,57,255" k="line_color"/>
-              <prop v="solid" k="line_style"/>
-              <prop v="0.8" k="line_width"/>
-              <prop v="MM" k="line_width_unit"/>
-              <prop v="0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0" k="ring_filter"/>
-              <prop v="0" k="use_custom_dash"/>
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+            <layer class="SimpleLine" enabled="1" locked="0" pass="4">
+              <prop k="capstyle" v="square"></prop>
+              <prop k="customdash" v="5;2"></prop>
+              <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="customdash_unit" v="MM"></prop>
+              <prop k="draw_inside_polygon" v="0"></prop>
+              <prop k="joinstyle" v="round"></prop>
+              <prop k="line_color" v="251,145,57,255"></prop>
+              <prop k="line_style" v="solid"></prop>
+              <prop k="line_width" v="0.8"></prop>
+              <prop k="line_width_unit" v="MM"></prop>
+              <prop k="offset" v="0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="ring_filter" v="0"></prop>
+              <prop k="use_custom_dash" v="0"></prop>
+              <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
-                </Option>
-              </data_defined_properties>
-            </layer>
-          </symbol>
-          <symbol type="line" alpha="0.235294" clip_to_extent="1" force_rhr="0" name="1">
-            <layer enabled="1" locked="0" class="SimpleLine" pass="3">
-              <prop v="square" k="capstyle"/>
-              <prop v="5;2" k="customdash"/>
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-              <prop v="MM" k="customdash_unit"/>
-              <prop v="0" k="draw_inside_polygon"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="143,143,143,255" k="line_color"/>
-              <prop v="solid" k="line_style"/>
-              <prop v="1" k="line_width"/>
-              <prop v="MM" k="line_width_unit"/>
-              <prop v="0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0" k="ring_filter"/>
-              <prop v="0" k="use_custom_dash"/>
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
-              <data_defined_properties>
-                <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
-                </Option>
-              </data_defined_properties>
-            </layer>
-            <layer enabled="1" locked="0" class="SimpleLine" pass="4">
-              <prop v="square" k="capstyle"/>
-              <prop v="5;2" k="customdash"/>
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-              <prop v="MM" k="customdash_unit"/>
-              <prop v="0" k="draw_inside_polygon"/>
-              <prop v="round" k="joinstyle"/>
-              <prop v="251,145,57,255" k="line_color"/>
-              <prop v="solid" k="line_style"/>
-              <prop v="0.8" k="line_width"/>
-              <prop v="MM" k="line_width_unit"/>
-              <prop v="0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0" k="ring_filter"/>
-              <prop v="0" k="use_custom_dash"/>
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
-              <data_defined_properties>
-                <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol type="line" alpha="1" clip_to_extent="1" force_rhr="0" name="2">
-            <layer enabled="1" locked="1" class="SimpleLine" pass="2">
-              <prop v="square" k="capstyle"/>
-              <prop v="5;2" k="customdash"/>
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-              <prop v="MM" k="customdash_unit"/>
-              <prop v="0" k="draw_inside_polygon"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="143,143,143,255" k="line_color"/>
-              <prop v="solid" k="line_style"/>
-              <prop v="1" k="line_width"/>
-              <prop v="MM" k="line_width_unit"/>
-              <prop v="0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0" k="ring_filter"/>
-              <prop v="0" k="use_custom_dash"/>
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <symbol alpha="0.235294" clip_to_extent="1" force_rhr="0" name="1" type="line">
+            <layer class="SimpleLine" enabled="1" locked="0" pass="3">
+              <prop k="capstyle" v="square"></prop>
+              <prop k="customdash" v="5;2"></prop>
+              <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="customdash_unit" v="MM"></prop>
+              <prop k="draw_inside_polygon" v="0"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="line_color" v="143,143,143,255"></prop>
+              <prop k="line_style" v="solid"></prop>
+              <prop k="line_width" v="1"></prop>
+              <prop k="line_width_unit" v="MM"></prop>
+              <prop k="offset" v="0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="ring_filter" v="0"></prop>
+              <prop k="use_custom_dash" v="0"></prop>
+              <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer enabled="1" locked="0" class="SimpleLine" pass="3">
-              <prop v="square" k="capstyle"/>
-              <prop v="5;2" k="customdash"/>
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-              <prop v="MM" k="customdash_unit"/>
-              <prop v="0" k="draw_inside_polygon"/>
-              <prop v="round" k="joinstyle"/>
-              <prop v="255,223,105,255" k="line_color"/>
-              <prop v="solid" k="line_style"/>
-              <prop v="0.8" k="line_width"/>
-              <prop v="MM" k="line_width_unit"/>
-              <prop v="0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0" k="ring_filter"/>
-              <prop v="0" k="use_custom_dash"/>
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+            <layer class="SimpleLine" enabled="1" locked="0" pass="4">
+              <prop k="capstyle" v="square"></prop>
+              <prop k="customdash" v="5;2"></prop>
+              <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="customdash_unit" v="MM"></prop>
+              <prop k="draw_inside_polygon" v="0"></prop>
+              <prop k="joinstyle" v="round"></prop>
+              <prop k="line_color" v="251,145,57,255"></prop>
+              <prop k="line_style" v="solid"></prop>
+              <prop k="line_width" v="0.8"></prop>
+              <prop k="line_width_unit" v="MM"></prop>
+              <prop k="offset" v="0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="ring_filter" v="0"></prop>
+              <prop k="use_custom_dash" v="0"></prop>
+              <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
-                </Option>
-              </data_defined_properties>
-            </layer>
-          </symbol>
-          <symbol type="line" alpha="0.247059" clip_to_extent="1" force_rhr="0" name="3">
-            <layer enabled="1" locked="1" class="SimpleLine" pass="2">
-              <prop v="square" k="capstyle"/>
-              <prop v="5;2" k="customdash"/>
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-              <prop v="MM" k="customdash_unit"/>
-              <prop v="0" k="draw_inside_polygon"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="143,143,143,255" k="line_color"/>
-              <prop v="solid" k="line_style"/>
-              <prop v="1" k="line_width"/>
-              <prop v="MM" k="line_width_unit"/>
-              <prop v="0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0" k="ring_filter"/>
-              <prop v="0" k="use_custom_dash"/>
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
-              <data_defined_properties>
-                <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
-                </Option>
-              </data_defined_properties>
-            </layer>
-            <layer enabled="1" locked="0" class="SimpleLine" pass="3">
-              <prop v="square" k="capstyle"/>
-              <prop v="5;2" k="customdash"/>
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-              <prop v="MM" k="customdash_unit"/>
-              <prop v="0" k="draw_inside_polygon"/>
-              <prop v="round" k="joinstyle"/>
-              <prop v="255,223,105,255" k="line_color"/>
-              <prop v="solid" k="line_style"/>
-              <prop v="0.8" k="line_width"/>
-              <prop v="MM" k="line_width_unit"/>
-              <prop v="0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0" k="ring_filter"/>
-              <prop v="0" k="use_custom_dash"/>
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
-              <data_defined_properties>
-                <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol type="line" alpha="1" clip_to_extent="1" force_rhr="0" name="4">
-            <layer enabled="1" locked="1" class="SimpleLine" pass="0">
-              <prop v="square" k="capstyle"/>
-              <prop v="5;2" k="customdash"/>
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-              <prop v="MM" k="customdash_unit"/>
-              <prop v="0" k="draw_inside_polygon"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="143,143,143,255" k="line_color"/>
-              <prop v="solid" k="line_style"/>
-              <prop v="0.7" k="line_width"/>
-              <prop v="MM" k="line_width_unit"/>
-              <prop v="0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0" k="ring_filter"/>
-              <prop v="0" k="use_custom_dash"/>
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="2" type="line">
+            <layer class="SimpleLine" enabled="1" locked="1" pass="2">
+              <prop k="capstyle" v="square"></prop>
+              <prop k="customdash" v="5;2"></prop>
+              <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="customdash_unit" v="MM"></prop>
+              <prop k="draw_inside_polygon" v="0"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="line_color" v="143,143,143,255"></prop>
+              <prop k="line_style" v="solid"></prop>
+              <prop k="line_width" v="1"></prop>
+              <prop k="line_width_unit" v="MM"></prop>
+              <prop k="offset" v="0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="ring_filter" v="0"></prop>
+              <prop k="use_custom_dash" v="0"></prop>
+              <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer enabled="1" locked="0" class="SimpleLine" pass="1">
-              <prop v="square" k="capstyle"/>
-              <prop v="5;2" k="customdash"/>
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-              <prop v="MM" k="customdash_unit"/>
-              <prop v="0" k="draw_inside_polygon"/>
-              <prop v="round" k="joinstyle"/>
-              <prop v="255,255,255,255" k="line_color"/>
-              <prop v="solid" k="line_style"/>
-              <prop v="0.6" k="line_width"/>
-              <prop v="MM" k="line_width_unit"/>
-              <prop v="0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0" k="ring_filter"/>
-              <prop v="0" k="use_custom_dash"/>
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+            <layer class="SimpleLine" enabled="1" locked="0" pass="3">
+              <prop k="capstyle" v="square"></prop>
+              <prop k="customdash" v="5;2"></prop>
+              <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="customdash_unit" v="MM"></prop>
+              <prop k="draw_inside_polygon" v="0"></prop>
+              <prop k="joinstyle" v="round"></prop>
+              <prop k="line_color" v="255,223,105,255"></prop>
+              <prop k="line_style" v="solid"></prop>
+              <prop k="line_width" v="0.8"></prop>
+              <prop k="line_width_unit" v="MM"></prop>
+              <prop k="offset" v="0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="ring_filter" v="0"></prop>
+              <prop k="use_custom_dash" v="0"></prop>
+              <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
-                </Option>
-              </data_defined_properties>
-            </layer>
-          </symbol>
-          <symbol type="line" alpha="1" clip_to_extent="1" force_rhr="0" name="5">
-            <layer enabled="1" locked="1" class="SimpleLine" pass="0">
-              <prop v="square" k="capstyle"/>
-              <prop v="5;2" k="customdash"/>
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-              <prop v="MM" k="customdash_unit"/>
-              <prop v="0" k="draw_inside_polygon"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="143,143,143,255" k="line_color"/>
-              <prop v="solid" k="line_style"/>
-              <prop v="0.7" k="line_width"/>
-              <prop v="MM" k="line_width_unit"/>
-              <prop v="0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0" k="ring_filter"/>
-              <prop v="0" k="use_custom_dash"/>
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
-              <data_defined_properties>
-                <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
-                </Option>
-              </data_defined_properties>
-            </layer>
-            <layer enabled="1" locked="0" class="SimpleLine" pass="1">
-              <prop v="square" k="capstyle"/>
-              <prop v="5;2" k="customdash"/>
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-              <prop v="MM" k="customdash_unit"/>
-              <prop v="0" k="draw_inside_polygon"/>
-              <prop v="round" k="joinstyle"/>
-              <prop v="255,255,255,255" k="line_color"/>
-              <prop v="solid" k="line_style"/>
-              <prop v="0.6" k="line_width"/>
-              <prop v="MM" k="line_width_unit"/>
-              <prop v="0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0" k="ring_filter"/>
-              <prop v="0" k="use_custom_dash"/>
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
-              <data_defined_properties>
-                <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol type="line" alpha="1" clip_to_extent="1" force_rhr="0" name="6">
-            <layer enabled="1" locked="0" class="SimpleLine" pass="0">
-              <prop v="square" k="capstyle"/>
-              <prop v="5;2" k="customdash"/>
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-              <prop v="MM" k="customdash_unit"/>
-              <prop v="0" k="draw_inside_polygon"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="143,143,143,255" k="line_color"/>
-              <prop v="solid" k="line_style"/>
-              <prop v="0.05" k="line_width"/>
-              <prop v="MM" k="line_width_unit"/>
-              <prop v="0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0" k="ring_filter"/>
-              <prop v="0" k="use_custom_dash"/>
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <symbol alpha="0.247059" clip_to_extent="1" force_rhr="0" name="3" type="line">
+            <layer class="SimpleLine" enabled="1" locked="1" pass="2">
+              <prop k="capstyle" v="square"></prop>
+              <prop k="customdash" v="5;2"></prop>
+              <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="customdash_unit" v="MM"></prop>
+              <prop k="draw_inside_polygon" v="0"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="line_color" v="143,143,143,255"></prop>
+              <prop k="line_style" v="solid"></prop>
+              <prop k="line_width" v="1"></prop>
+              <prop k="line_width_unit" v="MM"></prop>
+              <prop k="offset" v="0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="ring_filter" v="0"></prop>
+              <prop k="use_custom_dash" v="0"></prop>
+              <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+            <layer class="SimpleLine" enabled="1" locked="0" pass="3">
+              <prop k="capstyle" v="square"></prop>
+              <prop k="customdash" v="5;2"></prop>
+              <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="customdash_unit" v="MM"></prop>
+              <prop k="draw_inside_polygon" v="0"></prop>
+              <prop k="joinstyle" v="round"></prop>
+              <prop k="line_color" v="255,223,105,255"></prop>
+              <prop k="line_style" v="solid"></prop>
+              <prop k="line_width" v="0.8"></prop>
+              <prop k="line_width_unit" v="MM"></prop>
+              <prop k="offset" v="0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="ring_filter" v="0"></prop>
+              <prop k="use_custom_dash" v="0"></prop>
+              <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol type="line" alpha="1" clip_to_extent="1" force_rhr="0" name="7">
-            <layer enabled="1" locked="0" class="SimpleLine" pass="0">
-              <prop v="square" k="capstyle"/>
-              <prop v="5;2" k="customdash"/>
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-              <prop v="MM" k="customdash_unit"/>
-              <prop v="0" k="draw_inside_polygon"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="176,176,176,255" k="line_color"/>
-              <prop v="solid" k="line_style"/>
-              <prop v="0.05" k="line_width"/>
-              <prop v="MM" k="line_width_unit"/>
-              <prop v="0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0" k="ring_filter"/>
-              <prop v="0" k="use_custom_dash"/>
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="4" type="line">
+            <layer class="SimpleLine" enabled="1" locked="1" pass="0">
+              <prop k="capstyle" v="square"></prop>
+              <prop k="customdash" v="5;2"></prop>
+              <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="customdash_unit" v="MM"></prop>
+              <prop k="draw_inside_polygon" v="0"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="line_color" v="143,143,143,255"></prop>
+              <prop k="line_style" v="solid"></prop>
+              <prop k="line_width" v="0.7"></prop>
+              <prop k="line_width_unit" v="MM"></prop>
+              <prop k="offset" v="0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="ring_filter" v="0"></prop>
+              <prop k="use_custom_dash" v="0"></prop>
+              <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer enabled="1" locked="0" class="MarkerLine" pass="0">
-              <prop v="4" k="average_angle_length"/>
-              <prop v="3x:0,0,0,0,0,0" k="average_angle_map_unit_scale"/>
-              <prop v="MM" k="average_angle_unit"/>
-              <prop v="7" k="interval"/>
-              <prop v="3x:0,0,0,0,0,0" k="interval_map_unit_scale"/>
-              <prop v="MM" k="interval_unit"/>
-              <prop v="0" k="offset"/>
-              <prop v="0" k="offset_along_line"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_along_line_map_unit_scale"/>
-              <prop v="MM" k="offset_along_line_unit"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="interval" k="placement"/>
-              <prop v="0" k="ring_filter"/>
-              <prop v="1" k="rotate"/>
+            <layer class="SimpleLine" enabled="1" locked="0" pass="1">
+              <prop k="capstyle" v="square"></prop>
+              <prop k="customdash" v="5;2"></prop>
+              <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="customdash_unit" v="MM"></prop>
+              <prop k="draw_inside_polygon" v="0"></prop>
+              <prop k="joinstyle" v="round"></prop>
+              <prop k="line_color" v="255,255,255,255"></prop>
+              <prop k="line_style" v="solid"></prop>
+              <prop k="line_width" v="0.6"></prop>
+              <prop k="line_width_unit" v="MM"></prop>
+              <prop k="offset" v="0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="ring_filter" v="0"></prop>
+              <prop k="use_custom_dash" v="0"></prop>
+              <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
-              <symbol type="marker" alpha="1" clip_to_extent="1" force_rhr="0" name="@7@1">
-                <layer enabled="1" locked="0" class="SimpleMarker" pass="0">
-                  <prop v="0" k="angle"/>
-                  <prop v="255,0,0,255" k="color"/>
-                  <prop v="1" k="horizontal_anchor_point"/>
-                  <prop v="bevel" k="joinstyle"/>
-                  <prop v="line" k="name"/>
-                  <prop v="0,0" k="offset"/>
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-                  <prop v="MM" k="offset_unit"/>
-                  <prop v="143,143,143,255" k="outline_color"/>
-                  <prop v="solid" k="outline_style"/>
-                  <prop v="0.05" k="outline_width"/>
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-                  <prop v="MM" k="outline_width_unit"/>
-                  <prop v="area" k="scale_method"/>
-                  <prop v="1" k="size"/>
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-                  <prop v="MM" k="size_unit"/>
-                  <prop v="1" k="vertical_anchor_point"/>
+            </layer>
+          </symbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="5" type="line">
+            <layer class="SimpleLine" enabled="1" locked="1" pass="0">
+              <prop k="capstyle" v="square"></prop>
+              <prop k="customdash" v="5;2"></prop>
+              <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="customdash_unit" v="MM"></prop>
+              <prop k="draw_inside_polygon" v="0"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="line_color" v="143,143,143,255"></prop>
+              <prop k="line_style" v="solid"></prop>
+              <prop k="line_width" v="0.7"></prop>
+              <prop k="line_width_unit" v="MM"></prop>
+              <prop k="offset" v="0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="ring_filter" v="0"></prop>
+              <prop k="use_custom_dash" v="0"></prop>
+              <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+            <layer class="SimpleLine" enabled="1" locked="0" pass="1">
+              <prop k="capstyle" v="square"></prop>
+              <prop k="customdash" v="5;2"></prop>
+              <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="customdash_unit" v="MM"></prop>
+              <prop k="draw_inside_polygon" v="0"></prop>
+              <prop k="joinstyle" v="round"></prop>
+              <prop k="line_color" v="255,255,255,255"></prop>
+              <prop k="line_style" v="solid"></prop>
+              <prop k="line_width" v="0.6"></prop>
+              <prop k="line_width_unit" v="MM"></prop>
+              <prop k="offset" v="0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="ring_filter" v="0"></prop>
+              <prop k="use_custom_dash" v="0"></prop>
+              <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="6" type="line">
+            <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+              <prop k="capstyle" v="square"></prop>
+              <prop k="customdash" v="5;2"></prop>
+              <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="customdash_unit" v="MM"></prop>
+              <prop k="draw_inside_polygon" v="0"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="line_color" v="143,143,143,255"></prop>
+              <prop k="line_style" v="solid"></prop>
+              <prop k="line_width" v="0.05"></prop>
+              <prop k="line_width_unit" v="MM"></prop>
+              <prop k="offset" v="0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="ring_filter" v="0"></prop>
+              <prop k="use_custom_dash" v="0"></prop>
+              <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="7" type="line">
+            <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+              <prop k="capstyle" v="square"></prop>
+              <prop k="customdash" v="5;2"></prop>
+              <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="customdash_unit" v="MM"></prop>
+              <prop k="draw_inside_polygon" v="0"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="line_color" v="176,176,176,255"></prop>
+              <prop k="line_style" v="solid"></prop>
+              <prop k="line_width" v="0.05"></prop>
+              <prop k="line_width_unit" v="MM"></prop>
+              <prop k="offset" v="0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="ring_filter" v="0"></prop>
+              <prop k="use_custom_dash" v="0"></prop>
+              <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+            <layer class="MarkerLine" enabled="1" locked="0" pass="0">
+              <prop k="average_angle_length" v="4"></prop>
+              <prop k="average_angle_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="average_angle_unit" v="MM"></prop>
+              <prop k="interval" v="7"></prop>
+              <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="interval_unit" v="MM"></prop>
+              <prop k="offset" v="0"></prop>
+              <prop k="offset_along_line" v="0"></prop>
+              <prop k="offset_along_line_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_along_line_unit" v="MM"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="placement" v="interval"></prop>
+              <prop k="ring_filter" v="0"></prop>
+              <prop k="rotate" v="1"></prop>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+              <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="@7@1" type="marker">
+                <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                  <prop k="angle" v="0"></prop>
+                  <prop k="color" v="255,0,0,255"></prop>
+                  <prop k="horizontal_anchor_point" v="1"></prop>
+                  <prop k="joinstyle" v="bevel"></prop>
+                  <prop k="name" v="line"></prop>
+                  <prop k="offset" v="0,0"></prop>
+                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="offset_unit" v="MM"></prop>
+                  <prop k="outline_color" v="143,143,143,255"></prop>
+                  <prop k="outline_style" v="solid"></prop>
+                  <prop k="outline_width" v="0.05"></prop>
+                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="outline_width_unit" v="MM"></prop>
+                  <prop k="scale_method" v="area"></prop>
+                  <prop k="size" v="1"></prop>
+                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="size_unit" v="MM"></prop>
+                  <prop k="vertical_anchor_point" v="1"></prop>
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option type="QString" name="name" value=""/>
-                      <Option name="properties"/>
-                      <Option type="QString" name="type" value="collection"/>
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </layer>
           </symbol>
-          <symbol type="line" alpha="1" clip_to_extent="1" force_rhr="0" name="8">
-            <layer enabled="1" locked="0" class="SimpleLine" pass="0">
-              <prop v="round" k="capstyle"/>
-              <prop v="5;2" k="customdash"/>
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-              <prop v="MM" k="customdash_unit"/>
-              <prop v="0" k="draw_inside_polygon"/>
-              <prop v="round" k="joinstyle"/>
-              <prop v="182,217,255,255" k="line_color"/>
-              <prop v="solid" k="line_style"/>
-              <prop v="0.8" k="line_width"/>
-              <prop v="MM" k="line_width_unit"/>
-              <prop v="0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0" k="ring_filter"/>
-              <prop v="0" k="use_custom_dash"/>
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="8" type="line">
+            <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+              <prop k="capstyle" v="round"></prop>
+              <prop k="customdash" v="5;2"></prop>
+              <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="customdash_unit" v="MM"></prop>
+              <prop k="draw_inside_polygon" v="0"></prop>
+              <prop k="joinstyle" v="round"></prop>
+              <prop k="line_color" v="182,217,255,255"></prop>
+              <prop k="line_style" v="solid"></prop>
+              <prop k="line_width" v="0.8"></prop>
+              <prop k="line_width_unit" v="MM"></prop>
+              <prop k="offset" v="0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="ring_filter" v="0"></prop>
+              <prop k="use_custom_dash" v="0"></prop>
+              <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol type="line" alpha="1" clip_to_extent="1" force_rhr="0" name="9">
-            <layer enabled="1" locked="0" class="SimpleLine" pass="0">
-              <prop v="round" k="capstyle"/>
-              <prop v="5;2" k="customdash"/>
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-              <prop v="MM" k="customdash_unit"/>
-              <prop v="0" k="draw_inside_polygon"/>
-              <prop v="round" k="joinstyle"/>
-              <prop v="182,217,255,255" k="line_color"/>
-              <prop v="solid" k="line_style"/>
-              <prop v="0.2" k="line_width"/>
-              <prop v="MM" k="line_width_unit"/>
-              <prop v="0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0" k="ring_filter"/>
-              <prop v="0" k="use_custom_dash"/>
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="9" type="line">
+            <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+              <prop k="capstyle" v="round"></prop>
+              <prop k="customdash" v="5;2"></prop>
+              <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="customdash_unit" v="MM"></prop>
+              <prop k="draw_inside_polygon" v="0"></prop>
+              <prop k="joinstyle" v="round"></prop>
+              <prop k="line_color" v="182,217,255,255"></prop>
+              <prop k="line_style" v="solid"></prop>
+              <prop k="line_width" v="0.2"></prop>
+              <prop k="line_width_unit" v="MM"></prop>
+              <prop k="offset" v="0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="ring_filter" v="0"></prop>
+              <prop k="use_custom_dash" v="0"></prop>
+              <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -5547,40 +5779,71 @@ def my_form_open(dialog, layer, feature):
         </symbols>
       </renderer-v2>
       <customproperties>
-        <property key="dualview/previewExpressions" value="name"/>
-        <property key="embeddedWidgets/count" value="0"/>
-        <property key="variableNames"/>
-        <property key="variableValues"/>
+        <property key="dualview/previewExpressions" value="name"></property>
+        <property key="embeddedWidgets/count" value="0"></property>
+        <property key="variableNames"></property>
+        <property key="variableValues"></property>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
-        <DiagramCategory labelPlacementMethod="XHeight" minScaleDenominator="0" penAlpha="255" diagramOrientation="Up" penColor="#000000" scaleBasedVisibility="0" rotationOffset="270" maxScaleDenominator="1e+08" sizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" barWidth="5" backgroundColor="#ffffff" width="15" scaleDependency="Area" minimumSize="0" lineSizeScale="3x:0,0,0,0,0,0" sizeType="MM" backgroundAlpha="255" height="15" enabled="0" penWidth="0" opacity="1">
-          <fontProperties style="" description="Cantarell,11,-1,5,50,0,0,0,0,0"/>
-          <attribute color="#000000" field="" label=""/>
+      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="1" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+8" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" showAxis="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="0" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
+          <fontProperties description="Cantarell,11,-1,5,50,0,0,0,0,0" style=""></fontProperties>
+          <attribute color="#000000" field="" label=""></attribute>
+          <axisSymbol>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" type="line">
+              <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+                <prop k="capstyle" v="square"></prop>
+                <prop k="customdash" v="5;2"></prop>
+                <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="customdash_unit" v="MM"></prop>
+                <prop k="draw_inside_polygon" v="0"></prop>
+                <prop k="joinstyle" v="bevel"></prop>
+                <prop k="line_color" v="35,35,35,255"></prop>
+                <prop k="line_style" v="solid"></prop>
+                <prop k="line_width" v="0.26"></prop>
+                <prop k="line_width_unit" v="MM"></prop>
+                <prop k="offset" v="0"></prop>
+                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="offset_unit" v="MM"></prop>
+                <prop k="ring_filter" v="0"></prop>
+                <prop k="use_custom_dash" v="0"></prop>
+                <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings linePlacementFlags="18" dist="0" priority="0" zIndex="0" placement="2" obstacle="0" showAll="1">
+      <DiagramLayerSettings dist="0" linePlacementFlags="18" obstacle="0" placement="2" priority="0" showAll="1" zIndex="0">
         <properties>
           <Option type="Map">
-            <Option type="QString" name="name" value=""/>
-            <Option name="properties"/>
-            <Option type="QString" name="type" value="collection"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </properties>
       </DiagramLayerSettings>
       <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-        <activeChecks/>
-        <checkConfiguration/>
+        <activeChecks></activeChecks>
+        <checkConfiguration></checkConfiguration>
       </geometryOptions>
+      <referencedLayers></referencedLayers>
+      <referencingLayers></referencingLayers>
       <fieldConfiguration>
         <field name="fid">
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -5589,8 +5852,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -5599,8 +5862,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -5609,8 +5872,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -5619,8 +5882,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -5629,8 +5892,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -5639,8 +5902,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -5649,8 +5912,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -5659,8 +5922,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -5669,8 +5932,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -5679,97 +5942,97 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="QString" value="0"></Option>
+                <Option name="UseHtml" type="QString" value="0"></Option>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" field="fid" index="0"/>
-        <alias name="" field="osm_id" index="1"/>
-        <alias name="" field="name" index="2"/>
-        <alias name="" field="highway" index="3"/>
-        <alias name="" field="waterway" index="4"/>
-        <alias name="" field="aerialway" index="5"/>
-        <alias name="" field="barrier" index="6"/>
-        <alias name="" field="man_made" index="7"/>
-        <alias name="" field="z_order" index="8"/>
-        <alias name="" field="other_tags" index="9"/>
-        <alias name="" field="orig_ogc_fid" index="10"/>
+        <alias field="fid" index="0" name=""></alias>
+        <alias field="osm_id" index="1" name=""></alias>
+        <alias field="name" index="2" name=""></alias>
+        <alias field="highway" index="3" name=""></alias>
+        <alias field="waterway" index="4" name=""></alias>
+        <alias field="aerialway" index="5" name=""></alias>
+        <alias field="barrier" index="6" name=""></alias>
+        <alias field="man_made" index="7" name=""></alias>
+        <alias field="z_order" index="8" name=""></alias>
+        <alias field="other_tags" index="9" name=""></alias>
+        <alias field="orig_ogc_fid" index="10" name=""></alias>
       </aliases>
-      <excludeAttributesWMS/>
-      <excludeAttributesWFS/>
+      <excludeAttributesWMS></excludeAttributesWMS>
+      <excludeAttributesWFS></excludeAttributesWFS>
       <defaults>
-        <default applyOnUpdate="0" field="fid" expression=""/>
-        <default applyOnUpdate="0" field="osm_id" expression=""/>
-        <default applyOnUpdate="0" field="name" expression=""/>
-        <default applyOnUpdate="0" field="highway" expression=""/>
-        <default applyOnUpdate="0" field="waterway" expression=""/>
-        <default applyOnUpdate="0" field="aerialway" expression=""/>
-        <default applyOnUpdate="0" field="barrier" expression=""/>
-        <default applyOnUpdate="0" field="man_made" expression=""/>
-        <default applyOnUpdate="0" field="z_order" expression=""/>
-        <default applyOnUpdate="0" field="other_tags" expression=""/>
-        <default applyOnUpdate="0" field="orig_ogc_fid" expression=""/>
+        <default applyOnUpdate="0" expression="" field="fid"></default>
+        <default applyOnUpdate="0" expression="" field="osm_id"></default>
+        <default applyOnUpdate="0" expression="" field="name"></default>
+        <default applyOnUpdate="0" expression="" field="highway"></default>
+        <default applyOnUpdate="0" expression="" field="waterway"></default>
+        <default applyOnUpdate="0" expression="" field="aerialway"></default>
+        <default applyOnUpdate="0" expression="" field="barrier"></default>
+        <default applyOnUpdate="0" expression="" field="man_made"></default>
+        <default applyOnUpdate="0" expression="" field="z_order"></default>
+        <default applyOnUpdate="0" expression="" field="other_tags"></default>
+        <default applyOnUpdate="0" expression="" field="orig_ogc_fid"></default>
       </defaults>
       <constraints>
-        <constraint notnull_strength="1" constraints="3" field="fid" unique_strength="1" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="osm_id" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="name" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="highway" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="waterway" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="aerialway" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="barrier" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="man_made" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="z_order" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="other_tags" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="orig_ogc_fid" unique_strength="0" exp_strength="0"/>
+        <constraint constraints="3" exp_strength="0" field="fid" notnull_strength="1" unique_strength="1"></constraint>
+        <constraint constraints="0" exp_strength="0" field="osm_id" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="name" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="highway" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="waterway" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="aerialway" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="barrier" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="man_made" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="z_order" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="other_tags" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="orig_ogc_fid" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint field="fid" desc="" exp=""/>
-        <constraint field="osm_id" desc="" exp=""/>
-        <constraint field="name" desc="" exp=""/>
-        <constraint field="highway" desc="" exp=""/>
-        <constraint field="waterway" desc="" exp=""/>
-        <constraint field="aerialway" desc="" exp=""/>
-        <constraint field="barrier" desc="" exp=""/>
-        <constraint field="man_made" desc="" exp=""/>
-        <constraint field="z_order" desc="" exp=""/>
-        <constraint field="other_tags" desc="" exp=""/>
-        <constraint field="orig_ogc_fid" desc="" exp=""/>
+        <constraint desc="" exp="" field="fid"></constraint>
+        <constraint desc="" exp="" field="osm_id"></constraint>
+        <constraint desc="" exp="" field="name"></constraint>
+        <constraint desc="" exp="" field="highway"></constraint>
+        <constraint desc="" exp="" field="waterway"></constraint>
+        <constraint desc="" exp="" field="aerialway"></constraint>
+        <constraint desc="" exp="" field="barrier"></constraint>
+        <constraint desc="" exp="" field="man_made"></constraint>
+        <constraint desc="" exp="" field="z_order"></constraint>
+        <constraint desc="" exp="" field="other_tags"></constraint>
+        <constraint desc="" exp="" field="orig_ogc_fid"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
       </attributeactions>
-      <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column type="field" name="osm_id" width="-1" hidden="0"/>
-          <column type="field" name="name" width="-1" hidden="0"/>
-          <column type="field" name="highway" width="-1" hidden="0"/>
-          <column type="field" name="waterway" width="-1" hidden="0"/>
-          <column type="field" name="aerialway" width="-1" hidden="0"/>
-          <column type="field" name="barrier" width="-1" hidden="0"/>
-          <column type="field" name="man_made" width="-1" hidden="0"/>
-          <column type="field" name="z_order" width="-1" hidden="0"/>
-          <column type="field" name="other_tags" width="-1" hidden="0"/>
-          <column type="actions" width="-1" hidden="1"/>
-          <column type="field" name="fid" width="-1" hidden="0"/>
-          <column type="field" name="orig_ogc_fid" width="-1" hidden="0"/>
+          <column hidden="0" name="osm_id" type="field" width="-1"></column>
+          <column hidden="0" name="name" type="field" width="-1"></column>
+          <column hidden="0" name="highway" type="field" width="-1"></column>
+          <column hidden="0" name="waterway" type="field" width="-1"></column>
+          <column hidden="0" name="aerialway" type="field" width="-1"></column>
+          <column hidden="0" name="barrier" type="field" width="-1"></column>
+          <column hidden="0" name="man_made" type="field" width="-1"></column>
+          <column hidden="0" name="z_order" type="field" width="-1"></column>
+          <column hidden="0" name="other_tags" type="field" width="-1"></column>
+          <column hidden="1" type="actions" width="-1"></column>
+          <column hidden="0" name="fid" type="field" width="-1"></column>
+          <column hidden="0" name="orig_ogc_fid" type="field" width="-1"></column>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1"></editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath>/david/doc/teaching/QField_Workshop/citybees</editforminitfilepath>
-      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+      <editforminitcode># -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -5785,45 +6048,45 @@ from PyQt.QtWidgets import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-]]></editforminitcode>
+</editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <editable>
-        <field name="aerialway" editable="1"/>
-        <field name="barrier" editable="1"/>
-        <field name="fid" editable="1"/>
-        <field name="highway" editable="1"/>
-        <field name="man_made" editable="1"/>
-        <field name="name" editable="1"/>
-        <field name="orig_ogc_fid" editable="1"/>
-        <field name="osm_id" editable="1"/>
-        <field name="other_tags" editable="1"/>
-        <field name="waterway" editable="1"/>
-        <field name="z_order" editable="1"/>
+        <field editable="1" name="aerialway"></field>
+        <field editable="1" name="barrier"></field>
+        <field editable="1" name="fid"></field>
+        <field editable="1" name="highway"></field>
+        <field editable="1" name="man_made"></field>
+        <field editable="1" name="name"></field>
+        <field editable="1" name="orig_ogc_fid"></field>
+        <field editable="1" name="osm_id"></field>
+        <field editable="1" name="other_tags"></field>
+        <field editable="1" name="waterway"></field>
+        <field editable="1" name="z_order"></field>
       </editable>
       <labelOnTop>
-        <field labelOnTop="0" name="aerialway"/>
-        <field labelOnTop="0" name="barrier"/>
-        <field labelOnTop="0" name="fid"/>
-        <field labelOnTop="0" name="highway"/>
-        <field labelOnTop="0" name="man_made"/>
-        <field labelOnTop="0" name="name"/>
-        <field labelOnTop="0" name="orig_ogc_fid"/>
-        <field labelOnTop="0" name="osm_id"/>
-        <field labelOnTop="0" name="other_tags"/>
-        <field labelOnTop="0" name="waterway"/>
-        <field labelOnTop="0" name="z_order"/>
+        <field labelOnTop="0" name="aerialway"></field>
+        <field labelOnTop="0" name="barrier"></field>
+        <field labelOnTop="0" name="fid"></field>
+        <field labelOnTop="0" name="highway"></field>
+        <field labelOnTop="0" name="man_made"></field>
+        <field labelOnTop="0" name="name"></field>
+        <field labelOnTop="0" name="orig_ogc_fid"></field>
+        <field labelOnTop="0" name="osm_id"></field>
+        <field labelOnTop="0" name="other_tags"></field>
+        <field labelOnTop="0" name="waterway"></field>
+        <field labelOnTop="0" name="z_order"></field>
       </labelOnTop>
-      <widgets/>
+      <widgets></widgets>
       <previewExpression>name</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer styleCategories="AllStyleCategories" autoRefreshEnabled="0" autoRefreshTime="0" geometry="Polygon" refreshOnNotifyMessage="" simplifyAlgorithm="0" wkbType="Polygon" refreshOnNotifyEnabled="0" simplifyDrawingHints="1" minScale="0" readOnly="0" type="vector" simplifyMaxScale="1" maxScale="0" simplifyLocal="1" simplifyDrawingTol="1" labelsEnabled="1" hasScaleBasedVisibilityFlag="0">
+    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" geometry="Polygon" hasScaleBasedVisibilityFlag="0" labelsEnabled="1" maxScale="0" minScale="0" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" type="vector" wkbType="Polygon">
       <extent>
-        <xmin>1029970</xmin>
-        <ymin>5910190</ymin>
-        <xmax>1031640</xmax>
-        <ymax>5911930</ymax>
+        <xmin>1029974.6875</xmin>
+        <ymin>5910187</ymin>
+        <xmax>1031638.3125</xmax>
+        <ymax>5911926.5</ymax>
       </extent>
       <id>ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b</id>
       <datasource>./bees.gpkg|layername=area</datasource>
@@ -5833,13 +6096,14 @@ def my_form_open(dialog, layer, feature):
       <layername>Fields</layername>
       <srs>
         <spatialrefsys>
-          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+          <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
+          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
           <srsid>3857</srsid>
           <srid>3857</srid>
           <authid>EPSG:3857</authid>
           <description>WGS 84 / Pseudo-Mercator</description>
           <projectionacronym>merc</projectionacronym>
-          <ellipsoidacronym></ellipsoidacronym>
+          <ellipsoidacronym>WGS84</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -5859,11 +6123,12 @@ def my_form_open(dialog, layer, feature):
           <email></email>
           <role></role>
         </contact>
-        <links/>
+        <links></links>
         <fees></fees>
         <encoding></encoding>
         <crs>
           <spatialrefsys>
+            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -5871,11 +6136,11 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
+            <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial maxx="0" maxz="0" dimensions="2" minx="0" minz="0" crs="" maxy="0" miny="0"/>
+          <spatial crs="" dimensions="2" maxx="0" maxy="0" maxz="0" minx="0" miny="0" minz="0"></spatial>
           <temporal>
             <period>
               <start></start>
@@ -5885,423 +6150,423 @@ def my_form_open(dialog, layer, feature):
         </extent>
       </resourceMetadata>
       <provider encoding="UTF-8">ogr</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <legend type="default-vector"/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <legend type="default-vector"></legend>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"/>
+        <map-layer-style name="default"></map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
+      <auxiliaryLayer></auxiliaryLayer>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
       </flags>
-      <renderer-v2 attr="plant_species" enableorderby="0" type="categorizedSymbol" symbollevels="0" forceraster="0">
+      <renderer-v2 attr="plant_species" enableorderby="0" forceraster="0" symbollevels="0" type="categorizedSymbol">
         <categories>
-          <category symbol="0" render="true" value="colza" label="colza"/>
-          <category symbol="1" render="true" value="grass" label="grass"/>
-          <category symbol="2" render="true" value="lavender" label="lavender"/>
-          <category symbol="3" render="true" value="taraxacum" label="taraxacum"/>
-          <category symbol="4" render="true" value="weed" label="weed"/>
+          <category label="colza" render="true" symbol="0" value="colza"></category>
+          <category label="grass" render="true" symbol="1" value="grass"></category>
+          <category label="lavender" render="true" symbol="2" value="lavender"></category>
+          <category label="taraxacum" render="true" symbol="3" value="taraxacum"></category>
+          <category label="weed" render="true" symbol="4" value="weed"></category>
         </categories>
         <symbols>
-          <symbol type="fill" alpha="0.392157" clip_to_extent="1" force_rhr="0" name="0">
-            <layer enabled="1" locked="0" class="SimpleFill" pass="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="215,25,28,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="175,179,138,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+          <symbol alpha="0.392157" clip_to_extent="1" force_rhr="0" name="0" type="fill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="color" v="215,25,28,255"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="offset" v="0,0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="outline_color" v="175,179,138,255"></prop>
+              <prop k="outline_style" v="solid"></prop>
+              <prop k="outline_width" v="0.26"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
+              <prop k="style" v="solid"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer enabled="1" locked="0" class="PointPatternFill" pass="0">
-              <prop v="0" k="displacement_x"/>
-              <prop v="3x:0,0,0,0,0,0" k="displacement_x_map_unit_scale"/>
-              <prop v="MM" k="displacement_x_unit"/>
-              <prop v="1" k="displacement_y"/>
-              <prop v="3x:0,0,0,0,0,0" k="displacement_y_map_unit_scale"/>
-              <prop v="MM" k="displacement_y_unit"/>
-              <prop v="1.5" k="distance_x"/>
-              <prop v="3x:0,0,0,0,0,0" k="distance_x_map_unit_scale"/>
-              <prop v="MM" k="distance_x_unit"/>
-              <prop v="2" k="distance_y"/>
-              <prop v="3x:0,0,0,0,0,0" k="distance_y_map_unit_scale"/>
-              <prop v="MM" k="distance_y_unit"/>
-              <prop v="0" k="offset_x"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_x_map_unit_scale"/>
-              <prop v="MM" k="offset_x_unit"/>
-              <prop v="0" k="offset_y"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_y_map_unit_scale"/>
-              <prop v="MM" k="offset_y_unit"/>
-              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-              <prop v="MM" k="outline_width_unit"/>
+            <layer class="PointPatternFill" enabled="1" locked="0" pass="0">
+              <prop k="displacement_x" v="0"></prop>
+              <prop k="displacement_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="displacement_x_unit" v="MM"></prop>
+              <prop k="displacement_y" v="1"></prop>
+              <prop k="displacement_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="displacement_y_unit" v="MM"></prop>
+              <prop k="distance_x" v="1.5"></prop>
+              <prop k="distance_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_x_unit" v="MM"></prop>
+              <prop k="distance_y" v="2"></prop>
+              <prop k="distance_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_y_unit" v="MM"></prop>
+              <prop k="offset_x" v="0"></prop>
+              <prop k="offset_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_x_unit" v="MM"></prop>
+              <prop k="offset_y" v="0"></prop>
+              <prop k="offset_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_y_unit" v="MM"></prop>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
-              <symbol type="marker" alpha="0.498039" clip_to_extent="1" force_rhr="0" name="@0@1">
-                <layer enabled="1" locked="0" class="SimpleMarker" pass="0">
-                  <prop v="0" k="angle"/>
-                  <prop v="215,25,28,255" k="color"/>
-                  <prop v="1" k="horizontal_anchor_point"/>
-                  <prop v="bevel" k="joinstyle"/>
-                  <prop v="circle" k="name"/>
-                  <prop v="0,0" k="offset"/>
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-                  <prop v="MM" k="offset_unit"/>
-                  <prop v="0,0,0,0" k="outline_color"/>
-                  <prop v="solid" k="outline_style"/>
-                  <prop v="0" k="outline_width"/>
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-                  <prop v="MM" k="outline_width_unit"/>
-                  <prop v="area" k="scale_method"/>
-                  <prop v="1.2" k="size"/>
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-                  <prop v="MM" k="size_unit"/>
-                  <prop v="1" k="vertical_anchor_point"/>
+              <symbol alpha="0.498039" clip_to_extent="1" force_rhr="0" name="@0@1" type="marker">
+                <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                  <prop k="angle" v="0"></prop>
+                  <prop k="color" v="215,25,28,255"></prop>
+                  <prop k="horizontal_anchor_point" v="1"></prop>
+                  <prop k="joinstyle" v="bevel"></prop>
+                  <prop k="name" v="circle"></prop>
+                  <prop k="offset" v="0,0"></prop>
+                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="offset_unit" v="MM"></prop>
+                  <prop k="outline_color" v="0,0,0,0"></prop>
+                  <prop k="outline_style" v="solid"></prop>
+                  <prop k="outline_width" v="0"></prop>
+                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="outline_width_unit" v="MM"></prop>
+                  <prop k="scale_method" v="area"></prop>
+                  <prop k="size" v="1.2"></prop>
+                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="size_unit" v="MM"></prop>
+                  <prop k="vertical_anchor_point" v="1"></prop>
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option type="QString" name="name" value=""/>
-                      <Option name="properties"/>
-                      <Option type="QString" name="type" value="collection"/>
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </layer>
           </symbol>
-          <symbol type="fill" alpha="0.392157" clip_to_extent="1" force_rhr="0" name="1">
-            <layer enabled="1" locked="0" class="SimpleFill" pass="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="246,144,83,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="175,179,138,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+          <symbol alpha="0.392157" clip_to_extent="1" force_rhr="0" name="1" type="fill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="color" v="246,144,83,255"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="offset" v="0,0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="outline_color" v="175,179,138,255"></prop>
+              <prop k="outline_style" v="solid"></prop>
+              <prop k="outline_width" v="0.26"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
+              <prop k="style" v="solid"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer enabled="1" locked="0" class="PointPatternFill" pass="0">
-              <prop v="0" k="displacement_x"/>
-              <prop v="3x:0,0,0,0,0,0" k="displacement_x_map_unit_scale"/>
-              <prop v="MM" k="displacement_x_unit"/>
-              <prop v="1" k="displacement_y"/>
-              <prop v="3x:0,0,0,0,0,0" k="displacement_y_map_unit_scale"/>
-              <prop v="MM" k="displacement_y_unit"/>
-              <prop v="1.5" k="distance_x"/>
-              <prop v="3x:0,0,0,0,0,0" k="distance_x_map_unit_scale"/>
-              <prop v="MM" k="distance_x_unit"/>
-              <prop v="2" k="distance_y"/>
-              <prop v="3x:0,0,0,0,0,0" k="distance_y_map_unit_scale"/>
-              <prop v="MM" k="distance_y_unit"/>
-              <prop v="0" k="offset_x"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_x_map_unit_scale"/>
-              <prop v="MM" k="offset_x_unit"/>
-              <prop v="0" k="offset_y"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_y_map_unit_scale"/>
-              <prop v="MM" k="offset_y_unit"/>
-              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-              <prop v="MM" k="outline_width_unit"/>
+            <layer class="PointPatternFill" enabled="1" locked="0" pass="0">
+              <prop k="displacement_x" v="0"></prop>
+              <prop k="displacement_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="displacement_x_unit" v="MM"></prop>
+              <prop k="displacement_y" v="1"></prop>
+              <prop k="displacement_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="displacement_y_unit" v="MM"></prop>
+              <prop k="distance_x" v="1.5"></prop>
+              <prop k="distance_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_x_unit" v="MM"></prop>
+              <prop k="distance_y" v="2"></prop>
+              <prop k="distance_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_y_unit" v="MM"></prop>
+              <prop k="offset_x" v="0"></prop>
+              <prop k="offset_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_x_unit" v="MM"></prop>
+              <prop k="offset_y" v="0"></prop>
+              <prop k="offset_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_y_unit" v="MM"></prop>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
-              <symbol type="marker" alpha="0.498039" clip_to_extent="1" force_rhr="0" name="@1@1">
-                <layer enabled="1" locked="0" class="SimpleMarker" pass="0">
-                  <prop v="0" k="angle"/>
-                  <prop v="246,144,83,255" k="color"/>
-                  <prop v="1" k="horizontal_anchor_point"/>
-                  <prop v="bevel" k="joinstyle"/>
-                  <prop v="circle" k="name"/>
-                  <prop v="0,0" k="offset"/>
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-                  <prop v="MM" k="offset_unit"/>
-                  <prop v="0,0,0,0" k="outline_color"/>
-                  <prop v="solid" k="outline_style"/>
-                  <prop v="0" k="outline_width"/>
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-                  <prop v="MM" k="outline_width_unit"/>
-                  <prop v="area" k="scale_method"/>
-                  <prop v="1.2" k="size"/>
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-                  <prop v="MM" k="size_unit"/>
-                  <prop v="1" k="vertical_anchor_point"/>
+              <symbol alpha="0.498039" clip_to_extent="1" force_rhr="0" name="@1@1" type="marker">
+                <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                  <prop k="angle" v="0"></prop>
+                  <prop k="color" v="246,144,83,255"></prop>
+                  <prop k="horizontal_anchor_point" v="1"></prop>
+                  <prop k="joinstyle" v="bevel"></prop>
+                  <prop k="name" v="circle"></prop>
+                  <prop k="offset" v="0,0"></prop>
+                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="offset_unit" v="MM"></prop>
+                  <prop k="outline_color" v="0,0,0,0"></prop>
+                  <prop k="outline_style" v="solid"></prop>
+                  <prop k="outline_width" v="0"></prop>
+                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="outline_width_unit" v="MM"></prop>
+                  <prop k="scale_method" v="area"></prop>
+                  <prop k="size" v="1.2"></prop>
+                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="size_unit" v="MM"></prop>
+                  <prop k="vertical_anchor_point" v="1"></prop>
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option type="QString" name="name" value=""/>
-                      <Option name="properties"/>
-                      <Option type="QString" name="type" value="collection"/>
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </layer>
           </symbol>
-          <symbol type="fill" alpha="0.392157" clip_to_extent="1" force_rhr="0" name="2">
-            <layer enabled="1" locked="0" class="SimpleFill" pass="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="218,175,193,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="175,179,138,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+          <symbol alpha="0.392157" clip_to_extent="1" force_rhr="0" name="2" type="fill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="color" v="218,175,193,255"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="offset" v="0,0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="outline_color" v="175,179,138,255"></prop>
+              <prop k="outline_style" v="solid"></prop>
+              <prop k="outline_width" v="0.26"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
+              <prop k="style" v="solid"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer enabled="1" locked="0" class="PointPatternFill" pass="0">
-              <prop v="0" k="displacement_x"/>
-              <prop v="3x:0,0,0,0,0,0" k="displacement_x_map_unit_scale"/>
-              <prop v="MM" k="displacement_x_unit"/>
-              <prop v="1" k="displacement_y"/>
-              <prop v="3x:0,0,0,0,0,0" k="displacement_y_map_unit_scale"/>
-              <prop v="MM" k="displacement_y_unit"/>
-              <prop v="1.5" k="distance_x"/>
-              <prop v="3x:0,0,0,0,0,0" k="distance_x_map_unit_scale"/>
-              <prop v="MM" k="distance_x_unit"/>
-              <prop v="2" k="distance_y"/>
-              <prop v="3x:0,0,0,0,0,0" k="distance_y_map_unit_scale"/>
-              <prop v="MM" k="distance_y_unit"/>
-              <prop v="0" k="offset_x"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_x_map_unit_scale"/>
-              <prop v="MM" k="offset_x_unit"/>
-              <prop v="0" k="offset_y"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_y_map_unit_scale"/>
-              <prop v="MM" k="offset_y_unit"/>
-              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-              <prop v="MM" k="outline_width_unit"/>
+            <layer class="PointPatternFill" enabled="1" locked="0" pass="0">
+              <prop k="displacement_x" v="0"></prop>
+              <prop k="displacement_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="displacement_x_unit" v="MM"></prop>
+              <prop k="displacement_y" v="1"></prop>
+              <prop k="displacement_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="displacement_y_unit" v="MM"></prop>
+              <prop k="distance_x" v="1.5"></prop>
+              <prop k="distance_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_x_unit" v="MM"></prop>
+              <prop k="distance_y" v="2"></prop>
+              <prop k="distance_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_y_unit" v="MM"></prop>
+              <prop k="offset_x" v="0"></prop>
+              <prop k="offset_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_x_unit" v="MM"></prop>
+              <prop k="offset_y" v="0"></prop>
+              <prop k="offset_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_y_unit" v="MM"></prop>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
-              <symbol type="marker" alpha="0.498039" clip_to_extent="1" force_rhr="0" name="@2@1">
-                <layer enabled="1" locked="0" class="SimpleMarker" pass="0">
-                  <prop v="0" k="angle"/>
-                  <prop v="218,175,193,255" k="color"/>
-                  <prop v="1" k="horizontal_anchor_point"/>
-                  <prop v="bevel" k="joinstyle"/>
-                  <prop v="circle" k="name"/>
-                  <prop v="0,0" k="offset"/>
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-                  <prop v="MM" k="offset_unit"/>
-                  <prop v="0,0,0,0" k="outline_color"/>
-                  <prop v="solid" k="outline_style"/>
-                  <prop v="0" k="outline_width"/>
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-                  <prop v="MM" k="outline_width_unit"/>
-                  <prop v="area" k="scale_method"/>
-                  <prop v="1.2" k="size"/>
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-                  <prop v="MM" k="size_unit"/>
-                  <prop v="1" k="vertical_anchor_point"/>
+              <symbol alpha="0.498039" clip_to_extent="1" force_rhr="0" name="@2@1" type="marker">
+                <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                  <prop k="angle" v="0"></prop>
+                  <prop k="color" v="218,175,193,255"></prop>
+                  <prop k="horizontal_anchor_point" v="1"></prop>
+                  <prop k="joinstyle" v="bevel"></prop>
+                  <prop k="name" v="circle"></prop>
+                  <prop k="offset" v="0,0"></prop>
+                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="offset_unit" v="MM"></prop>
+                  <prop k="outline_color" v="0,0,0,0"></prop>
+                  <prop k="outline_style" v="solid"></prop>
+                  <prop k="outline_width" v="0"></prop>
+                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="outline_width_unit" v="MM"></prop>
+                  <prop k="scale_method" v="area"></prop>
+                  <prop k="size" v="1.2"></prop>
+                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="size_unit" v="MM"></prop>
+                  <prop k="vertical_anchor_point" v="1"></prop>
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option type="QString" name="name" value=""/>
-                      <Option name="properties"/>
-                      <Option type="QString" name="type" value="collection"/>
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </layer>
           </symbol>
-          <symbol type="fill" alpha="0.392157" clip_to_extent="1" force_rhr="0" name="3">
-            <layer enabled="1" locked="0" class="SimpleFill" pass="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="185,194,218,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="175,179,138,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+          <symbol alpha="0.392157" clip_to_extent="1" force_rhr="0" name="3" type="fill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="color" v="185,194,218,255"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="offset" v="0,0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="outline_color" v="175,179,138,255"></prop>
+              <prop k="outline_style" v="solid"></prop>
+              <prop k="outline_width" v="0.26"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
+              <prop k="style" v="solid"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer enabled="1" locked="0" class="PointPatternFill" pass="0">
-              <prop v="0" k="displacement_x"/>
-              <prop v="3x:0,0,0,0,0,0" k="displacement_x_map_unit_scale"/>
-              <prop v="MM" k="displacement_x_unit"/>
-              <prop v="1" k="displacement_y"/>
-              <prop v="3x:0,0,0,0,0,0" k="displacement_y_map_unit_scale"/>
-              <prop v="MM" k="displacement_y_unit"/>
-              <prop v="1.5" k="distance_x"/>
-              <prop v="3x:0,0,0,0,0,0" k="distance_x_map_unit_scale"/>
-              <prop v="MM" k="distance_x_unit"/>
-              <prop v="2" k="distance_y"/>
-              <prop v="3x:0,0,0,0,0,0" k="distance_y_map_unit_scale"/>
-              <prop v="MM" k="distance_y_unit"/>
-              <prop v="0" k="offset_x"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_x_map_unit_scale"/>
-              <prop v="MM" k="offset_x_unit"/>
-              <prop v="0" k="offset_y"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_y_map_unit_scale"/>
-              <prop v="MM" k="offset_y_unit"/>
-              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-              <prop v="MM" k="outline_width_unit"/>
+            <layer class="PointPatternFill" enabled="1" locked="0" pass="0">
+              <prop k="displacement_x" v="0"></prop>
+              <prop k="displacement_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="displacement_x_unit" v="MM"></prop>
+              <prop k="displacement_y" v="1"></prop>
+              <prop k="displacement_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="displacement_y_unit" v="MM"></prop>
+              <prop k="distance_x" v="1.5"></prop>
+              <prop k="distance_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_x_unit" v="MM"></prop>
+              <prop k="distance_y" v="2"></prop>
+              <prop k="distance_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_y_unit" v="MM"></prop>
+              <prop k="offset_x" v="0"></prop>
+              <prop k="offset_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_x_unit" v="MM"></prop>
+              <prop k="offset_y" v="0"></prop>
+              <prop k="offset_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_y_unit" v="MM"></prop>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
-              <symbol type="marker" alpha="0.498039" clip_to_extent="1" force_rhr="0" name="@3@1">
-                <layer enabled="1" locked="0" class="SimpleMarker" pass="0">
-                  <prop v="0" k="angle"/>
-                  <prop v="185,194,218,255" k="color"/>
-                  <prop v="1" k="horizontal_anchor_point"/>
-                  <prop v="bevel" k="joinstyle"/>
-                  <prop v="circle" k="name"/>
-                  <prop v="0,0" k="offset"/>
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-                  <prop v="MM" k="offset_unit"/>
-                  <prop v="0,0,0,0" k="outline_color"/>
-                  <prop v="solid" k="outline_style"/>
-                  <prop v="0" k="outline_width"/>
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-                  <prop v="MM" k="outline_width_unit"/>
-                  <prop v="area" k="scale_method"/>
-                  <prop v="1.2" k="size"/>
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-                  <prop v="MM" k="size_unit"/>
-                  <prop v="1" k="vertical_anchor_point"/>
+              <symbol alpha="0.498039" clip_to_extent="1" force_rhr="0" name="@3@1" type="marker">
+                <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                  <prop k="angle" v="0"></prop>
+                  <prop k="color" v="185,194,218,255"></prop>
+                  <prop k="horizontal_anchor_point" v="1"></prop>
+                  <prop k="joinstyle" v="bevel"></prop>
+                  <prop k="name" v="circle"></prop>
+                  <prop k="offset" v="0,0"></prop>
+                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="offset_unit" v="MM"></prop>
+                  <prop k="outline_color" v="0,0,0,0"></prop>
+                  <prop k="outline_style" v="solid"></prop>
+                  <prop k="outline_width" v="0"></prop>
+                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="outline_width_unit" v="MM"></prop>
+                  <prop k="scale_method" v="area"></prop>
+                  <prop k="size" v="1.2"></prop>
+                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="size_unit" v="MM"></prop>
+                  <prop k="vertical_anchor_point" v="1"></prop>
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option type="QString" name="name" value=""/>
-                      <Option name="properties"/>
-                      <Option type="QString" name="type" value="collection"/>
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </layer>
           </symbol>
-          <symbol type="fill" alpha="0.392157" clip_to_extent="1" force_rhr="0" name="4">
-            <layer enabled="1" locked="0" class="SimpleFill" pass="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="144,198,169,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="175,179,138,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+          <symbol alpha="0.392157" clip_to_extent="1" force_rhr="0" name="4" type="fill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="color" v="144,198,169,255"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="offset" v="0,0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="outline_color" v="175,179,138,255"></prop>
+              <prop k="outline_style" v="solid"></prop>
+              <prop k="outline_width" v="0.26"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
+              <prop k="style" v="solid"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer enabled="1" locked="0" class="PointPatternFill" pass="0">
-              <prop v="0" k="displacement_x"/>
-              <prop v="3x:0,0,0,0,0,0" k="displacement_x_map_unit_scale"/>
-              <prop v="MM" k="displacement_x_unit"/>
-              <prop v="1" k="displacement_y"/>
-              <prop v="3x:0,0,0,0,0,0" k="displacement_y_map_unit_scale"/>
-              <prop v="MM" k="displacement_y_unit"/>
-              <prop v="1.5" k="distance_x"/>
-              <prop v="3x:0,0,0,0,0,0" k="distance_x_map_unit_scale"/>
-              <prop v="MM" k="distance_x_unit"/>
-              <prop v="2" k="distance_y"/>
-              <prop v="3x:0,0,0,0,0,0" k="distance_y_map_unit_scale"/>
-              <prop v="MM" k="distance_y_unit"/>
-              <prop v="0" k="offset_x"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_x_map_unit_scale"/>
-              <prop v="MM" k="offset_x_unit"/>
-              <prop v="0" k="offset_y"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_y_map_unit_scale"/>
-              <prop v="MM" k="offset_y_unit"/>
-              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-              <prop v="MM" k="outline_width_unit"/>
+            <layer class="PointPatternFill" enabled="1" locked="0" pass="0">
+              <prop k="displacement_x" v="0"></prop>
+              <prop k="displacement_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="displacement_x_unit" v="MM"></prop>
+              <prop k="displacement_y" v="1"></prop>
+              <prop k="displacement_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="displacement_y_unit" v="MM"></prop>
+              <prop k="distance_x" v="1.5"></prop>
+              <prop k="distance_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_x_unit" v="MM"></prop>
+              <prop k="distance_y" v="2"></prop>
+              <prop k="distance_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_y_unit" v="MM"></prop>
+              <prop k="offset_x" v="0"></prop>
+              <prop k="offset_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_x_unit" v="MM"></prop>
+              <prop k="offset_y" v="0"></prop>
+              <prop k="offset_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_y_unit" v="MM"></prop>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
-              <symbol type="marker" alpha="0.498039" clip_to_extent="1" force_rhr="0" name="@4@1">
-                <layer enabled="1" locked="0" class="SimpleMarker" pass="0">
-                  <prop v="0" k="angle"/>
-                  <prop v="144,198,169,255" k="color"/>
-                  <prop v="1" k="horizontal_anchor_point"/>
-                  <prop v="bevel" k="joinstyle"/>
-                  <prop v="circle" k="name"/>
-                  <prop v="0,0" k="offset"/>
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-                  <prop v="MM" k="offset_unit"/>
-                  <prop v="0,0,0,0" k="outline_color"/>
-                  <prop v="solid" k="outline_style"/>
-                  <prop v="0" k="outline_width"/>
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-                  <prop v="MM" k="outline_width_unit"/>
-                  <prop v="area" k="scale_method"/>
-                  <prop v="1.2" k="size"/>
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-                  <prop v="MM" k="size_unit"/>
-                  <prop v="1" k="vertical_anchor_point"/>
+              <symbol alpha="0.498039" clip_to_extent="1" force_rhr="0" name="@4@1" type="marker">
+                <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                  <prop k="angle" v="0"></prop>
+                  <prop k="color" v="144,198,169,255"></prop>
+                  <prop k="horizontal_anchor_point" v="1"></prop>
+                  <prop k="joinstyle" v="bevel"></prop>
+                  <prop k="name" v="circle"></prop>
+                  <prop k="offset" v="0,0"></prop>
+                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="offset_unit" v="MM"></prop>
+                  <prop k="outline_color" v="0,0,0,0"></prop>
+                  <prop k="outline_style" v="solid"></prop>
+                  <prop k="outline_width" v="0"></prop>
+                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="outline_width_unit" v="MM"></prop>
+                  <prop k="scale_method" v="area"></prop>
+                  <prop k="size" v="1.2"></prop>
+                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="size_unit" v="MM"></prop>
+                  <prop k="vertical_anchor_point" v="1"></prop>
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option type="QString" name="name" value=""/>
-                      <Option name="properties"/>
-                      <Option type="QString" name="type" value="collection"/>
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
                     </Option>
                   </data_defined_properties>
                 </layer>
@@ -6310,80 +6575,80 @@ def my_form_open(dialog, layer, feature):
           </symbol>
         </symbols>
         <source-symbol>
-          <symbol type="fill" alpha="0.392157" clip_to_extent="1" force_rhr="0" name="0">
-            <layer enabled="1" locked="0" class="SimpleFill" pass="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="73,244,5,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="175,179,138,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+          <symbol alpha="0.392157" clip_to_extent="1" force_rhr="0" name="0" type="fill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="color" v="73,244,5,255"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="offset" v="0,0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="outline_color" v="175,179,138,255"></prop>
+              <prop k="outline_style" v="solid"></prop>
+              <prop k="outline_width" v="0.26"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
+              <prop k="style" v="solid"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer enabled="1" locked="0" class="PointPatternFill" pass="0">
-              <prop v="0" k="displacement_x"/>
-              <prop v="3x:0,0,0,0,0,0" k="displacement_x_map_unit_scale"/>
-              <prop v="MM" k="displacement_x_unit"/>
-              <prop v="1" k="displacement_y"/>
-              <prop v="3x:0,0,0,0,0,0" k="displacement_y_map_unit_scale"/>
-              <prop v="MM" k="displacement_y_unit"/>
-              <prop v="1.5" k="distance_x"/>
-              <prop v="3x:0,0,0,0,0,0" k="distance_x_map_unit_scale"/>
-              <prop v="MM" k="distance_x_unit"/>
-              <prop v="2" k="distance_y"/>
-              <prop v="3x:0,0,0,0,0,0" k="distance_y_map_unit_scale"/>
-              <prop v="MM" k="distance_y_unit"/>
-              <prop v="0" k="offset_x"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_x_map_unit_scale"/>
-              <prop v="MM" k="offset_x_unit"/>
-              <prop v="0" k="offset_y"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_y_map_unit_scale"/>
-              <prop v="MM" k="offset_y_unit"/>
-              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-              <prop v="MM" k="outline_width_unit"/>
+            <layer class="PointPatternFill" enabled="1" locked="0" pass="0">
+              <prop k="displacement_x" v="0"></prop>
+              <prop k="displacement_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="displacement_x_unit" v="MM"></prop>
+              <prop k="displacement_y" v="1"></prop>
+              <prop k="displacement_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="displacement_y_unit" v="MM"></prop>
+              <prop k="distance_x" v="1.5"></prop>
+              <prop k="distance_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_x_unit" v="MM"></prop>
+              <prop k="distance_y" v="2"></prop>
+              <prop k="distance_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_y_unit" v="MM"></prop>
+              <prop k="offset_x" v="0"></prop>
+              <prop k="offset_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_x_unit" v="MM"></prop>
+              <prop k="offset_y" v="0"></prop>
+              <prop k="offset_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_y_unit" v="MM"></prop>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
-              <symbol type="marker" alpha="0.498039" clip_to_extent="1" force_rhr="0" name="@0@1">
-                <layer enabled="1" locked="0" class="SimpleMarker" pass="0">
-                  <prop v="0" k="angle"/>
-                  <prop v="255,13,1,255" k="color"/>
-                  <prop v="1" k="horizontal_anchor_point"/>
-                  <prop v="bevel" k="joinstyle"/>
-                  <prop v="circle" k="name"/>
-                  <prop v="0,0" k="offset"/>
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-                  <prop v="MM" k="offset_unit"/>
-                  <prop v="0,0,0,0" k="outline_color"/>
-                  <prop v="solid" k="outline_style"/>
-                  <prop v="0" k="outline_width"/>
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-                  <prop v="MM" k="outline_width_unit"/>
-                  <prop v="area" k="scale_method"/>
-                  <prop v="1.2" k="size"/>
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-                  <prop v="MM" k="size_unit"/>
-                  <prop v="1" k="vertical_anchor_point"/>
+              <symbol alpha="0.498039" clip_to_extent="1" force_rhr="0" name="@0@1" type="marker">
+                <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                  <prop k="angle" v="0"></prop>
+                  <prop k="color" v="255,13,1,255"></prop>
+                  <prop k="horizontal_anchor_point" v="1"></prop>
+                  <prop k="joinstyle" v="bevel"></prop>
+                  <prop k="name" v="circle"></prop>
+                  <prop k="offset" v="0,0"></prop>
+                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="offset_unit" v="MM"></prop>
+                  <prop k="outline_color" v="0,0,0,0"></prop>
+                  <prop k="outline_style" v="solid"></prop>
+                  <prop k="outline_width" v="0"></prop>
+                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="outline_width_unit" v="MM"></prop>
+                  <prop k="scale_method" v="area"></prop>
+                  <prop k="size" v="1.2"></prop>
+                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="size_unit" v="MM"></prop>
+                  <prop k="vertical_anchor_point" v="1"></prop>
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option type="QString" name="name" value=""/>
-                      <Option name="properties"/>
-                      <Option type="QString" name="type" value="collection"/>
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
                     </Option>
                   </data_defined_properties>
                 </layer>
@@ -6391,118 +6656,197 @@ def my_form_open(dialog, layer, feature):
             </layer>
           </symbol>
         </source-symbol>
-        <colorramp type="gradient" name="[source]">
-          <prop v="215,25,28,255" k="color1"/>
-          <prop v="36,106,186,255" k="color2"/>
-          <prop v="0" k="discrete"/>
-          <prop v="gradient" k="rampType"/>
-          <prop v="0.25;253,174,97,255:0.497611;195,175,255,255:0.75;171,221,164,255" k="stops"/>
+        <colorramp name="[source]" type="gradient">
+          <prop k="color1" v="215,25,28,255"></prop>
+          <prop k="color2" v="36,106,186,255"></prop>
+          <prop k="discrete" v="0"></prop>
+          <prop k="rampType" v="gradient"></prop>
+          <prop k="stops" v="0.25;253,174,97,255:0.497611;195,175,255,255:0.75;171,221,164,255"></prop>
         </colorramp>
-        <rotation/>
-        <sizescale/>
+        <rotation></rotation>
+        <sizescale></sizescale>
       </renderer-v2>
       <labeling type="simple">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fieldName=" concat( &quot;plant_species&quot; , ' ('  || &quot;proprietor&quot;  || ')')" fontLetterSpacing="0" blendMode="0" fontSize="13" fontItalic="0" fontStrikeout="0" fontWordSpacing="0" isExpression="1" fontKerning="1" useSubstitutions="0" multilineHeight="1" namedStyle="Regular" fontCapitals="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontFamily="Sans Serif" textColor="0,0,0,255" fontSizeUnit="Point" fontUnderline="0" textOrientation="horizontal">
-            <text-buffer bufferNoFill="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1" bufferBlendMode="0" bufferSizeUnits="MM" bufferJoinStyle="128" bufferDraw="0" bufferColor="255,255,255,255" bufferOpacity="1"/>
-            <background shapeOffsetUnit="MM" shapeBorderWidthUnit="MM" shapeOffsetY="0" shapeBorderWidth="0" shapeType="0" shapeRadiiX="0" shapeDraw="0" shapeBlendMode="0" shapeOpacity="1" shapeFillColor="255,255,255,255" shapeRotationType="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRotation="0" shapeRadiiY="0" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255" shapeJoinStyle="64" shapeSizeUnit="MM" shapeSizeType="0" shapeSVGFile="" shapeSizeY="0" shapeSizeX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-            <shadow shadowRadiusUnit="MM" shadowOffsetUnit="MM" shadowOpacity="0.7" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowUnder="0" shadowOffsetDist="1" shadowColor="0,0,0,255" shadowScale="100" shadowOffsetAngle="135" shadowOffsetGlobal="1" shadowDraw="0" shadowRadius="1.5" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowBlendMode="6"/>
+          <text-style blendMode="0" fieldName=" concat( &quot;plant_species&quot; , ' ('  || &quot;proprietor&quot;  || ')')" fontCapitals="0" fontFamily="Sans Serif" fontItalic="0" fontKerning="1" fontLetterSpacing="0" fontSize="13" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontStrikeout="0" fontUnderline="0" fontWeight="50" fontWordSpacing="0" isExpression="1" multilineHeight="1" namedStyle="Normal" previewBkgrdColor="255,255,255,255" textColor="0,0,0,255" textOpacity="1" textOrientation="horizontal" useSubstitutions="0">
+            <text-buffer bufferBlendMode="0" bufferColor="255,255,255,255" bufferDraw="0" bufferJoinStyle="128" bufferNoFill="1" bufferOpacity="1" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM"></text-buffer>
+            <text-mask maskEnabled="0" maskJoinStyle="128" maskOpacity="1" maskSize="0" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSizeUnits="MM" maskType="0" maskedSymbolLayers=""></text-mask>
+            <background shapeBlendMode="0" shapeBorderColor="128,128,128,255" shapeBorderWidth="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeDraw="0" shapeFillColor="255,255,255,255" shapeJoinStyle="64" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeOffsetY="0" shapeOpacity="1" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiUnit="MM" shapeRadiiX="0" shapeRadiiY="0" shapeRotation="0" shapeRotationType="0" shapeSVGFile="" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeSizeUnit="MM" shapeSizeX="0" shapeSizeY="0" shapeType="0">
+              <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="markerSymbol" type="marker">
+                <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                  <prop k="angle" v="0"></prop>
+                  <prop k="color" v="114,155,111,255"></prop>
+                  <prop k="horizontal_anchor_point" v="1"></prop>
+                  <prop k="joinstyle" v="bevel"></prop>
+                  <prop k="name" v="circle"></prop>
+                  <prop k="offset" v="0,0"></prop>
+                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="offset_unit" v="MM"></prop>
+                  <prop k="outline_color" v="35,35,35,255"></prop>
+                  <prop k="outline_style" v="solid"></prop>
+                  <prop k="outline_width" v="0"></prop>
+                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="outline_width_unit" v="MM"></prop>
+                  <prop k="scale_method" v="diameter"></prop>
+                  <prop k="size" v="2"></prop>
+                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="size_unit" v="MM"></prop>
+                  <prop k="vertical_anchor_point" v="1"></prop>
+                  <data_defined_properties>
+                    <Option type="Map">
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
+                    </Option>
+                  </data_defined_properties>
+                </layer>
+              </symbol>
+            </background>
+            <shadow shadowBlendMode="6" shadowColor="0,0,0,255" shadowDraw="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowOpacity="0.7" shadowRadius="1.5" shadowRadiusAlphaOnly="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowUnder="0"></shadow>
             <dd_properties>
               <Option type="Map">
-                <Option type="QString" name="name" value=""/>
-                <Option name="properties"/>
-                <Option type="QString" name="type" value="collection"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </dd_properties>
-            <substitutions/>
+            <substitutions></substitutions>
           </text-style>
-          <text-format leftDirectionSymbol="&lt;" useMaxLineLengthForAutoWrap="1" formatNumbers="0" decimals="3" rightDirectionSymbol=">" placeDirectionSymbol="0" reverseDirectionSymbol="0" plussign="0" wrapChar="" multilineAlign="4294967295" addDirectionSymbol="0" autoWrapLength="0"/>
-          <placement quadOffset="4" repeatDistance="0" centroidInside="0" maxCurvedCharAngleOut="-25" centroidWhole="0" rotationAngle="0" priority="5" repeatDistanceUnits="MM" xOffset="0" placement="0" offsetType="0" geometryGeneratorType="PointGeometry" placementFlags="10" distMapUnitScale="3x:0,0,0,0,0,0" geometryGenerator="" dist="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" fitInPolygonOnly="0" maxCurvedCharAngleIn="25" overrunDistanceUnit="MM" geometryGeneratorEnabled="0" yOffset="0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" overrunDistance="0" offsetUnits="MM" preserveRotation="1" distUnits="MM" layerType="UnknownGeometry"/>
-          <rendering fontLimitPixelSize="0" obstacleType="0" labelPerPart="0" upsidedownLabels="0" obstacleFactor="1" obstacle="1" limitNumLabels="0" fontMaxPixelSize="10000" scaleMin="0" zIndex="0" minFeatureSize="0" displayAll="0" maxNumLabels="2000" scaleVisibility="1" fontMinPixelSize="3" drawLabels="1" scaleMax="5000" mergeLines="0"/>
+          <text-format addDirectionSymbol="0" autoWrapLength="0" decimals="3" formatNumbers="0" leftDirectionSymbol="&lt;" multilineAlign="4294967295" placeDirectionSymbol="0" plussign="0" reverseDirectionSymbol="0" rightDirectionSymbol=">" useMaxLineLengthForAutoWrap="1" wrapChar=""></text-format>
+          <placement centroidInside="0" centroidWhole="0" dist="0" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" fitInPolygonOnly="0" geometryGenerator="" geometryGeneratorEnabled="0" geometryGeneratorType="PointGeometry" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" layerType="PolygonGeometry" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" offsetType="0" offsetUnits="MM" overrunDistance="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" placement="0" placementFlags="10" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" preserveRotation="1" priority="5" quadOffset="4" repeatDistance="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" rotationAngle="0" xOffset="0" yOffset="0"></placement>
+          <rendering displayAll="0" drawLabels="1" fontLimitPixelSize="0" fontMaxPixelSize="10000" fontMinPixelSize="3" labelPerPart="0" limitNumLabels="0" maxNumLabels="2000" mergeLines="0" minFeatureSize="0" obstacle="1" obstacleFactor="1" obstacleType="0" scaleMax="5000" scaleMin="0" scaleVisibility="1" upsidedownLabels="0" zIndex="0"></rendering>
           <dd_properties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
-              <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option type="QString" name="anchorPoint" value="pole_of_inaccessibility"/>
-              <Option type="Map" name="ddProperties">
-                <Option type="QString" name="name" value=""/>
-                <Option name="properties"/>
-                <Option type="QString" name="type" value="collection"/>
+              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility"></Option>
+              <Option name="ddProperties" type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
-              <Option type="bool" name="drawToAllParts" value="false"/>
-              <Option type="QString" name="enabled" value="0"/>
-              <Option type="QString" name="lineSymbol" value="&lt;symbol type=&quot;line&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; force_rhr=&quot;0&quot; name=&quot;symbol&quot;>&lt;layer enabled=&quot;1&quot; locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot;>&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/>&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/>&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/>&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/>&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/>&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/>&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; name=&quot;name&quot; value=&quot;&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;type&quot; value=&quot;collection&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>"/>
-              <Option type="double" name="minLength" value="0"/>
-              <Option type="QString" name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0"/>
-              <Option type="QString" name="minLengthUnit" value="MM"/>
-              <Option type="double" name="offsetFromAnchor" value="0"/>
-              <Option type="QString" name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0"/>
-              <Option type="QString" name="offsetFromAnchorUnit" value="MM"/>
-              <Option type="double" name="offsetFromLabel" value="0"/>
-              <Option type="QString" name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0"/>
-              <Option type="QString" name="offsetFromLabelUnit" value="MM"/>
+              <Option name="drawToAllParts" type="bool" value="false"></Option>
+              <Option name="enabled" type="QString" value="0"></Option>
+              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior"></Option>
+              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; type=&quot;line&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; force_rhr=&quot;0&quot;>&lt;layer enabled=&quot;1&quot; pass=&quot;0&quot; locked=&quot;0&quot; class=&quot;SimpleLine&quot;>&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/>&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/>&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/>&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/>&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/>&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/>&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>"></Option>
+              <Option name="minLength" type="double" value="0"></Option>
+              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="minLengthUnit" type="QString" value="MM"></Option>
+              <Option name="offsetFromAnchor" type="double" value="0"></Option>
+              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="offsetFromAnchorUnit" type="QString" value="MM"></Option>
+              <Option name="offsetFromLabel" type="double" value="0"></Option>
+              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="offsetFromLabelUnit" type="QString" value="MM"></Option>
             </Option>
           </callout>
         </settings>
       </labeling>
       <customproperties>
-        <property key="QFieldSync/action" value="offline"/>
-        <property key="dualview/previewExpressions" value="represent_value(&quot;plant_species&quot;)  || ' ('  ||  represent_value(&quot;proprietor&quot;) || ' ) '"/>
-        <property key="embeddedWidgets/count" value="0"/>
-        <property key="isOfflineEditable" value="true"/>
-        <property key="remoteProvider" value="postgres"/>
-        <property key="remoteSource" value="dbname='demo' host=lizmapdemo.opengis.ch port=5432 user='editor1' password='editor1' sslmode=disable key='id' srid=2056 type=Polygon table=&quot;citybees&quot;.&quot;area&quot; (geom) sql="/>
-        <property key="variableNames"/>
-        <property key="variableValues"/>
+        <property key="QFieldSync/action" value="offline"></property>
+        <property key="dualview/previewExpressions" value="represent_value(&quot;plant_species&quot;)  || ' ('  ||  represent_value(&quot;proprietor&quot;) || ' ) '"></property>
+        <property key="embeddedWidgets/count" value="0"></property>
+        <property key="isOfflineEditable" value="true"></property>
+        <property key="remoteProvider" value="postgres"></property>
+        <property key="remoteSource" value="dbname='demo' host=lizmapdemo.opengis.ch port=5432 user='editor1' password='editor1' sslmode=disable key='id' srid=2056 type=Polygon table=&quot;citybees&quot;.&quot;area&quot; (geom) sql="></property>
+        <property key="variableNames"></property>
+        <property key="variableValues"></property>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
-        <DiagramCategory labelPlacementMethod="XHeight" minScaleDenominator="0" penAlpha="255" diagramOrientation="Up" penColor="#000000" scaleBasedVisibility="0" rotationOffset="0" maxScaleDenominator="1e+08" sizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" barWidth="5" backgroundColor="#ffffff" width="15" scaleDependency="Area" minimumSize="0" lineSizeScale="3x:0,0,0,0,0,0" sizeType="MM" backgroundAlpha="255" height="15" enabled="0" penWidth="0" opacity="1">
-          <fontProperties style="" description="Cantarell,11,-1,5,50,0,0,0,0,0"/>
-          <attribute color="#000000" field="" label=""/>
+      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="1" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+8" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="0" scaleBasedVisibility="0" scaleDependency="Area" showAxis="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="0" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
+          <fontProperties description="Cantarell,11,-1,5,50,0,0,0,0,0" style=""></fontProperties>
+          <attribute color="#000000" field="" label=""></attribute>
+          <axisSymbol>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" type="line">
+              <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+                <prop k="capstyle" v="square"></prop>
+                <prop k="customdash" v="5;2"></prop>
+                <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="customdash_unit" v="MM"></prop>
+                <prop k="draw_inside_polygon" v="0"></prop>
+                <prop k="joinstyle" v="bevel"></prop>
+                <prop k="line_color" v="35,35,35,255"></prop>
+                <prop k="line_style" v="solid"></prop>
+                <prop k="line_width" v="0.26"></prop>
+                <prop k="line_width_unit" v="MM"></prop>
+                <prop k="offset" v="0"></prop>
+                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="offset_unit" v="MM"></prop>
+                <prop k="ring_filter" v="0"></prop>
+                <prop k="use_custom_dash" v="0"></prop>
+                <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings linePlacementFlags="2" dist="0" priority="0" zIndex="0" placement="0" obstacle="0" showAll="1">
+      <DiagramLayerSettings dist="0" linePlacementFlags="2" obstacle="0" placement="0" priority="0" showAll="1" zIndex="0">
         <properties>
           <Option type="Map">
-            <Option type="QString" name="name" value=""/>
-            <Option type="Map" name="properties">
-              <Option type="Map" name="positionX">
-                <Option type="bool" name="active" value="true"/>
-                <Option type="QString" name="field" value="id"/>
-                <Option type="int" name="type" value="2"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties" type="Map">
+              <Option name="positionX" type="Map">
+                <Option name="active" type="bool" value="true"></Option>
+                <Option name="field" type="QString" value="id"></Option>
+                <Option name="type" type="int" value="2"></Option>
               </Option>
-              <Option type="Map" name="positionY">
-                <Option type="bool" name="active" value="true"/>
-                <Option type="QString" name="field" value="id"/>
-                <Option type="int" name="type" value="2"/>
+              <Option name="positionY" type="Map">
+                <Option name="active" type="bool" value="true"></Option>
+                <Option name="field" type="QString" value="id"></Option>
+                <Option name="type" type="int" value="2"></Option>
               </Option>
-              <Option type="Map" name="show">
-                <Option type="bool" name="active" value="true"/>
-                <Option type="QString" name="field" value="id"/>
-                <Option type="int" name="type" value="2"/>
+              <Option name="show" type="Map">
+                <Option name="active" type="bool" value="true"></Option>
+                <Option name="field" type="QString" value="id"></Option>
+                <Option name="type" type="int" value="2"></Option>
               </Option>
             </Option>
-            <Option type="QString" name="type" value="collection"/>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </properties>
       </DiagramLayerSettings>
       <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-        <activeChecks/>
-        <checkConfiguration/>
+        <activeChecks></activeChecks>
+        <checkConfiguration type="Map">
+          <Option name="QgsGeometryGapCheck" type="Map">
+            <Option name="allowedGapsBuffer" type="double" value="0"></Option>
+            <Option name="allowedGapsEnabled" type="bool" value="false"></Option>
+            <Option name="allowedGapsLayer" type="QString" value=""></Option>
+          </Option>
+        </checkConfiguration>
       </geometryOptions>
+      <referencedLayers></referencedLayers>
+      <referencingLayers>
+        <relation dataSource="./bees.gpkg|layername=Pollen_Consumption" id="Pollen_Con_field_id_ogr_dbname_fid" layerId="Pollen_Consumption_9dac944e_6937_4617_928b_0daaf97303e9" layerName="Pollen_Consumption" name="consumed_by_apiaries" providerKey="ogr" strength="1">
+          <fieldPair referenced="fid" referencing="field_id"></fieldPair>
+        </relation>
+        <relation dataSource="./bees.gpkg|layername=apiary" id="apiary_279_area_id_ogr_dbname_fid" layerId="apiary_27954fba_aad8_4336_8b19_23afed462c51" layerName="Apiary" name="apiary_area" providerKey="ogr" strength="0">
+          <fieldPair referenced="fid" referencing="area_id"></fieldPair>
+        </relation>
+      </referencingLayers>
       <fieldConfiguration>
         <field name="fid">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option type="Map">
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
+              </Option>
             </config>
           </editWidget>
         </field>
@@ -6510,15 +6854,15 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="ValueMap">
             <config>
               <Option type="Map">
-                <Option type="List" name="map">
+                <Option name="map" type="List">
                   <Option type="Map">
-                    <Option type="QString" name="Regional" value="cantonal"/>
+                    <Option name="Regional" type="QString" value="cantonal"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option type="QString" name="National" value="national"/>
+                    <Option name="National" type="QString" value="national"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option type="QString" name="Private" value="private"/>
+                    <Option name="Private" type="QString" value="private"></Option>
                   </Option>
                 </Option>
               </Option>
@@ -6529,21 +6873,21 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="ValueMap">
             <config>
               <Option type="Map">
-                <Option type="List" name="map">
+                <Option name="map" type="List">
                   <Option type="Map">
-                    <Option type="QString" name="Dandelions" value="taraxacum"/>
+                    <Option name="Dandelions" type="QString" value="taraxacum"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option type="QString" name="Grass" value="grass"/>
+                    <Option name="Grass" type="QString" value="grass"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option type="QString" name="Lavender" value="lavender"/>
+                    <Option name="Lavender" type="QString" value="lavender"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option type="QString" name="Colza" value="colza"/>
+                    <Option name="Colza" type="QString" value="colza"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option type="QString" name="Weed" value="weed"/>
+                    <Option name="Weed" type="QString" value="weed"></Option>
                   </Option>
                 </Option>
               </Option>
@@ -6554,19 +6898,19 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="ExternalResource">
             <config>
               <Option type="Map">
-                <Option type="int" name="DocumentViewer" value="0"/>
-                <Option type="int" name="DocumentViewerHeight" value="0"/>
-                <Option type="int" name="DocumentViewerWidth" value="0"/>
-                <Option type="bool" name="FileWidget" value="true"/>
-                <Option type="bool" name="FileWidgetButton" value="true"/>
-                <Option type="QString" name="FileWidgetFilter" value=""/>
-                <Option type="Map" name="PropertyCollection">
-                  <Option type="QString" name="name" value=""/>
-                  <Option type="invalid" name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                <Option name="DocumentViewer" type="int" value="0"></Option>
+                <Option name="DocumentViewerHeight" type="int" value="0"></Option>
+                <Option name="DocumentViewerWidth" type="int" value="0"></Option>
+                <Option name="FileWidget" type="bool" value="true"></Option>
+                <Option name="FileWidgetButton" type="bool" value="true"></Option>
+                <Option name="FileWidgetFilter" type="QString" value=""></Option>
+                <Option name="PropertyCollection" type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
-                <Option type="int" name="RelativeStorage" value="1"/>
-                <Option type="int" name="StorageMode" value="0"/>
+                <Option name="RelativeStorage" type="int" value="1"></Option>
+                <Option name="StorageMode" type="int" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -6575,10 +6919,11 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="DateTime">
             <config>
               <Option type="Map">
-                <Option type="QString" name="allow_null" value="0"/>
-                <Option type="QString" name="calendar_popup" value="0"/>
-                <Option type="QString" name="display_format" value="yyyy-MM-dd"/>
-                <Option type="QString" name="field_format" value="yyyy-MM-dd"/>
+                <Option name="allow_null" type="bool" value="false"></Option>
+                <Option name="calendar_popup" type="bool" value="false"></Option>
+                <Option name="display_format" type="QString" value="yyyy-MM-dd"></Option>
+                <Option name="field_format" type="QString" value="yyyy-MM-dd"></Option>
+                <Option name="field_iso_format" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -6587,77 +6932,77 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" name="IsMultiline" value="0"/>
-                <Option type="QString" name="UseHtml" value="0"/>
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" field="fid" index="0"/>
-        <alias name="Proprietor" field="proprietor" index="1"/>
-        <alias name="Plants" field="plant_species" index="2"/>
-        <alias name="Photo" field="picture" index="3"/>
-        <alias name="Date of Review" field="review_date" index="4"/>
-        <alias name="Reviewer" field="reviewer" index="5"/>
+        <alias field="fid" index="0" name=""></alias>
+        <alias field="proprietor" index="1" name="Proprietor"></alias>
+        <alias field="plant_species" index="2" name="Plants"></alias>
+        <alias field="picture" index="3" name="Photo"></alias>
+        <alias field="review_date" index="4" name="Date of Review"></alias>
+        <alias field="reviewer" index="5" name="Reviewer"></alias>
       </aliases>
-      <excludeAttributesWMS/>
-      <excludeAttributesWFS/>
+      <excludeAttributesWMS></excludeAttributesWMS>
+      <excludeAttributesWFS></excludeAttributesWFS>
       <defaults>
-        <default applyOnUpdate="0" field="fid" expression=""/>
-        <default applyOnUpdate="0" field="proprietor" expression=""/>
-        <default applyOnUpdate="0" field="plant_species" expression=""/>
-        <default applyOnUpdate="0" field="picture" expression=""/>
-        <default applyOnUpdate="0" field="review_date" expression=""/>
-        <default applyOnUpdate="0" field="reviewer" expression=""/>
+        <default applyOnUpdate="0" expression="" field="fid"></default>
+        <default applyOnUpdate="0" expression="" field="proprietor"></default>
+        <default applyOnUpdate="0" expression="" field="plant_species"></default>
+        <default applyOnUpdate="0" expression="" field="picture"></default>
+        <default applyOnUpdate="0" expression="" field="review_date"></default>
+        <default applyOnUpdate="0" expression="" field="reviewer"></default>
       </defaults>
       <constraints>
-        <constraint notnull_strength="1" constraints="3" field="fid" unique_strength="1" exp_strength="0"/>
-        <constraint notnull_strength="1" constraints="5" field="proprietor" unique_strength="0" exp_strength="1"/>
-        <constraint notnull_strength="1" constraints="5" field="plant_species" unique_strength="0" exp_strength="1"/>
-        <constraint notnull_strength="0" constraints="0" field="picture" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="review_date" unique_strength="0" exp_strength="0"/>
-        <constraint notnull_strength="0" constraints="0" field="reviewer" unique_strength="0" exp_strength="0"/>
+        <constraint constraints="3" exp_strength="0" field="fid" notnull_strength="1" unique_strength="1"></constraint>
+        <constraint constraints="1" exp_strength="0" field="proprietor" notnull_strength="1" unique_strength="0"></constraint>
+        <constraint constraints="1" exp_strength="0" field="plant_species" notnull_strength="1" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="picture" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="review_date" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="reviewer" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint field="fid" desc="" exp=""/>
-        <constraint field="proprietor" desc="cannot be empty" exp="&quot;proprietor&quot;"/>
-        <constraint field="plant_species" desc="cannot be empty" exp="&quot;plant_species&quot;"/>
-        <constraint field="picture" desc="" exp=""/>
-        <constraint field="review_date" desc="" exp=""/>
-        <constraint field="reviewer" desc="" exp=""/>
+        <constraint desc="" exp="" field="fid"></constraint>
+        <constraint desc="" exp="" field="proprietor"></constraint>
+        <constraint desc="" exp="" field="plant_species"></constraint>
+        <constraint desc="" exp="" field="picture"></constraint>
+        <constraint desc="" exp="" field="review_date"></constraint>
+        <constraint desc="" exp="" field="reviewer"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction key="Canvas" value="{8b7f5395-6a6a-41fd-9305-c25cfe525c83}"/>
-        <actionsetting capture="0" isEnabledOnlyWhenEditable="0" type="0" icon="" shortTitle="" notificationMessage="" name="" id="{8b7f5395-6a6a-41fd-9305-c25cfe525c83}" action="">
-          <actionScope id="Canvas"/>
-          <actionScope id="Feature"/>
-          <actionScope id="Field"/>
+        <defaultAction key="Canvas" value="{0447adbe-5095-4b56-baa8-01f73f1ebf0f}"></defaultAction>
+        <actionsetting action="" capture="0" icon="" id="{0447adbe-5095-4b56-baa8-01f73f1ebf0f}" isEnabledOnlyWhenEditable="0" name="" notificationMessage="" shortTitle="" type="0">
+          <actionScope id="Field"></actionScope>
+          <actionScope id="Canvas"></actionScope>
+          <actionScope id="Feature"></actionScope>
         </actionsetting>
       </attributeactions>
-      <attributetableconfig sortExpression="&quot;fid&quot;" sortOrder="0" actionWidgetStyle="dropDown">
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="&quot;fid&quot;" sortOrder="0">
         <columns>
-          <column type="field" name="proprietor" width="-1" hidden="0"/>
-          <column type="field" name="plant_species" width="-1" hidden="0"/>
-          <column type="field" name="picture" width="334" hidden="0"/>
-          <column type="field" name="review_date" width="-1" hidden="0"/>
-          <column type="field" name="reviewer" width="-1" hidden="0"/>
-          <column type="actions" width="-1" hidden="1"/>
-          <column type="field" name="fid" width="-1" hidden="0"/>
+          <column hidden="0" name="proprietor" type="field" width="-1"></column>
+          <column hidden="0" name="plant_species" type="field" width="-1"></column>
+          <column hidden="0" name="picture" type="field" width="334"></column>
+          <column hidden="0" name="review_date" type="field" width="-1"></column>
+          <column hidden="0" name="reviewer" type="field" width="-1"></column>
+          <column hidden="1" type="actions" width="-1"></column>
+          <column hidden="0" name="fid" type="field" width="-1"></column>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1">.</editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath>../demo_proj_citybees_218</editforminitfilepath>
-      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+      <editforminitcode># -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -6673,64 +7018,66 @@ from qgis.PyQt.QtWidgets import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-]]></editforminitcode>
+</editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>tablayout</editorlayout>
       <attributeEditorForm>
-        <attributeEditorContainer name="General" visibilityExpressionEnabled="0" groupBox="0" showLabel="1" columnCount="1" visibilityExpression="">
-          <attributeEditorField name="proprietor" showLabel="1" index="1"/>
-          <attributeEditorField name="plant_species" showLabel="1" index="2"/>
+        <attributeEditorContainer columnCount="1" groupBox="0" name="General" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+          <attributeEditorField index="1" name="proprietor" showLabel="1"></attributeEditorField>
+          <attributeEditorField index="2" name="plant_species" showLabel="1"></attributeEditorField>
         </attributeEditorContainer>
-        <attributeEditorContainer name="Picture" visibilityExpressionEnabled="0" groupBox="0" showLabel="1" columnCount="1" visibilityExpression="">
-          <attributeEditorField name="picture" showLabel="1" index="3"/>
+        <attributeEditorContainer columnCount="1" groupBox="0" name="Picture" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+          <attributeEditorField index="3" name="picture" showLabel="1"></attributeEditorField>
         </attributeEditorContainer>
-        <attributeEditorContainer name="Review" visibilityExpressionEnabled="0" groupBox="0" showLabel="1" columnCount="1" visibilityExpression="">
-          <attributeEditorField name="review_date" showLabel="1" index="4"/>
-          <attributeEditorField name="reviewer" showLabel="1" index="5"/>
+        <attributeEditorContainer columnCount="1" groupBox="0" name="Review" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+          <attributeEditorField index="4" name="review_date" showLabel="1"></attributeEditorField>
+          <attributeEditorField index="5" name="reviewer" showLabel="1"></attributeEditorField>
         </attributeEditorContainer>
-        <attributeEditorContainer name="Consuming Apiaries" visibilityExpressionEnabled="0" groupBox="0" showLabel="1" columnCount="1" visibilityExpression="">
-          <attributeEditorRelation showUnlinkButton="1" name="Pollen_Con_field_id_ogr_dbname_fid" showLabel="1" showLinkButton="1" relation="Pollen_Con_field_id_ogr_dbname_fid"/>
+        <attributeEditorContainer columnCount="1" groupBox="0" name="Consuming Apiaries" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+          <attributeEditorRelation name="Pollen_Con_field_id_ogr_dbname_fid" relation="Pollen_Con_field_id_ogr_dbname_fid" showLabel="1" showLinkButton="1" showSaveChildEditsButton="1" showUnlinkButton="1"></attributeEditorRelation>
         </attributeEditorContainer>
       </attributeEditorForm>
       <editable>
-        <field name="fid" editable="1"/>
-        <field name="id" editable="1"/>
-        <field name="picture" editable="1"/>
-        <field name="plant_species" editable="1"/>
-        <field name="proprietor" editable="1"/>
-        <field name="review_date" editable="1"/>
-        <field name="reviewer" editable="1"/>
+        <field editable="1" name="fid"></field>
+        <field editable="1" name="id"></field>
+        <field editable="1" name="picture"></field>
+        <field editable="1" name="plant_species"></field>
+        <field editable="1" name="proprietor"></field>
+        <field editable="1" name="review_date"></field>
+        <field editable="1" name="reviewer"></field>
       </editable>
       <labelOnTop>
-        <field labelOnTop="0" name="fid"/>
-        <field labelOnTop="0" name="id"/>
-        <field labelOnTop="0" name="picture"/>
-        <field labelOnTop="0" name="plant_species"/>
-        <field labelOnTop="0" name="proprietor"/>
-        <field labelOnTop="0" name="review_date"/>
-        <field labelOnTop="0" name="reviewer"/>
+        <field labelOnTop="0" name="fid"></field>
+        <field labelOnTop="0" name="id"></field>
+        <field labelOnTop="0" name="picture"></field>
+        <field labelOnTop="0" name="plant_species"></field>
+        <field labelOnTop="0" name="proprietor"></field>
+        <field labelOnTop="0" name="review_date"></field>
+        <field labelOnTop="0" name="reviewer"></field>
       </labelOnTop>
       <widgets>
         <widget name="Pollen_Con_field_id_ogr_dbname_fid">
           <config type="Map">
-            <Option type="QString" name="nm-rel" value=""/>
+            <Option name="force-suppress-popup" type="bool" value="false"></Option>
+            <Option name="nm-rel" type="QString" value=""></Option>
           </config>
         </widget>
         <widget name="apiary2018_area_id_area201805_id">
-          <config/>
+          <config></config>
         </widget>
         <widget name="apiary_036bee2c_a341_4b84_b25c_1bea7c01e9c2_area_id_area_60ff9e18_ea5b_4814_a227_157fe79ce94c_id">
           <config type="Map">
-            <Option type="QString" name="nm-rel" value=""/>
+            <Option name="nm-rel" type="QString" value=""></Option>
           </config>
         </widget>
         <widget name="apiary_279_area_id_ogr_dbname_fid">
           <config type="Map">
-            <Option type="QString" name="nm-rel" value=""/>
+            <Option name="force-suppress-popup" type="bool" value="false"></Option>
+            <Option name="nm-rel" type="QString" value=""></Option>
           </config>
         </widget>
         <widget name="ref_apiary_area_id_area201805_id">
-          <config/>
+          <config></config>
         </widget>
       </widgets>
       <previewExpression>represent_value("plant_species")  || ' ('  ||  represent_value("proprietor") || ' ) '
@@ -6739,13 +7086,13 @@ def my_form_open(dialog, layer, feature):
     </maplayer>
   </projectlayers>
   <layerorder>
-    <layer id="OpenStreetMap_442da2b8_ea6a_4114_a4f4_e472a9f7d8b9"/>
-    <layer id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b"/>
-    <layer id="countries_a5e8d4da_f5b9_48ce_9909_c3760e271a9e"/>
-    <layer id="buildings_3bd3a9b3_9f70_44bd_9390_807f598c2835"/>
-    <layer id="landscape_b275e43a_b9f2_4087_b31a_c5793005d343"/>
-    <layer id="lines_3691e21a_d6eb_4d63_a8f5_d5ada1aca9b8"/>
-    <layer id="apiary_27954fba_aad8_4336_8b19_23afed462c51"/>
+    <layer id="OpenStreetMap_442da2b8_ea6a_4114_a4f4_e472a9f7d8b9"></layer>
+    <layer id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b"></layer>
+    <layer id="countries_a5e8d4da_f5b9_48ce_9909_c3760e271a9e"></layer>
+    <layer id="buildings_3bd3a9b3_9f70_44bd_9390_807f598c2835"></layer>
+    <layer id="landscape_b275e43a_b9f2_4087_b31a_c5793005d343"></layer>
+    <layer id="lines_3691e21a_d6eb_4d63_a8f5_d5ada1aca9b8"></layer>
+    <layer id="apiary_27954fba_aad8_4336_8b19_23afed462c51"></layer>
   </layerorder>
   <properties>
     <DefaultStyles>
@@ -6758,7 +7105,7 @@ def my_form_open(dialog, layer, feature):
       <RandomColors type="bool">true</RandomColors>
     </DefaultStyles>
     <Digitizing>
-      <AvoidIntersectionsList type="QStringList"/>
+      <AvoidIntersectionsList type="QStringList"></AvoidIntersectionsList>
       <DefaultSnapTolerance type="double">0</DefaultSnapTolerance>
       <DefaultSnapToleranceUnit type="int">2</DefaultSnapToleranceUnit>
       <DefaultSnapType type="QString">off</DefaultSnapType>
@@ -6829,11 +7176,14 @@ def my_form_open(dialog, layer, feature):
     </Measurement>
     <PAL>
       <CandidatesLine type="int">50</CandidatesLine>
+      <CandidatesLinePerCM type="double">5</CandidatesLinePerCM>
       <CandidatesPoint type="int">16</CandidatesPoint>
       <CandidatesPolygon type="int">30</CandidatesPolygon>
+      <CandidatesPolygonPerCM type="double">2.5</CandidatesPolygonPerCM>
       <DrawOutlineLabels type="bool">true</DrawOutlineLabels>
       <DrawRectOnly type="bool">false</DrawRectOnly>
       <DrawUnplaced type="bool">false</DrawUnplaced>
+      <PlacementEngineVersion type="int">0</PlacementEngineVersion>
       <SearchMethod type="int">0</SearchMethod>
       <ShowingAllLabels type="bool">false</ShowingAllLabels>
       <ShowingCandidates type="bool">false</ShowingCandidates>
@@ -6850,7 +7200,7 @@ def my_form_open(dialog, layer, feature):
       <DegreeFormat type="QString">MU</DegreeFormat>
     </PositionPrecision>
     <RequiredLayers>
-      <Layers type="QStringList"/>
+      <Layers type="QStringList"></Layers>
     </RequiredLayers>
     <SpatialRefSys>
       <ProjectCRSID type="int">47</ProjectCRSID>
@@ -6859,12 +7209,12 @@ def my_form_open(dialog, layer, feature):
       <ProjectionsEnabled type="int">1</ProjectionsEnabled>
     </SpatialRefSys>
     <Variables>
-      <variableNames type="QStringList"/>
-      <variableValues type="QStringList"/>
+      <variableNames type="QStringList"></variableNames>
+      <variableValues type="QStringList"></variableValues>
     </Variables>
-    <WCSLayers type="QStringList"/>
+    <WCSLayers type="QStringList"></WCSLayers>
     <WCSUrl type="QString"></WCSUrl>
-    <WFSLayers type="QStringList"/>
+    <WFSLayers type="QStringList"></WFSLayers>
     <WFSLayersPrecision>
       <apiary20180528091231748 type="int">8</apiary20180528091231748>
       <apiary_036bee2c_a341_4b84_b25c_1bea7c01e9c2 type="int">8</apiary_036bee2c_a341_4b84_b25c_1bea7c01e9c2>
@@ -6876,9 +7226,9 @@ def my_form_open(dialog, layer, feature):
       <lines20180528144355951 type="int">8</lines20180528144355951>
     </WFSLayersPrecision>
     <WFSTLayers>
-      <Delete type="QStringList"/>
-      <Insert type="QStringList"/>
-      <Update type="QStringList"/>
+      <Delete type="QStringList"></Delete>
+      <Insert type="QStringList"></Insert>
+      <Update type="QStringList"></Update>
     </WFSTLayers>
     <WFSUrl type="QString"></WFSUrl>
     <WMSAccessConstraints type="QString">None</WMSAccessConstraints>
@@ -6908,8 +7258,8 @@ def my_form_open(dialog, layer, feature):
     <WMSOnlineResource type="QString">http://www.opengis.ch</WMSOnlineResource>
     <WMSPrecision type="QString">8</WMSPrecision>
     <WMSRequestDefinedDataSources type="bool">false</WMSRequestDefinedDataSources>
-    <WMSRestrictedComposers type="QStringList"/>
-    <WMSRestrictedLayers type="QStringList"/>
+    <WMSRestrictedComposers type="QStringList"></WMSRestrictedComposers>
+    <WMSRestrictedLayers type="QStringList"></WMSRestrictedLayers>
     <WMSRootName type="QString"></WMSRootName>
     <WMSSegmentizeFeatureInfoGeometry type="bool">false</WMSSegmentizeFeatureInfoGeometry>
     <WMSServiceAbstract type="QString"></WMSServiceAbstract>
@@ -6918,23 +7268,23 @@ def my_form_open(dialog, layer, feature):
     <WMSUrl type="QString"></WMSUrl>
     <WMSUseLayerIDs type="bool">false</WMSUseLayerIDs>
     <WMTSGrids>
-      <CRS type="QStringList"/>
-      <Config type="QStringList"/>
+      <CRS type="QStringList"></CRS>
+      <Config type="QStringList"></Config>
     </WMTSGrids>
     <WMTSJpegLayers>
-      <Group type="QStringList"/>
-      <Layer type="QStringList"/>
+      <Group type="QStringList"></Group>
+      <Layer type="QStringList"></Layer>
       <Project type="bool">false</Project>
     </WMTSJpegLayers>
     <WMTSLayers>
-      <Group type="QStringList"/>
-      <Layer type="QStringList"/>
+      <Group type="QStringList"></Group>
+      <Layer type="QStringList"></Layer>
       <Project type="bool">false</Project>
     </WMTSLayers>
     <WMTSMinScale type="int">5000</WMTSMinScale>
     <WMTSPngLayers>
-      <Group type="QStringList"/>
-      <Layer type="QStringList"/>
+      <Group type="QStringList"></Group>
+      <Layer type="QStringList"></Layer>
       <Project type="bool">false</Project>
     </WMTSPngLayers>
     <WMTSUrl type="QString"></WMTSUrl>
@@ -6950,63 +7300,63 @@ def my_form_open(dialog, layer, feature):
   </properties>
   <visibility-presets>
     <visibility-preset has-expanded-info="1" name="Diseases">
-      <layer style="default" id="buildings_3bd3a9b3_9f70_44bd_9390_807f598c2835" expanded="0"/>
-      <expanded-legend-nodes id="buildings_3bd3a9b3_9f70_44bd_9390_807f598c2835"/>
-      <layer style="default" id="lines_3691e21a_d6eb_4d63_a8f5_d5ada1aca9b8" expanded="0"/>
-      <expanded-legend-nodes id="lines_3691e21a_d6eb_4d63_a8f5_d5ada1aca9b8"/>
-      <layer style="default" id="landscape_b275e43a_b9f2_4087_b31a_c5793005d343" expanded="0"/>
-      <expanded-legend-nodes id="landscape_b275e43a_b9f2_4087_b31a_c5793005d343"/>
-      <layer style="Diseases" id="apiary_27954fba_aad8_4336_8b19_23afed462c51" expanded="1"/>
+      <layer expanded="0" id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" style="default" visible="1"></layer>
+      <expanded-legend-nodes id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b"></expanded-legend-nodes>
+      <layer expanded="0" id="lines_3691e21a_d6eb_4d63_a8f5_d5ada1aca9b8" style="default" visible="1"></layer>
+      <expanded-legend-nodes id="lines_3691e21a_d6eb_4d63_a8f5_d5ada1aca9b8"></expanded-legend-nodes>
+      <layer expanded="0" id="landscape_b275e43a_b9f2_4087_b31a_c5793005d343" style="default" visible="1"></layer>
+      <expanded-legend-nodes id="landscape_b275e43a_b9f2_4087_b31a_c5793005d343"></expanded-legend-nodes>
+      <layer expanded="1" id="apiary_27954fba_aad8_4336_8b19_23afed462c51" style="Diseases" visible="1"></layer>
       <expanded-legend-nodes id="apiary_27954fba_aad8_4336_8b19_23afed462c51">
-        <expanded-legend-node id="{2c8997f2-a415-45d2-bd98-2c0898cb3118}"/>
+        <expanded-legend-node id="{2c8997f2-a415-45d2-bd98-2c0898cb3118}"></expanded-legend-node>
       </expanded-legend-nodes>
-      <layer style="default" id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" expanded="0"/>
-      <expanded-legend-nodes id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b"/>
-      <expanded-group-nodes/>
+      <layer expanded="0" id="buildings_3bd3a9b3_9f70_44bd_9390_807f598c2835" style="default" visible="1"></layer>
+      <expanded-legend-nodes id="buildings_3bd3a9b3_9f70_44bd_9390_807f598c2835"></expanded-legend-nodes>
+      <expanded-group-nodes></expanded-group-nodes>
     </visibility-preset>
     <visibility-preset has-expanded-info="1" name="Heatmap">
-      <layer style="default" id="buildings_3bd3a9b3_9f70_44bd_9390_807f598c2835" expanded="0"/>
-      <expanded-legend-nodes id="buildings_3bd3a9b3_9f70_44bd_9390_807f598c2835"/>
-      <layer style="default" id="countries_a5e8d4da_f5b9_48ce_9909_c3760e271a9e" expanded="1"/>
-      <expanded-legend-nodes id="countries_a5e8d4da_f5b9_48ce_9909_c3760e271a9e"/>
-      <layer style="default" id="lines_3691e21a_d6eb_4d63_a8f5_d5ada1aca9b8" expanded="0"/>
-      <expanded-legend-nodes id="lines_3691e21a_d6eb_4d63_a8f5_d5ada1aca9b8"/>
-      <layer style="default" id="landscape_b275e43a_b9f2_4087_b31a_c5793005d343" expanded="0"/>
-      <expanded-legend-nodes id="landscape_b275e43a_b9f2_4087_b31a_c5793005d343"/>
-      <layer style="Heatmap" id="apiary_27954fba_aad8_4336_8b19_23afed462c51" expanded="1"/>
+      <layer expanded="1" id="countries_a5e8d4da_f5b9_48ce_9909_c3760e271a9e" style="default" visible="1"></layer>
+      <expanded-legend-nodes id="countries_a5e8d4da_f5b9_48ce_9909_c3760e271a9e"></expanded-legend-nodes>
+      <layer expanded="0" id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" style="default" visible="1"></layer>
+      <expanded-legend-nodes id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b"></expanded-legend-nodes>
+      <layer expanded="0" id="lines_3691e21a_d6eb_4d63_a8f5_d5ada1aca9b8" style="default" visible="1"></layer>
+      <expanded-legend-nodes id="lines_3691e21a_d6eb_4d63_a8f5_d5ada1aca9b8"></expanded-legend-nodes>
+      <layer expanded="0" id="landscape_b275e43a_b9f2_4087_b31a_c5793005d343" style="default" visible="1"></layer>
+      <expanded-legend-nodes id="landscape_b275e43a_b9f2_4087_b31a_c5793005d343"></expanded-legend-nodes>
+      <layer expanded="1" id="apiary_27954fba_aad8_4336_8b19_23afed462c51" style="Heatmap" visible="1"></layer>
       <expanded-legend-nodes id="apiary_27954fba_aad8_4336_8b19_23afed462c51">
-        <expanded-legend-node id="{2c8997f2-a415-45d2-bd98-2c0898cb3118}"/>
+        <expanded-legend-node id="{2c8997f2-a415-45d2-bd98-2c0898cb3118}"></expanded-legend-node>
       </expanded-legend-nodes>
-      <layer style="default" id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" expanded="0"/>
-      <expanded-legend-nodes id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b"/>
+      <layer expanded="0" id="buildings_3bd3a9b3_9f70_44bd_9390_807f598c2835" style="default" visible="1"></layer>
+      <expanded-legend-nodes id="buildings_3bd3a9b3_9f70_44bd_9390_807f598c2835"></expanded-legend-nodes>
       <expanded-group-nodes>
-        <expanded-group-node id="Basemap"/>
+        <expanded-group-node id="Basemap"></expanded-group-node>
       </expanded-group-nodes>
     </visibility-preset>
     <visibility-preset has-checked-group-info="1" has-expanded-info="1" name="Species">
-      <layer style="Species" id="apiary_27954fba_aad8_4336_8b19_23afed462c51" expanded="1"/>
+      <layer expanded="0" id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" style="default" visible="1"></layer>
+      <expanded-legend-nodes id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b"></expanded-legend-nodes>
+      <layer expanded="0" id="lines_3691e21a_d6eb_4d63_a8f5_d5ada1aca9b8" style="default" visible="1"></layer>
+      <expanded-legend-nodes id="lines_3691e21a_d6eb_4d63_a8f5_d5ada1aca9b8"></expanded-legend-nodes>
+      <layer expanded="1" id="apiary_27954fba_aad8_4336_8b19_23afed462c51" style="Species" visible="1"></layer>
       <expanded-legend-nodes id="apiary_27954fba_aad8_4336_8b19_23afed462c51">
-        <expanded-legend-node id="{2c8997f2-a415-45d2-bd98-2c0898cb3118}"/>
+        <expanded-legend-node id="{2c8997f2-a415-45d2-bd98-2c0898cb3118}"></expanded-legend-node>
       </expanded-legend-nodes>
-      <layer style="default" id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" expanded="0"/>
-      <expanded-legend-nodes id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b"/>
-      <layer style="default" id="lines_3691e21a_d6eb_4d63_a8f5_d5ada1aca9b8" expanded="0"/>
-      <expanded-legend-nodes id="lines_3691e21a_d6eb_4d63_a8f5_d5ada1aca9b8"/>
-      <layer style="default" id="buildings_3bd3a9b3_9f70_44bd_9390_807f598c2835" expanded="0"/>
-      <expanded-legend-nodes id="buildings_3bd3a9b3_9f70_44bd_9390_807f598c2835"/>
-      <layer style="default" id="landscape_b275e43a_b9f2_4087_b31a_c5793005d343" expanded="0"/>
-      <expanded-legend-nodes id="landscape_b275e43a_b9f2_4087_b31a_c5793005d343"/>
+      <layer expanded="0" id="landscape_b275e43a_b9f2_4087_b31a_c5793005d343" style="default" visible="1"></layer>
+      <expanded-legend-nodes id="landscape_b275e43a_b9f2_4087_b31a_c5793005d343"></expanded-legend-nodes>
+      <layer expanded="0" id="buildings_3bd3a9b3_9f70_44bd_9390_807f598c2835" style="default" visible="1"></layer>
+      <expanded-legend-nodes id="buildings_3bd3a9b3_9f70_44bd_9390_807f598c2835"></expanded-legend-nodes>
       <checked-group-nodes>
-        <checked-group-node id="Basemap/Offline local osm"/>
-        <checked-group-node id="Basemap"/>
-        <checked-group-node id="Tables"/>
+        <checked-group-node id="Basemap/Offline local osm"></checked-group-node>
+        <checked-group-node id="Tables"></checked-group-node>
+        <checked-group-node id="Basemap"></checked-group-node>
       </checked-group-nodes>
-      <expanded-group-nodes/>
+      <expanded-group-nodes></expanded-group-nodes>
     </visibility-preset>
   </visibility-presets>
   <transformContext>
-    <srcDest source="EPSG:21781" dest="EPSG:2056" coordinateOp=""/>
-    <srcDest source="EPSG:3857" dest="EPSG:23032" coordinateOp=""/>
+    <srcDest dest="EPSG:2056" destTransform="" source="EPSG:21781" sourceTransform=""></srcDest>
+    <srcDest dest="EPSG:23032" destTransform="" source="EPSG:3857" sourceTransform=""></srcDest>
   </transformContext>
   <projectMetadata>
     <identifier></identifier>
@@ -7024,200 +7374,215 @@ def my_form_open(dialog, layer, feature):
       <email></email>
       <role></role>
     </contact>
-    <links/>
+    <links></links>
     <author></author>
     <creation>2000-01-01T00:00:00</creation>
   </projectMetadata>
-  <Annotations/>
+  <Annotations></Annotations>
   <Layouts>
-    <Layout printResolution="300" worldFileMap="{5c99b08e-6df3-4fc4-b67e-956bf0e3b45c}" name="Bees in Laax" units="mm">
-      <Snapper snapToGrid="0" snapToItems="1" tolerance="5" snapToGuides="1"/>
-      <Grid resolution="10" offsetUnits="mm" offsetY="0" offsetX="0" resUnits="mm"/>
+    <Layout name="Bees in Laax" printResolution="300" units="mm" worldFileMap="{5c99b08e-6df3-4fc4-b67e-956bf0e3b45c}">
+      <Snapper snapToGrid="0" snapToGuides="1" snapToItems="1" tolerance="5"></Snapper>
+      <Grid offsetUnits="mm" offsetX="0" offsetY="0" resUnits="mm" resolution="10"></Grid>
       <PageCollection>
-        <symbol type="fill" alpha="1" clip_to_extent="1" force_rhr="0" name="">
-          <layer enabled="1" locked="0" class="SimpleFill" pass="0">
-            <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-            <prop v="255,255,255,255" k="color"/>
-            <prop v="miter" k="joinstyle"/>
-            <prop v="0,0" k="offset"/>
-            <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="35,35,35,255" k="outline_color"/>
-            <prop v="no" k="outline_style"/>
-            <prop v="0.26" k="outline_width"/>
-            <prop v="MM" k="outline_width_unit"/>
-            <prop v="solid" k="style"/>
+        <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" type="fill">
+          <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+            <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+            <prop k="color" v="255,255,255,255"></prop>
+            <prop k="joinstyle" v="miter"></prop>
+            <prop k="offset" v="0,0"></prop>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+            <prop k="offset_unit" v="MM"></prop>
+            <prop k="outline_color" v="35,35,35,255"></prop>
+            <prop k="outline_style" v="no"></prop>
+            <prop k="outline_width" v="0.26"></prop>
+            <prop k="outline_width_unit" v="MM"></prop>
+            <prop k="style" v="solid"></prop>
             <data_defined_properties>
               <Option type="Map">
-                <Option type="QString" name="name" value=""/>
-                <Option name="properties"/>
-                <Option type="QString" name="type" value="collection"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
           </layer>
         </symbol>
-        <LayoutItem position="0,0,mm" frameJoinStyle="miter" frame="false" background="true" uuid="{c59b3b52-5ddb-492d-bb03-29af0990322a}" positionLock="false" excludeFromExports="0" zValue="0" blendMode="0" type="65638" id="" visibility="1" itemRotation="0" groupUuid="" positionOnPage="0,0,mm" size="297,210,mm" outlineWidthM="0.3,mm" templateUuid="{c59b3b52-5ddb-492d-bb03-29af0990322a}" referencePoint="0" opacity="1">
-          <FrameColor alpha="255" red="0" green="0" blue="0"/>
-          <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+        <LayoutItem background="true" blendMode="0" excludeFromExports="0" frame="false" frameJoinStyle="miter" groupUuid="" id="" itemRotation="0" opacity="1" outlineWidthM="0.3,mm" position="0,0,mm" positionLock="false" positionOnPage="0,0,mm" referencePoint="0" size="297,210,mm" templateUuid="{c59b3b52-5ddb-492d-bb03-29af0990322a}" type="65638" uuid="{c59b3b52-5ddb-492d-bb03-29af0990322a}" visibility="1" zValue="0">
+          <FrameColor alpha="255" blue="0" green="0" red="0"></FrameColor>
+          <BackgroundColor alpha="255" blue="255" green="255" red="255"></BackgroundColor>
           <LayoutObject>
             <dataDefinedProperties>
               <Option type="Map">
-                <Option type="QString" name="name" value=""/>
-                <Option name="properties"/>
-                <Option type="QString" name="type" value="collection"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </dataDefinedProperties>
-            <customproperties/>
+            <customproperties></customproperties>
           </LayoutObject>
-          <symbol type="fill" alpha="1" clip_to_extent="1" force_rhr="0" name="">
-            <layer enabled="1" locked="0" class="SimpleFill" pass="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="255,255,255,255" k="color"/>
-              <prop v="miter" k="joinstyle"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="35,35,35,255" k="outline_color"/>
-              <prop v="no" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" type="fill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="color" v="255,255,255,255"></prop>
+              <prop k="joinstyle" v="miter"></prop>
+              <prop k="offset" v="0,0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="outline_color" v="35,35,35,255"></prop>
+              <prop k="outline_style" v="no"></prop>
+              <prop k="outline_width" v="0.26"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
+              <prop k="style" v="solid"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </LayoutItem>
-        <GuideCollection visible="1"/>
+        <GuideCollection visible="1"></GuideCollection>
       </PageCollection>
-      <LayoutItem position="222.229,162.983,mm" svgBorderColor="0,0,0,255" frameJoinStyle="miter" svgBorderWidth="0.2" frame="false" background="false" uuid="{878b644c-7911-46ac-a111-9c429bbd53f3}" positionLock="false" excludeFromExports="0" zValue="5" blendMode="0" type="65640" resizeMode="0" anchorPoint="0" pictureHeight="22.2076" id="" visibility="1" itemRotation="0" pictureWidth="22.0722" mapUuid="" pictureRotation="0" svgFillColor="255,255,255,255" northOffset="0" northMode="0" groupUuid="" positionOnPage="222.229,162.983,mm" size="68.5479,22.2076,mm" outlineWidthM="0.3,mm" file="../../../../../Pictures/openGIS-complete.png" templateUuid="{878b644c-7911-46ac-a111-9c429bbd53f3}" referencePoint="0" opacity="1">
-        <FrameColor alpha="255" red="0" green="0" blue="0"/>
-        <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+      <LayoutItem anchorPoint="0" background="false" blendMode="0" excludeFromExports="0" file="../../../../../Pictures/openGIS-complete.png" frame="false" frameJoinStyle="miter" groupUuid="" id="" itemRotation="0" mapUuid="" mode="1" northMode="0" northOffset="0" opacity="1" outlineWidthM="0.3,mm" pictureHeight="22.2076" pictureRotation="0" pictureWidth="67.6866" position="222.229,162.983,mm" positionLock="false" positionOnPage="222.229,162.983,mm" referencePoint="0" resizeMode="0" size="68.5479,22.2076,mm" svgBorderColor="0,0,0,255" svgBorderWidth="0.2" svgFillColor="255,255,255,255" templateUuid="{878b644c-7911-46ac-a111-9c429bbd53f3}" type="65640" uuid="{878b644c-7911-46ac-a111-9c429bbd53f3}" visibility="1" zValue="5">
+        <FrameColor alpha="255" blue="0" green="0" red="0"></FrameColor>
+        <BackgroundColor alpha="255" blue="255" green="255" red="255"></BackgroundColor>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
-              <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dataDefinedProperties>
-          <customproperties/>
+          <customproperties></customproperties>
         </LayoutObject>
       </LayoutItem>
-      <LayoutItem position="12.2296,23.0615,mm" frameJoinStyle="miter" frame="false" background="false" marginX="0" valign="32" uuid="{160169b2-2445-485d-9410-1bdd71c3bcc6}" positionLock="false" excludeFromExports="0" halign="8" zValue="4" blendMode="0" type="65641" htmlState="0" id="" visibility="1" itemRotation="0" marginY="0" groupUuid="" positionOnPage="12.2296,23.0615,mm" size="274.942,11.8802,mm" outlineWidthM="0.3,mm" templateUuid="{160169b2-2445-485d-9410-1bdd71c3bcc6}" referencePoint="0" opacity="1" labelText="Apiaries and beehives in the laax central and agglomeration. Collected by QField for QGIS.">
-        <FrameColor alpha="255" red="0" green="0" blue="0"/>
-        <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+      <LayoutItem background="false" blendMode="0" excludeFromExports="0" frame="false" frameJoinStyle="miter" groupUuid="" halign="8" htmlState="0" id="" itemRotation="0" labelText="Apiaries and beehives in the laax central and agglomeration. Collected by QField for QGIS." marginX="0" marginY="0" opacity="1" outlineWidthM="0.3,mm" position="12.2296,23.0615,mm" positionLock="false" positionOnPage="12.2296,23.0615,mm" referencePoint="0" size="274.942,11.8802,mm" templateUuid="{160169b2-2445-485d-9410-1bdd71c3bcc6}" type="65641" uuid="{160169b2-2445-485d-9410-1bdd71c3bcc6}" valign="32" visibility="1" zValue="4">
+        <FrameColor alpha="255" blue="0" green="0" red="0"></FrameColor>
+        <BackgroundColor alpha="255" blue="255" green="255" red="255"></BackgroundColor>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
-              <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dataDefinedProperties>
-          <customproperties/>
+          <customproperties></customproperties>
         </LayoutObject>
-        <LabelFont style="" description="Ubuntu,16,-1,5,50,0,0,0,0,0"/>
-        <FontColor alpha="255" red="0" green="0" blue="0"/>
+        <LabelFont description="Ubuntu,16,-1,5,50,0,0,0,0,0" style=""></LabelFont>
+        <FontColor alpha="255" blue="0" green="0" red="0"></FontColor>
       </LayoutItem>
-      <LayoutItem position="12.2296,5.94009,mm" frameJoinStyle="miter" frame="false" background="false" marginX="0" valign="32" uuid="{d040a3a5-8577-49ad-bacf-6037321d5814}" positionLock="false" excludeFromExports="0" halign="8" zValue="3" blendMode="0" type="65641" htmlState="0" id="" visibility="1" itemRotation="0" marginY="0" groupUuid="" positionOnPage="12.2296,5.94009,mm" size="274.942,17.1214,mm" outlineWidthM="0.3,mm" templateUuid="{d040a3a5-8577-49ad-bacf-6037321d5814}" referencePoint="0" opacity="1" labelText="Bees in Laax">
-        <FrameColor alpha="255" red="0" green="0" blue="0"/>
-        <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+      <LayoutItem background="false" blendMode="0" excludeFromExports="0" frame="false" frameJoinStyle="miter" groupUuid="" halign="8" htmlState="0" id="" itemRotation="0" labelText="Bees in Laax" marginX="0" marginY="0" opacity="1" outlineWidthM="0.3,mm" position="12.2296,5.94009,mm" positionLock="false" positionOnPage="12.2296,5.94009,mm" referencePoint="0" size="274.942,17.1214,mm" templateUuid="{d040a3a5-8577-49ad-bacf-6037321d5814}" type="65641" uuid="{d040a3a5-8577-49ad-bacf-6037321d5814}" valign="32" visibility="1" zValue="3">
+        <FrameColor alpha="255" blue="0" green="0" red="0"></FrameColor>
+        <BackgroundColor alpha="255" blue="255" green="255" red="255"></BackgroundColor>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
-              <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dataDefinedProperties>
-          <customproperties/>
+          <customproperties></customproperties>
         </LayoutObject>
-        <LabelFont style="" description="Ubuntu,33,-1,5,50,0,0,0,0,0"/>
-        <FontColor alpha="255" red="0" green="0" blue="0"/>
+        <LabelFont description="Ubuntu,33,-1,5,50,0,0,0,0,0" style=""></LabelFont>
+        <FontColor alpha="255" blue="0" green="0" red="0"></FontColor>
       </LayoutItem>
-      <LayoutItem rasterBorder="1" map_uuid="{5c99b08e-6df3-4fc4-b67e-956bf0e3b45c}" size="60.4,85.4,mm" legendFilterByAtlas="0" fontColor="#000000" frameJoinStyle="miter" lineSpacing="1" frame="false" groupUuid="" type="65642" opacity="1" uuid="{d0e753e6-3e8c-44fc-8987-59f706e0168b}" rasterBorderWidth="0" visibility="1" titleAlignment="1" id="" resizeToContents="1" referencePoint="0" itemRotation="0" templateUuid="{d0e753e6-3e8c-44fc-8987-59f706e0168b}" wrapChar="" outlineWidthM="0.3,mm" wmsLegendWidth="50" symbolAlignment="1" background="true" splitLayer="0" zValue="2" blendMode="0" excludeFromExports="0" positionOnPage="226.772,34.9417,mm" equalColumnWidth="0" positionLock="false" columnSpace="2" symbolHeight="4" wmsLegendHeight="25" boxSpace="2" rasterBorderColor="0,0,0,255" symbolWidth="7" position="226.772,34.9417,mm" title="" columnCount="1">
-        <FrameColor alpha="255" red="0" green="0" blue="0"/>
-        <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+      <LayoutItem background="true" blendMode="0" boxSpace="2" columnCount="1" columnSpace="2" equalColumnWidth="0" excludeFromExports="0" fontColor="#000000" frame="false" frameJoinStyle="miter" groupUuid="" id="" itemRotation="0" legendFilterByAtlas="0" lineSpacing="1" map_uuid="{5c99b08e-6df3-4fc4-b67e-956bf0e3b45c}" opacity="1" outlineWidthM="0.3,mm" position="226.772,34.9417,mm" positionLock="false" positionOnPage="226.772,34.9417,mm" rasterBorder="1" rasterBorderColor="0,0,0,255" rasterBorderWidth="0" referencePoint="0" resizeToContents="1" size="60.4,85.4,mm" splitLayer="0" symbolAlignment="1" symbolHeight="4" symbolWidth="7" templateUuid="{d0e753e6-3e8c-44fc-8987-59f706e0168b}" title="" titleAlignment="1" type="65642" uuid="{d0e753e6-3e8c-44fc-8987-59f706e0168b}" visibility="1" wmsLegendHeight="25" wmsLegendWidth="50" wrapChar="" zValue="2">
+        <FrameColor alpha="255" blue="0" green="0" red="0"></FrameColor>
+        <BackgroundColor alpha="255" blue="255" green="255" red="255"></BackgroundColor>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
-              <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dataDefinedProperties>
-          <customproperties/>
+          <customproperties></customproperties>
         </LayoutObject>
         <styles>
-          <style alignment="1" name="title" marginBottom="3.5">
-            <styleFont style="" description="Ubuntu,16,-1,5,50,0,0,0,0,0"/>
+          <style alignment="1" marginBottom="3.5" name="title">
+            <styleFont description="Ubuntu,16,-1,5,50,0,0,0,0,0" style=""></styleFont>
           </style>
-          <style alignment="1" name="group" marginTop="3">
-            <styleFont style="" description="Ubuntu,14,-1,5,50,0,0,0,0,0"/>
+          <style alignment="1" marginTop="3" name="group">
+            <styleFont description="Ubuntu,14,-1,5,50,0,0,0,0,0" style=""></styleFont>
           </style>
-          <style alignment="1" name="subgroup" marginTop="3">
-            <styleFont style="" description="Ubuntu,12,-1,5,50,0,0,0,0,0"/>
+          <style alignment="1" marginTop="3" name="subgroup">
+            <styleFont description="Ubuntu,12,-1,5,50,0,0,0,0,0" style=""></styleFont>
           </style>
-          <style alignment="1" name="symbol" marginTop="2.5">
-            <styleFont style="" description="Ubuntu,11,-1,5,50,0,0,0,0,0"/>
+          <style alignment="1" marginTop="2.5" name="symbol">
+            <styleFont description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""></styleFont>
           </style>
-          <style alignment="1" name="symbolLabel" marginLeft="2" marginTop="2">
-            <styleFont style="" description="Ubuntu,12,-1,5,50,0,0,0,0,0"/>
+          <style alignment="1" marginLeft="2" marginTop="2" name="symbolLabel">
+            <styleFont description="Ubuntu,12,-1,5,50,0,0,0,0,0" style=""></styleFont>
           </style>
         </styles>
         <layer-tree-group>
-          <customproperties/>
-          <layer-tree-layer id="apiary_27954fba_aad8_4336_8b19_23afed462c51" name="Apiary" expanded="1" checked="Qt::Checked" source="./bees.gpkg|layername=apiary" providerKey="ogr">
+          <customproperties></customproperties>
+          <layer-tree-layer checked="Qt::Checked" expanded="1" id="apiary_27954fba_aad8_4336_8b19_23afed462c51" name="Apiary" providerKey="ogr" source="./bees.gpkg|layername=apiary">
             <customproperties>
-              <property key="expandedLegendNodes" value="{2c8997f2-a415-45d2-bd98-2c0898cb3118}"/>
-              <property key="showFeatureCount" value="1"/>
+              <property key="expandedLegendNodes" value="{2c8997f2-a415-45d2-bd98-2c0898cb3118}"></property>
+              <property key="showFeatureCount" value="1"></property>
             </customproperties>
           </layer-tree-layer>
-          <layer-tree-layer id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" name="Fields" expanded="0" checked="Qt::Checked" source="./bees.gpkg|layername=area" providerKey="ogr">
+          <layer-tree-layer checked="Qt::Checked" expanded="0" id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" name="Fields" providerKey="ogr" source="./bees.gpkg|layername=area">
             <customproperties>
-              <property key="expandedLegendNodes"/>
-              <property key="showFeatureCount" value="0"/>
+              <property key="expandedLegendNodes"></property>
+              <property key="showFeatureCount" value="0"></property>
             </customproperties>
           </layer-tree-layer>
-          <layer-tree-layer id="countries_a5e8d4da_f5b9_48ce_9909_c3760e271a9e" name="Countries" expanded="1" checked="Qt::Checked" source="./basemaps/countries.gpkg|layername=countries" providerKey="ogr">
+          <layer-tree-layer checked="Qt::Checked" expanded="1" id="countries_a5e8d4da_f5b9_48ce_9909_c3760e271a9e" name="Countries" providerKey="ogr" source="./basemaps/countries.gpkg|layername=countries">
             <customproperties>
-              <property key="expandedLegendNodes"/>
+              <property key="expandedLegendNodes"></property>
             </customproperties>
           </layer-tree-layer>
-          <custom-order enabled="0"/>
+          <custom-order enabled="0"></custom-order>
         </layer-tree-group>
       </LayoutItem>
-      <LayoutItem position="12.2296,34.9417,mm" frameJoinStyle="miter" mapRotation="0" mapFlags="0" labelMargin="0,mm" frame="false" background="true" uuid="{5c99b08e-6df3-4fc4-b67e-956bf0e3b45c}" positionLock="false" excludeFromExports="0" keepLayerSet="false" followPreset="false" zValue="1" blendMode="0" type="65639" drawCanvasItems="true" id="" visibility="1" itemRotation="0" followPresetName="" groupUuid="" positionOnPage="12.2296,34.9417,mm" size="210,150.25,mm" outlineWidthM="0.3,mm" templateUuid="{5c99b08e-6df3-4fc4-b67e-956bf0e3b45c}" referencePoint="0" opacity="1">
-        <FrameColor alpha="255" red="0" green="0" blue="0"/>
-        <BackgroundColor alpha="255" red="253" green="253" blue="253"/>
+      <LayoutItem background="true" blendMode="0" drawCanvasItems="true" excludeFromExports="0" followPreset="false" followPresetName="" frame="false" frameJoinStyle="miter" groupUuid="" id="" itemRotation="0" keepLayerSet="false" labelMargin="0,mm" mapFlags="0" mapRotation="0" opacity="1" outlineWidthM="0.3,mm" position="12.2296,34.9417,mm" positionLock="false" positionOnPage="12.2296,34.9417,mm" referencePoint="0" size="210,150.25,mm" templateUuid="{5c99b08e-6df3-4fc4-b67e-956bf0e3b45c}" type="65639" uuid="{5c99b08e-6df3-4fc4-b67e-956bf0e3b45c}" visibility="1" zValue="1">
+        <FrameColor alpha="255" blue="0" green="0" red="0"></FrameColor>
+        <BackgroundColor alpha="255" blue="253" green="253" red="253"></BackgroundColor>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
-              <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dataDefinedProperties>
-          <customproperties/>
+          <customproperties></customproperties>
         </LayoutObject>
-        <Extent xmin="1029753.41299139172770083" xmax="1031922.99632693966850638" ymin="5910067.35689904168248177" ymax="5911619.63782131392508745"/>
-        <LayerSet/>
-        <AtlasMap margin="0.10000000000000001" atlasDriven="0" scalingMode="2"/>
-        <labelBlockingItems/>
+        <Extent xmax="1031922.99632693966850638" xmin="1029753.41299139172770083" ymax="5911619.63782131392508745" ymin="5910067.35689904168248177"></Extent>
+        <LayerSet></LayerSet>
+        <AtlasMap atlasDriven="0" margin="0.10000000000000001" scalingMode="2"></AtlasMap>
+        <labelBlockingItems></labelBlockingItems>
       </LayoutItem>
       <customproperties>
-        <property key="atlasRasterFormat" value="png"/>
+        <property key="atlasRasterFormat" value="png"></property>
       </customproperties>
-      <Atlas enabled="0" filterFeatures="0" coverageLayer="" pageNameExpression="" filenamePattern="'output_'||@atlas_featurenumber" hideCoverage="0" sortFeatures="0"/>
+      <Atlas coverageLayer="" enabled="0" filenamePattern="'output_'||@atlas_featurenumber" filterFeatures="0" hideCoverage="0" pageNameExpression="" sortFeatures="0"></Atlas>
     </Layout>
   </Layouts>
-  <Bookmarks/>
+  <Bookmarks></Bookmarks>
   <ProjectViewSettings UseProjectScales="0">
-    <Scales/>
+    <Scales></Scales>
   </ProjectViewSettings>
+  <ProjectTimeSettings frameRate="1" timeStep="1" timeStepUnit="h"></ProjectTimeSettings>
+  <ProjectDisplaySettings>
+    <BearingFormat id="bearing">
+      <Option type="Map">
+        <Option name="decimal_separator" type="QChar" value=""></Option>
+        <Option name="decimals" type="int" value="6"></Option>
+        <Option name="direction_format" type="int" value="0"></Option>
+        <Option name="rounding_type" type="int" value="0"></Option>
+        <Option name="show_plus" type="bool" value="false"></Option>
+        <Option name="show_thousand_separator" type="bool" value="true"></Option>
+        <Option name="show_trailing_zeros" type="bool" value="false"></Option>
+        <Option name="thousand_separator" type="QChar" value=""></Option>
+      </Option>
+    </BearingFormat>
+  </ProjectDisplaySettings>
 </qgis>

--- a/resources/demo_projects/simple_bee_farming.qgs
+++ b/resources/demo_projects/simple_bee_farming.qgs
@@ -1,10 +1,9 @@
-<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis projectname="Simple Bee Farming Demo" version="3.11.0-Master">
-  <homePath path=""/>
+<qgis projectname="Simple Bee Farming Demo" saveUser="david" saveUserFull="David" version="3.13.0-Master">
+  <homePath path=""></homePath>
   <title>Simple Bee Farming Demo</title>
-  <autotransaction active="0"/>
-  <evaluateDefaultValues active="0"/>
-  <trust active="0"/>
+  <autotransaction active="0"></autotransaction>
+  <evaluateDefaultValues active="0"></evaluateDefaultValues>
+  <trust active="0"></trust>
   <projectCrs>
     <spatialrefsys>
       <wkt>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</wkt>
@@ -19,21 +18,21 @@
     </spatialrefsys>
   </projectCrs>
   <layer-tree-group>
-    <customproperties/>
-    <layer-tree-layer checked="Qt::Checked" providerKey="ogr" id="apiary_27954fba_aad8_4336_8b19_23afed462c51" name="Apiary" source="./bees.gpkg|layername=apiary" expanded="1">
+    <customproperties></customproperties>
+    <layer-tree-layer checked="Qt::Checked" expanded="1" id="apiary_27954fba_aad8_4336_8b19_23afed462c51" name="Apiary" providerKey="ogr" source="./bees.gpkg|layername=apiary">
       <customproperties>
-        <property key="expandedLegendNodes" value="{2c8997f2-a415-45d2-bd98-2c0898cb3118}"/>
-        <property key="showFeatureCount" value="1"/>
+        <property key="expandedLegendNodes" value="{2c8997f2-a415-45d2-bd98-2c0898cb3118}"></property>
+        <property key="showFeatureCount" value="1"></property>
       </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer checked="Qt::Checked" providerKey="ogr" id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" name="Fields" source="./bumblebees.gpkg|layername=area" expanded="1">
+    <layer-tree-layer checked="Qt::Checked" expanded="1" id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" name="Fields" providerKey="ogr" source="./bumblebees.gpkg|layername=area">
       <customproperties>
-        <property key="expandedLegendNodes"/>
-        <property key="showFeatureCount" value="0"/>
+        <property key="expandedLegendNodes"></property>
+        <property key="showFeatureCount" value="0"></property>
       </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer checked="Qt::Checked" providerKey="wms" id="OpenStreetMap_442da2b8_ea6a_4114_a4f4_e472a9f7d8b9" name="Online OpenStreetMap" source="crs=EPSG:3857&amp;format&amp;type=xyz&amp;url=http://a.tile.openstreetmap.org/%7Bz%7D/%7Bx%7D/%7By%7D.png&amp;zmax=19&amp;zmin=0" expanded="0">
-      <customproperties/>
+    <layer-tree-layer checked="Qt::Checked" expanded="0" id="OpenStreetMap_442da2b8_ea6a_4114_a4f4_e472a9f7d8b9" name="Online OpenStreetMap" providerKey="wms" source="crs=EPSG:3857&amp;format&amp;type=xyz&amp;url=http://a.tile.openstreetmap.org/%7Bz%7D/%7Bx%7D/%7By%7D.png&amp;zmax=19&amp;zmin=0">
+      <customproperties></customproperties>
     </layer-tree-layer>
     <custom-order enabled="0">
       <item>OpenStreetMap_442da2b8_ea6a_4114_a4f4_e472a9f7d8b9</item>
@@ -41,13 +40,13 @@
       <item>apiary_27954fba_aad8_4336_8b19_23afed462c51</item>
     </custom-order>
   </layer-tree-group>
-  <snapping-settings unit="2" tolerance="0" type="1" mode="3" intersection-snapping="0" enabled="0">
+  <snapping-settings enabled="0" intersection-snapping="0" mode="3" tolerance="0" type="1" unit="2">
     <individual-layer-settings>
-      <layer-setting units="1" tolerance="12" type="1" id="apiary_27954fba_aad8_4336_8b19_23afed462c51" enabled="0"/>
-      <layer-setting units="1" tolerance="12" type="1" id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" enabled="0"/>
+      <layer-setting enabled="0" id="apiary_27954fba_aad8_4336_8b19_23afed462c51" tolerance="12" type="1" units="1"></layer-setting>
+      <layer-setting enabled="0" id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" tolerance="12" type="1" units="1"></layer-setting>
     </individual-layer-settings>
   </snapping-settings>
-  <relations/>
+  <relations></relations>
   <mapcanvas annotationsVisible="1" name="theMapCanvas">
     <units>meters</units>
     <extent>
@@ -71,110 +70,28 @@
       </spatialrefsys>
     </destinationsrs>
     <rendermaptile>0</rendermaptile>
-    <expressionContextScope/>
+    <expressionContextScope></expressionContextScope>
   </mapcanvas>
-  <DataPlotly>
-    <Option type="Map">
-      <Option type="Map" name="dynamic_properties">
-        <Option type="QString" value="" name="name"/>
-        <Option name="properties"/>
-        <Option type="QString" value="collection" name="type"/>
-      </Option>
-      <Option type="Map" name="plot_layout">
-        <Option type="QString" value="" name="additional_info_expression"/>
-        <Option type="QString" value="group" name="bar_mode"/>
-        <Option type="double" value="0" name="bargaps"/>
-        <Option type="bool" value="false" name="bins_check"/>
-        <Option type="bool" value="true" name="legend"/>
-        <Option type="QString" value="v" name="legend_orientation"/>
-        <Option type="invalid" name="legend_title"/>
-        <Option type="Map" name="polar">
-          <Option type="Map" name="angularaxis">
-            <Option type="QString" value="clockwise" name="direction"/>
-          </Option>
-        </Option>
-        <Option type="Map" name="range_slider">
-          <Option type="int" value="1" name="borderwidth"/>
-          <Option type="bool" value="false" name="visible"/>
-        </Option>
-        <Option type="QString" value="" name="title"/>
-        <Option type="invalid" name="x_inv"/>
-        <Option type="QString" value="" name="x_title"/>
-        <Option type="QString" value="linear" name="x_type"/>
-        <Option type="invalid" name="xaxis"/>
-        <Option type="invalid" name="y_inv"/>
-        <Option type="QString" value="" name="y_title"/>
-        <Option type="QString" value="linear" name="y_type"/>
-        <Option type="QString" value="" name="z_title"/>
-      </Option>
-      <Option type="Map" name="plot_properties">
-        <Option type="invalid" name="additional_hover_text"/>
-        <Option type="int" value="10" name="bins"/>
-        <Option type="QString" value="v" name="box_orientation"/>
-        <Option type="bool" value="false" name="box_outliers"/>
-        <Option type="bool" value="false" name="box_stat"/>
-        <Option type="invalid" name="color_scale"/>
-        <Option type="bool" value="false" name="color_scale_data_defined_in_check"/>
-        <Option type="bool" value="false" name="color_scale_data_defined_in_invert_check"/>
-        <Option type="QString" value="fill" name="cont_type"/>
-        <Option type="QString" value="Fill" name="contour_type_combo"/>
-        <Option type="bool" value="false" name="cumulative"/>
-        <Option type="List" name="custom">
-          <Option type="QString" value=""/>
-        </Option>
-        <Option type="QString" value="all" name="hover_text"/>
-        <Option type="QString" value="#8ebad9" name="in_color"/>
-        <Option type="bool" value="false" name="invert_color_scale"/>
-        <Option type="QString" value="increasing" name="invert_hist"/>
-        <Option type="QString" value="Solid Line" name="line_combo"/>
-        <Option type="QString" value="solid" name="line_dash"/>
-        <Option type="QString" value="markers" name="marker"/>
-        <Option type="double" value="10" name="marker_size"/>
-        <Option type="int" value="0" name="marker_symbol"/>
-        <Option type="QString" value="Points" name="marker_type_combo"/>
-        <Option type="double" value="1" name="marker_width"/>
-        <Option type="QString" value="" name="name"/>
-        <Option type="QString" value="" name="normalization"/>
-        <Option type="double" value="1" name="opacity"/>
-        <Option type="QString" value="#1f77b4" name="out_color"/>
-        <Option type="QString" value="" name="point_combo"/>
-        <Option type="bool" value="false" name="selected_features_only"/>
-        <Option type="bool" value="false" name="show_colorscale_legend"/>
-        <Option type="bool" value="true" name="show_lines"/>
-        <Option type="bool" value="true" name="show_lines_check"/>
-        <Option type="bool" value="true" name="show_mean_line"/>
-        <Option type="QString" value="both" name="violin_side"/>
-        <Option type="bool" value="false" name="visible_features_only"/>
-        <Option type="QString" value="" name="x_name"/>
-        <Option type="QString" value="" name="y_name"/>
-        <Option type="QString" value="" name="z_name"/>
-      </Option>
-      <Option type="QString" value="scatter" name="plot_type"/>
-      <Option type="QString" value="apiary_27954fba_aad8_4336_8b19_23afed462c51" name="source_layer_id"/>
-    </Option>
-  </DataPlotly>
-  <projectModels/>
   <legend updateDrawingOrder="true">
-    <legendlayer checked="Qt::Checked" open="true" drawingOrder="-1" showFeatureCount="1" name="Apiary">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile isInOverview="0" layerid="apiary_27954fba_aad8_4336_8b19_23afed462c51" visible="1"/>
+    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="Apiary" open="true" showFeatureCount="1">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile isInOverview="0" layerid="apiary_27954fba_aad8_4336_8b19_23afed462c51" visible="1"></legendlayerfile>
       </filegroup>
     </legendlayer>
-    <legendlayer checked="Qt::Checked" open="true" drawingOrder="-1" showFeatureCount="0" name="Fields">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile isInOverview="0" layerid="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" visible="1"/>
+    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="Fields" open="true" showFeatureCount="0">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile isInOverview="0" layerid="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" visible="1"></legendlayerfile>
       </filegroup>
     </legendlayer>
-    <legendlayer checked="Qt::Checked" open="false" drawingOrder="-1" showFeatureCount="0" name="Online OpenStreetMap">
-      <filegroup open="false" hidden="false">
-        <legendlayerfile isInOverview="0" layerid="OpenStreetMap_442da2b8_ea6a_4114_a4f4_e472a9f7d8b9" visible="1"/>
+    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="Online OpenStreetMap" open="false" showFeatureCount="0">
+      <filegroup hidden="false" open="false">
+        <legendlayerfile isInOverview="0" layerid="OpenStreetMap_442da2b8_ea6a_4114_a4f4_e472a9f7d8b9" visible="1"></legendlayerfile>
       </filegroup>
     </legendlayer>
   </legend>
-  <mapViewDocks/>
-  <mapViewDocks3D/>
+  <mapViewDocks></mapViewDocks>
   <projectlayers>
-    <maplayer autoRefreshTime="0" minScale="1e+08" refreshOnNotifyEnabled="0" hasScaleBasedVisibilityFlag="0" maxScale="0" type="raster" autoRefreshEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories">
+    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" maxScale="0" minScale="1e+8" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" type="raster">
       <extent>
         <xmin>-20037508.34278924390673637</xmin>
         <ymin>-20037508.34278925508260727</ymin>
@@ -207,7 +124,7 @@
         <type></type>
         <title></title>
         <abstract></abstract>
-        <links/>
+        <links></links>
         <fees></fees>
         <encoding></encoding>
         <crs>
@@ -220,17 +137,35 @@
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
+            <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
-        <extent/>
+        <extent></extent>
       </resourceMetadata>
       <provider>wms</provider>
       <noData>
-        <noDataList useSrcNoData="0" bandNo="1"/>
+        <noDataList bandNo="1" useSrcNoData="0"></noDataList>
       </noData>
+      <temporal enabled="0" fetchMode="0" mode="0" source="0">
+        <fixedRange>
+          <start></start>
+          <end></end>
+        </fixedRange>
+        <fixedReferenceRange>
+          <start></start>
+          <end></end>
+        </fixedReferenceRange>
+        <normalRange>
+          <start></start>
+          <end></end>
+        </normalRange>
+        <referenceRange>
+          <start></start>
+          <end></end>
+        </referenceRange>
+      </temporal>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"/>
+        <map-layer-style name="default"></map-layer-style>
       </map-layer-style-manager>
       <flags>
         <Identifiable>0</Identifiable>
@@ -238,12 +173,12 @@
         <Searchable>0</Searchable>
       </flags>
       <customproperties>
-        <property key="QFieldSync/action" value="no_action"/>
-        <property key="identify/format" value="Undefined"/>
+        <property key="QFieldSync/action" value="no_action"></property>
+        <property key="identify/format" value="Undefined"></property>
       </customproperties>
       <pipe>
-        <rasterrenderer band="1" type="singlebandcolordata" alphaBand="-1" nodataColor="" opacity="1">
-          <rasterTransparency/>
+        <rasterrenderer alphaBand="-1" band="1" nodataColor="" opacity="1" type="singlebandcolordata">
+          <rasterTransparency></rasterTransparency>
           <minMaxOrigin>
             <limits>None</limits>
             <extent>WholeRaster</extent>
@@ -253,18 +188,18 @@
             <stdDevFactor>2</stdDevFactor>
           </minMaxOrigin>
         </rasterrenderer>
-        <brightnesscontrast contrast="0" brightness="0"/>
-        <huesaturation colorizeStrength="100" colorizeBlue="128" saturation="0" colorizeRed="255" grayscaleMode="0" colorizeOn="0" colorizeGreen="128"/>
-        <rasterresampler maxOversampling="2"/>
+        <brightnesscontrast brightness="0" contrast="0"></brightnesscontrast>
+        <huesaturation colorizeBlue="128" colorizeGreen="128" colorizeOn="0" colorizeRed="255" colorizeStrength="100" grayscaleMode="0" saturation="0"></huesaturation>
+        <rasterresampler maxOversampling="2"></rasterresampler>
       </pipe>
       <blendMode>0</blendMode>
     </maplayer>
-    <maplayer minScale="0" wkbType="Point" type="vector" simplifyDrawingTol="1" styleCategories="AllStyleCategories" refreshOnNotifyMessage="" labelsEnabled="1" refreshOnNotifyEnabled="0" hasScaleBasedVisibilityFlag="0" autoRefreshEnabled="0" readOnly="0" autoRefreshTime="0" simplifyAlgorithm="0" maxScale="0" simplifyDrawingHints="0" geometry="Point" simplifyMaxScale="1" simplifyLocal="1">
+    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" geometry="Point" hasScaleBasedVisibilityFlag="0" labelsEnabled="1" maxScale="0" minScale="0" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="0" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" type="vector" wkbType="Point">
       <extent>
-        <xmin>1029520</xmin>
-        <ymin>5910540</ymin>
-        <xmax>1031390</xmax>
-        <ymax>5911980</ymax>
+        <xmin>1029518.875</xmin>
+        <ymin>5910544</ymin>
+        <xmax>1031392.6875</xmax>
+        <ymax>5911983</ymax>
       </extent>
       <id>apiary_27954fba_aad8_4336_8b19_23afed462c51</id>
       <datasource>./bees.gpkg|layername=apiary</datasource>
@@ -301,7 +236,7 @@
           <email></email>
           <role></role>
         </contact>
-        <links/>
+        <links></links>
         <fees></fees>
         <encoding></encoding>
         <crs>
@@ -314,11 +249,11 @@
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial minz="0" maxx="0" miny="0" crs="" maxy="0" dimensions="2" minx="0" maxz="0"/>
+          <spatial crs="" dimensions="2" maxx="0" maxy="0" maxz="0" minx="0" miny="0" minz="0"></spatial>
           <temporal>
             <period>
               <start></start>
@@ -328,141 +263,141 @@
         </extent>
       </resourceMetadata>
       <provider encoding="UTF-8">ogr</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <legend type="default-vector"/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <legend type="default-vector"></legend>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="Species">
         <map-layer-style name="Diseases">
-          <qgis minScale="0" simplifyAlgorithm="0" labelsEnabled="0" hasScaleBasedVisibilityFlag="0" maxScale="0" simplifyLocal="1" simplifyDrawingHints="0" readOnly="0" styleCategories="AllStyleCategories" simplifyMaxScale="1" version="3.11.0-Master" simplifyDrawingTol="1">
+          <qgis hasScaleBasedVisibilityFlag="0" labelsEnabled="0" maxScale="0" minScale="0" readOnly="0" simplifyAlgorithm="0" simplifyDrawingHints="0" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" version="3.11.0-Master">
             <flags>
               <Identifiable>1</Identifiable>
               <Removable>1</Removable>
               <Searchable>1</Searchable>
             </flags>
-            <renderer-v2 symbollevels="0" type="RuleRenderer" enableorderby="0" forceraster="0">
+            <renderer-v2 enableorderby="0" forceraster="0" symbollevels="0" type="RuleRenderer">
               <rules key="{4157b923-0ac3-4ea0-ba49-d157faf5f0b9}">
-                <rule filter="ELSE" label="No disease information" key="{9b02c077-cf2f-43ca-b6f1-f92c5f4ec2b7}" symbol="0"/>
-                <rule filter=" &quot;disease&quot; is not NULL" label="Diseases" key="{2c8997f2-a415-45d2-bd98-2c0898cb3118}">
-                  <rule filter="&quot;disease&quot; in(false, 'f')" label="good" key="{00cac068-dfab-4de1-b717-90ccb04e7578}" symbol="1"/>
-                  <rule filter="&quot;disease&quot; in (true, 't') and &quot;kind_of_disease&quot; != 'AFB'" label="ok" key="{b28ddc2f-8fe3-4b1b-a95f-24a6d59c38c7}" symbol="2"/>
-                  <rule filter="&quot;disease&quot;  in (true, 't') and &quot;kind_of_disease&quot; = 'AFB'" label="not ok" key="{c38c7fee-fcf0-4c65-832e-65626d4abae7}" symbol="3"/>
+                <rule filter="ELSE" key="{9b02c077-cf2f-43ca-b6f1-f92c5f4ec2b7}" label="No disease information" symbol="0"></rule>
+                <rule filter=" &quot;disease&quot; is not NULL" key="{2c8997f2-a415-45d2-bd98-2c0898cb3118}" label="Diseases">
+                  <rule filter="&quot;disease&quot; in(false, 'f')" key="{00cac068-dfab-4de1-b717-90ccb04e7578}" label="good" symbol="1"></rule>
+                  <rule filter="&quot;disease&quot; in (true, 't') and &quot;kind_of_disease&quot; != 'AFB'" key="{b28ddc2f-8fe3-4b1b-a95f-24a6d59c38c7}" label="ok" symbol="2"></rule>
+                  <rule filter="&quot;disease&quot;  in (true, 't') and &quot;kind_of_disease&quot; = 'AFB'" key="{c38c7fee-fcf0-4c65-832e-65626d4abae7}" label="not ok" symbol="3"></rule>
                 </rule>
               </rules>
               <symbols>
-                <symbol alpha="1" clip_to_extent="1" force_rhr="0" type="marker" name="0">
-                  <layer pass="0" class="SimpleMarker" locked="0" enabled="1">
-                    <prop k="angle" v="0"/>
-                    <prop k="color" v="255,255,255,255"/>
-                    <prop k="horizontal_anchor_point" v="1"/>
-                    <prop k="joinstyle" v="miter"/>
-                    <prop k="name" v="hexagon"/>
-                    <prop k="offset" v="0,0"/>
-                    <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                    <prop k="offset_unit" v="MM"/>
-                    <prop k="outline_color" v="250,139,57,255"/>
-                    <prop k="outline_style" v="solid"/>
-                    <prop k="outline_width" v="1"/>
-                    <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                    <prop k="outline_width_unit" v="MM"/>
-                    <prop k="scale_method" v="diameter"/>
-                    <prop k="size" v="6.8"/>
-                    <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                    <prop k="size_unit" v="MM"/>
-                    <prop k="vertical_anchor_point" v="1"/>
+                <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="0" type="marker">
+                  <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                    <prop k="angle" v="0"></prop>
+                    <prop k="color" v="255,255,255,255"></prop>
+                    <prop k="horizontal_anchor_point" v="1"></prop>
+                    <prop k="joinstyle" v="miter"></prop>
+                    <prop k="name" v="hexagon"></prop>
+                    <prop k="offset" v="0,0"></prop>
+                    <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="offset_unit" v="MM"></prop>
+                    <prop k="outline_color" v="250,139,57,255"></prop>
+                    <prop k="outline_style" v="solid"></prop>
+                    <prop k="outline_width" v="1"></prop>
+                    <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="outline_width_unit" v="MM"></prop>
+                    <prop k="scale_method" v="diameter"></prop>
+                    <prop k="size" v="6.8"></prop>
+                    <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="size_unit" v="MM"></prop>
+                    <prop k="vertical_anchor_point" v="1"></prop>
                     <data_defined_properties>
                       <Option type="Map">
-                        <Option type="QString" value="" name="name"/>
-                        <Option name="properties"/>
-                        <Option type="QString" value="collection" name="type"/>
+                        <Option name="name" type="QString" value=""></Option>
+                        <Option name="properties"></Option>
+                        <Option name="type" type="QString" value="collection"></Option>
                       </Option>
                     </data_defined_properties>
                   </layer>
                 </symbol>
-                <symbol alpha="1" clip_to_extent="1" force_rhr="0" type="marker" name="1">
-                  <layer pass="0" class="SimpleMarker" locked="0" enabled="1">
-                    <prop k="angle" v="0"/>
-                    <prop k="color" v="190,255,185,255"/>
-                    <prop k="horizontal_anchor_point" v="1"/>
-                    <prop k="joinstyle" v="miter"/>
-                    <prop k="name" v="hexagon"/>
-                    <prop k="offset" v="0,0"/>
-                    <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                    <prop k="offset_unit" v="MM"/>
-                    <prop k="outline_color" v="250,139,57,255"/>
-                    <prop k="outline_style" v="solid"/>
-                    <prop k="outline_width" v="1"/>
-                    <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                    <prop k="outline_width_unit" v="MM"/>
-                    <prop k="scale_method" v="diameter"/>
-                    <prop k="size" v="6.8"/>
-                    <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                    <prop k="size_unit" v="MM"/>
-                    <prop k="vertical_anchor_point" v="1"/>
+                <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="1" type="marker">
+                  <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                    <prop k="angle" v="0"></prop>
+                    <prop k="color" v="190,255,185,255"></prop>
+                    <prop k="horizontal_anchor_point" v="1"></prop>
+                    <prop k="joinstyle" v="miter"></prop>
+                    <prop k="name" v="hexagon"></prop>
+                    <prop k="offset" v="0,0"></prop>
+                    <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="offset_unit" v="MM"></prop>
+                    <prop k="outline_color" v="250,139,57,255"></prop>
+                    <prop k="outline_style" v="solid"></prop>
+                    <prop k="outline_width" v="1"></prop>
+                    <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="outline_width_unit" v="MM"></prop>
+                    <prop k="scale_method" v="diameter"></prop>
+                    <prop k="size" v="6.8"></prop>
+                    <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="size_unit" v="MM"></prop>
+                    <prop k="vertical_anchor_point" v="1"></prop>
                     <data_defined_properties>
                       <Option type="Map">
-                        <Option type="QString" value="" name="name"/>
-                        <Option name="properties"/>
-                        <Option type="QString" value="collection" name="type"/>
+                        <Option name="name" type="QString" value=""></Option>
+                        <Option name="properties"></Option>
+                        <Option name="type" type="QString" value="collection"></Option>
                       </Option>
                     </data_defined_properties>
                   </layer>
                 </symbol>
-                <symbol alpha="1" clip_to_extent="1" force_rhr="0" type="marker" name="2">
-                  <layer pass="0" class="SimpleMarker" locked="0" enabled="1">
-                    <prop k="angle" v="0"/>
-                    <prop k="color" v="250,176,124,255"/>
-                    <prop k="horizontal_anchor_point" v="1"/>
-                    <prop k="joinstyle" v="miter"/>
-                    <prop k="name" v="hexagon"/>
-                    <prop k="offset" v="0,0"/>
-                    <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                    <prop k="offset_unit" v="MM"/>
-                    <prop k="outline_color" v="250,139,57,255"/>
-                    <prop k="outline_style" v="solid"/>
-                    <prop k="outline_width" v="1"/>
-                    <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                    <prop k="outline_width_unit" v="MM"/>
-                    <prop k="scale_method" v="diameter"/>
-                    <prop k="size" v="6.8"/>
-                    <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                    <prop k="size_unit" v="MM"/>
-                    <prop k="vertical_anchor_point" v="1"/>
+                <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="2" type="marker">
+                  <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                    <prop k="angle" v="0"></prop>
+                    <prop k="color" v="250,176,124,255"></prop>
+                    <prop k="horizontal_anchor_point" v="1"></prop>
+                    <prop k="joinstyle" v="miter"></prop>
+                    <prop k="name" v="hexagon"></prop>
+                    <prop k="offset" v="0,0"></prop>
+                    <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="offset_unit" v="MM"></prop>
+                    <prop k="outline_color" v="250,139,57,255"></prop>
+                    <prop k="outline_style" v="solid"></prop>
+                    <prop k="outline_width" v="1"></prop>
+                    <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="outline_width_unit" v="MM"></prop>
+                    <prop k="scale_method" v="diameter"></prop>
+                    <prop k="size" v="6.8"></prop>
+                    <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="size_unit" v="MM"></prop>
+                    <prop k="vertical_anchor_point" v="1"></prop>
                     <data_defined_properties>
                       <Option type="Map">
-                        <Option type="QString" value="" name="name"/>
-                        <Option name="properties"/>
-                        <Option type="QString" value="collection" name="type"/>
+                        <Option name="name" type="QString" value=""></Option>
+                        <Option name="properties"></Option>
+                        <Option name="type" type="QString" value="collection"></Option>
                       </Option>
                     </data_defined_properties>
                   </layer>
                 </symbol>
-                <symbol alpha="1" clip_to_extent="1" force_rhr="0" type="marker" name="3">
-                  <layer pass="0" class="SimpleMarker" locked="0" enabled="1">
-                    <prop k="angle" v="0"/>
-                    <prop k="color" v="227,117,119,255"/>
-                    <prop k="horizontal_anchor_point" v="1"/>
-                    <prop k="joinstyle" v="miter"/>
-                    <prop k="name" v="hexagon"/>
-                    <prop k="offset" v="0,0"/>
-                    <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                    <prop k="offset_unit" v="MM"/>
-                    <prop k="outline_color" v="250,139,57,255"/>
-                    <prop k="outline_style" v="solid"/>
-                    <prop k="outline_width" v="1"/>
-                    <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                    <prop k="outline_width_unit" v="MM"/>
-                    <prop k="scale_method" v="diameter"/>
-                    <prop k="size" v="6.8"/>
-                    <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                    <prop k="size_unit" v="MM"/>
-                    <prop k="vertical_anchor_point" v="1"/>
+                <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="3" type="marker">
+                  <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                    <prop k="angle" v="0"></prop>
+                    <prop k="color" v="227,117,119,255"></prop>
+                    <prop k="horizontal_anchor_point" v="1"></prop>
+                    <prop k="joinstyle" v="miter"></prop>
+                    <prop k="name" v="hexagon"></prop>
+                    <prop k="offset" v="0,0"></prop>
+                    <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="offset_unit" v="MM"></prop>
+                    <prop k="outline_color" v="250,139,57,255"></prop>
+                    <prop k="outline_style" v="solid"></prop>
+                    <prop k="outline_width" v="1"></prop>
+                    <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="outline_width_unit" v="MM"></prop>
+                    <prop k="scale_method" v="diameter"></prop>
+                    <prop k="size" v="6.8"></prop>
+                    <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                    <prop k="size_unit" v="MM"></prop>
+                    <prop k="vertical_anchor_point" v="1"></prop>
                     <data_defined_properties>
                       <Option type="Map">
-                        <Option type="QString" value="" name="name"/>
-                        <Option name="properties"/>
-                        <Option type="QString" value="collection" name="type"/>
+                        <Option name="name" type="QString" value=""></Option>
+                        <Option name="properties"></Option>
+                        <Option name="type" type="QString" value="collection"></Option>
                       </Option>
                     </data_defined_properties>
                   </layer>
@@ -470,44 +405,44 @@
               </symbols>
             </renderer-v2>
             <customproperties>
-              <property key="embeddedWidgets/count" value="0"/>
-              <property key="isOfflineEditable" value="true"/>
-              <property key="remoteProvider" value="postgres"/>
-              <property key="remoteSource" value="dbname='demo' host=lizmapdemo.opengis.ch port=5432 user='editor1' password='editor1' sslmode=disable key='id' srid=2056 type=Point table=&quot;citybees&quot;.&quot;apiary&quot; (geom) sql="/>
-              <property key="variableNames"/>
-              <property key="variableValues"/>
+              <property key="embeddedWidgets/count" value="0"></property>
+              <property key="isOfflineEditable" value="true"></property>
+              <property key="remoteProvider" value="postgres"></property>
+              <property key="remoteSource" value="dbname='demo' host=lizmapdemo.opengis.ch port=5432 user='editor1' password='editor1' sslmode=disable key='id' srid=2056 type=Point table=&quot;citybees&quot;.&quot;apiary&quot; (geom) sql="></property>
+              <property key="variableNames"></property>
+              <property key="variableValues"></property>
             </customproperties>
             <blendMode>0</blendMode>
             <featureBlendMode>0</featureBlendMode>
             <layerOpacity>1</layerOpacity>
             <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
-              <DiagramCategory scaleBasedVisibility="0" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" width="15" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" penAlpha="255" maxScaleDenominator="1e+08" minimumSize="0" direction="1" labelPlacementMethod="XHeight" backgroundColor="#ffffff" height="15" opacity="1" spacingUnitScale="3x:0,0,0,0,0,0" showAxis="0" sizeType="MM" spacingUnit="MM" diagramOrientation="Up" minScaleDenominator="0" spacing="0" penColor="#000000" barWidth="5" backgroundAlpha="255" penWidth="0" enabled="0" rotationOffset="0">
-                <fontProperties style="" description="Cantarell,11,-1,5,50,0,0,0,0,0"/>
-                <attribute color="#000000" label="" field=""/>
+              <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="1" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="0" scaleBasedVisibility="0" scaleDependency="Area" showAxis="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="0" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
+                <fontProperties description="Cantarell,11,-1,5,50,0,0,0,0,0" style=""></fontProperties>
+                <attribute color="#000000" field="" label=""></attribute>
                 <axisSymbol>
-                  <symbol alpha="1" clip_to_extent="1" force_rhr="0" type="line" name="">
-                    <layer pass="0" class="SimpleLine" locked="0" enabled="1">
-                      <prop k="capstyle" v="square"/>
-                      <prop k="customdash" v="5;2"/>
-                      <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                      <prop k="customdash_unit" v="MM"/>
-                      <prop k="draw_inside_polygon" v="0"/>
-                      <prop k="joinstyle" v="bevel"/>
-                      <prop k="line_color" v="35,35,35,255"/>
-                      <prop k="line_style" v="solid"/>
-                      <prop k="line_width" v="0.26"/>
-                      <prop k="line_width_unit" v="MM"/>
-                      <prop k="offset" v="0"/>
-                      <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                      <prop k="offset_unit" v="MM"/>
-                      <prop k="ring_filter" v="0"/>
-                      <prop k="use_custom_dash" v="0"/>
-                      <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+                  <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" type="line">
+                    <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+                      <prop k="capstyle" v="square"></prop>
+                      <prop k="customdash" v="5;2"></prop>
+                      <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                      <prop k="customdash_unit" v="MM"></prop>
+                      <prop k="draw_inside_polygon" v="0"></prop>
+                      <prop k="joinstyle" v="bevel"></prop>
+                      <prop k="line_color" v="35,35,35,255"></prop>
+                      <prop k="line_style" v="solid"></prop>
+                      <prop k="line_width" v="0.26"></prop>
+                      <prop k="line_width_unit" v="MM"></prop>
+                      <prop k="offset" v="0"></prop>
+                      <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                      <prop k="offset_unit" v="MM"></prop>
+                      <prop k="ring_filter" v="0"></prop>
+                      <prop k="use_custom_dash" v="0"></prop>
+                      <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
                       <data_defined_properties>
                         <Option type="Map">
-                          <Option type="QString" value="" name="name"/>
-                          <Option name="properties"/>
-                          <Option type="QString" value="collection" name="type"/>
+                          <Option name="name" type="QString" value=""></Option>
+                          <Option name="properties"></Option>
+                          <Option name="type" type="QString" value="collection"></Option>
                         </Option>
                       </data_defined_properties>
                     </layer>
@@ -515,42 +450,42 @@
                 </axisSymbol>
               </DiagramCategory>
             </SingleCategoryDiagramRenderer>
-            <DiagramLayerSettings obstacle="0" linePlacementFlags="2" zIndex="0" dist="0" placement="0" priority="0" showAll="1">
+            <DiagramLayerSettings dist="0" linePlacementFlags="2" obstacle="0" placement="0" priority="0" showAll="1" zIndex="0">
               <properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
-                  <Option type="Map" name="properties">
-                    <Option type="Map" name="positionX">
-                      <Option type="bool" value="true" name="active"/>
-                      <Option type="QString" value="id" name="field"/>
-                      <Option type="int" value="2" name="type"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties" type="Map">
+                    <Option name="positionX" type="Map">
+                      <Option name="active" type="bool" value="true"></Option>
+                      <Option name="field" type="QString" value="id"></Option>
+                      <Option name="type" type="int" value="2"></Option>
                     </Option>
-                    <Option type="Map" name="positionY">
-                      <Option type="bool" value="true" name="active"/>
-                      <Option type="QString" value="id" name="field"/>
-                      <Option type="int" value="2" name="type"/>
+                    <Option name="positionY" type="Map">
+                      <Option name="active" type="bool" value="true"></Option>
+                      <Option name="field" type="QString" value="id"></Option>
+                      <Option name="type" type="int" value="2"></Option>
                     </Option>
-                    <Option type="Map" name="show">
-                      <Option type="bool" value="true" name="active"/>
-                      <Option type="QString" value="id" name="field"/>
-                      <Option type="int" value="2" name="type"/>
+                    <Option name="show" type="Map">
+                      <Option name="active" type="bool" value="true"></Option>
+                      <Option name="field" type="QString" value="id"></Option>
+                      <Option name="type" type="int" value="2"></Option>
                     </Option>
                   </Option>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </properties>
             </DiagramLayerSettings>
             <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-              <activeChecks/>
-              <checkConfiguration/>
+              <activeChecks></activeChecks>
+              <checkConfiguration></checkConfiguration>
             </geometryOptions>
-            <referencedLayers/>
-            <referencingLayers/>
+            <referencedLayers></referencedLayers>
+            <referencingLayers></referencingLayers>
             <fieldConfiguration>
               <field name="fid">
                 <editWidget type="TextEdit">
                   <config>
-                    <Option/>
+                    <Option></Option>
                   </config>
                 </editWidget>
               </field>
@@ -558,11 +493,11 @@
                 <editWidget type="Range">
                   <config>
                     <Option type="Map">
-                      <Option type="QString" value="1" name="AllowNull"/>
-                      <Option type="QString" value="10" name="Max"/>
-                      <Option type="QString" value="1" name="Min"/>
-                      <Option type="QString" value="1" name="Step"/>
-                      <Option type="QString" value="Slider" name="Style"/>
+                      <Option name="AllowNull" type="QString" value="1"></Option>
+                      <Option name="Max" type="QString" value="10"></Option>
+                      <Option name="Min" type="QString" value="1"></Option>
+                      <Option name="Step" type="QString" value="1"></Option>
+                      <Option name="Style" type="QString" value="Slider"></Option>
                     </Option>
                   </config>
                 </editWidget>
@@ -571,10 +506,10 @@
                 <editWidget type="ValueMap">
                   <config>
                     <Option type="Map">
-                      <Option type="Map" name="map">
-                        <Option type="QString" value="Apis Mellifera" name="Buckfast bee"/>
-                        <Option type="QString" value="Apis Mellifera Carnica" name="Carniolan honey bee"/>
-                        <Option type="QString" value="Apis Mellifera Mellifera" name="European honey bee"/>
+                      <Option name="map" type="Map">
+                        <Option name="Buckfast bee" type="QString" value="Apis Mellifera"></Option>
+                        <Option name="Carniolan honey bee" type="QString" value="Apis Mellifera Carnica"></Option>
+                        <Option name="European honey bee" type="QString" value="Apis Mellifera Mellifera"></Option>
                       </Option>
                     </Option>
                   </config>
@@ -584,10 +519,10 @@
                 <editWidget type="ValueMap">
                   <config>
                     <Option type="Map">
-                      <Option type="Map" name="map">
-                        <Option type="QString" value="10000" name="1000 - 10000"/>
-                        <Option type="QString" value="1000" name="&lt; 1000"/>
-                        <Option type="QString" value="100000" name="> 10000"/>
+                      <Option name="map" type="Map">
+                        <Option name="1000 - 10000" type="QString" value="10000"></Option>
+                        <Option name="&lt; 1000" type="QString" value="1000"></Option>
+                        <Option name="> 10000" type="QString" value="100000"></Option>
                       </Option>
                     </Option>
                   </config>
@@ -597,8 +532,8 @@
                 <editWidget type="TextEdit">
                   <config>
                     <Option type="Map">
-                      <Option type="QString" value="0" name="IsMultiline"/>
-                      <Option type="QString" value="0" name="UseHtml"/>
+                      <Option name="IsMultiline" type="QString" value="0"></Option>
+                      <Option name="UseHtml" type="QString" value="0"></Option>
                     </Option>
                   </config>
                 </editWidget>
@@ -607,19 +542,19 @@
                 <editWidget type="ExternalResource">
                   <config>
                     <Option type="Map">
-                      <Option type="int" value="1" name="DocumentViewer"/>
-                      <Option type="int" value="0" name="DocumentViewerHeight"/>
-                      <Option type="int" value="0" name="DocumentViewerWidth"/>
-                      <Option type="bool" value="true" name="FileWidget"/>
-                      <Option type="bool" value="true" name="FileWidgetButton"/>
-                      <Option type="QString" value="" name="FileWidgetFilter"/>
-                      <Option type="Map" name="PropertyCollection">
-                        <Option type="QString" value="" name="name"/>
-                        <Option type="invalid" name="properties"/>
-                        <Option type="QString" value="collection" name="type"/>
+                      <Option name="DocumentViewer" type="int" value="1"></Option>
+                      <Option name="DocumentViewerHeight" type="int" value="0"></Option>
+                      <Option name="DocumentViewerWidth" type="int" value="0"></Option>
+                      <Option name="FileWidget" type="bool" value="true"></Option>
+                      <Option name="FileWidgetButton" type="bool" value="true"></Option>
+                      <Option name="FileWidgetFilter" type="QString" value=""></Option>
+                      <Option name="PropertyCollection" type="Map">
+                        <Option name="name" type="QString" value=""></Option>
+                        <Option name="properties" type="invalid"></Option>
+                        <Option name="type" type="QString" value="collection"></Option>
                       </Option>
-                      <Option type="int" value="1" name="RelativeStorage"/>
-                      <Option type="int" value="0" name="StorageMode"/>
+                      <Option name="RelativeStorage" type="int" value="1"></Option>
+                      <Option name="StorageMode" type="int" value="0"></Option>
                     </Option>
                   </config>
                 </editWidget>
@@ -628,8 +563,8 @@
                 <editWidget type="CheckBox">
                   <config>
                     <Option type="Map">
-                      <Option type="QString" value="t" name="CheckedState"/>
-                      <Option type="QString" value="f" name="UncheckedState"/>
+                      <Option name="CheckedState" type="QString" value="t"></Option>
+                      <Option name="UncheckedState" type="QString" value="f"></Option>
                     </Option>
                   </config>
                 </editWidget>
@@ -638,9 +573,9 @@
                 <editWidget type="ValueMap">
                   <config>
                     <Option type="Map">
-                      <Option type="Map" name="map">
-                        <Option type="QString" value="AFB" name="American Foulbreed"/>
-                        <Option type="QString" value="EFB" name="European Foulbreed"/>
+                      <Option name="map" type="Map">
+                        <Option name="American Foulbreed" type="QString" value="AFB"></Option>
+                        <Option name="European Foulbreed" type="QString" value="EFB"></Option>
                       </Option>
                     </Option>
                   </config>
@@ -650,11 +585,11 @@
                 <editWidget type="Range">
                   <config>
                     <Option type="Map">
-                      <Option type="QString" value="1" name="AllowNull"/>
-                      <Option type="QString" value="100" name="Max"/>
-                      <Option type="QString" value="0" name="Min"/>
-                      <Option type="QString" value="5" name="Step"/>
-                      <Option type="QString" value="SpinBox" name="Style"/>
+                      <Option name="AllowNull" type="QString" value="1"></Option>
+                      <Option name="Max" type="QString" value="100"></Option>
+                      <Option name="Min" type="QString" value="0"></Option>
+                      <Option name="Step" type="QString" value="5"></Option>
+                      <Option name="Style" type="QString" value="SpinBox"></Option>
                     </Option>
                   </config>
                 </editWidget>
@@ -663,105 +598,105 @@
                 <editWidget type="RelationReference">
                   <config>
                     <Option type="Map">
-                      <Option type="bool" value="false" name="AllowAddFeatures"/>
-                      <Option type="bool" value="true" name="AllowNULL"/>
-                      <Option type="bool" value="true" name="MapIdentification"/>
-                      <Option type="bool" value="false" name="OrderByValue"/>
-                      <Option type="bool" value="false" name="ReadOnly"/>
-                      <Option type="QString" value="apiary_036bee2c_a341_4b84_b25c_1bea7c01e9c2_area_id_area_60ff9e18_ea5b_4814_a227_157fe79ce94c_id" name="Relation"/>
-                      <Option type="bool" value="false" name="ShowForm"/>
-                      <Option type="bool" value="true" name="ShowOpenFormButton"/>
+                      <Option name="AllowAddFeatures" type="bool" value="false"></Option>
+                      <Option name="AllowNULL" type="bool" value="true"></Option>
+                      <Option name="MapIdentification" type="bool" value="true"></Option>
+                      <Option name="OrderByValue" type="bool" value="false"></Option>
+                      <Option name="ReadOnly" type="bool" value="false"></Option>
+                      <Option name="Relation" type="QString" value="apiary_036bee2c_a341_4b84_b25c_1bea7c01e9c2_area_id_area_60ff9e18_ea5b_4814_a227_157fe79ce94c_id"></Option>
+                      <Option name="ShowForm" type="bool" value="false"></Option>
+                      <Option name="ShowOpenFormButton" type="bool" value="true"></Option>
                     </Option>
                   </config>
                 </editWidget>
               </field>
             </fieldConfiguration>
             <aliases>
-              <alias index="0" name="" field="fid"/>
-              <alias index="1" name="Number of Boxes" field="nbr_of_boxes"/>
-              <alias index="2" name="Species of Bees" field="bee_species"/>
-              <alias index="3" name="Amount of Bees" field="bee_amount"/>
-              <alias index="4" name="Beekeeper" field="beekeeper"/>
-              <alias index="5" name="Photo" field="picture"/>
-              <alias index="6" name="Infected" field="disease"/>
-              <alias index="7" name="Kind of Disease" field="kind_of_disease"/>
-              <alias index="8" name="Yearly Harvest (kg)" field="average_harvest"/>
-              <alias index="9" name="Area mostly used" field="area_id"/>
+              <alias field="fid" index="0" name=""></alias>
+              <alias field="nbr_of_boxes" index="1" name="Number of Boxes"></alias>
+              <alias field="bee_species" index="2" name="Species of Bees"></alias>
+              <alias field="bee_amount" index="3" name="Amount of Bees"></alias>
+              <alias field="beekeeper" index="4" name="Beekeeper"></alias>
+              <alias field="picture" index="5" name="Photo"></alias>
+              <alias field="disease" index="6" name="Infected"></alias>
+              <alias field="kind_of_disease" index="7" name="Kind of Disease"></alias>
+              <alias field="average_harvest" index="8" name="Yearly Harvest (kg)"></alias>
+              <alias field="area_id" index="9" name="Area mostly used"></alias>
             </aliases>
-            <excludeAttributesWMS/>
-            <excludeAttributesWFS/>
+            <excludeAttributesWMS></excludeAttributesWMS>
+            <excludeAttributesWFS></excludeAttributesWFS>
             <defaults>
-              <default expression="" applyOnUpdate="0" field="fid"/>
-              <default expression="" applyOnUpdate="0" field="nbr_of_boxes"/>
-              <default expression="" applyOnUpdate="0" field="bee_species"/>
-              <default expression="" applyOnUpdate="0" field="bee_amount"/>
-              <default expression="" applyOnUpdate="0" field="beekeeper"/>
-              <default expression="" applyOnUpdate="0" field="picture"/>
-              <default expression="" applyOnUpdate="0" field="disease"/>
-              <default expression="" applyOnUpdate="0" field="kind_of_disease"/>
-              <default expression="" applyOnUpdate="0" field="average_harvest"/>
-              <default expression="" applyOnUpdate="0" field="area_id"/>
+              <default applyOnUpdate="0" expression="" field="fid"></default>
+              <default applyOnUpdate="0" expression="" field="nbr_of_boxes"></default>
+              <default applyOnUpdate="0" expression="" field="bee_species"></default>
+              <default applyOnUpdate="0" expression="" field="bee_amount"></default>
+              <default applyOnUpdate="0" expression="" field="beekeeper"></default>
+              <default applyOnUpdate="0" expression="" field="picture"></default>
+              <default applyOnUpdate="0" expression="" field="disease"></default>
+              <default applyOnUpdate="0" expression="" field="kind_of_disease"></default>
+              <default applyOnUpdate="0" expression="" field="average_harvest"></default>
+              <default applyOnUpdate="0" expression="" field="area_id"></default>
             </defaults>
             <constraints>
-              <constraint constraints="3" unique_strength="1" exp_strength="0" notnull_strength="1" field="fid"/>
-              <constraint constraints="1" unique_strength="0" exp_strength="0" notnull_strength="1" field="nbr_of_boxes"/>
-              <constraint constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0" field="bee_species"/>
-              <constraint constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0" field="bee_amount"/>
-              <constraint constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0" field="beekeeper"/>
-              <constraint constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0" field="picture"/>
-              <constraint constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0" field="disease"/>
-              <constraint constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0" field="kind_of_disease"/>
-              <constraint constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0" field="average_harvest"/>
-              <constraint constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0" field="area_id"/>
+              <constraint constraints="3" exp_strength="0" field="fid" notnull_strength="1" unique_strength="1"></constraint>
+              <constraint constraints="1" exp_strength="0" field="nbr_of_boxes" notnull_strength="1" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="bee_species" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="bee_amount" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="beekeeper" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="picture" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="disease" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="kind_of_disease" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="average_harvest" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="area_id" notnull_strength="0" unique_strength="0"></constraint>
             </constraints>
             <constraintExpressions>
-              <constraint desc="" exp="" field="fid"/>
-              <constraint desc="" exp="" field="nbr_of_boxes"/>
-              <constraint desc="" exp="" field="bee_species"/>
-              <constraint desc="" exp="" field="bee_amount"/>
-              <constraint desc="" exp="" field="beekeeper"/>
-              <constraint desc="" exp="" field="picture"/>
-              <constraint desc="" exp="" field="disease"/>
-              <constraint desc="" exp="" field="kind_of_disease"/>
-              <constraint desc="" exp="" field="average_harvest"/>
-              <constraint desc="" exp="" field="area_id"/>
+              <constraint desc="" exp="" field="fid"></constraint>
+              <constraint desc="" exp="" field="nbr_of_boxes"></constraint>
+              <constraint desc="" exp="" field="bee_species"></constraint>
+              <constraint desc="" exp="" field="bee_amount"></constraint>
+              <constraint desc="" exp="" field="beekeeper"></constraint>
+              <constraint desc="" exp="" field="picture"></constraint>
+              <constraint desc="" exp="" field="disease"></constraint>
+              <constraint desc="" exp="" field="kind_of_disease"></constraint>
+              <constraint desc="" exp="" field="average_harvest"></constraint>
+              <constraint desc="" exp="" field="area_id"></constraint>
             </constraintExpressions>
-            <expressionfields/>
+            <expressionfields></expressionfields>
             <attributeactions>
-              <defaultAction key="Canvas" value="{82c96019-8b22-4c5d-a9b4-6d1a68e63e02}"/>
-              <actionsetting notificationMessage="" isEnabledOnlyWhenEditable="0" shortTitle="" action="" type="0" icon="" name="" id="{82c96019-8b22-4c5d-a9b4-6d1a68e63e02}" capture="0">
-                <actionScope id="Feature"/>
-                <actionScope id="Canvas"/>
-                <actionScope id="Field"/>
+              <defaultAction key="Canvas" value="{82c96019-8b22-4c5d-a9b4-6d1a68e63e02}"></defaultAction>
+              <actionsetting action="" capture="0" icon="" id="{82c96019-8b22-4c5d-a9b4-6d1a68e63e02}" isEnabledOnlyWhenEditable="0" name="" notificationMessage="" shortTitle="" type="0">
+                <actionScope id="Feature"></actionScope>
+                <actionScope id="Canvas"></actionScope>
+                <actionScope id="Field"></actionScope>
               </actionsetting>
             </attributeactions>
-            <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+            <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
               <columns>
-                <column width="165" type="field" hidden="0" name="nbr_of_boxes"/>
-                <column width="164" type="field" hidden="0" name="bee_species"/>
-                <column width="192" type="field" hidden="0" name="bee_amount"/>
-                <column width="-1" type="field" hidden="0" name="beekeeper"/>
-                <column width="-1" type="field" hidden="0" name="picture"/>
-                <column width="-1" type="field" hidden="0" name="disease"/>
-                <column width="188" type="field" hidden="0" name="kind_of_disease"/>
-                <column width="-1" type="field" hidden="0" name="review_date"/>
-                <column width="-1" type="field" hidden="0" name="reviewer"/>
-                <column width="-1" type="actions" hidden="1"/>
-                <column width="161" type="field" hidden="0" name="average_harvest"/>
-                <column width="-1" type="field" hidden="0" name="area_id"/>
-                <column width="-1" type="field" hidden="0" name="fid"/>
+                <column hidden="0" name="nbr_of_boxes" type="field" width="165"></column>
+                <column hidden="0" name="bee_species" type="field" width="164"></column>
+                <column hidden="0" name="bee_amount" type="field" width="192"></column>
+                <column hidden="0" name="beekeeper" type="field" width="-1"></column>
+                <column hidden="0" name="picture" type="field" width="-1"></column>
+                <column hidden="0" name="disease" type="field" width="-1"></column>
+                <column hidden="0" name="kind_of_disease" type="field" width="188"></column>
+                <column hidden="0" name="review_date" type="field" width="-1"></column>
+                <column hidden="0" name="reviewer" type="field" width="-1"></column>
+                <column hidden="1" type="actions" width="-1"></column>
+                <column hidden="0" name="average_harvest" type="field" width="161"></column>
+                <column hidden="0" name="area_id" type="field" width="-1"></column>
+                <column hidden="0" name="fid" type="field" width="-1"></column>
               </columns>
             </attributetableconfig>
             <conditionalstyles>
-              <rowstyles/>
-              <fieldstyles/>
+              <rowstyles></rowstyles>
+              <fieldstyles></fieldstyles>
             </conditionalstyles>
-            <storedexpressions/>
+            <storedexpressions></storedexpressions>
             <editform tolerant="1">/run/user/1000/gvfs/mtp:host=SAMSUNG_SAMSUNG_Android_1cc5ab8c12047ece/Phone/qfield/workshop_foss4g2018</editform>
-            <editforminit/>
+            <editforminit></editforminit>
             <editforminitcodesource>0</editforminitcodesource>
             <editforminitfilepath>/run/user/1000/gvfs/mtp:host=SAMSUNG_SAMSUNG_Android_1cc5ab8c12047ece/Phone/qfield/demo_proj_citybees_218</editforminitfilepath>
-            <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+            <editforminitcode># -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -777,139 +712,139 @@ from qgis.PyQt.QtWidgets import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-]]></editforminitcode>
+</editforminitcode>
             <featformsuppress>0</featformsuppress>
             <editorlayout>tablayout</editorlayout>
             <attributeEditorForm>
-              <attributeEditorContainer visibilityExpressionEnabled="0" groupBox="0" visibilityExpression="" showLabel="1" name="General" columnCount="1">
-                <attributeEditorField index="1" showLabel="1" name="nbr_of_boxes"/>
-                <attributeEditorField index="2" showLabel="1" name="bee_species"/>
-                <attributeEditorField index="3" showLabel="1" name="bee_amount"/>
-                <attributeEditorField index="4" showLabel="1" name="beekeeper"/>
-                <attributeEditorField index="8" showLabel="1" name="average_harvest"/>
+              <attributeEditorContainer columnCount="1" groupBox="0" name="General" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+                <attributeEditorField index="1" name="nbr_of_boxes" showLabel="1"></attributeEditorField>
+                <attributeEditorField index="2" name="bee_species" showLabel="1"></attributeEditorField>
+                <attributeEditorField index="3" name="bee_amount" showLabel="1"></attributeEditorField>
+                <attributeEditorField index="4" name="beekeeper" showLabel="1"></attributeEditorField>
+                <attributeEditorField index="8" name="average_harvest" showLabel="1"></attributeEditorField>
               </attributeEditorContainer>
-              <attributeEditorContainer visibilityExpressionEnabled="0" groupBox="0" visibilityExpression="" showLabel="1" name="Picture" columnCount="1">
-                <attributeEditorField index="5" showLabel="1" name="picture"/>
+              <attributeEditorContainer columnCount="1" groupBox="0" name="Picture" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+                <attributeEditorField index="5" name="picture" showLabel="1"></attributeEditorField>
               </attributeEditorContainer>
-              <attributeEditorContainer visibilityExpressionEnabled="0" groupBox="0" visibilityExpression="" showLabel="1" name="Issues" columnCount="1">
-                <attributeEditorField index="6" showLabel="1" name="disease"/>
-                <attributeEditorContainer visibilityExpressionEnabled="1" groupBox="1" visibilityExpression="disease in ('t', true, 1)" showLabel="1" name="Disease" columnCount="1">
-                  <attributeEditorField index="7" showLabel="1" name="kind_of_disease"/>
+              <attributeEditorContainer columnCount="1" groupBox="0" name="Issues" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+                <attributeEditorField index="6" name="disease" showLabel="1"></attributeEditorField>
+                <attributeEditorContainer columnCount="1" groupBox="1" name="Disease" showLabel="1" visibilityExpression="disease in ('t', true, 1)" visibilityExpressionEnabled="1">
+                  <attributeEditorField index="7" name="kind_of_disease" showLabel="1"></attributeEditorField>
                 </attributeEditorContainer>
               </attributeEditorContainer>
-              <attributeEditorContainer visibilityExpressionEnabled="0" groupBox="0" visibilityExpression="" showLabel="1" name="Review" columnCount="1">
-                <attributeEditorField index="-1" showLabel="1" name="review_date"/>
-                <attributeEditorField index="-1" showLabel="1" name="reviewer"/>
+              <attributeEditorContainer columnCount="1" groupBox="0" name="Review" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+                <attributeEditorField index="-1" name="review_date" showLabel="1"></attributeEditorField>
+                <attributeEditorField index="-1" name="reviewer" showLabel="1"></attributeEditorField>
               </attributeEditorContainer>
-              <attributeEditorContainer visibilityExpressionEnabled="0" groupBox="0" visibilityExpression="" showLabel="1" name="Area" columnCount="1">
-                <attributeEditorField index="9" showLabel="1" name="area_id"/>
+              <attributeEditorContainer columnCount="1" groupBox="0" name="Area" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+                <attributeEditorField index="9" name="area_id" showLabel="1"></attributeEditorField>
               </attributeEditorContainer>
             </attributeEditorForm>
             <editable>
-              <field editable="1" name="area_id"/>
-              <field editable="1" name="average_harvest"/>
-              <field editable="1" name="bee_amount"/>
-              <field editable="1" name="bee_species"/>
-              <field editable="1" name="beekeeper"/>
-              <field editable="1" name="disease"/>
-              <field editable="1" name="fid"/>
-              <field editable="1" name="id"/>
-              <field editable="1" name="kind_of_disease"/>
-              <field editable="1" name="nbr_of_boxes"/>
-              <field editable="1" name="picture"/>
-              <field editable="1" name="review_date"/>
-              <field editable="1" name="reviewer"/>
+              <field editable="1" name="area_id"></field>
+              <field editable="1" name="average_harvest"></field>
+              <field editable="1" name="bee_amount"></field>
+              <field editable="1" name="bee_species"></field>
+              <field editable="1" name="beekeeper"></field>
+              <field editable="1" name="disease"></field>
+              <field editable="1" name="fid"></field>
+              <field editable="1" name="id"></field>
+              <field editable="1" name="kind_of_disease"></field>
+              <field editable="1" name="nbr_of_boxes"></field>
+              <field editable="1" name="picture"></field>
+              <field editable="1" name="review_date"></field>
+              <field editable="1" name="reviewer"></field>
             </editable>
             <labelOnTop>
-              <field labelOnTop="0" name="area_id"/>
-              <field labelOnTop="0" name="average_harvest"/>
-              <field labelOnTop="0" name="bee_amount"/>
-              <field labelOnTop="0" name="bee_species"/>
-              <field labelOnTop="0" name="beekeeper"/>
-              <field labelOnTop="0" name="disease"/>
-              <field labelOnTop="0" name="fid"/>
-              <field labelOnTop="0" name="id"/>
-              <field labelOnTop="0" name="kind_of_disease"/>
-              <field labelOnTop="0" name="nbr_of_boxes"/>
-              <field labelOnTop="0" name="picture"/>
-              <field labelOnTop="0" name="review_date"/>
-              <field labelOnTop="0" name="reviewer"/>
+              <field labelOnTop="0" name="area_id"></field>
+              <field labelOnTop="0" name="average_harvest"></field>
+              <field labelOnTop="0" name="bee_amount"></field>
+              <field labelOnTop="0" name="bee_species"></field>
+              <field labelOnTop="0" name="beekeeper"></field>
+              <field labelOnTop="0" name="disease"></field>
+              <field labelOnTop="0" name="fid"></field>
+              <field labelOnTop="0" name="id"></field>
+              <field labelOnTop="0" name="kind_of_disease"></field>
+              <field labelOnTop="0" name="nbr_of_boxes"></field>
+              <field labelOnTop="0" name="picture"></field>
+              <field labelOnTop="0" name="review_date"></field>
+              <field labelOnTop="0" name="reviewer"></field>
             </labelOnTop>
             <widgets>
               <widget name="Pollen_Con_apiary_id_apiary_279_fid">
                 <config type="Map">
-                  <Option type="QString" value="" name="nm-rel"/>
+                  <Option name="nm-rel" type="QString" value=""></Option>
                 </config>
               </widget>
               <widget name="Reviews_c8_apiary_id_apiary_279_fid">
                 <config type="Map">
-                  <Option type="QString" value="" name="nm-rel"/>
+                  <Option name="nm-rel" type="QString" value=""></Option>
                 </config>
               </widget>
               <widget name="ref_apiary_apiary_id_apiary2018_id">
-                <config/>
+                <config></config>
               </widget>
             </widgets>
             <previewExpression>beekeeper+' - '+bee_species</previewExpression>
-            <mapTip/>
+            <mapTip></mapTip>
             <layerGeometryType>0</layerGeometryType>
           </qgis>
         </map-layer-style>
         <map-layer-style name="Heatmap">
-          <qgis minScale="0" simplifyAlgorithm="0" labelsEnabled="0" hasScaleBasedVisibilityFlag="0" maxScale="0" simplifyLocal="1" simplifyDrawingHints="0" readOnly="0" styleCategories="AllStyleCategories" simplifyMaxScale="1" version="3.11.0-Master" simplifyDrawingTol="1">
+          <qgis hasScaleBasedVisibilityFlag="0" labelsEnabled="0" maxScale="0" minScale="0" readOnly="0" simplifyAlgorithm="0" simplifyDrawingHints="0" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" version="3.11.0-Master">
             <flags>
               <Identifiable>1</Identifiable>
               <Removable>1</Removable>
               <Searchable>1</Searchable>
             </flags>
-            <renderer-v2 max_value="0" weight_expression="" radius_unit="0" type="heatmapRenderer" radius="10" radius_map_unit_scale="3x:0,0,0,0,0,0" quality="3" enableorderby="0" forceraster="0">
-              <colorramp type="gradient" name="[source]">
-                <prop k="color1" v="255,245,240,0"/>
-                <prop k="color2" v="103,0,13,255"/>
-                <prop k="discrete" v="0"/>
-                <prop k="rampType" v="gradient"/>
-                <prop k="stops" v="0.13;254,224,210,255:0.26;252,187,161,255:0.39;252,146,114,255:0.52;251,106,74,255:0.65;239,59,44,255:0.78;203,24,29,255:0.9;165,15,21,255"/>
+            <renderer-v2 enableorderby="0" forceraster="0" max_value="0" quality="3" radius="10" radius_map_unit_scale="3x:0,0,0,0,0,0" radius_unit="0" type="heatmapRenderer" weight_expression="">
+              <colorramp name="[source]" type="gradient">
+                <prop k="color1" v="255,245,240,0"></prop>
+                <prop k="color2" v="103,0,13,255"></prop>
+                <prop k="discrete" v="0"></prop>
+                <prop k="rampType" v="gradient"></prop>
+                <prop k="stops" v="0.13;254,224,210,255:0.26;252,187,161,255:0.39;252,146,114,255:0.52;251,106,74,255:0.65;239,59,44,255:0.78;203,24,29,255:0.9;165,15,21,255"></prop>
               </colorramp>
             </renderer-v2>
             <customproperties>
-              <property key="embeddedWidgets/count" value="0"/>
-              <property key="isOfflineEditable" value="true"/>
-              <property key="remoteProvider" value="postgres"/>
-              <property key="remoteSource" value="dbname='demo' host=lizmapdemo.opengis.ch port=5432 user='editor1' password='editor1' sslmode=disable key='id' srid=2056 type=Point table=&quot;citybees&quot;.&quot;apiary&quot; (geom) sql="/>
-              <property key="variableNames"/>
-              <property key="variableValues"/>
+              <property key="embeddedWidgets/count" value="0"></property>
+              <property key="isOfflineEditable" value="true"></property>
+              <property key="remoteProvider" value="postgres"></property>
+              <property key="remoteSource" value="dbname='demo' host=lizmapdemo.opengis.ch port=5432 user='editor1' password='editor1' sslmode=disable key='id' srid=2056 type=Point table=&quot;citybees&quot;.&quot;apiary&quot; (geom) sql="></property>
+              <property key="variableNames"></property>
+              <property key="variableValues"></property>
             </customproperties>
             <blendMode>6</blendMode>
             <featureBlendMode>0</featureBlendMode>
             <layerOpacity>0.8</layerOpacity>
             <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
-              <DiagramCategory scaleBasedVisibility="0" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" width="15" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" penAlpha="255" maxScaleDenominator="1e+08" minimumSize="0" direction="1" labelPlacementMethod="XHeight" backgroundColor="#ffffff" height="15" opacity="1" spacingUnitScale="3x:0,0,0,0,0,0" showAxis="0" sizeType="MM" spacingUnit="MM" diagramOrientation="Up" minScaleDenominator="0" spacing="0" penColor="#000000" barWidth="5" backgroundAlpha="255" penWidth="0" enabled="0" rotationOffset="0">
-                <fontProperties style="" description="Cantarell,11,-1,5,50,0,0,0,0,0"/>
-                <attribute color="#000000" label="" field=""/>
+              <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="1" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="0" scaleBasedVisibility="0" scaleDependency="Area" showAxis="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="0" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
+                <fontProperties description="Cantarell,11,-1,5,50,0,0,0,0,0" style=""></fontProperties>
+                <attribute color="#000000" field="" label=""></attribute>
                 <axisSymbol>
-                  <symbol alpha="1" clip_to_extent="1" force_rhr="0" type="line" name="">
-                    <layer pass="0" class="SimpleLine" locked="0" enabled="1">
-                      <prop k="capstyle" v="square"/>
-                      <prop k="customdash" v="5;2"/>
-                      <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                      <prop k="customdash_unit" v="MM"/>
-                      <prop k="draw_inside_polygon" v="0"/>
-                      <prop k="joinstyle" v="bevel"/>
-                      <prop k="line_color" v="35,35,35,255"/>
-                      <prop k="line_style" v="solid"/>
-                      <prop k="line_width" v="0.26"/>
-                      <prop k="line_width_unit" v="MM"/>
-                      <prop k="offset" v="0"/>
-                      <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                      <prop k="offset_unit" v="MM"/>
-                      <prop k="ring_filter" v="0"/>
-                      <prop k="use_custom_dash" v="0"/>
-                      <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+                  <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" type="line">
+                    <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+                      <prop k="capstyle" v="square"></prop>
+                      <prop k="customdash" v="5;2"></prop>
+                      <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                      <prop k="customdash_unit" v="MM"></prop>
+                      <prop k="draw_inside_polygon" v="0"></prop>
+                      <prop k="joinstyle" v="bevel"></prop>
+                      <prop k="line_color" v="35,35,35,255"></prop>
+                      <prop k="line_style" v="solid"></prop>
+                      <prop k="line_width" v="0.26"></prop>
+                      <prop k="line_width_unit" v="MM"></prop>
+                      <prop k="offset" v="0"></prop>
+                      <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                      <prop k="offset_unit" v="MM"></prop>
+                      <prop k="ring_filter" v="0"></prop>
+                      <prop k="use_custom_dash" v="0"></prop>
+                      <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
                       <data_defined_properties>
                         <Option type="Map">
-                          <Option type="QString" value="" name="name"/>
-                          <Option name="properties"/>
-                          <Option type="QString" value="collection" name="type"/>
+                          <Option name="name" type="QString" value=""></Option>
+                          <Option name="properties"></Option>
+                          <Option name="type" type="QString" value="collection"></Option>
                         </Option>
                       </data_defined_properties>
                     </layer>
@@ -917,42 +852,42 @@ def my_form_open(dialog, layer, feature):
                 </axisSymbol>
               </DiagramCategory>
             </SingleCategoryDiagramRenderer>
-            <DiagramLayerSettings obstacle="0" linePlacementFlags="2" zIndex="0" dist="0" placement="0" priority="0" showAll="1">
+            <DiagramLayerSettings dist="0" linePlacementFlags="2" obstacle="0" placement="0" priority="0" showAll="1" zIndex="0">
               <properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
-                  <Option type="Map" name="properties">
-                    <Option type="Map" name="positionX">
-                      <Option type="bool" value="true" name="active"/>
-                      <Option type="QString" value="id" name="field"/>
-                      <Option type="int" value="2" name="type"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties" type="Map">
+                    <Option name="positionX" type="Map">
+                      <Option name="active" type="bool" value="true"></Option>
+                      <Option name="field" type="QString" value="id"></Option>
+                      <Option name="type" type="int" value="2"></Option>
                     </Option>
-                    <Option type="Map" name="positionY">
-                      <Option type="bool" value="true" name="active"/>
-                      <Option type="QString" value="id" name="field"/>
-                      <Option type="int" value="2" name="type"/>
+                    <Option name="positionY" type="Map">
+                      <Option name="active" type="bool" value="true"></Option>
+                      <Option name="field" type="QString" value="id"></Option>
+                      <Option name="type" type="int" value="2"></Option>
                     </Option>
-                    <Option type="Map" name="show">
-                      <Option type="bool" value="true" name="active"/>
-                      <Option type="QString" value="id" name="field"/>
-                      <Option type="int" value="2" name="type"/>
+                    <Option name="show" type="Map">
+                      <Option name="active" type="bool" value="true"></Option>
+                      <Option name="field" type="QString" value="id"></Option>
+                      <Option name="type" type="int" value="2"></Option>
                     </Option>
                   </Option>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </properties>
             </DiagramLayerSettings>
             <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-              <activeChecks/>
-              <checkConfiguration/>
+              <activeChecks></activeChecks>
+              <checkConfiguration></checkConfiguration>
             </geometryOptions>
-            <referencedLayers/>
-            <referencingLayers/>
+            <referencedLayers></referencedLayers>
+            <referencingLayers></referencingLayers>
             <fieldConfiguration>
               <field name="fid">
                 <editWidget type="TextEdit">
                   <config>
-                    <Option/>
+                    <Option></Option>
                   </config>
                 </editWidget>
               </field>
@@ -960,11 +895,11 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="Range">
                   <config>
                     <Option type="Map">
-                      <Option type="QString" value="1" name="AllowNull"/>
-                      <Option type="QString" value="10" name="Max"/>
-                      <Option type="QString" value="1" name="Min"/>
-                      <Option type="QString" value="1" name="Step"/>
-                      <Option type="QString" value="Slider" name="Style"/>
+                      <Option name="AllowNull" type="QString" value="1"></Option>
+                      <Option name="Max" type="QString" value="10"></Option>
+                      <Option name="Min" type="QString" value="1"></Option>
+                      <Option name="Step" type="QString" value="1"></Option>
+                      <Option name="Style" type="QString" value="Slider"></Option>
                     </Option>
                   </config>
                 </editWidget>
@@ -973,10 +908,10 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="ValueMap">
                   <config>
                     <Option type="Map">
-                      <Option type="Map" name="map">
-                        <Option type="QString" value="Apis Mellifera" name="Buckfast bee"/>
-                        <Option type="QString" value="Apis Mellifera Carnica" name="Carniolan honey bee"/>
-                        <Option type="QString" value="Apis Mellifera Mellifera" name="European honey bee"/>
+                      <Option name="map" type="Map">
+                        <Option name="Buckfast bee" type="QString" value="Apis Mellifera"></Option>
+                        <Option name="Carniolan honey bee" type="QString" value="Apis Mellifera Carnica"></Option>
+                        <Option name="European honey bee" type="QString" value="Apis Mellifera Mellifera"></Option>
                       </Option>
                     </Option>
                   </config>
@@ -986,10 +921,10 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="ValueMap">
                   <config>
                     <Option type="Map">
-                      <Option type="Map" name="map">
-                        <Option type="QString" value="10000" name="1000 - 10000"/>
-                        <Option type="QString" value="1000" name="&lt; 1000"/>
-                        <Option type="QString" value="100000" name="> 10000"/>
+                      <Option name="map" type="Map">
+                        <Option name="1000 - 10000" type="QString" value="10000"></Option>
+                        <Option name="&lt; 1000" type="QString" value="1000"></Option>
+                        <Option name="> 10000" type="QString" value="100000"></Option>
                       </Option>
                     </Option>
                   </config>
@@ -999,8 +934,8 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="TextEdit">
                   <config>
                     <Option type="Map">
-                      <Option type="QString" value="0" name="IsMultiline"/>
-                      <Option type="QString" value="0" name="UseHtml"/>
+                      <Option name="IsMultiline" type="QString" value="0"></Option>
+                      <Option name="UseHtml" type="QString" value="0"></Option>
                     </Option>
                   </config>
                 </editWidget>
@@ -1009,19 +944,19 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="ExternalResource">
                   <config>
                     <Option type="Map">
-                      <Option type="int" value="1" name="DocumentViewer"/>
-                      <Option type="int" value="0" name="DocumentViewerHeight"/>
-                      <Option type="int" value="0" name="DocumentViewerWidth"/>
-                      <Option type="bool" value="true" name="FileWidget"/>
-                      <Option type="bool" value="true" name="FileWidgetButton"/>
-                      <Option type="QString" value="" name="FileWidgetFilter"/>
-                      <Option type="Map" name="PropertyCollection">
-                        <Option type="QString" value="" name="name"/>
-                        <Option type="invalid" name="properties"/>
-                        <Option type="QString" value="collection" name="type"/>
+                      <Option name="DocumentViewer" type="int" value="1"></Option>
+                      <Option name="DocumentViewerHeight" type="int" value="0"></Option>
+                      <Option name="DocumentViewerWidth" type="int" value="0"></Option>
+                      <Option name="FileWidget" type="bool" value="true"></Option>
+                      <Option name="FileWidgetButton" type="bool" value="true"></Option>
+                      <Option name="FileWidgetFilter" type="QString" value=""></Option>
+                      <Option name="PropertyCollection" type="Map">
+                        <Option name="name" type="QString" value=""></Option>
+                        <Option name="properties" type="invalid"></Option>
+                        <Option name="type" type="QString" value="collection"></Option>
                       </Option>
-                      <Option type="int" value="1" name="RelativeStorage"/>
-                      <Option type="int" value="0" name="StorageMode"/>
+                      <Option name="RelativeStorage" type="int" value="1"></Option>
+                      <Option name="StorageMode" type="int" value="0"></Option>
                     </Option>
                   </config>
                 </editWidget>
@@ -1030,8 +965,8 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="CheckBox">
                   <config>
                     <Option type="Map">
-                      <Option type="QString" value="t" name="CheckedState"/>
-                      <Option type="QString" value="f" name="UncheckedState"/>
+                      <Option name="CheckedState" type="QString" value="t"></Option>
+                      <Option name="UncheckedState" type="QString" value="f"></Option>
                     </Option>
                   </config>
                 </editWidget>
@@ -1040,9 +975,9 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="ValueMap">
                   <config>
                     <Option type="Map">
-                      <Option type="Map" name="map">
-                        <Option type="QString" value="AFB" name="American Foulbreed"/>
-                        <Option type="QString" value="EFB" name="European Foulbreed"/>
+                      <Option name="map" type="Map">
+                        <Option name="American Foulbreed" type="QString" value="AFB"></Option>
+                        <Option name="European Foulbreed" type="QString" value="EFB"></Option>
                       </Option>
                     </Option>
                   </config>
@@ -1052,11 +987,11 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="Range">
                   <config>
                     <Option type="Map">
-                      <Option type="QString" value="1" name="AllowNull"/>
-                      <Option type="QString" value="100" name="Max"/>
-                      <Option type="QString" value="0" name="Min"/>
-                      <Option type="QString" value="5" name="Step"/>
-                      <Option type="QString" value="SpinBox" name="Style"/>
+                      <Option name="AllowNull" type="QString" value="1"></Option>
+                      <Option name="Max" type="QString" value="100"></Option>
+                      <Option name="Min" type="QString" value="0"></Option>
+                      <Option name="Step" type="QString" value="5"></Option>
+                      <Option name="Style" type="QString" value="SpinBox"></Option>
                     </Option>
                   </config>
                 </editWidget>
@@ -1065,105 +1000,105 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="RelationReference">
                   <config>
                     <Option type="Map">
-                      <Option type="bool" value="false" name="AllowAddFeatures"/>
-                      <Option type="bool" value="true" name="AllowNULL"/>
-                      <Option type="bool" value="true" name="MapIdentification"/>
-                      <Option type="bool" value="false" name="OrderByValue"/>
-                      <Option type="bool" value="false" name="ReadOnly"/>
-                      <Option type="QString" value="apiary_036bee2c_a341_4b84_b25c_1bea7c01e9c2_area_id_area_60ff9e18_ea5b_4814_a227_157fe79ce94c_id" name="Relation"/>
-                      <Option type="bool" value="false" name="ShowForm"/>
-                      <Option type="bool" value="true" name="ShowOpenFormButton"/>
+                      <Option name="AllowAddFeatures" type="bool" value="false"></Option>
+                      <Option name="AllowNULL" type="bool" value="true"></Option>
+                      <Option name="MapIdentification" type="bool" value="true"></Option>
+                      <Option name="OrderByValue" type="bool" value="false"></Option>
+                      <Option name="ReadOnly" type="bool" value="false"></Option>
+                      <Option name="Relation" type="QString" value="apiary_036bee2c_a341_4b84_b25c_1bea7c01e9c2_area_id_area_60ff9e18_ea5b_4814_a227_157fe79ce94c_id"></Option>
+                      <Option name="ShowForm" type="bool" value="false"></Option>
+                      <Option name="ShowOpenFormButton" type="bool" value="true"></Option>
                     </Option>
                   </config>
                 </editWidget>
               </field>
             </fieldConfiguration>
             <aliases>
-              <alias index="0" name="" field="fid"/>
-              <alias index="1" name="Number of Boxes" field="nbr_of_boxes"/>
-              <alias index="2" name="Species of Bees" field="bee_species"/>
-              <alias index="3" name="Amount of Bees" field="bee_amount"/>
-              <alias index="4" name="Beekeeper" field="beekeeper"/>
-              <alias index="5" name="Photo" field="picture"/>
-              <alias index="6" name="Infected" field="disease"/>
-              <alias index="7" name="Kind of Disease" field="kind_of_disease"/>
-              <alias index="8" name="Yearly Harvest (kg)" field="average_harvest"/>
-              <alias index="9" name="Area mostly used" field="area_id"/>
+              <alias field="fid" index="0" name=""></alias>
+              <alias field="nbr_of_boxes" index="1" name="Number of Boxes"></alias>
+              <alias field="bee_species" index="2" name="Species of Bees"></alias>
+              <alias field="bee_amount" index="3" name="Amount of Bees"></alias>
+              <alias field="beekeeper" index="4" name="Beekeeper"></alias>
+              <alias field="picture" index="5" name="Photo"></alias>
+              <alias field="disease" index="6" name="Infected"></alias>
+              <alias field="kind_of_disease" index="7" name="Kind of Disease"></alias>
+              <alias field="average_harvest" index="8" name="Yearly Harvest (kg)"></alias>
+              <alias field="area_id" index="9" name="Area mostly used"></alias>
             </aliases>
-            <excludeAttributesWMS/>
-            <excludeAttributesWFS/>
+            <excludeAttributesWMS></excludeAttributesWMS>
+            <excludeAttributesWFS></excludeAttributesWFS>
             <defaults>
-              <default expression="" applyOnUpdate="0" field="fid"/>
-              <default expression="" applyOnUpdate="0" field="nbr_of_boxes"/>
-              <default expression="" applyOnUpdate="0" field="bee_species"/>
-              <default expression="" applyOnUpdate="0" field="bee_amount"/>
-              <default expression="" applyOnUpdate="0" field="beekeeper"/>
-              <default expression="" applyOnUpdate="0" field="picture"/>
-              <default expression="" applyOnUpdate="0" field="disease"/>
-              <default expression="" applyOnUpdate="0" field="kind_of_disease"/>
-              <default expression="" applyOnUpdate="0" field="average_harvest"/>
-              <default expression="" applyOnUpdate="0" field="area_id"/>
+              <default applyOnUpdate="0" expression="" field="fid"></default>
+              <default applyOnUpdate="0" expression="" field="nbr_of_boxes"></default>
+              <default applyOnUpdate="0" expression="" field="bee_species"></default>
+              <default applyOnUpdate="0" expression="" field="bee_amount"></default>
+              <default applyOnUpdate="0" expression="" field="beekeeper"></default>
+              <default applyOnUpdate="0" expression="" field="picture"></default>
+              <default applyOnUpdate="0" expression="" field="disease"></default>
+              <default applyOnUpdate="0" expression="" field="kind_of_disease"></default>
+              <default applyOnUpdate="0" expression="" field="average_harvest"></default>
+              <default applyOnUpdate="0" expression="" field="area_id"></default>
             </defaults>
             <constraints>
-              <constraint constraints="3" unique_strength="1" exp_strength="0" notnull_strength="1" field="fid"/>
-              <constraint constraints="1" unique_strength="0" exp_strength="0" notnull_strength="1" field="nbr_of_boxes"/>
-              <constraint constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0" field="bee_species"/>
-              <constraint constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0" field="bee_amount"/>
-              <constraint constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0" field="beekeeper"/>
-              <constraint constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0" field="picture"/>
-              <constraint constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0" field="disease"/>
-              <constraint constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0" field="kind_of_disease"/>
-              <constraint constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0" field="average_harvest"/>
-              <constraint constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0" field="area_id"/>
+              <constraint constraints="3" exp_strength="0" field="fid" notnull_strength="1" unique_strength="1"></constraint>
+              <constraint constraints="1" exp_strength="0" field="nbr_of_boxes" notnull_strength="1" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="bee_species" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="bee_amount" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="beekeeper" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="picture" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="disease" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="kind_of_disease" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="average_harvest" notnull_strength="0" unique_strength="0"></constraint>
+              <constraint constraints="0" exp_strength="0" field="area_id" notnull_strength="0" unique_strength="0"></constraint>
             </constraints>
             <constraintExpressions>
-              <constraint desc="" exp="" field="fid"/>
-              <constraint desc="" exp="" field="nbr_of_boxes"/>
-              <constraint desc="" exp="" field="bee_species"/>
-              <constraint desc="" exp="" field="bee_amount"/>
-              <constraint desc="" exp="" field="beekeeper"/>
-              <constraint desc="" exp="" field="picture"/>
-              <constraint desc="" exp="" field="disease"/>
-              <constraint desc="" exp="" field="kind_of_disease"/>
-              <constraint desc="" exp="" field="average_harvest"/>
-              <constraint desc="" exp="" field="area_id"/>
+              <constraint desc="" exp="" field="fid"></constraint>
+              <constraint desc="" exp="" field="nbr_of_boxes"></constraint>
+              <constraint desc="" exp="" field="bee_species"></constraint>
+              <constraint desc="" exp="" field="bee_amount"></constraint>
+              <constraint desc="" exp="" field="beekeeper"></constraint>
+              <constraint desc="" exp="" field="picture"></constraint>
+              <constraint desc="" exp="" field="disease"></constraint>
+              <constraint desc="" exp="" field="kind_of_disease"></constraint>
+              <constraint desc="" exp="" field="average_harvest"></constraint>
+              <constraint desc="" exp="" field="area_id"></constraint>
             </constraintExpressions>
-            <expressionfields/>
+            <expressionfields></expressionfields>
             <attributeactions>
-              <defaultAction key="Canvas" value="{083d0585-5cd8-41d2-8ece-4ee5023fa9a4}"/>
-              <actionsetting notificationMessage="" isEnabledOnlyWhenEditable="0" shortTitle="" action="" type="0" icon="" name="" id="{083d0585-5cd8-41d2-8ece-4ee5023fa9a4}" capture="0">
-                <actionScope id="Feature"/>
-                <actionScope id="Canvas"/>
-                <actionScope id="Field"/>
+              <defaultAction key="Canvas" value="{083d0585-5cd8-41d2-8ece-4ee5023fa9a4}"></defaultAction>
+              <actionsetting action="" capture="0" icon="" id="{083d0585-5cd8-41d2-8ece-4ee5023fa9a4}" isEnabledOnlyWhenEditable="0" name="" notificationMessage="" shortTitle="" type="0">
+                <actionScope id="Feature"></actionScope>
+                <actionScope id="Canvas"></actionScope>
+                <actionScope id="Field"></actionScope>
               </actionsetting>
             </attributeactions>
-            <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+            <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
               <columns>
-                <column width="165" type="field" hidden="0" name="nbr_of_boxes"/>
-                <column width="164" type="field" hidden="0" name="bee_species"/>
-                <column width="192" type="field" hidden="0" name="bee_amount"/>
-                <column width="-1" type="field" hidden="0" name="beekeeper"/>
-                <column width="-1" type="field" hidden="0" name="picture"/>
-                <column width="-1" type="field" hidden="0" name="disease"/>
-                <column width="188" type="field" hidden="0" name="kind_of_disease"/>
-                <column width="-1" type="field" hidden="0" name="review_date"/>
-                <column width="-1" type="field" hidden="0" name="reviewer"/>
-                <column width="-1" type="actions" hidden="1"/>
-                <column width="161" type="field" hidden="0" name="average_harvest"/>
-                <column width="-1" type="field" hidden="0" name="area_id"/>
-                <column width="-1" type="field" hidden="0" name="fid"/>
+                <column hidden="0" name="nbr_of_boxes" type="field" width="165"></column>
+                <column hidden="0" name="bee_species" type="field" width="164"></column>
+                <column hidden="0" name="bee_amount" type="field" width="192"></column>
+                <column hidden="0" name="beekeeper" type="field" width="-1"></column>
+                <column hidden="0" name="picture" type="field" width="-1"></column>
+                <column hidden="0" name="disease" type="field" width="-1"></column>
+                <column hidden="0" name="kind_of_disease" type="field" width="188"></column>
+                <column hidden="0" name="review_date" type="field" width="-1"></column>
+                <column hidden="0" name="reviewer" type="field" width="-1"></column>
+                <column hidden="1" type="actions" width="-1"></column>
+                <column hidden="0" name="average_harvest" type="field" width="161"></column>
+                <column hidden="0" name="area_id" type="field" width="-1"></column>
+                <column hidden="0" name="fid" type="field" width="-1"></column>
               </columns>
             </attributetableconfig>
             <conditionalstyles>
-              <rowstyles/>
-              <fieldstyles/>
+              <rowstyles></rowstyles>
+              <fieldstyles></fieldstyles>
             </conditionalstyles>
-            <storedexpressions/>
+            <storedexpressions></storedexpressions>
             <editform tolerant="1">/run/user/1000/gvfs/mtp:host=SAMSUNG_SAMSUNG_Android_1cc5ab8c12047ece/Phone/qfield/workshop_foss4g2018</editform>
-            <editforminit/>
+            <editforminit></editforminit>
             <editforminitcodesource>0</editforminitcodesource>
             <editforminitfilepath>/run/user/1000/gvfs/mtp:host=SAMSUNG_SAMSUNG_Android_1cc5ab8c12047ece/Phone/qfield/demo_proj_citybees_218</editforminitfilepath>
-            <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+            <editforminitcode># -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -1179,306 +1114,306 @@ from qgis.PyQt.QtWidgets import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-]]></editforminitcode>
+</editforminitcode>
             <featformsuppress>0</featformsuppress>
             <editorlayout>tablayout</editorlayout>
             <attributeEditorForm>
-              <attributeEditorContainer visibilityExpressionEnabled="0" groupBox="0" visibilityExpression="" showLabel="1" name="General" columnCount="1">
-                <attributeEditorField index="1" showLabel="1" name="nbr_of_boxes"/>
-                <attributeEditorField index="2" showLabel="1" name="bee_species"/>
-                <attributeEditorField index="3" showLabel="1" name="bee_amount"/>
-                <attributeEditorField index="4" showLabel="1" name="beekeeper"/>
-                <attributeEditorField index="8" showLabel="1" name="average_harvest"/>
+              <attributeEditorContainer columnCount="1" groupBox="0" name="General" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+                <attributeEditorField index="1" name="nbr_of_boxes" showLabel="1"></attributeEditorField>
+                <attributeEditorField index="2" name="bee_species" showLabel="1"></attributeEditorField>
+                <attributeEditorField index="3" name="bee_amount" showLabel="1"></attributeEditorField>
+                <attributeEditorField index="4" name="beekeeper" showLabel="1"></attributeEditorField>
+                <attributeEditorField index="8" name="average_harvest" showLabel="1"></attributeEditorField>
               </attributeEditorContainer>
-              <attributeEditorContainer visibilityExpressionEnabled="0" groupBox="0" visibilityExpression="" showLabel="1" name="Picture" columnCount="1">
-                <attributeEditorField index="5" showLabel="1" name="picture"/>
+              <attributeEditorContainer columnCount="1" groupBox="0" name="Picture" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+                <attributeEditorField index="5" name="picture" showLabel="1"></attributeEditorField>
               </attributeEditorContainer>
-              <attributeEditorContainer visibilityExpressionEnabled="0" groupBox="0" visibilityExpression="" showLabel="1" name="Issues" columnCount="1">
-                <attributeEditorField index="6" showLabel="1" name="disease"/>
-                <attributeEditorContainer visibilityExpressionEnabled="1" groupBox="1" visibilityExpression="disease in ('t', true, 1)" showLabel="1" name="Disease" columnCount="1">
-                  <attributeEditorField index="7" showLabel="1" name="kind_of_disease"/>
+              <attributeEditorContainer columnCount="1" groupBox="0" name="Issues" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+                <attributeEditorField index="6" name="disease" showLabel="1"></attributeEditorField>
+                <attributeEditorContainer columnCount="1" groupBox="1" name="Disease" showLabel="1" visibilityExpression="disease in ('t', true, 1)" visibilityExpressionEnabled="1">
+                  <attributeEditorField index="7" name="kind_of_disease" showLabel="1"></attributeEditorField>
                 </attributeEditorContainer>
               </attributeEditorContainer>
-              <attributeEditorContainer visibilityExpressionEnabled="0" groupBox="0" visibilityExpression="" showLabel="1" name="Review" columnCount="1">
-                <attributeEditorField index="-1" showLabel="1" name="review_date"/>
-                <attributeEditorField index="-1" showLabel="1" name="reviewer"/>
+              <attributeEditorContainer columnCount="1" groupBox="0" name="Review" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+                <attributeEditorField index="-1" name="review_date" showLabel="1"></attributeEditorField>
+                <attributeEditorField index="-1" name="reviewer" showLabel="1"></attributeEditorField>
               </attributeEditorContainer>
-              <attributeEditorContainer visibilityExpressionEnabled="0" groupBox="0" visibilityExpression="" showLabel="1" name="Area" columnCount="1">
-                <attributeEditorField index="9" showLabel="1" name="area_id"/>
+              <attributeEditorContainer columnCount="1" groupBox="0" name="Area" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+                <attributeEditorField index="9" name="area_id" showLabel="1"></attributeEditorField>
               </attributeEditorContainer>
             </attributeEditorForm>
             <editable>
-              <field editable="1" name="area_id"/>
-              <field editable="1" name="average_harvest"/>
-              <field editable="1" name="bee_amount"/>
-              <field editable="1" name="bee_species"/>
-              <field editable="1" name="beekeeper"/>
-              <field editable="1" name="disease"/>
-              <field editable="1" name="fid"/>
-              <field editable="1" name="id"/>
-              <field editable="1" name="kind_of_disease"/>
-              <field editable="1" name="nbr_of_boxes"/>
-              <field editable="1" name="picture"/>
-              <field editable="1" name="review_date"/>
-              <field editable="1" name="reviewer"/>
+              <field editable="1" name="area_id"></field>
+              <field editable="1" name="average_harvest"></field>
+              <field editable="1" name="bee_amount"></field>
+              <field editable="1" name="bee_species"></field>
+              <field editable="1" name="beekeeper"></field>
+              <field editable="1" name="disease"></field>
+              <field editable="1" name="fid"></field>
+              <field editable="1" name="id"></field>
+              <field editable="1" name="kind_of_disease"></field>
+              <field editable="1" name="nbr_of_boxes"></field>
+              <field editable="1" name="picture"></field>
+              <field editable="1" name="review_date"></field>
+              <field editable="1" name="reviewer"></field>
             </editable>
             <labelOnTop>
-              <field labelOnTop="0" name="area_id"/>
-              <field labelOnTop="0" name="average_harvest"/>
-              <field labelOnTop="0" name="bee_amount"/>
-              <field labelOnTop="0" name="bee_species"/>
-              <field labelOnTop="0" name="beekeeper"/>
-              <field labelOnTop="0" name="disease"/>
-              <field labelOnTop="0" name="fid"/>
-              <field labelOnTop="0" name="id"/>
-              <field labelOnTop="0" name="kind_of_disease"/>
-              <field labelOnTop="0" name="nbr_of_boxes"/>
-              <field labelOnTop="0" name="picture"/>
-              <field labelOnTop="0" name="review_date"/>
-              <field labelOnTop="0" name="reviewer"/>
+              <field labelOnTop="0" name="area_id"></field>
+              <field labelOnTop="0" name="average_harvest"></field>
+              <field labelOnTop="0" name="bee_amount"></field>
+              <field labelOnTop="0" name="bee_species"></field>
+              <field labelOnTop="0" name="beekeeper"></field>
+              <field labelOnTop="0" name="disease"></field>
+              <field labelOnTop="0" name="fid"></field>
+              <field labelOnTop="0" name="id"></field>
+              <field labelOnTop="0" name="kind_of_disease"></field>
+              <field labelOnTop="0" name="nbr_of_boxes"></field>
+              <field labelOnTop="0" name="picture"></field>
+              <field labelOnTop="0" name="review_date"></field>
+              <field labelOnTop="0" name="reviewer"></field>
             </labelOnTop>
             <widgets>
               <widget name="Pollen_Con_apiary_id_apiary_279_fid">
                 <config type="Map">
-                  <Option type="QString" value="" name="nm-rel"/>
+                  <Option name="nm-rel" type="QString" value=""></Option>
                 </config>
               </widget>
               <widget name="Reviews_c8_apiary_id_apiary_279_fid">
                 <config type="Map">
-                  <Option type="QString" value="" name="nm-rel"/>
+                  <Option name="nm-rel" type="QString" value=""></Option>
                 </config>
               </widget>
               <widget name="ref_apiary_apiary_id_apiary2018_id">
-                <config/>
+                <config></config>
               </widget>
             </widgets>
             <previewExpression>beekeeper+' - '+bee_species</previewExpression>
-            <mapTip/>
+            <mapTip></mapTip>
             <layerGeometryType>0</layerGeometryType>
           </qgis>
         </map-layer-style>
-        <map-layer-style name="Species"/>
+        <map-layer-style name="Species"></map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
+      <auxiliaryLayer></auxiliaryLayer>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
       </flags>
-      <renderer-v2 toleranceUnitScale="3x:0,0,0,0,0,0" tolerance="15" toleranceUnit="MM" type="pointCluster" enableorderby="0" forceraster="0">
-        <renderer-v2 symbollevels="0" type="categorizedSymbol" attr="bee_species" enableorderby="0" forceraster="0">
+      <renderer-v2 enableorderby="0" forceraster="0" tolerance="15" toleranceUnit="MM" toleranceUnitScale="3x:0,0,0,0,0,0" type="pointCluster">
+        <renderer-v2 attr="bee_species" enableorderby="0" forceraster="0" symbollevels="0" type="categorizedSymbol">
           <categories>
-            <category render="true" label="European honey bee" value="Apis Mellifera Mellifera" symbol="0"/>
-            <category render="true" label="Buckfast bee" value="Apis Mellifera" symbol="1"/>
-            <category render="true" label="Carniolan honey bee" value="Apis Mellifera Carnica" symbol="2"/>
+            <category label="European honey bee" render="true" symbol="0" value="Apis Mellifera Mellifera"></category>
+            <category label="Buckfast bee" render="true" symbol="1" value="Apis Mellifera"></category>
+            <category label="Carniolan honey bee" render="true" symbol="2" value="Apis Mellifera Carnica"></category>
           </categories>
           <symbols>
-            <symbol alpha="1" clip_to_extent="1" force_rhr="0" type="marker" name="0">
-              <layer pass="0" class="SimpleMarker" locked="0" enabled="1">
-                <prop k="angle" v="0"/>
-                <prop k="color" v="154,150,84,255"/>
-                <prop k="horizontal_anchor_point" v="1"/>
-                <prop k="joinstyle" v="miter"/>
-                <prop k="name" v="hexagon"/>
-                <prop k="offset" v="0,0"/>
-                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="offset_unit" v="MM"/>
-                <prop k="outline_color" v="250,139,57,255"/>
-                <prop k="outline_style" v="solid"/>
-                <prop k="outline_width" v="1"/>
-                <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="outline_width_unit" v="MM"/>
-                <prop k="scale_method" v="diameter"/>
-                <prop k="size" v="6.8"/>
-                <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="size_unit" v="MM"/>
-                <prop k="vertical_anchor_point" v="1"/>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="0" type="marker">
+              <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                <prop k="angle" v="0"></prop>
+                <prop k="color" v="154,150,84,255"></prop>
+                <prop k="horizontal_anchor_point" v="1"></prop>
+                <prop k="joinstyle" v="miter"></prop>
+                <prop k="name" v="hexagon"></prop>
+                <prop k="offset" v="0,0"></prop>
+                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="offset_unit" v="MM"></prop>
+                <prop k="outline_color" v="250,139,57,255"></prop>
+                <prop k="outline_style" v="solid"></prop>
+                <prop k="outline_width" v="1"></prop>
+                <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="outline_width_unit" v="MM"></prop>
+                <prop k="scale_method" v="diameter"></prop>
+                <prop k="size" v="6.8"></prop>
+                <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="size_unit" v="MM"></prop>
+                <prop k="vertical_anchor_point" v="1"></prop>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option type="QString" value="" name="name"/>
-                    <Option name="properties"/>
-                    <Option type="QString" value="collection" name="type"/>
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
                   </Option>
                 </data_defined_properties>
               </layer>
             </symbol>
-            <symbol alpha="1" clip_to_extent="1" force_rhr="0" type="marker" name="1">
-              <layer pass="0" class="SimpleMarker" locked="0" enabled="1">
-                <prop k="angle" v="0"/>
-                <prop k="color" v="112,142,166,255"/>
-                <prop k="horizontal_anchor_point" v="1"/>
-                <prop k="joinstyle" v="miter"/>
-                <prop k="name" v="hexagon"/>
-                <prop k="offset" v="0,0"/>
-                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="offset_unit" v="MM"/>
-                <prop k="outline_color" v="250,139,57,255"/>
-                <prop k="outline_style" v="solid"/>
-                <prop k="outline_width" v="1"/>
-                <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="outline_width_unit" v="MM"/>
-                <prop k="scale_method" v="diameter"/>
-                <prop k="size" v="6.8"/>
-                <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="size_unit" v="MM"/>
-                <prop k="vertical_anchor_point" v="1"/>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="1" type="marker">
+              <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                <prop k="angle" v="0"></prop>
+                <prop k="color" v="112,142,166,255"></prop>
+                <prop k="horizontal_anchor_point" v="1"></prop>
+                <prop k="joinstyle" v="miter"></prop>
+                <prop k="name" v="hexagon"></prop>
+                <prop k="offset" v="0,0"></prop>
+                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="offset_unit" v="MM"></prop>
+                <prop k="outline_color" v="250,139,57,255"></prop>
+                <prop k="outline_style" v="solid"></prop>
+                <prop k="outline_width" v="1"></prop>
+                <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="outline_width_unit" v="MM"></prop>
+                <prop k="scale_method" v="diameter"></prop>
+                <prop k="size" v="6.8"></prop>
+                <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="size_unit" v="MM"></prop>
+                <prop k="vertical_anchor_point" v="1"></prop>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option type="QString" value="" name="name"/>
-                    <Option name="properties"/>
-                    <Option type="QString" value="collection" name="type"/>
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
                   </Option>
                 </data_defined_properties>
               </layer>
             </symbol>
-            <symbol alpha="1" clip_to_extent="1" force_rhr="0" type="marker" name="2">
-              <layer pass="0" class="SimpleMarker" locked="0" enabled="1">
-                <prop k="angle" v="0"/>
-                <prop k="color" v="79,94,69,255"/>
-                <prop k="horizontal_anchor_point" v="1"/>
-                <prop k="joinstyle" v="miter"/>
-                <prop k="name" v="hexagon"/>
-                <prop k="offset" v="0,0"/>
-                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="offset_unit" v="MM"/>
-                <prop k="outline_color" v="250,139,57,255"/>
-                <prop k="outline_style" v="solid"/>
-                <prop k="outline_width" v="1"/>
-                <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="outline_width_unit" v="MM"/>
-                <prop k="scale_method" v="diameter"/>
-                <prop k="size" v="6.8"/>
-                <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="size_unit" v="MM"/>
-                <prop k="vertical_anchor_point" v="1"/>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="2" type="marker">
+              <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                <prop k="angle" v="0"></prop>
+                <prop k="color" v="79,94,69,255"></prop>
+                <prop k="horizontal_anchor_point" v="1"></prop>
+                <prop k="joinstyle" v="miter"></prop>
+                <prop k="name" v="hexagon"></prop>
+                <prop k="offset" v="0,0"></prop>
+                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="offset_unit" v="MM"></prop>
+                <prop k="outline_color" v="250,139,57,255"></prop>
+                <prop k="outline_style" v="solid"></prop>
+                <prop k="outline_width" v="1"></prop>
+                <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="outline_width_unit" v="MM"></prop>
+                <prop k="scale_method" v="diameter"></prop>
+                <prop k="size" v="6.8"></prop>
+                <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="size_unit" v="MM"></prop>
+                <prop k="vertical_anchor_point" v="1"></prop>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option type="QString" value="" name="name"/>
-                    <Option name="properties"/>
-                    <Option type="QString" value="collection" name="type"/>
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
                   </Option>
                 </data_defined_properties>
               </layer>
             </symbol>
           </symbols>
           <source-symbol>
-            <symbol alpha="1" clip_to_extent="1" force_rhr="0" type="marker" name="0">
-              <layer pass="0" class="SimpleMarker" locked="0" enabled="1">
-                <prop k="angle" v="0"/>
-                <prop k="color" v="255,255,255,255"/>
-                <prop k="horizontal_anchor_point" v="1"/>
-                <prop k="joinstyle" v="miter"/>
-                <prop k="name" v="hexagon"/>
-                <prop k="offset" v="0,0"/>
-                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="offset_unit" v="MM"/>
-                <prop k="outline_color" v="250,139,57,255"/>
-                <prop k="outline_style" v="solid"/>
-                <prop k="outline_width" v="1"/>
-                <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="outline_width_unit" v="MM"/>
-                <prop k="scale_method" v="diameter"/>
-                <prop k="size" v="8.8"/>
-                <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="size_unit" v="MM"/>
-                <prop k="vertical_anchor_point" v="1"/>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="0" type="marker">
+              <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                <prop k="angle" v="0"></prop>
+                <prop k="color" v="255,255,255,255"></prop>
+                <prop k="horizontal_anchor_point" v="1"></prop>
+                <prop k="joinstyle" v="miter"></prop>
+                <prop k="name" v="hexagon"></prop>
+                <prop k="offset" v="0,0"></prop>
+                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="offset_unit" v="MM"></prop>
+                <prop k="outline_color" v="250,139,57,255"></prop>
+                <prop k="outline_style" v="solid"></prop>
+                <prop k="outline_width" v="1"></prop>
+                <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="outline_width_unit" v="MM"></prop>
+                <prop k="scale_method" v="diameter"></prop>
+                <prop k="size" v="8.8"></prop>
+                <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="size_unit" v="MM"></prop>
+                <prop k="vertical_anchor_point" v="1"></prop>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option type="QString" value="" name="name"/>
-                    <Option name="properties"/>
-                    <Option type="QString" value="collection" name="type"/>
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
                   </Option>
                 </data_defined_properties>
               </layer>
-              <layer pass="0" class="SimpleMarker" locked="0" enabled="1">
-                <prop k="angle" v="0"/>
-                <prop k="color" v="250,176,124,255"/>
-                <prop k="horizontal_anchor_point" v="1"/>
-                <prop k="joinstyle" v="bevel"/>
-                <prop k="name" v="hexagon"/>
-                <prop k="offset" v="0,0"/>
-                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="offset_unit" v="MM"/>
-                <prop k="outline_color" v="250,176,124,255"/>
-                <prop k="outline_style" v="solid"/>
-                <prop k="outline_width" v="0.2"/>
-                <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="outline_width_unit" v="MM"/>
-                <prop k="scale_method" v="diameter"/>
-                <prop k="size" v="3.6"/>
-                <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="size_unit" v="MM"/>
-                <prop k="vertical_anchor_point" v="1"/>
+              <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                <prop k="angle" v="0"></prop>
+                <prop k="color" v="250,176,124,255"></prop>
+                <prop k="horizontal_anchor_point" v="1"></prop>
+                <prop k="joinstyle" v="bevel"></prop>
+                <prop k="name" v="hexagon"></prop>
+                <prop k="offset" v="0,0"></prop>
+                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="offset_unit" v="MM"></prop>
+                <prop k="outline_color" v="250,176,124,255"></prop>
+                <prop k="outline_style" v="solid"></prop>
+                <prop k="outline_width" v="0.2"></prop>
+                <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="outline_width_unit" v="MM"></prop>
+                <prop k="scale_method" v="diameter"></prop>
+                <prop k="size" v="3.6"></prop>
+                <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="size_unit" v="MM"></prop>
+                <prop k="vertical_anchor_point" v="1"></prop>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option type="QString" value="" name="name"/>
-                    <Option name="properties"/>
-                    <Option type="QString" value="collection" name="type"/>
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
                   </Option>
                 </data_defined_properties>
               </layer>
             </symbol>
           </source-symbol>
-          <rotation/>
-          <sizescale/>
+          <rotation></rotation>
+          <sizescale></sizescale>
         </renderer-v2>
-        <symbol alpha="1" clip_to_extent="1" force_rhr="0" type="marker" name="centerSymbol">
-          <layer pass="0" class="SimpleMarker" locked="0" enabled="1">
-            <prop k="angle" v="0"/>
-            <prop k="color" v="255,255,255,255"/>
-            <prop k="horizontal_anchor_point" v="1"/>
-            <prop k="joinstyle" v="miter"/>
-            <prop k="name" v="hexagon"/>
-            <prop k="offset" v="0,0"/>
-            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-            <prop k="offset_unit" v="MM"/>
-            <prop k="outline_color" v="250,139,57,255"/>
-            <prop k="outline_style" v="solid"/>
-            <prop k="outline_width" v="1"/>
-            <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-            <prop k="outline_width_unit" v="MM"/>
-            <prop k="scale_method" v="diameter"/>
-            <prop k="size" v="10.8"/>
-            <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-            <prop k="size_unit" v="MM"/>
-            <prop k="vertical_anchor_point" v="1"/>
+        <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="centerSymbol" type="marker">
+          <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+            <prop k="angle" v="0"></prop>
+            <prop k="color" v="255,255,255,255"></prop>
+            <prop k="horizontal_anchor_point" v="1"></prop>
+            <prop k="joinstyle" v="miter"></prop>
+            <prop k="name" v="hexagon"></prop>
+            <prop k="offset" v="0,0"></prop>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+            <prop k="offset_unit" v="MM"></prop>
+            <prop k="outline_color" v="250,139,57,255"></prop>
+            <prop k="outline_style" v="solid"></prop>
+            <prop k="outline_width" v="1"></prop>
+            <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+            <prop k="outline_width_unit" v="MM"></prop>
+            <prop k="scale_method" v="diameter"></prop>
+            <prop k="size" v="10.8"></prop>
+            <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+            <prop k="size_unit" v="MM"></prop>
+            <prop k="vertical_anchor_point" v="1"></prop>
             <data_defined_properties>
               <Option type="Map">
-                <Option type="QString" value="" name="name"/>
-                <Option name="properties"/>
-                <Option type="QString" value="collection" name="type"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
           </layer>
-          <layer pass="0" class="FontMarker" locked="0" enabled="1">
-            <prop k="angle" v="0"/>
-            <prop k="chr" v="A"/>
-            <prop k="color" v="250,176,124,255"/>
-            <prop k="font" v="Cantarell"/>
-            <prop k="horizontal_anchor_point" v="1"/>
-            <prop k="joinstyle" v="bevel"/>
-            <prop k="offset" v="0,-1.20000000000000218"/>
-            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-            <prop k="offset_unit" v="MM"/>
-            <prop k="outline_color" v="35,35,35,255"/>
-            <prop k="outline_width" v="0"/>
-            <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-            <prop k="outline_width_unit" v="MM"/>
-            <prop k="size" v="6"/>
-            <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-            <prop k="size_unit" v="MM"/>
-            <prop k="vertical_anchor_point" v="1"/>
+          <layer class="FontMarker" enabled="1" locked="0" pass="0">
+            <prop k="angle" v="0"></prop>
+            <prop k="chr" v="A"></prop>
+            <prop k="color" v="250,176,124,255"></prop>
+            <prop k="font" v="Cantarell"></prop>
+            <prop k="horizontal_anchor_point" v="1"></prop>
+            <prop k="joinstyle" v="bevel"></prop>
+            <prop k="offset" v="0,-1.20000000000000218"></prop>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+            <prop k="offset_unit" v="MM"></prop>
+            <prop k="outline_color" v="35,35,35,255"></prop>
+            <prop k="outline_width" v="0"></prop>
+            <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+            <prop k="outline_width_unit" v="MM"></prop>
+            <prop k="size" v="6"></prop>
+            <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+            <prop k="size_unit" v="MM"></prop>
+            <prop k="vertical_anchor_point" v="1"></prop>
             <data_defined_properties>
               <Option type="Map">
-                <Option type="QString" value="" name="name"/>
-                <Option type="Map" name="properties">
-                  <Option type="Map" name="char">
-                    <Option type="bool" value="true" name="active"/>
-                    <Option type="QString" value="@cluster_size" name="expression"/>
-                    <Option type="int" value="3" name="type"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties" type="Map">
+                  <Option name="char" type="Map">
+                    <Option name="active" type="bool" value="true"></Option>
+                    <Option name="expression" type="QString" value="@cluster_size"></Option>
+                    <Option name="type" type="int" value="3"></Option>
                   </Option>
                 </Option>
-                <Option type="QString" value="collection" name="type"/>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
           </layer>
@@ -1486,95 +1421,126 @@ def my_form_open(dialog, layer, feature):
       </renderer-v2>
       <labeling type="simple">
         <settings calloutType="simple">
-          <text-style textColor="0,0,0,255" fontFamily="Sans Serif" isExpression="1" textOpacity="1" useSubstitutions="0" fontUnderline="0" fontKerning="1" fontWordSpacing="0" fontCapitals="0" namedStyle="Regular" fontSizeMapUnitScale="3x:0,0,0,0,0,0" textOrientation="horizontal" fontWeight="50" fontItalic="0" fieldName="concat(&quot;bee_amount&quot; ,  ' (' || nbr_of_boxes || ' boxes)' )" previewBkgrdColor="255,255,255,255" multilineHeight="1" fontSizeUnit="Point" fontLetterSpacing="0" fontStrikeout="0" fontSize="12" blendMode="0">
-            <text-buffer bufferSize="1" bufferOpacity="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferNoFill="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferSizeUnits="MM"/>
-            <text-mask maskJoinStyle="128" maskedSymbolLayers="" maskType="0" maskSizeUnits="MM" maskOpacity="1" maskSize="0" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0"/>
-            <background shapeOffsetX="0" shapeRotationType="0" shapeType="0" shapeRadiiUnit="MM" shapeSizeY="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeBlendMode="0" shapeOffsetY="0" shapeFillColor="255,255,255,255" shapeSizeType="0" shapeBorderWidth="0" shapeJoinStyle="64" shapeDraw="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOpacity="1" shapeSVGFile="" shapeOffsetUnit="MM" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeX="0" shapeBorderColor="128,128,128,255" shapeRotation="0" shapeRadiiY="0"/>
-            <shadow shadowOffsetUnit="MM" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowBlendMode="6" shadowOffsetDist="1" shadowOffsetAngle="135" shadowColor="0,0,0,255" shadowOpacity="0.7" shadowDraw="0" shadowRadius="1.5" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowUnder="0" shadowRadiusAlphaOnly="0" shadowRadiusUnit="MM"/>
+          <text-style blendMode="0" fieldName="concat(&quot;bee_amount&quot; ,  ' (' || nbr_of_boxes || ' boxes)' )" fontCapitals="0" fontFamily="Sans Serif" fontItalic="0" fontKerning="1" fontLetterSpacing="0" fontSize="12" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontStrikeout="0" fontUnderline="0" fontWeight="50" fontWordSpacing="0" isExpression="1" multilineHeight="1" namedStyle="Normal" previewBkgrdColor="255,255,255,255" textColor="0,0,0,255" textOpacity="1" textOrientation="horizontal" useSubstitutions="0">
+            <text-buffer bufferBlendMode="0" bufferColor="255,255,255,255" bufferDraw="0" bufferJoinStyle="128" bufferNoFill="1" bufferOpacity="1" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM"></text-buffer>
+            <text-mask maskEnabled="0" maskJoinStyle="128" maskOpacity="1" maskSize="0" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSizeUnits="MM" maskType="0" maskedSymbolLayers=""></text-mask>
+            <background shapeBlendMode="0" shapeBorderColor="128,128,128,255" shapeBorderWidth="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeDraw="0" shapeFillColor="255,255,255,255" shapeJoinStyle="64" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeOffsetY="0" shapeOpacity="1" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiUnit="MM" shapeRadiiX="0" shapeRadiiY="0" shapeRotation="0" shapeRotationType="0" shapeSVGFile="" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeSizeUnit="MM" shapeSizeX="0" shapeSizeY="0" shapeType="0">
+              <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="markerSymbol" type="marker">
+                <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                  <prop k="angle" v="0"></prop>
+                  <prop k="color" v="255,158,23,255"></prop>
+                  <prop k="horizontal_anchor_point" v="1"></prop>
+                  <prop k="joinstyle" v="bevel"></prop>
+                  <prop k="name" v="circle"></prop>
+                  <prop k="offset" v="0,0"></prop>
+                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="offset_unit" v="MM"></prop>
+                  <prop k="outline_color" v="35,35,35,255"></prop>
+                  <prop k="outline_style" v="solid"></prop>
+                  <prop k="outline_width" v="0"></prop>
+                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="outline_width_unit" v="MM"></prop>
+                  <prop k="scale_method" v="diameter"></prop>
+                  <prop k="size" v="2"></prop>
+                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="size_unit" v="MM"></prop>
+                  <prop k="vertical_anchor_point" v="1"></prop>
+                  <data_defined_properties>
+                    <Option type="Map">
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
+                    </Option>
+                  </data_defined_properties>
+                </layer>
+              </symbol>
+            </background>
+            <shadow shadowBlendMode="6" shadowColor="0,0,0,255" shadowDraw="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowOpacity="0.7" shadowRadius="1.5" shadowRadiusAlphaOnly="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowUnder="0"></shadow>
             <dd_properties>
               <Option type="Map">
-                <Option type="QString" value="" name="name"/>
-                <Option name="properties"/>
-                <Option type="QString" value="collection" name="type"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </dd_properties>
-            <substitutions/>
+            <substitutions></substitutions>
           </text-style>
-          <text-format wrapChar="" formatNumbers="0" addDirectionSymbol="0" plussign="0" useMaxLineLengthForAutoWrap="1" decimals="3" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;" rightDirectionSymbol=">" multilineAlign="3" autoWrapLength="0"/>
-          <placement repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" rotationAngle="0" xOffset="0" maxCurvedCharAngleOut="-25" offsetType="0" geometryGeneratorEnabled="0" layerType="UnknownGeometry" repeatDistance="0" quadOffset="4" offsetUnits="MM" overrunDistanceUnit="MM" fitInPolygonOnly="0" centroidWhole="0" geometryGenerator="" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" placement="0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" distMapUnitScale="3x:0,0,0,0,0,0" overrunDistance="0" preserveRotation="1" priority="5" yOffset="0" maxCurvedCharAngleIn="25" dist="4.5" centroidInside="0" repeatDistanceUnits="MM" placementFlags="10" distUnits="MM" geometryGeneratorType="PointGeometry"/>
-          <rendering fontMaxPixelSize="10000" scaleMin="0" minFeatureSize="0" limitNumLabels="0" mergeLines="0" obstacleType="0" maxNumLabels="2000" labelPerPart="0" scaleMax="2500" zIndex="0" upsidedownLabels="0" drawLabels="1" fontLimitPixelSize="0" obstacleFactor="1" fontMinPixelSize="3" obstacle="1" displayAll="0" scaleVisibility="1"/>
+          <text-format addDirectionSymbol="0" autoWrapLength="0" decimals="3" formatNumbers="0" leftDirectionSymbol="&lt;" multilineAlign="3" placeDirectionSymbol="0" plussign="0" reverseDirectionSymbol="0" rightDirectionSymbol=">" useMaxLineLengthForAutoWrap="1" wrapChar=""></text-format>
+          <placement centroidInside="0" centroidWhole="0" dist="4.5" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" fitInPolygonOnly="0" geometryGenerator="" geometryGeneratorEnabled="0" geometryGeneratorType="PointGeometry" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" layerType="PointGeometry" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" offsetType="0" offsetUnits="MM" overrunDistance="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" placement="0" placementFlags="10" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" preserveRotation="1" priority="5" quadOffset="4" repeatDistance="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" rotationAngle="0" xOffset="0" yOffset="0"></placement>
+          <rendering displayAll="0" drawLabels="1" fontLimitPixelSize="0" fontMaxPixelSize="10000" fontMinPixelSize="3" labelPerPart="0" limitNumLabels="0" maxNumLabels="2000" mergeLines="0" minFeatureSize="0" obstacle="1" obstacleFactor="1" obstacleType="0" scaleMax="2500" scaleMin="0" scaleVisibility="1" upsidedownLabels="0" zIndex="0"></rendering>
           <dd_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
-              <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option type="QString" value="pole_of_inaccessibility" name="anchorPoint"/>
-              <Option type="Map" name="ddProperties">
-                <Option type="QString" value="" name="name"/>
-                <Option name="properties"/>
-                <Option type="QString" value="collection" name="type"/>
+              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility"></Option>
+              <Option name="ddProperties" type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
-              <Option type="bool" value="false" name="drawToAllParts"/>
-              <Option type="QString" value="0" name="enabled"/>
-              <Option type="QString" value="&lt;symbol alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; name=&quot;symbol&quot;>&lt;layer pass=&quot;0&quot; class=&quot;SimpleLine&quot; locked=&quot;0&quot; enabled=&quot;1&quot;>&lt;prop k=&quot;capstyle&quot; v=&quot;square&quot;/>&lt;prop k=&quot;customdash&quot; v=&quot;5;2&quot;/>&lt;prop k=&quot;customdash_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;customdash_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;draw_inside_polygon&quot; v=&quot;0&quot;/>&lt;prop k=&quot;joinstyle&quot; v=&quot;bevel&quot;/>&lt;prop k=&quot;line_color&quot; v=&quot;60,60,60,255&quot;/>&lt;prop k=&quot;line_style&quot; v=&quot;solid&quot;/>&lt;prop k=&quot;line_width&quot; v=&quot;0.3&quot;/>&lt;prop k=&quot;line_width_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;offset&quot; v=&quot;0&quot;/>&lt;prop k=&quot;offset_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;offset_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;ring_filter&quot; v=&quot;0&quot;/>&lt;prop k=&quot;use_custom_dash&quot; v=&quot;0&quot;/>&lt;prop k=&quot;width_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol"/>
-              <Option type="double" value="0" name="minLength"/>
-              <Option type="QString" value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale"/>
-              <Option type="QString" value="MM" name="minLengthUnit"/>
-              <Option type="double" value="0" name="offsetFromAnchor"/>
-              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale"/>
-              <Option type="QString" value="MM" name="offsetFromAnchorUnit"/>
-              <Option type="double" value="0" name="offsetFromLabel"/>
-              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale"/>
-              <Option type="QString" value="MM" name="offsetFromLabelUnit"/>
+              <Option name="drawToAllParts" type="bool" value="false"></Option>
+              <Option name="enabled" type="QString" value="0"></Option>
+              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior"></Option>
+              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; clip_to_extent=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; alpha=&quot;1&quot;>&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;>&lt;prop k=&quot;capstyle&quot; v=&quot;square&quot;/>&lt;prop k=&quot;customdash&quot; v=&quot;5;2&quot;/>&lt;prop k=&quot;customdash_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;customdash_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;draw_inside_polygon&quot; v=&quot;0&quot;/>&lt;prop k=&quot;joinstyle&quot; v=&quot;bevel&quot;/>&lt;prop k=&quot;line_color&quot; v=&quot;60,60,60,255&quot;/>&lt;prop k=&quot;line_style&quot; v=&quot;solid&quot;/>&lt;prop k=&quot;line_width&quot; v=&quot;0.3&quot;/>&lt;prop k=&quot;line_width_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;offset&quot; v=&quot;0&quot;/>&lt;prop k=&quot;offset_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;offset_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;ring_filter&quot; v=&quot;0&quot;/>&lt;prop k=&quot;use_custom_dash&quot; v=&quot;0&quot;/>&lt;prop k=&quot;width_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>"></Option>
+              <Option name="minLength" type="double" value="0"></Option>
+              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="minLengthUnit" type="QString" value="MM"></Option>
+              <Option name="offsetFromAnchor" type="double" value="0"></Option>
+              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="offsetFromAnchorUnit" type="QString" value="MM"></Option>
+              <Option name="offsetFromLabel" type="double" value="0"></Option>
+              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="offsetFromLabelUnit" type="QString" value="MM"></Option>
             </Option>
           </callout>
         </settings>
       </labeling>
       <customproperties>
-        <property key="QFieldSync/action" value="offline"/>
-        <property key="dualview/previewExpressions" value="concat( &quot;beekeeper&quot;,  ' - ' ||  represent_value( &quot;bee_species&quot; ) )"/>
-        <property key="embeddedWidgets/count" value="0"/>
-        <property key="isOfflineEditable" value="true"/>
-        <property key="remoteProvider" value="postgres"/>
-        <property key="remoteSource" value="dbname='demo' host=lizmapdemo.opengis.ch port=5432 user='editor1' password='editor1' sslmode=disable key='id' srid=2056 type=Point table=&quot;citybees&quot;.&quot;apiary&quot; (geom) sql="/>
-        <property key="variableNames"/>
-        <property key="variableValues"/>
+        <property key="QFieldSync/action" value="offline"></property>
+        <property key="dualview/previewExpressions" value="concat( &quot;beekeeper&quot;,  ' - ' ||  represent_value( &quot;bee_species&quot; ) )"></property>
+        <property key="embeddedWidgets/count" value="0"></property>
+        <property key="isOfflineEditable" value="true"></property>
+        <property key="remoteProvider" value="postgres"></property>
+        <property key="remoteSource" value="dbname='demo' host=lizmapdemo.opengis.ch port=5432 user='editor1' password='editor1' sslmode=disable key='id' srid=2056 type=Point table=&quot;citybees&quot;.&quot;apiary&quot; (geom) sql="></property>
+        <property key="variableNames"></property>
+        <property key="variableValues"></property>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
-        <DiagramCategory scaleBasedVisibility="0" lineSizeType="MM" width="15" sizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" penAlpha="255" maxScaleDenominator="1e+08" minimumSize="0" direction="1" labelPlacementMethod="XHeight" backgroundColor="#ffffff" height="15" opacity="1" spacingUnitScale="3x:0,0,0,0,0,0" showAxis="0" sizeType="MM" spacingUnit="MM" diagramOrientation="Up" minScaleDenominator="0" spacing="0" penColor="#000000" barWidth="5" backgroundAlpha="255" penWidth="0" enabled="0" rotationOffset="0">
-          <fontProperties style="" description="Cantarell,11,-1,5,50,0,0,0,0,0"/>
-          <attribute color="#000000" label="" field=""/>
+        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="1" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+8" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="0" scaleBasedVisibility="0" scaleDependency="Area" showAxis="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="0" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
+          <fontProperties description="Cantarell,11,-1,5,50,0,0,0,0,0" style=""></fontProperties>
+          <attribute color="#000000" field="" label=""></attribute>
           <axisSymbol>
-            <symbol alpha="1" clip_to_extent="1" force_rhr="0" type="line" name="">
-              <layer pass="0" class="SimpleLine" locked="0" enabled="1">
-                <prop k="capstyle" v="square"/>
-                <prop k="customdash" v="5;2"/>
-                <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="customdash_unit" v="MM"/>
-                <prop k="draw_inside_polygon" v="0"/>
-                <prop k="joinstyle" v="bevel"/>
-                <prop k="line_color" v="35,35,35,255"/>
-                <prop k="line_style" v="solid"/>
-                <prop k="line_width" v="0.26"/>
-                <prop k="line_width_unit" v="MM"/>
-                <prop k="offset" v="0"/>
-                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="offset_unit" v="MM"/>
-                <prop k="ring_filter" v="0"/>
-                <prop k="use_custom_dash" v="0"/>
-                <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" type="line">
+              <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+                <prop k="capstyle" v="square"></prop>
+                <prop k="customdash" v="5;2"></prop>
+                <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="customdash_unit" v="MM"></prop>
+                <prop k="draw_inside_polygon" v="0"></prop>
+                <prop k="joinstyle" v="bevel"></prop>
+                <prop k="line_color" v="35,35,35,255"></prop>
+                <prop k="line_style" v="solid"></prop>
+                <prop k="line_width" v="0.26"></prop>
+                <prop k="line_width_unit" v="MM"></prop>
+                <prop k="offset" v="0"></prop>
+                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="offset_unit" v="MM"></prop>
+                <prop k="ring_filter" v="0"></prop>
+                <prop k="use_custom_dash" v="0"></prop>
+                <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option type="QString" value="" name="name"/>
-                    <Option name="properties"/>
-                    <Option type="QString" value="collection" name="type"/>
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
                   </Option>
                 </data_defined_properties>
               </layer>
@@ -1582,42 +1548,42 @@ def my_form_open(dialog, layer, feature):
           </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings obstacle="0" linePlacementFlags="2" zIndex="0" dist="0" placement="0" priority="0" showAll="1">
+      <DiagramLayerSettings dist="0" linePlacementFlags="2" obstacle="0" placement="0" priority="0" showAll="1" zIndex="0">
         <properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
-            <Option type="Map" name="properties">
-              <Option type="Map" name="positionX">
-                <Option type="bool" value="true" name="active"/>
-                <Option type="QString" value="id" name="field"/>
-                <Option type="int" value="2" name="type"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties" type="Map">
+              <Option name="positionX" type="Map">
+                <Option name="active" type="bool" value="true"></Option>
+                <Option name="field" type="QString" value="id"></Option>
+                <Option name="type" type="int" value="2"></Option>
               </Option>
-              <Option type="Map" name="positionY">
-                <Option type="bool" value="true" name="active"/>
-                <Option type="QString" value="id" name="field"/>
-                <Option type="int" value="2" name="type"/>
+              <Option name="positionY" type="Map">
+                <Option name="active" type="bool" value="true"></Option>
+                <Option name="field" type="QString" value="id"></Option>
+                <Option name="type" type="int" value="2"></Option>
               </Option>
-              <Option type="Map" name="show">
-                <Option type="bool" value="true" name="active"/>
-                <Option type="QString" value="id" name="field"/>
-                <Option type="int" value="2" name="type"/>
+              <Option name="show" type="Map">
+                <Option name="active" type="bool" value="true"></Option>
+                <Option name="field" type="QString" value="id"></Option>
+                <Option name="type" type="int" value="2"></Option>
               </Option>
             </Option>
-            <Option type="QString" value="collection" name="type"/>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </properties>
       </DiagramLayerSettings>
       <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-        <activeChecks/>
-        <checkConfiguration/>
+        <activeChecks></activeChecks>
+        <checkConfiguration></checkConfiguration>
       </geometryOptions>
-      <referencedLayers/>
-      <referencingLayers/>
+      <referencedLayers></referencedLayers>
+      <referencingLayers></referencingLayers>
       <fieldConfiguration>
         <field name="fid">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
@@ -1625,12 +1591,12 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="Range">
             <config>
               <Option type="Map">
-                <Option type="bool" value="true" name="AllowNull"/>
-                <Option type="int" value="10" name="Max"/>
-                <Option type="int" value="1" name="Min"/>
-                <Option type="int" value="0" name="Precision"/>
-                <Option type="int" value="1" name="Step"/>
-                <Option type="QString" value="Slider" name="Style"/>
+                <Option name="AllowNull" type="bool" value="true"></Option>
+                <Option name="Max" type="int" value="10"></Option>
+                <Option name="Min" type="int" value="1"></Option>
+                <Option name="Precision" type="int" value="0"></Option>
+                <Option name="Step" type="int" value="1"></Option>
+                <Option name="Style" type="QString" value="Slider"></Option>
               </Option>
             </config>
           </editWidget>
@@ -1639,15 +1605,15 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="ValueMap">
             <config>
               <Option type="Map">
-                <Option type="List" name="map">
+                <Option name="map" type="List">
                   <Option type="Map">
-                    <Option type="QString" value="Apis Mellifera" name="Buckfast bee"/>
+                    <Option name="Buckfast bee" type="QString" value="Apis Mellifera"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option type="QString" value="Apis Mellifera Carnica" name="Carniolan honey bee"/>
+                    <Option name="Carniolan honey bee" type="QString" value="Apis Mellifera Carnica"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option type="QString" value="Apis Mellifera Mellifera" name="European honey bee"/>
+                    <Option name="European honey bee" type="QString" value="Apis Mellifera Mellifera"></Option>
                   </Option>
                 </Option>
               </Option>
@@ -1658,10 +1624,16 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="ValueMap">
             <config>
               <Option type="Map">
-                <Option type="Map" name="map">
-                  <Option type="QString" value="10000" name="1000 - 10000"/>
-                  <Option type="QString" value="1000" name="&lt; 1000"/>
-                  <Option type="QString" value="100000" name="> 10000"/>
+                <Option name="map" type="List">
+                  <Option type="Map">
+                    <Option name="1000 - 10000" type="QString" value="10000"></Option>
+                  </Option>
+                  <Option type="Map">
+                    <Option name="&lt; 1000" type="QString" value="1000"></Option>
+                  </Option>
+                  <Option type="Map">
+                    <Option name="> 10000" type="QString" value="100000"></Option>
+                  </Option>
                 </Option>
               </Option>
             </config>
@@ -1671,8 +1643,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="bool" value="false" name="IsMultiline"/>
-                <Option type="bool" value="false" name="UseHtml"/>
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -1681,19 +1653,19 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="ExternalResource">
             <config>
               <Option type="Map">
-                <Option type="int" value="1" name="DocumentViewer"/>
-                <Option type="int" value="0" name="DocumentViewerHeight"/>
-                <Option type="int" value="0" name="DocumentViewerWidth"/>
-                <Option type="bool" value="true" name="FileWidget"/>
-                <Option type="bool" value="true" name="FileWidgetButton"/>
-                <Option type="QString" value="" name="FileWidgetFilter"/>
-                <Option type="Map" name="PropertyCollection">
-                  <Option type="QString" value="" name="name"/>
-                  <Option type="invalid" name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                <Option name="DocumentViewer" type="int" value="1"></Option>
+                <Option name="DocumentViewerHeight" type="int" value="0"></Option>
+                <Option name="DocumentViewerWidth" type="int" value="0"></Option>
+                <Option name="FileWidget" type="bool" value="true"></Option>
+                <Option name="FileWidgetButton" type="bool" value="true"></Option>
+                <Option name="FileWidgetFilter" type="QString" value=""></Option>
+                <Option name="PropertyCollection" type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
-                <Option type="int" value="1" name="RelativeStorage"/>
-                <Option type="int" value="0" name="StorageMode"/>
+                <Option name="RelativeStorage" type="int" value="1"></Option>
+                <Option name="StorageMode" type="int" value="0"></Option>
               </Option>
             </config>
           </editWidget>
@@ -1702,8 +1674,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="CheckBox">
             <config>
               <Option type="Map">
-                <Option type="QString" value="t" name="CheckedState"/>
-                <Option type="QString" value="f" name="UncheckedState"/>
+                <Option name="CheckedState" type="QString" value="t"></Option>
+                <Option name="UncheckedState" type="QString" value="f"></Option>
               </Option>
             </config>
           </editWidget>
@@ -1712,12 +1684,12 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="ValueMap">
             <config>
               <Option type="Map">
-                <Option type="List" name="map">
+                <Option name="map" type="List">
                   <Option type="Map">
-                    <Option type="QString" value="AFB" name="American Foulbreed"/>
+                    <Option name="American Foulbreed" type="QString" value="AFB"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option type="QString" value="EFB" name="European Foulbreed"/>
+                    <Option name="European Foulbreed" type="QString" value="EFB"></Option>
                   </Option>
                 </Option>
               </Option>
@@ -1728,12 +1700,12 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="Range">
             <config>
               <Option type="Map">
-                <Option type="bool" value="true" name="AllowNull"/>
-                <Option type="int" value="1000" name="Max"/>
-                <Option type="int" value="0" name="Min"/>
-                <Option type="int" value="0" name="Precision"/>
-                <Option type="int" value="5" name="Step"/>
-                <Option type="QString" value="SpinBox" name="Style"/>
+                <Option name="AllowNull" type="bool" value="true"></Option>
+                <Option name="Max" type="int" value="1000"></Option>
+                <Option name="Min" type="int" value="0"></Option>
+                <Option name="Precision" type="int" value="0"></Option>
+                <Option name="Step" type="int" value="5"></Option>
+                <Option name="Style" type="QString" value="SpinBox"></Option>
               </Option>
             </config>
           </editWidget>
@@ -1742,103 +1714,103 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="RelationReference">
             <config>
               <Option type="Map">
-                <Option type="bool" value="false" name="AllowAddFeatures"/>
-                <Option type="bool" value="true" name="AllowNULL"/>
-                <Option type="bool" value="true" name="MapIdentification"/>
-                <Option type="bool" value="false" name="OrderByValue"/>
-                <Option type="bool" value="false" name="ReadOnly"/>
-                <Option type="QString" value="apiary_279_area_id_ogr_dbname_fid" name="Relation"/>
-                <Option type="bool" value="false" name="ShowForm"/>
-                <Option type="bool" value="true" name="ShowOpenFormButton"/>
+                <Option name="AllowAddFeatures" type="bool" value="false"></Option>
+                <Option name="AllowNULL" type="bool" value="true"></Option>
+                <Option name="MapIdentification" type="bool" value="true"></Option>
+                <Option name="OrderByValue" type="bool" value="false"></Option>
+                <Option name="ReadOnly" type="bool" value="false"></Option>
+                <Option name="Relation" type="QString" value="apiary_279_area_id_ogr_dbname_fid"></Option>
+                <Option name="ShowForm" type="bool" value="false"></Option>
+                <Option name="ShowOpenFormButton" type="bool" value="true"></Option>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias index="0" name="" field="fid"/>
-        <alias index="1" name="Number of Boxes" field="nbr_of_boxes"/>
-        <alias index="2" name="Species of Bees" field="bee_species"/>
-        <alias index="3" name="Amount of Bees" field="bee_amount"/>
-        <alias index="4" name="Beekeeper" field="beekeeper"/>
-        <alias index="5" name="Photo" field="picture"/>
-        <alias index="6" name="Infected" field="disease"/>
-        <alias index="7" name="Kind of Disease" field="kind_of_disease"/>
-        <alias index="8" name="Yearly Harvest (kg)" field="average_harvest"/>
-        <alias index="9" name="Area mostly used" field="area_id"/>
+        <alias field="fid" index="0" name=""></alias>
+        <alias field="nbr_of_boxes" index="1" name="Number of Boxes"></alias>
+        <alias field="bee_species" index="2" name="Species of Bees"></alias>
+        <alias field="bee_amount" index="3" name="Amount of Bees"></alias>
+        <alias field="beekeeper" index="4" name="Beekeeper"></alias>
+        <alias field="picture" index="5" name="Photo"></alias>
+        <alias field="disease" index="6" name="Infected"></alias>
+        <alias field="kind_of_disease" index="7" name="Kind of Disease"></alias>
+        <alias field="average_harvest" index="8" name="Yearly Harvest (kg)"></alias>
+        <alias field="area_id" index="9" name="Area mostly used"></alias>
       </aliases>
-      <excludeAttributesWMS/>
-      <excludeAttributesWFS/>
+      <excludeAttributesWMS></excludeAttributesWMS>
+      <excludeAttributesWFS></excludeAttributesWFS>
       <defaults>
-        <default expression="" applyOnUpdate="0" field="fid"/>
-        <default expression="" applyOnUpdate="0" field="nbr_of_boxes"/>
-        <default expression="" applyOnUpdate="0" field="bee_species"/>
-        <default expression="" applyOnUpdate="0" field="bee_amount"/>
-        <default expression="" applyOnUpdate="0" field="beekeeper"/>
-        <default expression="" applyOnUpdate="0" field="picture"/>
-        <default expression="" applyOnUpdate="0" field="disease"/>
-        <default expression="" applyOnUpdate="0" field="kind_of_disease"/>
-        <default expression="" applyOnUpdate="0" field="average_harvest"/>
-        <default expression="" applyOnUpdate="0" field="area_id"/>
+        <default applyOnUpdate="0" expression="" field="fid"></default>
+        <default applyOnUpdate="0" expression="" field="nbr_of_boxes"></default>
+        <default applyOnUpdate="0" expression="" field="bee_species"></default>
+        <default applyOnUpdate="0" expression="" field="bee_amount"></default>
+        <default applyOnUpdate="0" expression="" field="beekeeper"></default>
+        <default applyOnUpdate="0" expression="" field="picture"></default>
+        <default applyOnUpdate="0" expression="" field="disease"></default>
+        <default applyOnUpdate="0" expression="" field="kind_of_disease"></default>
+        <default applyOnUpdate="0" expression="" field="average_harvest"></default>
+        <default applyOnUpdate="0" expression="" field="area_id"></default>
       </defaults>
       <constraints>
-        <constraint constraints="3" unique_strength="1" exp_strength="0" notnull_strength="1" field="fid"/>
-        <constraint constraints="5" unique_strength="0" exp_strength="1" notnull_strength="1" field="nbr_of_boxes"/>
-        <constraint constraints="5" unique_strength="0" exp_strength="1" notnull_strength="1" field="bee_species"/>
-        <constraint constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0" field="bee_amount"/>
-        <constraint constraints="5" unique_strength="0" exp_strength="1" notnull_strength="1" field="beekeeper"/>
-        <constraint constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0" field="picture"/>
-        <constraint constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0" field="disease"/>
-        <constraint constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0" field="kind_of_disease"/>
-        <constraint constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0" field="average_harvest"/>
-        <constraint constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0" field="area_id"/>
+        <constraint constraints="3" exp_strength="0" field="fid" notnull_strength="1" unique_strength="1"></constraint>
+        <constraint constraints="5" exp_strength="1" field="nbr_of_boxes" notnull_strength="1" unique_strength="0"></constraint>
+        <constraint constraints="1" exp_strength="0" field="bee_species" notnull_strength="1" unique_strength="0"></constraint>
+        <constraint constraints="1" exp_strength="0" field="bee_amount" notnull_strength="2" unique_strength="0"></constraint>
+        <constraint constraints="5" exp_strength="1" field="beekeeper" notnull_strength="1" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="picture" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="disease" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="kind_of_disease" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="average_harvest" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="area_id" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint desc="" exp="" field="fid"/>
-        <constraint desc="must be between 1 and 10" exp="1 &lt;= nbr_of_boxes and nbr_of_boxes &lt;= 10" field="nbr_of_boxes"/>
-        <constraint desc="cannot be empty" exp="&quot;bee_species&quot;" field="bee_species"/>
-        <constraint desc="" exp="" field="bee_amount"/>
-        <constraint desc="at least 2 letters" exp="length(beekeeper)>1" field="beekeeper"/>
-        <constraint desc="" exp="" field="picture"/>
-        <constraint desc="" exp="" field="disease"/>
-        <constraint desc="" exp="" field="kind_of_disease"/>
-        <constraint desc="" exp="" field="average_harvest"/>
-        <constraint desc="" exp="" field="area_id"/>
+        <constraint desc="" exp="" field="fid"></constraint>
+        <constraint desc="must be between 1 and 10" exp="1 &lt;= nbr_of_boxes and nbr_of_boxes &lt;= 10" field="nbr_of_boxes"></constraint>
+        <constraint desc="" exp="" field="bee_species"></constraint>
+        <constraint desc="" exp="" field="bee_amount"></constraint>
+        <constraint desc="at least 2 letters" exp="length(beekeeper)>1" field="beekeeper"></constraint>
+        <constraint desc="" exp="" field="picture"></constraint>
+        <constraint desc="" exp="" field="disease"></constraint>
+        <constraint desc="" exp="" field="kind_of_disease"></constraint>
+        <constraint desc="" exp="" field="average_harvest"></constraint>
+        <constraint desc="" exp="" field="area_id"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction key="Canvas" value="{9c6cab86-7710-48f6-a961-0273bcaaeca9}"/>
-        <actionsetting notificationMessage="" isEnabledOnlyWhenEditable="0" shortTitle="" action="" type="0" icon="" name="" id="{9c6cab86-7710-48f6-a961-0273bcaaeca9}" capture="0">
-          <actionScope id="Feature"/>
-          <actionScope id="Canvas"/>
-          <actionScope id="Field"/>
+        <defaultAction key="Canvas" value="{1574e26d-c5c7-4a8d-9e8e-efb71cdb0d73}"></defaultAction>
+        <actionsetting action="" capture="0" icon="" id="{1574e26d-c5c7-4a8d-9e8e-efb71cdb0d73}" isEnabledOnlyWhenEditable="0" name="" notificationMessage="" shortTitle="" type="0">
+          <actionScope id="Canvas"></actionScope>
+          <actionScope id="Feature"></actionScope>
+          <actionScope id="Field"></actionScope>
         </actionsetting>
       </attributeactions>
-      <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="&quot;fid&quot;">
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="&quot;fid&quot;" sortOrder="0">
         <columns>
-          <column width="165" type="field" hidden="0" name="nbr_of_boxes"/>
-          <column width="164" type="field" hidden="0" name="bee_species"/>
-          <column width="192" type="field" hidden="0" name="bee_amount"/>
-          <column width="203" type="field" hidden="0" name="beekeeper"/>
-          <column width="-1" type="field" hidden="0" name="picture"/>
-          <column width="-1" type="field" hidden="0" name="disease"/>
-          <column width="188" type="field" hidden="0" name="kind_of_disease"/>
-          <column width="-1" type="actions" hidden="1"/>
-          <column width="161" type="field" hidden="0" name="average_harvest"/>
-          <column width="150" type="field" hidden="0" name="area_id"/>
-          <column width="-1" type="field" hidden="0" name="fid"/>
+          <column hidden="0" name="nbr_of_boxes" type="field" width="165"></column>
+          <column hidden="0" name="bee_species" type="field" width="164"></column>
+          <column hidden="0" name="bee_amount" type="field" width="192"></column>
+          <column hidden="0" name="beekeeper" type="field" width="203"></column>
+          <column hidden="0" name="picture" type="field" width="-1"></column>
+          <column hidden="0" name="disease" type="field" width="-1"></column>
+          <column hidden="0" name="kind_of_disease" type="field" width="188"></column>
+          <column hidden="1" type="actions" width="-1"></column>
+          <column hidden="0" name="average_harvest" type="field" width="161"></column>
+          <column hidden="0" name="area_id" type="field" width="150"></column>
+          <column hidden="0" name="fid" type="field" width="-1"></column>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1">../../../OPENGIS.ch-CLOUD/public/qfield_workshop_odense/qfield_workshop_odense</editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath>../../../OPENGIS.ch-CLOUD/public/qfield_workshop_odense/demo_proj_citybees_218</editforminitfilepath>
-      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+      <editforminitcode># -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -1854,87 +1826,87 @@ from qgis.PyQt.QtWidgets import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-]]></editforminitcode>
+</editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>tablayout</editorlayout>
       <attributeEditorForm>
-        <attributeEditorContainer visibilityExpressionEnabled="0" groupBox="0" visibilityExpression="" showLabel="1" name="General" columnCount="1">
-          <attributeEditorField index="1" showLabel="1" name="nbr_of_boxes"/>
-          <attributeEditorField index="2" showLabel="1" name="bee_species"/>
-          <attributeEditorField index="3" showLabel="1" name="bee_amount"/>
-          <attributeEditorField index="4" showLabel="1" name="beekeeper"/>
-          <attributeEditorField index="8" showLabel="1" name="average_harvest"/>
+        <attributeEditorContainer columnCount="1" groupBox="0" name="General" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+          <attributeEditorField index="1" name="nbr_of_boxes" showLabel="1"></attributeEditorField>
+          <attributeEditorField index="2" name="bee_species" showLabel="1"></attributeEditorField>
+          <attributeEditorField index="3" name="bee_amount" showLabel="1"></attributeEditorField>
+          <attributeEditorField index="4" name="beekeeper" showLabel="1"></attributeEditorField>
+          <attributeEditorField index="8" name="average_harvest" showLabel="1"></attributeEditorField>
         </attributeEditorContainer>
-        <attributeEditorContainer visibilityExpressionEnabled="0" groupBox="0" visibilityExpression="" showLabel="1" name="Picture" columnCount="1">
-          <attributeEditorField index="5" showLabel="1" name="picture"/>
+        <attributeEditorContainer columnCount="1" groupBox="0" name="Picture" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+          <attributeEditorField index="5" name="picture" showLabel="1"></attributeEditorField>
         </attributeEditorContainer>
-        <attributeEditorContainer visibilityExpressionEnabled="0" groupBox="0" visibilityExpression="" showLabel="1" name="Issues" columnCount="1">
-          <attributeEditorField index="6" showLabel="1" name="disease"/>
-          <attributeEditorContainer visibilityExpressionEnabled="1" groupBox="1" visibilityExpression="disease in ('t', true, 1)" showLabel="0" name="" columnCount="1">
-            <attributeEditorField index="7" showLabel="1" name="kind_of_disease"/>
+        <attributeEditorContainer columnCount="1" groupBox="0" name="Issues" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+          <attributeEditorField index="6" name="disease" showLabel="1"></attributeEditorField>
+          <attributeEditorContainer columnCount="1" groupBox="1" name="" showLabel="0" visibilityExpression="disease in ('t', true, 1)" visibilityExpressionEnabled="1">
+            <attributeEditorField index="7" name="kind_of_disease" showLabel="1"></attributeEditorField>
           </attributeEditorContainer>
         </attributeEditorContainer>
-        <attributeEditorContainer visibilityExpressionEnabled="0" groupBox="0" visibilityExpression="" showLabel="1" name="Review" columnCount="1">
-          <attributeEditorRelation showLabel="1" showUnlinkButton="1" relation="" name="Reviews_c8_apiary_id_apiary_279_fid" showLinkButton="1"/>
+        <attributeEditorContainer columnCount="1" groupBox="0" name="Review" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+          <attributeEditorRelation name="" relation="" showLabel="1" showLinkButton="1" showSaveChildEditsButton="1" showUnlinkButton="1"></attributeEditorRelation>
         </attributeEditorContainer>
-        <attributeEditorContainer visibilityExpressionEnabled="0" groupBox="0" visibilityExpression="" showLabel="1" name="Consumption" columnCount="1">
-          <attributeEditorRelation showLabel="1" showUnlinkButton="1" relation="" name="Pollen_Con_apiary_id_apiary_279_fid" showLinkButton="1"/>
+        <attributeEditorContainer columnCount="1" groupBox="0" name="Consumption" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+          <attributeEditorRelation name="" relation="" showLabel="1" showLinkButton="1" showSaveChildEditsButton="1" showUnlinkButton="1"></attributeEditorRelation>
         </attributeEditorContainer>
       </attributeEditorForm>
       <editable>
-        <field editable="1" name="area_id"/>
-        <field editable="1" name="average_harvest"/>
-        <field editable="1" name="bee_amount"/>
-        <field editable="1" name="bee_species"/>
-        <field editable="1" name="beekeeper"/>
-        <field editable="1" name="disease"/>
-        <field editable="1" name="fid"/>
-        <field editable="1" name="id"/>
-        <field editable="1" name="kind_of_disease"/>
-        <field editable="1" name="nbr_of_boxes"/>
-        <field editable="1" name="picture"/>
-        <field editable="1" name="review_date"/>
-        <field editable="1" name="reviewer"/>
+        <field editable="1" name="area_id"></field>
+        <field editable="1" name="average_harvest"></field>
+        <field editable="1" name="bee_amount"></field>
+        <field editable="1" name="bee_species"></field>
+        <field editable="1" name="beekeeper"></field>
+        <field editable="1" name="disease"></field>
+        <field editable="1" name="fid"></field>
+        <field editable="1" name="id"></field>
+        <field editable="1" name="kind_of_disease"></field>
+        <field editable="1" name="nbr_of_boxes"></field>
+        <field editable="1" name="picture"></field>
+        <field editable="1" name="review_date"></field>
+        <field editable="1" name="reviewer"></field>
       </editable>
       <labelOnTop>
-        <field labelOnTop="0" name="area_id"/>
-        <field labelOnTop="0" name="average_harvest"/>
-        <field labelOnTop="0" name="bee_amount"/>
-        <field labelOnTop="0" name="bee_species"/>
-        <field labelOnTop="0" name="beekeeper"/>
-        <field labelOnTop="0" name="disease"/>
-        <field labelOnTop="0" name="fid"/>
-        <field labelOnTop="0" name="id"/>
-        <field labelOnTop="0" name="kind_of_disease"/>
-        <field labelOnTop="0" name="nbr_of_boxes"/>
-        <field labelOnTop="0" name="picture"/>
-        <field labelOnTop="0" name="review_date"/>
-        <field labelOnTop="0" name="reviewer"/>
+        <field labelOnTop="0" name="area_id"></field>
+        <field labelOnTop="0" name="average_harvest"></field>
+        <field labelOnTop="0" name="bee_amount"></field>
+        <field labelOnTop="0" name="bee_species"></field>
+        <field labelOnTop="0" name="beekeeper"></field>
+        <field labelOnTop="0" name="disease"></field>
+        <field labelOnTop="0" name="fid"></field>
+        <field labelOnTop="0" name="id"></field>
+        <field labelOnTop="0" name="kind_of_disease"></field>
+        <field labelOnTop="0" name="nbr_of_boxes"></field>
+        <field labelOnTop="0" name="picture"></field>
+        <field labelOnTop="0" name="review_date"></field>
+        <field labelOnTop="0" name="reviewer"></field>
       </labelOnTop>
       <widgets>
         <widget name="Pollen_Con_apiary_id_apiary_279_fid">
           <config type="Map">
-            <Option type="QString" value="" name="nm-rel"/>
+            <Option name="nm-rel" type="QString" value=""></Option>
           </config>
         </widget>
         <widget name="Reviews_c8_apiary_id_apiary_279_fid">
           <config type="Map">
-            <Option type="QString" value="" name="nm-rel"/>
+            <Option name="nm-rel" type="QString" value=""></Option>
           </config>
         </widget>
         <widget name="ref_apiary_apiary_id_apiary2018_id">
-          <config/>
+          <config></config>
         </widget>
       </widgets>
       <previewExpression>concat( "beekeeper",  ' - ' ||  represent_value( "bee_species" ) )</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer minScale="0" wkbType="Polygon" type="vector" simplifyDrawingTol="1" styleCategories="AllStyleCategories" refreshOnNotifyMessage="" labelsEnabled="1" refreshOnNotifyEnabled="0" hasScaleBasedVisibilityFlag="0" autoRefreshEnabled="0" readOnly="0" autoRefreshTime="0" simplifyAlgorithm="0" maxScale="0" simplifyDrawingHints="1" geometry="Polygon" simplifyMaxScale="1" simplifyLocal="1">
+    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" geometry="Polygon" hasScaleBasedVisibilityFlag="0" labelsEnabled="1" maxScale="0" minScale="0" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" type="vector" wkbType="Polygon">
       <extent>
-        <xmin>1029970</xmin>
-        <ymin>5910190</ymin>
-        <xmax>1031640</xmax>
-        <ymax>5911930</ymax>
+        <xmin>1029974.6875</xmin>
+        <ymin>5910187</ymin>
+        <xmax>1031638.3125</xmax>
+        <ymax>5911926.5</ymax>
       </extent>
       <id>ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b</id>
       <datasource>./bumblebees.gpkg|layername=area</datasource>
@@ -1971,7 +1943,7 @@ def my_form_open(dialog, layer, feature):
           <email></email>
           <role></role>
         </contact>
-        <links/>
+        <links></links>
         <fees></fees>
         <encoding></encoding>
         <crs>
@@ -1984,11 +1956,11 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial minz="0" maxx="0" miny="0" crs="" maxy="0" dimensions="2" minx="0" maxz="0"/>
+          <spatial crs="" dimensions="2" maxx="0" maxy="0" maxz="0" minx="0" miny="0" minz="0"></spatial>
           <temporal>
             <period>
               <start></start>
@@ -1998,423 +1970,423 @@ def my_form_open(dialog, layer, feature):
         </extent>
       </resourceMetadata>
       <provider encoding="UTF-8">ogr</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <legend type="default-vector"/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <legend type="default-vector"></legend>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"/>
+        <map-layer-style name="default"></map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
+      <auxiliaryLayer></auxiliaryLayer>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
       </flags>
-      <renderer-v2 symbollevels="0" type="categorizedSymbol" attr="plant_species" enableorderby="0" forceraster="0">
+      <renderer-v2 attr="plant_species" enableorderby="0" forceraster="0" symbollevels="0" type="categorizedSymbol">
         <categories>
-          <category render="true" label="colza" value="colza" symbol="0"/>
-          <category render="true" label="grass" value="grass" symbol="1"/>
-          <category render="true" label="lavender" value="lavender" symbol="2"/>
-          <category render="true" label="taraxacum" value="taraxacum" symbol="3"/>
-          <category render="true" label="weed" value="weed" symbol="4"/>
+          <category label="colza" render="true" symbol="0" value="colza"></category>
+          <category label="grass" render="true" symbol="1" value="grass"></category>
+          <category label="lavender" render="true" symbol="2" value="lavender"></category>
+          <category label="taraxacum" render="true" symbol="3" value="taraxacum"></category>
+          <category label="weed" render="true" symbol="4" value="weed"></category>
         </categories>
         <symbols>
-          <symbol alpha="0.392157" clip_to_extent="1" force_rhr="0" type="fill" name="0">
-            <layer pass="0" class="SimpleFill" locked="0" enabled="1">
-              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="color" v="215,25,28,255"/>
-              <prop k="joinstyle" v="bevel"/>
-              <prop k="offset" v="0,0"/>
-              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_unit" v="MM"/>
-              <prop k="outline_color" v="175,179,138,255"/>
-              <prop k="outline_style" v="solid"/>
-              <prop k="outline_width" v="0.26"/>
-              <prop k="outline_width_unit" v="MM"/>
-              <prop k="style" v="solid"/>
+          <symbol alpha="0.392157" clip_to_extent="1" force_rhr="0" name="0" type="fill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="color" v="215,25,28,255"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="offset" v="0,0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="outline_color" v="175,179,138,255"></prop>
+              <prop k="outline_style" v="solid"></prop>
+              <prop k="outline_width" v="0.26"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
+              <prop k="style" v="solid"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
-                  <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer pass="0" class="PointPatternFill" locked="0" enabled="1">
-              <prop k="displacement_x" v="0"/>
-              <prop k="displacement_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="displacement_x_unit" v="MM"/>
-              <prop k="displacement_y" v="1"/>
-              <prop k="displacement_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="displacement_y_unit" v="MM"/>
-              <prop k="distance_x" v="1.5"/>
-              <prop k="distance_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="distance_x_unit" v="MM"/>
-              <prop k="distance_y" v="2"/>
-              <prop k="distance_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="distance_y_unit" v="MM"/>
-              <prop k="offset_x" v="0"/>
-              <prop k="offset_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_x_unit" v="MM"/>
-              <prop k="offset_y" v="0"/>
-              <prop k="offset_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_y_unit" v="MM"/>
-              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="outline_width_unit" v="MM"/>
+            <layer class="PointPatternFill" enabled="1" locked="0" pass="0">
+              <prop k="displacement_x" v="0"></prop>
+              <prop k="displacement_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="displacement_x_unit" v="MM"></prop>
+              <prop k="displacement_y" v="1"></prop>
+              <prop k="displacement_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="displacement_y_unit" v="MM"></prop>
+              <prop k="distance_x" v="1.5"></prop>
+              <prop k="distance_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_x_unit" v="MM"></prop>
+              <prop k="distance_y" v="2"></prop>
+              <prop k="distance_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_y_unit" v="MM"></prop>
+              <prop k="offset_x" v="0"></prop>
+              <prop k="offset_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_x_unit" v="MM"></prop>
+              <prop k="offset_y" v="0"></prop>
+              <prop k="offset_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_y_unit" v="MM"></prop>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
-                  <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
-              <symbol alpha="0.498039" clip_to_extent="1" force_rhr="0" type="marker" name="@0@1">
-                <layer pass="0" class="SimpleMarker" locked="0" enabled="1">
-                  <prop k="angle" v="0"/>
-                  <prop k="color" v="215,25,28,255"/>
-                  <prop k="horizontal_anchor_point" v="1"/>
-                  <prop k="joinstyle" v="bevel"/>
-                  <prop k="name" v="circle"/>
-                  <prop k="offset" v="0,0"/>
-                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                  <prop k="offset_unit" v="MM"/>
-                  <prop k="outline_color" v="0,0,0,0"/>
-                  <prop k="outline_style" v="solid"/>
-                  <prop k="outline_width" v="0"/>
-                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                  <prop k="outline_width_unit" v="MM"/>
-                  <prop k="scale_method" v="area"/>
-                  <prop k="size" v="1.2"/>
-                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                  <prop k="size_unit" v="MM"/>
-                  <prop k="vertical_anchor_point" v="1"/>
+              <symbol alpha="0.498039" clip_to_extent="1" force_rhr="0" name="@0@1" type="marker">
+                <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                  <prop k="angle" v="0"></prop>
+                  <prop k="color" v="215,25,28,255"></prop>
+                  <prop k="horizontal_anchor_point" v="1"></prop>
+                  <prop k="joinstyle" v="bevel"></prop>
+                  <prop k="name" v="circle"></prop>
+                  <prop k="offset" v="0,0"></prop>
+                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="offset_unit" v="MM"></prop>
+                  <prop k="outline_color" v="0,0,0,0"></prop>
+                  <prop k="outline_style" v="solid"></prop>
+                  <prop k="outline_width" v="0"></prop>
+                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="outline_width_unit" v="MM"></prop>
+                  <prop k="scale_method" v="area"></prop>
+                  <prop k="size" v="1.2"></prop>
+                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="size_unit" v="MM"></prop>
+                  <prop k="vertical_anchor_point" v="1"></prop>
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option type="QString" value="" name="name"/>
-                      <Option name="properties"/>
-                      <Option type="QString" value="collection" name="type"/>
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </layer>
           </symbol>
-          <symbol alpha="0.392157" clip_to_extent="1" force_rhr="0" type="fill" name="1">
-            <layer pass="0" class="SimpleFill" locked="0" enabled="1">
-              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="color" v="246,144,83,255"/>
-              <prop k="joinstyle" v="bevel"/>
-              <prop k="offset" v="0,0"/>
-              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_unit" v="MM"/>
-              <prop k="outline_color" v="175,179,138,255"/>
-              <prop k="outline_style" v="solid"/>
-              <prop k="outline_width" v="0.26"/>
-              <prop k="outline_width_unit" v="MM"/>
-              <prop k="style" v="solid"/>
+          <symbol alpha="0.392157" clip_to_extent="1" force_rhr="0" name="1" type="fill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="color" v="246,144,83,255"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="offset" v="0,0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="outline_color" v="175,179,138,255"></prop>
+              <prop k="outline_style" v="solid"></prop>
+              <prop k="outline_width" v="0.26"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
+              <prop k="style" v="solid"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
-                  <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer pass="0" class="PointPatternFill" locked="0" enabled="1">
-              <prop k="displacement_x" v="0"/>
-              <prop k="displacement_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="displacement_x_unit" v="MM"/>
-              <prop k="displacement_y" v="1"/>
-              <prop k="displacement_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="displacement_y_unit" v="MM"/>
-              <prop k="distance_x" v="1.5"/>
-              <prop k="distance_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="distance_x_unit" v="MM"/>
-              <prop k="distance_y" v="2"/>
-              <prop k="distance_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="distance_y_unit" v="MM"/>
-              <prop k="offset_x" v="0"/>
-              <prop k="offset_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_x_unit" v="MM"/>
-              <prop k="offset_y" v="0"/>
-              <prop k="offset_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_y_unit" v="MM"/>
-              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="outline_width_unit" v="MM"/>
+            <layer class="PointPatternFill" enabled="1" locked="0" pass="0">
+              <prop k="displacement_x" v="0"></prop>
+              <prop k="displacement_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="displacement_x_unit" v="MM"></prop>
+              <prop k="displacement_y" v="1"></prop>
+              <prop k="displacement_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="displacement_y_unit" v="MM"></prop>
+              <prop k="distance_x" v="1.5"></prop>
+              <prop k="distance_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_x_unit" v="MM"></prop>
+              <prop k="distance_y" v="2"></prop>
+              <prop k="distance_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_y_unit" v="MM"></prop>
+              <prop k="offset_x" v="0"></prop>
+              <prop k="offset_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_x_unit" v="MM"></prop>
+              <prop k="offset_y" v="0"></prop>
+              <prop k="offset_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_y_unit" v="MM"></prop>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
-                  <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
-              <symbol alpha="0.498039" clip_to_extent="1" force_rhr="0" type="marker" name="@1@1">
-                <layer pass="0" class="SimpleMarker" locked="0" enabled="1">
-                  <prop k="angle" v="0"/>
-                  <prop k="color" v="246,144,83,255"/>
-                  <prop k="horizontal_anchor_point" v="1"/>
-                  <prop k="joinstyle" v="bevel"/>
-                  <prop k="name" v="circle"/>
-                  <prop k="offset" v="0,0"/>
-                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                  <prop k="offset_unit" v="MM"/>
-                  <prop k="outline_color" v="0,0,0,0"/>
-                  <prop k="outline_style" v="solid"/>
-                  <prop k="outline_width" v="0"/>
-                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                  <prop k="outline_width_unit" v="MM"/>
-                  <prop k="scale_method" v="area"/>
-                  <prop k="size" v="1.2"/>
-                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                  <prop k="size_unit" v="MM"/>
-                  <prop k="vertical_anchor_point" v="1"/>
+              <symbol alpha="0.498039" clip_to_extent="1" force_rhr="0" name="@1@1" type="marker">
+                <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                  <prop k="angle" v="0"></prop>
+                  <prop k="color" v="246,144,83,255"></prop>
+                  <prop k="horizontal_anchor_point" v="1"></prop>
+                  <prop k="joinstyle" v="bevel"></prop>
+                  <prop k="name" v="circle"></prop>
+                  <prop k="offset" v="0,0"></prop>
+                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="offset_unit" v="MM"></prop>
+                  <prop k="outline_color" v="0,0,0,0"></prop>
+                  <prop k="outline_style" v="solid"></prop>
+                  <prop k="outline_width" v="0"></prop>
+                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="outline_width_unit" v="MM"></prop>
+                  <prop k="scale_method" v="area"></prop>
+                  <prop k="size" v="1.2"></prop>
+                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="size_unit" v="MM"></prop>
+                  <prop k="vertical_anchor_point" v="1"></prop>
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option type="QString" value="" name="name"/>
-                      <Option name="properties"/>
-                      <Option type="QString" value="collection" name="type"/>
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </layer>
           </symbol>
-          <symbol alpha="0.392157" clip_to_extent="1" force_rhr="0" type="fill" name="2">
-            <layer pass="0" class="SimpleFill" locked="0" enabled="1">
-              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="color" v="218,175,193,255"/>
-              <prop k="joinstyle" v="bevel"/>
-              <prop k="offset" v="0,0"/>
-              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_unit" v="MM"/>
-              <prop k="outline_color" v="175,179,138,255"/>
-              <prop k="outline_style" v="solid"/>
-              <prop k="outline_width" v="0.26"/>
-              <prop k="outline_width_unit" v="MM"/>
-              <prop k="style" v="solid"/>
+          <symbol alpha="0.392157" clip_to_extent="1" force_rhr="0" name="2" type="fill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="color" v="218,175,193,255"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="offset" v="0,0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="outline_color" v="175,179,138,255"></prop>
+              <prop k="outline_style" v="solid"></prop>
+              <prop k="outline_width" v="0.26"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
+              <prop k="style" v="solid"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
-                  <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer pass="0" class="PointPatternFill" locked="0" enabled="1">
-              <prop k="displacement_x" v="0"/>
-              <prop k="displacement_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="displacement_x_unit" v="MM"/>
-              <prop k="displacement_y" v="1"/>
-              <prop k="displacement_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="displacement_y_unit" v="MM"/>
-              <prop k="distance_x" v="1.5"/>
-              <prop k="distance_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="distance_x_unit" v="MM"/>
-              <prop k="distance_y" v="2"/>
-              <prop k="distance_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="distance_y_unit" v="MM"/>
-              <prop k="offset_x" v="0"/>
-              <prop k="offset_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_x_unit" v="MM"/>
-              <prop k="offset_y" v="0"/>
-              <prop k="offset_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_y_unit" v="MM"/>
-              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="outline_width_unit" v="MM"/>
+            <layer class="PointPatternFill" enabled="1" locked="0" pass="0">
+              <prop k="displacement_x" v="0"></prop>
+              <prop k="displacement_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="displacement_x_unit" v="MM"></prop>
+              <prop k="displacement_y" v="1"></prop>
+              <prop k="displacement_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="displacement_y_unit" v="MM"></prop>
+              <prop k="distance_x" v="1.5"></prop>
+              <prop k="distance_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_x_unit" v="MM"></prop>
+              <prop k="distance_y" v="2"></prop>
+              <prop k="distance_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_y_unit" v="MM"></prop>
+              <prop k="offset_x" v="0"></prop>
+              <prop k="offset_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_x_unit" v="MM"></prop>
+              <prop k="offset_y" v="0"></prop>
+              <prop k="offset_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_y_unit" v="MM"></prop>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
-                  <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
-              <symbol alpha="0.498039" clip_to_extent="1" force_rhr="0" type="marker" name="@2@1">
-                <layer pass="0" class="SimpleMarker" locked="0" enabled="1">
-                  <prop k="angle" v="0"/>
-                  <prop k="color" v="218,175,193,255"/>
-                  <prop k="horizontal_anchor_point" v="1"/>
-                  <prop k="joinstyle" v="bevel"/>
-                  <prop k="name" v="circle"/>
-                  <prop k="offset" v="0,0"/>
-                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                  <prop k="offset_unit" v="MM"/>
-                  <prop k="outline_color" v="0,0,0,0"/>
-                  <prop k="outline_style" v="solid"/>
-                  <prop k="outline_width" v="0"/>
-                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                  <prop k="outline_width_unit" v="MM"/>
-                  <prop k="scale_method" v="area"/>
-                  <prop k="size" v="1.2"/>
-                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                  <prop k="size_unit" v="MM"/>
-                  <prop k="vertical_anchor_point" v="1"/>
+              <symbol alpha="0.498039" clip_to_extent="1" force_rhr="0" name="@2@1" type="marker">
+                <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                  <prop k="angle" v="0"></prop>
+                  <prop k="color" v="218,175,193,255"></prop>
+                  <prop k="horizontal_anchor_point" v="1"></prop>
+                  <prop k="joinstyle" v="bevel"></prop>
+                  <prop k="name" v="circle"></prop>
+                  <prop k="offset" v="0,0"></prop>
+                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="offset_unit" v="MM"></prop>
+                  <prop k="outline_color" v="0,0,0,0"></prop>
+                  <prop k="outline_style" v="solid"></prop>
+                  <prop k="outline_width" v="0"></prop>
+                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="outline_width_unit" v="MM"></prop>
+                  <prop k="scale_method" v="area"></prop>
+                  <prop k="size" v="1.2"></prop>
+                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="size_unit" v="MM"></prop>
+                  <prop k="vertical_anchor_point" v="1"></prop>
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option type="QString" value="" name="name"/>
-                      <Option name="properties"/>
-                      <Option type="QString" value="collection" name="type"/>
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </layer>
           </symbol>
-          <symbol alpha="0.392157" clip_to_extent="1" force_rhr="0" type="fill" name="3">
-            <layer pass="0" class="SimpleFill" locked="0" enabled="1">
-              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="color" v="185,194,218,255"/>
-              <prop k="joinstyle" v="bevel"/>
-              <prop k="offset" v="0,0"/>
-              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_unit" v="MM"/>
-              <prop k="outline_color" v="175,179,138,255"/>
-              <prop k="outline_style" v="solid"/>
-              <prop k="outline_width" v="0.26"/>
-              <prop k="outline_width_unit" v="MM"/>
-              <prop k="style" v="solid"/>
+          <symbol alpha="0.392157" clip_to_extent="1" force_rhr="0" name="3" type="fill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="color" v="185,194,218,255"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="offset" v="0,0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="outline_color" v="175,179,138,255"></prop>
+              <prop k="outline_style" v="solid"></prop>
+              <prop k="outline_width" v="0.26"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
+              <prop k="style" v="solid"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
-                  <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer pass="0" class="PointPatternFill" locked="0" enabled="1">
-              <prop k="displacement_x" v="0"/>
-              <prop k="displacement_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="displacement_x_unit" v="MM"/>
-              <prop k="displacement_y" v="1"/>
-              <prop k="displacement_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="displacement_y_unit" v="MM"/>
-              <prop k="distance_x" v="1.5"/>
-              <prop k="distance_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="distance_x_unit" v="MM"/>
-              <prop k="distance_y" v="2"/>
-              <prop k="distance_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="distance_y_unit" v="MM"/>
-              <prop k="offset_x" v="0"/>
-              <prop k="offset_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_x_unit" v="MM"/>
-              <prop k="offset_y" v="0"/>
-              <prop k="offset_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_y_unit" v="MM"/>
-              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="outline_width_unit" v="MM"/>
+            <layer class="PointPatternFill" enabled="1" locked="0" pass="0">
+              <prop k="displacement_x" v="0"></prop>
+              <prop k="displacement_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="displacement_x_unit" v="MM"></prop>
+              <prop k="displacement_y" v="1"></prop>
+              <prop k="displacement_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="displacement_y_unit" v="MM"></prop>
+              <prop k="distance_x" v="1.5"></prop>
+              <prop k="distance_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_x_unit" v="MM"></prop>
+              <prop k="distance_y" v="2"></prop>
+              <prop k="distance_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_y_unit" v="MM"></prop>
+              <prop k="offset_x" v="0"></prop>
+              <prop k="offset_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_x_unit" v="MM"></prop>
+              <prop k="offset_y" v="0"></prop>
+              <prop k="offset_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_y_unit" v="MM"></prop>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
-                  <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
-              <symbol alpha="0.498039" clip_to_extent="1" force_rhr="0" type="marker" name="@3@1">
-                <layer pass="0" class="SimpleMarker" locked="0" enabled="1">
-                  <prop k="angle" v="0"/>
-                  <prop k="color" v="185,194,218,255"/>
-                  <prop k="horizontal_anchor_point" v="1"/>
-                  <prop k="joinstyle" v="bevel"/>
-                  <prop k="name" v="circle"/>
-                  <prop k="offset" v="0,0"/>
-                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                  <prop k="offset_unit" v="MM"/>
-                  <prop k="outline_color" v="0,0,0,0"/>
-                  <prop k="outline_style" v="solid"/>
-                  <prop k="outline_width" v="0"/>
-                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                  <prop k="outline_width_unit" v="MM"/>
-                  <prop k="scale_method" v="area"/>
-                  <prop k="size" v="1.2"/>
-                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                  <prop k="size_unit" v="MM"/>
-                  <prop k="vertical_anchor_point" v="1"/>
+              <symbol alpha="0.498039" clip_to_extent="1" force_rhr="0" name="@3@1" type="marker">
+                <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                  <prop k="angle" v="0"></prop>
+                  <prop k="color" v="185,194,218,255"></prop>
+                  <prop k="horizontal_anchor_point" v="1"></prop>
+                  <prop k="joinstyle" v="bevel"></prop>
+                  <prop k="name" v="circle"></prop>
+                  <prop k="offset" v="0,0"></prop>
+                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="offset_unit" v="MM"></prop>
+                  <prop k="outline_color" v="0,0,0,0"></prop>
+                  <prop k="outline_style" v="solid"></prop>
+                  <prop k="outline_width" v="0"></prop>
+                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="outline_width_unit" v="MM"></prop>
+                  <prop k="scale_method" v="area"></prop>
+                  <prop k="size" v="1.2"></prop>
+                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="size_unit" v="MM"></prop>
+                  <prop k="vertical_anchor_point" v="1"></prop>
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option type="QString" value="" name="name"/>
-                      <Option name="properties"/>
-                      <Option type="QString" value="collection" name="type"/>
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </layer>
           </symbol>
-          <symbol alpha="0.392157" clip_to_extent="1" force_rhr="0" type="fill" name="4">
-            <layer pass="0" class="SimpleFill" locked="0" enabled="1">
-              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="color" v="144,198,169,255"/>
-              <prop k="joinstyle" v="bevel"/>
-              <prop k="offset" v="0,0"/>
-              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_unit" v="MM"/>
-              <prop k="outline_color" v="175,179,138,255"/>
-              <prop k="outline_style" v="solid"/>
-              <prop k="outline_width" v="0.26"/>
-              <prop k="outline_width_unit" v="MM"/>
-              <prop k="style" v="solid"/>
+          <symbol alpha="0.392157" clip_to_extent="1" force_rhr="0" name="4" type="fill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="color" v="144,198,169,255"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="offset" v="0,0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="outline_color" v="175,179,138,255"></prop>
+              <prop k="outline_style" v="solid"></prop>
+              <prop k="outline_width" v="0.26"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
+              <prop k="style" v="solid"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
-                  <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer pass="0" class="PointPatternFill" locked="0" enabled="1">
-              <prop k="displacement_x" v="0"/>
-              <prop k="displacement_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="displacement_x_unit" v="MM"/>
-              <prop k="displacement_y" v="1"/>
-              <prop k="displacement_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="displacement_y_unit" v="MM"/>
-              <prop k="distance_x" v="1.5"/>
-              <prop k="distance_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="distance_x_unit" v="MM"/>
-              <prop k="distance_y" v="2"/>
-              <prop k="distance_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="distance_y_unit" v="MM"/>
-              <prop k="offset_x" v="0"/>
-              <prop k="offset_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_x_unit" v="MM"/>
-              <prop k="offset_y" v="0"/>
-              <prop k="offset_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_y_unit" v="MM"/>
-              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="outline_width_unit" v="MM"/>
+            <layer class="PointPatternFill" enabled="1" locked="0" pass="0">
+              <prop k="displacement_x" v="0"></prop>
+              <prop k="displacement_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="displacement_x_unit" v="MM"></prop>
+              <prop k="displacement_y" v="1"></prop>
+              <prop k="displacement_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="displacement_y_unit" v="MM"></prop>
+              <prop k="distance_x" v="1.5"></prop>
+              <prop k="distance_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_x_unit" v="MM"></prop>
+              <prop k="distance_y" v="2"></prop>
+              <prop k="distance_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_y_unit" v="MM"></prop>
+              <prop k="offset_x" v="0"></prop>
+              <prop k="offset_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_x_unit" v="MM"></prop>
+              <prop k="offset_y" v="0"></prop>
+              <prop k="offset_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_y_unit" v="MM"></prop>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
-                  <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
-              <symbol alpha="0.498039" clip_to_extent="1" force_rhr="0" type="marker" name="@4@1">
-                <layer pass="0" class="SimpleMarker" locked="0" enabled="1">
-                  <prop k="angle" v="0"/>
-                  <prop k="color" v="144,198,169,255"/>
-                  <prop k="horizontal_anchor_point" v="1"/>
-                  <prop k="joinstyle" v="bevel"/>
-                  <prop k="name" v="circle"/>
-                  <prop k="offset" v="0,0"/>
-                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                  <prop k="offset_unit" v="MM"/>
-                  <prop k="outline_color" v="0,0,0,0"/>
-                  <prop k="outline_style" v="solid"/>
-                  <prop k="outline_width" v="0"/>
-                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                  <prop k="outline_width_unit" v="MM"/>
-                  <prop k="scale_method" v="area"/>
-                  <prop k="size" v="1.2"/>
-                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                  <prop k="size_unit" v="MM"/>
-                  <prop k="vertical_anchor_point" v="1"/>
+              <symbol alpha="0.498039" clip_to_extent="1" force_rhr="0" name="@4@1" type="marker">
+                <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                  <prop k="angle" v="0"></prop>
+                  <prop k="color" v="144,198,169,255"></prop>
+                  <prop k="horizontal_anchor_point" v="1"></prop>
+                  <prop k="joinstyle" v="bevel"></prop>
+                  <prop k="name" v="circle"></prop>
+                  <prop k="offset" v="0,0"></prop>
+                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="offset_unit" v="MM"></prop>
+                  <prop k="outline_color" v="0,0,0,0"></prop>
+                  <prop k="outline_style" v="solid"></prop>
+                  <prop k="outline_width" v="0"></prop>
+                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="outline_width_unit" v="MM"></prop>
+                  <prop k="scale_method" v="area"></prop>
+                  <prop k="size" v="1.2"></prop>
+                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="size_unit" v="MM"></prop>
+                  <prop k="vertical_anchor_point" v="1"></prop>
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option type="QString" value="" name="name"/>
-                      <Option name="properties"/>
-                      <Option type="QString" value="collection" name="type"/>
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
                     </Option>
                   </data_defined_properties>
                 </layer>
@@ -2423,80 +2395,80 @@ def my_form_open(dialog, layer, feature):
           </symbol>
         </symbols>
         <source-symbol>
-          <symbol alpha="0.392157" clip_to_extent="1" force_rhr="0" type="fill" name="0">
-            <layer pass="0" class="SimpleFill" locked="0" enabled="1">
-              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="color" v="73,244,5,255"/>
-              <prop k="joinstyle" v="bevel"/>
-              <prop k="offset" v="0,0"/>
-              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_unit" v="MM"/>
-              <prop k="outline_color" v="175,179,138,255"/>
-              <prop k="outline_style" v="solid"/>
-              <prop k="outline_width" v="0.26"/>
-              <prop k="outline_width_unit" v="MM"/>
-              <prop k="style" v="solid"/>
+          <symbol alpha="0.392157" clip_to_extent="1" force_rhr="0" name="0" type="fill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="color" v="73,244,5,255"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="offset" v="0,0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="outline_color" v="175,179,138,255"></prop>
+              <prop k="outline_style" v="solid"></prop>
+              <prop k="outline_width" v="0.26"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
+              <prop k="style" v="solid"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
-                  <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer pass="0" class="PointPatternFill" locked="0" enabled="1">
-              <prop k="displacement_x" v="0"/>
-              <prop k="displacement_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="displacement_x_unit" v="MM"/>
-              <prop k="displacement_y" v="1"/>
-              <prop k="displacement_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="displacement_y_unit" v="MM"/>
-              <prop k="distance_x" v="1.5"/>
-              <prop k="distance_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="distance_x_unit" v="MM"/>
-              <prop k="distance_y" v="2"/>
-              <prop k="distance_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="distance_y_unit" v="MM"/>
-              <prop k="offset_x" v="0"/>
-              <prop k="offset_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_x_unit" v="MM"/>
-              <prop k="offset_y" v="0"/>
-              <prop k="offset_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_y_unit" v="MM"/>
-              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="outline_width_unit" v="MM"/>
+            <layer class="PointPatternFill" enabled="1" locked="0" pass="0">
+              <prop k="displacement_x" v="0"></prop>
+              <prop k="displacement_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="displacement_x_unit" v="MM"></prop>
+              <prop k="displacement_y" v="1"></prop>
+              <prop k="displacement_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="displacement_y_unit" v="MM"></prop>
+              <prop k="distance_x" v="1.5"></prop>
+              <prop k="distance_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_x_unit" v="MM"></prop>
+              <prop k="distance_y" v="2"></prop>
+              <prop k="distance_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_y_unit" v="MM"></prop>
+              <prop k="offset_x" v="0"></prop>
+              <prop k="offset_x_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_x_unit" v="MM"></prop>
+              <prop k="offset_y" v="0"></prop>
+              <prop k="offset_y_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_y_unit" v="MM"></prop>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
-                  <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
-              <symbol alpha="0.498039" clip_to_extent="1" force_rhr="0" type="marker" name="@0@1">
-                <layer pass="0" class="SimpleMarker" locked="0" enabled="1">
-                  <prop k="angle" v="0"/>
-                  <prop k="color" v="255,13,1,255"/>
-                  <prop k="horizontal_anchor_point" v="1"/>
-                  <prop k="joinstyle" v="bevel"/>
-                  <prop k="name" v="circle"/>
-                  <prop k="offset" v="0,0"/>
-                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                  <prop k="offset_unit" v="MM"/>
-                  <prop k="outline_color" v="0,0,0,0"/>
-                  <prop k="outline_style" v="solid"/>
-                  <prop k="outline_width" v="0"/>
-                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                  <prop k="outline_width_unit" v="MM"/>
-                  <prop k="scale_method" v="area"/>
-                  <prop k="size" v="1.2"/>
-                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                  <prop k="size_unit" v="MM"/>
-                  <prop k="vertical_anchor_point" v="1"/>
+              <symbol alpha="0.498039" clip_to_extent="1" force_rhr="0" name="@0@1" type="marker">
+                <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                  <prop k="angle" v="0"></prop>
+                  <prop k="color" v="255,13,1,255"></prop>
+                  <prop k="horizontal_anchor_point" v="1"></prop>
+                  <prop k="joinstyle" v="bevel"></prop>
+                  <prop k="name" v="circle"></prop>
+                  <prop k="offset" v="0,0"></prop>
+                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="offset_unit" v="MM"></prop>
+                  <prop k="outline_color" v="0,0,0,0"></prop>
+                  <prop k="outline_style" v="solid"></prop>
+                  <prop k="outline_width" v="0"></prop>
+                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="outline_width_unit" v="MM"></prop>
+                  <prop k="scale_method" v="area"></prop>
+                  <prop k="size" v="1.2"></prop>
+                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="size_unit" v="MM"></prop>
+                  <prop k="vertical_anchor_point" v="1"></prop>
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option type="QString" value="" name="name"/>
-                      <Option name="properties"/>
-                      <Option type="QString" value="collection" name="type"/>
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
                     </Option>
                   </data_defined_properties>
                 </layer>
@@ -2504,107 +2476,138 @@ def my_form_open(dialog, layer, feature):
             </layer>
           </symbol>
         </source-symbol>
-        <colorramp type="gradient" name="[source]">
-          <prop k="color1" v="215,25,28,255"/>
-          <prop k="color2" v="36,106,186,255"/>
-          <prop k="discrete" v="0"/>
-          <prop k="rampType" v="gradient"/>
-          <prop k="stops" v="0.25;253,174,97,255:0.497611;195,175,255,255:0.75;171,221,164,255"/>
+        <colorramp name="[source]" type="gradient">
+          <prop k="color1" v="215,25,28,255"></prop>
+          <prop k="color2" v="36,106,186,255"></prop>
+          <prop k="discrete" v="0"></prop>
+          <prop k="rampType" v="gradient"></prop>
+          <prop k="stops" v="0.25;253,174,97,255:0.497611;195,175,255,255:0.75;171,221,164,255"></prop>
         </colorramp>
-        <rotation/>
-        <sizescale/>
+        <rotation></rotation>
+        <sizescale></sizescale>
       </renderer-v2>
       <labeling type="simple">
         <settings calloutType="simple">
-          <text-style textColor="0,0,0,255" fontFamily="Sans Serif" isExpression="1" textOpacity="1" useSubstitutions="0" fontUnderline="0" fontKerning="1" fontWordSpacing="0" fontCapitals="0" namedStyle="Regular" fontSizeMapUnitScale="3x:0,0,0,0,0,0" textOrientation="horizontal" fontWeight="50" fontItalic="0" fieldName=" concat( &quot;plant_species&quot; , ' ('  || &quot;proprietor&quot;  || ')')" previewBkgrdColor="255,255,255,255" multilineHeight="1" fontSizeUnit="Point" fontLetterSpacing="0" fontStrikeout="0" fontSize="13" blendMode="0">
-            <text-buffer bufferSize="1" bufferOpacity="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferNoFill="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferSizeUnits="MM"/>
-            <text-mask maskJoinStyle="128" maskedSymbolLayers="" maskType="0" maskSizeUnits="MM" maskOpacity="1" maskSize="0" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0"/>
-            <background shapeOffsetX="0" shapeRotationType="0" shapeType="0" shapeRadiiUnit="MM" shapeSizeY="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeBlendMode="0" shapeOffsetY="0" shapeFillColor="255,255,255,255" shapeSizeType="0" shapeBorderWidth="0" shapeJoinStyle="64" shapeDraw="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOpacity="1" shapeSVGFile="" shapeOffsetUnit="MM" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeX="0" shapeBorderColor="128,128,128,255" shapeRotation="0" shapeRadiiY="0"/>
-            <shadow shadowOffsetUnit="MM" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowBlendMode="6" shadowOffsetDist="1" shadowOffsetAngle="135" shadowColor="0,0,0,255" shadowOpacity="0.7" shadowDraw="0" shadowRadius="1.5" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowUnder="0" shadowRadiusAlphaOnly="0" shadowRadiusUnit="MM"/>
+          <text-style blendMode="0" fieldName=" concat( &quot;plant_species&quot; , ' ('  || &quot;proprietor&quot;  || ')')" fontCapitals="0" fontFamily="Sans Serif" fontItalic="0" fontKerning="1" fontLetterSpacing="0" fontSize="13" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontStrikeout="0" fontUnderline="0" fontWeight="50" fontWordSpacing="0" isExpression="1" multilineHeight="1" namedStyle="Normal" previewBkgrdColor="255,255,255,255" textColor="0,0,0,255" textOpacity="1" textOrientation="horizontal" useSubstitutions="0">
+            <text-buffer bufferBlendMode="0" bufferColor="255,255,255,255" bufferDraw="0" bufferJoinStyle="128" bufferNoFill="1" bufferOpacity="1" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM"></text-buffer>
+            <text-mask maskEnabled="0" maskJoinStyle="128" maskOpacity="1" maskSize="0" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSizeUnits="MM" maskType="0" maskedSymbolLayers=""></text-mask>
+            <background shapeBlendMode="0" shapeBorderColor="128,128,128,255" shapeBorderWidth="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeDraw="0" shapeFillColor="255,255,255,255" shapeJoinStyle="64" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeOffsetY="0" shapeOpacity="1" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiUnit="MM" shapeRadiiX="0" shapeRadiiY="0" shapeRotation="0" shapeRotationType="0" shapeSVGFile="" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeSizeUnit="MM" shapeSizeX="0" shapeSizeY="0" shapeType="0">
+              <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="markerSymbol" type="marker">
+                <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+                  <prop k="angle" v="0"></prop>
+                  <prop k="color" v="164,113,88,255"></prop>
+                  <prop k="horizontal_anchor_point" v="1"></prop>
+                  <prop k="joinstyle" v="bevel"></prop>
+                  <prop k="name" v="circle"></prop>
+                  <prop k="offset" v="0,0"></prop>
+                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="offset_unit" v="MM"></prop>
+                  <prop k="outline_color" v="35,35,35,255"></prop>
+                  <prop k="outline_style" v="solid"></prop>
+                  <prop k="outline_width" v="0"></prop>
+                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="outline_width_unit" v="MM"></prop>
+                  <prop k="scale_method" v="diameter"></prop>
+                  <prop k="size" v="2"></prop>
+                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="size_unit" v="MM"></prop>
+                  <prop k="vertical_anchor_point" v="1"></prop>
+                  <data_defined_properties>
+                    <Option type="Map">
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
+                    </Option>
+                  </data_defined_properties>
+                </layer>
+              </symbol>
+            </background>
+            <shadow shadowBlendMode="6" shadowColor="0,0,0,255" shadowDraw="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowOpacity="0.7" shadowRadius="1.5" shadowRadiusAlphaOnly="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowUnder="0"></shadow>
             <dd_properties>
               <Option type="Map">
-                <Option type="QString" value="" name="name"/>
-                <Option name="properties"/>
-                <Option type="QString" value="collection" name="type"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </dd_properties>
-            <substitutions/>
+            <substitutions></substitutions>
           </text-style>
-          <text-format wrapChar="" formatNumbers="0" addDirectionSymbol="0" plussign="0" useMaxLineLengthForAutoWrap="1" decimals="3" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;" rightDirectionSymbol=">" multilineAlign="4294967295" autoWrapLength="0"/>
-          <placement repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" rotationAngle="0" xOffset="0" maxCurvedCharAngleOut="-25" offsetType="0" geometryGeneratorEnabled="0" layerType="UnknownGeometry" repeatDistance="0" quadOffset="4" offsetUnits="MM" overrunDistanceUnit="MM" fitInPolygonOnly="0" centroidWhole="0" geometryGenerator="" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" placement="0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" distMapUnitScale="3x:0,0,0,0,0,0" overrunDistance="0" preserveRotation="1" priority="5" yOffset="0" maxCurvedCharAngleIn="25" dist="0" centroidInside="0" repeatDistanceUnits="MM" placementFlags="10" distUnits="MM" geometryGeneratorType="PointGeometry"/>
-          <rendering fontMaxPixelSize="10000" scaleMin="0" minFeatureSize="0" limitNumLabels="0" mergeLines="0" obstacleType="0" maxNumLabels="2000" labelPerPart="0" scaleMax="5000" zIndex="0" upsidedownLabels="0" drawLabels="1" fontLimitPixelSize="0" obstacleFactor="1" fontMinPixelSize="3" obstacle="1" displayAll="0" scaleVisibility="1"/>
+          <text-format addDirectionSymbol="0" autoWrapLength="0" decimals="3" formatNumbers="0" leftDirectionSymbol="&lt;" multilineAlign="4294967295" placeDirectionSymbol="0" plussign="0" reverseDirectionSymbol="0" rightDirectionSymbol=">" useMaxLineLengthForAutoWrap="1" wrapChar=""></text-format>
+          <placement centroidInside="0" centroidWhole="0" dist="0" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" fitInPolygonOnly="0" geometryGenerator="" geometryGeneratorEnabled="0" geometryGeneratorType="PointGeometry" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" layerType="PolygonGeometry" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" offsetType="0" offsetUnits="MM" overrunDistance="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" placement="0" placementFlags="10" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" preserveRotation="1" priority="5" quadOffset="4" repeatDistance="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" rotationAngle="0" xOffset="0" yOffset="0"></placement>
+          <rendering displayAll="0" drawLabels="1" fontLimitPixelSize="0" fontMaxPixelSize="10000" fontMinPixelSize="3" labelPerPart="0" limitNumLabels="0" maxNumLabels="2000" mergeLines="0" minFeatureSize="0" obstacle="1" obstacleFactor="1" obstacleType="0" scaleMax="5000" scaleMin="0" scaleVisibility="1" upsidedownLabels="0" zIndex="0"></rendering>
           <dd_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
-              <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option type="QString" value="pole_of_inaccessibility" name="anchorPoint"/>
-              <Option type="Map" name="ddProperties">
-                <Option type="QString" value="" name="name"/>
-                <Option name="properties"/>
-                <Option type="QString" value="collection" name="type"/>
+              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility"></Option>
+              <Option name="ddProperties" type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
-              <Option type="bool" value="false" name="drawToAllParts"/>
-              <Option type="QString" value="0" name="enabled"/>
-              <Option type="QString" value="&lt;symbol alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; name=&quot;symbol&quot;>&lt;layer pass=&quot;0&quot; class=&quot;SimpleLine&quot; locked=&quot;0&quot; enabled=&quot;1&quot;>&lt;prop k=&quot;capstyle&quot; v=&quot;square&quot;/>&lt;prop k=&quot;customdash&quot; v=&quot;5;2&quot;/>&lt;prop k=&quot;customdash_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;customdash_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;draw_inside_polygon&quot; v=&quot;0&quot;/>&lt;prop k=&quot;joinstyle&quot; v=&quot;bevel&quot;/>&lt;prop k=&quot;line_color&quot; v=&quot;60,60,60,255&quot;/>&lt;prop k=&quot;line_style&quot; v=&quot;solid&quot;/>&lt;prop k=&quot;line_width&quot; v=&quot;0.3&quot;/>&lt;prop k=&quot;line_width_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;offset&quot; v=&quot;0&quot;/>&lt;prop k=&quot;offset_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;offset_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;ring_filter&quot; v=&quot;0&quot;/>&lt;prop k=&quot;use_custom_dash&quot; v=&quot;0&quot;/>&lt;prop k=&quot;width_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol"/>
-              <Option type="double" value="0" name="minLength"/>
-              <Option type="QString" value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale"/>
-              <Option type="QString" value="MM" name="minLengthUnit"/>
-              <Option type="double" value="0" name="offsetFromAnchor"/>
-              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale"/>
-              <Option type="QString" value="MM" name="offsetFromAnchorUnit"/>
-              <Option type="double" value="0" name="offsetFromLabel"/>
-              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale"/>
-              <Option type="QString" value="MM" name="offsetFromLabelUnit"/>
+              <Option name="drawToAllParts" type="bool" value="false"></Option>
+              <Option name="enabled" type="QString" value="0"></Option>
+              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior"></Option>
+              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; clip_to_extent=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; alpha=&quot;1&quot;>&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;>&lt;prop k=&quot;capstyle&quot; v=&quot;square&quot;/>&lt;prop k=&quot;customdash&quot; v=&quot;5;2&quot;/>&lt;prop k=&quot;customdash_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;customdash_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;draw_inside_polygon&quot; v=&quot;0&quot;/>&lt;prop k=&quot;joinstyle&quot; v=&quot;bevel&quot;/>&lt;prop k=&quot;line_color&quot; v=&quot;60,60,60,255&quot;/>&lt;prop k=&quot;line_style&quot; v=&quot;solid&quot;/>&lt;prop k=&quot;line_width&quot; v=&quot;0.3&quot;/>&lt;prop k=&quot;line_width_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;offset&quot; v=&quot;0&quot;/>&lt;prop k=&quot;offset_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;offset_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;ring_filter&quot; v=&quot;0&quot;/>&lt;prop k=&quot;use_custom_dash&quot; v=&quot;0&quot;/>&lt;prop k=&quot;width_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>"></Option>
+              <Option name="minLength" type="double" value="0"></Option>
+              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="minLengthUnit" type="QString" value="MM"></Option>
+              <Option name="offsetFromAnchor" type="double" value="0"></Option>
+              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="offsetFromAnchorUnit" type="QString" value="MM"></Option>
+              <Option name="offsetFromLabel" type="double" value="0"></Option>
+              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              <Option name="offsetFromLabelUnit" type="QString" value="MM"></Option>
             </Option>
           </callout>
         </settings>
       </labeling>
       <customproperties>
-        <property key="QFieldSync/action" value="offline"/>
-        <property key="dualview/previewExpressions" value="represent_value(&quot;plant_species&quot;)  || ' ('  ||  represent_value(&quot;proprietor&quot;) || ' ) '"/>
-        <property key="embeddedWidgets/count" value="0"/>
-        <property key="isOfflineEditable" value="true"/>
-        <property key="remoteProvider" value="postgres"/>
-        <property key="remoteSource" value="dbname='demo' host=lizmapdemo.opengis.ch port=5432 user='editor1' password='editor1' sslmode=disable key='id' srid=2056 type=Polygon table=&quot;citybees&quot;.&quot;area&quot; (geom) sql="/>
-        <property key="variableNames"/>
-        <property key="variableValues"/>
+        <property key="QFieldSync/action" value="offline"></property>
+        <property key="dualview/previewExpressions" value="represent_value(&quot;plant_species&quot;)  || ' ('  ||  represent_value(&quot;proprietor&quot;) || ' ) '"></property>
+        <property key="embeddedWidgets/count" value="0"></property>
+        <property key="isOfflineEditable" value="true"></property>
+        <property key="remoteProvider" value="postgres"></property>
+        <property key="remoteSource" value="dbname='demo' host=lizmapdemo.opengis.ch port=5432 user='editor1' password='editor1' sslmode=disable key='id' srid=2056 type=Polygon table=&quot;citybees&quot;.&quot;area&quot; (geom) sql="></property>
+        <property key="variableNames"></property>
+        <property key="variableValues"></property>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
-        <DiagramCategory scaleBasedVisibility="0" lineSizeType="MM" width="15" sizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" penAlpha="255" maxScaleDenominator="1e+08" minimumSize="0" direction="1" labelPlacementMethod="XHeight" backgroundColor="#ffffff" height="15" opacity="1" spacingUnitScale="3x:0,0,0,0,0,0" showAxis="0" sizeType="MM" spacingUnit="MM" diagramOrientation="Up" minScaleDenominator="0" spacing="0" penColor="#000000" barWidth="5" backgroundAlpha="255" penWidth="0" enabled="0" rotationOffset="0">
-          <fontProperties style="" description="Cantarell,11,-1,5,50,0,0,0,0,0"/>
-          <attribute color="#000000" label="" field=""/>
+        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="1" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+8" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="0" scaleBasedVisibility="0" scaleDependency="Area" showAxis="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="0" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
+          <fontProperties description="Cantarell,11,-1,5,50,0,0,0,0,0" style=""></fontProperties>
+          <attribute color="#000000" field="" label=""></attribute>
           <axisSymbol>
-            <symbol alpha="1" clip_to_extent="1" force_rhr="0" type="line" name="">
-              <layer pass="0" class="SimpleLine" locked="0" enabled="1">
-                <prop k="capstyle" v="square"/>
-                <prop k="customdash" v="5;2"/>
-                <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="customdash_unit" v="MM"/>
-                <prop k="draw_inside_polygon" v="0"/>
-                <prop k="joinstyle" v="bevel"/>
-                <prop k="line_color" v="35,35,35,255"/>
-                <prop k="line_style" v="solid"/>
-                <prop k="line_width" v="0.26"/>
-                <prop k="line_width_unit" v="MM"/>
-                <prop k="offset" v="0"/>
-                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="offset_unit" v="MM"/>
-                <prop k="ring_filter" v="0"/>
-                <prop k="use_custom_dash" v="0"/>
-                <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" type="line">
+              <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+                <prop k="capstyle" v="square"></prop>
+                <prop k="customdash" v="5;2"></prop>
+                <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="customdash_unit" v="MM"></prop>
+                <prop k="draw_inside_polygon" v="0"></prop>
+                <prop k="joinstyle" v="bevel"></prop>
+                <prop k="line_color" v="35,35,35,255"></prop>
+                <prop k="line_style" v="solid"></prop>
+                <prop k="line_width" v="0.26"></prop>
+                <prop k="line_width_unit" v="MM"></prop>
+                <prop k="offset" v="0"></prop>
+                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                <prop k="offset_unit" v="MM"></prop>
+                <prop k="ring_filter" v="0"></prop>
+                <prop k="use_custom_dash" v="0"></prop>
+                <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option type="QString" value="" name="name"/>
-                    <Option name="properties"/>
-                    <Option type="QString" value="collection" name="type"/>
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
                   </Option>
                 </data_defined_properties>
               </layer>
@@ -2612,42 +2615,48 @@ def my_form_open(dialog, layer, feature):
           </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings obstacle="0" linePlacementFlags="2" zIndex="0" dist="0" placement="0" priority="0" showAll="1">
+      <DiagramLayerSettings dist="0" linePlacementFlags="2" obstacle="0" placement="0" priority="0" showAll="1" zIndex="0">
         <properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
-            <Option type="Map" name="properties">
-              <Option type="Map" name="positionX">
-                <Option type="bool" value="true" name="active"/>
-                <Option type="QString" value="id" name="field"/>
-                <Option type="int" value="2" name="type"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties" type="Map">
+              <Option name="positionX" type="Map">
+                <Option name="active" type="bool" value="true"></Option>
+                <Option name="field" type="QString" value="id"></Option>
+                <Option name="type" type="int" value="2"></Option>
               </Option>
-              <Option type="Map" name="positionY">
-                <Option type="bool" value="true" name="active"/>
-                <Option type="QString" value="id" name="field"/>
-                <Option type="int" value="2" name="type"/>
+              <Option name="positionY" type="Map">
+                <Option name="active" type="bool" value="true"></Option>
+                <Option name="field" type="QString" value="id"></Option>
+                <Option name="type" type="int" value="2"></Option>
               </Option>
-              <Option type="Map" name="show">
-                <Option type="bool" value="true" name="active"/>
-                <Option type="QString" value="id" name="field"/>
-                <Option type="int" value="2" name="type"/>
+              <Option name="show" type="Map">
+                <Option name="active" type="bool" value="true"></Option>
+                <Option name="field" type="QString" value="id"></Option>
+                <Option name="type" type="int" value="2"></Option>
               </Option>
             </Option>
-            <Option type="QString" value="collection" name="type"/>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </properties>
       </DiagramLayerSettings>
       <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-        <activeChecks/>
-        <checkConfiguration/>
+        <activeChecks></activeChecks>
+        <checkConfiguration type="Map">
+          <Option name="QgsGeometryGapCheck" type="Map">
+            <Option name="allowedGapsBuffer" type="double" value="0"></Option>
+            <Option name="allowedGapsEnabled" type="bool" value="false"></Option>
+            <Option name="allowedGapsLayer" type="QString" value=""></Option>
+          </Option>
+        </checkConfiguration>
       </geometryOptions>
-      <referencedLayers/>
-      <referencingLayers/>
+      <referencedLayers></referencedLayers>
+      <referencingLayers></referencingLayers>
       <fieldConfiguration>
         <field name="fid">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
@@ -2655,15 +2664,15 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="ValueMap">
             <config>
               <Option type="Map">
-                <Option type="List" name="map">
+                <Option name="map" type="List">
                   <Option type="Map">
-                    <Option type="QString" value="cantonal" name="Regional"/>
+                    <Option name="Regional" type="QString" value="cantonal"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option type="QString" value="national" name="National"/>
+                    <Option name="National" type="QString" value="national"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option type="QString" value="private" name="Private"/>
+                    <Option name="Private" type="QString" value="private"></Option>
                   </Option>
                 </Option>
               </Option>
@@ -2674,21 +2683,21 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="ValueMap">
             <config>
               <Option type="Map">
-                <Option type="List" name="map">
+                <Option name="map" type="List">
                   <Option type="Map">
-                    <Option type="QString" value="taraxacum" name="Dandelions"/>
+                    <Option name="Dandelions" type="QString" value="taraxacum"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option type="QString" value="grass" name="Grass"/>
+                    <Option name="Grass" type="QString" value="grass"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option type="QString" value="lavender" name="Lavender"/>
+                    <Option name="Lavender" type="QString" value="lavender"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option type="QString" value="colza" name="Colza"/>
+                    <Option name="Colza" type="QString" value="colza"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option type="QString" value="weed" name="Weed"/>
+                    <Option name="Weed" type="QString" value="weed"></Option>
                   </Option>
                 </Option>
               </Option>
@@ -2699,78 +2708,78 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="ExternalResource">
             <config>
               <Option type="Map">
-                <Option type="int" value="0" name="DocumentViewer"/>
-                <Option type="int" value="0" name="DocumentViewerHeight"/>
-                <Option type="int" value="0" name="DocumentViewerWidth"/>
-                <Option type="bool" value="true" name="FileWidget"/>
-                <Option type="bool" value="true" name="FileWidgetButton"/>
-                <Option type="QString" value="" name="FileWidgetFilter"/>
-                <Option type="Map" name="PropertyCollection">
-                  <Option type="QString" value="" name="name"/>
-                  <Option type="invalid" name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                <Option name="DocumentViewer" type="int" value="0"></Option>
+                <Option name="DocumentViewerHeight" type="int" value="0"></Option>
+                <Option name="DocumentViewerWidth" type="int" value="0"></Option>
+                <Option name="FileWidget" type="bool" value="true"></Option>
+                <Option name="FileWidgetButton" type="bool" value="true"></Option>
+                <Option name="FileWidgetFilter" type="QString" value=""></Option>
+                <Option name="PropertyCollection" type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
-                <Option type="int" value="1" name="RelativeStorage"/>
-                <Option type="int" value="0" name="StorageMode"/>
+                <Option name="RelativeStorage" type="int" value="1"></Option>
+                <Option name="StorageMode" type="int" value="0"></Option>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias index="0" name="" field="fid"/>
-        <alias index="1" name="Proprietor" field="proprietor"/>
-        <alias index="2" name="Plants" field="plant_species"/>
-        <alias index="3" name="Photo" field="picture"/>
+        <alias field="fid" index="0" name=""></alias>
+        <alias field="proprietor" index="1" name="Proprietor"></alias>
+        <alias field="plant_species" index="2" name="Plants"></alias>
+        <alias field="picture" index="3" name="Photo"></alias>
       </aliases>
-      <excludeAttributesWMS/>
-      <excludeAttributesWFS/>
+      <excludeAttributesWMS></excludeAttributesWMS>
+      <excludeAttributesWFS></excludeAttributesWFS>
       <defaults>
-        <default expression="" applyOnUpdate="0" field="fid"/>
-        <default expression="'national'" applyOnUpdate="0" field="proprietor"/>
-        <default expression="'grass'" applyOnUpdate="0" field="plant_species"/>
-        <default expression="" applyOnUpdate="0" field="picture"/>
+        <default applyOnUpdate="0" expression="" field="fid"></default>
+        <default applyOnUpdate="0" expression="'national'" field="proprietor"></default>
+        <default applyOnUpdate="0" expression="'grass'" field="plant_species"></default>
+        <default applyOnUpdate="0" expression="" field="picture"></default>
       </defaults>
       <constraints>
-        <constraint constraints="3" unique_strength="1" exp_strength="0" notnull_strength="1" field="fid"/>
-        <constraint constraints="5" unique_strength="0" exp_strength="1" notnull_strength="1" field="proprietor"/>
-        <constraint constraints="5" unique_strength="0" exp_strength="1" notnull_strength="1" field="plant_species"/>
-        <constraint constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0" field="picture"/>
+        <constraint constraints="3" exp_strength="0" field="fid" notnull_strength="1" unique_strength="1"></constraint>
+        <constraint constraints="1" exp_strength="0" field="proprietor" notnull_strength="1" unique_strength="0"></constraint>
+        <constraint constraints="1" exp_strength="0" field="plant_species" notnull_strength="1" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="picture" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint desc="" exp="" field="fid"/>
-        <constraint desc="cannot be empty" exp="&quot;proprietor&quot;" field="proprietor"/>
-        <constraint desc="cannot be empty" exp="&quot;plant_species&quot;" field="plant_species"/>
-        <constraint desc="" exp="" field="picture"/>
+        <constraint desc="" exp="" field="fid"></constraint>
+        <constraint desc="" exp="" field="proprietor"></constraint>
+        <constraint desc="" exp="" field="plant_species"></constraint>
+        <constraint desc="" exp="" field="picture"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction key="Canvas" value="{6cc0fff2-3e5d-43b0-a5f5-d5fae7c1b525}"/>
-        <actionsetting notificationMessage="" isEnabledOnlyWhenEditable="0" shortTitle="" action="" type="0" icon="" name="" id="{6cc0fff2-3e5d-43b0-a5f5-d5fae7c1b525}" capture="0">
-          <actionScope id="Feature"/>
-          <actionScope id="Canvas"/>
-          <actionScope id="Field"/>
+        <defaultAction key="Canvas" value="{013e3b47-07ab-4d56-94b5-1676081be4f9}"></defaultAction>
+        <actionsetting action="" capture="0" icon="" id="{013e3b47-07ab-4d56-94b5-1676081be4f9}" isEnabledOnlyWhenEditable="0" name="" notificationMessage="" shortTitle="" type="0">
+          <actionScope id="Canvas"></actionScope>
+          <actionScope id="Feature"></actionScope>
+          <actionScope id="Field"></actionScope>
         </actionsetting>
       </attributeactions>
-      <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="&quot;fid&quot;">
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="&quot;fid&quot;" sortOrder="0">
         <columns>
-          <column width="-1" type="field" hidden="0" name="proprietor"/>
-          <column width="-1" type="field" hidden="0" name="plant_species"/>
-          <column width="334" type="field" hidden="0" name="picture"/>
-          <column width="-1" type="actions" hidden="1"/>
-          <column width="-1" type="field" hidden="0" name="fid"/>
+          <column hidden="0" name="proprietor" type="field" width="-1"></column>
+          <column hidden="0" name="plant_species" type="field" width="-1"></column>
+          <column hidden="0" name="picture" type="field" width="334"></column>
+          <column hidden="1" type="actions" width="-1"></column>
+          <column hidden="0" name="fid" type="field" width="-1"></column>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1">.</editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath>../demo_proj_citybees_218</editforminitfilepath>
-      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+      <editforminitcode># -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -2786,57 +2795,57 @@ from qgis.PyQt.QtWidgets import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-]]></editforminitcode>
+</editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>tablayout</editorlayout>
       <attributeEditorForm>
-        <attributeEditorContainer visibilityExpressionEnabled="0" groupBox="0" visibilityExpression="" showLabel="1" name="General" columnCount="1">
-          <attributeEditorField index="1" showLabel="1" name="proprietor"/>
-          <attributeEditorField index="2" showLabel="1" name="plant_species"/>
+        <attributeEditorContainer columnCount="1" groupBox="0" name="General" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+          <attributeEditorField index="1" name="proprietor" showLabel="1"></attributeEditorField>
+          <attributeEditorField index="2" name="plant_species" showLabel="1"></attributeEditorField>
         </attributeEditorContainer>
-        <attributeEditorContainer visibilityExpressionEnabled="0" groupBox="0" visibilityExpression="" showLabel="1" name="Picture" columnCount="1">
-          <attributeEditorField index="3" showLabel="1" name="picture"/>
+        <attributeEditorContainer columnCount="1" groupBox="0" name="Picture" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+          <attributeEditorField index="3" name="picture" showLabel="1"></attributeEditorField>
         </attributeEditorContainer>
       </attributeEditorForm>
       <editable>
-        <field editable="1" name="fid"/>
-        <field editable="1" name="id"/>
-        <field editable="1" name="picture"/>
-        <field editable="1" name="plant_species"/>
-        <field editable="1" name="proprietor"/>
-        <field editable="1" name="review_date"/>
-        <field editable="1" name="reviewer"/>
+        <field editable="1" name="fid"></field>
+        <field editable="1" name="id"></field>
+        <field editable="1" name="picture"></field>
+        <field editable="1" name="plant_species"></field>
+        <field editable="1" name="proprietor"></field>
+        <field editable="1" name="review_date"></field>
+        <field editable="1" name="reviewer"></field>
       </editable>
       <labelOnTop>
-        <field labelOnTop="0" name="fid"/>
-        <field labelOnTop="0" name="id"/>
-        <field labelOnTop="0" name="picture"/>
-        <field labelOnTop="0" name="plant_species"/>
-        <field labelOnTop="0" name="proprietor"/>
-        <field labelOnTop="0" name="review_date"/>
-        <field labelOnTop="0" name="reviewer"/>
+        <field labelOnTop="0" name="fid"></field>
+        <field labelOnTop="0" name="id"></field>
+        <field labelOnTop="0" name="picture"></field>
+        <field labelOnTop="0" name="plant_species"></field>
+        <field labelOnTop="0" name="proprietor"></field>
+        <field labelOnTop="0" name="review_date"></field>
+        <field labelOnTop="0" name="reviewer"></field>
       </labelOnTop>
       <widgets>
         <widget name="Pollen_Con_field_id_ogr_dbname_fid">
           <config type="Map">
-            <Option type="QString" value="" name="nm-rel"/>
+            <Option name="nm-rel" type="QString" value=""></Option>
           </config>
         </widget>
         <widget name="apiary2018_area_id_area201805_id">
-          <config/>
+          <config></config>
         </widget>
         <widget name="apiary_036bee2c_a341_4b84_b25c_1bea7c01e9c2_area_id_area_60ff9e18_ea5b_4814_a227_157fe79ce94c_id">
           <config type="Map">
-            <Option type="QString" value="" name="nm-rel"/>
+            <Option name="nm-rel" type="QString" value=""></Option>
           </config>
         </widget>
         <widget name="apiary_279_area_id_ogr_dbname_fid">
           <config type="Map">
-            <Option type="QString" value="" name="nm-rel"/>
+            <Option name="nm-rel" type="QString" value=""></Option>
           </config>
         </widget>
         <widget name="ref_apiary_area_id_area201805_id">
-          <config/>
+          <config></config>
         </widget>
       </widgets>
       <previewExpression>represent_value("plant_species")  || ' ('  ||  represent_value("proprietor") || ' ) '
@@ -2845,9 +2854,9 @@ def my_form_open(dialog, layer, feature):
     </maplayer>
   </projectlayers>
   <layerorder>
-    <layer id="OpenStreetMap_442da2b8_ea6a_4114_a4f4_e472a9f7d8b9"/>
-    <layer id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b"/>
-    <layer id="apiary_27954fba_aad8_4336_8b19_23afed462c51"/>
+    <layer id="OpenStreetMap_442da2b8_ea6a_4114_a4f4_e472a9f7d8b9"></layer>
+    <layer id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b"></layer>
+    <layer id="apiary_27954fba_aad8_4336_8b19_23afed462c51"></layer>
   </layerorder>
   <properties>
     <DefaultStyles>
@@ -2860,7 +2869,7 @@ def my_form_open(dialog, layer, feature):
       <RandomColors type="bool">true</RandomColors>
     </DefaultStyles>
     <Digitizing>
-      <AvoidIntersectionsList type="QStringList"/>
+      <AvoidIntersectionsList type="QStringList"></AvoidIntersectionsList>
       <DefaultSnapTolerance type="double">0</DefaultSnapTolerance>
       <DefaultSnapToleranceUnit type="int">2</DefaultSnapToleranceUnit>
       <DefaultSnapType type="QString">off</DefaultSnapType>
@@ -2955,7 +2964,7 @@ def my_form_open(dialog, layer, feature):
       <DegreeFormat type="QString">MU</DegreeFormat>
     </PositionPrecision>
     <RequiredLayers>
-      <Layers type="QStringList"/>
+      <Layers type="QStringList"></Layers>
     </RequiredLayers>
     <SpatialRefSys>
       <ProjectCRSID type="int">47</ProjectCRSID>
@@ -2964,12 +2973,12 @@ def my_form_open(dialog, layer, feature):
       <ProjectionsEnabled type="int">1</ProjectionsEnabled>
     </SpatialRefSys>
     <Variables>
-      <variableNames type="QStringList"/>
-      <variableValues type="QStringList"/>
+      <variableNames type="QStringList"></variableNames>
+      <variableValues type="QStringList"></variableValues>
     </Variables>
-    <WCSLayers type="QStringList"/>
+    <WCSLayers type="QStringList"></WCSLayers>
     <WCSUrl type="QString"></WCSUrl>
-    <WFSLayers type="QStringList"/>
+    <WFSLayers type="QStringList"></WFSLayers>
     <WFSLayersPrecision>
       <apiary20180528091231748 type="int">8</apiary20180528091231748>
       <apiary_036bee2c_a341_4b84_b25c_1bea7c01e9c2 type="int">8</apiary_036bee2c_a341_4b84_b25c_1bea7c01e9c2>
@@ -2981,9 +2990,9 @@ def my_form_open(dialog, layer, feature):
       <lines20180528144355951 type="int">8</lines20180528144355951>
     </WFSLayersPrecision>
     <WFSTLayers>
-      <Delete type="QStringList"/>
-      <Insert type="QStringList"/>
-      <Update type="QStringList"/>
+      <Delete type="QStringList"></Delete>
+      <Insert type="QStringList"></Insert>
+      <Update type="QStringList"></Update>
     </WFSTLayers>
     <WFSUrl type="QString"></WFSUrl>
     <WMSAccessConstraints type="QString">None</WMSAccessConstraints>
@@ -3013,8 +3022,8 @@ def my_form_open(dialog, layer, feature):
     <WMSOnlineResource type="QString">http://www.opengis.ch</WMSOnlineResource>
     <WMSPrecision type="QString">8</WMSPrecision>
     <WMSRequestDefinedDataSources type="bool">false</WMSRequestDefinedDataSources>
-    <WMSRestrictedComposers type="QStringList"/>
-    <WMSRestrictedLayers type="QStringList"/>
+    <WMSRestrictedComposers type="QStringList"></WMSRestrictedComposers>
+    <WMSRestrictedLayers type="QStringList"></WMSRestrictedLayers>
     <WMSRootName type="QString"></WMSRootName>
     <WMSSegmentizeFeatureInfoGeometry type="bool">false</WMSSegmentizeFeatureInfoGeometry>
     <WMSServiceAbstract type="QString"></WMSServiceAbstract>
@@ -3023,23 +3032,23 @@ def my_form_open(dialog, layer, feature):
     <WMSUrl type="QString"></WMSUrl>
     <WMSUseLayerIDs type="bool">false</WMSUseLayerIDs>
     <WMTSGrids>
-      <CRS type="QStringList"/>
-      <Config type="QStringList"/>
+      <CRS type="QStringList"></CRS>
+      <Config type="QStringList"></Config>
     </WMTSGrids>
     <WMTSJpegLayers>
-      <Group type="QStringList"/>
-      <Layer type="QStringList"/>
+      <Group type="QStringList"></Group>
+      <Layer type="QStringList"></Layer>
       <Project type="bool">false</Project>
     </WMTSJpegLayers>
     <WMTSLayers>
-      <Group type="QStringList"/>
-      <Layer type="QStringList"/>
+      <Group type="QStringList"></Group>
+      <Layer type="QStringList"></Layer>
       <Project type="bool">false</Project>
     </WMTSLayers>
     <WMTSMinScale type="int">5000</WMTSMinScale>
     <WMTSPngLayers>
-      <Group type="QStringList"/>
-      <Layer type="QStringList"/>
+      <Group type="QStringList"></Group>
+      <Layer type="QStringList"></Layer>
       <Project type="bool">false</Project>
     </WMTSPngLayers>
     <WMTSUrl type="QString"></WMTSUrl>
@@ -3054,46 +3063,46 @@ def my_form_open(dialog, layer, feature):
     </qfieldsync>
   </properties>
   <visibility-presets>
-    <visibility-preset has-expanded-info="1" name="Diseases" has-checked-group-info="1">
-      <layer style="Diseases" id="apiary_27954fba_aad8_4336_8b19_23afed462c51" expanded="1"/>
+    <visibility-preset has-checked-group-info="1" has-expanded-info="1" name="Diseases">
+      <layer expanded="0" id="OpenStreetMap_442da2b8_ea6a_4114_a4f4_e472a9f7d8b9" style="default" visible="1"></layer>
+      <expanded-legend-nodes id="OpenStreetMap_442da2b8_ea6a_4114_a4f4_e472a9f7d8b9"></expanded-legend-nodes>
+      <layer expanded="0" id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" style="default" visible="1"></layer>
+      <expanded-legend-nodes id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b"></expanded-legend-nodes>
+      <layer expanded="1" id="apiary_27954fba_aad8_4336_8b19_23afed462c51" style="Diseases" visible="1"></layer>
       <expanded-legend-nodes id="apiary_27954fba_aad8_4336_8b19_23afed462c51">
-        <expanded-legend-node id="{2c8997f2-a415-45d2-bd98-2c0898cb3118}"/>
+        <expanded-legend-node id="{2c8997f2-a415-45d2-bd98-2c0898cb3118}"></expanded-legend-node>
       </expanded-legend-nodes>
-      <layer style="default" id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" expanded="0"/>
-      <expanded-legend-nodes id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b"/>
-      <layer style="default" id="OpenStreetMap_442da2b8_ea6a_4114_a4f4_e472a9f7d8b9" expanded="0"/>
-      <expanded-legend-nodes id="OpenStreetMap_442da2b8_ea6a_4114_a4f4_e472a9f7d8b9"/>
-      <checked-group-nodes/>
-      <expanded-group-nodes/>
+      <checked-group-nodes></checked-group-nodes>
+      <expanded-group-nodes></expanded-group-nodes>
     </visibility-preset>
-    <visibility-preset has-expanded-info="1" name="Heatmap" has-checked-group-info="1">
-      <layer style="Heatmap" id="apiary_27954fba_aad8_4336_8b19_23afed462c51" expanded="1"/>
+    <visibility-preset has-checked-group-info="1" has-expanded-info="1" name="Heatmap">
+      <layer expanded="0" id="OpenStreetMap_442da2b8_ea6a_4114_a4f4_e472a9f7d8b9" style="default" visible="1"></layer>
+      <expanded-legend-nodes id="OpenStreetMap_442da2b8_ea6a_4114_a4f4_e472a9f7d8b9"></expanded-legend-nodes>
+      <layer expanded="1" id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" style="default" visible="1"></layer>
+      <expanded-legend-nodes id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b"></expanded-legend-nodes>
+      <layer expanded="1" id="apiary_27954fba_aad8_4336_8b19_23afed462c51" style="Heatmap" visible="1"></layer>
       <expanded-legend-nodes id="apiary_27954fba_aad8_4336_8b19_23afed462c51">
-        <expanded-legend-node id="{2c8997f2-a415-45d2-bd98-2c0898cb3118}"/>
+        <expanded-legend-node id="{2c8997f2-a415-45d2-bd98-2c0898cb3118}"></expanded-legend-node>
       </expanded-legend-nodes>
-      <layer style="default" id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" expanded="1"/>
-      <expanded-legend-nodes id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b"/>
-      <layer style="default" id="OpenStreetMap_442da2b8_ea6a_4114_a4f4_e472a9f7d8b9" expanded="0"/>
-      <expanded-legend-nodes id="OpenStreetMap_442da2b8_ea6a_4114_a4f4_e472a9f7d8b9"/>
-      <checked-group-nodes/>
-      <expanded-group-nodes/>
+      <checked-group-nodes></checked-group-nodes>
+      <expanded-group-nodes></expanded-group-nodes>
     </visibility-preset>
-    <visibility-preset has-expanded-info="1" name="Species" has-checked-group-info="1">
-      <layer style="Species" id="apiary_27954fba_aad8_4336_8b19_23afed462c51" expanded="1"/>
+    <visibility-preset has-checked-group-info="1" has-expanded-info="1" name="Species">
+      <layer expanded="0" id="OpenStreetMap_442da2b8_ea6a_4114_a4f4_e472a9f7d8b9" style="default" visible="1"></layer>
+      <expanded-legend-nodes id="OpenStreetMap_442da2b8_ea6a_4114_a4f4_e472a9f7d8b9"></expanded-legend-nodes>
+      <layer expanded="1" id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" style="default" visible="1"></layer>
+      <expanded-legend-nodes id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b"></expanded-legend-nodes>
+      <layer expanded="1" id="apiary_27954fba_aad8_4336_8b19_23afed462c51" style="Species" visible="1"></layer>
       <expanded-legend-nodes id="apiary_27954fba_aad8_4336_8b19_23afed462c51">
-        <expanded-legend-node id="{2c8997f2-a415-45d2-bd98-2c0898cb3118}"/>
+        <expanded-legend-node id="{2c8997f2-a415-45d2-bd98-2c0898cb3118}"></expanded-legend-node>
       </expanded-legend-nodes>
-      <layer style="default" id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" expanded="1"/>
-      <expanded-legend-nodes id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b"/>
-      <layer style="default" id="OpenStreetMap_442da2b8_ea6a_4114_a4f4_e472a9f7d8b9" expanded="0"/>
-      <expanded-legend-nodes id="OpenStreetMap_442da2b8_ea6a_4114_a4f4_e472a9f7d8b9"/>
-      <checked-group-nodes/>
-      <expanded-group-nodes/>
+      <checked-group-nodes></checked-group-nodes>
+      <expanded-group-nodes></expanded-group-nodes>
     </visibility-preset>
   </visibility-presets>
   <transformContext>
-    <srcDest dest="EPSG:2056" sourceTransform="" destTransform="" source="EPSG:21781"/>
-    <srcDest dest="EPSG:23032" sourceTransform="" destTransform="" source="EPSG:3857"/>
+    <srcDest dest="EPSG:2056" destTransform="" source="EPSG:21781" sourceTransform=""></srcDest>
+    <srcDest dest="EPSG:23032" destTransform="" source="EPSG:3857" sourceTransform=""></srcDest>
   </transformContext>
   <projectMetadata>
     <identifier></identifier>
@@ -3111,200 +3120,215 @@ def my_form_open(dialog, layer, feature):
       <email></email>
       <role></role>
     </contact>
-    <links/>
+    <links></links>
     <author></author>
     <creation>2000-01-01T00:00:00</creation>
   </projectMetadata>
-  <Annotations/>
+  <Annotations></Annotations>
   <Layouts>
-    <Layout units="mm" worldFileMap="{5c99b08e-6df3-4fc4-b67e-956bf0e3b45c}" printResolution="300" name="Bees in Laax">
-      <Snapper snapToItems="1" snapToGuides="1" tolerance="5" snapToGrid="0"/>
-      <Grid offsetY="0" offsetX="0" offsetUnits="mm" resolution="10" resUnits="mm"/>
+    <Layout name="Bees in Laax" printResolution="300" units="mm" worldFileMap="{5c99b08e-6df3-4fc4-b67e-956bf0e3b45c}">
+      <Snapper snapToGrid="0" snapToGuides="1" snapToItems="1" tolerance="5"></Snapper>
+      <Grid offsetUnits="mm" offsetX="0" offsetY="0" resUnits="mm" resolution="10"></Grid>
       <PageCollection>
-        <symbol alpha="1" clip_to_extent="1" force_rhr="0" type="fill" name="">
-          <layer pass="0" class="SimpleFill" locked="0" enabled="1">
-            <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-            <prop k="color" v="255,255,255,255"/>
-            <prop k="joinstyle" v="miter"/>
-            <prop k="offset" v="0,0"/>
-            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-            <prop k="offset_unit" v="MM"/>
-            <prop k="outline_color" v="35,35,35,255"/>
-            <prop k="outline_style" v="no"/>
-            <prop k="outline_width" v="0.26"/>
-            <prop k="outline_width_unit" v="MM"/>
-            <prop k="style" v="solid"/>
+        <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" type="fill">
+          <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+            <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+            <prop k="color" v="255,255,255,255"></prop>
+            <prop k="joinstyle" v="miter"></prop>
+            <prop k="offset" v="0,0"></prop>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+            <prop k="offset_unit" v="MM"></prop>
+            <prop k="outline_color" v="35,35,35,255"></prop>
+            <prop k="outline_style" v="no"></prop>
+            <prop k="outline_width" v="0.26"></prop>
+            <prop k="outline_width_unit" v="MM"></prop>
+            <prop k="style" v="solid"></prop>
             <data_defined_properties>
               <Option type="Map">
-                <Option type="QString" value="" name="name"/>
-                <Option name="properties"/>
-                <Option type="QString" value="collection" name="type"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
           </layer>
         </symbol>
-        <LayoutItem referencePoint="0" templateUuid="{c59b3b52-5ddb-492d-bb03-29af0990322a}" groupUuid="" id="" position="0,0,mm" positionOnPage="0,0,mm" type="65638" zValue="0" frame="false" uuid="{c59b3b52-5ddb-492d-bb03-29af0990322a}" outlineWidthM="0.3,mm" frameJoinStyle="miter" excludeFromExports="0" itemRotation="0" positionLock="false" opacity="1" background="true" visibility="1" blendMode="0" size="297,210,mm">
-          <FrameColor green="0" blue="0" alpha="255" red="0"/>
-          <BackgroundColor green="255" blue="255" alpha="255" red="255"/>
+        <LayoutItem background="true" blendMode="0" excludeFromExports="0" frame="false" frameJoinStyle="miter" groupUuid="" id="" itemRotation="0" opacity="1" outlineWidthM="0.3,mm" position="0,0,mm" positionLock="false" positionOnPage="0,0,mm" referencePoint="0" size="297,210,mm" templateUuid="{c59b3b52-5ddb-492d-bb03-29af0990322a}" type="65638" uuid="{c59b3b52-5ddb-492d-bb03-29af0990322a}" visibility="1" zValue="0">
+          <FrameColor alpha="255" blue="0" green="0" red="0"></FrameColor>
+          <BackgroundColor alpha="255" blue="255" green="255" red="255"></BackgroundColor>
           <LayoutObject>
             <dataDefinedProperties>
               <Option type="Map">
-                <Option type="QString" value="" name="name"/>
-                <Option name="properties"/>
-                <Option type="QString" value="collection" name="type"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </dataDefinedProperties>
-            <customproperties/>
+            <customproperties></customproperties>
           </LayoutObject>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" type="fill" name="">
-            <layer pass="0" class="SimpleFill" locked="0" enabled="1">
-              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="color" v="255,255,255,255"/>
-              <prop k="joinstyle" v="miter"/>
-              <prop k="offset" v="0,0"/>
-              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_unit" v="MM"/>
-              <prop k="outline_color" v="35,35,35,255"/>
-              <prop k="outline_style" v="no"/>
-              <prop k="outline_width" v="0.26"/>
-              <prop k="outline_width_unit" v="MM"/>
-              <prop k="style" v="solid"/>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" type="fill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="color" v="255,255,255,255"></prop>
+              <prop k="joinstyle" v="miter"></prop>
+              <prop k="offset" v="0,0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="outline_color" v="35,35,35,255"></prop>
+              <prop k="outline_style" v="no"></prop>
+              <prop k="outline_width" v="0.26"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
+              <prop k="style" v="solid"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
-                  <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </LayoutItem>
-        <GuideCollection visible="1"/>
+        <GuideCollection visible="1"></GuideCollection>
       </PageCollection>
-      <LayoutItem referencePoint="0" resizeMode="0" pictureWidth="22.0722" templateUuid="{878b644c-7911-46ac-a111-9c429bbd53f3}" groupUuid="" id="" svgBorderColor="0,0,0,255" position="222.229,162.983,mm" positionOnPage="222.229,162.983,mm" northOffset="0" type="65640" svgFillColor="255,255,255,255" zValue="5" frame="false" uuid="{878b644c-7911-46ac-a111-9c429bbd53f3}" outlineWidthM="0.3,mm" frameJoinStyle="miter" pictureHeight="22.2076" excludeFromExports="0" anchorPoint="0" file="../../../../../Pictures/openGIS-complete.png" itemRotation="0" positionLock="false" opacity="1" background="false" visibility="1" blendMode="0" pictureRotation="0" northMode="0" size="68.5479,22.2076,mm" svgBorderWidth="0.2" mapUuid="">
-        <FrameColor green="0" blue="0" alpha="255" red="0"/>
-        <BackgroundColor green="255" blue="255" alpha="255" red="255"/>
+      <LayoutItem anchorPoint="0" background="false" blendMode="0" excludeFromExports="0" file="../../../../../Pictures/openGIS-complete.png" frame="false" frameJoinStyle="miter" groupUuid="" id="" itemRotation="0" mapUuid="" mode="1" northMode="0" northOffset="0" opacity="1" outlineWidthM="0.3,mm" pictureHeight="22.2076" pictureRotation="0" pictureWidth="67.6866" position="222.229,162.983,mm" positionLock="false" positionOnPage="222.229,162.983,mm" referencePoint="0" resizeMode="0" size="68.5479,22.2076,mm" svgBorderColor="0,0,0,255" svgBorderWidth="0.2" svgFillColor="255,255,255,255" templateUuid="{878b644c-7911-46ac-a111-9c429bbd53f3}" type="65640" uuid="{878b644c-7911-46ac-a111-9c429bbd53f3}" visibility="1" zValue="5">
+        <FrameColor alpha="255" blue="0" green="0" red="0"></FrameColor>
+        <BackgroundColor alpha="255" blue="255" green="255" red="255"></BackgroundColor>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
-              <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dataDefinedProperties>
-          <customproperties/>
+          <customproperties></customproperties>
         </LayoutObject>
       </LayoutItem>
-      <LayoutItem labelText="Apiaries and beehives in the laax central and agglomeration. Collected by QField for QGIS." referencePoint="0" templateUuid="{160169b2-2445-485d-9410-1bdd71c3bcc6}" groupUuid="" id="" marginX="0" position="12.2296,23.0615,mm" positionOnPage="12.2296,23.0615,mm" type="65641" zValue="4" frame="false" uuid="{160169b2-2445-485d-9410-1bdd71c3bcc6}" outlineWidthM="0.3,mm" frameJoinStyle="miter" excludeFromExports="0" itemRotation="0" positionLock="false" opacity="1" background="false" valign="32" marginY="0" visibility="1" halign="8" blendMode="0" htmlState="0" size="274.942,11.8802,mm">
-        <FrameColor green="0" blue="0" alpha="255" red="0"/>
-        <BackgroundColor green="255" blue="255" alpha="255" red="255"/>
+      <LayoutItem background="false" blendMode="0" excludeFromExports="0" frame="false" frameJoinStyle="miter" groupUuid="" halign="8" htmlState="0" id="" itemRotation="0" labelText="Apiaries and beehives in the laax central and agglomeration. Collected by QField for QGIS." marginX="0" marginY="0" opacity="1" outlineWidthM="0.3,mm" position="12.2296,23.0615,mm" positionLock="false" positionOnPage="12.2296,23.0615,mm" referencePoint="0" size="274.942,11.8802,mm" templateUuid="{160169b2-2445-485d-9410-1bdd71c3bcc6}" type="65641" uuid="{160169b2-2445-485d-9410-1bdd71c3bcc6}" valign="32" visibility="1" zValue="4">
+        <FrameColor alpha="255" blue="0" green="0" red="0"></FrameColor>
+        <BackgroundColor alpha="255" blue="255" green="255" red="255"></BackgroundColor>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
-              <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dataDefinedProperties>
-          <customproperties/>
+          <customproperties></customproperties>
         </LayoutObject>
-        <LabelFont style="" description="Ubuntu,16,-1,5,50,0,0,0,0,0"/>
-        <FontColor green="0" blue="0" alpha="255" red="0"/>
+        <LabelFont description="Ubuntu,16,-1,5,50,0,0,0,0,0" style=""></LabelFont>
+        <FontColor alpha="255" blue="0" green="0" red="0"></FontColor>
       </LayoutItem>
-      <LayoutItem labelText="Bees in Laax" referencePoint="0" templateUuid="{d040a3a5-8577-49ad-bacf-6037321d5814}" groupUuid="" id="" marginX="0" position="12.2296,5.94009,mm" positionOnPage="12.2296,5.94009,mm" type="65641" zValue="3" frame="false" uuid="{d040a3a5-8577-49ad-bacf-6037321d5814}" outlineWidthM="0.3,mm" frameJoinStyle="miter" excludeFromExports="0" itemRotation="0" positionLock="false" opacity="1" background="false" valign="32" marginY="0" visibility="1" halign="8" blendMode="0" htmlState="0" size="274.942,17.1214,mm">
-        <FrameColor green="0" blue="0" alpha="255" red="0"/>
-        <BackgroundColor green="255" blue="255" alpha="255" red="255"/>
+      <LayoutItem background="false" blendMode="0" excludeFromExports="0" frame="false" frameJoinStyle="miter" groupUuid="" halign="8" htmlState="0" id="" itemRotation="0" labelText="Bees in Laax" marginX="0" marginY="0" opacity="1" outlineWidthM="0.3,mm" position="12.2296,5.94009,mm" positionLock="false" positionOnPage="12.2296,5.94009,mm" referencePoint="0" size="274.942,17.1214,mm" templateUuid="{d040a3a5-8577-49ad-bacf-6037321d5814}" type="65641" uuid="{d040a3a5-8577-49ad-bacf-6037321d5814}" valign="32" visibility="1" zValue="3">
+        <FrameColor alpha="255" blue="0" green="0" red="0"></FrameColor>
+        <BackgroundColor alpha="255" blue="255" green="255" red="255"></BackgroundColor>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
-              <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dataDefinedProperties>
-          <customproperties/>
+          <customproperties></customproperties>
         </LayoutObject>
-        <LabelFont style="" description="Ubuntu,33,-1,5,50,0,0,0,0,0"/>
-        <FontColor green="0" blue="0" alpha="255" red="0"/>
+        <LabelFont description="Ubuntu,33,-1,5,50,0,0,0,0,0" style=""></LabelFont>
+        <FontColor alpha="255" blue="0" green="0" red="0"></FontColor>
       </LayoutItem>
-      <LayoutItem zValue="2" columnCount="1" rasterBorder="1" title="" lineSpacing="1" position="226.772,34.9417,mm" visibility="1" blendMode="0" titleAlignment="1" referencePoint="0" splitLayer="0" symbolAlignment="1" columnSpace="2" rasterBorderColor="0,0,0,255" id="" size="60.4,85.4,mm" resizeToContents="1" equalColumnWidth="0" uuid="{d0e753e6-3e8c-44fc-8987-59f706e0168b}" wrapChar="" outlineWidthM="0.3,mm" symbolWidth="7" itemRotation="0" rasterBorderWidth="0" positionLock="false" symbolHeight="4" map_uuid="{5c99b08e-6df3-4fc4-b67e-956bf0e3b45c}" type="65642" wmsLegendWidth="50" positionOnPage="226.772,34.9417,mm" fontColor="#000000" opacity="1" excludeFromExports="0" boxSpace="2" frame="false" templateUuid="{d0e753e6-3e8c-44fc-8987-59f706e0168b}" background="true" legendFilterByAtlas="0" groupUuid="" wmsLegendHeight="25" frameJoinStyle="miter">
-        <FrameColor green="0" blue="0" alpha="255" red="0"/>
-        <BackgroundColor green="255" blue="255" alpha="255" red="255"/>
+      <LayoutItem background="true" blendMode="0" boxSpace="2" columnCount="1" columnSpace="2" equalColumnWidth="0" excludeFromExports="0" fontColor="#000000" frame="false" frameJoinStyle="miter" groupUuid="" id="" itemRotation="0" legendFilterByAtlas="0" lineSpacing="1" map_uuid="{5c99b08e-6df3-4fc4-b67e-956bf0e3b45c}" opacity="1" outlineWidthM="0.3,mm" position="226.772,34.9417,mm" positionLock="false" positionOnPage="226.772,34.9417,mm" rasterBorder="1" rasterBorderColor="0,0,0,255" rasterBorderWidth="0" referencePoint="0" resizeToContents="1" size="60.4,85.4,mm" splitLayer="0" symbolAlignment="1" symbolHeight="4" symbolWidth="7" templateUuid="{d0e753e6-3e8c-44fc-8987-59f706e0168b}" title="" titleAlignment="1" type="65642" uuid="{d0e753e6-3e8c-44fc-8987-59f706e0168b}" visibility="1" wmsLegendHeight="25" wmsLegendWidth="50" wrapChar="" zValue="2">
+        <FrameColor alpha="255" blue="0" green="0" red="0"></FrameColor>
+        <BackgroundColor alpha="255" blue="255" green="255" red="255"></BackgroundColor>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
-              <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dataDefinedProperties>
-          <customproperties/>
+          <customproperties></customproperties>
         </LayoutObject>
         <styles>
           <style alignment="1" marginBottom="3.5" name="title">
-            <styleFont style="" description="Ubuntu,16,-1,5,50,0,0,0,0,0"/>
+            <styleFont description="Ubuntu,16,-1,5,50,0,0,0,0,0" style=""></styleFont>
           </style>
-          <style alignment="1" name="group" marginTop="3">
-            <styleFont style="" description="Ubuntu,14,-1,5,50,0,0,0,0,0"/>
+          <style alignment="1" marginTop="3" name="group">
+            <styleFont description="Ubuntu,14,-1,5,50,0,0,0,0,0" style=""></styleFont>
           </style>
-          <style alignment="1" name="subgroup" marginTop="3">
-            <styleFont style="" description="Ubuntu,12,-1,5,50,0,0,0,0,0"/>
+          <style alignment="1" marginTop="3" name="subgroup">
+            <styleFont description="Ubuntu,12,-1,5,50,0,0,0,0,0" style=""></styleFont>
           </style>
-          <style alignment="1" name="symbol" marginTop="2.5">
-            <styleFont style="" description="Ubuntu,11,-1,5,50,0,0,0,0,0"/>
+          <style alignment="1" marginTop="2.5" name="symbol">
+            <styleFont description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""></styleFont>
           </style>
-          <style alignment="1" marginLeft="2" name="symbolLabel" marginTop="2">
-            <styleFont style="" description="Ubuntu,12,-1,5,50,0,0,0,0,0"/>
+          <style alignment="1" marginLeft="2" marginTop="2" name="symbolLabel">
+            <styleFont description="Ubuntu,12,-1,5,50,0,0,0,0,0" style=""></styleFont>
           </style>
         </styles>
         <layer-tree-group>
-          <customproperties/>
-          <layer-tree-layer checked="Qt::Checked" providerKey="ogr" id="apiary_27954fba_aad8_4336_8b19_23afed462c51" name="Apiary" source="./bees.gpkg|layername=apiary" expanded="1">
+          <customproperties></customproperties>
+          <layer-tree-layer checked="Qt::Checked" expanded="1" id="apiary_27954fba_aad8_4336_8b19_23afed462c51" name="Apiary" providerKey="ogr" source="./bees.gpkg|layername=apiary">
             <customproperties>
-              <property key="expandedLegendNodes" value="{2c8997f2-a415-45d2-bd98-2c0898cb3118}"/>
-              <property key="showFeatureCount" value="1"/>
+              <property key="expandedLegendNodes" value="{2c8997f2-a415-45d2-bd98-2c0898cb3118}"></property>
+              <property key="showFeatureCount" value="1"></property>
             </customproperties>
           </layer-tree-layer>
-          <layer-tree-layer checked="Qt::Checked" providerKey="ogr" id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" name="Fields" source="./bumblebees.gpkg|layername=area" expanded="0">
+          <layer-tree-layer checked="Qt::Checked" expanded="0" id="ogr_dbname___home_marco_dev_QField_demo_projects_citybees_new_gpkg__table__area___geom__sql__ba518f87_384f_494b_acd8_66843717f48b" name="Fields" providerKey="ogr" source="./bumblebees.gpkg|layername=area">
             <customproperties>
-              <property key="expandedLegendNodes"/>
-              <property key="showFeatureCount" value="0"/>
+              <property key="expandedLegendNodes"></property>
+              <property key="showFeatureCount" value="0"></property>
             </customproperties>
           </layer-tree-layer>
-          <layer-tree-layer checked="Qt::Checked" id="countries_a5e8d4da_f5b9_48ce_9909_c3760e271a9e" name="Countries" expanded="1">
+          <layer-tree-layer checked="Qt::Checked" expanded="1" id="countries_a5e8d4da_f5b9_48ce_9909_c3760e271a9e" name="Countries">
             <customproperties>
-              <property key="expandedLegendNodes"/>
+              <property key="expandedLegendNodes"></property>
             </customproperties>
           </layer-tree-layer>
-          <custom-order enabled="0"/>
+          <custom-order enabled="0"></custom-order>
         </layer-tree-group>
       </LayoutItem>
-      <LayoutItem followPreset="false" referencePoint="0" templateUuid="{5c99b08e-6df3-4fc4-b67e-956bf0e3b45c}" groupUuid="" id="" drawCanvasItems="true" position="12.2296,34.9417,mm" positionOnPage="12.2296,34.9417,mm" type="65639" followPresetName="" zValue="1" frame="false" uuid="{5c99b08e-6df3-4fc4-b67e-956bf0e3b45c}" outlineWidthM="0.3,mm" frameJoinStyle="miter" excludeFromExports="0" labelMargin="0,mm" itemRotation="0" positionLock="false" opacity="1" background="true" visibility="1" mapRotation="0" blendMode="0" mapFlags="0" keepLayerSet="false" size="210,150.25,mm">
-        <FrameColor green="0" blue="0" alpha="255" red="0"/>
-        <BackgroundColor green="253" blue="253" alpha="255" red="253"/>
+      <LayoutItem background="true" blendMode="0" drawCanvasItems="true" excludeFromExports="0" followPreset="false" followPresetName="" frame="false" frameJoinStyle="miter" groupUuid="" id="" itemRotation="0" keepLayerSet="false" labelMargin="0,mm" mapFlags="0" mapRotation="0" opacity="1" outlineWidthM="0.3,mm" position="12.2296,34.9417,mm" positionLock="false" positionOnPage="12.2296,34.9417,mm" referencePoint="0" size="210,150.25,mm" templateUuid="{5c99b08e-6df3-4fc4-b67e-956bf0e3b45c}" type="65639" uuid="{5c99b08e-6df3-4fc4-b67e-956bf0e3b45c}" visibility="1" zValue="1">
+        <FrameColor alpha="255" blue="0" green="0" red="0"></FrameColor>
+        <BackgroundColor alpha="255" blue="253" green="253" red="253"></BackgroundColor>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
-              <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option name="name" type="QString" value=""></Option>
+              <Option name="properties"></Option>
+              <Option name="type" type="QString" value="collection"></Option>
             </Option>
           </dataDefinedProperties>
-          <customproperties/>
+          <customproperties></customproperties>
         </LayoutObject>
-        <Extent ymin="5910067.35689904168248177" ymax="5911619.63782131392508745" xmax="1031922.99632693966850638" xmin="1029753.41299139172770083"/>
-        <LayerSet/>
-        <AtlasMap atlasDriven="0" margin="0.10000000000000001" scalingMode="2"/>
-        <labelBlockingItems/>
+        <Extent xmax="1031922.99632693966850638" xmin="1029753.41299139172770083" ymax="5911619.63782131392508745" ymin="5910067.35689904168248177"></Extent>
+        <LayerSet></LayerSet>
+        <AtlasMap atlasDriven="0" margin="0.10000000000000001" scalingMode="2"></AtlasMap>
+        <labelBlockingItems></labelBlockingItems>
       </LayoutItem>
       <customproperties>
-        <property key="atlasRasterFormat" value="png"/>
+        <property key="atlasRasterFormat" value="png"></property>
       </customproperties>
-      <Atlas filterFeatures="0" coverageLayer="" filenamePattern="'output_'||@atlas_featurenumber" hideCoverage="0" pageNameExpression="" sortFeatures="0" enabled="0"/>
+      <Atlas coverageLayer="" enabled="0" filenamePattern="'output_'||@atlas_featurenumber" filterFeatures="0" hideCoverage="0" pageNameExpression="" sortFeatures="0"></Atlas>
     </Layout>
   </Layouts>
-  <Bookmarks/>
+  <Bookmarks></Bookmarks>
   <ProjectViewSettings UseProjectScales="0">
-    <Scales/>
+    <Scales></Scales>
   </ProjectViewSettings>
+  <ProjectTimeSettings frameRate="1" timeStep="1" timeStepUnit="h"></ProjectTimeSettings>
+  <ProjectDisplaySettings>
+    <BearingFormat id="bearing">
+      <Option type="Map">
+        <Option name="decimal_separator" type="QChar" value=""></Option>
+        <Option name="decimals" type="int" value="6"></Option>
+        <Option name="direction_format" type="int" value="0"></Option>
+        <Option name="rounding_type" type="int" value="0"></Option>
+        <Option name="show_plus" type="bool" value="false"></Option>
+        <Option name="show_thousand_separator" type="bool" value="true"></Option>
+        <Option name="show_trailing_zeros" type="bool" value="false"></Option>
+        <Option name="thousand_separator" type="QChar" value=""></Option>
+      </Option>
+    </BearingFormat>
+  </ProjectDisplaySettings>
 </qgis>

--- a/src/core/androidplatformutilities.cpp
+++ b/src/core/androidplatformutilities.cpp
@@ -260,6 +260,7 @@ bool AndroidPlatformUtilities::checkAndAcquirePermissions( const QString &permis
 
 void AndroidPlatformUtilities::setScreenLockPermission( const bool allowLock )
 {
+  /*
   if ( mActivity.isValid() )
   {
     QAndroidJniObject window = mActivity.callObjectMethod( "getWindow", "()Landroid/view/Window;" );
@@ -277,6 +278,7 @@ void AndroidPlatformUtilities::setScreenLockPermission( const bool allowLock )
       }
     }
   }
+  */
 }
 
 void AndroidPlatformUtilities::showRateThisApp() const

--- a/src/core/androidplatformutilities.cpp
+++ b/src/core/androidplatformutilities.cpp
@@ -260,7 +260,6 @@ bool AndroidPlatformUtilities::checkAndAcquirePermissions( const QString &permis
 
 void AndroidPlatformUtilities::setScreenLockPermission( const bool allowLock )
 {
-  /*
   if ( mActivity.isValid() )
   {
     QAndroidJniObject window = mActivity.callObjectMethod( "getWindow", "()Landroid/view/Window;" );
@@ -278,7 +277,6 @@ void AndroidPlatformUtilities::setScreenLockPermission( const bool allowLock )
       }
     }
   }
-  */
 }
 
 void AndroidPlatformUtilities::showRateThisApp() const

--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -293,20 +293,20 @@ void AttributeFormModelBase::flatten( QgsAttributeEditorContainer *container, QS
 
         // create constraint description
         QStringList descriptions;
-        if( !field.constraints().constraintDescription().isEmpty() )
+        if ( !field.constraints().constraintDescription().isEmpty() )
         {
           descriptions << field.constraints().constraintDescription();
         }
         if ( field.constraints().constraints() & QgsFieldConstraints::ConstraintNotNull )
         {
-          descriptions << tr("Not NULL");
+          descriptions << tr( "Not NULL" );
         }
-        if( field.constraints().constraints() & QgsFieldConstraints::ConstraintUnique )
+        if ( field.constraints().constraints() & QgsFieldConstraints::ConstraintUnique )
         {
-          descriptions << tr("Unique");
+          descriptions << tr( "Unique" );
         }
 
-        item->setData( descriptions.join(", "), AttributeFormModel::ConstraintDescription );
+        item->setData( descriptions.join( ", " ), AttributeFormModel::ConstraintDescription );
 
         updateAttributeValue( item );
 
@@ -387,7 +387,7 @@ void AttributeFormModelBase::updateVisibility( int fieldIndex )
     QStandardItem *item = constraintIterator.key();
 
     QStringList errors;
-    bool hardConstraintSatisfied = QgsVectorLayerUtils::validateAttribute( mLayer, mFeatureModel->feature(), item->data( AttributeFormModel::FieldIndex).toInt(), errors, QgsFieldConstraints::ConstraintStrengthHard );
+    bool hardConstraintSatisfied = QgsVectorLayerUtils::validateAttribute( mLayer, mFeatureModel->feature(), item->data( AttributeFormModel::FieldIndex ).toInt(), errors, QgsFieldConstraints::ConstraintStrengthHard );
     if ( hardConstraintSatisfied != item->data( AttributeFormModel::ConstraintHardValid ).toBool() )
     {
       item->setData( hardConstraintSatisfied, AttributeFormModel::ConstraintHardValid );
@@ -398,7 +398,7 @@ void AttributeFormModelBase::updateVisibility( int fieldIndex )
     }
 
     QStringList softErrors;
-    bool softConstraintSatisfied = QgsVectorLayerUtils::validateAttribute( mLayer, mFeatureModel->feature(), item->data( AttributeFormModel::FieldIndex).toInt(), softErrors, QgsFieldConstraints::ConstraintStrengthSoft );
+    bool softConstraintSatisfied = QgsVectorLayerUtils::validateAttribute( mLayer, mFeatureModel->feature(), item->data( AttributeFormModel::FieldIndex ).toInt(), softErrors, QgsFieldConstraints::ConstraintStrengthSoft );
     if ( softConstraintSatisfied != item->data( AttributeFormModel::ConstraintSoftValid ).toBool() )
     {
       item->setData( softConstraintSatisfied, AttributeFormModel::ConstraintSoftValid );

--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -290,7 +290,23 @@ void AttributeFormModelBase::flatten( QgsAttributeEditorContainer *container, QS
         item->setData( true, AttributeFormModel::CurrentlyVisible );
         item->setData( true, AttributeFormModel::ConstraintHardValid );
         item->setData( true, AttributeFormModel::ConstraintSoftValid );
-        item->setData( field.constraints().constraintDescription(), AttributeFormModel::ConstraintDescription );
+
+        // create constraint description
+        QStringList descriptions;
+        if( !field.constraints().constraintDescription().isEmpty() )
+        {
+          descriptions << field.constraints().constraintDescription();
+        }
+        if ( field.constraints().constraints() & QgsFieldConstraints::ConstraintNotNull )
+        {
+          descriptions << tr("Not NULL");
+        }
+        if( field.constraints().constraints() & QgsFieldConstraints::ConstraintUnique )
+        {
+          descriptions << tr("Unique");
+        }
+
+        item->setData( descriptions.join(", "), AttributeFormModel::ConstraintDescription );
 
         updateAttributeValue( item );
 

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -242,7 +242,8 @@ Page {
           top: fieldLabel.bottom
         }
 
-        text: !ConstraintHardValid ? qsTr( "Error: " ) + ConstraintDescription : !ConstraintSoftValid ? qsTr( "Warning: " ) + ConstraintDescription : ''
+        //text: !ConstraintHardValid ? qsTr( "Error: " ) + ConstraintDescription : !ConstraintSoftValid ? qsTr( "Warning: " ) + ConstraintDescription : ''
+        text: !ConstraintHardValid ? ConstraintDescription : !ConstraintSoftValid ? ConstraintDescription : ''
         height: ConstraintHardValid || ConstraintSoftValid ? 0 : undefined
         visible: !ConstraintHardValid || !ConstraintSoftValid
 

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -242,7 +242,6 @@ Page {
           top: fieldLabel.bottom
         }
 
-        //text: !ConstraintHardValid ? qsTr( "Error: " ) + ConstraintDescription : !ConstraintSoftValid ? qsTr( "Warning: " ) + ConstraintDescription : ''
         text: !ConstraintHardValid ? ConstraintDescription : !ConstraintSoftValid ? ConstraintDescription : ''
         height: ConstraintHardValid || ConstraintSoftValid ? 0 : undefined
         visible: !ConstraintHardValid || !ConstraintSoftValid


### PR DESCRIPTION
I thought it's a bug, but apparently it has not been implemented before.

Now Not Null and Unique Constraints are supported.
![WhatsApp Image 2020-03-25 at 10 50 07](https://user-images.githubusercontent.com/28384354/77524014-f1d28480-6e86-11ea-9c2f-4f9a09ecaa26.jpeg)

The descriptionmessage is the list of all the messages including the ones generated for not null and unique. They are not separated by it's strength. This could be improved but is actually how QGIS behaves as well.
