### PR TITLE
QField 💖 Topology

### DIFF
--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -338,6 +338,9 @@ void FeatureModel::create()
     QgsMessageLog::logMessage( tr( "Feature could not be added" ), "QField", Qgis::Critical );
   }
 
+  if ( QgsProject::instance()->topologicalEditing() )
+    mLayer->addTopologicalPoints( mFeature.geometry() );
+
   if ( commit() )
   {
     QgsFeature feat;

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -25,8 +25,6 @@
 #include <QGeoPositionInfoSource>
 #include <qgsrelationmanager.h>
 
-#include <QDebug>
-
 FeatureModel::FeatureModel( QObject *parent )
   : QAbstractListModel( parent )
 {
@@ -450,7 +448,8 @@ void FeatureModel::applyVertexModelToGeometry()
   mFeature.setGeometry( mVertexModel->geometry() );
 }
 
-//! a filter just to gather all matches at the same place
+// a filter to gather all matches at the same place
+// taken from QGIS' qgsvectortool.cpp
 class MatchCollectingFilter : public QgsPointLocator::MatchFilter
 {
   public:

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -338,6 +338,15 @@ void FeatureModel::create()
     return;
 
   startEditing();
+
+  const QList<QgsVectorLayer *> intersectionLayers = QgsProject::instance()->avoidIntersectionsLayers();
+  if ( !intersectionLayers.isEmpty() && mFeature.geometry().type() == QgsWkbTypes::PolygonGeometry )
+  {
+    QgsGeometry geom = mFeature.geometry();
+    geom.avoidIntersections( intersectionLayers );
+    mFeature.setGeometry( geom );
+  }
+
   connect( mLayer, &QgsVectorLayer::featureAdded, this, &FeatureModel::featureAdded );
   if ( !mLayer->addFeature( mFeature ) )
   {

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -167,6 +167,9 @@ class FeatureModel : public QAbstractListModel
     //! Apply the vertex model changes to the layer topography.
     Q_INVOKABLE void applyVertexModelToLayerTopography();
 
+    //! Update the linked geometry rubber band to match the feature's geometry
+    Q_INVOKABLE void updateRubberband() const;
+
   public slots:
     void applyGeometry();
     void removeLayer( QObject *layer );

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -164,6 +164,9 @@ class FeatureModel : public QAbstractListModel
     //! \note This shall be used if the feature model is used with the vertex model rather than the geometry and rubberband model
     Q_INVOKABLE void applyVertexModelToGeometry();
 
+    //! Apply the vertex model changes to the layer topography.
+    Q_INVOKABLE void applyVertexModelToLayerTopography();
+
   public slots:
     void applyGeometry();
     void removeLayer( QObject *layer );

--- a/src/core/geometry.cpp
+++ b/src/core/geometry.cpp
@@ -36,7 +36,7 @@ QgsGeometry Geometry::asQgsGeometry() const
     {
       QgsPolygon *polygon = new QgsPolygon();
       QgsLineString *ring = new QgsLineString();
-      ring->setPoints( mRubberbandModel->pointSequence( mVectorLayer->crs(), mVectorLayer->wkbType() ) );
+      ring->setPoints( mRubberbandModel->pointSequence( mVectorLayer->crs(), mVectorLayer->wkbType(), true ) );
       polygon->setExteriorRing( ring );
       geom = polygon;
       break;
@@ -72,6 +72,14 @@ void Geometry::setRubberbandModel( RubberbandModel *rubberbandModel )
 void Geometry::applyRubberband()
 {
   // TODO: Will need to be implemented for multipart features or polygons with holes.
+}
+
+void Geometry::updateRubberband( const QgsGeometry &geometry )
+{
+  if ( !mRubberbandModel )
+    return;
+
+  mRubberbandModel->setDataFromGeometry( geometry );
 }
 
 QgsVectorLayer *Geometry::vectorLayer() const

--- a/src/core/geometry.h
+++ b/src/core/geometry.h
@@ -20,6 +20,7 @@ class Geometry : public QObject
 
     RubberbandModel *rubberbandModel() const;
     void setRubberbandModel( RubberbandModel *rubberbandModel );
+    void updateRubberband( const QgsGeometry &geometry );
 
     Q_INVOKABLE void applyRubberband();
 

--- a/src/core/rubberbandmodel.cpp
+++ b/src/core/rubberbandmodel.cpp
@@ -250,6 +250,36 @@ void RubberbandModel::reset()
   emit frozenChanged();
 }
 
+void RubberbandModel::setDataFromGeometry( const QgsGeometry &geometry )
+{
+  if ( geometry.type() != mGeometryType )
+    return;
+
+  mPointList.clear();
+  const QgsAbstractGeometry *abstractGeom = geometry.constGet();
+  if ( !abstractGeom )
+    return;
+
+  QgsVertexId vertexId;
+  QgsPoint pt;
+  while ( abstractGeom->nextVertex( vertexId, pt ) )
+  {
+    if ( vertexId.part > 1 || vertexId.ring > 0 )
+      break;
+
+    // skip first vertex on polygon, as it's duplicate of the last one
+    if ( geometry.type() == QgsWkbTypes::PolygonGeometry && vertexId.vertex == 0 )
+      continue;
+
+    mPointList << pt;
+  }
+
+  mCurrentCoordinateIndex = mPointList.size() - 1;
+
+  emit verticesInserted( 0, mPointList.size() );
+  emit vertexCountChanged();
+}
+
 QgsWkbTypes::GeometryType RubberbandModel::geometryType() const
 {
   return mGeometryType;

--- a/src/core/rubberbandmodel.h
+++ b/src/core/rubberbandmodel.h
@@ -23,6 +23,7 @@
 #include <qgis.h>
 #include <qgspoint.h>
 #include <qgsabstractgeometry.h>
+#include <qgsgeometry.h>
 
 class QgsVectorLayer;
 
@@ -113,6 +114,8 @@ class RubberbandModel : public QObject
     void setFrozen( const bool &frozen );
 
     void setGeometryType( const QgsWkbTypes::GeometryType &geometryType );
+
+    void setDataFromGeometry( const QgsGeometry &geometry );
 
   signals:
     void vertexChanged( int index );

--- a/src/core/rubberbandmodel.h
+++ b/src/core/rubberbandmodel.h
@@ -115,6 +115,10 @@ class RubberbandModel : public QObject
 
     void setGeometryType( const QgsWkbTypes::GeometryType &geometryType );
 
+    /**
+     * Sets the model data to match a given \a geometry
+     * \note rings and multiparts are discarded
+     */
     void setDataFromGeometry( const QgsGeometry &geometry );
 
   signals:

--- a/src/core/vertexmodel.h
+++ b/src/core/vertexmodel.h
@@ -69,6 +69,7 @@ class VertexModel : public QStandardItemModel
       PointRole = Qt::UserRole + 1,
       CurrentVertexRole,
       SegmentVertexRole,
+      OriginalPointRole,
     };
 
     enum EditingMode
@@ -152,8 +153,14 @@ class VertexModel : public QStandardItemModel
     //! Returns the geometry type
     QgsWkbTypes::GeometryType geometryType() const;
 
-    //! list of points. Segment vertex, if any, will be skipped.
+    //! Returns a list of point (segment vertex, if any, will be skipped)
     QVector<QgsPoint> flatVertices() const;
+
+    //! Returns a list of moved vertices found in linked geometry
+    QVector<QPair<QgsPoint,QgsPoint>> verticesMoved() const;
+
+    //! Returns a list of added vertices not found in linked geometry
+    QVector<QgsPoint> verticesDeleted() const { return mVerticesDeleted; }
 
     QHash<int, QByteArray> roleNames() const override;
 
@@ -201,6 +208,9 @@ class VertexModel : public QStandardItemModel
     QgsCoordinateTransform mTransform = QgsCoordinateTransform();
     bool mIsMulti = false;
     bool mDirty = false;
+
+    QVector<QgsPoint> mVerticesDeleted;
+
     /**
      * @brief setCurrentVertex set the current vertex viewed/edited in the model
      * @param newVertex the new vertex index

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1001,6 +1001,12 @@ ApplicationWindow {
     onShowMessage: displayToast(message)
 
     onEditGeometry: {
+      // Set overall selected (i.e. current) layer to that of the feature geometry being edited,
+      // important for snapping settings to make sense when set to current layer
+      if ( dashBoard.currentLayer != featureForm.selection.selectedLayer ) {
+        dashBoard.currentLayer = featureForm.selection.selectedLayer
+        displayToast( qsTr( "Current layer switched to the one holding the selected geometry." ) );
+      }
       vertexModel.geometry = featureForm.selection.selectedGeometry
       vertexModel.crs = featureForm.selection.selectedLayer.crs
       geometryEditingFeature.currentLayer = featureForm.selection.selectedLayer

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -660,6 +660,7 @@ ApplicationWindow {
           digitizingFeature.geometry.applyRubberband()
           digitizingFeature.applyGeometry()
           digitizingRubberband.model.frozen = true
+          digitizingFeature.updateRubberband()
         }
 
         if ( !digitizingFeature.suppressFeatureForm() )


### PR DESCRIPTION
With these commits, QField now behaves properly in topological editing mode. Shared nodes are treated as such when moving / deleting vertices, and additional vertices are added on nodes overlapping segments.

Here's a lovely screencast:
![Peek 2020-04-07 12-38](https://user-images.githubusercontent.com/1728657/78637179-10e40400-78d4-11ea-9ecf-eb097de87d95.gif)

There's no UI to toggle topological editing on/off yet, but that's the easy part. 

@m-kuhn , @3nids , your reviews are appreciated.

@signedav , I've opened this now (instead of waiting for the UI to be added) as I think this needs consideration vis-a-vis auto save.