### PR TITLE
Set no sub models if the form has no tabs

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -198,13 +198,13 @@ Page {
               }
             }
 
-            model: SubModel {
+            SubModel {
               id: contentModel
               model: form.model
-              rootIndex: form.model.hasTabs
-                         ? form.model.index(currentIndex, 0)
-                         : form.model.index(0, 0)
+              rootIndex: form.model.index(currentIndex, 0)
             }
+
+            model: form.model.hasTabs ? contentModel : form.model
 
             delegate: fieldItem
           }


### PR DESCRIPTION
Set the form.model instead of sub model when it has no tabs.

Fixes #1255