### PR TITLE
Add a bit of margin area at the right edge of the settings list

### DIFF
--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -110,19 +110,16 @@ Page {
 
 
       ListView {
-//        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
-//        ScrollBar.vertical.policy: ScrollBar.AsNeeded
         flickableDirection: Flickable.VerticalFlick
         boundsBehavior: Flickable.StopAtBounds
         width: mainWindow.width
         clip: true
-        //rowSpacing: 10
         ScrollBar.vertical: ScrollBar {}
 
         model: settingsModel
 
         delegate: Row {
-          width: parent.width
+          width: parent.width - 16
 
           Column {
             width: parent.width - toggle.width


### PR DESCRIPTION
@3nids , just noticed we lost some padding on the right edge of the settings list, making the switch touch the edge of the window / device. This PR fixes that visual regression.