### PR TITLE
Replace deprecated Environment.getExternalStorageDirectory();

### DIFF
--- a/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -143,7 +143,7 @@ public class QFieldActivity extends Activity {
         }
 
         if (mExternalStorageAvailable) {
-            String storagePath = Environment.getExternalStorageDirectory().getAbsolutePath();
+            String storagePath = Context.getExternalFilesDirs(null).getAbsolutePath();
             mLocalizedDataPathsDir = storagePath + "/QField/basemaps/";
         }
 
@@ -308,7 +308,7 @@ public class QFieldActivity extends Activity {
             // create symlink
             // alias paths for storage dir (/sdcard or similar)
             String storagePathAlias = getFilesDir() + "/storage";
-            String storagePath = Environment.getExternalStorageDirectory()
+            String storagePath = Context.getExternalFilesDirs(null)
                 .getAbsolutePath();
 
             if (mExternalStorageAvailable) {

--- a/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -57,7 +57,7 @@ public class QFieldProjectActivity extends Activity {
         // Roots
         if (!getIntent().hasExtra("path")) {
 
-            File externalStorageDirectory = Environment.getExternalStorageDirectory();
+            File externalStorageDirectory = Context.getExternalFilesDirs(null);
             Log.d(TAG, "externalStorageDirectory: " + externalStorageDirectory);
             if (externalStorageDirectory != null){
                 values.add(new QFieldProjectListItem(externalStorageDirectory, getString(R.string.primary_storage),


### PR DESCRIPTION
`Environment.getExternalStorageDirectory()` is deprecated https://developer.android.com/reference/android/os/

I replaced it with `Context.getExternalFilesDirs(null)`. It solves it on opening local projects from e.g. `storage/emulated/0`.

But I'm not aware of the risks and the parts in `QFieldActivity.java`

