### PR TITLE
Revive tracker indicator in new legend item

### DIFF
--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -266,6 +266,7 @@ QHash<int, QByteArray> FlatLayerTreeModel::roleNames() const
   roleNames[Visible] = "Visible";
   roleNames[Type] = "Type";
   roleNames[Name] = "Name";
+  roleNames[InTracking] = "InTracking";
   return roleNames;
 }
 

--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -54,7 +54,7 @@ ListView {
 
       Text {
         id: layerName
-        width: rectangle.width - ( LegendImage != '' ? 34 : 10 )
+        width: rectangle.width - ( LegendImage != '' ? 34 : 10 ) - ( InTracking ? 34 : 0 )
         padding: 5
         text: Name
         horizontalAlignment: itemType == "group" ? Text.AlignHCenter : Text.AlignLeft
@@ -63,6 +63,30 @@ ListView {
         color: itemType === "layer" && vectorLayer != null && vectorLayer == currentLayer ? Theme.mainColor : Theme.darkGray
         elide: Text.ElideRight
         opacity: Visible ? 1 : 0.25
+      }
+
+      Rectangle {
+          visible: InTracking ? true : false
+          height: 24
+          width: 24
+          anchors.verticalCenter: parent.verticalCenter
+          radius: height / 2
+          color: Theme.mainColor
+
+          SequentialAnimation on color  {
+              loops: Animation.Infinite
+              ColorAnimation  { from: Theme.mainColor; to: "#5a8725"; duration: 2000; easing.type: Easing.InOutQuad }
+              ColorAnimation  { from: "#5a8725"; to: Theme.mainColor; duration: 1000; easing.type: Easing.InOutQuad }
+          }
+
+          Image {
+              anchors.fill: parent
+              anchors.margins: 4
+              fillMode: Image.PreserveAspectFit
+              horizontalAlignment: Image.AlignHCenter
+              verticalAlignment: Image.AlignVCenter
+              source: Theme.getThemeIcon( 'ic_directions_walk_black_24dp' )
+          }
       }
     }
   }


### PR DESCRIPTION
Say hello to the tracker indicator in the new legend item:
![image](https://user-images.githubusercontent.com/1728657/81645097-27412a80-9453-11ea-97ec-e29604b23afc.png)

I've located it along the right edge of the legend area, I find that aesthetically a bit nicer, and it links to our big brother QGIS' indicator UI/UX.

