### PR TITLE
Legend follow-ups

### DIFF
--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -29,6 +29,17 @@ FlatLayerTreeModel::FlatLayerTreeModel( QgsLayerTree *layerTree, QgsProject *pro
   mLayerTreeModel = new QgsLayerTreeModel( layerTree, this );
   setSourceModel ( mLayerTreeModel );
   connect( mProject, &QgsProject::readProject, this, [ = ] { buildMap( mLayerTreeModel ); } );
+  connect( mLayerTreeModel, &QAbstractItemModel::dataChanged, this, &FlatLayerTreeModel::updateMap );
+}
+
+void FlatLayerTreeModel::updateMap( const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles )
+{
+  Q_UNUSED( bottomRight )
+  QModelIndex modifiedIndex = mapFromSource( topLeft );
+  if ( modifiedIndex.isValid() )
+  {
+    emit dataChanged( modifiedIndex, modifiedIndex, roles );
+  }
 }
 
 int FlatLayerTreeModel::buildMap( QgsLayerTreeModel *model, const QModelIndex &parent, int row )

--- a/src/core/layertreemodel.h
+++ b/src/core/layertreemodel.h
@@ -44,6 +44,7 @@ class FlatLayerTreeModel : public QAbstractProxyModel
 
     explicit FlatLayerTreeModel( QgsLayerTree *layerTree, QgsProject *project, QObject *parent = nullptr );
 
+    void updateMap( const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles );
     int buildMap( QgsLayerTreeModel *model, const QModelIndex &parent = QModelIndex(), int row = 0 );
 
     void setSourceModel( QgsLayerTreeModel *sourceModel );

--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -47,6 +47,7 @@ ListView {
         }
         width: 24
         height: 24
+        fillMode: Image.PreserveAspectFit
         anchors.verticalCenter: parent.verticalCenter
         opacity: Visible ? 1 : 0.25
       }


### PR DESCRIPTION
Two legend improvements that appear to have been eaten away by the large amount of rebasing that was needed last week:
- have the flat layer tree proxy handle dataChanged signal to make sure we show proper feature count in legend
- have the legend item respect legend symbols' ratio.