### PR TITLE
fix fetching of master when preparing a release

### DIFF
--- a/scripts/ci/prepare-release.sh
+++ b/scripts/ci/prepare-release.sh
@@ -20,7 +20,7 @@ fi
 travis_to_release_branch
 
 # Get git sha for master branch
-git fetch origin master --depth 1
+git fetch origin master:master --depth 1
 GIT_MASTER_SHA=$(git rev-list -n1 master)
 
 # If the current commit is the latest on master -> we need to create a new release branch


### PR DESCRIPTION
I guess it's because there is no master branch on the local remote so you need to provide the destination branch
successfully tested in the release process of 1.5.1 (see https://github.com/opengisch/QField/commit/528e0ed9db3d81d9ebcd9a0e87df32f00014c7e8)