### PR TITLE
Increase the touch-only hoverhandler timer to avoid location marker jumping around

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -175,7 +175,7 @@ ApplicationWindow {
 
     Timer {
         id: resetIsBeingTouchedTimer
-        interval: 100
+        interval: 750
         repeat: false
 
         onTriggered: {


### PR DESCRIPTION
Increase the touch-only hoverhandler timer to avoid location marker jumping around when slowly dragging finger on the screen.

@m-kuhn , as discussed.