### PR TITLE
Add missing vector topology icons

### DIFF
--- a/images/themes/qfield/nodpi/ic_topology_green_24dp.svg
+++ b/images/themes/qfield/nodpi/ic_topology_green_24dp.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6.35 6.35" height="24" width="24"><g fill="none" stroke="#80cc28" stroke-width=".529"><path d="M3.175.265V2.38m-.581 1.257l-1.8 1.918M3.704 2.91h2.117"/><path stroke-linecap="round" d="M2.382 2.117h1.587v1.587H2.382z"/></g></svg>

--- a/images/themes/qfield/nodpi/ic_topology_white_24dp.svg
+++ b/images/themes/qfield/nodpi/ic_topology_white_24dp.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 6.35 6.35"><g fill="none" stroke="#fff" stroke-width=".529"><path d="M3.175.265V2.38m-.581 1.257l-1.8 1.918M3.704 2.91h2.117"/><path stroke-linecap="round" d="M2.382 2.117h1.587v1.587H2.382z"/></g></svg>


### PR DESCRIPTION
This was missing from my original PR adding a topology button to QField. 

It's not used ATM, but it's nice for the project to keep vector version of icons if edits are required in the future, or derived icons are needed.