### PR TITLE
Fix crash on coordinate transform

### DIFF
--- a/src/core/rubberbandmodel.cpp
+++ b/src/core/rubberbandmodel.cpp
@@ -15,8 +15,10 @@
  ***************************************************************************/
 #include "rubberbandmodel.h"
 #include "snappingutils.h"
+
 #include <qgsvectorlayer.h>
 #include <qgsproject.h>
+#include <qgslogger.h>
 
 RubberbandModel::RubberbandModel( QObject *parent )
   : QObject( parent )
@@ -168,7 +170,19 @@ QgsPoint RubberbandModel::currentPoint( const QgsCoordinateReferenceSystem &crs,
   double z = QgsWkbTypes::hasZ( currentPt.wkbType() ) ? currentPt.z() : 0;
   double m = QgsWkbTypes::hasM( currentPt.wkbType() ) ? currentPt.m() : 0;
 
-  ct.transformInPlace( x, y, z );
+  try
+  {
+    ct.transformInPlace( x, y, z );
+  }
+  catch ( const QgsCsException &exp )
+  {
+    QgsDebugMsg( exp.what() );
+  }
+  catch(...)
+  {
+    // catch any other errors
+    QgsDebugMsg( "Transform exception caught - possibly because of missing gsb file." );
+  }
 
   QgsPoint resultPt( x, y );
   if ( QgsWkbTypes::hasZ( currentPt.wkbType() ) && QgsWkbTypes::hasZ( wkbType ) )

--- a/src/qgsquick/qgsquickcoordinatetransformer.cpp
+++ b/src/qgsquick/qgsquickcoordinatetransformer.cpp
@@ -118,6 +118,11 @@ void QgsQuickCoordinateTransformer::updatePosition()
   {
     QgsDebugMsg( exp.what() );
   }
+  catch(...)
+  {
+    // catch any other errors
+    QgsDebugMsg( "Transform exception caught - possibly because of missing gsb file." );
+  }
 
   if ( mSkipAltitudeTransformation )
     z = mSourcePosition.z();


### PR DESCRIPTION
Catching all exceptions instead of only `QgsCsException`.

Occured most possibly because of missing gsb file on device. this has not been integrated with proj4