### PR TITLE
Fix Feature Form problems depending on isEnabled and AttributeAllowEdit

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -350,6 +350,7 @@ void AttributeFormModelBase::flatten( QgsAttributeEditorContainer *container, QS
         item->setData( true, AttributeFormModel::CurrentlyVisible );
         item->setData( true, AttributeFormModel::ConstraintHardValid );
         item->setData( true, AttributeFormModel::ConstraintSoftValid );
+        item->setData( true, AttributeFormModel::AttributeAllowEdit );
 
         items.append( item );
 

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -262,13 +262,8 @@ Page {
           anchors { left: parent.left; right: parent.right }
 
           //disable widget if the form is in ReadOnly mode, or if it's an RelationEditor widget in an embedded form
-          property bool isEnabled: AttributeAllowEdit && !!AttributeEditable && (
-                                     form.state !== 'ReadOnly'
-                                     || EditorWidget === 'RelationEditor'
-                                     || EditorWidget === 'ValueRelation'
-                                     || EditorWidget === 'ExternalResource'
-                                     )
-          property bool readOnly: form.state === 'ReadOnly' || embedded && EditorWidget === 'RelationEditor'
+          property bool isEnabled: AttributeAllowEdit && !!AttributeEditable &&
+                                   form.state !== 'ReadOnly' && !( embedded && EditorWidget === 'RelationEditor' )
           property var value: AttributeValue
           property var config: ( EditorWidgetConfig || {} )
           property var widget: EditorWidget

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -261,9 +261,15 @@ Page {
           height: childrenRect.height
           anchors { left: parent.left; right: parent.right }
 
-          //disable widget if the form is in ReadOnly mode, or if it's an RelationEditor widget in an embedded form
-          property bool isEnabled: AttributeAllowEdit && !!AttributeEditable &&
-                                   form.state !== 'ReadOnly' && !( embedded && EditorWidget === 'RelationEditor' )
+          //disable widget if it's:
+          // - not activated in multi edit mode
+          // - not set to editable in the widget configuration
+          // - not in edit mode (ReadOnly)
+          // - a relation in an embedded form or in multi edit mode
+          property bool isEnabled: AttributeAllowEdit
+                                   && !!AttributeEditable
+                                   && form.state !== 'ReadOnly'
+                                   && !( Type === 'relation' && ( embedded || form.model.featureModel.modelMode == FeatureModel.MultiFeatureModel ) )
           property var value: AttributeValue
           property var config: ( EditorWidgetConfig || {} )
           property var widget: EditorWidget
@@ -338,7 +344,7 @@ Page {
       Label {
         id: multiEditAttributeLabel
         text: (AttributeAllowEdit ? qsTr( "Value applied" ) : qsTr( "Value skipped" ) ) + qsTr( " (click to toggle)" )
-        visible: form.model.featureModel.modelMode == FeatureModel.MultiFeatureModel
+        visible: form.model.featureModel.modelMode == FeatureModel.MultiFeatureModel && Type !== 'relation'
         height: form.model.featureModel.modelMode == FeatureModel.MultiFeatureModel ? undefined : 0
         bottomPadding: form.model.featureModel.modelMode == FeatureModel.MultiFeatureModel ? 15 : 0
         anchors { left: parent.left; top: placeholder.bottom;  rightMargin: 10; }

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -134,7 +134,7 @@ Item {
   Image {
     id: image
     visible: isImage
-    enabled: isImage && isEnabled
+    enabled: isImage
     width: 200
     autoTransform: true
     fillMode: Image.PreserveAspectFit
@@ -188,7 +188,7 @@ Item {
     anchors.bottom: parent.bottom
 
     bgcolor: "transparent"
-    visible: !readOnly && isImage && isEnabled
+    visible: isImage && isEnabled
 
     onClicked: {
         if ( settings.valueBool("nativeCamera", true) ) {
@@ -212,7 +212,7 @@ Item {
     anchors.bottom: parent.bottom
 
     bgcolor: "transparent"
-    visible: !readOnly && isImage && isEnabled
+    visible: isImage && isEnabled
 
     onClicked: {
           var filepath = getPictureFilePath()

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -11,9 +11,9 @@ import org.qfield 1.0
 import org.qgis 1.0
 
 Rectangle{
-    height: !readOnly ? referencingFeatureListView.height + itemHeight : Math.max( referencingFeatureListView.height, itemHeight) //because no additional addEntry item on readOnly
+    height: isEnabled ? referencingFeatureListView.height + itemHeight : Math.max( referencingFeatureListView.height, itemHeight) //because no additional addEntry item on readOnly (isEnabled false)
     property int itemHeight: 32
-    enabled: isEnabled
+    enabled: true
 
     border.color: 'lightgray'
     border.width: 1
@@ -52,12 +52,12 @@ Rectangle{
       Rectangle{
           anchors.fill: parent
           color: 'lightgrey'
-          visible: !readOnly
+          visible: isEnabled
 
           Text {
-              visible: !readOnly
+              visible: isEnabled
               color: 'grey'
-              text: !readOnly && !constraintsHardValid ? qsTr( 'Ensure contraints') : ''
+              text: isEnabled && !constraintsHardValid ? qsTr( 'Ensure contraints') : ''
               anchors { leftMargin: 10; left: parent.left; right: addButton.left; verticalCenter: parent.verticalCenter }
               font.bold: true
               font.italic: true
@@ -125,7 +125,7 @@ Rectangle{
             id: featureText
             anchors { leftMargin: 10; left: parent.left; right: deleteButtonRow.left; verticalCenter: parent.verticalCenter }
             font.bold: true
-            color: readOnly ? 'grey' : 'black'
+            color: !isEnabled ? 'grey' : 'black'
             text: { text: nmRelationId ? model.nmDisplayString : model.displayString }
           }
 
@@ -133,7 +133,7 @@ Rectangle{
             anchors.fill: parent
 
             onClicked: {
-                embeddedPopup.state = !readOnly ? 'Edit' : 'ReadOnly'
+                embeddedPopup.state = isEnabled ? 'Edit' : 'ReadOnly'
                 embeddedPopup.currentLayer = nmRelationId ?  relationEditorModel.nmRelation.referencedLayer : relationEditorModel.relation.referencingLayer
                 embeddedPopup.linkedRelation = relationEditorModel.relation
                 embeddedPopup.linkedParentFeature = relationEditorModel.feature
@@ -152,7 +152,7 @@ Rectangle{
                 id: deleteButton
                 width: parent.height
                 height: parent.height
-                visible: !readOnly
+                visible: isEnabled
 
                 contentItem: Rectangle {
                     anchors.fill: parent

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -13,11 +13,11 @@ Item {
     height: textArea.height == 0 ? fontMetrics.height + 20: 0
     topPadding: 10
     bottomPadding: 10
-    visible: height !== 0 && ! isEnabled
+    visible: height !== 0 && !isEnabled
     anchors.left: parent.left
     anchors.right: parent.right
     font: Theme.defaultFont
-    color: value == null || (! enabled ? 'gray' : 'black')
+    color: 'gray'
 
     text: value == null ? '' : stringUtilities.insertLinks(value)
 
@@ -33,7 +33,7 @@ Item {
     anchors.left: parent.left
     anchors.right: parent.right
     font: Theme.defaultFont
-    color: (value == null || ! isEnabled) ? 'gray' : 'black'
+    color: 'black'
 
     text: value == null ? '' : value
 

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -15,7 +15,7 @@ Item {
   signal valueChanged(var value, bool isNull)
 
   height: !config['AllowMulti'] ? valueRelationCombobox.height : valueRelationList.height
-  enabled: isEnabled
+  enabled: true
 
   RelationCombobox {
     id: valueRelationCombobox
@@ -103,7 +103,7 @@ Item {
             id: checkBox
             width: parent.height
             height: parent.height
-            enabled: !readOnly
+            enabled: isEnabled
 
             checked: model.checked
 
@@ -122,7 +122,7 @@ Item {
           id: valueText
           anchors { leftMargin: 10; left: checkBoxRow.right; right: parent.right; verticalCenter: parent.verticalCenter }
           font.bold: true
-          color: readOnly ? 'grey' : 'black'
+          color: !isEnabled ? 'grey' : 'black'
           text: { text: model.displayString }
         }
 
@@ -130,7 +130,7 @@ Item {
           anchors.fill: parent
 
           onClicked: {
-            if( !readOnly ){
+            if( isEnabled ){
               checkBox.checked = !checkBox.checked
             }
           }


### PR DESCRIPTION
**Fix Relation Editor** 
Has been always disabled because of the `AttributeAllowEdit`. Now `AttributeAllowEdit` on the `ElementType` relation is always true, but on multi edit the relation editor widget is disabled.

**Clean up isEnabled vs ReadOnly** 
Since the enable state of the feature (with special cases on relation editor, value relation and external ressource) has been handled by two values, what can be done by one.

**Color or Text Editor** 
Fixing the color on TextEditor widget (has been always black before - is now gray on not edit state).

fixes #1123