### PR TITLE
Add option to change attachments on desktop build

### DIFF
--- a/src/core/androidpicturesource.cpp
+++ b/src/core/androidpicturesource.cpp
@@ -23,9 +23,8 @@
 #include <QDebug>
 
 AndroidPictureSource::AndroidPictureSource( const QString &prefix )
-  : PictureSource( nullptr )
+  : PictureSource( nullptr, prefix )
   , QAndroidActivityResultReceiver()
-  , mPrefix( prefix )
 {
 
 }
@@ -54,5 +53,10 @@ void AndroidPictureSource::handleActivityResult( int receiverRequestCode, int re
       emit pictureReceived( QString() );
     }
   }
+
+}
+
+void AndroidPictureSource::init()
+{
 
 }

--- a/src/core/androidpicturesource.cpp
+++ b/src/core/androidpicturesource.cpp
@@ -55,8 +55,3 @@ void AndroidPictureSource::handleActivityResult( int receiverRequestCode, int re
   }
 
 }
-
-void AndroidPictureSource::init()
-{
-
-}

--- a/src/core/androidpicturesource.cpp
+++ b/src/core/androidpicturesource.cpp
@@ -25,6 +25,7 @@
 AndroidPictureSource::AndroidPictureSource( const QString &prefix )
   : PictureSource( nullptr, prefix )
   , QAndroidActivityResultReceiver()
+  , mPrefix( prefix )
 {
 
 }

--- a/src/core/androidpicturesource.h
+++ b/src/core/androidpicturesource.h
@@ -31,6 +31,8 @@ class AndroidPictureSource : public PictureSource, public QAndroidActivityResult
     //! QAndroidActivityResultReceiver
     void handleActivityResult( int receiverRequestCode, int resultCode, const QAndroidJniObject &data ) override;
 
+    void init() override;
+
   private:
     QString mPrefix;
 };

--- a/src/core/androidpicturesource.h
+++ b/src/core/androidpicturesource.h
@@ -31,8 +31,6 @@ class AndroidPictureSource : public PictureSource, public QAndroidActivityResult
     //! QAndroidActivityResultReceiver
     void handleActivityResult( int receiverRequestCode, int resultCode, const QAndroidJniObject &data ) override;
 
-    void init() override;
-
   private:
     QString mPrefix;
 };

--- a/src/core/androidpicturesource.h
+++ b/src/core/androidpicturesource.h
@@ -26,12 +26,20 @@ class AndroidPictureSource : public PictureSource, public QAndroidActivityResult
     Q_OBJECT
 
   public:
+    /**
+     * Construct a new Android Picture Source object
+     * 
+     * @param prefix The project folder. Base directory path for all relative paths.
+     */
     AndroidPictureSource( const QString &prefix );
 
     //! QAndroidActivityResultReceiver
     void handleActivityResult( int receiverRequestCode, int resultCode, const QAndroidJniObject &data ) override;
 
   private:
+    /**
+     * Base directory path for all relative paths.
+     */
     QString mPrefix;
 };
 

--- a/src/core/picturesource.cpp
+++ b/src/core/picturesource.cpp
@@ -15,10 +15,24 @@
  ***************************************************************************/
 #include "picturesource.h"
 
-PictureSource::PictureSource( QObject *parent )
+#include <QFileDialog>
+
+PictureSource::PictureSource( QObject *parent, const QString &prefix, const QString &pictureFilePath )
   : QObject( parent )
+  , mPrefix( prefix )
+  , mPictureFilePath( pictureFilePath )
 {
 
+}
+
+void PictureSource::init()
+{
+  QString path { QFileDialog::getOpenFileName( nullptr, tr( "Select Media File" ), mPrefix, tr( "JPEG images (*.jpg *.jpeg)" ) ) };
+
+  if ( path.startsWith( mPrefix ) )
+    path = path.remove( mPrefix );
+
+  emit pictureReceived( path );
 }
 
 PictureSource::~PictureSource()

--- a/src/core/picturesource.cpp
+++ b/src/core/picturesource.cpp
@@ -15,24 +15,19 @@
  ***************************************************************************/
 #include "picturesource.h"
 
-#include <QFileDialog>
+#include <QTimer>
 
 PictureSource::PictureSource( QObject *parent, const QString &prefix, const QString &pictureFilePath )
   : QObject( parent )
   , mPrefix( prefix )
   , mPictureFilePath( pictureFilePath )
 {
+  if ( mPictureFilePath.startsWith( mPrefix ) )
+    mPictureFilePath = mPictureFilePath.remove( mPrefix );
 
-}
-
-void PictureSource::init()
-{
-  QString path { QFileDialog::getOpenFileName( nullptr, tr( "Select Media File" ), mPrefix, tr( "JPEG images (*.jpg *.jpeg)" ) ) };
-
-  if ( path.startsWith( mPrefix ) )
-    path = path.remove( mPrefix );
-
-  emit pictureReceived( path );
+  QTimer::singleShot(0, this, [ = ] () {
+    emit pictureReceived( mPictureFilePath );
+  });
 }
 
 PictureSource::~PictureSource()

--- a/src/core/picturesource.cpp
+++ b/src/core/picturesource.cpp
@@ -22,6 +22,10 @@ PictureSource::PictureSource( QObject *parent, const QString &prefix, const QStr
   , mPrefix( prefix )
   , mPictureFilePath( pictureFilePath )
 {
+  // prevent emit signal if the pictureFilePath is empty ( e.g. when AndroidPictureSource )
+  if ( mPictureFilePath.isEmpty() )
+    return;
+
   if ( mPictureFilePath.startsWith( mPrefix ) )
     mPictureFilePath = mPictureFilePath.remove( mPrefix );
 

--- a/src/core/picturesource.h
+++ b/src/core/picturesource.h
@@ -30,8 +30,6 @@ class PictureSource : public QObject
 
     virtual ~PictureSource();
 
-    Q_INVOKABLE void init();
-
   signals:
     /**
      * Emit this signal when a picture really has been received.

--- a/src/core/picturesource.h
+++ b/src/core/picturesource.h
@@ -26,15 +26,20 @@ class PictureSource : public QObject
 {
     Q_OBJECT
   public:
-    explicit PictureSource( QObject *parent = nullptr );
+    explicit PictureSource( QObject *parent = nullptr, const QString &prefix = QString(), const QString &pictureFilePath = QString() );
 
     virtual ~PictureSource();
+
+    Q_INVOKABLE void init();
 
   signals:
     /**
      * Emit this signal when a picture really has been received.
      */
     void pictureReceived( const QString &path );
+  protected:
+    QString mPrefix;
+    QString mPictureFilePath;
 };
 
 #endif // PICTURESOURCE_H

--- a/src/core/picturesource.h
+++ b/src/core/picturesource.h
@@ -26,17 +26,40 @@ class PictureSource : public QObject
 {
     Q_OBJECT
   public:
+    /**
+     * Construct a new Picture Source object.
+     * 
+     * @note Subclasses which implement their own file dialog should provide an empty string for \a pictureFilePath and emit \a pictureReceived when appropriate.
+     * @param parent Parent object
+     * @param prefix The project folder. Base directory path for all relative paths.
+     * @param pictureFilePath Suggested file path to permanently store the file. If the file is not existing yet, it must be an empty string.
+     */
     explicit PictureSource( QObject *parent = nullptr, const QString &prefix = QString(), const QString &pictureFilePath = QString() );
 
+    /**
+     * Destroy the Picture Source object
+     */
     virtual ~PictureSource();
 
   signals:
+  
     /**
-     * Emit this signal when a picture really has been received.
+     * Emit this signal when a picture really has been received. 
+     * 
+     * @note When the constructor received a non-empty \a pictureFilePath, the signal is emitted in the constructor.
      */
     void pictureReceived( const QString &path );
+  
   private:
+
+    /**
+     * Base directory path for all relative paths.
+     */
     QString mPrefix;
+
+    /**
+     * Suggested file path to permanently store the file. If the file is not existing yet, it must be an empty string.
+     */
     QString mPictureFilePath;
 };
 

--- a/src/core/picturesource.h
+++ b/src/core/picturesource.h
@@ -35,7 +35,7 @@ class PictureSource : public QObject
      * Emit this signal when a picture really has been received.
      */
     void pictureReceived( const QString &path );
-  protected:
+  private:
     QString mPrefix;
     QString mPictureFilePath;
 };

--- a/src/core/platformutilities.cpp
+++ b/src/core/platformutilities.cpp
@@ -16,6 +16,8 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsmessagelog.h"
+
 #include "platformutilities.h"
 #include "projectsource.h"
 #include <QDebug>
@@ -77,8 +79,20 @@ PictureSource *PlatformUtilities::getCameraPicture( const QString &prefix, const
 
 PictureSource *PlatformUtilities::getGalleryPicture( const QString &prefix, const QString &pictureFilePath )
 {
-  Q_UNUSED( pictureFilePath )
-  return new PictureSource( nullptr, prefix, pictureFilePath );
+  QString destinationFile = QStringLiteral( "%1/%2" ).arg( prefix, pictureFilePath );
+  QString fileName = QFileDialog::getOpenFileName( nullptr, tr( "Select Media File" ), prefix, tr( "JPEG images (*.jpg *.jpeg)" ) );
+
+  if ( QFileInfo::exists( fileName ) )
+  {
+    // if the file is already in the prefixed path, no need to copy
+    if ( fileName.startsWith( prefix ) )
+      return new PictureSource( nullptr, prefix, fileName );
+    else if ( QFile::copy( fileName, destinationFile ) )
+      return new PictureSource( nullptr, prefix, destinationFile );
+  }
+
+  QgsMessageLog::logMessage( tr( "Failed to save gallery picture." ), "QField", Qgis::Critical );
+  return new PictureSource( nullptr, prefix, QString() );
 }
 
 ViewStatus *PlatformUtilities::open( const QString &uri )

--- a/src/core/platformutilities.cpp
+++ b/src/core/platformutilities.cpp
@@ -89,9 +89,10 @@ PictureSource *PlatformUtilities::getGalleryPicture( const QString &prefix, cons
       return new PictureSource( nullptr, prefix, fileName );
     else if ( QFile::copy( fileName, destinationFile ) )
       return new PictureSource( nullptr, prefix, destinationFile );
+
+    QgsMessageLog::logMessage( tr( "Failed to save gallery picture." ), "QField", Qgis::Critical );
   }
 
-  QgsMessageLog::logMessage( tr( "Failed to save gallery picture." ), "QField", Qgis::Critical );
   return new PictureSource( nullptr, prefix, QString() );
 }
 

--- a/src/core/platformutilities.cpp
+++ b/src/core/platformutilities.cpp
@@ -77,9 +77,8 @@ PictureSource *PlatformUtilities::getCameraPicture( const QString &prefix, const
 
 PictureSource *PlatformUtilities::getGalleryPicture( const QString &prefix, const QString &pictureFilePath )
 {
-  Q_UNUSED( prefix )
   Q_UNUSED( pictureFilePath )
-  return nullptr;
+  return new PictureSource( nullptr, prefix, pictureFilePath );
 }
 
 ViewStatus *PlatformUtilities::open( const QString &uri )

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -174,7 +174,6 @@ Item {
         var evaluated_filepath = expressionEvaluator.evaluate()
         var filepath = !evaluated_filepath || FileUtils.fileSuffix(evaluated_filepath) === '' ? 'DCIM/JPEG_'+(new Date()).toISOString().replace(/[^0-9]/g, "")+'.jpg' : evaluated_filepath
         __pictureSource = platformUtilities.getGalleryPicture(qgisProject.homePath+'/', filepath)
-        __pictureSource.init()
     }
 
     iconSource: Theme.getThemeIcon("baseline_photo_library_black_24")

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -174,6 +174,7 @@ Item {
         var evaluated_filepath = expressionEvaluator.evaluate()
         var filepath = !evaluated_filepath || FileUtils.fileSuffix(evaluated_filepath) === '' ? 'DCIM/JPEG_'+(new Date()).toISOString().replace(/[^0-9]/g, "")+'.jpg' : evaluated_filepath
         __pictureSource = platformUtilities.getGalleryPicture(qgisProject.homePath+'/', filepath)
+        __pictureSource.init()
     }
 
     iconSource: Theme.getThemeIcon("baseline_photo_library_black_24")


### PR DESCRIPTION
Clicking on the gallery button opens a standard qt file dialog, instead of silently ignoring it.