### PR TITLE
New legend widget post public release fixes

### DIFF
--- a/src/core/layertreemapcanvasbridge.cpp
+++ b/src/core/layertreemapcanvasbridge.cpp
@@ -151,7 +151,6 @@ void LayerTreeMapCanvasBridge::mapThemeChanged()
 {
   QgsProject::instance()->mapThemeCollection()->applyTheme( mModel->mapTheme(), mRoot, mModel->layerTreeModel() );
   // rebuilt the flat layer tree model
-  mModel->buildMap( mModel->layerTreeModel() );
 }
 
 void LayerTreeMapCanvasBridge::layerInTrackingChanged( QgsVectorLayer *layer, bool tracking )

--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -58,6 +58,10 @@ int FlatLayerTreeModel::buildMap( QgsLayerTreeModel *model, const QModelIndex &p
   for ( int i = 0; i < nbRows; i++ )
   {
     QModelIndex index = model->index( i, 0, parent );
+    QgsLayerTreeNode *node = mLayerTreeModel->index2node( index );
+    if ( node && node-> customProperty( QStringLiteral( "nodeHidden" ), QStringLiteral( "false" ) ).toString() == QStringLiteral( "true" ) )
+      continue;
+
     mRowMap[index] = row;
     mIndexMap[row] = index;
     row++;
@@ -363,6 +367,8 @@ void FlatLayerTreeModel::setMapTheme( const QString &mapTheme )
 
   mMapTheme = mapTheme;
   emit mapThemeChanged();
+
+  buildMap( mLayerTreeModel );
 }
 
 void FlatLayerTreeModel::updateCurrentMapTheme()

--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -224,7 +224,7 @@ QVariant FlatLayerTreeModel::data( const QModelIndex &index, int role ) const
       {
         if ( sym->flags() & Qt::ItemIsUserCheckable )
         {
-          return sym->data( Qt::CheckStateRole ).toBool();
+          return sym->data( Qt::CheckStateRole ).toBool() && sym->layerNode()->isVisible();
         }
         else
         {

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -12,7 +12,10 @@ Popup {
   property var index
 
   property bool zoomToLayerButtonVisible: false
+
   property bool trackingButtonVisible: false
+  property var trackingButtonText
+
   property alias itemVisible: itemVisibleCheckBox.checked
 
   padding: 0
@@ -117,7 +120,6 @@ Popup {
       }
     }
   }
-
 
   function isTrackingButtonVisible() {
     if ( !index )

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -92,7 +92,7 @@ Popup {
         Layout.maximumWidth: parent.width - 20
         font: Theme.defaultFont
         text: qsTr('Zoom to layer')
-        visible: trackingButtonVisible
+        visible: zoomToLayerButtonVisible
 
         onClicked: {
           mapCanvas.mapSettings.setCenterToLayer( layerTree.data( index, FlatLayerTreeModel.MapLayerPointer ) )

--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -124,7 +124,7 @@ ListView {
       }
       onPressed: {
           var item = table.itemAt(table.contentX + mouse.x, table.contentY + mouse.y)
-          if (item && item.itemType !== "group") {
+          if (item && item.itemType) {
               pressedItem = item;
               pressedItem.color = Theme.lightGray
           }


### PR DESCRIPTION
This fixes #1109 , #1111 , as well as an unreported crasher when using the zoom to layer button on a group.

I've also taken the time to further cleanup the layer tree item properties QML some more (follow up to the removal of the dual qml file for that item).

