### PR TITLE
Pass visibility state on tracking start

### DIFF
--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -158,7 +158,7 @@ Popup {
                  trackingModel.stopTracker(layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer));
                  displayToast( qsTr( 'Track on layer %1 stopped' ).arg( layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer).name  ) )
             } else {
-                trackingModel.createTracker(layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer), itemVisible);
+                trackingModel.createTracker(layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer), itemVisibleCheckBox.checked );
             }
             close()
         }


### PR DESCRIPTION
Since this has been removed here 7cd89195625c3418a2cb7abe39c09ef89aeace1c
```
 property alias itemVisible: itemVisibleCheckBox.checked
``` 
tracking could not been started.

Now we get the `itemVisibile` state from the checkbox directly. Needs less code and I don't see any risks in getting it from the checkbox instead getting it from the alias...