### PR TITLE
Add support for loading of datasets stored in a localized data path (i.e. 'basemaps')

### DIFF
--- a/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -82,6 +82,7 @@ public class QFieldActivity extends Activity {
     private boolean mExternalStorageWriteable = false;
     private String mDotQgis2Dir;
     private String mShareDir;
+    private String mLocalizedDataPathsDir;
     private ProgressBar progressBar;
     private TextView unpackingTitle;
     private TextView unpackingMessage;
@@ -139,6 +140,11 @@ public class QFieldActivity extends Activity {
             mExternalStorageWriteable = false;
         } else {
             mExternalStorageAvailable = mExternalStorageWriteable = false;
+        }
+
+        if (mExternalStorageAvailable) {
+            String storagePath = Environment.getExternalStorageDirectory().getAbsolutePath();
+            mLocalizedDataPathsDir = storagePath + "/QField/basemaps/";
         }
 
         if (mExternalStorageWriteable) {
@@ -218,6 +224,7 @@ public class QFieldActivity extends Activity {
         intent.putExtra("DOTQGIS2_DIR", mDotQgis2Dir);
         intent.putExtra("SHARE_DIR", mShareDir);
         intent.putExtra("PACKAGE_PATH", getFilesDir().toString() + "/share");
+        intent.putExtra("LOCALIZED_DATA_PATHS", mLocalizedDataPathsDir);
 
         Intent sourceIntent = getIntent();
         if (sourceIntent.getAction() == Intent.ACTION_VIEW) {
@@ -305,7 +312,10 @@ public class QFieldActivity extends Activity {
                 .getAbsolutePath();
 
             if (mExternalStorageAvailable) {
+                mLocalizedDataPathsDir = storagePath + "/QField/basemaps/";
                 if (mExternalStorageWriteable) {
+                    new File(mLocalizedDataPathsDir).mkdir();
+
                     String pathAlias;
                     String externalFilesDir = getExternalFilesDir(null).getAbsolutePath();
                     String filesDir = getFilesDir().getAbsolutePath();

--- a/src/core/androidplatformutilities.cpp
+++ b/src/core/androidplatformutilities.cpp
@@ -53,6 +53,11 @@ QString AndroidPlatformUtilities::qgsProject() const
   return getIntentExtra( "QGS_PROJECT" );
 }
 
+QString AndroidPlatformUtilities::localizedDataPaths() const
+{
+  return getIntentExtra( "LOCALIZED_DATA_PATHS" );
+}
+
 QString AndroidPlatformUtilities::getIntentExtra( const QString &extra, QAndroidJniObject extras ) const
 {
   if ( extras == nullptr )

--- a/src/core/androidplatformutilities.h
+++ b/src/core/androidplatformutilities.h
@@ -31,6 +31,7 @@ class AndroidPlatformUtilities : public PlatformUtilities
     virtual QString shareDir() const override;
     virtual QString packagePath() const override;
     virtual QString qgsProject() const override;
+    virtual QString localizedDataPaths() const override;
     virtual PictureSource *getCameraPicture( const QString &prefix, const QString &pictureFilePath, const QString &suffix ) override;
     virtual PictureSource *getGalleryPicture( const QString &prefix, const QString &pictureFilePath ) override;
     virtual ViewStatus *open( const QString &uri ) override;

--- a/src/core/platformutilities.cpp
+++ b/src/core/platformutilities.cpp
@@ -51,6 +51,11 @@ QString PlatformUtilities::qgsProject() const
   return QString();
 }
 
+QString PlatformUtilities::localizedDataPaths() const
+{
+  return QString();
+}
+
 bool PlatformUtilities::createDir( const QString &path, const QString &dirname ) const
 {
   QDir parentDir( path );

--- a/src/core/platformutilities.h
+++ b/src/core/platformutilities.h
@@ -40,6 +40,7 @@ class PlatformUtilities : public QObject
     virtual QString shareDir() const;
     virtual QString packagePath() const;
     virtual QString qgsProject() const;
+    virtual QString localizedDataPaths() const;
     Q_INVOKABLE bool createDir( const QString &path, const QString &dirname ) const;
     Q_INVOKABLE bool rmFile( const QString &filename ) const;
     Q_INVOKABLE bool renameFile( const QString &filename, const QString &newname ) const;

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -36,6 +36,7 @@
 #include <QStyleHints>
 
 #include <qgslayertreemodel.h>
+#include <qgslocalizeddatapathregistry.h>
 #include <qgsproject.h>
 #include <qgsfeature.h>
 #include <qgsvectorlayer.h>
@@ -127,6 +128,13 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   handler.reset( mAuthRequestHandler );
   QgsNetworkAccessManager::instance()->setAuthHandler( std::move( handler ) );
 
+  //set localized data paths
+  QStringList localizedDataPaths = mPlatformUtils.localizedDataPaths().split( ';' );
+  if ( localizedDataPaths.size() != 0 )
+  {
+    QgsApplication::instance()->localizedDataPathRegistry()->setPaths( localizedDataPaths );
+  }
+
   QFontDatabase::addApplicationFont( ":/fonts/Cadastra-Bold.ttf" );
   QFontDatabase::addApplicationFont( ":/fonts/Cadastra-BoldItalic.ttf" );
   QFontDatabase::addApplicationFont( ":/fonts/Cadastra-Condensed.ttf" );
@@ -135,7 +143,6 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   QFontDatabase::addApplicationFont( ":/fonts/Cadastra-Semibolditalic.ttf" );
   QFontDatabase::addApplicationFont( ":/fonts/CadastraSymbol-Mask.ttf" );
   QFontDatabase::addApplicationFont( ":/fonts/CadastraSymbol-Regular.ttf" );
-
 
   mProject = QgsProject::instance();
   mGpkgFlusher = qgis::make_unique<QgsGpkgFlusher>( mProject );


### PR DESCRIPTION
This PR implements a localized data paths for QField, and adds a static data path (root_external_storage/QField/basemaps/) on the android platform. 

The implementation envisions the possibility of passing on multiple data paths via a string using semicolon as separator. 

