### PR TITLE
follow up upgrade to Qt 5.13+

### DIFF
--- a/src/core/featurelistmodel.h
+++ b/src/core/featurelistmodel.h
@@ -65,6 +65,8 @@ class FeatureListModel : public QAbstractItemModel
     virtual int columnCount( const QModelIndex &parent ) const override;
     virtual QVariant data( const QModelIndex &index, int role ) const override;
 
+    Q_INVOKABLE QVariant dataFromRowIndex( int row, int role ){ return data( index( row, 0, QModelIndex() ), role ); }
+
     virtual QHash<int, QByteArray> roleNames() const override;
 
     QgsVectorLayer *currentLayer() const;

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -257,8 +257,6 @@ Page {
 
         Loader {
           id: attributeEditorLoader
-          //asynchronous: true
-          //visible: status == Loader.Ready
 
           height: childrenRect.height
           anchors { left: parent.left; right: parent.right }

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -198,7 +198,7 @@ Page {
             model: SubModel {
               id: contentModel
               model: form.model
-              rootIndex: form.model && form.model.hasTabs ? form.model.index(currentIndex, 0) : undefined
+              rootIndex: form.model && form.model.hasTabs ? form.model.index(currentIndex, 0) : null
             }
 
             delegate: fieldItem
@@ -257,8 +257,8 @@ Page {
 
         Loader {
           id: attributeEditorLoader
-          asynchronous: true
-          visible: status == Loader.Ready
+          //asynchronous: true
+          //visible: status == Loader.Ready
 
           height: childrenRect.height
           anchors { left: parent.left; right: parent.right }

--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -1,8 +1,11 @@
-import QtQuick 2.0
-import QtQuick.Controls 2.4
+import QtQuick 2.12
+import QtQuick.Controls 2.12
 
 Item {
   signal valueChanged( var value, bool isNull )
+
+  property alias checked: checkBox.checked
+  property alias indicator: checkBox.indicator
 
   height: childrenRect.height
 
@@ -12,6 +15,7 @@ Item {
   }
 
   CheckBox {
+    id: checkBox
 
     property var currentValue: value
     //if the field type is boolean, ignore the configured 'CheckedState' and 'UncheckedState' values and work with true/false always

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -1,10 +1,11 @@
-import QtQuick 2.11
-import QtQuick.Controls 2.4
+import QtQuick 2.12
+import QtQuick.Controls 2.12
 
 
 import QtGraphicalEffects 1.0
 import QtQuick.Layouts 1.0
 import ".."
+import "."
 import Theme 1.0
 
 import org.qfield 1.0

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -5,7 +5,6 @@ import QtQuick.Controls 2.12
 import QtGraphicalEffects 1.0
 import QtQuick.Layouts 1.0
 import ".."
-import "."
 import Theme 1.0
 
 import org.qfield 1.0


### PR DESCRIPTION
this fixes value relation widget

also, going through JS with C++ variables is not supported anymore

for instance:
var modelIndex = myModel.index(row, col, ...)
var data = myModel.data(modelIndex, role)

is not working while

var data = myModel.data(myModel.index(row, col, ...), role)

is working. But, Qt emits a warning:

Passing incompatible arguments to C++ functions from JavaScript is dangerous and deprecated.
This will throw a JavaScript TypeError in future releases of Qt!

therefore, it is advised to create helpers in the C++ classes directly:
QVariant MyModel::dataFromRow(row, role)