### PR TITLE
Rename occurrances of RubberBand to Rubberband

### DIFF
--- a/scripts/spell_check/spelling.dat
+++ b/scripts/spell_check/spelling.dat
@@ -6266,6 +6266,7 @@ rquest:request
 rquested:requested
 rquesting:requesting
 rquests:requests
+RubberBand:Rubberband
 rucuperate:recuperate
 rudimentatry:rudimentary
 rulle:rule

--- a/src/core/utils/geometryutils.cpp
+++ b/src/core/utils/geometryutils.cpp
@@ -38,13 +38,13 @@ QgsGeometry GeometryUtils::polygonFromRubberband( RubberbandModel *rubberBandMod
   return g;
 }
 
-QgsGeometry::OperationResult GeometryUtils::addRingFromRubberBand( QgsVectorLayer *layer, QgsFeatureId fid, RubberbandModel *rubberBandModel )
+QgsGeometry::OperationResult GeometryUtils::addRingFromRubberband( QgsVectorLayer *layer, QgsFeatureId fid, RubberbandModel *rubberBandModel )
 {
   QgsPointSequence ring = rubberBandModel->pointSequence( layer->crs(), layer->wkbType(), true );
   return layer->addRing( ring, &fid );
 }
 
-QgsGeometry::OperationResult GeometryUtils::splitFeatureFromRubberBand( QgsVectorLayer *layer, RubberbandModel *rubberBandModel )
+QgsGeometry::OperationResult GeometryUtils::splitFeatureFromRubberband( QgsVectorLayer *layer, RubberbandModel *rubberBandModel )
 {
   QgsPointSequence line = rubberBandModel->pointSequence( layer->crs(), QgsWkbTypes::Point, false );
   return layer->splitFeatures( line, true );

--- a/src/core/utils/geometryutils.h
+++ b/src/core/utils/geometryutils.h
@@ -35,10 +35,10 @@ class GeometryUtils : public QObject
     static Q_INVOKABLE QgsGeometry polygonFromRubberband( RubberbandModel *rubberBandModel, const QgsCoordinateReferenceSystem &crs );
 
     //! Add a ring to a polyon with given \a fid using the ring in the rubberband model.
-    static Q_INVOKABLE QgsGeometry::OperationResult addRingFromRubberBand( QgsVectorLayer *layer, QgsFeatureId fid, RubberbandModel *rubberBandModel );
+    static Q_INVOKABLE QgsGeometry::OperationResult addRingFromRubberband( QgsVectorLayer *layer, QgsFeatureId fid, RubberbandModel *rubberBandModel );
 
     //! This will perform a split using the line in the rubberband model. It works with the layer selection if some features are selected.
-    static Q_INVOKABLE QgsGeometry::OperationResult splitFeatureFromRubberBand( QgsVectorLayer *layer, RubberbandModel *rubberBandModel );
+    static Q_INVOKABLE QgsGeometry::OperationResult splitFeatureFromRubberband( QgsVectorLayer *layer, RubberbandModel *rubberBandModel );
 
 };
 

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -77,14 +77,17 @@ Popup {
         property var padlockIcon: Theme.getThemeIcon('ic_lock_black_24dp')
         property var padlockSize: fontMetrics.height - 5
 
-        visible: layerTree.data(index, FlatLayerTreeModel.ReadOnly) || layerTree.data(index, FlatLayerTreeModel.GeometryLocked)
+        visible: index && (
+                   layerTree.data(index, FlatLayerTreeModel.ReadOnly)
+                   || layerTree.data(index, FlatLayerTreeModel.GeometryLocked)
+                   )
         Layout.fillWidth: true
         Layout.maximumWidth: parent.width - 20
 
         wrapMode: Text.WordWrap
         textFormat: Text.RichText
         text: '<img src="' + padlockIcon + '" width="' + padlockSize + '" height="' + padlockSize + '"> '
-              + (layerTree.data(index, FlatLayerTreeModel.ReadOnly)
+              + (index && layerTree.data(index, FlatLayerTreeModel.ReadOnly)
                   ? qsTr('This layer is configured as "Read-Only" which disables adding, deleting and editing features.')
                   : qsTr('This layer is configured as "Lock Geometries" which disables adding and deleting features, as well as modifying the geometries of existing features.'))
       }

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -79,8 +79,7 @@ Popup {
 
         visible: index && (
                    layerTree.data(index, FlatLayerTreeModel.ReadOnly)
-                   || layerTree.data(index, FlatLayerTreeModel.GeometryLocked)
-                   )
+                   || layerTree.data(index, FlatLayerTreeModel.GeometryLocked))
         Layout.fillWidth: true
         Layout.maximumWidth: parent.width - 20
 

--- a/src/qml/geometry_editors/FillRingToolBar.qml
+++ b/src/qml/geometry_editors/FillRingToolBar.qml
@@ -47,7 +47,7 @@ VisibilityFadingRow {
       rubberbandModel.frozen = true
       if (!featureModel.currentLayer.editBuffer())
         featureModel.currentLayer.startEditing()
-      var result = GeometryUtils.addRingFromRubberBand(featureModel.currentLayer, featureModel.feature.id, rubberbandModel)
+      var result = GeometryUtils.addRingFromRubberband(featureModel.currentLayer, featureModel.feature.id, rubberbandModel)
       if ( result !== QgsGeometryStatic.Success )
       {
         if ( result === QgsGeometryStatic.AddRingNotClosed )

--- a/src/qml/geometry_editors/SplitFeatureToolbar.qml
+++ b/src/qml/geometry_editors/SplitFeatureToolbar.qml
@@ -45,7 +45,7 @@ VisibilityFadingRow {
       if (!featureModel.currentLayer.editBuffer())
         featureModel.currentLayer.startEditing()
 
-      var result = GeometryUtils.splitFeatureFromRubberBand(featureModel.currentLayer, drawLineToolbar.rubberbandModel)
+      var result = GeometryUtils.splitFeatureFromRubberband(featureModel.currentLayer, drawLineToolbar.rubberbandModel)
       if ( result !== QgsGeometryStatic.Success )
       {
         displayToast( qsTr( 'Feature could not be split' ) );

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -432,7 +432,7 @@ ApplicationWindow {
 
       // highlighting geometry (point, line, surface)
       Rubberband {
-        id: editingRubberBand
+        id: editingRubberband
         vertexModel: vertexModel
         mapSettings: mapCanvas.mapSettings
         width: 4

--- a/test/test_geometryutils.cpp
+++ b/test/test_geometryutils.cpp
@@ -51,7 +51,7 @@ class TestGeometryUtils: public QObject
     }
 
 
-    void testPolygonFromRubberBand()
+    void testPolygonFromRubberband()
     {
       const QgsCoordinateReferenceSystem crs = QgsCoordinateReferenceSystem::fromEpsgId( 3946 );
 
@@ -65,31 +65,31 @@ class TestGeometryUtils: public QObject
     }
 
 
-    void testAddRingFromRubberBand()
+    void testAddRingFromRubberband()
     {
       QVERIFY( mLayer->startEditing() );
-      QCOMPARE( GeometryUtils::addRingFromRubberBand( mLayer.get(), 100, mModel.get() ), QgsGeometry::AddRingNotInExistingFeature );
+      QCOMPARE( GeometryUtils::addRingFromRubberband( mLayer.get(), 100, mModel.get() ), QgsGeometry::AddRingNotInExistingFeature );
 
       mModel->addVertexFromPoint( QgsPoint( 8.1, 8.1 ) );
       mModel->addVertexFromPoint( QgsPoint( 8.9, 8.1 ) );
       mModel->addVertexFromPoint( QgsPoint( 8.1, 8.9 ) );
       mLayer->select( 1 );
 
-      QCOMPARE( GeometryUtils::addRingFromRubberBand( mLayer.get(), 1, mModel.get() ), QgsGeometry::Success );
+      QCOMPARE( GeometryUtils::addRingFromRubberband( mLayer.get(), 1, mModel.get() ), QgsGeometry::Success );
       QVERIFY( mLayer->rollBack() );
     }
 
 
-    void testSplitFeatureFromRubberBand()
+    void testSplitFeatureFromRubberband()
     {
       QVERIFY( mLayer->startEditing() );
-      QCOMPARE( GeometryUtils::splitFeatureFromRubberBand( mLayer.get(), mModel.get() ), QgsGeometry::NothingHappened );
+      QCOMPARE( GeometryUtils::splitFeatureFromRubberband( mLayer.get(), mModel.get() ), QgsGeometry::NothingHappened );
 
       mModel->addVertexFromPoint( QgsPoint( 7.5, 8.5 ) );
       mModel->addVertexFromPoint( QgsPoint( 9.5, 8.5 ) );
       mLayer->select( 1 );
 
-      QCOMPARE( GeometryUtils::splitFeatureFromRubberBand( mLayer.get(), mModel.get() ), QgsGeometry::Success );
+      QCOMPARE( GeometryUtils::splitFeatureFromRubberband( mLayer.get(), mModel.get() ), QgsGeometry::Success );
       QVERIFY( mLayer->rollBack() );
     }
 


### PR DESCRIPTION
Make sure all occurrences of `Rubberband` is written with a single capital, not `RubberBand`.

Seems that Rubberband is much more popular in the codebase, even though QGIS spelling is `QgsRubberBand`
```
$ rg RubberBand | wc -l
14
$ rg Rubberband | wc -l
237
```
Not the most important fix in the world, but consistency is good.

I am cheap on PRs and fixed a warning too, that I have introduced with geometry locking.