### PR TITLE
When zoom to layer is clicked, layer properties should close

### DIFF
--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -98,6 +98,8 @@ Popup {
 
         onClicked: {
           mapCanvas.mapSettings.setCenterToLayer( layerTree.data( index, FlatLayerTreeModel.MapLayerPointer ) )
+          close()
+          dashBoard.visible = false
         }
       }
 


### PR DESCRIPTION
It also closes the drawer, I assume the user is lost on the map and want to recenter, so they no longer need the drawer. Closes #1226

![Peek 2020-08-19 15-46](https://user-images.githubusercontent.com/2820439/90636409-3cd4a600-e233-11ea-8082-58037a4edbbe.gif)
