### PR TITLE
Only show feature form HTML widgets when the form is focused

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -291,7 +291,7 @@ Page {
 
         WebView {
           id: htmlItem
-          visible: TabIndex === form.currentTab
+          visible: TabIndex === form.currentTab && ( form.focus || featureForm.focus )
           anchors {
             left: parent.left
             rightMargin: 12

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -615,6 +615,11 @@ ApplicationWindow {
     allowLayerChange: !digitizingToolbar.isDigitizing
     mapSettings: mapCanvas.mapSettings
     interactive: !welcomeScreen.visible
+
+    onOpenedChanged: {
+      if ( !opened && featureForm.visible )
+        featureForm.focus = true
+    }
   }
 
   /* The main menu */


### PR DESCRIPTION
@signedav , this fixes unwanted overlay of dashboard drawer, welcome screen, et cie.

We now have to cross fingers for Qt 6 gives us a better WebView item (or an equivalent alternative).