### PR TITLE
Keep relation editor widget enabled in embedded forms

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -364,11 +364,11 @@ Page {
             // - not activated in multi edit mode
             // - not set to editable in the widget configuration
             // - not in edit mode (ReadOnly)
-            // - a relation in an embedded form or in multi edit mode
+            // - a relation in multi edit mode
             property bool isEnabled: AttributeAllowEdit
                                      && !!AttributeEditable
                                      && form.state !== 'ReadOnly'
-                                     && !( Type === 'relation' && ( embedded || form.model.featureModel.modelMode == FeatureModel.MultiFeatureModel ) )
+                                     && !( Type === 'relation' && form.model.featureModel.modelMode == FeatureModel.MultiFeatureModel )
             property var value: AttributeValue
             property var config: ( EditorWidgetConfig || {} )
             property var widget: EditorWidget


### PR DESCRIPTION
fixes #1283

This was avoided when introducing relation editor widgets because there has been crashes with nested relations. 
I'm pretty confident that this crash cause is resolved meanwhile because there are apparently no problems anymore.
