### PR TITLE
Improve legend icon matching and fix unwanted indent

### DIFF
--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -27,6 +27,7 @@ FlatLayerTreeModel::FlatLayerTreeModel( QgsLayerTree *layerTree, QgsProject *pro
   , mProject( project )
 {
   mLayerTreeModel = new QgsLayerTreeModel( layerTree, this );
+  mLayerTreeModel->setFlag( QgsLayerTreeModel::ShowLegendAsTree, true );
   setSourceModel ( mLayerTreeModel );
   connect( mProject, &QgsProject::readProject, this, [ = ] { buildMap( mLayerTreeModel ); } );
   connect( mLayerTreeModel, &QAbstractItemModel::dataChanged, this, &FlatLayerTreeModel::updateMap );
@@ -135,15 +136,24 @@ QVariant FlatLayerTreeModel::data( const QModelIndex &index, int role ) const
     {
       QString id;
 
-      if ( QgsLayerTreeModelLegendNode *sym = mLayerTreeModel->index2legendNode( mapToSource( index ) ) )
+      QModelIndex sourceIndex = mapToSource( index );
+      if ( QgsLayerTreeModelLegendNode *sym = mLayerTreeModel->index2legendNode( sourceIndex ) )
       {
         id += QStringLiteral( "legend" );
         id += '/' + sym->layerNode()->layerId();
-        id += '/' + sym->data( Qt::DisplayRole ).toString();
+        QStringList legendParts;
+        while ( sym )
+        {
+          legendParts << sym->data( Qt::DisplayRole ).toString();
+          sourceIndex = sourceIndex.parent();
+          sym = mLayerTreeModel->index2legendNode( sourceIndex );
+        }
+        std::reverse( legendParts.begin(), legendParts.end() );
+        id += '/' + legendParts.join( QStringLiteral( "~__~" ) );
       }
       else
       {
-        QgsLayerTreeNode *node = mLayerTreeModel->index2node( mapToSource( index ) );
+        QgsLayerTreeNode *node = mLayerTreeModel->index2node( sourceIndex );
 
         if ( QgsLayerTree::isLayer( node ) )
         {


### PR DESCRIPTION
This PR both fixes and improve the legend image provider by setting the layer tree model to show legend items as tree instead of a flattened fake tree. 

With the QgsLayerTreeModel::ShowLegendAsTree flag, we avoid the fake tree hackery in the layer model icon creation whereas indent spacing is added _within_ the pixmap itself. This created tiny, non-centered icons in the legend. See how beautiful things are now:
![Screenshot from 2020-06-02 14-55-39](https://user-images.githubusercontent.com/1728657/83496152-df0da900-a4e2-11ea-9988-eb5af8751d22.png)
_Before, the rule-based children rules to parent ones would show tiny, tiny icons_

In addition, getting the proper parent / children structure allows for a more accurate matching of legend IDs and their respective preview images. Since we're doing string matching (first match being returned), we ended up sometimes serving wrong legend icon. For e.g., take this rule-based symbol tree:

- my A items
-- valid
-- invalid
- my B items
-- valid
-- invalid

Until this PR, we would _wrongly_ return my A items' valid legend image for my B items' valid node. With the improved code, we take parent legend strings into account, improving matching behavior. See for e.g. this improved legend:
![Screenshot from 2020-06-02 14-55-29](https://user-images.githubusercontent.com/1728657/83496449-504d5c00-a4e3-11ea-911d-330c7fd3f5b5.png)
_Before, the symbol-less rules would match children items which do have symbols_