### PR TITLE
More search bar UI/UX improvements

### DIFF
--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -85,7 +85,7 @@ Rectangle {
       StateChangeScript {
         script: {
           show()
-          locatorItem.searching = false
+          locatorItem.state = "off"
           if( featureFormList.state === "Edit" ){
             ///e.g. tip on the canvas during an edit
             featureFormList.confirm()

--- a/src/qml/LocatorItem.qml
+++ b/src/qml/LocatorItem.qml
@@ -87,13 +87,17 @@ Item {
     sourceSize.height: 20 * screen.devicePixelRatio
     fillMode: Image.PreserveAspectFit
     anchors.centerIn: busyIndicator
+    opacity: searchField.text.length > 0 ? 1 : 0.25
     visible: locatorItem.searching
 
     MouseArea {
       anchors.fill: parent
       onClicked: {
-        locatorItem.searching = false
-        searchField.text = '';
+        if (searchField.text.length > 0) {
+          searchField.text = '';
+        } else {
+          locatorItem.searching = false
+        }
       }
     }
   }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -234,8 +234,8 @@ ApplicationWindow {
       anchors.fill: parent
 
       onClicked:  {
-          if (locatorItem.searching) {
-              locatorItem.searching = false
+          if (locatorItem.state == "on") {
+              locatorItem.state = "off"
           }
           else if (geometryEditorsToolbar.canvasClicked(point)) {
             // for instance, the vertex editor will select a vertex if possible
@@ -585,7 +585,7 @@ ApplicationWindow {
 
   DropShadow {
     anchors.fill: locatorItem
-    visible: locatorItem.searching
+    visible: locatorItem.searchFieldVisible
     verticalOffset: 2
     radius: 10
     samples: 17


### PR DESCRIPTION
This PR further improves the search bar experience by:
- Tweaking the clear button so that it will _only_ clear the search bar text input if that has text entered vs. clear and closing bar at the same time. If the user click on the X when there is no text entered, the search bar will then close.
- Super nice animation on bar _closing_ (we were only animating the bar showing).

GIF of animation on search bar closing:
![Peek 2020-08-02 12-28](https://user-images.githubusercontent.com/1728657/89116227-b2aee280-d4bb-11ea-9132-3b48f3ec4e0c.gif)
