### PR TITLE
Fix build warnings

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -261,7 +261,7 @@ void AttributeFormModelBase::updateAttributeValue( QStandardItem *item )
       QVariant result = exp.evaluate( &expressionContext );
 
       QString resultString;
-      switch( result.type() )
+      switch( static_cast<QMetaType::Type>( result.type() ) )
       {
         case QMetaType::Int:
         case QMetaType::UInt:


### PR DESCRIPTION
https://github.com/opengisch/QField/runs/1015392941#step:4:322

```
../src/core/attributeformmodelbase.cpp:273:14: warning: comparison of two values with different enumeration types in switch statement ('QVariant::Type' and 'QMetaType::Type') [-Wenum-compare-switch]
        case QMetaType::Bool:
             ^~~~~~~~~~~~~~~
../src/core/attributeformmodelbase.cpp:270:14: warning: comparison of two values with different enumeration types in switch statement ('QVariant::Type' and 'QMetaType::Type') [-Wenum-compare-switch]
        case QMetaType::ULongLong:
             ^~~~~~~~~~~~~~~~~~~~
../src/core/attributeformmodelbase.cpp:269:14: warning: comparison of two values with different enumeration types in switch statement ('QVariant::Type' and 'QMetaType::Type') [-Wenum-compare-switch]
        case QMetaType::LongLong:
             ^~~~~~~~~~~~~~~~~~~
../src/core/attributeformmodelbase.cpp:268:14: warning: comparison of two values with different enumeration types in switch statement ('QVariant::Type' and 'QMetaType::Type') [-Wenum-compare-switch]
        case QMetaType::Double:
```