### PR TITLE
Fix last user-added global variable not saved

### DIFF
--- a/src/core/expressionvariablemodel.cpp
+++ b/src/core/expressionvariablemodel.cpp
@@ -53,7 +53,7 @@ void ExpressionVariableModel::removeCustomVariable( int row )
 void ExpressionVariableModel::save()
 {
   QVariantMap variables;
-  for ( int i = 0; i < rowCount() - 1; ++i )
+  for ( int i = 0; i < rowCount(); ++i )
   {
     if ( item( i )->isEditable() )
     {


### PR DESCRIPTION
This is a follow up to the global variable editor's upgrade done as part of the QtQuick2 upgrade work. 

In the old variable editor, the last row/item was used to add a new variable and therefore had to be skipped. This is not the case anymore, we need to save that last item.

@3nids , @m-kuhn , this will need backporting to 1.6.

