### PR TITLE
Make fields with web links open externally

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -51,6 +51,7 @@ SET(QFIELD_CORE_SRCS
   utils/fileutils.cpp
   utils/geometryutils.cpp
   utils/featureutils.cpp
+  utils/stringutils.cpp
   expressionevaluator.cpp
 )
 
@@ -107,6 +108,7 @@ SET(QFIELD_CORE_HDRS
   utils/fileutils.h
   utils/geometryutils.h
   utils/featureutils.h
+  utils/stringutils.h
   expressionevaluator.h
 )
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -52,6 +52,7 @@ SET(QFIELD_CORE_SRCS
   utils/geometryutils.cpp
   utils/featureutils.cpp
   utils/stringutils.cpp
+  utils/urlutils.cpp
   expressionevaluator.cpp
 )
 
@@ -109,6 +110,7 @@ SET(QFIELD_CORE_HDRS
   utils/geometryutils.h
   utils/featureutils.h
   utils/stringutils.h
+  utils/urlutils.h
   expressionevaluator.h
 )
 

--- a/src/core/core.pro
+++ b/src/core/core.pro
@@ -73,6 +73,7 @@ HEADERS += \
     utils/featureutils.h \
     utils/geometryutils.h \
     utils/fileutils.h \
+    utils/stringutils.h \
     expressionevaluator.h
 
 SOURCES += \
@@ -128,6 +129,7 @@ SOURCES += \
     utils/featureutils.cpp \
     utils/geometryutils.cpp \
     utils/fileutils.cpp \
+    utils/stringutils.cpp \
     expressionevaluator.cpp
 
 INCLUDEPATH += ../../3rdparty/tessellate \

--- a/src/core/core.pro
+++ b/src/core/core.pro
@@ -74,6 +74,7 @@ HEADERS += \
     utils/geometryutils.h \
     utils/fileutils.h \
     utils/stringutils.h \
+    utils/urlutils.h \
     expressionevaluator.h
 
 SOURCES += \
@@ -130,6 +131,7 @@ SOURCES += \
     utils/geometryutils.cpp \
     utils/fileutils.cpp \
     utils/stringutils.cpp \
+    utils/urlutils.cpp \
     expressionevaluator.cpp
 
 INCLUDEPATH += ../../3rdparty/tessellate \

--- a/src/core/platformutilities.cpp
+++ b/src/core/platformutilities.cpp
@@ -134,8 +134,3 @@ bool PlatformUtilities::checkWriteExternalStoragePermissions() const
 {
   return true;
 }
-
-QString PlatformUtilities::insertLinks( const QString &string )
-{
-  return QgsStringUtils::insertLinks( string );
-}

--- a/src/core/platformutilities.cpp
+++ b/src/core/platformutilities.cpp
@@ -17,6 +17,8 @@
  ***************************************************************************/
 
 #include "qgsmessagelog.h"
+#include "qgsstringutils.h"
+
 
 #include "platformutilities.h"
 #include "projectsource.h"
@@ -133,3 +135,7 @@ bool PlatformUtilities::checkWriteExternalStoragePermissions() const
   return true;
 }
 
+QString PlatformUtilities::insertLinks( const QString &string )
+{
+  return QgsStringUtils::insertLinks( string );
+}

--- a/src/core/platformutilities.cpp
+++ b/src/core/platformutilities.cpp
@@ -17,8 +17,6 @@
  ***************************************************************************/
 
 #include "qgsmessagelog.h"
-#include "qgsstringutils.h"
-
 
 #include "platformutilities.h"
 #include "projectsource.h"
@@ -134,3 +132,4 @@ bool PlatformUtilities::checkWriteExternalStoragePermissions() const
 {
   return true;
 }
+

--- a/src/core/platformutilities.h
+++ b/src/core/platformutilities.h
@@ -116,7 +116,5 @@ class PlatformUtilities : public QObject
     */
     Q_INVOKABLE virtual void showRateThisApp() const {};
 
-
-    Q_INVOKABLE QString insertLinks( const QString &string );
 };
 #endif // PLATFORMUTILITIES_H

--- a/src/core/platformutilities.h
+++ b/src/core/platformutilities.h
@@ -116,5 +116,7 @@ class PlatformUtilities : public QObject
     */
     Q_INVOKABLE virtual void showRateThisApp() const {};
 
+
+    Q_INVOKABLE QString insertLinks( const QString &string );
 };
 #endif // PLATFORMUTILITIES_H

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -101,6 +101,7 @@
 #include "featureutils.h"
 #include "expressionevaluator.h"
 #include "stringutils.h"
+#include "urlutils.h"
 
 #define QUOTE(string) _QUOTE(string)
 #define _QUOTE(string) #string
@@ -273,6 +274,7 @@ void QgisMobileapp::initDeclarative()
   REGISTER_SINGLETON( "org.qfield", FeatureUtils, "FeatureUtils" );
   REGISTER_SINGLETON( "org.qfield", FileUtils, "FileUtils" );
   REGISTER_SINGLETON( "org.qfield", StringUtils, "StringUtils" );
+  REGISTER_SINGLETON( "org.qfield", UrlUtils, "UrlUtils" );
 
   qmlRegisterUncreatableType<AppInterface>( "org.qgis", 1, 0, "QgisInterface", "QgisInterface is only provided by the environment and cannot be created ad-hoc" );
   qmlRegisterUncreatableType<Settings>( "org.qgis", 1, 0, "Settings", "" );

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -100,6 +100,7 @@
 #include "fileutils.h"
 #include "featureutils.h"
 #include "expressionevaluator.h"
+#include "stringutils.h"
 
 #define QUOTE(string) _QUOTE(string)
 #define _QUOTE(string) #string
@@ -271,6 +272,7 @@ void QgisMobileapp::initDeclarative()
   REGISTER_SINGLETON( "org.qfield", GeometryUtils, "GeometryUtils" );
   REGISTER_SINGLETON( "org.qfield", FeatureUtils, "FeatureUtils" );
   REGISTER_SINGLETON( "org.qfield", FileUtils, "FileUtils" );
+  REGISTER_SINGLETON( "org.qfield", StringUtils, "StringUtils" );
 
   qmlRegisterUncreatableType<AppInterface>( "org.qgis", 1, 0, "QgisInterface", "QgisInterface is only provided by the environment and cannot be created ad-hoc" );
   qmlRegisterUncreatableType<Settings>( "org.qgis", 1, 0, "Settings", "" );

--- a/src/core/utils/stringutils.cpp
+++ b/src/core/utils/stringutils.cpp
@@ -20,19 +20,10 @@
 #include "qgsstringutils.h"
 
 
-#include <QUrl>
-
-
 StringUtils::StringUtils( QObject *parent )
   : QObject( parent )
 {
 
-}
-
-
-bool StringUtils::isRelativeUrl( const QString &url )
-{
-  return QUrl( url ).isRelative();
 }
 
 

--- a/src/core/utils/stringutils.cpp
+++ b/src/core/utils/stringutils.cpp
@@ -1,0 +1,42 @@
+/***************************************************************************
+                        stringutils.cpp
+                        ---------------
+  begin                : Jun 2020
+  copyright            : (C) 2020 by Ivan Ivanov
+  email                : ivan@opengis.ch
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "stringutils.h"
+
+#include "qgsstringutils.h"
+
+
+#include <QUrl>
+
+
+StringUtils::StringUtils( QObject *parent )
+  : QObject( parent )
+{
+
+}
+
+
+bool StringUtils::isRelativeUrl( const QString &url )
+{
+  return QUrl( url ).isRelative();
+}
+
+
+QString StringUtils::insertLinks( const QString &string )
+{
+  return QgsStringUtils::insertLinks( string );
+}

--- a/src/core/utils/stringutils.h
+++ b/src/core/utils/stringutils.h
@@ -1,0 +1,40 @@
+/***************************************************************************
+                        stringutils.h
+                        ---------------
+  begin                : Jun 2020
+  copyright            : (C) 2020 by Ivan Ivanov
+  email                : ivan@opengis.ch
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef STRINGUTILS_H
+#define STRINGUTILS_H
+
+#include <QObject>
+
+
+class StringUtils : public QObject
+{
+    Q_OBJECT
+
+  public:
+
+
+    explicit StringUtils( QObject *parent = nullptr );
+
+
+    static Q_INVOKABLE bool isRelativeUrl( const QString &url );
+
+
+    static Q_INVOKABLE QString insertLinks( const QString &string );
+};
+
+#endif // STRINGUTILS_H

--- a/src/core/utils/stringutils.h
+++ b/src/core/utils/stringutils.h
@@ -31,9 +31,15 @@ class StringUtils : public QObject
     explicit StringUtils( QObject *parent = nullptr );
 
 
+    /**
+     * Checks whether the provided string is a relative url (has no protocol or starts with `file://`).
+     */
     static Q_INVOKABLE bool isRelativeUrl( const QString &url );
 
 
+    /**
+     * Returns a string with any URL (e.g., http(s)/ftp) and mailto: text converted to valid HTML <a …> links.
+     */
     static Q_INVOKABLE QString insertLinks( const QString &string );
 };
 

--- a/src/core/utils/urlutils.cpp
+++ b/src/core/utils/urlutils.cpp
@@ -27,7 +27,10 @@ UrlUtils::UrlUtils( QObject *parent )
 }
 
 
-bool UrlUtils::isRelativeUrl( const QString &url )
+bool UrlUtils::isRelativeOrFileUrl( const QString &url )
 {
+  if ( url.startsWith( QStringLiteral( "file:///" ) ) )
+    return true;
+
   return QUrl( url ).isRelative();
 }

--- a/src/core/utils/urlutils.cpp
+++ b/src/core/utils/urlutils.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
-                        stringutils.h
+                        urlutils.cpp
                         ---------------
   begin                : Jun 2020
   copyright            : (C) 2020 by Ivan Ivanov
@@ -15,26 +15,19 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef STRINGUTILS_H
-#define STRINGUTILS_H
+#include "urlutils.h"
 
-#include <QObject>
+#include <QUrl>
 
 
-class StringUtils : public QObject
+UrlUtils::UrlUtils( QObject *parent )
+  : QObject( parent )
 {
-    Q_OBJECT
 
-  public:
-
-
-    explicit StringUtils( QObject *parent = nullptr );
+}
 
 
-    /**
-     * Returns a string with any URL (e.g., http(s)/ftp) and mailto: text converted to valid HTML <a …> links.
-     */
-    static Q_INVOKABLE QString insertLinks( const QString &string );
-};
-
-#endif // STRINGUTILS_H
+bool UrlUtils::isRelativeUrl( const QString &url )
+{
+  return QUrl( url ).isRelative();
+}

--- a/src/core/utils/urlutils.h
+++ b/src/core/utils/urlutils.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-                        stringutils.h
+                        urlutils.h
                         ---------------
   begin                : Jun 2020
   copyright            : (C) 2020 by Ivan Ivanov
@@ -15,26 +15,26 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef STRINGUTILS_H
-#define STRINGUTILS_H
+#ifndef URLUTILS_H
+#define URLUTILS_H
 
 #include <QObject>
 
 
-class StringUtils : public QObject
+class UrlUtils : public QObject
 {
     Q_OBJECT
 
   public:
 
 
-    explicit StringUtils( QObject *parent = nullptr );
+    explicit UrlUtils( QObject *parent = nullptr );
 
 
     /**
-     * Returns a string with any URL (e.g., http(s)/ftp) and mailto: text converted to valid HTML <a …> links.
+     * Checks whether the provided string is a relative url (has no protocol or starts with `file://`).
      */
-    static Q_INVOKABLE QString insertLinks( const QString &string );
+    static Q_INVOKABLE bool isRelativeUrl( const QString &url );
 };
 
-#endif // STRINGUTILS_H
+#endif // URLUTILS_H

--- a/src/core/utils/urlutils.h
+++ b/src/core/utils/urlutils.h
@@ -34,7 +34,7 @@ class UrlUtils : public QObject
     /**
      * Checks whether the provided string is a relative url (has no protocol or starts with `file://`).
      */
-    static Q_INVOKABLE bool isRelativeUrl( const QString &url );
+    static Q_INVOKABLE bool isRelativeOrFileUrl( const QString &url );
 };
 
 #endif // URLUTILS_H

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -282,6 +282,8 @@ Page {
           property var currentFeature: form.model.featureModel.feature
           property var currentLayer: form.model.featureModel.currentLayer
           property bool autoSave: qfieldSettings.autoSave
+          // TODO investigate why StringUtils are not available in ./editorwidget/*.qml files
+          property var stringUtilities: StringUtils
 
           active: widget !== 'Hidden'
           source: 'editorwidgets/' + ( widget || 'TextEdit' ) + '.qml'

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -262,7 +262,12 @@ Page {
           anchors { left: parent.left; right: parent.right }
 
           //disable widget if the form is in ReadOnly mode, or if it's an RelationEditor widget in an embedded form
-          enabled: (form.state !== 'ReadOnly' || EditorWidget === 'RelationEditor' || EditorWidget === 'ValueRelation' || EditorWidget === 'ExternalResource' ) && !!AttributeEditable
+          property bool isEnabled: !!AttributeEditable && (
+                                     form.state !== 'ReadOnly'
+                                     || EditorWidget === 'RelationEditor'
+                                     || EditorWidget === 'ValueRelation'
+                                     || EditorWidget === 'ExternalResource'
+                                     )
           property bool readOnly: form.state === 'ReadOnly' || embedded && EditorWidget === 'RelationEditor'
           property var value: AttributeValue
           property var config: ( EditorWidgetConfig || {} )

--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -5,6 +5,7 @@ Item {
   signal valueChanged( var value, bool isNull )
 
   height: childrenRect.height
+  enabled: isEnabled
 
   anchors {
     right: parent.right

--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -26,6 +26,7 @@ Item {
   signal valueChanged(var value, bool isNull)
 
   height: childrenRect.height
+  enabled: isEnabled
 
   ColumnLayout {
     id: main

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -21,7 +21,7 @@ Item {
 
   //on all mimetypes "image/..." and on empty values it should appear as an image widget except when it's configured as a link
   property bool isImage: {
-    if ( value == undefined ) {
+    if ( value == null ) {
       return true
     } else if ( config.UseLink ) {
       return false
@@ -110,12 +110,8 @@ Item {
         if ( ! value )
           return
 
-        // we assume a `http://...` or `file://...` paths that exist
+        // matches `http://...` but not `file://...` paths
         if ( ! StringUtils.isRelativeUrl(value))
-          __viewStatus = platformUtilities.open( value )
-
-        // absolute paths `/path/to/image.jpg`
-        if (FileUtils.fileExists(value) )
           __viewStatus = platformUtilities.open(value)
 
         // relative paths `./path/to/image.jpg` or 'path/to/image.jpg`

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -90,7 +90,7 @@ Item {
     color: FileUtils.fileExists(qgisProject.homePath + '/' + value) ? '#0000EE' : 'black'
 
     text: {
-      if(StringUtils.isRelativeUrl(value))
+      if(UrlUtils.isRelativeUrl(value))
         return config.FullUrl ? value : FileUtils.fileName(value)
 
       return StringUtils.insertLinks(value)
@@ -111,7 +111,7 @@ Item {
           return
 
         // matches `http://...` but not `file://...` paths
-        if ( ! StringUtils.isRelativeUrl(value)) {
+        if ( ! UrlUtils.isRelativeUrl(value)) {
           __viewStatus = Qt.openUrlExternally(value)
           return
         }

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -90,7 +90,7 @@ Item {
     color: FileUtils.fileExists(qgisProject.homePath + '/' + value) ? '#0000EE' : 'black'
 
     text: {
-      if(UrlUtils.isRelativeUrl(value))
+      if(UrlUtils.isRelativeOrFileUrl(value))
         return config.FullUrl ? value : FileUtils.fileName(value)
 
       return StringUtils.insertLinks(value)
@@ -111,7 +111,7 @@ Item {
           return
 
         // matches `http://...` but not `file://...` paths
-        if ( ! UrlUtils.isRelativeUrl(value)) {
+        if ( ! UrlUtils.isRelativeOrFileUrl(value)) {
           Qt.openUrlExternally(value)
           return
         }

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -15,6 +15,7 @@ Item {
   anchors.right: parent.right
 
   height: Math.max(isImage? image.height : linkField.height, button_camera.height, button_gallery.height)
+  enabled: isEnabled
 
   property PictureSource __pictureSource
   property ViewStatus __viewStatus

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -112,13 +112,15 @@ Item {
 
         // matches `http://...` but not `file://...` paths
         if ( ! UrlUtils.isRelativeUrl(value)) {
-          __viewStatus = Qt.openUrlExternally(value)
+          Qt.openUrlExternally(value)
           return
         }
 
         // relative paths `./path/to/image.jpg` or 'path/to/image.jpg`
-        if (FileUtils.fileExists(qgisProject.homePath + '/' + value) )
+        if (FileUtils.fileExists(qgisProject.homePath + '/' + value) ) {
           __viewStatus = platformUtilities.open(qgisProject.homePath + '/' + value)
+          return
+        }
       }
     }
 

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -15,7 +15,6 @@ Item {
   anchors.right: parent.right
 
   height: Math.max(isImage? image.height : linkField.height, button_camera.height, button_gallery.height)
-  enabled: isEnabled
 
   property PictureSource __pictureSource
   property ViewStatus __viewStatus
@@ -85,13 +84,17 @@ Item {
     topPadding: 10
     bottomPadding: 10
     visible: !isImage
-    enabled: !isImage
     anchors.left: parent.left
     anchors.right: parent.right
     font: Theme.defaultFont
     color: FileUtils.fileExists(qgisProject.homePath + '/' + value) ? '#0000EE' : 'black'
 
-    text: FileUtils.fileName( qgisProject.homePath + '/' + value )
+    text: {
+      if(StringUtils.isRelativeUrl(value))
+        return config.FullUrl ? value : FileUtils.fileName(value)
+
+      return StringUtils.insertLinks(value)
+    }
 
     background: Rectangle {
       y: linkField.height - height - linkField.bottomPadding / 2
@@ -104,8 +107,20 @@ Item {
       anchors.fill: parent
 
       onClicked: {
-        if (value && FileUtils.fileExists(qgisProject.homePath + '/' + value) )
-          __viewStatus = platformUtilities.open( qgisProject.homePath + '/' + value );
+        if ( ! value )
+          return
+
+        // we assume a `http://...` or `file://...` paths that exist
+        if ( ! StringUtils.isRelativeUrl(value))
+          __viewStatus = platformUtilities.open( value )
+
+        // absolute paths `/path/to/image.jpg`
+        if (FileUtils.fileExists(value) )
+          __viewStatus = platformUtilities.open(value)
+
+        // relative paths `./path/to/image.jpg` or 'path/to/image.jpg`
+        if (FileUtils.fileExists(qgisProject.homePath + '/' + value) )
+          __viewStatus = platformUtilities.open(qgisProject.homePath + '/' + value)
       }
     }
 
@@ -119,7 +134,7 @@ Item {
   Image {
     id: image
     visible: isImage
-    enabled: isImage
+    enabled: isImage && isEnabled
     width: 200
     autoTransform: true
     fillMode: Image.PreserveAspectFit
@@ -173,7 +188,7 @@ Item {
     anchors.bottom: parent.bottom
 
     bgcolor: "transparent"
-    visible: !readOnly && isImage
+    visible: !readOnly && isImage && isEnabled
 
     onClicked: {
         if ( settings.valueBool("nativeCamera", true) ) {
@@ -197,7 +212,7 @@ Item {
     anchors.bottom: parent.bottom
 
     bgcolor: "transparent"
-    visible: !readOnly && isImage
+    visible: !readOnly && isImage && isEnabled
 
     onClicked: {
           var filepath = getPictureFilePath()

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -111,8 +111,10 @@ Item {
           return
 
         // matches `http://...` but not `file://...` paths
-        if ( ! StringUtils.isRelativeUrl(value))
-          __viewStatus = platformUtilities.open(value)
+        if ( ! StringUtils.isRelativeUrl(value)) {
+          __viewStatus = Qt.openUrlExternally(value)
+          return
+        }
 
         // relative paths `./path/to/image.jpg` or 'path/to/image.jpg`
         if (FileUtils.fileExists(qgisProject.homePath + '/' + value) )

--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -6,6 +6,7 @@ import Theme 1.0
 Item {
   signal valueChanged(var value, bool isNull)
   height: childrenRect.height
+  enabled: isEnabled
 
   id: rangeItem
   property string widgetStyle: config["Style"] ? config["Style"] : "TextField"

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -13,6 +13,7 @@ import org.qgis 1.0
 Rectangle{
     height: !readOnly ? referencingFeatureListView.height + itemHeight : Math.max( referencingFeatureListView.height, itemHeight) //because no additional addEntry item on readOnly
     property int itemHeight: 32
+    enabled: isEnabled
 
     border.color: 'lightgray'
     border.width: 1

--- a/src/qml/editorwidgets/RelationReference.qml
+++ b/src/qml/editorwidgets/RelationReference.qml
@@ -11,6 +11,7 @@ import ".."
 
 RelationCombobox {
   id: relationReference
+  enabled: isEnabled
 
   signal valueChanged(var value, bool isNull)
 

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -21,7 +21,7 @@ Item {
 
     text: value == null ? '' : stringUtilities.insertLinks(value)
 
-    onLinkActivated: platformUtilities.open(link)
+    onLinkActivated: Qt.openUrlExternally(link)
   }
 
   TextField {

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -33,7 +33,7 @@ Item {
     anchors.left: parent.left
     anchors.right: parent.right
     font: Theme.defaultFont
-    color: value == null || !enabled ? 'gray' : 'black'
+    color: (value == null || ! isEnabled) ? 'gray' : 'black'
 
     text: value == null ? '' : value
 

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.12
 import Theme 1.0
 
 Item {
+  id: topItem
   signal valueChanged(var value, bool isNull)
   height: childrenRect.height
 
@@ -12,7 +13,7 @@ Item {
     height: textArea.height == 0 ? fontMetrics.height + 20: 0
     topPadding: 10
     bottomPadding: 10
-    visible: height !== 0 && ! enabled
+    visible: height !== 0 && ! isEnabled
     anchors.left: parent.left
     anchors.right: parent.right
     font: Theme.defaultFont
@@ -28,7 +29,7 @@ Item {
     height: textArea.height == 0 ? fontMetrics.height + 20: 0
     topPadding: 10
     bottomPadding: 10
-    visible: height !== 0 && enabled
+    visible: height !== 0 && isEnabled
     anchors.left: parent.left
     anchors.right: parent.right
     font: Theme.defaultFont
@@ -76,7 +77,7 @@ Item {
   TextArea {
     id: textArea
     height: config['IsMultiline'] === true ? undefined : 0
-    visible: height !== 0
+    visible: height !== 0 && isEnabled
     anchors.left: parent.left
     anchors.right: parent.right
     wrapMode: Text.Wrap

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -6,18 +6,35 @@ Item {
   signal valueChanged(var value, bool isNull)
   height: childrenRect.height
 
+  // Due to QTextEdit::onLinkActivated does not work on Android & iOS, we need a separate `Text` element to support links https://bugreports.qt.io/browse/QTBUG-38487
+  Label {
+    id: textReadonlyValue
+    height: textArea.height == 0 ? fontMetrics.height + 20: 0
+    topPadding: 10
+    bottomPadding: 10
+    visible: height !== 0 && ! enabled
+    anchors.left: parent.left
+    anchors.right: parent.right
+    font: Theme.defaultFont
+    color: value == null || !enabled ? 'gray' : 'black'
+
+    text: value == null ? '' : platformUtilities.insertLinks( value )
+
+    onLinkActivated: Qt.openUrlExternally(link)
+  }
+
   TextField {
     id: textField
     height: textArea.height == 0 ? fontMetrics.height + 20: 0
     topPadding: 10
     bottomPadding: 10
-    visible: height !== 0
+    visible: height !== 0 && enabled
     anchors.left: parent.left
     anchors.right: parent.right
     font: Theme.defaultFont
-    color: value === undefined || !enabled ? 'gray' : 'black'
+    color: value == null || !enabled ? 'gray' : 'black'
 
-    text: value !== undefined ? value : ''
+    text: value == null ? '' : value
 
     validator: {
       if (field.isNumeric)

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -17,11 +17,11 @@ Item {
     anchors.left: parent.left
     anchors.right: parent.right
     font: Theme.defaultFont
-    color: value == null || !enabled ? 'gray' : 'black'
+    color: value == null || (! enabled ? 'gray' : 'black')
 
-    text: value == null ? '' : platformUtilities.insertLinks( value )
+    text: value == null ? '' : stringUtilities.insertLinks(value)
 
-    onLinkActivated: Qt.openUrlExternally(link)
+    onLinkActivated: platformUtilities.open(link)
   }
 
   TextField {

--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -21,6 +21,7 @@ Item {
   }
 
   height: childrenRect.height + 10
+  enabled: isEnabled
 
 
   ComboBox {

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -15,6 +15,7 @@ Item {
   signal valueChanged(var value, bool isNull)
 
   height: !config['AllowMulti'] ? valueRelationCombobox.height : valueRelationList.height
+  enabled: isEnabled
 
   RelationCombobox {
     id: valueRelationCombobox

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,3 +25,8 @@ ENDMACRO (ADD_QFIELD_TEST)
 
 ADD_QFIELD_TEST(vertexmodeltest test_vertexmodel.cpp)
 ADD_QFIELD_TEST(referencingfeaturelistmodeltest test_referencingfeaturelistmodel.cpp)
+ADD_QFIELD_TEST(featureutilstest test_featureutils.cpp)
+ADD_QFIELD_TEST(fileutilstest test_fileutils.cpp)
+ADD_QFIELD_TEST(geometryutilstest test_geometryutils.cpp)
+ADD_QFIELD_TEST(stringutilstest test_stringutils.cpp)
+ADD_QFIELD_TEST(urlutilstest test_urlutils.cpp)

--- a/test/test.pro
+++ b/test/test.pro
@@ -27,6 +27,11 @@ LIBS += ../3rdparty/tessellate/libtessellate.a \
 SOURCES += \
     test_vertexmodel.cpp \
     test_referencingfeaturelistmodel.cpp \
+    test_featureutils.cpp \
+    test_fileutils.cpp \
+    test_geometryutils.cpp \
+    test_stringutils.cpp \
+    test_urltils.cpp \
     main.cpp
 
 HEADERS +=

--- a/test/test_featureutils.cpp
+++ b/test/test_featureutils.cpp
@@ -1,0 +1,48 @@
+/***************************************************************************
+                        test_featureutils.h
+                        --------------------
+  begin                : Jun 2020
+  copyright            : (C) 2020 by Ivan Ivanov
+  email                : ivan@opengis.ch
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QtTest>
+
+#include "qfield_testbase.h"
+
+#include "utils/featureutils.h"
+
+#include "qgsvectorlayer.h"
+
+
+class TestFeatureUtils: public QObject
+{
+    Q_OBJECT
+  private slots:
+
+
+    void testInitFeature()
+    {
+      std::unique_ptr<QgsVectorLayer> vl( new QgsVectorLayer( QStringLiteral( "Polygon?crs=epsg:3946" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) ) );
+
+      QgsGeometry geometry = QgsGeometry::fromWkt( QStringLiteral( "Polygon (((8 8, 9 8, 8 9, 8 8)))" ) );
+
+      QgsFeature f = FeatureUtils::initFeature( vl.get(), geometry );
+
+      QCOMPARE( f.fields(), vl->fields() );
+      QVERIFY( f.geometry().equals( geometry ) );
+    }
+
+};
+
+QFIELDTEST_MAIN( TestFeatureUtils )
+#include "test_featureutils.moc"

--- a/test/test_fileutils.cpp
+++ b/test/test_fileutils.cpp
@@ -1,0 +1,74 @@
+/***************************************************************************
+                        test_fileutils.h
+                        --------------------
+  begin                : Jun 2020
+  copyright            : (C) 2020 by Ivan Ivanov
+  email                : ivan@opengis.ch
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QtTest>
+
+#include "qfield_testbase.h"
+
+#include "utils/fileutils.h"
+
+
+class TestFileUtils: public QObject
+{
+    Q_OBJECT
+  private slots:
+
+
+    void testMimeTypeName()
+    {
+      QCOMPARE( FileUtils::mimeTypeName( QStringLiteral( "filename.txt" ) ), QStringLiteral( "text/plain" ) );
+    }
+
+
+    void testFileName()
+    {
+      QCOMPARE( FileUtils::fileName( QStringLiteral( "filename.suffix" ) ), QStringLiteral( "filename.suffix" ) );
+      QCOMPARE( FileUtils::fileName( QStringLiteral( "path/to/filename.suffix" ) ), QStringLiteral( "filename.suffix" ) );
+      QCOMPARE( FileUtils::fileName( QStringLiteral( "./path/to/filename.suffix" ) ), QStringLiteral( "filename.suffix" ) );
+      QCOMPARE( FileUtils::fileName( QStringLiteral( "../path/to/filename.suffix" ) ), QStringLiteral( "filename.suffix" ) );
+      QCOMPARE( FileUtils::fileName( QStringLiteral( "/path/to/filename.suffix" ) ), QStringLiteral( "filename.suffix" ) );
+      QCOMPARE( FileUtils::fileName( QStringLiteral( "filename.dbl.suffix" ) ), QStringLiteral( "filename.dbl.suffix" ) );
+      QCOMPARE( FileUtils::fileName( QStringLiteral( "nosuffix" ) ), QStringLiteral( "nosuffix" ) );
+    }
+
+
+    void testFileSuffix()
+    {
+      QCOMPARE( FileUtils::fileSuffix( QStringLiteral( "filename.suffix" ) ), QStringLiteral( "suffix" ) );
+      QCOMPARE( FileUtils::fileSuffix( QStringLiteral( "path/to/filename.suffix" ) ), QStringLiteral( "suffix" ) );
+      QCOMPARE( FileUtils::fileSuffix( QStringLiteral( "./path/to/filename.suffix" ) ), QStringLiteral( "suffix" ) );
+      QCOMPARE( FileUtils::fileSuffix( QStringLiteral( "../path/to/filename.suffix" ) ), QStringLiteral( "suffix" ) );
+      QCOMPARE( FileUtils::fileSuffix( QStringLiteral( "/path/to/filename.suffix" ) ), QStringLiteral( "suffix" ) );
+      QCOMPARE( FileUtils::fileSuffix( QStringLiteral( "filename.dbl.suffix" ) ), QStringLiteral( "suffix" ) );
+      QCOMPARE( FileUtils::fileSuffix( QStringLiteral( "nosuffix" ) ), QStringLiteral( "" ) );
+    }
+
+
+    void testFileExists()
+    {
+      QTemporaryFile *f = new QTemporaryFile();
+
+      QVERIFY( f->open() );
+      QString fileName( f->fileName() );
+      QVERIFY( FileUtils::fileExists( fileName ) );
+      delete f;
+      QVERIFY( ! FileUtils::fileExists( fileName ) );
+    }
+};
+
+QFIELDTEST_MAIN( TestFileUtils )
+#include "test_fileutils.moc"

--- a/test/test_geometryutils.cpp
+++ b/test/test_geometryutils.cpp
@@ -1,0 +1,103 @@
+/***************************************************************************
+                        test_geometryutils.h
+                        --------------------
+  begin                : Jun 2020
+  copyright            : (C) 2020 by Ivan Ivanov
+  email                : ivan@opengis.ch
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QtTest>
+
+#include "qfield_testbase.h"
+
+#include "utils/geometryutils.h"
+#include "rubberbandmodel.h"
+
+#include "qgsvectorlayer.h"
+
+
+class TestGeometryUtils: public QObject
+{
+    Q_OBJECT
+  private slots:
+    void initTestCase()
+    {
+      mModel = std::unique_ptr<RubberbandModel>( new RubberbandModel() );
+      mLayer = std::unique_ptr<QgsVectorLayer>( new QgsVectorLayer( QStringLiteral( "Polygon?crs=epsg:3946" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) ) );
+
+      QgsFeature f( mLayer->fields(), 1 );
+      f.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "Polygon ((8 8, 9 8, 8 9, 8 8))" ) ) );
+
+      QVERIFY( mLayer->startEditing() );
+      QVERIFY( mLayer->addFeature( f ) );
+      QVERIFY( mLayer->commitChanges() );
+
+      mModel->setGeometryType( mLayer->geometryType() );
+    }
+
+
+    void cleanup()
+    {
+      mModel->reset();
+    }
+
+
+    void testPolygonFromRubberBand()
+    {
+      const QgsCoordinateReferenceSystem crs = QgsCoordinateReferenceSystem::fromEpsgId( 3946 );
+
+      mModel->addVertexFromPoint( QgsPoint( 0, 0 ) );
+      mModel->addVertexFromPoint( QgsPoint( 2, 1 ) );
+      mModel->addVertexFromPoint( QgsPoint( 1, 2 ) );
+
+      QgsGeometry geom = GeometryUtils::polygonFromRubberband( mModel.get(), crs );
+
+      QCOMPARE( geom.asWkt(), QStringLiteral( "Polygon ((0 0, 2 1, 1 2, 1 2, 0 0))" ) );
+    }
+
+
+    void testAddRingFromRubberBand()
+    {
+      QVERIFY( mLayer->startEditing() );
+      QCOMPARE( GeometryUtils::addRingFromRubberBand( mLayer.get(), 100, mModel.get() ), QgsGeometry::AddRingNotInExistingFeature );
+
+      mModel->addVertexFromPoint( QgsPoint( 8.1, 8.1 ) );
+      mModel->addVertexFromPoint( QgsPoint( 8.9, 8.1 ) );
+      mModel->addVertexFromPoint( QgsPoint( 8.1, 8.9 ) );
+      mLayer->select( 1 );
+
+      QCOMPARE( GeometryUtils::addRingFromRubberBand( mLayer.get(), 1, mModel.get() ), QgsGeometry::Success );
+      QVERIFY( mLayer->rollBack() );
+    }
+
+
+    void testSplitFeatureFromRubberBand()
+    {
+      QVERIFY( mLayer->startEditing() );
+      QCOMPARE( GeometryUtils::splitFeatureFromRubberBand( mLayer.get(), mModel.get() ), QgsGeometry::NothingHappened );
+
+      mModel->addVertexFromPoint( QgsPoint( 7.5, 8.5 ) );
+      mModel->addVertexFromPoint( QgsPoint( 9.5, 8.5 ) );
+      mLayer->select( 1 );
+
+      QCOMPARE( GeometryUtils::splitFeatureFromRubberBand( mLayer.get(), mModel.get() ), QgsGeometry::Success );
+      QVERIFY( mLayer->rollBack() );
+    }
+
+
+  private:
+    std::unique_ptr<RubberbandModel> mModel;
+    std::unique_ptr<QgsVectorLayer> mLayer;
+};
+
+QFIELDTEST_MAIN( TestGeometryUtils )
+#include "test_geometryutils.moc"

--- a/test/test_stringutils.cpp
+++ b/test/test_stringutils.cpp
@@ -1,0 +1,41 @@
+/***************************************************************************
+                        test_stringutils.h
+                        --------------------
+  begin                : Jun 2020
+  copyright            : (C) 2020 by Ivan Ivanov
+  email                : ivan@opengis.ch
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QtTest>
+
+#include "qfield_testbase.h"
+
+#include "utils/stringutils.h"
+
+
+class TestStringUtils: public QObject
+{
+    Q_OBJECT
+  private slots:
+
+    void testInsertLinks()
+    {
+      QCOMPARE( StringUtils::insertLinks( QStringLiteral( "http://osm.org/" ) ), QStringLiteral( "<a href=\"http://osm.org/\">http://osm.org/</a>" ) );
+      QCOMPARE( StringUtils::insertLinks( QStringLiteral( "https://osm.org/" ) ), QStringLiteral( "<a href=\"https://osm.org/\">https://osm.org/</a>" ) );
+      QCOMPARE( StringUtils::insertLinks( QStringLiteral( "before https://osm.org/ after" ) ), QStringLiteral( "before <a href=\"https://osm.org/\">https://osm.org/</a> after" ) );
+      QCOMPARE( StringUtils::insertLinks( QStringLiteral( "before https://osm.org/path?resource=;or=this%20one after" ) ), QStringLiteral( "before <a href=\"https://osm.org/path?resource=;or=this%20one\">https://osm.org/path?resource=;or=this%20one</a> after" ) );
+    }
+
+};
+
+QFIELDTEST_MAIN( TestStringUtils )
+#include "test_stringutils.moc"

--- a/test/test_urlutils.cpp
+++ b/test/test_urlutils.cpp
@@ -1,0 +1,49 @@
+/***************************************************************************
+                        test_urlutils.h
+                        --------------------
+  begin                : Jun 2020
+  copyright            : (C) 2020 by Ivan Ivanov
+  email                : ivan@opengis.ch
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QtTest>
+#include <QFileInfo>
+#include <QDebug>
+
+#include "qfield_testbase.h"
+
+#include "utils/urlutils.h"
+
+
+class TestUrlUtils: public QObject
+{
+    Q_OBJECT
+  private slots:
+
+    void testHasError()
+    {
+      // should be considered relative
+      QVERIFY( UrlUtils::isRelativeOrFileUrl( QStringLiteral( "path/to/file" ) ) );
+      QVERIFY( UrlUtils::isRelativeOrFileUrl( QStringLiteral( "/path/to/file" ) ) );
+      QVERIFY( UrlUtils::isRelativeOrFileUrl( QStringLiteral( "file:///path/to/file" ) ) );
+
+      // should NOT be considered relative
+      QVERIFY( ! UrlUtils::isRelativeOrFileUrl( QStringLiteral( "http://osm.org" ) ) );
+      QVERIFY( ! UrlUtils::isRelativeOrFileUrl( QStringLiteral( "http://osm.org/test?query=1" ) ) );
+      QVERIFY( ! UrlUtils::isRelativeOrFileUrl( QStringLiteral( "https://osm.org/test?query=1" ) ) );
+    }
+
+
+};
+
+QFIELDTEST_MAIN( TestUrlUtils )
+#include "test_urlutils.moc"


### PR DESCRIPTION
When `TextEdit` or `ExternalAttachment` contains a web URL, convert it to an anchor via `QStringUtils::insertLinks` and display it. 

There is a need of aditional Text QML element, because links in TextEdit do not open on Android and it's quite dirty to automatically convert to RichText format.

|before|after|
|---------|------|
|![image](https://user-images.githubusercontent.com/2820439/85294124-ed7a2f80-b4a6-11ea-9613-176a8f604a89.png)|![image](https://user-images.githubusercontent.com/2820439/85293872-9bd1a500-b4a6-11ea-9945-838a43a0b273.png)|
