### PR TITLE
Value Relation Polishing

### DIFF
--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -81,11 +81,14 @@ Item {
       }
 
       contentItem: Text {
-        height: 36
+        id: textLabel
+        height: fontMetrics.height + 20
         text: comboBox.displayText
+        font: Theme.defaultFont
         horizontalAlignment: Text.AlignLeft
         verticalAlignment: Text.AlignVCenter
         elide: Text.ElideRight
+        color: value === undefined || !enabled ? 'gray' : 'black'
       }
 
       background: Item {
@@ -93,9 +96,17 @@ Item {
         implicitHeight: 36
 
         Rectangle {
+          y: textLabel.height - 8
+          width: comboBox.width
+          height: comboBox.activeFocus ? 2 : 1
+          color: comboBox.activeFocus ? "#4CAF50" : "#C8E6C9"
+        }
+
+        Rectangle {
+          visible: enabled
           anchors.fill: parent
           id: backgroundRect
-          border.color: comboBox.pressed ? "#17a81a" : "#21be2b"
+          border.color: comboBox.pressed ? "#4CAF50" : "#C8E6C9"
           border.width: comboBox.visualFocus ? 2 : 1
           color: Theme.lightGray
           radius: 2

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -21,6 +21,7 @@ Item {
     id: valueRelationCombobox
     visible: !config['AllowMulti']
     property var _relation: undefined
+    enabled: isEnabled
 
     FeatureListModel {
       id: featureListModel


### PR DESCRIPTION
This backport slipped through the cracks
This fixes an issue in 1.6 where comboboxes are editable even when the attribute form is not in edit mode

See #1154