### PR TITLE
Fix wrong trimming of project filenames having many dots (fixes #969)

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -362,7 +362,7 @@ void QgisMobileapp::onReadProject( const QDomDocument &doc )
 
   QList<QPair<QString, QString>> projects = recentProjects();
   QFileInfo fi( mProject->fileName() );
-  QPair<QString, QString> project = qMakePair( mProject->title().isEmpty() ? fi.baseName() : mProject->title(), mProject->fileName() );
+  QPair<QString, QString> project = qMakePair( mProject->title().isEmpty() ? fi.completeBaseName() : mProject->title(), mProject->fileName() );
   if ( projects.contains( project ) )
     projects.removeAt( projects.indexOf( project ) );
   projects.insert( 0, project );


### PR DESCRIPTION
When the project title was derived from the project filename, QField was trimming on first dot when multiple dots were present. This PR fixes that. Proof:
![Screenshot from 2020-05-04 16-23-57](https://user-images.githubusercontent.com/1728657/80952313-ad41ed80-8e23-11ea-8255-5fb44e47734a.png)
