### PR TITLE
Fix center GPS over menu

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -923,9 +923,7 @@ ApplicationWindow {
       font: Theme.defaultFont
       width: parent.width
       onTriggered: {
-        var coord = positionSource.position.coordinate;
-        var loc = Qt.point( coord.longitude, coord.latitude );
-        mapCanvas.mapSettings.setCenter( locationMarker.coordinateTransform.transform( loc ) )
+        mapCanvas.mapSettings.setCenter(positionSource.projectedPosition)
       }
     }
 


### PR DESCRIPTION
use the positionSource.projectedPosition to center position (like we do on symbol click).

fixes #895

I didn't made research why the old functionality does not work.