### PR TITLE
Prepare and show changelog

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,5 +1,6 @@
 [main]
 host = https://www.transifex.com
+lang_map = zh-Hant: zh_TW
 
 [qfield-for-qgis.qfield]
 file_filter = i18n/qfield_<lang>.ts

--- a/src/qml/About.qml
+++ b/src/qml/About.qml
@@ -87,5 +87,29 @@ Item {
       }
       onClicked: Qt.openUrlExternally("https://www.opengis.ch/android-gis/qfield/donate-and-sponsor/")
     }
+    Button {
+      id: changelogButton
+      Layout.fillWidth: true
+      Layout.fillHeight: false
+
+      text: qsTr( 'Changelog' )
+
+      font: Theme.defaultFont
+
+      contentItem: Text {
+        text: changelogButton.text
+        font: changelogButton.font
+        color: 'white'
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+        elide: Text.ElideRight
+      }
+
+      background: Rectangle {
+        color: Theme.mainColor
+      }
+
+      onClicked: changelogPopup.open()
+    }
   }
 }

--- a/src/qml/About.qml
+++ b/src/qml/About.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
 
 import Theme 1.0
+import org.qfield 1.0
 
 Item {
   Rectangle {
@@ -87,7 +88,7 @@ Item {
       }
       onClicked: Qt.openUrlExternally("https://www.opengis.ch/android-gis/qfield/donate-and-sponsor/")
     }
-    Button {
+    QfButton {
       id: changelogButton
       Layout.fillWidth: true
       Layout.fillHeight: false

--- a/src/qml/Changelog.qml
+++ b/src/qml/Changelog.qml
@@ -2,7 +2,9 @@ import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
 import QtGraphicalEffects 1.0
+
 import Theme 1.0
+import org.qfield 1.0
 
 Item {
   signal close()
@@ -116,7 +118,7 @@ Item {
       Layout.maximumHeight: contentHeight
     }
 
-    Button {
+    QfButton {
       id: closeButton
       Layout.fillWidth: true
       Layout.fillHeight: true

--- a/src/qml/Changelog.qml
+++ b/src/qml/Changelog.qml
@@ -116,6 +116,8 @@ Item {
       Layout.fillHeight: true
       Layout.minimumHeight: contentHeight
       Layout.maximumHeight: contentHeight
+
+      onLinkActivated: Qt.openUrlExternally(link)
     }
 
     QfButton {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1536,8 +1536,8 @@ ApplicationWindow {
     id: changelogPopup
     parent: ApplicationWindow.overlay
 
-    property var expireDate: new Date(2019,9,16)
-    visible: settings.value( "/QField/CurrentVersion", "" ) !== versionCode
+    property var expireDate: new Date(2038,1,19)
+    visible: settings.value( "/QField/ChangelogVersion", "" ) !== versionCode
                && expireDate > new Date()
 
     x: 24
@@ -1546,7 +1546,7 @@ ApplicationWindow {
     height: parent.height - 48
     padding: 0
     modal: true
-    closePolicy: Popup.CloseOnEscape
+    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
 
     Flickable {
       id: changelogFlickable
@@ -1564,6 +1564,10 @@ ApplicationWindow {
           changelogPopup.close()
         }
       }
+    }
+
+    onClosed: {
+      changelogFlickable.contentY = 0
     }
   }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1547,6 +1547,7 @@ ApplicationWindow {
     padding: 0
     modal: true
     closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+    focus: visible
 
     Flickable {
       id: changelogFlickable
@@ -1568,6 +1569,13 @@ ApplicationWindow {
 
     onClosed: {
       changelogFlickable.contentY = 0
+    }
+
+    Keys.onReleased: {
+      if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
+        event.accepted = true
+        visible = false
+      }
     }
   }
 


### PR DESCRIPTION
Implements the feature request in #1192 . This PR uses the Markdown instead of HTML (the gif in the issue). The changelog is loaded once on startup and cached until the app is restarted. Please write stricter markdown in the release notes, all the newlines matter.

![Peek 2020-08-20 18-04](https://user-images.githubusercontent.com/2820439/90789541-b3df6c80-e30f-11ea-9037-a81025b678ee.gif)

