### PR TITLE
Improve visual look of layer properties tracking button

### DIFF
--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -20,7 +20,6 @@ LayerTreeItemProperties {
     itemVisible = layerTree.data(index, FlatLayerTreeModel.Visible)
     title = qsTr("%1 : Properties and Functions").arg(layerTree.data(index, 0))
     trackingButtonVisible = layerTree.data(index, FlatLayerTreeModel.Type) === 'layer' && layerTree.data(index, FlatLayerTreeModel.Trackable) && positionSource.active ? true : false
-    trackingButtonBgColor = trackingModel.layerInTracking( layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer) ) ? '#F6A564' : '#64B5F6'
     trackingButtonText = trackingModel.layerInTracking( layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer) ) ? qsTr('Stop tracking') : qsTr('Start tracking')
   }
 

--- a/src/qml/ui/LayerTreeItemProperties.qml
+++ b/src/qml/ui/LayerTreeItemProperties.qml
@@ -25,9 +25,11 @@ Popup {
 
         ColumnLayout{
             spacing: 4
+            width: Math.min(mainWindow.width - 20, parent.width)
 
             CheckBox {
                 id: itemVisibleCheckBox
+                Layout.fillWidth: true
                 text: qsTr("Show on map canvas")
                 font: Theme.defaultFont
 
@@ -37,16 +39,12 @@ Popup {
                 indicator.implicitWidth: 24
             }
 
-            Button {
+            QfButton {
                 id: trackingButton
-                Layout.fillHeight: true
                 Layout.fillWidth: true
                 font: Theme.defaultFont
                 text: trackingButtonText
                 visible: trackingButtonVisible
-                background: Rectangle {
-                    color: trackingButtonBgColor
-                }
 
                 onClicked: {
                     trackingButtonClicked()


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1728657/81169147-8d94fb80-8fc2-11ea-98d4-5d8500f6762b.png)

PR:
![image](https://user-images.githubusercontent.com/1728657/81169156-91c11900-8fc2-11ea-95da-9aad7453989f.png)

@signedav , I've led go of the start / stop custom colors in favor of QField's green. I think the Start / stop tracking conditional label in the button suffice here.