### PR TITLE
Fix #1119 Button to edit geometry no longer available

### DIFF
--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -171,7 +171,7 @@ Rectangle {
 
     visible: stateMachine.state === "digitize"
              && ! selection.focusedGeometry.isNull
-             && ! selection.selectedLayer.customProperty( "QFieldSync/is_geometry_locked", false )
+             && ! selection.focusedLayer.customProperty( "QFieldSync/is_geometry_locked", false )
 
     anchors.right: editButton.left
 


### PR DESCRIPTION
Use the recently renamed `focusedLayer` instead of `selectedLayer`

Fixes #1119 