### PR TITLE
Add support for filtering in value relations + cascading dependency support

### DIFF
--- a/src/core/featurelistmodel.cpp
+++ b/src/core/featurelistmodel.cpp
@@ -185,6 +185,9 @@ void FeatureListModel::processReloadLayer()
 
   request.setSubsetOfAttributes( referencedColumns, fields );
 
+  if ( ! mFilterExpression.isEmpty() )
+    request.setFilterExpression( mFilterExpression );
+
   int keyIndex = fields.indexOf( mKeyField );
   int displayValueIndex = fields.indexOf( mDisplayValueField );
 
@@ -258,4 +261,19 @@ void FeatureListModel::setOrderByValue( bool orderByValue )
   mOrderByValue = orderByValue;
   reloadLayer();
   emit orderByValueChanged();
+}
+
+QString FeatureListModel::filterExpression() const
+{
+  return mFilterExpression;
+}
+
+void FeatureListModel::setFilterExpression( const QString &filterExpression )
+{
+  if ( mFilterExpression == filterExpression )
+    return;
+
+  mFilterExpression = filterExpression;
+  reloadLayer();
+  emit filterExpressionChanged();
 }

--- a/src/core/featurelistmodel.cpp
+++ b/src/core/featurelistmodel.cpp
@@ -17,6 +17,8 @@
 #include "qgsvectorlayer.h"
 
 #include <qgsproject.h>
+#include <qgsexpressioncontextutils.h>
+#include <qgsvaluerelationfieldformatter.h>
 
 FeatureListModel::FeatureListModel( QObject *parent )
   : QAbstractItemModel( parent )
@@ -185,8 +187,20 @@ void FeatureListModel::processReloadLayer()
 
   request.setSubsetOfAttributes( referencedColumns, fields );
 
-  if ( ! mFilterExpression.isEmpty() )
+  if ( ! mFilterExpression.isEmpty()
+       && ( ! QgsValueRelationFieldFormatter::expressionRequiresFormScope( mFilterExpression )
+            || QgsValueRelationFieldFormatter::expressionIsUsable( mFilterExpression, mCurrentFormFeature )
+          ) )
+  {
+    QgsExpression exp( mFilterExpression );
+    QgsExpressionContext filterContext = QgsExpressionContext( QgsExpressionContextUtils::globalProjectLayerScopes( mCurrentLayer ) );
+
+    if ( mCurrentFormFeature.isValid( ) && QgsValueRelationFieldFormatter::expressionRequiresFormScope( mFilterExpression ) )
+      filterContext.appendScope( QgsExpressionContextUtils::formScope( mCurrentFormFeature ) );
+
+    request.setExpressionContext( filterContext );
     request.setFilterExpression( mFilterExpression );
+  }
 
   int keyIndex = fields.indexOf( mKeyField );
   int displayValueIndex = fields.indexOf( mDisplayValueField );
@@ -276,4 +290,19 @@ void FeatureListModel::setFilterExpression( const QString &filterExpression )
   mFilterExpression = filterExpression;
   reloadLayer();
   emit filterExpressionChanged();
+}
+
+QgsFeature FeatureListModel::currentFormFeature() const
+{
+  return mCurrentFormFeature;
+}
+
+void FeatureListModel::setCurrentFormFeature( const QgsFeature &feature )
+{
+  if ( mCurrentFormFeature == feature )
+    return;
+
+  mCurrentFormFeature = feature;
+  reloadLayer();
+  emit currentFormFeatureChanged();
 }

--- a/src/core/featurelistmodel.h
+++ b/src/core/featurelistmodel.h
@@ -19,8 +19,9 @@
 #include <QAbstractItemModel>
 #include <QTimer>
 
+#include <qgsfeature.h>
+
 class QgsVectorLayer;
-class QgsFeature;
 
 /**
  * Provides access to a list of features from a layer.
@@ -59,6 +60,11 @@ class FeatureListModel : public QAbstractItemModel
       * Expression to filter features with. Empty string if no filter is applied.
       */
     Q_PROPERTY( QString filterExpression READ filterExpression WRITE setFilterExpression NOTIFY filterExpressionChanged )
+
+    /**
+      * The current form feature, used to evaluate expressions such as `current_value('attr1')`
+      **/
+    Q_PROPERTY( QgsFeature currentFormFeature READ currentFormFeature WRITE setCurrentFormFeature NOTIFY currentFormFeatureChanged )
 
   public:
     enum FeatureListRoles
@@ -125,6 +131,16 @@ class FeatureListModel : public QAbstractItemModel
      */
     void setFilterExpression( const QString &filterExpression );
 
+    /**
+     * The current form feature, used to evaluate expressions such as `current_value('attr1')`
+     */
+    QgsFeature currentFormFeature() const;
+
+    /**
+     * Sets the current form feature, used to evaluate expressions such as `current_value('attr1')`
+     */
+    void setCurrentFormFeature( const QgsFeature &feature );
+
   signals:
     void currentLayerChanged();
     void keyFieldChanged();
@@ -132,6 +148,7 @@ class FeatureListModel : public QAbstractItemModel
     void orderByValueChanged();
     void addNullChanged();
     void filterExpressionChanged();
+    void currentFormFeatureChanged();
 
   private slots:
     void onFeatureAdded();
@@ -173,6 +190,7 @@ class FeatureListModel : public QAbstractItemModel
     bool mOrderByValue = false;
     bool mAddNull = false;
     QString mFilterExpression;
+    QgsFeature mCurrentFormFeature;
 
     QTimer mReloadTimer;
 };

--- a/src/core/featurelistmodel.h
+++ b/src/core/featurelistmodel.h
@@ -45,8 +45,14 @@ class FeatureListModel : public QAbstractItemModel
        */
     Q_PROPERTY( QString displayValueField READ displayValueField WRITE setDisplayValueField NOTIFY displayValueFieldChanged )
 
+    /**
+      * Whether the features should be ordered by value
+      */
     Q_PROPERTY( bool orderByValue READ orderByValue WRITE setOrderByValue NOTIFY orderByValueChanged )
 
+    /**
+      * Whether a null values is allowed in the list
+      */
     Q_PROPERTY( bool addNull READ addNull WRITE setAddNull NOTIFY addNullChanged )
 
     /**
@@ -123,8 +129,8 @@ class FeatureListModel : public QAbstractItemModel
     void currentLayerChanged();
     void keyFieldChanged();
     void displayValueFieldChanged();
-    void addNullChanged();
     void orderByValueChanged();
+    void addNullChanged();
     void filterExpressionChanged();
 
   private slots:

--- a/src/core/featurelistmodel.h
+++ b/src/core/featurelistmodel.h
@@ -20,6 +20,7 @@
 #include <QTimer>
 
 class QgsVectorLayer;
+class QgsFeature;
 
 /**
  * Provides access to a list of features from a layer.
@@ -47,6 +48,11 @@ class FeatureListModel : public QAbstractItemModel
     Q_PROPERTY( bool orderByValue READ orderByValue WRITE setOrderByValue NOTIFY orderByValueChanged )
 
     Q_PROPERTY( bool addNull READ addNull WRITE setAddNull NOTIFY addNullChanged )
+
+    /**
+      * Expression to filter features with. Empty string if no filter is applied.
+      */
+    Q_PROPERTY( QString filterExpression READ filterExpression WRITE setFilterExpression NOTIFY filterExpressionChanged )
 
   public:
     enum FeatureListRoles
@@ -103,12 +109,23 @@ class FeatureListModel : public QAbstractItemModel
        */
     void setAddNull( bool addNull );
 
+    /**
+     * Expression to filter features with. Empty string if no filter is applied.
+     */
+    QString filterExpression() const;
+
+    /**
+     * Sets an expression to filter features with. Empty string if no filter is applied.
+     */
+    void setFilterExpression( const QString &filterExpression );
+
   signals:
     void currentLayerChanged();
     void keyFieldChanged();
     void displayValueFieldChanged();
     void addNullChanged();
     void orderByValueChanged();
+    void filterExpressionChanged();
 
   private slots:
     void onFeatureAdded();
@@ -149,6 +166,7 @@ class FeatureListModel : public QAbstractItemModel
     QString mDisplayValueField;
     bool mOrderByValue = false;
     bool mAddNull = false;
+    QString mFilterExpression;
 
     QTimer mReloadTimer;
 };

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -14,6 +14,7 @@ Page {
   signal confirmed
   signal cancelled
   signal temporaryStored
+  signal valueChanged(var field, var oldValue, var newValue)
   signal aboutToSave
 
   property AttributeFormModel model
@@ -300,11 +301,15 @@ Page {
         Connections {
           target: form
           onAboutToSave: {
-            try {
-              attributeEditorLoader.item.pushChanges()
+            // it may not be implemented
+            if ( attributeEditorLoader.item.pushChanges ) {
+              attributeEditorLoader.item.pushChanges( form.model.featureModel.feature )
             }
-            catch ( err )
-            {}
+          }
+          onValueChanged: (field, oldValue, newValue) => {
+            // it may not be implemented
+            if ( attributeEditorLoader.item.siblingValueChanged )
+              attributeEditorLoader.item.siblingValueChanged( field, form.model.featureModel.feature )
           }
         }
 
@@ -313,7 +318,11 @@ Page {
           onValueChanged: {
             if( AttributeValue != value && !( AttributeValue === undefined && isNull ) ) //do not compare AttributeValue and value with strict comparison operators
             {
+              var oldValue = AttributeValue
               AttributeValue = isNull ? undefined : value
+
+              valueChanged(Field, oldValue, AttributeValue)
+
               if ( qfieldSettings.autoSave && !dontSave ) {
                 // indirect action, no need to check for success and display a toast, the log is enough
                 save()

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -30,6 +30,7 @@ Item {
       displayValueField: config['Value']
       addNull: config['AllowNull']
       orderByValue: config['OrderByValue']
+      filterExpression: config['FilterExpression']
     }
   }
 
@@ -58,6 +59,7 @@ Item {
         displayValueField: config['Value']
         addNull: config['AllowNull']
         orderByValue: config['OrderByValue']
+        filterExpression: config['FilterExpression']
         onListUpdated: {
           valueRelation.valueChanged( attributeValue, false )
         }

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -148,5 +148,9 @@ Item {
       }
     }
   }
+
+  function siblingValueChanged(field, feature) {
+    featureListModel.currentFormFeature = feature
+  }
 }
 


### PR DESCRIPTION
Value relations now support filtering the values with filter expression. What is more, cascading dependencies (e.g. using `current_value('attr1')` are also supported.

![Peek 2020-07-22 21-46](https://user-images.githubusercontent.com/2820439/88215824-e6407000-cc64-11ea-8541-c2e65bb35d12.gif)


Fixes https://github.com/opengisch/QField/issues/436