### PR TITLE
Calculate APP_VERSION_CODE with number of commits instead of datetime

### DIFF
--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -21,17 +21,17 @@ if [[ -n ${CI_TAG} ]]; then
 
 elif [[ ${CI_PULL_REQUEST} = false ]]; then
   ARCH_NUMBER=$(arch_to_build_number ${ARCH})
-  # DATE as YYYY DDD HH MM (without spaces)
-  CUR_DATE=$(date +%Y%j%H%M)
+  # get numbers of masters commits
+  NUMBER_OF_COMMITS=$(curl -I -k "https://api.github.com/repos/opengisch/QField/commits?per_page=1&sha=${CURRENT_COMMIT}" | sed -n '/^[Ll]ink:/ s/.*"next".*page=\([0-9]*\).*"last".*/\1/p')
   echo "Building dev (nightly)"
   export APP_NAME="QField Dev"
   export PKG_NAME="qfield_dev"
   export APP_ICON="qfield_logo_beta"
   export APP_VERSION=""
-  # remove first 3 digits of the year (so YDDDHHMM) + arch
-  #        YDDDHHMMA
+  # take 0193 + number of masters commits + arch
+  # 0193 has no meaning - it's just where we had to start
   # max = 2100000000
-  export APP_VERSION_CODE=${CUR_DATE:3:8}${ARCH_NUMBER}
+  export APP_VERSION_CODE=0193${NUMBER_OF_COMMITS}${ARCH_NUMBER}
   export APP_VERSION_STR="${LAST_TAG}-dev (commit ${CURRENT_COMMIT})"
 
 else

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -31,7 +31,7 @@ elif [[ ${CI_PULL_REQUEST} = false ]]; then
   # take 0 + (1930000 + number of masters commits) + arch
   # 01930000 has no meaning - it's just where we had to start
   # max = 2100000000
-  export APP_VERSION_CODE=0$((1930000+${NUMBER_OF_COMMITS}))${ARCH_NUMBER}
+  export APP_VERSION_CODE=0$((1930000+NUMBER_OF_COMMITS))${ARCH_NUMBER}
   export APP_VERSION_STR="${LAST_TAG}-dev (commit ${CURRENT_COMMIT})"
 
 else

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -28,10 +28,10 @@ elif [[ ${CI_PULL_REQUEST} = false ]]; then
   export PKG_NAME="qfield_dev"
   export APP_ICON="qfield_logo_beta"
   export APP_VERSION=""
-  # take 0193 + number of masters commits + arch
-  # 0193 has no meaning - it's just where we had to start
+  # take 0 + (1930000 + number of masters commits) + arch
+  # 01930000 has no meaning - it's just where we had to start
   # max = 2100000000
-  export APP_VERSION_CODE=0193${NUMBER_OF_COMMITS}${ARCH_NUMBER}
+  export APP_VERSION_CODE=0$((1930000+${NUMBER_OF_COMMITS}))${ARCH_NUMBER}
   export APP_VERSION_STR="${LAST_TAG}-dev (commit ${CURRENT_COMMIT})"
 
 else


### PR DESCRIPTION
Current calculation:
It takes the last digit of the current year (Y) = 0
It takes the day of the year (DDD) = 202
It takes the hour of the day (HH) = 12
It takes the minutes of the hour (MM) = 22
It takes the arch nr = 1

equals 020212221 - that's bad.

Since we have today the 202 day of the year the check to be lower than 20000000 blocked the build (because we don't want to come too close to the maximum 2100000000)

It's not so good to use the date as version, so in this PR it replaces it with the number of the masters commits: 2523

Current version number is 019309501

I suggest to go on with 0193 2523 1

So we have the abstract number 0193 then the commit number and then the arch number.