### PR TITLE
QField 💖 QML & HTML

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ IF (ANDROID)
   ADD_CUSTOM_TARGET(assets ALL DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/android-build/assets/assets.zip")
 ENDIF (ANDROID)
 
-FIND_PACKAGE(Qt5 COMPONENTS Test Concurrent Core Qml Gui Xml Positioning Widgets PrintSupport Network Quick Svg OpenGL Sql PrintSupport Sensors REQUIRED)
+FIND_PACKAGE(Qt5 COMPONENTS Test Concurrent Core Qml Gui Xml Positioning Widgets PrintSupport Network Quick Svg OpenGL Sql PrintSupport Sensors WebView REQUIRED)
 
 ADD_SUBDIRECTORY(3rdparty/tessellate)
 ADD_SUBDIRECTORY(src/qgsquick)

--- a/sdk.conf
+++ b/sdk.conf
@@ -1,1 +1,1 @@
-osgeo4a_version=newmodules
+osgeo4a_version=20200820

--- a/sdk.conf
+++ b/sdk.conf
@@ -1,1 +1,1 @@
-osgeo4a_version=20200818
+osgeo4a_version=newmodules

--- a/src/app/app.pro
+++ b/src/app/app.pro
@@ -7,7 +7,7 @@ include( ../../qgis.pri )
 include( ../../version.pri )
 include( ../../assets.pri )
 
-QT += widgets concurrent xml positioning printsupport svg sql opengl sensors quick quickcontrols2 qml
+QT += widgets concurrent xml positioning printsupport svg sql opengl sensors quick quickcontrols2 qml webview
 
 android {
     QT += androidextras

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -26,6 +26,7 @@
 #include <QLabel>
 #include <QDialog>
 #include <QApplication>
+#include <QtWebView/QtWebView>
 
 #include "qgsapplication.h"
 #include "qgslogger.h"
@@ -101,9 +102,10 @@ int main( int argc, char **argv )
   app.setPluginPath( QApplication::applicationDirPath() );
   app.setPkgDataPath( AndroidPlatformUtilities().packagePath() );
 #else
+  QtWebView::initialize();
   QgsApplication app( argc, argv, true );
-  QSettings settings;
 
+  QSettings settings;
   app.setThemeName( settings.value( "/Themes", "default" ).toString() );
   app.setPrefixPath( CMAKE_INSTALL_PREFIX, true );
 #endif

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -167,6 +167,7 @@ TARGET_LINK_LIBRARIES(qfield_core
   Qt5::Positioning
   Qt5::Sql
   Qt5::Concurrent
+  Qt5::WebView
   ${QGIS_CORE_LIBRARY}
   ${QGIS_ANALYSIS_LIBRARY}
 )

--- a/src/core/attributeformmodel.h
+++ b/src/core/attributeformmodel.h
@@ -52,7 +52,7 @@ class AttributeFormModel : public QSortFilterProxyModel
       ConstraintSoftValid,
       ConstraintDescription,
       AttributeAllowEdit,
-      EditorWidgetCode
+      EditorWidgetCode //<! Returns a QML or HTML code string used by the relevant widgets
     };
 
     Q_ENUM( FeatureRoles )

--- a/src/core/attributeformmodel.h
+++ b/src/core/attributeformmodel.h
@@ -51,7 +51,8 @@ class AttributeFormModel : public QSortFilterProxyModel
       ConstraintHardValid,
       ConstraintSoftValid,
       ConstraintDescription,
-      AttributeAllowEdit
+      AttributeAllowEdit,
+      EditorWidgetCode
     };
 
     Q_ENUM( FeatureRoles )

--- a/src/core/attributeformmodelbase.h
+++ b/src/core/attributeformmodelbase.h
@@ -104,6 +104,7 @@ class AttributeFormModelBase : public QStandardItemModel
     typedef QPair<QgsExpression, QVector<QStandardItem *> > VisibilityExpression;
     QList<VisibilityExpression> mVisibilityExpressions;
     QMap<QStandardItem *, QgsFieldConstraints> mConstraints;
+    QMap<QStandardItem *, QString> mEditorWidgetCodes;
 
     QgsExpressionContext mExpressionContext;
     bool mConstraintsHardValid = true;

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -49,7 +49,7 @@ FeatureModel::ModelModes FeatureModel::modelMode() const
 
 void FeatureModel::setFeature( const QgsFeature &feature )
 {
-  if ( mModelMode != SingleFeatureModel || mFeature == feature )
+  if ( mModelMode != SingleFeatureModel || feature == mFeature )
     return;
 
   beginResetModel();
@@ -341,9 +341,20 @@ bool FeatureModel::save()
       {
         QgsFeature modifiedFeature;
         if ( mLayer->getFeatures( QgsFeatureRequest().setFilterFid( mFeature.id() ) ).nextFeature( modifiedFeature ) )
-          setFeature( modifiedFeature );
+        {
+          if ( modifiedFeature != mFeature )
+          {
+            setFeature( modifiedFeature );
+          }
+          else
+          {
+            emit featureUpdated();
+          }
+        }
         else
+        {
           QgsMessageLog::logMessage( tr( "Feature %1 could not be fetched after commit" ).arg( mFeature.id() ), QStringLiteral( "QField" ), Qgis::Warning );
+        }
       }
       break;
     }

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -199,9 +199,14 @@ class FeatureModel : public QAbstractListModel
 
   signals:
     void modelModeChanged();
+
+    //! Emitted when the model's feature has been saved (i.e. updated) but not changed as a result
     void featureUpdated();
+    //! Emitted when the model's single feature has been changed
     void featureChanged();
+    //! Emitted when the model's multi features list has been changed
     void featuresChanged();
+
     void linkedParentFeatureChanged();
     void linkedRelationChanged();
     void vertexModelChanged();

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -199,6 +199,7 @@ class FeatureModel : public QAbstractListModel
 
   signals:
     void modelModeChanged();
+    void featureUpdated();
     void featureChanged();
     void featuresChanged();
     void linkedParentFeatureChanged();

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -209,160 +209,206 @@ Page {
     id: fieldItem
 
     Item {
-      id: fieldContainer
-      visible: Type === 'field' || Type === 'relation'
       height: childrenRect.height
-
       anchors {
         left: parent.left
         right: parent.right
         leftMargin: 12
       }
 
-      Label {
-        id: fieldLabel
-        width: parent.width
-        text: Name || ''
-        wrapMode: Text.WordWrap
-        font.pointSize: 12
-        font.bold: true
-        color: ConstraintHardValid ? form.state === 'ReadOnly' || embedded && EditorWidget === 'RelationEditor' ? 'grey' : ConstraintSoftValid ? 'black' : Theme.warningColor : Theme.errorColor
-      }
+      Item {
+        property string qmlCode: EditorWidgetCode
 
-      Label {
-        id: constraintDescriptionLabel
+        id: qmlContainer
+        visible: Type == 'qml' && form.model.featureModel.modelMode != FeatureModel.MultiFeatureModel
+        height: visible ? childrenRect.height : 0
         anchors {
           left: parent.left
           right: parent.right
-          top: fieldLabel.bottom
         }
 
-        font.pointSize: fieldLabel.font.pointSize/3*2
-        text: {
-          if ( ConstraintHardValid && ConstraintSoftValid )
-            return '';
-
-          return ConstraintDescription || '';
+        Label {
+          id: qmlLabel
+          width: parent.width
+          text: Name || ''
+          wrapMode: Text.WordWrap
+          font.pointSize: 12
+          font.bold: true
+          bottomPadding: 5
+          color: 'grey'
         }
-        height:  !ConstraintHardValid || !ConstraintSoftValid ? undefined : 0
-        visible: !ConstraintHardValid || !ConstraintSoftValid
 
-        color: !ConstraintHardValid ? Theme.errorColor : Theme.darkGray
+        Item {
+          id: qmlItem
+          height: childrenRect.height
+          anchors {
+            left: parent.left
+            rightMargin: 12
+            right: parent.right
+            top: qmlLabel.bottom
+          }
+        }
+
+        onQmlCodeChanged: {
+          var obj = Qt.createQmlObject(qmlContainer.qmlCode,qmlItem,'qmlContent')
+        }
       }
 
       Item {
-        id: placeholder
-        height: childrenRect.height
-        anchors { left: parent.left; right: rememberCheckbox.left; top: constraintDescriptionLabel.bottom; rightMargin: 10; }
+        id: fieldContainer
+        visible: Type === 'field' || Type === 'relation'
+        height: visible ? childrenRect.height : 0
+        anchors {
+          left: parent.left
+          right: parent.right
+        }
 
-        Loader {
-          id: attributeEditorLoader
+        Label {
+          id: fieldLabel
+          width: parent.width
+          text: Name || ''
+          wrapMode: Text.WordWrap
+          font.pointSize: 12
+          font.bold: true
+          bottomPadding: 5
+          color: ConstraintHardValid ? form.state === 'ReadOnly' || embedded && EditorWidget === 'RelationEditor' ? 'grey' : ConstraintSoftValid ? 'black' : Theme.warningColor : Theme.errorColor
+        }
 
+        Label {
+          id: constraintDescriptionLabel
+          anchors {
+            left: parent.left
+            right: parent.right
+            top: fieldLabel.bottom
+          }
+
+          font.pointSize: fieldLabel.font.pointSize/3*2
+          text: {
+            if ( ConstraintHardValid && ConstraintSoftValid )
+              return '';
+
+            return ConstraintDescription || '';
+          }
+          height:  !ConstraintHardValid || !ConstraintSoftValid ? undefined : 0
+          visible: !ConstraintHardValid || !ConstraintSoftValid
+
+          color: !ConstraintHardValid ? Theme.errorColor : Theme.darkGray
+        }
+
+        Item {
+          id: placeholder
           height: childrenRect.height
-          anchors { left: parent.left; right: parent.right }
+          anchors { left: parent.left; right: rememberCheckbox.left; top: constraintDescriptionLabel.bottom; rightMargin: 10; }
 
-          //disable widget if it's:
-          // - not activated in multi edit mode
-          // - not set to editable in the widget configuration
-          // - not in edit mode (ReadOnly)
-          // - a relation in an embedded form or in multi edit mode
-          property bool isEnabled: AttributeAllowEdit
-                                   && !!AttributeEditable
-                                   && form.state !== 'ReadOnly'
-                                   && !( Type === 'relation' && ( embedded || form.model.featureModel.modelMode == FeatureModel.MultiFeatureModel ) )
-          property var value: AttributeValue
-          property var config: ( EditorWidgetConfig || {} )
-          property var widget: EditorWidget
-          property var field: Field
-          property var relationId: RelationId
-          property var nmRelationId: NmRelationId
-          property var constraintHardValid: ConstraintHardValid
-          property var constraintSoftValid: ConstraintSoftValid
-          property bool constraintsHardValid: form.model.constraintsHardValid
-          property bool constraintsSoftValid: form.model.constraintsSoftValid
-          property var currentFeature: form.model.featureModel.feature
-          property var currentLayer: form.model.featureModel.currentLayer
-          property bool autoSave: qfieldSettings.autoSave
-          // TODO investigate why StringUtils are not available in ./editorwidget/*.qml files
-          property var stringUtilities: StringUtils
+          Loader {
+            id: attributeEditorLoader
 
-          active: widget !== 'Hidden'
-          source: 'editorwidgets/' + ( widget || 'TextEdit' ) + '.qml'
+            height: childrenRect.height
+            anchors { left: parent.left; right: parent.right }
 
-          onStatusChanged: {
-            if ( attributeEditorLoader.status === Loader.Error )
-            {
-              source = 'editorwidgets/TextEdit.qml'
+            //disable widget if it's:
+            // - not activated in multi edit mode
+            // - not set to editable in the widget configuration
+            // - not in edit mode (ReadOnly)
+            // - a relation in an embedded form or in multi edit mode
+            property bool isEnabled: AttributeAllowEdit
+                                     && !!AttributeEditable
+                                     && form.state !== 'ReadOnly'
+                                     && !( Type === 'relation' && ( embedded || form.model.featureModel.modelMode == FeatureModel.MultiFeatureModel ) )
+            property var value: AttributeValue
+            property var config: ( EditorWidgetConfig || {} )
+            property var widget: EditorWidget
+            property var field: Field
+            property var relationId: RelationId
+            property var nmRelationId: NmRelationId
+            property var constraintHardValid: ConstraintHardValid
+            property var constraintSoftValid: ConstraintSoftValid
+            property bool constraintsHardValid: form.model.constraintsHardValid
+            property bool constraintsSoftValid: form.model.constraintsSoftValid
+            property var currentFeature: form.model.featureModel.feature
+            property var currentLayer: form.model.featureModel.currentLayer
+            property bool autoSave: qfieldSettings.autoSave
+            // TODO investigate why StringUtils are not available in ./editorwidget/*.qml files
+            property var stringUtilities: StringUtils
+
+            active: widget !== 'Hidden'
+            source: 'editorwidgets/' + ( widget || 'TextEdit' ) + '.qml'
+
+            onStatusChanged: {
+              if ( attributeEditorLoader.status === Loader.Error )
+              {
+                source = 'editorwidgets/TextEdit.qml'
+              }
             }
           }
-        }
 
-        Connections {
-          target: form
-          onAboutToSave: {
-            // it may not be implemented
-            if ( attributeEditorLoader.item.pushChanges ) {
-              attributeEditorLoader.item.pushChanges( form.model.featureModel.feature )
+          Connections {
+            target: form
+            onAboutToSave: {
+              // it may not be implemented
+              if ( attributeEditorLoader.item.pushChanges ) {
+                attributeEditorLoader.item.pushChanges( form.model.featureModel.feature )
+              }
             }
+            onValueChanged: (field, oldValue, newValue) => {
+                              // it may not be implemented
+                              if ( attributeEditorLoader.item.siblingValueChanged )
+                              attributeEditorLoader.item.siblingValueChanged( field, form.model.featureModel.feature )
+                            }
           }
-          onValueChanged: (field, oldValue, newValue) => {
-            // it may not be implemented
-            if ( attributeEditorLoader.item.siblingValueChanged )
-              attributeEditorLoader.item.siblingValueChanged( field, form.model.featureModel.feature )
-          }
-        }
 
-        Connections {
-          target: attributeEditorLoader.item
-          onValueChanged: {
-            if( AttributeValue != value && !( AttributeValue === undefined && isNull ) ) //do not compare AttributeValue and value with strict comparison operators
-            {
-              var oldValue = AttributeValue
-              AttributeValue = isNull ? undefined : value
+          Connections {
+            target: attributeEditorLoader.item
+            onValueChanged: {
+              if( AttributeValue != value && !( AttributeValue === undefined && isNull ) ) //do not compare AttributeValue and value with strict comparison operators
+              {
+                var oldValue = AttributeValue
+                AttributeValue = isNull ? undefined : value
 
-              valueChanged(Field, oldValue, AttributeValue)
+                valueChanged(Field, oldValue, AttributeValue)
 
-              if ( qfieldSettings.autoSave && !dontSave ) {
-                // indirect action, no need to check for success and display a toast, the log is enough
-                save()
+                if ( qfieldSettings.autoSave && !dontSave ) {
+                  // indirect action, no need to check for success and display a toast, the log is enough
+                  save()
+                }
               }
             }
           }
         }
-      }
 
-      CheckBox {
-        id: rememberCheckbox
-        checked: RememberValue ? true : false 
-        visible: form.state === "Add" && EditorWidget !== "Hidden" && EditorWidget !== 'RelationEditor'
-        width: visible ? undefined : 0
+        CheckBox {
+          id: rememberCheckbox
+          checked: RememberValue ? true : false
+          visible: form.state === "Add" && EditorWidget !== "Hidden" && EditorWidget !== 'RelationEditor'
+          width: visible ? undefined : 0
 
-        anchors { right: parent.right; top: constraintDescriptionLabel.bottom }
+          anchors { right: parent.right; top: constraintDescriptionLabel.bottom }
 
-        onCheckedChanged: {
-          RememberValue = checked
+          onCheckedChanged: {
+            RememberValue = checked
+          }
+
+          indicator.height: 16
+          indicator.width: 16
+          icon.height: 16
+          icon.width: 16
         }
 
-        indicator.height: 16
-        indicator.width: 16
-        icon.height: 16
-        icon.width: 16
-      }
+        Label {
+          id: multiEditAttributeLabel
+          text: (AttributeAllowEdit ? qsTr( "Value applied" ) : qsTr( "Value skipped" ) ) + qsTr( " (click to toggle)" )
+          visible: form.model.featureModel.modelMode == FeatureModel.MultiFeatureModel && Type !== 'relation'
+          height: form.model.featureModel.modelMode == FeatureModel.MultiFeatureModel ? undefined : 0
+          bottomPadding: form.model.featureModel.modelMode == FeatureModel.MultiFeatureModel ? 15 : 0
+          anchors { left: parent.left; top: placeholder.bottom;  rightMargin: 10; }
+          font: Theme.tipFont
+          color: AttributeAllowEdit ? Theme.mainColor : Theme.lightGray
 
-      Label {
-        id: multiEditAttributeLabel
-        text: (AttributeAllowEdit ? qsTr( "Value applied" ) : qsTr( "Value skipped" ) ) + qsTr( " (click to toggle)" )
-        visible: form.model.featureModel.modelMode == FeatureModel.MultiFeatureModel && Type !== 'relation'
-        height: form.model.featureModel.modelMode == FeatureModel.MultiFeatureModel ? undefined : 0
-        bottomPadding: form.model.featureModel.modelMode == FeatureModel.MultiFeatureModel ? 15 : 0
-        anchors { left: parent.left; top: placeholder.bottom;  rightMargin: 10; }
-        font: Theme.tipFont
-        color: AttributeAllowEdit ? Theme.mainColor : Theme.lightGray
-
-        MouseArea {
-          anchors.fill: parent
-          onClicked: {
+          MouseArea {
+            anchors.fill: parent
+            onClicked: {
               AttributeAllowEdit = !AttributeAllowEdit
+            }
           }
         }
       }

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -288,7 +288,7 @@ Page {
           }
           onLoadingChanged: {
             if ( !loading )
-              runJavaScript("document.body.offsetHeight", function(result) { htmlItem.height = ( result + 20 ) * screen.devicePixelRatio; } );
+              runJavaScript("document.body.offsetHeight", function(result) { htmlItem.height = ( result + 20 ) } );
           }
         }
 

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -4,6 +4,7 @@ import QtQuick.Layouts 1.12
 import QtGraphicalEffects 1.0
 import QtQml.Models 2.11
 import QtQml 2.3
+import QtWebView 1.14
 
 import org.qgis 1.0
 import org.qfield 1.0
@@ -217,7 +218,7 @@ Page {
       }
 
       Item {
-        property string qmlCode: EditorWidgetCode
+        property string qmlCode: EditorWidgetCode !== undefined ? EditorWidgetCode : ''
 
         id: qmlContainer
         visible: Type == 'qml' && form.model.featureModel.modelMode != FeatureModel.MultiFeatureModel
@@ -250,7 +251,50 @@ Page {
         }
 
         onQmlCodeChanged: {
-          var obj = Qt.createQmlObject(qmlContainer.qmlCode,qmlItem,'qmlContent')
+          if ( visible )
+            var obj = Qt.createQmlObject(qmlContainer.qmlCode,qmlItem,'qmlContent');
+        }
+      }
+
+      Item {
+        property string htmlCode: EditorWidgetCode !== undefined ? EditorWidgetCode : ''
+
+        id: htmlContainer
+        visible: Type == 'html' && form.model.featureModel.modelMode != FeatureModel.MultiFeatureModel
+        height: visible ? childrenRect.height : 0
+        anchors {
+          left: parent.left
+          right: parent.right
+        }
+
+        Label {
+          id: htmlLabel
+          width: parent.width
+          text: Name || ''
+          wrapMode: Text.WordWrap
+          font.pointSize: 12
+          font.bold: true
+          bottomPadding: 5
+          color: 'grey'
+        }
+
+        WebView {
+          id: htmlItem
+          anchors {
+            left: parent.left
+            rightMargin: 12
+            right: parent.right
+            top: htmlLabel.bottom
+          }
+          onLoadingChanged: {
+            if ( !loading )
+              runJavaScript("document.body.offsetHeight", function(result) { htmlItem.height = ( result + 20 ) * screen.devicePixelRatio; } );
+          }
+        }
+
+        onHtmlCodeChanged: {
+          if ( visible )
+            htmlItem.loadHtml(htmlContainer.htmlCode);
         }
       }
 


### PR DESCRIPTION
This PR implements QML widget support in the feature form. An obligatory GIF:
![Peek 2020-08-17 13-33](https://user-images.githubusercontent.com/1728657/90364275-55f02200-e08e-11ea-8fce-77355d478ed3.gif)

As the above screencast demonstrates, the current implementation QField supports expression.evaluate(...). The method I've settled on to do it (i.e. string substitution in the QML source string) was the most appropriate solution I could come up with. On the plus side, the general idea behind it can easily be used to come up with an HTML widget support (via the WebView item).

