### PR TITLE
Qml callback warning

### DIFF
--- a/src/qml/CoordinateLocator.qml
+++ b/src/qml/CoordinateLocator.qml
@@ -116,7 +116,8 @@ Item {
 
     Connections {
       target: snappingUtils
-      onSnappingResultChanged: {
+
+      function onSnappingResultChanged() {
         crosshairCircle.border.color = overrideLocation == undefined ? ( snappingUtils.snappingResult.isValid ? "#9b59b6" : locator.color ) : "#AD1457"
         crosshairCircle.width = snappingUtils.snappingResult.isValid ? 32: 48
       }

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -165,7 +165,7 @@ Drawer {
         Connections {
           target: iface
 
-          onLoadProjectEnded: {
+          function onLoadProjectEnded() {
             mapThemeContainer.isLoading = true
             var themes = qgisProject.mapThemeCollection.mapThemes
             mapThemeComboBox.model = themes

--- a/src/qml/DigitizingToolbar.qml
+++ b/src/qml/DigitizingToolbar.qml
@@ -22,7 +22,8 @@ VisibilityFadingRow {
 
   Connections {
       target: rubberbandModel
-      onVertexCountChanged: {
+
+      function onVertexCountChanged() {
           // set geometry valid
           if ( Number( rubberbandModel ? rubberbandModel.geometryType : 0 ) === 0 )
           {

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -88,12 +88,18 @@ Page {
 
         Connections {
           target: master
-          onReset: tabRow.currentIndex = 0
+
+          function onReset() {
+            tabRow.currentIndex = 0
+          }
         }
 
         Connections {
           target: swipeView
-          onCurrentIndexChanged: tabRow.currentIndex = swipeView.currentIndex
+
+          function onCurrentIndexChanged(currentIndex) {
+            tabRow.currentIndex = swipeView.currentIndex
+          }
         }
 
         Repeater {
@@ -186,7 +192,10 @@ Page {
 
             Connections {
               target: master
-              onReset: content.contentY = 0
+
+              function onReset() {
+                content.contentY = 0
+              }
             }
 
             model: SubModel {
@@ -522,7 +531,8 @@ Page {
 
   Connections {
     target: Qt.inputMethod
-    onVisibleChanged: {
+
+    function onVisibleChanged() {
       Qt.inputMethod.commit()
     }
   }

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -398,22 +398,26 @@ Page {
 
           Connections {
             target: form
-            onAboutToSave: {
+
+            function onAboutToSave() {
               // it may not be implemented
               if ( attributeEditorLoader.item.pushChanges ) {
                 attributeEditorLoader.item.pushChanges( form.model.featureModel.feature )
               }
             }
-            onValueChanged: (field, oldValue, newValue) => {
-                              // it may not be implemented
-                              if ( attributeEditorLoader.item.siblingValueChanged )
-                              attributeEditorLoader.item.siblingValueChanged( field, form.model.featureModel.feature )
-                            }
+
+            function onValueChanged(field, oldValue, newValue) {
+              // it may not be implemented
+              if ( attributeEditorLoader.item.siblingValueChanged ) {
+                attributeEditorLoader.item.siblingValueChanged( field, form.model.featureModel.feature )
+              }
+            }
           }
 
           Connections {
             target: attributeEditorLoader.item
-            onValueChanged: {
+
+            function onValueChanged(value, isNull) {
               if( AttributeValue != value && !( AttributeValue === undefined && isNull ) ) //do not compare AttributeValue and value with strict comparison operators
               {
                 var oldValue = AttributeValue

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -432,7 +432,7 @@ Rectangle {
   Connections {
     target: globalFeaturesList.model
 
-    onRowsInserted: {
+    function onRowsInserted(parent, first, VectorLayerStatic) {
       if ( model.rowCount() > 0 ) {
         state = "FeatureList"
       } else {
@@ -441,13 +441,13 @@ Rectangle {
       }
     }
 
-    onCountChanged: {
+    function onCountChanged() {
       if ( model.rowCount() === 0 ) {
         state = "Hidden"
       }
     }
 
-    onModelReset: {
+    function onModelReset() {
       if ( model.rowCount() > 0 ) {
         state = "FeatureList"
       } else {
@@ -579,7 +579,7 @@ Rectangle {
   Connections {
     target: qgisProject
 
-    onLayersWillBeRemoved: {
+    function onLayersWillBeRemoved(layerIds) {
         if( state != "FeatureList" ) {
           if( featureListToolBar.state === "Edit"){
               featureForm.state = "FeatureForm"

--- a/src/qml/GeometryHighlighter.qml
+++ b/src/qml/GeometryHighlighter.qml
@@ -9,7 +9,8 @@ Item {
 
   Connections {
     target: geometryRenderer.geometryWrapper
-    onQgsGeometryChanged: {
+
+    function onQgsGeometryChanged() {
       timer.restart()
     }
   }

--- a/src/qml/GeometryRenderer.qml
+++ b/src/qml/GeometryRenderer.qml
@@ -21,7 +21,7 @@ Item {
   Connections {
     target: geometryWrapper
 
-    onQgsGeometryChanged: {
+    function onQgsGeometryChanged() {
       geometryComponent.sourceComponent = undefined
       if (geometryWrapper && geometryWrapper.qgsGeometry.type === QgsWkbTypes.PointGeometry) {
         geometryComponent.sourceComponent = pointHighlight

--- a/src/qml/LocationMarker.qml
+++ b/src/qml/LocationMarker.qml
@@ -92,7 +92,8 @@ Item {
 
   Connections {
     target: mapSettings
-    onExtentChanged: {
+
+    function onExtentChanged() {
       marker.location = mapSettings.coordinateToScreen( location )
       directionMarker.location = mapSettings.coordinateToScreen( location )
       directionMarker.direction = direction

--- a/src/qml/MessageLog.qml
+++ b/src/qml/MessageLog.qml
@@ -81,7 +81,7 @@ Page {
   Connections {
     target: model
 
-    onRowsInserted: {
+    function onRowsInserted(parent, first, last) {
       if ( !visible )
         unreadMessages = true
     }

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -197,8 +197,7 @@ Rectangle {
     Connections {
       target: selection
 
-      onFocusedItemChanged:
-      {
+      function onFocusedItemChanged() {
         editGeomButton.readOnly = selection.focusedLayer && selection.focusedLayer.readOnly
       }
     }
@@ -230,8 +229,7 @@ Rectangle {
     Connections {
       target: selection
 
-      onFocusedItemChanged:
-      {
+      function onFocusedItemChanged() {
         editButton.readOnly = selection.focusedLayer && selection.focusedLayer.readOnly
       }
     }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1025,7 +1025,7 @@ ApplicationWindow {
     Connections {
         target: printMenu
 
-        onEnablePrintItem: {
+        function onEnablePrintItem(rows) {
           printItem.enabled = rows
         }
     }
@@ -1083,7 +1083,7 @@ ApplicationWindow {
     Connections {
       target: iface
 
-      onLoadProjectEnded: {
+      function onLoadProjectEnded() {
         layoutListInstantiator.model.project = qgisProject
         layoutListInstantiator.model.reloadModel()
         printMenu.enablePrintItem(layoutListInstantiator.model.rowCount())
@@ -1307,12 +1307,12 @@ ApplicationWindow {
     Connections {
       target: iface
 
-      onLoadProjectStarted: {
+      function onLoadProjectStarted(path) {
         busyMessageText.text = qsTr( "Loading Project: %1" ).arg( path )
         busyMessage.visible = true
       }
 
-      onLoadProjectEnded: {
+      function onLoadProjectEnded() {
         busyMessage.visible = false
         mapCanvasBackground.color = mapCanvas.mapSettings.backgroundColor
       }
@@ -1377,7 +1377,8 @@ ApplicationWindow {
 
     Connections {
       target: iface
-      onLoadProjectEnded: {
+
+      function onLoadProjectEnded() {
         if( !qfieldAuthRequestHandler.handleLayerLogins() )
         {
           //project loaded without more layer handling needed
@@ -1388,7 +1389,7 @@ ApplicationWindow {
     Connections {
         target: iface
 
-        onLoadProjectStarted: {
+        function onLoadProjectStarted(path) {
           messageLogModel.suppressTags(["WFS","WMS"])
         }
     }
@@ -1396,13 +1397,13 @@ ApplicationWindow {
     Connections {
       target: qfieldAuthRequestHandler
 
-      onShowLoginDialog: {
+      function onShowLoginDialog(realm) {
         loginDialogPopup.realm = realm || ""
         badLayersView.visible = false
         loginDialogPopup.open()
       }
 
-      onReloadEverything: {
+      function onReloadEverything() {
         iface.reloadProject( qgisProject.fileName )
       }
     }
@@ -1695,7 +1696,7 @@ ApplicationWindow {
   Connections {
     target: welcomeScreen.__projectSource
 
-    onProjectOpened: {
+    function onProjectOpened(path) {
       iface.loadProject( path )
     }
   }


### PR DESCRIPTION
Attempts to fix:

> fix QML Connections: Implicitly defined onFoo properties in Connections are deprecated

This was already attempted a few weeks ago https://github.com/opengisch/QField/pull/1079, but it was reverted https://github.com/opengisch/QField/pull/1134 . Hopefully the change will work this time or the needed changes should be applied.