### PR TITLE
Fix feature count when deleting a feature

### DIFF
--- a/src/core/multifeaturelistmodel.cpp
+++ b/src/core/multifeaturelistmodel.cpp
@@ -72,6 +72,10 @@ void MultiFeatureListModel::appendFeatures( const QList<IdentifyTool::IdentifyRe
 
 void MultiFeatureListModel::clear()
 {
+  // the model is already empty, no need to trigger "resetModel"
+  if ( mFeatures.count() == 0 )
+    return;
+
   beginResetModel();
   mFeatures.clear();
   endResetModel();
@@ -204,6 +208,8 @@ int MultiFeatureListModel::count() const
 
 void MultiFeatureListModel::deleteFeature( QgsVectorLayer *layer, QgsFeatureId fid )
 {
+  beginResetModel();
+
   //delete child features in case of compositions
   const QList<QgsRelation> referencingRelations = QgsProject::instance()->relationManager()->referencedRelations( layer );
   for ( const QgsRelation &referencingRelation : referencingRelations )
@@ -226,6 +232,7 @@ void MultiFeatureListModel::deleteFeature( QgsVectorLayer *layer, QgsFeatureId f
   layer->startEditing();
   layer->deleteFeature( fid );
   layer->commitChanges();
+  endResetModel();
 }
 
 void MultiFeatureListModel::layerDeleted( QObject *object )

--- a/src/core/multifeaturelistmodel.cpp
+++ b/src/core/multifeaturelistmodel.cpp
@@ -73,7 +73,7 @@ void MultiFeatureListModel::appendFeatures( const QList<IdentifyTool::IdentifyRe
 void MultiFeatureListModel::clear()
 {
   // the model is already empty, no need to trigger "resetModel"
-  if ( mFeatures.count() == 0 )
+  if ( mFeatures.isEmpty() )
     return;
 
   beginResetModel();

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -462,4 +462,14 @@ Rectangle {
         state = "Hidden"
     }
   }
+
+  Connections {
+    target: globalFeaturesList.model
+
+    onCountChanged: {
+      if ( globalFeaturesList.model.count == 0 ) {
+        hide()
+      }
+    }
+  }
 }

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -409,6 +409,8 @@ Rectangle {
     onModelReset: {
       if ( model.rowCount() > 0 ) {
         state = "FeatureList"
+      } else {
+        state = "Hidden"
       }
     }
   }
@@ -463,13 +465,4 @@ Rectangle {
     }
   }
 
-  Connections {
-    target: globalFeaturesList.model
-
-    onCountChanged: {
-      if ( globalFeaturesList.model.count == 0 ) {
-        hide()
-      }
-    }
-  }
 }


### PR DESCRIPTION
When deleting a feature from the feature list model, the number of features in the header remains the old one. For example, if we have selected the first item fron a list of three features, the header shows 1/3. If we delete the first one, the header remains showing 1/3, even though there are only two features left.

What is more, when we delete all features, there is a blank feature list form on the screen. In this PR, if there are no more features, the list is closed.

|before|after|
|--------|------|
| ![Peek 2020-05-14 18-03](https://user-images.githubusercontent.com/2820439/81951011-50a5b600-960d-11ea-93e4-a7c710e3d15e.gif) | ![Peek 2020-05-14 17-59](https://user-images.githubusercontent.com/2820439/81950604-d07f5080-960c-11ea-81f7-0f18d1a88b0b.gif) |

