### PR TITLE
follow up upgrade to Qt 5.13+

### DIFF
--- a/src/core/featurelistmodel.h
+++ b/src/core/featurelistmodel.h
@@ -65,6 +65,8 @@ class FeatureListModel : public QAbstractItemModel
     virtual int columnCount( const QModelIndex &parent ) const override;
     virtual QVariant data( const QModelIndex &index, int role ) const override;
 
+    Q_INVOKABLE QVariant dataFromRowIndex( int row, int role ){ return data( index( row, 0, QModelIndex() ), role ); }
+
     virtual QHash<int, QByteArray> roleNames() const override;
 
     QgsVectorLayer *currentLayer() const;

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -256,8 +256,8 @@ Page {
 
         Loader {
           id: attributeEditorLoader
-          asynchronous: true
-          visible: status == Loader.Ready
+          //asynchronous: true
+          //visible: status == Loader.Ready
 
           height: childrenRect.height
           anchors { left: parent.left; right: parent.right }

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -32,7 +32,8 @@ Item {
     ComboBox {
       id: comboBox
 
-      property var myCurrentValue: value
+      // the currentValue is a read-only property of ComboBox
+      property var comboBoxCurrentValue: value
       property var _cachedCurrentValue
 
       textRole: 'display'
@@ -48,18 +49,18 @@ Item {
 
       // Workaround to get a signal when the value has changed
       onMyCurrentValueChanged: {
-        currentIndex = featureListModel.findKey(myCurrentValue)
+        currentIndex = featureListModel.findKey(comboBoxCurrentValue)
       }
 
       Connections {
         target: featureListModel
 
         onModelAboutToBeReset: {
-          comboBox._cachedCurrentValue = comboBox.myCurrentValue
+          comboBox._cachedCurrentValue = comboBox.comboBoxCurrentValue
         }
 
         onModelReset: {
-          comboBox.currentIndex = featureListModel.findKey(comboBox.myCurrentValue)
+          comboBox.currentIndex = featureListModel.findKey(comboBox.comboBoxCurrentValue)
         }
       }
 
@@ -176,7 +177,7 @@ Item {
 
         onSaved: {
           var referencedValue = attributeFormModel.attribute(relationCombobox._relation.resolveReferencedField(field.name))
-          comboBox.myCurrentValue = referencedValue
+          comboBox.comboBoxCurrentValue = referencedValue
           popup.close()
         }
 

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.0
-import QtQuick.Controls 2.0
+import QtQuick 2.12
+import QtQuick.Controls 2.12
 import QtGraphicalEffects 1.0
 import QtQuick.Layouts 1.0
 import "." as QField
@@ -12,7 +12,7 @@ Item {
   id: relationCombobox
 
   Component.onCompleted: {
-    comboBox.currentIndex = featureListModel.findKey(comboBox.value)
+    comboBox.currentIndex = featureListModel.findKey(value)
     comboBox.visible = _relation !== undefined ? _relation.isValid : true
     addButton.visible = _relation !== undefined ? _relation.isValid : false
     invalidWarning.visible = _relation !== undefined ? !(_relation.isValid) : false
@@ -32,7 +32,7 @@ Item {
     ComboBox {
       id: comboBox
 
-      property var currentValue: value
+      property var myCurrentValue: value
       property var _cachedCurrentValue
 
       textRole: 'display'
@@ -42,25 +42,24 @@ Item {
       model: featureListModel
 
       onCurrentIndexChanged: {
-        var idx = featureListModel.index(currentIndex, 0, undefined)
-        var newValue = featureListModel.data(idx, FeatureListModel.KeyFieldRole)
+        var newValue = featureListModel.dataFromRowIndex(currentIndex, FeatureListModel.KeyFieldRole)
         valueChanged(newValue, false)
       }
 
       // Workaround to get a signal when the value has changed
-      onCurrentValueChanged: {
-        currentIndex = featureListModel.findKey(currentValue)
+      onMyCurrentValueChanged: {
+        currentIndex = featureListModel.findKey(myCurrentValue)
       }
 
       Connections {
         target: featureListModel
 
         onModelAboutToBeReset: {
-          comboBox._cachedCurrentValue = comboBox.currentValue
+          comboBox._cachedCurrentValue = comboBox.myCurrentValue
         }
 
         onModelReset: {
-          comboBox.currentIndex = featureListModel.findKey(comboBox.currentValue)
+          comboBox.currentIndex = featureListModel.findKey(comboBox.myCurrentValue)
         }
       }
 
@@ -139,7 +138,7 @@ Item {
   AttributeFormModel {
    id: attributeFormModel
    featureModel: FeatureModel {
-       currentLayer: relationCombobox._relation.referencedLayer
+       currentLayer: relationCombobox._relation ? relationCombobox._relation.referencedLayer : null
      }
   }
 
@@ -177,7 +176,7 @@ Item {
 
         onSaved: {
           var referencedValue = attributeFormModel.attribute(relationCombobox._relation.resolveReferencedField(field.name))
-          comboBox.currentValue = referencedValue
+          comboBox.myCurrentValue = referencedValue
           popup.close()
         }
 

--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -1,8 +1,11 @@
-import QtQuick 2.0
-import QtQuick.Controls 2.4
+import QtQuick 2.12
+import QtQuick.Controls 2.12
 
 Item {
   signal valueChanged( var value, bool isNull )
+
+  property alias checked: checkBox.checked
+  property alias indicator: checkBox.indicator
 
   height: childrenRect.height
 
@@ -12,6 +15,7 @@ Item {
   }
 
   CheckBox {
+    id: checkBox
 
     property var currentValue: value
     //if the field type is boolean, ignore the configured 'CheckedState' and 'UncheckedState' values and work with true/false always

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -1,10 +1,11 @@
-import QtQuick 2.11
-import QtQuick.Controls 2.4
+import QtQuick 2.12
+import QtQuick.Controls 2.12
 
 
 import QtGraphicalEffects 1.0
 import QtQuick.Layouts 1.0
 import ".."
+import "."
 import Theme 1.0
 
 import org.qfield 1.0


### PR DESCRIPTION
this fixes value relation widget

also, going through JS with C++ variables is not supported anymore

for instance:
```
var modelIndex = myModel.index(row, col, ...)
var data = myModel.data(modelIndex, role)
```

is not working while

`var data = myModel.data(myModel.index(row, col, ...), role)
`
is working. But, Qt emits a warning:

Passing incompatible arguments to C++ functions from JavaScript is dangerous and deprecated.
This will throw a JavaScript TypeError in future releases of Qt!

therefore, it is advised to create helpers in the C++ classes directly:
`QVariant MyModel::dataFromRow(row, role)`