### PR TITLE
targetSdkVersion 29 upgrade and `getExternalStorageDirectory()`

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -50,6 +50,7 @@ jobs:
           ARCH: ${{ matrix.arch }}
         run: |
           export QFIELD_SDK_VERSION=$(awk -F "=" '/osgeo4a_version/{print $2}' sdk.conf)
+          export ANDROID_NDK_PLATFORM=android-29
           ./scripts/ci/docker_pull.sh
           ./scripts/ci/pull_translations.sh
           ./scripts/ci/build.sh

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,11 +43,11 @@ android {
      *                   on Android.
      *
      * are defined in gradle.properties file. This file is
-     * updated by QtCreator and androiddeployqt tools.
+     * updated by QtCredftor and androiddeployqt tools.
      * Changing them manually might break the compilation!
      *******************************************************/
 
-    compileSdkVersion androidCompileSdkVersion.toInteger()
+    compileSdkVersion 29
 
 
     /*

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,11 +43,11 @@ android {
      *                   on Android.
      *
      * are defined in gradle.properties file. This file is
-     * updated by QtCredftor and androiddeployqt tools.
+     * updated by QtCreator and androiddeployqt tools.
      * Changing them manually might break the compilation!
      *******************************************************/
 
-    compileSdkVersion 29
+    compileSdkVersion androidCompileSdkVersion.toInteger()
 
 
     /*

--- a/cmake/AndroidManifest.xml.in
+++ b/cmake/AndroidManifest.xml.in
@@ -111,7 +111,7 @@
     </provider>
 
   </application>
-  <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="28" />
+  <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="29" />
   <supports-screens android:largeScreens="true" android:normalScreens="true" android:anyDensity="true" android:smallScreens="true"/>
 
   <!-- The permissions are specified manually. This way we do not request the microphone permissions which would be pulled in

--- a/cmake/AndroidManifest.xml.in
+++ b/cmake/AndroidManifest.xml.in
@@ -4,7 +4,8 @@
     android:hardwareAccelerated="true"
     android:name="org.qtproject.qt5.android.bindings.QtApplication"
     android:label="@string/app_name"
-    android:icon="@drawable/qfield_logo" >
+    android:icon="@drawable/qfield_logo"
+    android:requestLegacyExternalStorage="true" >
     <activity
       android:name="ch.opengis.@APP_PACKAGE_NAME@.QFieldActivity"
       android:noHistory="true"

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -49,9 +49,10 @@ echo "APP_ICON: ${APP_ICON}"
 echo "APP_VERSION: ${APP_VERSION}"
 echo "APP_VERSION_CODE: ${APP_VERSION_CODE}"
 echo "APP_VERSION_STR: ${APP_VERSION_STR}"
-
+echo "ANDROID_NDK_PLATFORM : ${ANDROID_NDK_PLATFORM}"
 
 docker run -v $(pwd):/usr/src/qfield \
   -e "BUILD_FOLDER=build-${ARCH}" \
   -e ARCH -e STOREPASS -e KEYNAME -e KEYPASS -e APP_PACKAGE_NAME -e APP_NAME -e APP_ICON -e APP_VERSION -e APP_VERSION_CODE -e APP_VERSION_STR \
+  -e ANDROID_NDK_PLATFORM \
   opengisch/qfield-sdk:${QFIELD_SDK_VERSION} /usr/src/qfield/scripts/docker-build.sh


### PR DESCRIPTION
**_Remember, remember the 2nd of November_**

![image](https://user-images.githubusercontent.com/28384354/91609050-f7248580-e976-11ea-852d-d275ce7bcaf9.png)
https://developer.android.com/distribute/best-practices/develop/target-sdk

Easy. But on targetSdkVersion 29 the function used in opening the main storage of android is deprecated: [Environment.getExternalStorageDirectory()](https://developer.android.com/reference/android/os/Environment#getExternalStorageDirectory())

**There are two possiblities:**
1. Implement the file opener etc. with functions and ways that are supported with 29 (see https://developer.android.com/training/data-storage#filesExternal)
2. If time runs out I think this commit here would make it as well to support the [legacy function](https://developer.android.com/training/data-storage/use-cases#opt-out-scoped-storage): ab091f421716ba47edf8cf5beae6b075ddab945c 

But I think the way to set the compileSdkVersion like I did in the mentioned commit is not the proper way. I just did it as a test. Anyway the option 1 would be nicer if we will keep these java parts in future.