### PR TITLE
Use the new multi-select feature to offer a better feature deletion UI/UX

### DIFF
--- a/src/core/multifeaturelistmodel.cpp
+++ b/src/core/multifeaturelistmodel.cpp
@@ -68,9 +68,24 @@ int MultiFeatureListModel::selectedCount() const
   return mSourceModel->selectedCount();
 }
 
+bool MultiFeatureListModel::canEditAttributesSelection()
+{
+  return mSourceModel->canEditAttributesSelection();
+}
+
+bool MultiFeatureListModel::canDeleteSelection()
+{
+  return mSourceModel->canDeleteSelection();
+}
+
 bool MultiFeatureListModel::deleteFeature( QgsVectorLayer *layer, QgsFeatureId fid )
 {
   return mSourceModel->deleteFeature( layer, fid );
+}
+
+bool MultiFeatureListModel::deleteSelection()
+{
+  return mSourceModel->deleteSelection();
 }
 
 void MultiFeatureListModel::toggleSelectedItem( int item )

--- a/src/core/multifeaturelistmodel.h
+++ b/src/core/multifeaturelistmodel.h
@@ -32,6 +32,8 @@ class MultiFeatureListModel : public QSortFilterProxyModel
     Q_PROPERTY( int count READ count NOTIFY countChanged )
     Q_PROPERTY( QList<QgsFeature> selectedFeatures READ selectedFeatures NOTIFY selectedCountChanged )
     Q_PROPERTY( int selectedCount READ selectedCount NOTIFY selectedCountChanged )
+    Q_PROPERTY( bool canEditAttributesSelection READ canEditAttributesSelection NOTIFY selectedCountChanged  )
+    Q_PROPERTY( bool canDeleteSelection READ canDeleteSelection NOTIFY selectedCountChanged  )
 
   public:
     enum FeatureListRoles
@@ -65,7 +67,13 @@ class MultiFeatureListModel : public QSortFilterProxyModel
 
     void checkSelectedCount();
 
+    bool canEditAttributesSelection();
+
+    bool canDeleteSelection();
+
     Q_INVOKABLE bool deleteFeature( QgsVectorLayer *layer, QgsFeatureId fid );
+
+    Q_INVOKABLE bool deleteSelection();
 
     void toggleSelectedItem( int item );
 

--- a/src/core/multifeaturelistmodel.h
+++ b/src/core/multifeaturelistmodel.h
@@ -67,12 +67,21 @@ class MultiFeatureListModel : public QSortFilterProxyModel
 
     void checkSelectedCount();
 
+    //! Returns TRUE if the selected features can have their attributes value changed
     bool canEditAttributesSelection();
 
+    //! Returns TRUE if the selected features can be deleted
     bool canDeleteSelection();
 
+    /**
+     * Deletes a feature from a vector layer
+     *
+     * \param layer The layer from which a feature will be removed
+     * \param fid The id of the feature to remove
+     */
     Q_INVOKABLE bool deleteFeature( QgsVectorLayer *layer, QgsFeatureId fid );
 
+    //! Deletes selected features
     Q_INVOKABLE bool deleteSelection();
 
     void toggleSelectedItem( int item );

--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -413,7 +413,7 @@ bool MultiFeatureListModelBase::deleteSelection()
 
   const QList< QPair< QgsVectorLayer *, QgsFeature > > selectedFeatures = mSelectedFeatures;
   bool isSuccess = false;
-  for ( auto pair : selectedFeatures )
+  for ( const auto pair : selectedFeatures )
   {
     isSuccess = deleteFeature( pair.first, pair.second.id(), true );
     if ( !isSuccess )

--- a/src/core/multifeaturelistmodelbase.h
+++ b/src/core/multifeaturelistmodelbase.h
@@ -63,7 +63,13 @@ class MultiFeatureListModelBase : public QAbstractItemModel
 
     int selectedCount() const;
 
-    bool deleteFeature( QgsVectorLayer *layer, QgsFeatureId fid );
+    bool canEditAttributesSelection();
+
+    bool canDeleteSelection();
+
+    bool deleteFeature( QgsVectorLayer *layer, QgsFeatureId fid, bool selectionDelete = false );
+
+    bool deleteSelection();
 
     void toggleSelectedItem( int item );
 

--- a/src/core/trackingmodel.cpp
+++ b/src/core/trackingmodel.cpp
@@ -117,7 +117,7 @@ bool TrackingModel::setData( const QModelIndex &index, const QVariant &value, in
   return true;
 }
 
-bool TrackingModel::featureInTracking( QgsVectorLayer *layer, QgsFeatureId featureId )
+bool TrackingModel::featureInTracking( QgsVectorLayer *layer, const QgsFeatureId featureId )
 {
   if ( trackerIterator( layer ) != mTrackers.constEnd() )
   {
@@ -134,10 +134,9 @@ bool TrackingModel::featuresInTracking( QgsVectorLayer *layer, const QList<QgsFe
   {
     int listIndex = trackerIterator( layer ) - mTrackers.constBegin();
     QgsFeatureId fid = mTrackers[ listIndex ]->feature().id();
-    for ( const QgsFeature &feature : features )
+    if ( std::any_of( features.begin(), features.end(), [fid]( const QgsFeature &f ) { return f.id() == fid; } ) )
     {
-      if ( feature.id() == fid )
-        return true;
+      return true;
     }
   }
   return false;

--- a/src/core/trackingmodel.cpp
+++ b/src/core/trackingmodel.cpp
@@ -117,7 +117,7 @@ bool TrackingModel::setData( const QModelIndex &index, const QVariant &value, in
   return true;
 }
 
-bool TrackingModel::featureInTracking( QgsVectorLayer *layer, const QgsFeatureId &featureId )
+bool TrackingModel::featureInTracking( QgsVectorLayer *layer, QgsFeatureId featureId )
 {
   if ( trackerIterator( layer ) != mTrackers.constEnd() )
   {
@@ -134,7 +134,7 @@ bool TrackingModel::featuresInTracking( QgsVectorLayer *layer, const QList<QgsFe
   {
     int listIndex = trackerIterator( layer ) - mTrackers.constBegin();
     QgsFeatureId fid = mTrackers[ listIndex ]->feature().id();
-    for ( auto feature : features )
+    for ( const QgsFeature &feature : features )
     {
       if ( feature.id() == fid )
         return true;

--- a/src/core/trackingmodel.cpp
+++ b/src/core/trackingmodel.cpp
@@ -128,6 +128,21 @@ bool TrackingModel::featureInTracking( QgsVectorLayer *layer, const QgsFeatureId
   return false;
 }
 
+bool TrackingModel::featuresInTracking( QgsVectorLayer *layer, const QList<QgsFeature> features )
+{
+  if ( trackerIterator( layer ) != mTrackers.constEnd() )
+  {
+    int listIndex = trackerIterator( layer ) - mTrackers.constBegin();
+    QgsFeatureId fid = mTrackers[ listIndex ]->feature().id();
+    for ( auto feature : features )
+    {
+      if ( feature.id() == fid )
+        return true;
+    }
+  }
+  return false;
+}
+
 bool TrackingModel::layerInTracking( QgsVectorLayer *layer )
 {
   return trackerIterator( layer ) != mTrackers.constEnd();

--- a/src/core/trackingmodel.cpp
+++ b/src/core/trackingmodel.cpp
@@ -117,7 +117,7 @@ bool TrackingModel::setData( const QModelIndex &index, const QVariant &value, in
   return true;
 }
 
-bool TrackingModel::featureInTracking( QgsVectorLayer *layer, const QgsFeatureId featureId )
+bool TrackingModel::featureInTracking( QgsVectorLayer *layer, const QgsFeatureId &featureId )
 {
   if ( trackerIterator( layer ) != mTrackers.constEnd() )
   {
@@ -128,7 +128,7 @@ bool TrackingModel::featureInTracking( QgsVectorLayer *layer, const QgsFeatureId
   return false;
 }
 
-bool TrackingModel::featuresInTracking( QgsVectorLayer *layer, const QList<QgsFeature> features )
+bool TrackingModel::featuresInTracking( QgsVectorLayer *layer, const QList<QgsFeature> &features )
 {
   if ( trackerIterator( layer ) != mTrackers.constEnd() )
   {

--- a/src/core/trackingmodel.h
+++ b/src/core/trackingmodel.h
@@ -62,9 +62,9 @@ class TrackingModel : public QAbstractItemModel
     //! sets the information that this \a layer is \a visible or not, means the tracking component should be as well
     Q_INVOKABLE void setLayerVisible( QgsVectorLayer *layer, bool visible );
     //! if the \a feature id is in a tracking session
-    Q_INVOKABLE bool featureInTracking( QgsVectorLayer *layer,  const QgsFeatureId featureId );
+    Q_INVOKABLE bool featureInTracking( QgsVectorLayer *layer,  const QgsFeatureId &featureId );
     //! if any of the \a features are in a tracking session
-    Q_INVOKABLE bool featuresInTracking( QgsVectorLayer *layer,  const QList<QgsFeature> features );
+    Q_INVOKABLE bool featuresInTracking( QgsVectorLayer *layer,  const QList<QgsFeature> &features );
     //! if the \a layer is in a tracking session
     Q_INVOKABLE bool layerInTracking( QgsVectorLayer *layer );
 

--- a/src/core/trackingmodel.h
+++ b/src/core/trackingmodel.h
@@ -62,9 +62,9 @@ class TrackingModel : public QAbstractItemModel
     //! sets the information that this \a layer is \a visible or not, means the tracking component should be as well
     Q_INVOKABLE void setLayerVisible( QgsVectorLayer *layer, bool visible );
     //! if the \a feature id is in a tracking session
-    Q_INVOKABLE bool featureInTracking( QgsVectorLayer *layer,  const QgsFeatureId &featureId );
+    Q_INVOKABLE bool featureInTracking( QgsVectorLayer *layer, QgsFeatureId featureId );
     //! if any of the \a features are in a tracking session
-    Q_INVOKABLE bool featuresInTracking( QgsVectorLayer *layer,  const QList<QgsFeature> &features );
+    Q_INVOKABLE bool featuresInTracking( QgsVectorLayer *layer, const QList<QgsFeature> &features );
     //! if the \a layer is in a tracking session
     Q_INVOKABLE bool layerInTracking( QgsVectorLayer *layer );
 

--- a/src/core/trackingmodel.h
+++ b/src/core/trackingmodel.h
@@ -61,8 +61,10 @@ class TrackingModel : public QAbstractItemModel
     Q_INVOKABLE void stopTracker( QgsVectorLayer *layer );
     //! sets the information that this \a layer is \a visible or not, means the tracking component should be as well
     Q_INVOKABLE void setLayerVisible( QgsVectorLayer *layer, bool visible );
-    //! if the \a feature is in a tracking session
+    //! if the \a feature id is in a tracking session
     Q_INVOKABLE bool featureInTracking( QgsVectorLayer *layer,  const QgsFeatureId featureId );
+    //! if any of the \a features are in a tracking session
+    Q_INVOKABLE bool featuresInTracking( QgsVectorLayer *layer,  const QList<QgsFeature> features );
     //! if the \a layer is in a tracking session
     Q_INVOKABLE bool layerInTracking( QgsVectorLayer *layer );
 

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -446,7 +446,7 @@ Rectangle {
     visible: false
 
     title: qsTr( "Delete feature(s)" )
-    text: qsTr( "Should the %1 selected feature(s) really be deleted?" ).arg( selectedCount )
+    text: qsTr( "Should the %n feature(s) selected really be deleted?", "0", selectedCount )
     standardButtons: StandardButton.Ok | StandardButton.Cancel
     onAccepted: {
       if ( isDeleted ) {
@@ -456,9 +456,9 @@ Rectangle {
       isDeleted = featureForm.model.deleteSelection()
 
       if ( isDeleted ) {
-        displayToast( qsTr( "Successfully deleted %1 selected feature(s)" ) ).arg( selectedCount )
+        displayToast( qsTr( "Successfully deleted %n feature(s)", "", selectedCount ) );
       } else {
-        displayToast( qsTr( "Failed to delete %1 selected featur(s)" ) ).arg( selectedCount )
+        displayToast( qsTr( "Failed to delete %n feature(s)", "", selectedCount ) );
       }
 
       visible = false

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -334,7 +334,6 @@ Rectangle {
     enabled: ( stateMachine.state === "digitize" && toolBar.model && toolBar.model.canDeleteSelection )
 
     onClicked: {
-      console.log('ddd');
       multiDeleteClicked();
     }
 

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -25,7 +25,7 @@ Rectangle {
   id: toolBar
 
   property string currentName: ''
-  property bool showEditButtons
+  property bool allowDelete
   property MultiFeatureListModel model
   property FeatureListModelSelection selection
   property FeaturelistExtentController extentController
@@ -36,6 +36,7 @@ Rectangle {
   signal save
   signal cancel
   signal multiEditClicked
+  signal multiDeleteClicked
 
   anchors.top:parent.top
   anchors.left: parent.left
@@ -296,17 +297,15 @@ Rectangle {
   QfToolButton {
     id: multiEditButton
 
-    property bool readOnly: false
+    anchors.right: multiDeleteButton.left
 
-    anchors.right: parent.right
-
-    width: ( !readOnly && parent.state == "Indication" && toolBar.model && toolBar.model.selectedCount > 1 ? 48: 0 )
+    width: ( parent.state == "Indication" && toolBar.model && toolBar.model.canEditAttributesSelection && toolBar.model.selectedCount > 1 ? 48: 0 )
     height: 48
     clip: true
 
     iconSource: Theme.getThemeIcon( "ic_edit_attributes_white" )
 
-    enabled: ( toolBar.model && toolBar.model.selectedCount )
+    enabled: ( toolBar.model && toolBar.model.canEditAttributesSelection && toolBar.model.selectedCount > 1 )
 
     onClicked: {
       multiEditClicked();
@@ -317,13 +316,31 @@ Rectangle {
         easing.type: Easing.InQuart
       }
     }
+  }
 
-    Connections {
-      target: selection
+  QfToolButton {
+    id: multiDeleteButton
 
-      onFocusedItemChanged:
-      {
-        multiEditButton.readOnly = selection.focusedLayer && selection.focusedLayer.readOnly
+    property bool readOnly: false
+
+    anchors.right: parent.right
+
+    width: ( stateMachine.state === "digitize" && parent.state == "Indication" && toolBar.model && toolBar.model.canDeleteSelection ? 48: 0 )
+    height: 48
+    clip: true
+
+    iconSource: Theme.getThemeIcon( "ic_delete_forever_white_24dp" )
+
+    enabled: ( stateMachine.state === "digitize" && toolBar.model && toolBar.model.canDeleteSelection )
+
+    onClicked: {
+      console.log('ddd');
+      multiDeleteClicked();
+    }
+
+    Behavior on width {
+      PropertyAnimation {
+        easing.type: Easing.InQuart
       }
     }
   }


### PR DESCRIPTION
This PR updates QField's feature deletion UI/UX by relying on multi-selection. A GIF:
![Peek 2020-07-18 16-38](https://user-images.githubusercontent.com/1728657/87849756-4ce82580-c915-11ea-84ca-aeed98b92f56.gif)

There as several advantages to this:
- obvious one: we can delete more than one feature at a time :tada: 
- reduces accidental deletion triggering by putting this behind a long press action
- reduces the visual clutteredness of the list by avoiding a repetition of the delete button
- makes the UI/UX matches what has become the normal on smartphones (i.e. long press to activate selection and deletion)