### PR TITLE
fix crash on exit

### DIFF
--- a/src/core/distancearea.cpp
+++ b/src/core/distancearea.cpp
@@ -29,10 +29,14 @@ DistanceArea::DistanceArea( QObject *parent )
 void DistanceArea::init()
 {
   if ( mProject )
+  {
     mDistanceArea.setEllipsoid( mProject->ellipsoid() );
+    mDistanceArea.setSourceCrs( mCrs, mProject->transformContext() );
+  }
   else
+  {
     mDistanceArea.setEllipsoid( geoNone() );
-  mDistanceArea.setSourceCrs( mCrs, mProject->transformContext() );
+  }
 
   emit lengthUnitsChanged();
   emit areaUnitsChanged();


### PR DESCRIPTION
when running on the desktop, I always had a crash on exit.
this happens at the deletion of the project (mProject = 0)