### PR TITLE
Respect hyperlink attachments

### DIFF
--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -59,7 +59,23 @@ Item {
     id: expressionEvaluator
     feature: currentFeature
     layer: currentLayer
-    expressionText: currentLayer ? currentLayer.customProperty('QFieldSync/photo_naming')!==undefined ? JSON.parse(currentLayer.customProperty('QFieldSync/photo_naming'))[field.name] : '' : ''
+    expressionText: {
+      if ( currentLayer && currentLayer.customProperty('QFieldSync/photo_naming') !== undefined ) {
+        return JSON.parse(currentLayer.customProperty('QFieldSync/photo_naming'))[field.name] 
+      } else {
+        return ''
+      }
+    }
+  }
+
+  function getPictureFilePath() {
+    var evaluatedFilepath = expressionEvaluator.evaluate()
+    
+    if ( evaluatedFilepath && FileUtils.fileSuffix(evaluatedFilepath) !== '' ) {
+      return evaluatedFilepath
+    } else {
+      return 'DCIM/JPEG_' + (new Date()).toISOString().replace(/[^0-9]/g, '') + '.jpg'
+    }
   }
 
   Label {
@@ -160,8 +176,7 @@ Item {
 
     onClicked: {
         if ( settings.valueBool("nativeCamera", true) ) {
-            var evaluated_filepath = expressionEvaluator.evaluate()
-            var filepath = !evaluated_filepath || FileUtils.fileSuffix(evaluated_filepath) === '' ? 'DCIM/JPEG_'+(new Date()).toISOString().replace(/[^0-9]/g, "")+'.jpg' : evaluated_filepath
+            var filepath = getPictureFilePath()
             __pictureSource = platformUtilities.getCameraPicture(qgisProject.homePath+'/', filepath, FileUtils.fileSuffix(filepath) )
         } else {
             platformUtilities.createDir( qgisProject.homePath, 'DCIM' )
@@ -184,8 +199,7 @@ Item {
     visible: !readOnly && isImage
 
     onClicked: {
-        var evaluated_filepath = expressionEvaluator.evaluate()
-        var filepath = !evaluated_filepath || FileUtils.fileSuffix(evaluated_filepath) === '' ? 'DCIM/JPEG_'+(new Date()).toISOString().replace(/[^0-9]/g, "")+'.jpg' : evaluated_filepath
+          var filepath = getPictureFilePath()
         __pictureSource = platformUtilities.getGalleryPicture(qgisProject.homePath+'/', filepath)
     }
 
@@ -226,8 +240,7 @@ Item {
         visible: true
 
         onFinished: {
-            var evaluated_filepath = expressionEvaluator.evaluate()
-            var filepath = !evaluated_filepath || FileUtils.fileSuffix(evaluated_filepath) === '' ? 'DCIM/JPEG_'+(new Date()).toISOString().replace(/[^0-9]/g, "")+'.jpg' : evaluated_filepath
+            var filepath = getPictureFilePath()
             platformUtilities.renameFile( path, qgisProject.homePath +'/' + filepath)
             valueChanged(filepath, false)
             campopup.close()

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -20,14 +20,20 @@ Item {
   property ViewStatus __viewStatus
 
   //on all mimetypes image/... and on empty values it should appear as an image widget
-  property bool isImage: value === undefined
-    || (
-      ! config.UseLink
-      && ( 
+  property bool isImage: {
+    if ( value == undefined ) {
+      return true
+    } else if ( config.UseLink ) {
+      return false
+    } else if ( 
         FileUtils.mimeTypeName( qgisProject.homePath + '/' + value ).startsWith("image/") 
         || FileUtils.fileName( qgisProject.homePath + '/' + value ) === ''
-      )
-    )
+    ) {
+      return true
+    } else {
+      return false
+    }
+  }
 
   //to not break any binding of image.source
   property var currentValue: value

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -20,7 +20,14 @@ Item {
   property ViewStatus __viewStatus
 
   //on all mimetypes image/... and on empty values it should appear as an image widget
-  property bool isImage: value === undefined || FileUtils.mimeTypeName( qgisProject.homePath + '/' + value ).startsWith("image/") || FileUtils.fileName( qgisProject.homePath + '/' + value ) === ''
+  property bool isImage: value === undefined
+    || (
+      ! config.UseLink
+      && ( 
+        FileUtils.mimeTypeName( qgisProject.homePath + '/' + value ).startsWith("image/") 
+        || FileUtils.fileName( qgisProject.homePath + '/' + value ) === ''
+      )
+    )
 
   //to not break any binding of image.source
   property var currentValue: value

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -19,7 +19,7 @@ Item {
   property PictureSource __pictureSource
   property ViewStatus __viewStatus
 
-  //on all mimetypes image/... and on empty values it should appear as an image widget
+  //on all mimetypes "image/..." and on empty values it should appear as an image widget except when it's configured as a link
   property bool isImage: {
     if ( value == undefined ) {
       return true


### PR DESCRIPTION
Fixes https://github.com/opengisch/QField/issues/1019
![image](https://user-images.githubusercontent.com/2820439/82037161-6cab6500-96aa-11ea-8e1f-a08abc6b7f63.png)

NOTE: in QField only the filename is shown, unlike QGIS, where the whole path is visualized
https://github.com/opengisch/QField/pull/1029/files#diff-bacb7c98c9810cffdfedd42311433719R71