### PR TITLE
Add multi-selection capability to the feature list form

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -24,6 +24,7 @@ SET(QFIELD_CORE_SRCS
   maptoscreen.cpp
   messagelogmodel.cpp
   modelhelper.cpp
+  multifeaturelistmodelbase.cpp
   multifeaturelistmodel.cpp
   picturesource.cpp
   platformutilities.cpp
@@ -82,6 +83,7 @@ SET(QFIELD_CORE_HDRS
   maptoscreen.h
   messagelogmodel.h
   modelhelper.h
+  multifeaturelistmodelbase.h
   multifeaturelistmodel.h
   picturesource.h
   platformutilities.h

--- a/src/core/attributeformmodel.h
+++ b/src/core/attributeformmodel.h
@@ -50,7 +50,8 @@ class AttributeFormModel : public QSortFilterProxyModel
       CurrentlyVisible,
       ConstraintHardValid,
       ConstraintSoftValid,
-      ConstraintDescription
+      ConstraintDescription,
+      AttributeAllowEdit
     };
 
     Q_ENUM( FeatureRoles )

--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -404,11 +404,11 @@ void AttributeFormModelBase::updateVisibility( int fieldIndex )
   {
     QStandardItem *item = constraintIterator.key();
 
-    int fieldIndex = item->data( AttributeFormModel::FieldIndex ).toInt();
+    int fidx = item->data( AttributeFormModel::FieldIndex ).toInt();
     if ( mFeatureModel->data( mFeatureModel->index( fieldIndex ), FeatureModel::AttributeAllowEdit ) == true )
     {
       QStringList errors;
-      bool hardConstraintSatisfied = QgsVectorLayerUtils::validateAttribute( mLayer, mFeatureModel->feature(), fieldIndex, errors, QgsFieldConstraints::ConstraintStrengthHard );
+      bool hardConstraintSatisfied = QgsVectorLayerUtils::validateAttribute( mLayer, mFeatureModel->feature(), fidx, errors, QgsFieldConstraints::ConstraintStrengthHard );
       if ( hardConstraintSatisfied != item->data( AttributeFormModel::ConstraintHardValid ).toBool() )
       {
         item->setData( hardConstraintSatisfied, AttributeFormModel::ConstraintHardValid );
@@ -419,7 +419,7 @@ void AttributeFormModelBase::updateVisibility( int fieldIndex )
       }
 
       QStringList softErrors;
-      bool softConstraintSatisfied = QgsVectorLayerUtils::validateAttribute( mLayer, mFeatureModel->feature(), item->data( AttributeFormModel::FieldIndex ).toInt(), softErrors, QgsFieldConstraints::ConstraintStrengthSoft );
+      bool softConstraintSatisfied = QgsVectorLayerUtils::validateAttribute( mLayer, mFeatureModel->feature(), fidx, softErrors, QgsFieldConstraints::ConstraintStrengthSoft );
       if ( softConstraintSatisfied != item->data( AttributeFormModel::ConstraintSoftValid ).toBool() )
       {
         item->setData( softConstraintSatisfied, AttributeFormModel::ConstraintSoftValid );

--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -113,16 +113,12 @@ void AttributeFormModelBase::setFeatureModel( FeatureModel *featureModel )
   if ( mFeatureModel )
   {
     disconnect( mFeatureModel, &FeatureModel::currentLayerChanged, this, &AttributeFormModelBase::onLayerChanged );
-    disconnect( mFeatureModel, &FeatureModel::featureChanged, this, &AttributeFormModelBase::onFeatureChanged );
     disconnect( mFeatureModel, &FeatureModel::modelReset, this, &AttributeFormModelBase::onFeatureChanged );
   }
 
   mFeatureModel = featureModel;
 
   connect( mFeatureModel, &FeatureModel::currentLayerChanged, this, &AttributeFormModelBase::onLayerChanged );
-  connect( mFeatureModel, &FeatureModel::featureChanged, this, &AttributeFormModelBase::onFeatureChanged );
-  connect( mFeatureModel, &FeatureModel::featuresChanged, this, &AttributeFormModelBase::onFeatureChanged );
-  connect( mFeatureModel, &FeatureModel::modelMode, this, &AttributeFormModelBase::onFeatureChanged );
   connect( mFeatureModel, &FeatureModel::modelReset, this, &AttributeFormModelBase::onFeatureChanged );
 
   emit featureModelChanged();
@@ -405,7 +401,7 @@ void AttributeFormModelBase::updateVisibility( int fieldIndex )
     QStandardItem *item = constraintIterator.key();
 
     int fidx = item->data( AttributeFormModel::FieldIndex ).toInt();
-    if ( mFeatureModel->data( mFeatureModel->index( fieldIndex ), FeatureModel::AttributeAllowEdit ) == true )
+    if ( mFeatureModel->data( mFeatureModel->index( fidx ), FeatureModel::AttributeAllowEdit ) == true )
     {
       QStringList errors;
       bool hardConstraintSatisfied = QgsVectorLayerUtils::validateAttribute( mLayer, mFeatureModel->feature(), fidx, errors, QgsFieldConstraints::ConstraintStrengthHard );

--- a/src/core/core.pro
+++ b/src/core/core.pro
@@ -24,6 +24,7 @@ HEADERS += \
     appinterface.h \
     featurelistextentcontroller.h \
     geometryeditorsmodel.h \
+    multifeaturelistmodelbase.h \
     multifeaturelistmodel.h \
     featurelistmodelselection.h \
     featuremodel.h \
@@ -81,6 +82,7 @@ SOURCES += \
     appinterface.cpp \
     featurelistextentcontroller.cpp \
     geometryeditorsmodel.cpp \
+    multifeaturelistmodelbase.cpp \
     multifeaturelistmodel.cpp \
     featurelistmodelselection.cpp \
     featuremodel.cpp \

--- a/src/core/featurelistextentcontroller.cpp
+++ b/src/core/featurelistextentcontroller.cpp
@@ -49,8 +49,8 @@ void FeatureListExtentController::zoomToSelected( bool skipIfIntersects ) const
 {
   if ( mModel && mSelection && mMapSettings )
   {
-    QgsFeature feat = mSelection->selectedFeature();
-    QgsVectorLayer *layer = mSelection->selectedLayer();
+    QgsFeature feat = mSelection->focusedFeature();
+    QgsVectorLayer *layer = mSelection->focusedLayer();
 
     QgsCoordinateTransform transf( layer->crs(), mMapSettings->destinationCrs(), mMapSettings->mapSettings().transformContext() );
     QgsGeometry geom( feat.geometry() );
@@ -76,7 +76,7 @@ void FeatureListExtentController::onModelChanged()
 {
   if ( mModel && mSelection )
   {
-    connect( mSelection, &FeatureListModelSelection::selectionChanged, this, &FeatureListExtentController::onCurrentSelectionChanged );
+    connect( mSelection, &FeatureListModelSelection::focusedItemChanged, this, &FeatureListExtentController::onCurrentSelectionChanged );
   }
 }
 

--- a/src/core/featurelistmodelselection.cpp
+++ b/src/core/featurelistmodelselection.cpp
@@ -39,11 +39,6 @@ void FeatureListModelSelection::setFocusedItem( int item )
   emit focusedItemChanged();
 }
 
-QList<QgsFeature> FeatureListModelSelection::selectedFeatures() const
-{
-  return mModel->selectedFeatures();
-}
-
 void FeatureListModelSelection::toggleSelectedItem( int item )
 {
   mModel->toggleSelectedItem( item );

--- a/src/core/featurelistmodelselection.cpp
+++ b/src/core/featurelistmodelselection.cpp
@@ -25,25 +25,23 @@ FeatureListModelSelection::FeatureListModelSelection( QObject *parent )
 {
 }
 
-int FeatureListModelSelection::selection()
+int FeatureListModelSelection::focusedItem()
 {
-  if ( mSelection  && mSelection->selectedIndexes().count() )
-  {
-    return mSelection->selectedIndexes().first().row();
-  }
-  return -1;
+  return mFocusedItem;
 }
 
-void FeatureListModelSelection::setSelection( int selection )
+void FeatureListModelSelection::setFocusedItem( int item )
 {
-  if ( mSelection )
-  {
-    if ( !mSelection->selectedIndexes().count() || mSelection->selectedIndexes().first().row() != selection )
-    {
-      mSelection->select( mModel->index( selection, 0 ), QItemSelectionModel::ClearAndSelect );
-      emit selectionChanged();
-    }
-  }
+  if ( mFocusedItem == item )
+    return;
+
+  mFocusedItem = item;
+  emit focusedItemChanged();
+}
+
+void FeatureListModelSelection::toggleSelectedItem( int item )
+{
+  mModel->toggleSelectedItem( item );
 }
 
 MultiFeatureListModel *FeatureListModelSelection::model() const
@@ -55,6 +53,7 @@ void FeatureListModelSelection::setModel( MultiFeatureListModel *model )
 {
   if ( mModel != model )
   {
+    mFocusedItem = -1;
     delete mSelection;
     mSelection = new QItemSelectionModel( model );
     mModel = model;
@@ -62,26 +61,26 @@ void FeatureListModelSelection::setModel( MultiFeatureListModel *model )
   }
 }
 
-QgsVectorLayer *FeatureListModelSelection::selectedLayer() const
+QgsVectorLayer *FeatureListModelSelection::focusedLayer() const
 {
-  if ( mSelection->selectedIndexes().count() )
+  if ( mFocusedItem > -1 )
   {
-    return mModel->data( mSelection->selectedIndexes().first(), MultiFeatureListModel::LayerRole ).value<QgsVectorLayer *>();
+    return mModel->data( mModel->index( mFocusedItem, 0 ), MultiFeatureListModel::LayerRole ).value<QgsVectorLayer *>();
   }
   return nullptr;
 }
 
-QgsFeature FeatureListModelSelection::selectedFeature() const
+QgsFeature FeatureListModelSelection::focusedFeature() const
 {
-  if ( mSelection->selectedIndexes().count() )
+  if ( mFocusedItem > -1 )
   {
-    QgsFeature feature = mModel->data( mSelection->selectedIndexes().first(), MultiFeatureListModel::FeatureRole ).value<QgsFeature>();
+    QgsFeature feature = mModel->data( mModel->index( mFocusedItem, 0 ), MultiFeatureListModel::FeatureRole ).value<QgsFeature>();
     return feature;
   }
   return QgsFeature();
 }
 
-QgsGeometry FeatureListModelSelection::selectedGeometry() const
+QgsGeometry FeatureListModelSelection::focusedGeometry() const
 {
-  return selectedFeature().geometry();
+  return focusedFeature().geometry();
 }

--- a/src/core/featurelistmodelselection.cpp
+++ b/src/core/featurelistmodelselection.cpp
@@ -25,7 +25,7 @@ FeatureListModelSelection::FeatureListModelSelection( QObject *parent )
 {
 }
 
-int FeatureListModelSelection::focusedItem()
+int FeatureListModelSelection::focusedItem() const
 {
   return mFocusedItem;
 }
@@ -39,9 +39,15 @@ void FeatureListModelSelection::setFocusedItem( int item )
   emit focusedItemChanged();
 }
 
+QList<QgsFeature> FeatureListModelSelection::selectedFeatures() const
+{
+  return mModel->selectedFeatures();
+}
+
 void FeatureListModelSelection::toggleSelectedItem( int item )
 {
   mModel->toggleSelectedItem( item );
+  emit selectedFeaturesChanged();
 }
 
 MultiFeatureListModel *FeatureListModelSelection::model() const

--- a/src/core/featurelistmodelselection.cpp
+++ b/src/core/featurelistmodelselection.cpp
@@ -55,8 +55,6 @@ void FeatureListModelSelection::setModel( MultiFeatureListModel *model )
   if ( mModel != model )
   {
     mFocusedItem = -1;
-    delete mSelection;
-    mSelection = new QItemSelectionModel( model );
     mModel = model;
     emit modelChanged();
   }

--- a/src/core/featurelistmodelselection.cpp
+++ b/src/core/featurelistmodelselection.cpp
@@ -45,6 +45,12 @@ void FeatureListModelSelection::toggleSelectedItem( int item )
   emit selectedFeaturesChanged();
 }
 
+void FeatureListModelSelection::clear()
+{
+  mFocusedItem = -1;
+  emit focusedItemChanged();
+}
+
 MultiFeatureListModel *FeatureListModelSelection::model() const
 {
   return mModel;

--- a/src/core/featurelistmodelselection.h
+++ b/src/core/featurelistmodelselection.h
@@ -27,32 +27,35 @@ class FeatureListModelSelection : public QObject
 {
     Q_OBJECT
     Q_PROPERTY( MultiFeatureListModel *model READ model WRITE setModel NOTIFY modelChanged )
-    Q_PROPERTY( int selection READ selection WRITE setSelection NOTIFY selectionChanged )
-    Q_PROPERTY( QgsVectorLayer *selectedLayer READ selectedLayer NOTIFY selectionChanged )
-    Q_PROPERTY( QgsFeature selectedFeature READ selectedFeature NOTIFY selectionChanged )
-    Q_PROPERTY( QgsGeometry selectedGeometry READ selectedGeometry NOTIFY selectionChanged )
+    Q_PROPERTY( int focusedItem READ focusedItem WRITE setFocusedItem NOTIFY focusedItemChanged )
+    Q_PROPERTY( QgsVectorLayer *focusedLayer READ focusedLayer NOTIFY focusedItemChanged )
+    Q_PROPERTY( QgsFeature focusedFeature READ focusedFeature NOTIFY focusedItemChanged )
+    Q_PROPERTY( QgsGeometry focusedGeometry READ focusedGeometry NOTIFY focusedItemChanged )
 
   public:
     explicit FeatureListModelSelection( QObject *parent = nullptr );
 
-    int selection();
-    void setSelection( int selection );
+    int focusedItem();
+
+    void setFocusedItem( int item );
+
+    Q_INVOKABLE void toggleSelectedItem( int item );
 
     MultiFeatureListModel *model() const;
     void setModel( MultiFeatureListModel *model );
 
-    QgsVectorLayer *selectedLayer() const;
-    QgsFeature selectedFeature() const;
-
-    QgsGeometry selectedGeometry() const;
+    QgsVectorLayer *focusedLayer() const;
+    QgsFeature focusedFeature() const;
+    QgsGeometry focusedGeometry() const;
 
   signals:
     void modelChanged();
-    void selectionChanged();
+    void focusedItemChanged();
 
   private:
     MultiFeatureListModel *mModel = nullptr;
     QItemSelectionModel *mSelection = nullptr;
+    int mFocusedItem = -1;
 };
 
 #endif // FEATURELISTMODELSELECTION_H

--- a/src/core/featurelistmodelselection.h
+++ b/src/core/featurelistmodelselection.h
@@ -31,13 +31,16 @@ class FeatureListModelSelection : public QObject
     Q_PROPERTY( QgsVectorLayer *focusedLayer READ focusedLayer NOTIFY focusedItemChanged )
     Q_PROPERTY( QgsFeature focusedFeature READ focusedFeature NOTIFY focusedItemChanged )
     Q_PROPERTY( QgsGeometry focusedGeometry READ focusedGeometry NOTIFY focusedItemChanged )
+    Q_PROPERTY( QList<QgsFeature> selectedFeatures READ selectedFeatures NOTIFY selectedFeaturesChanged )
 
   public:
     explicit FeatureListModelSelection( QObject *parent = nullptr );
 
-    int focusedItem();
+    int focusedItem() const;
 
     void setFocusedItem( int item );
+
+    QList<QgsFeature> selectedFeatures() const;
 
     Q_INVOKABLE void toggleSelectedItem( int item );
 
@@ -51,6 +54,7 @@ class FeatureListModelSelection : public QObject
   signals:
     void modelChanged();
     void focusedItemChanged();
+    void selectedFeaturesChanged();
 
   private:
     MultiFeatureListModel *mModel = nullptr;

--- a/src/core/featurelistmodelselection.h
+++ b/src/core/featurelistmodelselection.h
@@ -31,7 +31,6 @@ class FeatureListModelSelection : public QObject
     Q_PROPERTY( QgsVectorLayer *focusedLayer READ focusedLayer NOTIFY focusedItemChanged )
     Q_PROPERTY( QgsFeature focusedFeature READ focusedFeature NOTIFY focusedItemChanged )
     Q_PROPERTY( QgsGeometry focusedGeometry READ focusedGeometry NOTIFY focusedItemChanged )
-    Q_PROPERTY( QList<QgsFeature> selectedFeatures READ selectedFeatures NOTIFY selectedFeaturesChanged )
 
   public:
     explicit FeatureListModelSelection( QObject *parent = nullptr );
@@ -39,8 +38,6 @@ class FeatureListModelSelection : public QObject
     int focusedItem() const;
 
     void setFocusedItem( int item );
-
-    QList<QgsFeature> selectedFeatures() const;
 
     Q_INVOKABLE void toggleSelectedItem( int item );
 

--- a/src/core/featurelistmodelselection.h
+++ b/src/core/featurelistmodelselection.h
@@ -40,6 +40,8 @@ class FeatureListModelSelection : public QObject
 
     Q_INVOKABLE void toggleSelectedItem( int item );
 
+    Q_INVOKABLE void clear();
+
     MultiFeatureListModel *model() const;
     void setModel( MultiFeatureListModel *model );
 

--- a/src/core/featurelistmodelselection.h
+++ b/src/core/featurelistmodelselection.h
@@ -19,7 +19,6 @@
 #define FEATURELISTMODELSELECTION_H
 
 #include <QObject>
-#include <QItemSelectionModel>
 
 #include "multifeaturelistmodel.h"
 
@@ -55,7 +54,6 @@ class FeatureListModelSelection : public QObject
 
   private:
     MultiFeatureListModel *mModel = nullptr;
-    QItemSelectionModel *mSelection = nullptr;
     int mFocusedItem = -1;
 };
 

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -343,7 +343,6 @@ bool FeatureModel::save()
           feature.setAttribute( i, mFeature.attributes().at( i ) );
         }
 
-        qDebug() << QString( "feat id %1" ).arg( feature.id() );
         if ( !mLayer->updateFeature( feature ) )
         {
           QgsMessageLog::logMessage( tr( "Cannot update feature" ), QStringLiteral( "QField" ), Qgis::Warning );

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -345,6 +345,7 @@ bool FeatureModel::save()
         else
           QgsMessageLog::logMessage( tr( "Feature %1 could not be fetched after commit" ).arg( mFeature.id() ), QStringLiteral( "QField" ), Qgis::Warning );
       }
+      break;
     }
 
     case MultiFeatureModel:

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -75,14 +75,18 @@ void FeatureModel::setFeatures( const QList<QgsFeature> &features )
     for ( int i = 0; i < mFeature.attributes().count(); i++ )
     {
       bool equalValue = true;
-      for ( const QgsFeature &feature : mFeatures )
+      struct AttributeNotEqual
       {
-        if ( feature.attributes().at( i ) != mFeature.attributes().at( i ) )
-        {
-          mFeature.setAttribute( i, QVariant() );
-          equalValue = false;
-          break;
-        }
+        const int attributeIndex;
+        const QgsFeature &feature;
+        AttributeNotEqual( const QgsFeature &feature, int attributeIndex ) : attributeIndex( attributeIndex ), feature( feature ) {}
+        bool operator()( const QgsFeature &f) const { return feature.attributes().at( attributeIndex ) != f.attributes().at( attributeIndex ); }
+      };
+
+      if ( std::any_of( mFeatures.begin(), mFeatures.end(), AttributeNotEqual( mFeature, i ) ) )
+      {
+        mFeature.setAttribute( i, QVariant() );
+        equalValue = false;
       }
       mAttributesAllowEdit << equalValue;
     }

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -65,7 +65,8 @@ class FeatureModel : public QAbstractListModel
       AttributeValue,
       Field,
       RememberAttribute,
-      LinkedAttribute  //! value of this attribute is given by the parent feature and does not to be available for editing in the form
+      LinkedAttribute,  //! value of this attribute is given by the parent feature and does not to be available for editing in the form
+      AttributeAllowEdit, //! value of this attribute is equal across features being edited
     };
     Q_ENUM( FeatureRoles )
 
@@ -222,7 +223,7 @@ class FeatureModel : public QAbstractListModel
     QgsVectorLayer *mLayer = nullptr;
     QgsFeature mFeature;
     QList<QgsFeature> mFeatures;
-    QList<bool> mAttributesEqualValue;
+    QList<bool> mAttributesAllowEdit;
     QgsFeature mLinkedParentFeature;
     QgsRelation mLinkedRelation;
     QList<int> mLinkedAttributeIndexes;

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -32,7 +32,9 @@ class VertexModel;
 class FeatureModel : public QAbstractListModel
 {
     Q_OBJECT
+    Q_PROPERTY( FeatureModel::ModelModes modelMode READ modelMode WRITE setModelMode NOTIFY modelModeChanged )
     Q_PROPERTY( QgsFeature feature READ feature WRITE setFeature NOTIFY featureChanged )
+    Q_PROPERTY( QList<QgsFeature> features READ features WRITE setFeatures NOTIFY featuresChanged )
     Q_PROPERTY( QgsFeature linkedParentFeature READ linkedParentFeature WRITE setLinkedParentFeature NOTIFY linkedParentFeatureChanged )
     Q_PROPERTY( QgsRelation linkedRelation READ linkedRelation WRITE setLinkedRelation NOTIFY linkedRelationChanged )
     //! the vertex model is used to highlight vertices on the map
@@ -50,6 +52,13 @@ class FeatureModel : public QAbstractListModel
     };
 
   public:
+    enum ModelModes
+    {
+      SingleFeatureModel = 1,
+      MultiFeatureModel,
+    };
+    Q_ENUM( ModelModes )
+
     enum FeatureRoles
     {
       AttributeName = Qt::UserRole + 1,
@@ -61,7 +70,9 @@ class FeatureModel : public QAbstractListModel
     Q_ENUM( FeatureRoles )
 
     explicit FeatureModel( QObject *parent = nullptr );
-    explicit FeatureModel( const QgsFeature &feat, QObject *parent = nullptr );
+
+    void setModelMode( const ModelModes mode );
+    ModelModes modelMode() const;
 
     void setFeature( const QgsFeature &feature );
 
@@ -69,6 +80,13 @@ class FeatureModel : public QAbstractListModel
      * Return the feature wrapped in a QVariant for passing it around in QML
      */
     QgsFeature feature() const;
+
+    void setFeatures( const QList<QgsFeature> &features );
+
+    /**
+     * Return the features list for passing it around in QML
+     */
+    QList<QgsFeature> features() const;
 
     /**
      * A linked feature is a parent feature of a relation passing it's pk(s) to the created child features fk(s)
@@ -179,7 +197,9 @@ class FeatureModel : public QAbstractListModel
     void removeLayer( QObject *layer );
 
   signals:
+    void modelModeChanged();
     void featureChanged();
+    void featuresChanged();
     void linkedParentFeatureChanged();
     void linkedRelationChanged();
     void vertexModelChanged();
@@ -198,8 +218,11 @@ class FeatureModel : public QAbstractListModel
     bool startEditing();
     void setLinkedFeatureValues();
 
+    ModelModes mModelMode = SingleFeatureModel;
     QgsVectorLayer *mLayer = nullptr;
     QgsFeature mFeature;
+    QList<QgsFeature> mFeatures;
+    QList<bool> mAttributesEqualValue;
     QgsFeature mLinkedParentFeature;
     QgsRelation mLinkedRelation;
     QList<int> mLinkedAttributeIndexes;

--- a/src/core/featureslocatorfilter.cpp
+++ b/src/core/featureslocatorfilter.cpp
@@ -148,7 +148,7 @@ void FeaturesLocatorFilter::triggerResultFromAction( const QgsLocatorResult &res
     QMap<QgsVectorLayer *, QgsFeatureRequest> requests;
     requests.insert( layer, featureRequest );
     mLocatorBridge->featureListController()->model()->setFeatures( requests );
-    mLocatorBridge->featureListController()->selection()->setSelection( 0 );
+    mLocatorBridge->featureListController()->selection()->setFocusedItem( 0 );
     mLocatorBridge->featureListController()->requestFeatureFormState();
   }
   else

--- a/src/core/identifytool.cpp
+++ b/src/core/identifytool.cpp
@@ -56,7 +56,7 @@ void IdentifyTool::identify( const QPointF &point ) const
     return;
   }
 
-  mModel->clear();
+  mModel->clear( true );
 
   QgsPointXY mapPoint = mMapSettings->screenToCoordinate( point );
 

--- a/src/core/multifeaturelistmodel.cpp
+++ b/src/core/multifeaturelistmodel.cpp
@@ -35,7 +35,7 @@ MultiFeatureListModel::MultiFeatureListModel( QObject *parent )
   setSourceModel( mSourceModel );
   connect( mSourceModel, &MultiFeatureListModelBase::modelReset, this, &MultiFeatureListModel::countChanged );
   connect( mSourceModel, &MultiFeatureListModelBase::countChanged, this, &MultiFeatureListModel::countChanged );
-  connect( mSourceModel, &MultiFeatureListModelBase::selectedCountChanged, this, &MultiFeatureListModel::selectedCountChanged );
+  connect( mSourceModel, &MultiFeatureListModelBase::selectedCountChanged, this, &MultiFeatureListModel::checkSelectedCount);
 }
 
 
@@ -87,6 +87,16 @@ void MultiFeatureListModel::toggleSelectedItem( int item )
     mFilterLayer = nullptr;
     invalidateFilter();
   }
+}
+
+void MultiFeatureListModel::checkSelectedCount()
+{
+  if ( mSourceModel->selectedCount() == 0 && mFilterLayer != nullptr )
+  {
+    mFilterLayer = nullptr;
+    invalidateFilter();
+  }
+  emit selectedCountChanged();
 }
 
 QList<QgsFeature> MultiFeatureListModel::selectedFeatures()

--- a/src/core/multifeaturelistmodel.cpp
+++ b/src/core/multifeaturelistmodel.cpp
@@ -89,6 +89,11 @@ void MultiFeatureListModel::toggleSelectedItem( int item )
   }
 }
 
+QList<QgsFeature> MultiFeatureListModel::selectedFeatures()
+{
+  return mSourceModel->selectedFeatures();
+}
+
 bool MultiFeatureListModel::filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const
 {
   if ( mFilterLayer != nullptr )

--- a/src/core/multifeaturelistmodel.cpp
+++ b/src/core/multifeaturelistmodel.cpp
@@ -29,362 +29,71 @@
 #include <QDebug>
 
 MultiFeatureListModel::MultiFeatureListModel( QObject *parent )
-  :  QAbstractItemModel( parent )
+  : QSortFilterProxyModel( parent )
+  , mSourceModel( new MultiFeatureListModelBase( this ) )
 {
-  connect( this, &MultiFeatureListModel::modelReset, this, &MultiFeatureListModel::countChanged );
+  setSourceModel( mSourceModel );
+  connect( mSourceModel, &MultiFeatureListModelBase::modelReset, this, &MultiFeatureListModel::countChanged );
+  connect( mSourceModel, &MultiFeatureListModelBase::countChanged, this, &MultiFeatureListModel::countChanged );
+  connect( mSourceModel, &MultiFeatureListModelBase::selectedCountChanged, this, &MultiFeatureListModel::selectedCountChanged );
 }
+
 
 void MultiFeatureListModel::setFeatures( const QMap<QgsVectorLayer *, QgsFeatureRequest> requests )
 {
-  beginResetModel();
-
-  mFeatures.clear();
-
-  QMap<QgsVectorLayer *, QgsFeatureRequest>::ConstIterator it;
-  for ( it = requests.constBegin(); it != requests.constEnd(); it++ )
-  {
-    QgsFeature feat;
-    QgsFeatureIterator fit = it.key()->getFeatures( it.value() );
-    while ( fit.nextFeature( feat ) )
-    {
-      mFeatures.append( QPair< QgsVectorLayer *, QgsFeature >( it.key(), feat ) );
-      connect( it.key(), &QgsVectorLayer::destroyed, this, &MultiFeatureListModel::layerDeleted, Qt::UniqueConnection );
-      connect( it.key(), &QgsVectorLayer::featureDeleted, this, &MultiFeatureListModel::featureDeleted, Qt::UniqueConnection );
-      connect( it.key(), &QgsVectorLayer::attributeValueChanged, this, &MultiFeatureListModel::attributeValueChanged, Qt::UniqueConnection );
-    }
-  }
-
-  endResetModel();
+  mSourceModel->setFeatures( requests );
 }
 
 void MultiFeatureListModel::appendFeatures( const QList<IdentifyTool::IdentifyResult> &results )
 {
-  beginInsertRows( QModelIndex(), mFeatures.count(), mFeatures.count() + results.count() - 1 );
-  for ( const IdentifyTool::IdentifyResult &result : results )
+  mSourceModel->appendFeatures( results );
+}
+
+void MultiFeatureListModel::clear( const bool keepSelected )
+{
+  if ( !keepSelected )
   {
-    QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( result.layer );
-    mFeatures.append( QPair<QgsVectorLayer *, QgsFeature>( layer, result.feature ) );
-    connect( layer, &QObject::destroyed, this, &MultiFeatureListModel::layerDeleted, Qt::UniqueConnection );
-    connect( layer, &QgsVectorLayer::featureDeleted, this, &MultiFeatureListModel::featureDeleted, Qt::UniqueConnection );
-    connect( layer, &QgsVectorLayer::attributeValueChanged, this, &MultiFeatureListModel::attributeValueChanged, Qt::UniqueConnection );
+    mFilterLayer = nullptr;
   }
-  endInsertRows();
-}
-
-void MultiFeatureListModel::clear()
-{
-  // the model is already empty, no need to trigger "resetModel"
-  if ( mFeatures.isEmpty() )
-    return;
-
-  beginResetModel();
-  mFeatures.clear();
-  endResetModel();
-}
-
-QHash<int, QByteArray> MultiFeatureListModel::roleNames() const
-{
-  QHash<int, QByteArray> roleNames;
-
-  roleNames[Qt::DisplayRole] = "display";
-  roleNames[FeatureIdRole] = "featureId";
-  roleNames[FeatureRole] = "feature";
-  roleNames[LayerNameRole] = "layerName";
-  roleNames[LayerRole] = "currentLayer";
-  roleNames[GeometryRole] = "geometry";
-  roleNames[CrsRole] = "crs";
-  roleNames[DeleteFeatureRole] = "deleteFeatureCapability";
-  roleNames[EditGeometryRole] = "editGeometryCapability";
-
-  return roleNames;
-}
-
-QModelIndex MultiFeatureListModel::index( int row, int column, const QModelIndex &parent ) const
-{
-  Q_UNUSED( parent )
-
-  if ( row < 0 || row >= mFeatures.size() || column != 0 )
-    return QModelIndex();
-
-  return createIndex( row, column, const_cast<QPair< QgsVectorLayer *, QgsFeature >*>( &mFeatures.at( row ) ) );
-}
-
-QModelIndex MultiFeatureListModel::parent( const QModelIndex &child ) const
-{
-  Q_UNUSED( child );
-  return QModelIndex();
-}
-
-int MultiFeatureListModel::rowCount( const QModelIndex &parent ) const
-{
-  if ( parent.isValid() )
-    return 0;
-  else
-    return mFeatures.count();
-}
-
-int MultiFeatureListModel::columnCount( const QModelIndex &parent ) const
-{
-  Q_UNUSED( parent )
-  return 1;
-}
-
-QVariant MultiFeatureListModel::data( const QModelIndex &index, int role ) const
-{
-  QPair< QgsVectorLayer *, QgsFeature > *feature = toFeature( index );
-  if ( !feature )
-    return QVariant();
-
-  switch ( role )
-  {
-    case FeatureIdRole:
-      return feature->second.id();
-
-    case FeatureRole:
-      return feature->second;
-
-    case Qt::DisplayRole:
-    {
-      QgsExpressionContext context = QgsExpressionContext()
-                                     << QgsExpressionContextUtils::globalScope()
-                                     << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
-                                     << QgsExpressionContextUtils::layerScope( feature->first );
-      context.setFeature( feature->second );
-      
-      const QString displayString = QgsExpression( feature->first->displayExpression() ).evaluate( &context ).toString();
-
-      if ( displayString.isEmpty() )
-        return feature->second.id();
-
-      return displayString;
-    }
-
-    case LayerNameRole:
-      return feature->first->name();
-
-    case LayerRole:
-      return QVariant::fromValue<QgsVectorLayer *>( feature->first );
-
-    case GeometryRole:
-      return QVariant::fromValue<QgsGeometry>( feature->second.geometry() );
-
-    case CrsRole:
-      return QVariant::fromValue<QgsCoordinateReferenceSystem>( feature->first->crs() );
-
-    case DeleteFeatureRole:
-      return ! feature->first->readOnly()
-             && ( feature->first->dataProvider()->capabilities() & QgsVectorDataProvider::DeleteFeatures )
-             && ! feature->first->customProperty( QStringLiteral( "QFieldSync/is_geometry_locked" ), false ).toBool();
-
-    case EditGeometryRole:
-      return ! feature->first->readOnly()
-             && ( feature->first->dataProvider()->capabilities() & QgsVectorDataProvider::ChangeGeometries )
-             && ! feature->first->customProperty( QStringLiteral( "QFieldSync/is_geometry_locked" ), false ).toBool();
-  }
-
-  return QVariant();
-}
-
-bool MultiFeatureListModel::removeRows( int row, int count, const QModelIndex &parent = QModelIndex() )
-{
-  if ( !count )
-    return true;
-
-  int i = 0;
-  QMutableListIterator<QPair< QgsVectorLayer *, QgsFeature >> it( mFeatures );
-  while ( i < row )
-  {
-    it.next();
-    i++;
-  }
-
-  int last = row + count - 1;
-
-  beginRemoveRows( parent, row, last );
-  while ( i <= last )
-  {
-    it.next();
-    it.remove();
-    i++;
-  }
-  endRemoveRows();
-
-  return true;
+  mSourceModel->clear( keepSelected );
 }
 
 int MultiFeatureListModel::count() const
 {
-  return mFeatures.size();
+  return mSourceModel->count();
+}
+
+int MultiFeatureListModel::selectedCount() const
+{
+  return mSourceModel->selectedCount();
 }
 
 bool MultiFeatureListModel::deleteFeature( QgsVectorLayer *layer, QgsFeatureId fid )
 {
-  if ( !layer )
-  {
-      QgsMessageLog::logMessage( tr( "Cannot start editing, no layer" ), "QField", Qgis::Warning );
-      return false;
-  }
-
-  if ( ! layer->startEditing() )
-  {
-    QgsMessageLog::logMessage( tr( "Cannot start editing" ), "QField", Qgis::Warning );
-    return false;
-  }
-
-  beginResetModel();
-
-  //delete child features in case of compositions
-  const QList<QgsRelation> referencingRelations = QgsProject::instance()->relationManager()->referencedRelations( layer );
-  QList<QgsVectorLayer *> childLayersEdited;
-  bool isSuccess = true;
-  for ( const QgsRelation &referencingRelation : referencingRelations )
-  {
-    if ( referencingRelation.strength() == QgsRelation::Composition )
-    {
-      QgsVectorLayer *childLayer = referencingRelation.referencingLayer();
-
-      if ( childLayer->startEditing() )
-      {
-        QgsFeatureIterator relatedFeaturesIt = referencingRelation.getRelatedFeatures( layer->getFeature( fid ) );
-        QgsFeature childFeature;
-        while ( relatedFeaturesIt.nextFeature( childFeature ) )
-        {
-          if ( ! childLayer->deleteFeature( childFeature.id() ) )
-          {
-            QgsMessageLog::logMessage( tr( "Cannot delete feature from child layer" ), "QField", Qgis::Critical );
-            isSuccess = false;
-          }
-        }
-      }
-      else
-      {
-        QgsMessageLog::logMessage( tr( "Cannot start editing child layer" ), "QField", Qgis::Critical );
-        isSuccess = false;
-        break;
-      }
-
-      if ( isSuccess )
-        childLayersEdited.append( childLayer );
-      else
-        break;
-    }
-  }
-
-  // we need to either commit or rollback the child layers that have experienced any modification
-  for ( QgsVectorLayer *childLayer : qgis::as_const( childLayersEdited ) )
-  {
-    // if everything went well so far, we try to commit
-    if ( isSuccess )
-    {
-      if ( ! childLayer->commitChanges() )
-      {
-        QgsMessageLog::logMessage( tr( "Cannot commit layer changes in layer %1." ).arg( childLayer->name() ), "QField", Qgis::Critical );
-        isSuccess = false;
-      }
-    }
-
-    // if the commit failed, we try to rollback the changes and the rest of the modified layers (parent and children) will be rollbacked
-    if ( ! isSuccess )
-    {
-      if ( ! childLayer->rollBack() )
-        QgsMessageLog::logMessage( tr( "Cannot rollback layer changes in layer %1" ).arg( childLayer->name() ), "QField", Qgis::Critical );
-    }
-  }
-
-  if ( isSuccess )
-  {
-    //delete parent
-    if ( layer->deleteFeature( fid ) )
-    {
-      // commit parent changes
-      if ( ! layer->commitChanges() )
-        isSuccess = false;
-    }
-    else
-    {
-      QgsMessageLog::logMessage( tr( "Cannot delete feature %1" ).arg( fid ), "QField", Qgis::Warning );
-  
-      isSuccess = false;
-    }
-  }
-
-  if ( ! isSuccess )
-  {
-    if ( ! layer->rollBack() )
-      QgsMessageLog::logMessage( tr( "Cannot rollback layer changes in layer %1" ).arg( layer->name() ), "QField", Qgis::Critical );
-  }
-
-  //delete parent
-  layer->startEditing();
-  layer->deleteFeature( fid );
-  layer->commitChanges();
-  endResetModel();
-  
-  return isSuccess;
+  return mSourceModel->deleteFeature( layer, fid );
 }
 
-void MultiFeatureListModel::layerDeleted( QObject *object )
+void MultiFeatureListModel::toggleSelectedItem( int item )
 {
-  int firstRowToRemove = -1;
-  int count = 0;
-  int currentRow = 0;
-
-  /*
-   * Features on the same layer are always subsequent.
-   * We therefore can search for the first feature and
-   * count all subsequent ones.
-   * Once there is a feature of a different layer found
-   * we can stop searching.
-   */
-  for ( auto it = mFeatures.constBegin(); it != mFeatures.constEnd(); it++ )
+  QModelIndex sourceItem = mapToSource( index( item, 0 ) );
+  mSourceModel->toggleSelectedItem( sourceItem.row() );
+  if ( mSourceModel->selectedCount() > 0 && mFilterLayer == nullptr )
   {
-    if ( it->first == object )
-    {
-      if ( firstRowToRemove == -1 )
-        firstRowToRemove = currentRow;
-
-      count++;
-    }
-    else if ( firstRowToRemove != -1 )
-    {
-      break;
-    }
-    currentRow++;
+    mFilterLayer =  mSourceModel->data( sourceItem, MultiFeatureListModel::LayerRole ).value<QgsVectorLayer *>();
+    invalidateFilter();
   }
-
-  removeRows( firstRowToRemove, count );
-}
-
-void MultiFeatureListModel::featureDeleted( QgsFeatureId fid )
-{
-  QgsVectorLayer *l = qobject_cast<QgsVectorLayer *>( sender() );
-  Q_ASSERT( l );
-
-  int i = 0;
-  for ( auto it = mFeatures.constBegin(); it != mFeatures.constEnd(); it++ )
+  else if ( mSourceModel->selectedCount() == 0 && mFilterLayer != nullptr )
   {
-    if ( it->first == l && it->second.id() == fid )
-    {
-      removeRows( i, 1 );
-      break;
-    }
-    ++i;
+    mFilterLayer = nullptr;
+    invalidateFilter();
   }
 }
 
-void MultiFeatureListModel::attributeValueChanged( QgsFeatureId fid, int idx, const QVariant &value )
+bool MultiFeatureListModel::filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const
 {
-  QgsVectorLayer *l = qobject_cast<QgsVectorLayer *>( sender() );
-  Q_ASSERT( l );
-
-  int i = 0;
-  for ( auto it = mFeatures.begin(); it != mFeatures.end(); it++ )
+  if ( mFilterLayer != nullptr )
   {
-    if ( it->first == l && it->second.id() == fid )
-    {
-      it->second.setAttribute( idx, value );
-      break;
-    }
-    ++i;
+    return mFilterLayer == mSourceModel->data( mSourceModel->index( source_row, 0, source_parent ), MultiFeatureListModel::LayerRole ).value<QgsVectorLayer *>();
   }
+  return true;
 }

--- a/src/core/multifeaturelistmodel.h
+++ b/src/core/multifeaturelistmodel.h
@@ -63,6 +63,8 @@ class MultiFeatureListModel : public QSortFilterProxyModel
 
     int selectedCount() const;
 
+    void checkSelectedCount();
+
     Q_INVOKABLE bool deleteFeature( QgsVectorLayer *layer, QgsFeatureId fid );
 
     void toggleSelectedItem( int item );

--- a/src/core/multifeaturelistmodel.h
+++ b/src/core/multifeaturelistmodel.h
@@ -30,6 +30,7 @@ class MultiFeatureListModel : public QSortFilterProxyModel
     Q_OBJECT
 
     Q_PROPERTY( int count READ count NOTIFY countChanged )
+    Q_PROPERTY( QList<QgsFeature> selectedFeatures READ selectedFeatures NOTIFY selectedCountChanged )
     Q_PROPERTY( int selectedCount READ selectedCount NOTIFY selectedCountChanged )
 
   public:
@@ -65,6 +66,8 @@ class MultiFeatureListModel : public QSortFilterProxyModel
     Q_INVOKABLE bool deleteFeature( QgsVectorLayer *layer, QgsFeatureId fid );
 
     void toggleSelectedItem( int item );
+
+    QList<QgsFeature> selectedFeatures();
 
   signals:
 

--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -113,6 +113,16 @@ void MultiFeatureListModelBase::toggleSelectedItem( int item )
   emit selectedCountChanged();
 }
 
+QList<QgsFeature> MultiFeatureListModelBase::selectedFeatures()
+{
+  QList<QgsFeature> features;
+  for ( const QPair< QgsVectorLayer *, QgsFeature > &pair : mFeatures )
+  {
+    features << pair.second;
+  }
+  return features;
+}
+
 QHash<int, QByteArray> MultiFeatureListModelBase::roleNames() const
 {
   QHash<int, QByteArray> roleNames;

--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -1,0 +1,430 @@
+/***************************************************************************
+                            featurelistmodelbase.cpp
+                              -------------------
+              begin                : 10.12.2014
+              copyright            : (C) 2014 by Matthias Kuhn
+              email                : matthias (at) opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <qgsvectorlayer.h>
+#include <qgsvectordataprovider.h>
+#include <qgsproject.h>
+#include <qgsgeometry.h>
+#include <qgscoordinatereferencesystem.h>
+#include <qgsexpressioncontextutils.h>
+#include <qgsrelationmanager.h>
+#include <qgsmessagelog.h>
+
+#include "multifeaturelistmodel.h"
+#include "multifeaturelistmodelbase.h"
+
+#include <QDebug>
+
+MultiFeatureListModelBase::MultiFeatureListModelBase( QObject *parent )
+  :  QAbstractItemModel( parent )
+{
+  connect( this, &MultiFeatureListModelBase::modelReset, this, &MultiFeatureListModelBase::countChanged );
+}
+
+void MultiFeatureListModelBase::setFeatures( const QMap<QgsVectorLayer *, QgsFeatureRequest> requests )
+{
+  beginResetModel();
+
+  mFeatures.clear();
+
+  QMap<QgsVectorLayer *, QgsFeatureRequest>::ConstIterator it;
+  for ( it = requests.constBegin(); it != requests.constEnd(); it++ )
+  {
+    QgsFeature feat;
+    QgsFeatureIterator fit = it.key()->getFeatures( it.value() );
+    while ( fit.nextFeature( feat ) )
+    {
+      mFeatures.append( QPair< QgsVectorLayer *, QgsFeature >( it.key(), feat ) );
+      connect( it.key(), &QgsVectorLayer::destroyed, this, &MultiFeatureListModelBase::layerDeleted, Qt::UniqueConnection );
+      connect( it.key(), &QgsVectorLayer::featureDeleted, this, &MultiFeatureListModelBase::featureDeleted, Qt::UniqueConnection );
+      connect( it.key(), &QgsVectorLayer::attributeValueChanged, this, &MultiFeatureListModelBase::attributeValueChanged, Qt::UniqueConnection );
+    }
+  }
+
+  endResetModel();
+}
+
+void MultiFeatureListModelBase::appendFeatures( const QList<IdentifyTool::IdentifyResult> &results )
+{
+  beginInsertRows( QModelIndex(), mFeatures.count(), mFeatures.count() + results.count() - 1 );
+
+  for ( const IdentifyTool::IdentifyResult &result : results )
+  {
+    QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( result.layer );
+    QPair<QgsVectorLayer *, QgsFeature> item( layer, result.feature );
+    if ( !mFeatures.contains( item ) )
+    {
+      mFeatures.append( QPair<QgsVectorLayer *, QgsFeature>( layer, result.feature ) );
+      connect( layer, &QObject::destroyed, this, &MultiFeatureListModelBase::layerDeleted, Qt::UniqueConnection );
+      connect( layer, &QgsVectorLayer::featureDeleted, this, &MultiFeatureListModelBase::featureDeleted, Qt::UniqueConnection );
+      connect( layer, &QgsVectorLayer::attributeValueChanged, this, &MultiFeatureListModelBase::attributeValueChanged, Qt::UniqueConnection );
+    }
+  }
+
+  endInsertRows();
+}
+
+void MultiFeatureListModelBase::clear( const bool keepSelected )
+{
+  // the model is already empty, no need to trigger "resetModel"
+  if ( mFeatures.isEmpty() )
+    return;
+
+  beginResetModel();
+  mFeatures.clear();
+  if ( keepSelected )
+  {
+    mFeatures = mSelectedFeatures;
+  }
+  else
+  {
+    mSelectedFeatures.clear();
+  }
+  endResetModel();
+}
+
+void MultiFeatureListModelBase::toggleSelectedItem( int item )
+{
+  if ( !mSelectedFeatures.contains( mFeatures.at( item ) ) )
+  {
+    mSelectedFeatures << mFeatures.at( item );
+  }
+  else
+  {
+    mSelectedFeatures.removeAll( mFeatures.at( item ) );
+  }
+
+  QModelIndex modifiedIndex = index( item, 0 );
+  emit dataChanged( modifiedIndex, modifiedIndex, QVector<int>() << MultiFeatureListModel::FeatureSelectedRole );
+  emit selectedCountChanged();
+}
+
+QHash<int, QByteArray> MultiFeatureListModelBase::roleNames() const
+{
+  QHash<int, QByteArray> roleNames;
+
+  roleNames[Qt::DisplayRole] = "display";
+  roleNames[MultiFeatureListModel::FeatureIdRole] = "featureId";
+  roleNames[MultiFeatureListModel::FeatureSelectedRole] = "featureSelected";
+  roleNames[MultiFeatureListModel::FeatureRole] = "feature";
+  roleNames[MultiFeatureListModel::LayerNameRole] = "layerName";
+  roleNames[MultiFeatureListModel::LayerRole] = "currentLayer";
+  roleNames[MultiFeatureListModel::GeometryRole] = "geometry";
+  roleNames[MultiFeatureListModel::CrsRole] = "crs";
+  roleNames[MultiFeatureListModel::DeleteFeatureRole] = "deleteFeatureCapability";
+  roleNames[MultiFeatureListModel::EditGeometryRole] = "editGeometryCapability";
+
+  return roleNames;
+}
+
+QModelIndex MultiFeatureListModelBase::index( int row, int column, const QModelIndex &parent ) const
+{
+  Q_UNUSED( parent )
+
+  if ( row < 0 || row >= mFeatures.size() || column != 0 )
+    return QModelIndex();
+
+  return createIndex( row, column, const_cast<QPair< QgsVectorLayer *, QgsFeature >*>( &mFeatures.at( row ) ) );
+}
+
+QModelIndex MultiFeatureListModelBase::parent( const QModelIndex &child ) const
+{
+  Q_UNUSED( child );
+  return QModelIndex();
+}
+
+int MultiFeatureListModelBase::rowCount( const QModelIndex &parent ) const
+{
+  if ( parent.isValid() )
+    return 0;
+  else
+    return mFeatures.count();
+}
+
+int MultiFeatureListModelBase::columnCount( const QModelIndex &parent ) const
+{
+  Q_UNUSED( parent )
+  return 1;
+}
+
+QVariant MultiFeatureListModelBase::data( const QModelIndex &index, int role ) const
+{
+  QPair< QgsVectorLayer *, QgsFeature > *feature = toFeature( index );
+  if ( !feature )
+    return QVariant();
+
+  switch ( role )
+  {
+    case MultiFeatureListModel::FeatureIdRole:
+      return feature->second.id();
+
+    case MultiFeatureListModel::FeatureSelectedRole:
+      return mSelectedFeatures.contains( mFeatures.at( index.row() ) );
+
+    case MultiFeatureListModel::FeatureRole:
+      return feature->second;
+
+    case Qt::DisplayRole:
+    {
+      QgsExpressionContext context = QgsExpressionContext()
+                                     << QgsExpressionContextUtils::globalScope()
+                                     << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+                                     << QgsExpressionContextUtils::layerScope( feature->first );
+      context.setFeature( feature->second );
+      
+      const QString displayString = QgsExpression( feature->first->displayExpression() ).evaluate( &context ).toString();
+
+      if ( displayString.isEmpty() )
+        return feature->second.id();
+
+      return displayString;
+    }
+
+    case MultiFeatureListModel::LayerNameRole:
+      return feature->first->name();
+
+    case MultiFeatureListModel::LayerRole:
+      return QVariant::fromValue<QgsVectorLayer *>( feature->first );
+
+    case MultiFeatureListModel::GeometryRole:
+      return QVariant::fromValue<QgsGeometry>( feature->second.geometry() );
+
+    case MultiFeatureListModel::CrsRole:
+      return QVariant::fromValue<QgsCoordinateReferenceSystem>( feature->first->crs() );
+
+    case MultiFeatureListModel::DeleteFeatureRole:
+      return ! feature->first->readOnly()
+             && ( feature->first->dataProvider()->capabilities() & QgsVectorDataProvider::DeleteFeatures )
+             && ! feature->first->customProperty( QStringLiteral( "QFieldSync/is_geometry_locked" ), false ).toBool();
+
+    case MultiFeatureListModel::EditGeometryRole:
+      return ! feature->first->readOnly()
+             && ( feature->first->dataProvider()->capabilities() & QgsVectorDataProvider::ChangeGeometries )
+             && ! feature->first->customProperty( QStringLiteral( "QFieldSync/is_geometry_locked" ), false ).toBool();
+  }
+
+  return QVariant();
+}
+
+bool MultiFeatureListModelBase::removeRows( int row, int count, const QModelIndex &parent = QModelIndex() )
+{
+  if ( !count )
+    return true;
+
+  int i = 0;
+  QMutableListIterator<QPair< QgsVectorLayer *, QgsFeature >> it( mFeatures );
+  while ( i < row )
+  {
+    it.next();
+    i++;
+  }
+
+  int last = row + count - 1;
+
+  beginRemoveRows( parent, row, last );
+  while ( i <= last )
+  {
+    it.next();
+    it.remove();
+    i++;
+  }
+  endRemoveRows();
+
+  return true;
+}
+
+int MultiFeatureListModelBase::count() const
+{
+  return mFeatures.size();
+}
+
+int MultiFeatureListModelBase::selectedCount() const
+{
+  return mSelectedFeatures.size();
+}
+
+bool MultiFeatureListModelBase::deleteFeature( QgsVectorLayer *layer, QgsFeatureId fid )
+{
+  if ( !layer )
+  {
+      QgsMessageLog::logMessage( tr( "Cannot start editing, no layer" ), "QField", Qgis::Warning );
+      return false;
+  }
+
+  if ( ! layer->startEditing() )
+  {
+    QgsMessageLog::logMessage( tr( "Cannot start editing" ), "QField", Qgis::Warning );
+    return false;
+  }
+
+  beginResetModel();
+
+  //delete child features in case of compositions
+  const QList<QgsRelation> referencingRelations = QgsProject::instance()->relationManager()->referencedRelations( layer );
+  QList<QgsVectorLayer *> childLayersEdited;
+  bool isSuccess = true;
+  for ( const QgsRelation &referencingRelation : referencingRelations )
+  {
+    if ( referencingRelation.strength() == QgsRelation::Composition )
+    {
+      QgsVectorLayer *childLayer = referencingRelation.referencingLayer();
+
+      if ( childLayer->startEditing() )
+      {
+        QgsFeatureIterator relatedFeaturesIt = referencingRelation.getRelatedFeatures( layer->getFeature( fid ) );
+        QgsFeature childFeature;
+        while ( relatedFeaturesIt.nextFeature( childFeature ) )
+        {
+          if ( ! childLayer->deleteFeature( childFeature.id() ) )
+          {
+            QgsMessageLog::logMessage( tr( "Cannot delete feature from child layer" ), "QField", Qgis::Critical );
+            isSuccess = false;
+          }
+        }
+      }
+      else
+      {
+        QgsMessageLog::logMessage( tr( "Cannot start editing child layer" ), "QField", Qgis::Critical );
+        isSuccess = false;
+        break;
+      }
+
+      if ( isSuccess )
+        childLayersEdited.append( childLayer );
+      else
+        break;
+    }
+  }
+
+  // we need to either commit or rollback the child layers that have experienced any modification
+  for ( QgsVectorLayer *childLayer : qgis::as_const( childLayersEdited ) )
+  {
+    // if everything went well so far, we try to commit
+    if ( isSuccess )
+    {
+      if ( ! childLayer->commitChanges() )
+      {
+        QgsMessageLog::logMessage( tr( "Cannot commit layer changes in layer %1." ).arg( childLayer->name() ), "QField", Qgis::Critical );
+        isSuccess = false;
+      }
+    }
+
+    // if the commit failed, we try to rollback the changes and the rest of the modified layers (parent and children) will be rollbacked
+    if ( ! isSuccess )
+    {
+      if ( ! childLayer->rollBack() )
+        QgsMessageLog::logMessage( tr( "Cannot rollback layer changes in layer %1" ).arg( childLayer->name() ), "QField", Qgis::Critical );
+    }
+  }
+
+  if ( isSuccess )
+  {
+    //delete parent
+    if ( layer->deleteFeature( fid ) )
+    {
+      // commit parent changes
+      if ( ! layer->commitChanges() )
+        isSuccess = false;
+    }
+    else
+    {
+      QgsMessageLog::logMessage( tr( "Cannot delete feature %1" ).arg( fid ), "QField", Qgis::Warning );
+  
+      isSuccess = false;
+    }
+  }
+
+  if ( ! isSuccess )
+  {
+    if ( ! layer->rollBack() )
+      QgsMessageLog::logMessage( tr( "Cannot rollback layer changes in layer %1" ).arg( layer->name() ), "QField", Qgis::Critical );
+  }
+
+  //delete parent
+  layer->startEditing();
+  layer->deleteFeature( fid );
+  layer->commitChanges();
+  endResetModel();
+
+  return isSuccess;
+}
+
+void MultiFeatureListModelBase::layerDeleted( QObject *object )
+{
+  int firstRowToRemove = -1;
+  int count = 0;
+  int currentRow = 0;
+
+  /*
+   * Features on the same layer are always subsequent.
+   * We therefore can search for the first feature and
+   * count all subsequent ones.
+   * Once there is a feature of a different layer found
+   * we can stop searching.
+   */
+  for ( auto it = mFeatures.constBegin(); it != mFeatures.constEnd(); it++ )
+  {
+    if ( it->first == object )
+    {
+      if ( firstRowToRemove == -1 )
+        firstRowToRemove = currentRow;
+
+      count++;
+    }
+    else if ( firstRowToRemove != -1 )
+    {
+      break;
+    }
+    currentRow++;
+  }
+
+  removeRows( firstRowToRemove, count );
+}
+
+void MultiFeatureListModelBase::featureDeleted( QgsFeatureId fid )
+{
+  QgsVectorLayer *l = qobject_cast<QgsVectorLayer *>( sender() );
+  Q_ASSERT( l );
+
+  int i = 0;
+  for ( auto it = mFeatures.constBegin(); it != mFeatures.constEnd(); it++ )
+  {
+    if ( it->first == l && it->second.id() == fid )
+    {
+      removeRows( i, 1 );
+      break;
+    }
+    ++i;
+  }
+}
+
+void MultiFeatureListModelBase::attributeValueChanged( QgsFeatureId fid, int idx, const QVariant &value )
+{
+  QgsVectorLayer *l = qobject_cast<QgsVectorLayer *>( sender() );
+  Q_ASSERT( l );
+
+  int i = 0;
+  for ( auto it = mFeatures.begin(); it != mFeatures.end(); it++ )
+  {
+    if ( it->first == l && it->second.id() == fid )
+    {
+      it->second.setAttribute( idx, value );
+      break;
+    }
+    ++i;
+  }
+}

--- a/src/core/multifeaturelistmodelbase.h
+++ b/src/core/multifeaturelistmodelbase.h
@@ -1,0 +1,95 @@
+/***************************************************************************
+                            featurelistmodelbase.cpp
+                              -------------------
+              begin                : 10.12.2014
+              copyright            : (C) 2014 by Matthias Kuhn
+              email                : matthias.kuhn (at) opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef MULTIFEATURELISTMODELBASE_H
+#define MULTIFEATURELISTMODELBASE_H
+
+#include <QAbstractItemModel>
+
+#include <qgsfeaturerequest.h>
+
+#include "identifytool.h"
+
+class MultiFeatureListModelBase : public QAbstractItemModel
+{
+    Q_OBJECT
+
+  public:
+
+    explicit MultiFeatureListModelBase( QObject *parent = nullptr );
+
+    /**
+     * @brief setFeatures
+     * @param requests
+     */
+    void setFeatures( const QMap<QgsVectorLayer *, QgsFeatureRequest> requests );
+
+    void appendFeatures( const QList<IdentifyTool::IdentifyResult> &results );
+
+    void clear( const bool keepSelected = false );
+
+    QHash<int, QByteArray> roleNames() const override;
+    QModelIndex index( int row, int column, const QModelIndex &parent = QModelIndex() ) const override;
+    QModelIndex parent( const QModelIndex &child ) const override;
+    int rowCount( const QModelIndex &parent ) const override;
+    int columnCount( const QModelIndex &parent ) const override;
+    QVariant data( const QModelIndex &index, int role ) const override;
+
+    /**
+     * Removes a defined number of rows starting from a given position. The parent index is not
+     * used as we have a list only.
+     *
+     * @param row   The first row to remove
+     * @param count The numbe rof rows to remove
+     * @param parent Can savely be omitted as it is unused and defaults to an invalid index
+     */
+    virtual bool removeRows( int row, int count, const QModelIndex &parent ) override;
+
+    int count() const;
+
+    int selectedCount() const;
+
+    bool deleteFeature( QgsVectorLayer *layer, QgsFeatureId fid );
+
+    void toggleSelectedItem( int item );
+
+  signals:
+
+    void countChanged();
+
+    void selectedCountChanged();
+
+  private slots:
+
+    void layerDeleted( QObject *object );
+
+    void featureDeleted( QgsFeatureId fid );
+
+    void attributeValueChanged( QgsFeatureId fid, int idx, const QVariant &value );
+
+  private:
+
+    inline QPair< QgsVectorLayer *, QgsFeature > *toFeature( const QModelIndex &index ) const
+    {
+      return static_cast<QPair< QgsVectorLayer *, QgsFeature >*>( index.internalPointer() );
+    }
+
+    QList< QPair< QgsVectorLayer *, QgsFeature > > mFeatures;
+    QList< QPair< QgsVectorLayer *, QgsFeature > > mSelectedFeatures;
+};
+
+#endif // MULTIFEATURELISTMODELBASE_H

--- a/src/core/multifeaturelistmodelbase.h
+++ b/src/core/multifeaturelistmodelbase.h
@@ -67,6 +67,8 @@ class MultiFeatureListModelBase : public QAbstractItemModel
 
     void toggleSelectedItem( int item );
 
+    QList<QgsFeature> selectedFeatures();
+
   signals:
 
     void countChanged();

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -247,7 +247,7 @@ Page {
         height:  !ConstraintHardValid || !ConstraintSoftValid ? undefined : 0
         visible: !ConstraintHardValid || !ConstraintSoftValid
 
-        color: !ConstraintHardValid ? Theme.errorColor : Theme.warningColor
+        color: !ConstraintHardValid ? Theme.errorColor : Theme.darkGray
       }
 
       Item {

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -262,7 +262,7 @@ Page {
           anchors { left: parent.left; right: parent.right }
 
           //disable widget if the form is in ReadOnly mode, or if it's an RelationEditor widget in an embedded form
-          property bool isEnabled: !!AttributeEditable && (
+          property bool isEnabled: AttributeAllowEdit && !!AttributeEditable && (
                                      form.state !== 'ReadOnly'
                                      || EditorWidget === 'RelationEditor'
                                      || EditorWidget === 'ValueRelation'
@@ -338,6 +338,24 @@ Page {
         indicator.width: 16
         icon.height: 16
         icon.width: 16
+      }
+
+      Label {
+        id: multiEditAttributeLabel
+        text: (AttributeAllowEdit ? "Value applied" : "Value skipped") + " (click to toggle)"
+        visible: form.model.featureModel.modelMode == FeatureModel.MultiFeatureModel
+        height: form.model.featureModel.modelMode == FeatureModel.MultiFeatureModel ? undefined : 0
+        bottomPadding: form.model.featureModel.modelMode == FeatureModel.MultiFeatureModel ? 15 : 0
+        anchors { left: parent.left; top: placeholder.bottom;  rightMargin: 10; }
+        font: Theme.tipFont
+        color: AttributeAllowEdit ? Theme.mainColor : Theme.lightGray
+
+        MouseArea {
+          anchors.fill: parent
+          onClicked: {
+              AttributeAllowEdit = !AttributeAllowEdit
+          }
+        }
       }
     }
   }

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -266,7 +266,6 @@ Rectangle {
     onShownChanged: {
       if ( shown )
       {
-        featureForm.selection.focusedItem = -1
         height = parent.height - featureListToolBar.height
       }
       else

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -201,15 +201,19 @@ Rectangle {
 
         onClicked: {
           if ( featureForm.selection.model.selectedCount == 0 ) {
+            featureFormList.model.featureModel.modelMode = FeatureModel.SingleFeatureModel
             featureForm.selection.focusedItem = index
             featureForm.state = "FeatureForm"
           } else {
             featureForm.selection.toggleSelectedItem( index );
+            featureForm.selection.focusedItem = featureForm.selection.model.selectedCount > 0 ? index : -1;
           }
         }
 
         onPressAndHold:
         {
+          featureFormList.model.featureModel.modelMode = FeatureModel.MultiFeatureModel
+          featureForm.selection.focusedItem = index
           featureForm.selection.toggleSelectedItem( index );
         }
       }
@@ -262,6 +266,7 @@ Rectangle {
     onShownChanged: {
       if ( shown )
       {
+        featureForm.selection.focusedItem = -1
         height = parent.height - featureListToolBar.height
       }
       else
@@ -289,7 +294,8 @@ Rectangle {
     model: AttributeFormModel {
       featureModel: FeatureModel {
         currentLayer: featureForm.selection.focusedLayer
-        features: featureForm.selection.features
+        feature: featureForm.selection.focusedFeature
+        features: featureForm.selection.model.selectedFeatures
       }
     }
 
@@ -341,14 +347,22 @@ Rectangle {
 
     onSave: {
       featureFormList.confirm()
-      featureForm.state = "FeatureForm"
+      featureForm.state = featureForm.selection.model.selectedCount > 0 ? "FeatureList" : "FeatureForm"
       displayToast( qsTr( "Changes saved" ) )
     }
 
     onCancel: {
       featureFormList.model.featureModel.reset()
-      featureForm.state = "FeatureForm"
+      featureForm.state = featureForm.selection.model.selectedCount > 0 ? "FeatureList" : "FeatureForm"
       displayToast( qsTr( "Last changes discarded" ) )
+    }
+
+    onMultiEditClicked: {
+        if (featureForm.selection.focusedItem == -1) {
+          // focus on the first selected item to grab its layer
+          featureForm.selection.focusedItem = 0;
+        }
+        featureForm.state = "FeatureFormEdit"
     }
   }
 

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -447,6 +447,9 @@ Rectangle {
   {
     props.isVisible = false
     focus = false
+
+    featureForm.selection.clear()
+
     model.clear()
   }
 

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -170,9 +170,15 @@ Rectangle {
 
       height: Math.max( 48, featureText.height )
 
+      CheckBox {
+          anchors { leftMargin: 5; left: parent.left; verticalCenter: parent.verticalCenter }
+          checked: featureSelected
+          visible: featureForm.selection.model.selectedCount > 0
+      }
+
       Text {
         id: featureText
-        anchors { leftMargin: 10; left: parent.left; right: editRow.left; verticalCenter: parent.verticalCenter }
+        anchors { leftMargin: featureForm.selection.model.selectedCount > 0 ? 50 : 10; left: parent.left; right: editRow.left; verticalCenter: parent.verticalCenter }
         font.bold: true
         text: display
       }
@@ -182,7 +188,7 @@ Rectangle {
         height: parent.height
         width: 6
         color: featureForm.selectionColor
-        opacity: ( index == featureForm.selection.selection )
+        opacity: index == featureForm.selection.focusedItem ? 1 : 0
         Behavior on opacity {
           PropertyAnimation {
             easing.type: Easing.InQuart
@@ -194,13 +200,17 @@ Rectangle {
         anchors.fill: parent
 
         onClicked: {
-          featureForm.selection.selection = index
-          featureForm.state = "FeatureForm"
+          if ( featureForm.selection.model.selectedCount == 0 ) {
+            featureForm.selection.focusedItem = index
+            featureForm.state = "FeatureForm"
+          } else {
+            featureForm.selection.toggleSelectedItem( index );
+          }
         }
 
         onPressAndHold:
         {
-          featureForm.selection.selection = index
+          featureForm.selection.toggleSelectedItem( index );
         }
       }
 
@@ -278,8 +288,8 @@ Rectangle {
 
     model: AttributeFormModel {
       featureModel: FeatureModel {
-        currentLayer: featureForm.selection.selectedLayer
-        feature: featureForm.selection.selectedFeature
+        currentLayer: featureForm.selection.focusedLayer
+        feature: featureForm.selection.focusedFeature
       }
     }
 
@@ -308,7 +318,7 @@ Rectangle {
     }
 
     onEditAttributesButtonClicked: {
-        if( trackingModel.featureInTracking(selection.selectedLayer, selection.selectedFeature.id) )
+        if( trackingModel.featureInTracking(selection.focusedLayer, selection.focusedFeature.id) )
         {
             displayToast( qsTr( "Stop tracking this feature to edit attributes" ) )
         }
@@ -319,7 +329,7 @@ Rectangle {
     }
 
     onEditGeometryButtonClicked: {
-        if( trackingModel.featureInTracking(selection.selectedLayer, selection.selectedFeature.id) )
+        if( trackingModel.featureInTracking(selection.focusedLayer, selection.focusedFeature.id) )
         {
             displayToast( qsTr( "Stop tracking this feature to edit geometry" ) )
         }

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -289,7 +289,7 @@ Rectangle {
     model: AttributeFormModel {
       featureModel: FeatureModel {
         currentLayer: featureForm.selection.focusedLayer
-        feature: featureForm.selection.focusedFeature
+        features: featureForm.selection.features
       }
     }
 

--- a/src/qml/FeatureListSelectionHighlight.qml
+++ b/src/qml/FeatureListSelectionHighlight.qml
@@ -17,7 +17,7 @@ Repeater {
     geometryWrapper.qgsGeometry: model.geometry
     geometryWrapper.crs: model.crs
 
-    color: selectionModel && model.index === selectionModel.selection ? featureListSelectionHighlight.selectionColor : featureListSelectionHighlight.color
+    color: selectionModel && model.index === selectionModel.focusedItem ? featureListSelectionHighlight.selectionColor : featureListSelectionHighlight.color
     borderColor: "white"
   }
 

--- a/src/qml/FeatureListSelectionHighlight.qml
+++ b/src/qml/FeatureListSelectionHighlight.qml
@@ -8,7 +8,8 @@ Repeater {
   property FeatureListModelSelection selectionModel
   property MapSettings mapSettings
   property color color: "yellow"
-  property color selectionColor: "red"
+  property color focusedColor: "red"
+  property color selectedColor: "green"
 
   model: selectionModel.model
 
@@ -17,7 +18,7 @@ Repeater {
     geometryWrapper.qgsGeometry: model.geometry
     geometryWrapper.crs: model.crs
 
-    color: selectionModel && model.index === selectionModel.focusedItem ? featureListSelectionHighlight.selectionColor : featureListSelectionHighlight.color
+    color: model.featureSelected ? featureListSelectionHighlight.selectedColor : selectionModel && model.index === selectionModel.focusedItem ? featureListSelectionHighlight.focusedColor : featureListSelectionHighlight.color
     borderColor: "white"
   }
 

--- a/src/qml/FeatureListSelectionHighlight.qml
+++ b/src/qml/FeatureListSelectionHighlight.qml
@@ -17,7 +17,8 @@ Repeater {
     geometryWrapper.qgsGeometry: model.geometry
     geometryWrapper.crs: model.crs
 
-    color: selectionModel && model.index === selectionModel.selection ? "red" : "yellow"
+    color: selectionModel && model.index === selectionModel.selection ? featureListSelectionHighlight.selectionColor : featureListSelectionHighlight.color
+    borderColor: "white"
   }
 
 }

--- a/src/qml/FeatureListSelectionHighlight.qml
+++ b/src/qml/FeatureListSelectionHighlight.qml
@@ -18,7 +18,7 @@ Repeater {
     geometryWrapper.qgsGeometry: model.geometry
     geometryWrapper.crs: model.crs
 
-    color: model.featureSelected ? featureListSelectionHighlight.selectedColor : selectionModel && model.index === selectionModel.focusedItem ? featureListSelectionHighlight.focusedColor : featureListSelectionHighlight.color
+    color: model.featureSelected ? featureListSelectionHighlight.selectedColor : model.selectedCount === 0 && selectionModel && model.index === selectionModel.focusedItem ? featureListSelectionHighlight.focusedColor : featureListSelectionHighlight.color
     borderColor: "white"
   }
 

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -35,6 +35,7 @@ Rectangle {
   signal editGeometryButtonClicked
   signal save
   signal cancel
+  signal multiEditClicked
 
   anchors.top:parent.top
   anchors.left: parent.left
@@ -152,7 +153,7 @@ Rectangle {
     iconSource: Theme.getThemeIcon( "ic_clear_white_24dp" )
 
     onClicked: {
-      selection.selectionChanged()
+      selection.focusedItemChanged()
       toolBar.cancel()
     }
 
@@ -283,6 +284,30 @@ Rectangle {
 
     onClicked: {
       selection.focusedItem = selection.focusedItem - 1
+    }
+
+    Behavior on width {
+      PropertyAnimation {
+        easing.type: Easing.InQuart
+      }
+    }
+  }
+
+  QfToolButton {
+    id: multiEditButton
+
+    anchors.right: parent.right
+
+    width: ( parent.state == "Indication" && toolBar.model && toolBar.model.selectedCount > 1 ? 48: 0 )
+    height: 48
+    clip: true
+
+    iconSource: Theme.getThemeIcon( "ic_edit_attributes_white" )
+
+    enabled: ( toolBar.model && toolBar.model.selectedCount )
+
+    onClicked: {
+      multiEditClicked();
     }
 
     Behavior on width {

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -197,7 +197,7 @@ Rectangle {
 
       onFocusedItemChanged:
       {
-        editGeomButton.readOnly = selection.focusedLayer.readOnly
+        editGeomButton.readOnly = selection.focusedLayer && selection.focusedLayer.readOnly
       }
     }
   }
@@ -230,7 +230,7 @@ Rectangle {
 
       onFocusedItemChanged:
       {
-        editButton.readOnly = selection.focusedLayer.readOnly
+        editButton.readOnly = selection.focusedLayer && selection.focusedLayer.readOnly
       }
     }
   }
@@ -296,9 +296,11 @@ Rectangle {
   QfToolButton {
     id: multiEditButton
 
+    property bool readOnly: false
+
     anchors.right: parent.right
 
-    width: ( parent.state == "Indication" && toolBar.model && toolBar.model.selectedCount > 1 ? 48: 0 )
+    width: ( !readOnly && parent.state == "Indication" && toolBar.model && toolBar.model.selectedCount > 1 ? 48: 0 )
     height: 48
     clip: true
 
@@ -313,6 +315,15 @@ Rectangle {
     Behavior on width {
       PropertyAnimation {
         easing.type: Easing.InQuart
+      }
+    }
+
+    Connections {
+      target: selection
+
+      onFocusedItemChanged:
+      {
+        multiEditButton.readOnly = selection.focusedLayer && selection.focusedLayer.readOnly
       }
     }
   }

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -103,10 +103,10 @@ Rectangle {
 
     iconSource: Theme.getThemeIcon( "ic_chevron_right_white_24dp" )
 
-    enabled: ( toolBar.model && ( selection.selection + 1 ) < toolBar.model.count )
+    enabled: ( toolBar.model && ( selection.focusedItem + 1 ) < toolBar.model.count )
 
     onClicked: {
-      selection.selection = selection.selection + 1
+      selection.focusedItem = selection.focusedItem + 1
     }
 
     Behavior on width {
@@ -169,7 +169,7 @@ Rectangle {
     property bool readOnly: false
 
     visible: stateMachine.state === "digitize"
-             && ! selection.selectedGeometry.isNull
+             && ! selection.focusedGeometry.isNull
              && ! selection.selectedLayer.customProperty( "QFieldSync/is_geometry_locked", false )
 
     anchors.right: editButton.left
@@ -194,9 +194,9 @@ Rectangle {
     Connections {
       target: selection
 
-      onSelectionChanged:
+      onFocusedItemChanged:
       {
-        editGeomButton.readOnly = selection.selectedLayer.readOnly
+        editGeomButton.readOnly = selection.focusedLayer.readOnly
       }
     }
   }
@@ -227,9 +227,9 @@ Rectangle {
     Connections {
       target: selection
 
-      onSelectionChanged:
+      onFocusedItemChanged:
       {
-        editButton.readOnly = selection.selectedLayer.readOnly
+        editButton.readOnly = selection.focusedLayer.readOnly
       }
     }
   }
@@ -237,7 +237,7 @@ Rectangle {
   QfToolButton {
     id: followCurrentButton
     
-    visible: !selection.selectedGeometry.isNull
+    visible: !selection.focusedGeometry.isNull
 
     anchors.left: previousButton.right
 
@@ -279,10 +279,10 @@ Rectangle {
 
     iconSource: Theme.getThemeIcon( "ic_chevron_left_white_24dp" )
 
-    enabled: ( selection.selection > 0 )
+    enabled: ( selection.focusedItem > 0 )
 
     onClicked: {
-      selection.selection = selection.selection - 1
+      selection.focusedItem = selection.focusedItem - 1
     }
 
     Behavior on width {

--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -10,9 +10,9 @@ Item {
 
   id: rangeItem
   property string widgetStyle: config["Style"] ? config["Style"] : "TextField"
-  property int precision: config["Precision"]
-  property real from: config["Min"]
-  property real to: config["Max"]
+  property int precision: config["Precision"] ? config["Precision"] : 0
+  property real from: config["Min"] ? config["Min"] : 0
+  property real to: config["Max"] ? config["Max"] : 0
   property real step: config["Step"] ? config["Step"] : 1
   property string suffix: config["Suffix"] ? config["Suffix"] : ""
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -458,8 +458,9 @@ ApplicationWindow {
       //model: featureForm.model
       //selection: featureForm.selection
 
-      color: Theme.mainColor
-      selectionColor: "#ff7777"
+      color: "yellow"
+      focusedColor: "#ff7777"
+      selectedColor: Theme.mainColor
       width: 5
     }
   }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1200,14 +1200,14 @@ ApplicationWindow {
     onEditGeometry: {
       // Set overall selected (i.e. current) layer to that of the feature geometry being edited,
       // important for snapping settings to make sense when set to current layer
-      if ( dashBoard.currentLayer != featureForm.selection.selectedLayer ) {
-        dashBoard.currentLayer = featureForm.selection.selectedLayer
+      if ( dashBoard.currentLayer != featureForm.selection.focusedLayer ) {
+        dashBoard.currentLayer = featureForm.selection.focusedLayer
         displayToast( qsTr( "Current layer switched to the one holding the selected geometry." ) );
       }
-      geometryEditingFeature.vertexModel.geometry = featureForm.selection.selectedGeometry
-      geometryEditingFeature.vertexModel.crs = featureForm.selection.selectedLayer.crs
-      geometryEditingFeature.currentLayer = featureForm.selection.selectedLayer
-      geometryEditingFeature.feature = featureForm.selection.selectedFeature
+      geometryEditingFeature.vertexModel.geometry = featureForm.selection.focusedGeometry
+      geometryEditingFeature.vertexModel.crs = featureForm.selection.focusedLayer.crs
+      geometryEditingFeature.currentLayer = featureForm.selection.focusedLayer
+      geometryEditingFeature.feature = featureForm.selection.focusedFeature
 
       if (!vertexModel.editingAllowed)
       {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -458,7 +458,7 @@ ApplicationWindow {
       //model: featureForm.model
       //selection: featureForm.selection
 
-      color: "yellow"
+      color: Theme.mainColor
       selectionColor: "#ff7777"
       width: 5
     }


### PR DESCRIPTION
@m-kuhn , part A.

This PR adds a  multi-selection capability to the feature list form. It is activated by a long press over a list item. Long pressing the item will select that item and enable the multi-selection behavior, whereas subsequent clicks to other list items will toggle the selection state. If all items are deselected, the list goes back to normal behavior (i.e. a click opens the feature form).

When multi-selection behavior is enabled, the feature list is filtered to _only_ show features from the layer within which features are being selected. This is a needed restriction to use this feature to unlock multi-feature editing (aka part B).

Selected features (and the filter layer) are remember when clicking on the canvas to identify features, which allows users to go through a series of identify "tap" on the screen to select as many features as needed.

Now, time for a glorious GIF:
![Peek 2020-06-20 15-40](https://user-images.githubusercontent.com/1728657/85197638-83c61e00-b30c-11ea-87d8-b6a845c77aff.gif)

