### PR TITLE
Show multiline widget also in r/o mode

### DIFF
--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -79,7 +79,8 @@ Item {
   TextArea {
     id: textArea
     height: config['IsMultiline'] === true ? undefined : 0
-    visible: height !== 0 && isEnabled
+    visible: height !== 0
+    enabled: isEnabled
     anchors.left: parent.left
     anchors.right: parent.right
     wrapMode: Text.Wrap


### PR DESCRIPTION
Fixes #1212

While the single line edit is replace with a label in r/o mode, the multiline one is is just not editable.