### PR TITLE
Update dialogs to QtQuick 2 Dialog items

### DIFF
--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -18,7 +18,6 @@
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
-import QtQuick.Dialogs 1.2
 
 import org.qgis 1.0
 import org.qfield 1.0
@@ -461,18 +460,28 @@ Rectangle {
     model.clear()
   }
 
-  MessageDialog {
+  Dialog {
     id: mergeDialog
+    parent: mainWindow.contentItem
 
-    property int selectedCount
-    property string featureDisplayName
-    property bool isMerged
+    property int selectedCount: 0
+    property string featureDisplayName: ''
+    property bool isMerged: false
 
     visible: false
+    modal: true
+
+    x: ( mainWindow.width - width ) / 2
+    y: ( mainWindow.height - height ) / 2
 
     title: qsTr( "Merge feature(s)" )
-    text: qsTr( "Should the %n feature(s) selected really be merge?\n\nThe features geometries will be combined into feature '%1', which will keep its attributes.", "0", selectedCount ).arg( featureDisplayName )
-    standardButtons: StandardButton.Ok | StandardButton.Cancel
+    Label {
+      width: parent.width
+      wrapMode: Text.WordWrap
+      text: qsTr( "Should the %n feature(s) selected really be merge?\n\nThe features geometries will be combined into feature '%1', which will keep its attributes.", "0", mergeDialog.selectedCount ).arg( mergeDialog.featureDisplayName )
+    }
+
+    standardButtons: Dialog.Ok | Dialog.Cancel
     onAccepted: {
       if ( isMerged ) {
         return;
@@ -502,17 +511,27 @@ Rectangle {
     }
   }
 
-  MessageDialog {
+  Dialog {
     id: deleteDialog
+    parent: mainWindow.contentItem
 
-    property int selectedCount
-    property bool isDeleted
+    property int selectedCount: 0
+    property bool isDeleted: false
 
     visible: false
+    modal: true
+
+    x: ( mainWindow.width - width ) / 2
+    y: ( mainWindow.height - height ) / 2
 
     title: qsTr( "Delete feature(s)" )
-    text: qsTr( "Should the %n feature(s) selected really be deleted?", "0", selectedCount )
-    standardButtons: StandardButton.Ok | StandardButton.Cancel
+    Label {
+      width: parent.width
+      wrapMode: Text.WordWrap
+      text: qsTr( "Should the %n feature(s) selected really be deleted?", "0", deleteDialog.selectedCount )
+    }
+
+    standardButtons: Dialog.Ok | Dialog.Cancel
     onAccepted: {
       if ( isDeleted ) {
         return;

--- a/src/qml/Tracking.qml
+++ b/src/qml/Tracking.qml
@@ -1,6 +1,5 @@
 import QtQuick 2.12
 import QtQuick.Controls 2.12
-import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.12
 import QtPositioning 5.3
 

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -1,6 +1,5 @@
 import QtQuick 2.12
 import QtQuick.Controls 2.12
-import QtQuick.Dialogs 1.2
 import QtGraphicalEffects 1.0
 import QtQuick.Layouts 1.12
 
@@ -189,8 +188,9 @@ Rectangle{
     }
 
     //the delete entry stuff
-    MessageDialog {
+    Dialog {
       id: deleteDialog
+      parent: mainWindow.contentItem
 
       property int referencingFeatureId
       property string referencingFeatureDisplayMessage
@@ -198,14 +198,20 @@ Rectangle{
       property string nmReferencedFeatureDisplayMessage
 
       visible: false
+      modal: yes
 
       title: nmRelationId ?
                qsTr( 'Unlink feature %1 (%2) of %3' ).arg( nmReferencedFeatureDisplayMessage ).arg( nmReferencedFeatureId ).arg( relationEditorModel.nmRelation.referencedLayer.name ) :
                qsTr( 'Delete feature %1 (%2) on %3' ).arg( referencingFeatureDisplayMessage ).arg( referencingFeatureId ).arg( relationEditorModel.relation.referencingLayer.name )
-      text:  nmRelationId ?
+      Label {
+        width: parent.width
+        wrapMode: Text.WordWrap
+        text:  nmRelationId ?
                qsTr( 'Should the feature <b>%1 (%2)</b> of layer <b>%3</b> be unlinked?<br><i>(The connection will be deleted on layer <b>%4</b>)</i>').arg( nmReferencedFeatureDisplayMessage ).arg( nmReferencedFeatureId ).arg( relationEditorModel.nmRelation.referencedLayer.name ).arg( relationEditorModel.relation.referencingLayer.name ) :
                qsTr( 'Should the feature <b>%1 (%2)</b> on layer <b>%3</b> be deleted?').arg( referencingFeatureDisplayMessage ).arg( referencingFeatureId ).arg( relationEditorModel.relation.referencingLayer.name )
-      standardButtons: StandardButton.Ok | StandardButton.Cancel
+      }
+
+      standardButtons: Dialog.Ok | Dialog.Cancel
       onAccepted: {
         if ( ! referencingFeatureListView.model.deleteFeature( referencingFeatureId ) ) {
           displayToast( qsTr( "Failed to delete referencing feature" ) )

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -17,7 +17,6 @@
 
 import QtQuick 2.12
 import QtQuick.Controls 2.12
-import QtQuick.Dialogs 1.3
 import QtGraphicalEffects 1.0
 import Qt.labs.settings 1.0 as LabSettings
 import QtQml 2.12
@@ -1315,7 +1314,6 @@ ApplicationWindow {
 
       onLoadProjectEnded: {
         busyMessage.visible = false
-        openProjectDialog.folder = qgisProject.homePath
         mapCanvasBackground.color = mapCanvas.mapSettings.backgroundColor
       }
     }
@@ -1531,21 +1529,6 @@ ApplicationWindow {
 
     Component.onCompleted: {
         focusstack.addFocusTaker( this )
-    }
-  }
-
-  FileDialog {
-    id: openProjectDialog
-    title: qsTr( "Open project" )
-    visible: false
-    nameFilters: [ qsTr( "QGIS projects (*.qgs *.qgz)" ), qsTr( "All files (*)" ) ]
-
-    width: mainWindow.width
-    height: mainWindow.height
-
-    onAccepted: {
-      iface.loadProject( openProjectDialog.fileUrl.toString().slice(7) )
-      mainWindow.keyHandler.focus=true
     }
   }
 


### PR DESCRIPTION
Those QtQuick2 dialogs look much, _much_ nicer:

Old dialog (left) vs. QtQuick2 dialog (right):
![image](https://user-images.githubusercontent.com/1728657/90593426-13575280-e212-11ea-9585-601691d77be4.png)

