### PR TITLE
Validate numeric fields on TextEdit widget

### DIFF
--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -19,7 +19,22 @@ Item {
 
     text: value !== undefined ? value : ''
 
-    inputMethodHints: Qt.ImhNone
+    validator: {
+      if (field.isNumeric)
+          if ( platformUtilities.fieldType( field ) === 'double')
+          {
+            doubleValidator;
+          }
+          else
+          {
+            intValidator;
+          }
+      else {
+        null;
+      }
+    }
+
+    inputMethodHints: field.isNumeric ? Qt.ImhFormattedNumbersOnly : Qt.ImhNone
 
     background: Rectangle {
       y: textField.height - height - textField.bottomPadding / 2


### PR DESCRIPTION
The validation of fields has been removed on the implementation of the nice functionalities on the range widget.

I think it should be still on the text edit widget, because otherwise customers have to reconfigure all of their text edits using numbers. 

resolves #1026

Or if we decide to have it not anymore in the textedit, it would need the information in the documentation.