### PR TITLE
fix snapping when digitizing with pen

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -235,11 +235,12 @@ ApplicationWindow {
           else if ( type === "stylus" && ( ( stateMachine.state === "digitize" && dashBoard.currentLayer ) || stateMachine.state === 'measure' ) ) {
                 if ( Number( currentRubberband.model.geometryType ) === QgsWkbTypes.PointGeometry ||
                      Number( currentRubberband.model.geometryType ) === QgsWkbTypes.NullGeometry )
+                {
                   digitizingToolbar.confirm()
+                }
                 else
                 {
-                    var mapPoint = mapSettings.screenToCoordinate(point)
-                    currentRubberband.model.addVertexFromPoint(mapPoint)
+                    currentRubberband.model.addVertex()
                     coordinateLocator.flash()
                 }
           }


### PR DESCRIPTION
the clicked point instead of the snapped point was used

the original code was introduced at the time when we had a timer to detect double taps, which is no longer used