### PR TITLE
Show at least the feature ID, if the display expression evaluates to an empty string

### DIFF
--- a/src/core/multifeaturelistmodel.cpp
+++ b/src/core/multifeaturelistmodel.cpp
@@ -145,7 +145,13 @@ QVariant MultiFeatureListModel::data( const QModelIndex &index, int role ) const
                                      << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
                                      << QgsExpressionContextUtils::layerScope( feature->first );
       context.setFeature( feature->second );
-      return QgsExpression( feature->first->displayExpression() ).evaluate( &context ).toString();
+      
+      const QString displayString = QgsExpression( feature->first->displayExpression() ).evaluate( &context ).toString();
+
+      if ( displayString.isEmpty() )
+        return feature->second.id();
+
+      return displayString;
     }
 
     case LayerNameRole:


### PR DESCRIPTION
|before|after|
|--------|------|
| ![image](https://user-images.githubusercontent.com/2820439/81837727-e37f1b80-954d-11ea-9d73-1a1f72ac9560.png) | ![image](https://user-images.githubusercontent.com/2820439/81837516-a581f780-954d-11ea-91af-0cbaafac1b7e.png)| 


