### PR TITLE
Changelog improvements

### DIFF
--- a/src/qml/About.qml
+++ b/src/qml/About.qml
@@ -91,24 +91,8 @@ Item {
     QfButton {
       id: changelogButton
       Layout.fillWidth: true
-      Layout.fillHeight: false
 
       text: qsTr( 'Changelog' )
-
-      font: Theme.defaultFont
-
-      contentItem: Text {
-        text: changelogButton.text
-        font: changelogButton.font
-        color: 'white'
-        horizontalAlignment: Text.AlignHCenter
-        verticalAlignment: Text.AlignVCenter
-        elide: Text.ElideRight
-      }
-
-      background: Rectangle {
-        color: Theme.mainColor
-      }
 
       onClicked: changelogPopup.open()
     }

--- a/src/qml/Changelog.qml
+++ b/src/qml/Changelog.qml
@@ -44,69 +44,8 @@ Item {
 
     Text {
       id: changelogBody
+      property bool isSuccess: false
       color: '#95000000'
-      text: {
-        var RELEASES_URL = 'https://api.github.com/repos/opengisch/qfield/releases'
-        var xhr = new XMLHttpRequest()
-        var parseVersion = function(str) {
-          str = str.replace(/^[a-z]*/, '')
-
-          var parts = str.split('.')
-
-          if (parts[0] >= 0 && parts[1] >= 0 && parts[2] >= 0)
-            return [parts[0], parts[1], parts[2]]
-
-          return []
-        }
-
-        xhr.open('GET', RELEASES_URL)
-        xhr.onreadystatechange = function() {
-          if (xhr.readyState === XMLHttpRequest.DONE) {
-            var resp = xhr.responseText
-            var changelog = ''
-
-            try {
-              var releases = JSON.parse(resp)
-              var qfieldVersion = parseVersion(version)
-
-              for (var i = 0, l = releases.length; i < l; i++) {
-                var release = releases[i]
-                var releaseVersion = parseVersion(release['tag_name'])
-
-                if (releaseVersion.length === 0)
-                  continue
-
-                var releaseChangelog = '\n#\n# ' + release['name'] + '\n\n' + release['body'] + '\n'
-
-                // most probably developer version with no proper version set
-                if (qfieldVersion.length === 0)
-                  qfieldVersion = releaseVersion
-
-                if (qfieldVersion[0] !== releaseVersion[0] || qfieldVersion[1] !== releaseVersion[1])
-                  continue
-
-                // prepend the current release
-                changelog = releaseChangelog + changelog
-              }
-
-              if ( changelog.length === 0 )
-                throw new Error('Empty changelog!')
-
-              changelog += '\n' + '[' + qsTr('Previous releases on GitHub') + '](https://github.com/opengisch/qfield/releases)'
-              changelog = changelog.replace(/^##(.+)$/gm, function(full) {
-                return '\n###\n' + full + '\n\n\n'
-              })
-
-              changelogBody.text = changelog
-            } catch (err) {
-              changelogBody.text = qsTr('Temporarily cannot retrieve the changelog. Please check your internet connection.')
-            }
-          }
-        }
-        xhr.send()
-
-        return qsTr('Loading…')
-      }
       font: Theme.tipFont
 
       fontSizeMode: Text.VerticalFit
@@ -149,5 +88,72 @@ Item {
         // bottom
         height: 20
     }
+  }
+
+  function refreshChangelog() {
+    if ( changelogBody.isSuccess )
+      return
+
+    var RELEASES_URL = 'https://api.github.com/repos/opengisch/qfield/releases'
+    var xhr = new XMLHttpRequest()
+    var parseVersion = function(str) {
+      str = str.replace(/^[a-z]*/, '')
+
+      var parts = str.split('.')
+
+      if (parts[0] >= 0 && parts[1] >= 0 && parts[2] >= 0)
+        return [parts[0], parts[1], parts[2]]
+
+      return []
+    }
+
+    xhr.open('GET', RELEASES_URL)
+    xhr.onreadystatechange = function() {
+      if (xhr.readyState === XMLHttpRequest.DONE) {
+        var resp = xhr.responseText
+        var changelog = ''
+
+        try {
+          var releases = JSON.parse(resp)
+          var qfieldVersion = parseVersion(version)
+
+          for (var i = 0, l = releases.length; i < l; i++) {
+            var release = releases[i]
+            var releaseVersion = parseVersion(release['tag_name'])
+
+            if (releaseVersion.length === 0)
+              continue
+
+            var releaseChangelog = '\n#\n# ' + release['name'] + '\n\n' + release['body'] + '\n'
+
+            // most probably developer version with no proper version set
+            if (qfieldVersion.length === 0)
+              qfieldVersion = releaseVersion
+
+            if (qfieldVersion[0] !== releaseVersion[0] || qfieldVersion[1] !== releaseVersion[1])
+              continue
+
+            // prepend the current release
+            changelog = releaseChangelog + changelog
+          }
+
+          if ( changelog.length === 0 )
+            throw new Error('Empty changelog!')
+
+          changelog += '\n' + '[' + qsTr('Previous releases on GitHub') + '](https://github.com/opengisch/qfield/releases)'
+          changelog = changelog.replace(/^##(.+)$/gm, function(full) {
+            return '\n###\n' + full + '\n\n\n'
+          })
+
+          changelogBody.text = changelog
+          changelogBody.isSuccess = true
+        } catch (err) {
+          changelogBody.text = qsTr('Temporarily cannot retrieve the changelog. Please check your internet connection.')
+        }
+      }
+    }
+    xhr.send()
+
+    changelogBody.text = qsTr('Loading…')
   }
 }

--- a/src/qml/Changelog.qml
+++ b/src/qml/Changelog.qml
@@ -62,25 +62,8 @@ Item {
     QfButton {
       id: closeButton
       Layout.fillWidth: true
-      Layout.fillHeight: true
 
       text: qsTr( 'OK' )
-
-      font: Theme.defaultFont
-
-      contentItem: Text {
-        text: closeButton.text
-        font: closeButton.font
-        color: 'white'
-        horizontalAlignment: Text.AlignHCenter
-        verticalAlignment: Text.AlignVCenter
-        elide: Text.ElideRight
-      }
-
-      background: Rectangle {
-        color: Theme.mainColor
-      }
-
       onClicked: close()
     }
 

--- a/src/qml/Changelog.qml
+++ b/src/qml/Changelog.qml
@@ -142,10 +142,7 @@ Item {
         color: Theme.mainColor
       }
 
-      onClicked: {
-        settings.setValue( '/QField/ChangelogVersion', versionCode )
-        close()
-      }
+      onClicked: close()
     }
 
     Item {

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -25,7 +25,6 @@ import org.qfield 1.0
 Rectangle {
   id: toolBar
 
-  property string currentName: ''
   property bool allowDelete
   property MultiFeatureListModel model
   property FeatureListModelSelection selection

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1572,6 +1572,10 @@ ApplicationWindow {
       changelogFlickable.contentY = 0
     }
 
+    onOpened: {
+      changelog.refreshChangelog()
+    }
+
     Keys.onReleased: {
       if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
         event.accepted = true

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1568,6 +1568,7 @@ ApplicationWindow {
     }
 
     onClosed: {
+      settings.setValue( "/QField/ChangelogVersion", versionCode )
       changelogFlickable.contentY = 0
     }
 


### PR DESCRIPTION
- Don't reappear the changelog once it was closed via button click, back button tapping on the modal background
- Refresh changelog if failed to load last time - previosly the changelog was showing "failed to fetch" until the app is relaunched.

One unrelated change I have forgot when fixing the `NavigationBar` : there was unused property `currentName`, that remained after the multiselect implementation.