### PR TITLE
Multi selection UI/UX improvements

### DIFF
--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -80,7 +80,7 @@ void FeatureModel::setFeatures( const QList<QgsFeature> &features )
         const int attributeIndex;
         const QgsFeature &feature;
         AttributeNotEqual( const QgsFeature &feature, int attributeIndex ) : attributeIndex( attributeIndex ), feature( feature ) {}
-        bool operator()( const QgsFeature &f) const { return feature.attributes().at( attributeIndex ) != f.attributes().at( attributeIndex ); }
+        bool operator()( const QgsFeature &f) const { return f.attributes().size() > attributeIndex && feature.attributes().at( attributeIndex ) != f.attributes().at( attributeIndex ); }
       };
 
       if ( std::any_of( mFeatures.begin(), mFeatures.end(), AttributeNotEqual( mFeature, i ) ) )

--- a/src/core/multifeaturelistmodel.cpp
+++ b/src/core/multifeaturelistmodel.cpp
@@ -58,6 +58,12 @@ void MultiFeatureListModel::clear( const bool keepSelected )
   mSourceModel->clear( keepSelected );
 }
 
+void MultiFeatureListModel::clearSelection()
+{
+  mFilterLayer = nullptr;
+  mSourceModel->clearSelection();
+}
+
 int MultiFeatureListModel::count() const
 {
   return mSourceModel->count();

--- a/src/core/multifeaturelistmodel.h
+++ b/src/core/multifeaturelistmodel.h
@@ -61,6 +61,8 @@ class MultiFeatureListModel : public QSortFilterProxyModel
 
     Q_INVOKABLE void clear( const bool keepSelected = false );
 
+    Q_INVOKABLE void clearSelection();
+
     int count() const;
 
     int selectedCount() const;

--- a/src/core/multifeaturelistmodel.h
+++ b/src/core/multifeaturelistmodel.h
@@ -52,19 +52,34 @@ class MultiFeatureListModel : public QSortFilterProxyModel
     explicit MultiFeatureListModel( QObject *parent = nullptr );
 
     /**
-     * @brief setFeatures
-     * @param requests
+     * Resets the model to contain features found from a list of \a requests.
      */
     void setFeatures( const QMap<QgsVectorLayer *, QgsFeatureRequest> requests );
 
+    /**
+     * Appends features from a list of \a results.
+     */
     void appendFeatures( const QList<IdentifyTool::IdentifyResult> &results );
 
+    /**
+     * Resets the model to either an empty feature list or one that contains only the selected features.
+     * \param keepSelected if set to TRUE, selected features will be kept when resetting the model.
+     */
     Q_INVOKABLE void clear( const bool keepSelected = false );
 
+    /**
+     * Empties the list of selected features.
+     */
     Q_INVOKABLE void clearSelection();
 
+    /**
+     * Returns the number of features in the model.
+     */
     int count() const;
 
+    /**
+     * Returns the number of selected features in the model.
+     */
     int selectedCount() const;
 
     void checkSelectedCount();

--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -79,8 +79,12 @@ void MultiFeatureListModelBase::appendFeatures( const QList<IdentifyTool::Identi
       }
     }
   }
-
   endInsertRows();
+
+  if ( !mSelectedFeatures.isEmpty() )
+  {
+    emit selectedCountChanged();
+  }
 }
 
 void MultiFeatureListModelBase::clear( const bool keepSelected )
@@ -100,6 +104,17 @@ void MultiFeatureListModelBase::clear( const bool keepSelected )
     mSelectedFeatures.clear();
   }
   endResetModel();
+}
+
+void MultiFeatureListModelBase::clearSelection()
+{
+  if ( mSelectedFeatures.isEmpty() )
+  {
+    return;
+  }
+
+  mSelectedFeatures.clear();
+  emit selectedCountChanged();
 }
 
 void MultiFeatureListModelBase::toggleSelectedItem( int item )

--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -72,6 +72,11 @@ void MultiFeatureListModelBase::appendFeatures( const QList<IdentifyTool::Identi
       connect( layer, &QObject::destroyed, this, &MultiFeatureListModelBase::layerDeleted, Qt::UniqueConnection );
       connect( layer, &QgsVectorLayer::featureDeleted, this, &MultiFeatureListModelBase::featureDeleted, Qt::UniqueConnection );
       connect( layer, &QgsVectorLayer::attributeValueChanged, this, &MultiFeatureListModelBase::attributeValueChanged, Qt::UniqueConnection );
+
+      if ( !mSelectedFeatures.isEmpty() )
+      {
+        mSelectedFeatures.append( QPair<QgsVectorLayer *, QgsFeature>( layer, result.feature ) );
+      }
     }
   }
 

--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -68,15 +68,23 @@ void MultiFeatureListModelBase::appendFeatures( const QList<IdentifyTool::Identi
     QPair<QgsVectorLayer *, QgsFeature> item( layer, result.feature );
     if ( !mFeatures.contains( item ) )
     {
-      mFeatures.append( QPair<QgsVectorLayer *, QgsFeature>( layer, result.feature ) );
+      mFeatures.append( item );
       connect( layer, &QObject::destroyed, this, &MultiFeatureListModelBase::layerDeleted, Qt::UniqueConnection );
       connect( layer, &QgsVectorLayer::featureDeleted, this, &MultiFeatureListModelBase::featureDeleted, Qt::UniqueConnection );
       connect( layer, &QgsVectorLayer::attributeValueChanged, this, &MultiFeatureListModelBase::attributeValueChanged, Qt::UniqueConnection );
 
       if ( !mSelectedFeatures.isEmpty() )
       {
-        mSelectedFeatures.append( QPair<QgsVectorLayer *, QgsFeature>( layer, result.feature ) );
+        mSelectedFeatures.append( item );
       }
+    }
+    else if ( mSelectedFeatures.size() > 1 && mSelectedFeatures.contains( item ) )
+    {
+      int row = mFeatures.indexOf( item );
+      mSelectedFeatures.removeAll( item );
+
+      QModelIndex index = createIndex( row, 0 );
+      emit dataChanged( index, index, QVector<int>() << MultiFeatureListModel::FeatureSelectedRole );
     }
   }
   endInsertRows();

--- a/src/core/multifeaturelistmodelbase.h
+++ b/src/core/multifeaturelistmodelbase.h
@@ -42,6 +42,8 @@ class MultiFeatureListModelBase : public QAbstractItemModel
 
     void clear( const bool keepSelected = false );
 
+    void clearSelection();
+
     QHash<int, QByteArray> roleNames() const override;
     QModelIndex index( int row, int column, const QModelIndex &parent = QModelIndex() ) const override;
     QModelIndex parent( const QModelIndex &child ) const override;

--- a/src/core/multifeaturelistmodelbase.h
+++ b/src/core/multifeaturelistmodelbase.h
@@ -33,15 +33,24 @@ class MultiFeatureListModelBase : public QAbstractItemModel
     explicit MultiFeatureListModelBase( QObject *parent = nullptr );
 
     /**
-     * @brief setFeatures
-     * @param requests
+     * Resets the model to contain features found from a list of \a requests.
      */
     void setFeatures( const QMap<QgsVectorLayer *, QgsFeatureRequest> requests );
 
+    /**
+     * Appends features from a list of \a results.
+     */
     void appendFeatures( const QList<IdentifyTool::IdentifyResult> &results );
 
+    /**
+     * Resets the model to either an empty feature list or one that contains only the selected features.
+     * \param keepSelected if set to TRUE, selected features will be kept when resetting the model.
+     */
     void clear( const bool keepSelected = false );
 
+    /**
+     * Empties the list of selected features.
+     */
     void clearSelection();
 
     QHash<int, QByteArray> roleNames() const override;
@@ -61,8 +70,14 @@ class MultiFeatureListModelBase : public QAbstractItemModel
      */
     virtual bool removeRows( int row, int count, const QModelIndex &parent ) override;
 
+    /**
+     * Returns the number of features in the model.
+     */
     int count() const;
 
+    /**
+     * Returns the number of selected features in the model.
+     */
     int selectedCount() const;
 
     bool canEditAttributesSelection();

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -163,11 +163,14 @@ Rectangle {
       }
     }
 
-    delegate: Item {
+    add: Transition {
+        ColorAnimation { property: "color"; to: "#00FFFFFF"; duration: 400 }
+        PropertyAction { property: "color"; value: Theme.mainColor }
+    }
+
+    delegate: Rectangle {
       anchors { left: parent.left; right: parent.right }
-
       focus: true
-
       height: Math.max( 48, featureText.height )
 
       CheckBox {

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -164,7 +164,7 @@ Rectangle {
     }
 
     add: Transition {
-        ColorAnimation { property: "color"; to: "#00FFFFFF"; duration: 400 }
+        ColorAnimation { property: "color"; to: "#00FFFFFF"; duration: 250 }
         PropertyAction { property: "color"; value: Theme.mainColor }
     }
 

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -295,6 +295,30 @@ Rectangle {
   }
 
   QfToolButton {
+    id: multiClearButton
+
+    anchors.left: parent.left
+
+    width: ( parent.state == "Indication" && toolBar.model && toolBar.model.selectedCount > 0  ? 48: 0 )
+    height: 48
+    clip: true
+
+    iconSource: Theme.getThemeIcon( "ic_chevron_left_white_24dp" )
+
+    enabled: ( toolBar.model && toolBar.model.selectedCount > 0 )
+
+    onClicked: {
+      toolBar.model.clearSelection();
+    }
+
+    Behavior on width {
+      PropertyAnimation {
+        easing.type: Easing.InQuart
+      }
+    }
+  }
+
+  QfToolButton {
     id: multiEditButton
 
     anchors.right: multiDeleteButton.left

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -303,7 +303,7 @@ Rectangle {
     height: 48
     clip: true
 
-    iconSource: Theme.getThemeIcon( "ic_chevron_left_white_24dp" )
+    iconSource: Theme.getThemeIcon( "ic_clear_white_24dp" )
 
     enabled: ( toolBar.model && toolBar.model.selectedCount > 0 )
 


### PR DESCRIPTION
This PR further refines the UI/UX of the feature list's multi selection mode. First, zhe GIF:
![Peek 2020-07-25 14-15](https://user-images.githubusercontent.com/1728657/88451515-722ee380-ce81-11ea-99d5-d8d1c9775d1a.gif)

- When feature(s) is/are selected, tap on the canvas to identify additional features will have those newly identified features selected by default
- When feature(s) is/are selected, a new 'clear selection' button appears in the left end of the navigation bar, allows someone to exit the multi selection mode without having to uncheck all features

The PR also fixes a crasher.