### PR TITLE
Show "No Value" when there is no value in attachments

### DIFF
--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -90,10 +90,22 @@ Item {
     color: FileUtils.fileExists(qgisProject.homePath + '/' + value) ? '#0000EE' : 'black'
 
     text: {
-      if(UrlUtils.isRelativeOrFileUrl(value))
-        return config.FullUrl ? value : FileUtils.fileName(value)
+      var fieldValue = value
 
-      return StringUtils.insertLinks(value)
+      if(UrlUtils.isRelativeOrFileUrl(fieldValue))
+        fieldValue = config.FullUrl ? fieldValue : FileUtils.fileName(fieldValue)
+
+      fieldValue = StringUtils.insertLinks(fieldValue)
+
+      if ( !fieldValue )
+      {
+        font.italic = true
+        return qsTr('No Document Path Value')
+      }
+
+      font.italic = false
+
+      return fieldValue
     }
 
     background: Rectangle {

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -99,9 +99,12 @@ Item {
 
       if ( !fieldValue )
       {
+        font.italic = true
         color = 'gray'
         return qsTr('No Value')
       }
+
+      font.italic = false
 
       return fieldValue
     }

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -100,7 +100,6 @@ Item {
       if ( !fieldValue )
       {
         font.italic = true
-        color = 'gray'
         return qsTr('No Value')
       }
 

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -87,7 +87,7 @@ Item {
     anchors.left: parent.left
     anchors.right: parent.right
     font: Theme.defaultFont
-    color: FileUtils.fileExists(qgisProject.homePath + '/' + value) ? '#0000EE' : 'black'
+    color: FileUtils.fileExists(qgisProject.homePath + '/' + value) ? Theme.hyperlinkBlue : 'gray'
 
     text: {
       var fieldValue = value
@@ -99,11 +99,9 @@ Item {
 
       if ( !fieldValue )
       {
-        font.italic = true
-        return qsTr('No Document Path Value')
+        color = 'gray'
+        return qsTr('No Value')
       }
-
-      font.italic = false
 
       return fieldValue
     }

--- a/src/qml/imports/Theme/Theme.qml
+++ b/src/qml/imports/Theme/Theme.qml
@@ -9,6 +9,7 @@ QtObject {
     readonly property color gray: "#888888"
     readonly property color lightGray: "#dddddd"
     readonly property color light: "#ffffff"
+    readonly property color hyperlinkBlue: '#0000EE'
 
     property color mainColor: "#80cc28"
     property color errorColor: "#c0392b"


### PR DESCRIPTION
Tries to prevent #1213 , #1284 and other issue reports due to misconfiguration. Now it should "No Value" when there is no value. Since there are two words separated by space and different color, it's quite hard to be confused filename in my opinion.

The wording in QGIS:

> Use hyperlink for document path (read-only)

However "No Document Path Value" does not sound ok to me, as we work only with pics. "No File Path", "No Attachment Path Value", "NULL"... I am quite open for the wording here. 

![image](https://user-images.githubusercontent.com/2820439/92578543-a6752c80-f294-11ea-8092-33185b9757c4.png)
