### PR TITLE
WIP Make text fields with links open externally

### DIFF
--- a/src/core/platformutilities.cpp
+++ b/src/core/platformutilities.cpp
@@ -17,6 +17,8 @@
  ***************************************************************************/
 
 #include "qgsmessagelog.h"
+#include "qgsstringutils.h"
+
 
 #include "platformutilities.h"
 #include "projectsource.h"
@@ -133,3 +135,7 @@ bool PlatformUtilities::checkWriteExternalStoragePermissions() const
   return true;
 }
 
+QString PlatformUtilities::insertLinks( const QString &string )
+{
+  return QgsStringUtils::insertLinks( string );
+}

--- a/src/core/platformutilities.h
+++ b/src/core/platformutilities.h
@@ -116,5 +116,7 @@ class PlatformUtilities : public QObject
     */
     Q_INVOKABLE virtual void showRateThisApp() const {};
 
+
+    Q_INVOKABLE QString insertLinks( const QString &string );
 };
 #endif // PLATFORMUTILITIES_H

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -6,18 +6,35 @@ Item {
   signal valueChanged(var value, bool isNull)
   height: childrenRect.height
 
+  // Due to QTextEdit::onLinkActivated does not work on Android & iOS, we need a separate `Text` element to support links https://bugreports.qt.io/browse/QTBUG-38487
+  Text {
+    id: textReadonlyValue
+    height: textArea.height == 0 ? fontMetrics.height + 20: 0
+    topPadding: 10
+    bottomPadding: 10
+    visible: height !== 0 && ! enabled
+    anchors.left: parent.left
+    anchors.right: parent.right
+    font: Theme.defaultFont
+    color: value == null || !enabled ? 'gray' : 'black'
+
+    text: value == null ? '' : platformUtilities.insertLinks( value )
+
+    onLinkActivated: Qt.openUrlExternally(link)
+  }
+
   TextField {
     id: textField
     height: textArea.height == 0 ? fontMetrics.height + 20: 0
     topPadding: 10
     bottomPadding: 10
-    visible: height !== 0
+    visible: height !== 0 && enabled
     anchors.left: parent.left
     anchors.right: parent.right
     font: Theme.defaultFont
-    color: value === undefined || !enabled ? 'gray' : 'black'
+    color: value == null || !enabled ? 'gray' : 'black'
 
-    text: value !== undefined ? value : ''
+    text: value == null ? '' : value
 
     validator: {
       if (field.isNumeric)


### PR DESCRIPTION
When text contains a valid URL, convert it to an anchor via `QStringUtils::insertLinks` and display it.

Because of a bug in QML, there is a need of aditional `Text` QML element, because links in `TextEdit` do not open on Android and it's quite dirty to automatically convert to `RichText` format.

However, I still have an issue with clickable text with links, it just refuses to trigger `onLinkActivated` when a link is clicked. I tried to enforce "readOnly" property to true of the parent element, but I either failed, or it's not the source of the problem. Need help to get it finished.

Adding `QStringUtils` to `PlatformUtilities` also feels weird. Because `QStringUtils` is not a `QObject`, I either need to create a new strinutils wrapper, or put it in already existing utils.