### PR TITLE
fix display field not shown in value relation

### DIFF
--- a/src/core/featurechecklistmodel.cpp
+++ b/src/core/featurechecklistmodel.cpp
@@ -21,9 +21,9 @@
 #include "qgspostgresstringutils.h"
 #endif
 
-FeatureCheckListModel::FeatureCheckListModel()
+FeatureCheckListModel::FeatureCheckListModel(QObject *parent)
+    : FeatureListModel(parent)
 {
-
 }
 
 QVariant FeatureCheckListModel::data( const QModelIndex &index, int role ) const
@@ -33,6 +33,7 @@ QVariant FeatureCheckListModel::data( const QModelIndex &index, int role ) const
     return mCheckedEntries.contains( FeatureListModel::data( index, FeatureListModel::KeyFieldRole ).toString() );
   }
   else
+    qDebug() << index.row() << role << FeatureListModel::data( index, role );
     return FeatureListModel::data( index, role );
 }
 

--- a/src/core/featurechecklistmodel.cpp
+++ b/src/core/featurechecklistmodel.cpp
@@ -29,12 +29,9 @@ FeatureCheckListModel::FeatureCheckListModel( QObject *parent )
 QVariant FeatureCheckListModel::data( const QModelIndex &index, int role ) const
 {
   if ( role == CheckedRole )
-  {
     return mCheckedEntries.contains( FeatureListModel::data( index, FeatureListModel::KeyFieldRole ).toString() );
-  }
   else
-    qDebug() << index.row() << role << FeatureListModel::data( index, role );
-  return FeatureListModel::data( index, role );
+    return FeatureListModel::data( index, role );
 }
 
 bool FeatureCheckListModel::setData( const QModelIndex &index, const QVariant &value, int role )

--- a/src/core/featurechecklistmodel.cpp
+++ b/src/core/featurechecklistmodel.cpp
@@ -15,14 +15,14 @@
  ***************************************************************************/
 
 #include "featurechecklistmodel.h"
-#include "qgsvaluerelationfieldformatter.h"
 #include "qgsmessagelog.h"
+#include "qgsvaluerelationfieldformatter.h"
 #if VERSION_INT >= 30600
 #include "qgspostgresstringutils.h"
 #endif
 
-FeatureCheckListModel::FeatureCheckListModel(QObject *parent)
-    : FeatureListModel(parent)
+FeatureCheckListModel::FeatureCheckListModel( QObject *parent )
+  : FeatureListModel( parent )
 {
 }
 
@@ -34,7 +34,7 @@ QVariant FeatureCheckListModel::data( const QModelIndex &index, int role ) const
   }
   else
     qDebug() << index.row() << role << FeatureListModel::data( index, role );
-    return FeatureListModel::data( index, role );
+  return FeatureListModel::data( index, role );
 }
 
 bool FeatureCheckListModel::setData( const QModelIndex &index, const QVariant &value, int role )
@@ -74,7 +74,7 @@ QVariant FeatureCheckListModel::attributeValue() const
   for ( const QString &s : qgis::as_const( mCheckedEntries ) )
   {
     // Convert to proper type
-    const QVariant::Type type { fkType() };
+    const QVariant::Type type {fkType()};
     switch ( type )
     {
       case QVariant::Type::Int:
@@ -89,8 +89,7 @@ QVariant FeatureCheckListModel::attributeValue() const
     }
   }
 
-  if ( mAttributeField.type() == QVariant::Map ||
-       mAttributeField.type() == QVariant::List )
+  if ( mAttributeField.type() == QVariant::Map || mAttributeField.type() == QVariant::List )
   {
     value = vl;
   }
@@ -169,7 +168,7 @@ QVariant::Type FeatureCheckListModel::fkType() const
   if ( currentLayer() )
   {
     QgsFields fields = currentLayer()->fields();
-    int idx { fields.indexOf( keyField() ) };
+    int idx {fields.indexOf( keyField() )};
     if ( idx >= 0 )
     {
       return fields.at( idx ).type();

--- a/src/core/featurechecklistmodel.h
+++ b/src/core/featurechecklistmodel.h
@@ -35,11 +35,11 @@ class FeatureCheckListModel : public FeatureListModel
     Q_PROPERTY( QgsField attributeField READ attributeField WRITE setAttributeField NOTIFY attributeFieldChanged )
 
   public:
-    FeatureCheckListModel();
+    FeatureCheckListModel(QObject* parent = nullptr);
 
     enum FeatureListRoles
     {
-      CheckedRole
+      CheckedRole = Qt::UserRole + 100 // do not overlap with the roles of the base model
     };
 
     virtual QVariant data( const QModelIndex &index, int role ) const override;

--- a/src/core/featurechecklistmodel.h
+++ b/src/core/featurechecklistmodel.h
@@ -18,67 +18,68 @@
 #define FEATURECHECKLISTMODEL_H
 
 #include "featurelistmodel.h"
+
 #include <qgsvectorlayer.h>
 
 class FeatureCheckListModel : public FeatureListModel
 {
-    Q_OBJECT
+  Q_OBJECT
 
-    /**
+  /**
      * The attribute value to generate checklist
      */
-    Q_PROPERTY( QVariant attributeValue READ attributeValue WRITE setAttributeValue NOTIFY attributeValueChanged )
+  Q_PROPERTY( QVariant attributeValue READ attributeValue WRITE setAttributeValue NOTIFY attributeValueChanged )
 
-    /**
+  /**
      * The attribute field to have information about type (JSON/HSTORE) etc.
      */
-    Q_PROPERTY( QgsField attributeField READ attributeField WRITE setAttributeField NOTIFY attributeFieldChanged )
+  Q_PROPERTY( QgsField attributeField READ attributeField WRITE setAttributeField NOTIFY attributeFieldChanged )
 
-  public:
-    FeatureCheckListModel(QObject* parent = nullptr);
+public:
+  FeatureCheckListModel( QObject *parent = nullptr );
 
-    enum FeatureListRoles
-    {
-      CheckedRole = Qt::UserRole + 100 // do not overlap with the roles of the base model
-    };
+  enum FeatureListRoles
+  {
+    CheckedRole = Qt::UserRole + 100 // do not overlap with the roles of the base model
+  };
 
-    virtual QVariant data( const QModelIndex &index, int role ) const override;
-    virtual bool setData( const QModelIndex &index, const QVariant &value, int role ) override;
+  virtual QVariant data( const QModelIndex &index, int role ) const override;
+  virtual bool setData( const QModelIndex &index, const QVariant &value, int role ) override;
 
-    QHash<int, QByteArray> roleNames() const override;
+  QHash<int, QByteArray> roleNames() const override;
 
-    /**
+  /**
      * the attribute value. A QVariantList or an hstore formatted string, depending on the field type.
      */
-    QVariant attributeValue() const;
+  QVariant attributeValue() const;
 
-    /**
+  /**
      * the attribute value. A QVariantList or an hstore formatted string, depending on the field type.
      */
-    void setAttributeValue( const QVariant &attributeValue );
+  void setAttributeValue( const QVariant &attributeValue );
 
-    /**
+  /**
      * the current attribute field
      */
-    QgsField attributeField() const;
+  QgsField attributeField() const;
 
-    /**
+  /**
      * the current attribute field
      */
-    void setAttributeField( const QgsField &field );
+  void setAttributeField( const QgsField &field );
 
-  signals:
-    void attributeValueChanged();
-    void attributeFieldChanged();
-    void listUpdated();
+signals:
+  void attributeValueChanged();
+  void attributeFieldChanged();
+  void listUpdated();
 
-  private:
-    void setChecked( const QModelIndex &index );
-    void setUnchecked( const QModelIndex &index );
-    QVariant::Type fkType() const;
+private:
+  void setChecked( const QModelIndex &index );
+  void setUnchecked( const QModelIndex &index );
+  QVariant::Type fkType() const;
 
-    QgsField mAttributeField;
-    QStringList mCheckedEntries;
+  QgsField mAttributeField;
+  QStringList mCheckedEntries;
 };
 
 #endif // FEATURECHECKLISTMODEL_H

--- a/src/core/featurelistmodel.cpp
+++ b/src/core/featurelistmodel.cpp
@@ -14,12 +14,12 @@
  *                                                                         *
  ***************************************************************************/
 #include "featurelistmodel.h"
-
 #include "qgsvectorlayer.h"
+
 #include <qgsproject.h>
 
-FeatureListModel::FeatureListModel(QObject *parent)
-  : QAbstractItemModel(parent)
+FeatureListModel::FeatureListModel( QObject *parent )
+  : QAbstractItemModel( parent )
   , mCurrentLayer( nullptr )
 {
   mReloadTimer.setInterval( 100 );
@@ -208,8 +208,7 @@ void FeatureListModel::processReloadLayer()
 
   if ( mOrderByValue )
   {
-    qSort( entries.begin(), entries.end(), []( const Entry & entry1, const Entry & entry2 )
-    {
+    qSort( entries.begin(), entries.end(), []( const Entry &entry1, const Entry &entry2 ) {
       if ( entry1.key.isNull() )
         return true;
 

--- a/src/core/featurelistmodel.cpp
+++ b/src/core/featurelistmodel.cpp
@@ -18,8 +18,9 @@
 #include "qgsvectorlayer.h"
 #include <qgsproject.h>
 
-FeatureListModel::FeatureListModel()
-  : mCurrentLayer( nullptr )
+FeatureListModel::FeatureListModel(QObject *parent)
+  : QAbstractItemModel(parent)
+  , mCurrentLayer( nullptr )
 {
   mReloadTimer.setInterval( 100 );
   mReloadTimer.setSingleShot( true );
@@ -177,6 +178,8 @@ void FeatureListModel::processReloadLayer()
 
   if ( !keyField().isNull() )
     referencedColumns << mKeyField;
+
+  referencedColumns << mDisplayValueField;
 
   QgsFields fields = mCurrentLayer->fields();
 

--- a/src/core/featurelistmodel.h
+++ b/src/core/featurelistmodel.h
@@ -57,7 +57,7 @@ class FeatureListModel : public QAbstractItemModel
 
     Q_ENUM( FeatureListRoles )
 
-    FeatureListModel();
+    FeatureListModel(QObject* parent = nullptr);
 
     virtual QModelIndex index( int row, int column, const QModelIndex &parent ) const override;
     virtual QModelIndex parent( const QModelIndex &child ) const override;

--- a/src/core/featurelistmodel.h
+++ b/src/core/featurelistmodel.h
@@ -29,128 +29,128 @@ class QgsVectorLayer;
  */
 class FeatureListModel : public QAbstractItemModel
 {
-    Q_OBJECT
+  Q_OBJECT
 
-    /**
+  /**
      * The vector layer to list
      */
-    Q_PROPERTY( QgsVectorLayer *currentLayer READ currentLayer WRITE setCurrentLayer NOTIFY currentLayerChanged )
-    /**
+  Q_PROPERTY( QgsVectorLayer *currentLayer READ currentLayer WRITE setCurrentLayer NOTIFY currentLayerChanged )
+  /**
      * The primary key field
      */
-    Q_PROPERTY( QString keyField READ keyField WRITE setKeyField NOTIFY keyFieldChanged )
-    /**
+  Q_PROPERTY( QString keyField READ keyField WRITE setKeyField NOTIFY keyFieldChanged )
+  /**
      * The display value field
      */
-    Q_PROPERTY( QString displayValueField READ displayValueField WRITE setDisplayValueField NOTIFY displayValueFieldChanged )
+  Q_PROPERTY( QString displayValueField READ displayValueField WRITE setDisplayValueField NOTIFY displayValueFieldChanged )
 
-    Q_PROPERTY( bool orderByValue READ orderByValue WRITE setOrderByValue NOTIFY orderByValueChanged )
+  Q_PROPERTY( bool orderByValue READ orderByValue WRITE setOrderByValue NOTIFY orderByValueChanged )
 
-    Q_PROPERTY( bool addNull READ addNull WRITE setAddNull NOTIFY addNullChanged )
+  Q_PROPERTY( bool addNull READ addNull WRITE setAddNull NOTIFY addNullChanged )
 
-  public:
-    enum FeatureListRoles
-    {
-      KeyFieldRole = Qt::UserRole + 1,
-      DisplayStringRole
-    };
+public:
+  enum FeatureListRoles
+  {
+    KeyFieldRole = Qt::UserRole + 1,
+    DisplayStringRole
+  };
 
-    Q_ENUM( FeatureListRoles )
+  Q_ENUM( FeatureListRoles )
 
-    FeatureListModel(QObject* parent = nullptr);
+  FeatureListModel( QObject *parent = nullptr );
 
-    virtual QModelIndex index( int row, int column, const QModelIndex &parent ) const override;
-    virtual QModelIndex parent( const QModelIndex &child ) const override;
-    virtual int rowCount( const QModelIndex &parent ) const override;
-    virtual int columnCount( const QModelIndex &parent ) const override;
-    virtual QVariant data( const QModelIndex &index, int role ) const override;
+  virtual QModelIndex index( int row, int column, const QModelIndex &parent ) const override;
+  virtual QModelIndex parent( const QModelIndex &child ) const override;
+  virtual int rowCount( const QModelIndex &parent ) const override;
+  virtual int columnCount( const QModelIndex &parent ) const override;
+  virtual QVariant data( const QModelIndex &index, int role ) const override;
 
-    Q_INVOKABLE QVariant dataFromRowIndex( int row, int role ){ return data( index( row, 0, QModelIndex() ), role ); }
+  Q_INVOKABLE QVariant dataFromRowIndex( int row, int role ) { return data( index( row, 0, QModelIndex() ), role ); }
 
-    virtual QHash<int, QByteArray> roleNames() const override;
+  virtual QHash<int, QByteArray> roleNames() const override;
 
-    QgsVectorLayer *currentLayer() const;
-    void setCurrentLayer( QgsVectorLayer *currentLayer );
+  QgsVectorLayer *currentLayer() const;
+  void setCurrentLayer( QgsVectorLayer *currentLayer );
 
-    QString keyField() const;
-    void setKeyField( const QString &keyField );
+  QString keyField() const;
+  void setKeyField( const QString &keyField );
 
-    QString displayValueField() const;
-    void setDisplayValueField( const QString &displayValueField );
+  QString displayValueField() const;
+  void setDisplayValueField( const QString &displayValueField );
 
-    /**
+  /**
      * Get the row for a given key value.
      */
-    Q_INVOKABLE int findKey( const QVariant &key ) const;
+  Q_INVOKABLE int findKey( const QVariant &key ) const;
 
-    /**
+  /**
      * Orders all the values alphabethically by their displayString.
      */
-    bool orderByValue() const;
+  bool orderByValue() const;
 
-    /**
+  /**
      * Orders all the values alphabethically by their displayString.
      */
-    void setOrderByValue( bool orderByValue );
+  void setOrderByValue( bool orderByValue );
 
-    /**
+  /**
      * Add a NULL value as the first entry.
      */
-    bool addNull() const;
+  bool addNull() const;
 
-    /**
+  /**
      * Add a NULL value as the first entry.
      */
-    void setAddNull( bool addNull );
+  void setAddNull( bool addNull );
 
-  signals:
-    void currentLayerChanged();
-    void keyFieldChanged();
-    void displayValueFieldChanged();
-    void addNullChanged();
-    void orderByValueChanged();
+signals:
+  void currentLayerChanged();
+  void keyFieldChanged();
+  void displayValueFieldChanged();
+  void addNullChanged();
+  void orderByValueChanged();
 
-  private slots:
-    void onFeatureAdded();
-    void onFeatureDeleted();
-    /**
+private slots:
+  void onFeatureAdded();
+  void onFeatureDeleted();
+  /**
      * Reloads a layer. This will normally be triggered
      * by \see reloadLayer and should not be called directly.
      */
-    void processReloadLayer();
+  void processReloadLayer();
 
-  private:
-    struct Entry
-    {
-      Entry( const QString &displayString, const QVariant &key )
-        : displayString( displayString )
-        , key( key )
-      {}
+private:
+  struct Entry
+  {
+    Entry( const QString &displayString, const QVariant &key )
+      : displayString( displayString )
+      , key( key )
+    {}
 
-      Entry() = default;
+    Entry() = default;
 
-      QString displayString;
-      QVariant key;
-    };
+    QString displayString;
+    QVariant key;
+  };
 
-    /**
+  /**
      * Triggers a reload of the values from the layer.
      * To avoid having the (expensive) reload operation happening for
      * every property change, it will only execute this after a very short delay.
      * This allows changing multiple properties at once and have a single reload
      * in the end.
      */
-    void reloadLayer();
+  void reloadLayer();
 
-    QgsVectorLayer *mCurrentLayer = nullptr;
+  QgsVectorLayer *mCurrentLayer = nullptr;
 
-    QList<Entry> mEntries;
-    QString mKeyField;
-    QString mDisplayValueField;
-    bool mOrderByValue = false;
-    bool mAddNull = false;
+  QList<Entry> mEntries;
+  QString mKeyField;
+  QString mDisplayValueField;
+  bool mOrderByValue = false;
+  bool mAddNull = false;
 
-    QTimer mReloadTimer;
+  QTimer mReloadTimer;
 };
 
 #endif // FEATURELISTMODEL_H

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -59,7 +59,7 @@ Item {
         addNull: config['AllowNull']
         orderByValue: config['OrderByValue']
         onListUpdated: {
-          valueChanged( attributeValue, false )
+          valueRelation.valueChanged( attributeValue, false )
         }
     }
 


### PR DESCRIPTION
the display field was not part of the fetched attributes, hence the list remained empty.

this also fixes the initialization of inherited classes

I run clang-format on the second commit, so better inspect changes of the first commit