### PR TITLE
Shows navbar position prefix only when more than 1 listed feat

### DIFF
--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -78,7 +78,11 @@ Rectangle {
 
       text: {
         if ( model && selection && selection.focusedItem > -1 && toolBar.state === 'Navigation' ) {
-          return ( selection.focusedItem + 1 ) + '/' + model.count + ': ' + FeatureUtils.displayName(selection.focusedLayer, selection.focusedFeature)
+          var featurePosition = model.count > 1
+              ? ( ( selection.focusedItem + 1 ) + '/' + model.count + ': ' )
+              : '';
+
+          return featurePosition + FeatureUtils.displayName(selection.focusedLayer, selection.focusedFeature)
         }
         else {
           return qsTr('Features')


### PR DESCRIPTION
I think showing 1/1 brings extra noise in the overall UX without any additional information to the user.

| before | after | but still |
|----------|----------|----------|
| ![image](https://user-images.githubusercontent.com/2820439/92635813-1b6d5400-f2df-11ea-9e20-36a276fae8f5.png) | ![image](https://user-images.githubusercontent.com/2820439/92635648-da753f80-f2de-11ea-8d14-a89406a11330.png)  | ![image](https://user-images.githubusercontent.com/2820439/92635611-cd585080-f2de-11ea-854a-8f2aca8792a7.png) |


