### PR TITLE
fix allow mutli mode for value relation

### DIFF
--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -37,7 +37,7 @@ Item {
   Rectangle{
     id: valueRelationList
 
-    visible: config['AllowMulti']
+    visible: Number(config['AllowMulti']) === 1
 
     height: Math.max( valueListView.height, itemHeight)
 


### PR DESCRIPTION
`config['AllowMulti']` was returning `"0"`, which translates to `true`.

I am a bit surprised to stumble on this only now, and I would expect the same issue in other places.
Is this something related to newer versions of Qt???