### PR TITLE
Make cascading dependencies work since the init phase

### DIFF
--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -27,6 +27,7 @@ Item {
       id: featureListModel
 
       currentLayer: qgisProject.mapLayer(config['Layer'])
+      currentFormFeature: currentFeature
       keyField: config['Key']
       displayValueField: config['Value']
       addNull: config['AllowNull']
@@ -56,6 +57,7 @@ Item {
         //passing "" instead of undefined, so the model is cleared on adding new features
         attributeValue: value !== undefined ? value : ""
         currentLayer: qgisProject.mapLayer(config['Layer'])
+        currentFormFeature: currentFeature
         keyField: config['Key']
         displayValueField: config['Value']
         addNull: config['AllowNull']


### PR DESCRIPTION
The current feature was invalid in the init phase, which skips the application of the filter expression. Fix https://github.com/opengisch/QField/issues/1323