### PR TITLE
Revert "Bump Android target sdk to 29 (Android 10)"

### DIFF
--- a/cmake/AndroidManifest.xml.in
+++ b/cmake/AndroidManifest.xml.in
@@ -110,7 +110,7 @@
     </provider>
 
   </application>
-  <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="29" />
+  <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="28" />
   <supports-screens android:largeScreens="true" android:normalScreens="true" android:anyDensity="true" android:smallScreens="true"/>
 
   <!-- The permissions are specified manually. This way we do not request the microphone permissions which would be pulled in


### PR DESCRIPTION
To be able to use function getExternalStorageDirectory again.

Talked with @m-kuhn about it. The prio to upgrade is not that high. So we can find a proper solution for this #1269