### PR TITLE
Revert "fix QML Connections: Implicitly defined onFoo properties in Connections are deprecated"

### DIFF
--- a/src/qml/CoordinateLocator.qml
+++ b/src/qml/CoordinateLocator.qml
@@ -116,7 +116,7 @@ Item {
 
     Connections {
       target: snappingUtils
-      function onSnappingResultChanged() {
+      onSnappingResultChanged: {
         crosshairCircle.border.color = overrideLocation == undefined ? ( snappingUtils.snappingResult.isValid ? "#9b59b6" : locator.color ) : "#AD1457"
         crosshairCircle.width = snappingUtils.snappingResult.isValid ? 32: 48
       }

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -141,7 +141,7 @@ Drawer {
         Connections {
           target: iface
 
-          function onLoadProjectEnded() {
+          onLoadProjectEnded: {
             mapThemeContainer.isLoading = true
             var themes = qgisProject.mapThemeCollection.mapThemes
             mapThemeComboBox.model = themes

--- a/src/qml/DigitizingToolbar.qml
+++ b/src/qml/DigitizingToolbar.qml
@@ -22,7 +22,7 @@ VisibilityFadingRow {
 
   Connections {
       target: rubberbandModel
-      function onVertexCountChanged() {
+      onVertexCountChanged: {
           // set geometry valid
           if ( Number( rubberbandModel ? rubberbandModel.geometryType : 0 ) === 0 )
           {

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -86,12 +86,12 @@ Page {
 
         Connections {
           target: master
-          function onReset(){ tabRow.currentIndex = 0 }
+          onReset: tabRow.currentIndex = 0
         }
 
         Connections {
           target: swipeView
-          function onCurrentIndexChanged(){ tabRow.currentIndex = swipeView.currentIndex }
+          onCurrentIndexChanged: tabRow.currentIndex = swipeView.currentIndex
         }
 
         Repeater {
@@ -184,7 +184,7 @@ Page {
 
             Connections {
               target: master
-              function onReset(){ content.contentY = 0 }
+              onReset: content.contentY = 0
             }
 
             model: SubModel {
@@ -299,7 +299,7 @@ Page {
 
         Connections {
           target: form
-          function onAboutToSave() {
+          onAboutToSave: {
             try {
               attributeEditorLoader.item.pushChanges()
             }
@@ -310,7 +310,7 @@ Page {
 
         Connections {
           target: attributeEditorLoader.item
-          function onValueChanged(value) {
+          onValueChanged: {
             if( AttributeValue != value && !( AttributeValue === undefined && isNull ) ) //do not compare AttributeValue and value with strict comparison operators
             {
               AttributeValue = isNull ? undefined : value
@@ -423,7 +423,7 @@ Page {
 
   Connections {
     target: Qt.inputMethod
-    function onVisibleChanged() {
+    onVisibleChanged: {
       Qt.inputMethod.commit()
     }
   }

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -419,7 +419,7 @@ Rectangle {
   Connections {
     target: globalFeaturesList.model
 
-    function onRowsInserted(parent, first, last) {
+    onRowsInserted: {
       if ( model.rowCount() > 0 ) {
         state = "FeatureList"
       } else {
@@ -428,7 +428,7 @@ Rectangle {
       }
     }
 
-    function onModelReset() {
+    onModelReset: {
       if ( model.rowCount() > 0 ) {
         state = "FeatureList"
       } else {
@@ -497,7 +497,7 @@ Rectangle {
   Connections {
     target: qgisProject
 
-    function onLayersWillBeRemoved(layerIds) {
+    onLayersWillBeRemoved: {
         if( state != "FeatureList" ) {
           if( featureListToolBar.state === "Edit"){
               featureForm.state = "FeatureForm"

--- a/src/qml/GeometryHighlighter.qml
+++ b/src/qml/GeometryHighlighter.qml
@@ -9,7 +9,7 @@ Item {
 
   Connections {
     target: geometryRenderer.geometryWrapper
-    function onQgsGeometryChanged() {
+    onQgsGeometryChanged: {
       timer.restart()
     }
   }

--- a/src/qml/GeometryRenderer.qml
+++ b/src/qml/GeometryRenderer.qml
@@ -21,7 +21,7 @@ Item {
   Connections {
     target: geometryWrapper
 
-    function onQgsGeometryChanged() {
+    onQgsGeometryChanged: {
       geometryComponent.sourceComponent = undefined
       if (geometryWrapper && geometryWrapper.qgsGeometry.type === QgsWkbTypes.PointGeometry) {
         geometryComponent.sourceComponent = pointHighlight

--- a/src/qml/LocationMarker.qml
+++ b/src/qml/LocationMarker.qml
@@ -92,7 +92,7 @@ Item {
 
   Connections {
     target: mapSettings
-    function onExtentChanged() {
+    onExtentChanged: {
       marker.location = mapSettings.coordinateToScreen( location )
       directionMarker.location = mapSettings.coordinateToScreen( location )
       directionMarker.direction = direction

--- a/src/qml/MessageLog.qml
+++ b/src/qml/MessageLog.qml
@@ -81,7 +81,7 @@ Page {
   Connections {
     target: model
 
-    function onRowsInserted(parent, first, last) {
+    onRowsInserted: {
       if ( !visible )
         unreadMessages = true
     }

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -195,7 +195,7 @@ Rectangle {
     Connections {
       target: selection
 
-      function onFocusedItemChanged()
+      onFocusedItemChanged:
       {
         editGeomButton.readOnly = selection.focusedLayer && selection.focusedLayer.readOnly
       }
@@ -228,7 +228,7 @@ Rectangle {
     Connections {
       target: selection
 
-      function onFocusedItemChanged()
+      onFocusedItemChanged:
       {
         editButton.readOnly = selection.focusedLayer && selection.focusedLayer.readOnly
       }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -998,7 +998,7 @@ ApplicationWindow {
     Connections {
         target: printMenu
 
-        function onEnablePrintItem(rows) {
+        onEnablePrintItem: {
           printItem.enabled = rows
         }
     }
@@ -1058,7 +1058,7 @@ ApplicationWindow {
     Connections {
       target: iface
 
-      function onLoadProjectEnded() {
+      onLoadProjectEnded: {
         layoutListInstantiator.model.project = qgisProject
         layoutListInstantiator.model.reloadModel()
         printMenu.enablePrintItem(layoutListInstantiator.model.rowCount())
@@ -1282,12 +1282,12 @@ ApplicationWindow {
     Connections {
       target: iface
 
-      function onLoadProjectStarted(path) {
+      onLoadProjectStarted: {
         busyMessageText.text = qsTr( "Loading Project: %1" ).arg( path )
         busyMessage.visible = true
       }
 
-      function onLoadProjectEnded() {
+      onLoadProjectEnded: {
         busyMessage.visible = false
         openProjectDialog.folder = qgisProject.homePath
         mapCanvasBackground.color = mapCanvas.mapSettings.backgroundColor
@@ -1353,7 +1353,7 @@ ApplicationWindow {
 
     Connections {
       target: iface
-      function onLoadProjectEnded() {
+      onLoadProjectEnded: {
         if( !qfieldAuthRequestHandler.handleLayerLogins() )
         {
           //project loaded without more layer handling needed
@@ -1364,7 +1364,7 @@ ApplicationWindow {
     Connections {
         target: iface
 
-        function onLoadProjectStarted(path) {
+        onLoadProjectStarted: {
           messageLogModel.suppressTags(["WFS","WMS"])
         }
     }
@@ -1372,13 +1372,13 @@ ApplicationWindow {
     Connections {
       target: qfieldAuthRequestHandler
 
-      function onShowLoginDialog(realm) {
+      onShowLoginDialog: {
         loginDialogPopup.realm = realm || ""
         badLayersView.visible = false
         loginDialogPopup.open()
       }
 
-      function onReloadEverything() {
+      onReloadEverything: {
         iface.reloadProject( qgisProject.fileName )
       }
     }
@@ -1682,7 +1682,7 @@ ApplicationWindow {
   Connections {
     target: welcomeScreen.__projectSource
 
-    function onProjectOpened(path) {
+    onProjectOpened: {
       iface.loadProject( path )
     }
   }
@@ -1702,3 +1702,4 @@ ApplicationWindow {
       isHovering: hoverHandler.hovered
   }
 }
+


### PR DESCRIPTION
Reverts opengisch/QField#1079

Should work stable on anyting between 5.12 and 5.15. 5.15 shows deprecation warnings.
Let's re-evaluate when Qt 6 is here and/or 5.12 is legacy.