### PR TITLE
Fix go to coordinate transform crash

### DIFF
--- a/src/core/gotolocatorfilter.cpp
+++ b/src/core/gotolocatorfilter.cpp
@@ -121,6 +121,11 @@ void GotoLocatorFilter::fetchResults( const QString &string, const QgsLocatorCon
           Q_UNUSED( e )
           return;
         }
+        catch(...)
+        {
+          // catch any other errors
+          return;
+        }
         data[QStringLiteral( "point" )] = transformedPoint;
       }
 


### PR DESCRIPTION
```
--------- beginning of crash
10-02 14:29:07.740 10705 10750 F libc    : Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE) in tid 10750 (qtMainLoopThrea), pid 10705 (gis.qfield_beta)
10-02 14:29:07.786  7659  7674 I roid.honeyboar: Background concurrent copying GC freed 169253(7315KB) AllocSpace objects, 0(0B) LOS objects, 46% free, 27MB/51MB, paused 628us total 121.440ms
10-02 14:29:07.796  7659  7659 I HONEYBOARD: bz  buildTransSuggestions mComposingTextTrans.getTransComposing() :  
10-02 14:29:07.796  7659  7659 I HONEYBOARD: a [PF_EN] updateSelectList() 0 
10-02 14:29:07.797  7659  7659 I HONEYBOARD: a [PF_EN] getSuggestion() 1 
10-02 14:29:07.797  7659  7659 I HONEYBOARD: aw setCandidates size : 8 
10-02 14:29:07.797  7659  7659 I HONEYBOARD: av printCandidateList size : 8 
10-02 14:29:07.797  7659  7659 I HONEYBOARD: b updateTextCandidates size : 8 
10-02 14:29:07.798  7659  7659 I HONEYBOARD: CandidateTable setVisibilityCandidateTable : GONE 
10-02 14:29:07.798  7659  7659 I HONEYBOARD: a execute :  true
10-02 14:29:07.812  7659  7659 E DecorView: mWindow.mActivityCurrentConfig is null
10-02 14:29:07.814  7659  7659 I HONEYBOARD: a setContainerVisibility :  true
10-02 14:29:07.816 11085 11085 E crash_dump64: unknown process state: t
10-02 14:29:07.828  7659  7659 E DecorView: mWindow.mActivityCurrentConfig is null
10-02 14:29:07.856 11085 11085 I crash_dump64: obtaining output fd from tombstoned, type: kDebuggerdTombstone
10-02 14:29:07.861  4633  4633 I /system/bin/tombstoned: received crash request for pid 10750
10-02 14:29:07.863 11085 11085 I crash_dump64: performing dump of process 10705 (target tid = 10750)
10-02 14:29:07.877 11085 11085 F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
10-02 14:29:07.878 11085 11085 F DEBUG   : Build fingerprint: 'samsung/a51nsxx/a51:10/QP1A.190711.020/A515FXXU3BTH4:user/release-keys'
10-02 14:29:07.878 11085 11085 F DEBUG   : Revision: '6'
10-02 14:29:07.878 11085 11085 F DEBUG   : ABI: 'arm64'
10-02 14:29:07.878 11085 11085 F DEBUG   : Timestamp: 2020-10-02 14:29:07+0700
10-02 14:29:07.878 11085 11085 F DEBUG   : pid: 10705, tid: 10750, name: qtMainLoopThrea  >>> ch.opengis.qfield_beta <<<
10-02 14:29:07.878 11085 11085 F DEBUG   : uid: 10302
10-02 14:29:07.879 11085 11085 F DEBUG   : signal 6 (SIGABRT), code -1 (SI_QUEUE), fault addr --------
10-02 14:29:07.879 11085 11085 F DEBUG   : Abort message: 'terminating with uncaught exception of type QgsCsException'
10-02 14:29:07.879 11085 11085 F DEBUG   :     x0  0000000000000000  x1  00000000000029fe  x2  0000000000000006  x3  0000007d02df6380
10-02 14:29:07.879 11085 11085 F DEBUG   :     x4  fefefefefefefeff  x5  fefefefefefefeff  x6  fefefefefefefeff  x7  7f7f7f7f7f7f7f7f
10-02 14:29:07.879 11085 11085 F DEBUG   :     x8  00000000000000f0  x9  e8160e6c2dc18eb2  x10 0000000000000001  x11 0000000000000000
10-02 14:29:07.879 11085 11085 F DEBUG   :     x12 fffffff0fffffbdf  x13 6e6f697470656378  x14 0000000000000000  x15 0000007d967ab412
10-02 14:29:07.879 11085 11085 F DEBUG   :     x16 0000007d967b18c0  x17 0000007d9678e930  x18 0000007ca4bf2000  x19 00000000000029d1
10-02 14:29:07.879 11085 11085 F DEBUG   :     x20 00000000000029fe  x21 00000000ffffffff  x22 ffffff80ffffffc8  x23 0000007d02df65d0
10-02 14:29:07.879 11085 11085 F DEBUG   :     x24 0000007d02df64b0  x25 0000007d02df64f0  x26 0000007c76fa6358  x27 0000007c76fa6350
10-02 14:29:07.879 11085 11085 F DEBUG   :     x28 0000007ca1916538  x29 0000007d02df6420
10-02 14:29:07.879 11085 11085 F DEBUG   :     sp  0000007d02df6360  lr  0000007d96743108  pc  0000007d96743134
10-02 14:29:07.886 11085 11085 F DEBUG   : 
10-02 14:29:07.886 11085 11085 F DEBUG   : backtrace:
10-02 14:29:07.887 11085 11085 F DEBUG   :       #00 pc 0000000000083134  /apex/com.android.runtime/lib64/bionic/libc.so (abort+160) (BuildId: 668befe909364b16346dcf2cd89684ff)
10-02 14:29:07.887 11085 11085 F DEBUG   :       #01 pc 000000000009ce88  /data/app/ch.opengis.qfield_beta-zBASB7ynUhPKIRQALwEGGg==/lib/arm64/libc++_shared.so (BuildId: 67e966ac77ca70ae9867f54c3711ee9a6c96e3b6)
10-02 14:29:07.887 11085 11085 F DEBUG   :       #02 pc 000000000009d094  /data/app/ch.opengis.qfield_beta-zBASB7ynUhPKIRQALwEGGg==/lib/arm64/libc++_shared.so (BuildId: 67e966ac77ca70ae9867f54c3711ee9a6c96e3b6)
10-02 14:29:07.887 11085 11085 F DEBUG   :       #03 pc 00000000000aead0  /data/app/ch.opengis.qfield_beta-zBASB7ynUhPKIRQALwEGGg==/lib/arm64/libc++_shared.so (BuildId: 67e966ac77ca70ae9867f54c3711ee9a6c96e3b6)
10-02 14:29:07.887 11085 11085 F DEBUG   :       #04 pc 00000000000ae3d8  /data/app/ch.opengis.qfield_beta-zBASB7ynUhPKIRQALwEGGg==/lib/arm64/libc++_shared.so (__cxa_rethrow+196) (BuildId: 67e966ac77ca70ae9867f54c3711ee9a6c96e3b6)
10-02 14:29:07.887 11085 11085 F DEBUG   :       #05 pc 00000000009bdee0  /data/app/ch.opengis.qfield_beta-zBASB7ynUhPKIRQALwEGGg==/lib/arm64/libqgis_core_arm64-v8a.so (QgsCoordinateTransform::transform(QgsPointXY const&, QgsCoordinateTransform::TransformDirection) const+172) (BuildId: 44fc8f6285a5a423a33964434e110e449abaf311)
10-02 14:29:07.887 11085 11085 F DEBUG   :       #06 pc 00000000001ced80  /data/app/ch.opengis.qfield_beta-zBASB7ynUhPKIRQALwEGGg==/lib/arm64/libqfield_core_arm64-v8a.so (GotoLocatorFilter::fetchResults(QString const&, QgsLocatorContext const&, QgsFeedback*)+2840) (BuildId: 1eab66e6a992b858e72b2b6459b2b6bc05544f33)
10-02 14:29:07.887 11085 11085 F DEBUG   :       #07 pc 0000000000759e38  /data/app/ch.opengis.qfield_beta-zBASB7ynUhPKIRQALwEGGg==/lib/arm64/libqgis_core_arm64-v8a.so (QgsLocator::fetchResults(QString const&, QgsLocatorContext const&, QgsFeedback*)+1476) (BuildId: 44fc8f6285a5a423a33964434e110e449abaf311)
10-02 14:29:07.887 11085 11085 F DEBUG   :       #08 pc 000000000075fd84  /data/app/ch.opengis.qfield_beta-zBASB7ynUhPKIRQALwEGGg==/lib/arm64/libqgis_core_arm64-v8a.so (QgsLocatorModelBridge::performSearch(QString const&)+220) (BuildId: 44fc8f6285a5a423a33964434e110e449abaf311)
10-02 14:29:07.887 11085 11085 F DEBUG   :       #09 pc 0000000000398d60  /data/app/ch.opengis.qfield_beta-zBASB7ynUhPKIRQALwEGGg==/lib/arm64/libqgis_core_arm64-v8a.so (QgsLocatorModelBridge::qt_metacall(QMetaObject::Call, int, void**)+144) (BuildId: 44fc8f6285a5a423a33964434e110e449abaf311)
10-02 14:29:07.887 11085 11085 F DEBUG   :       #10 pc 00000000001777e4  /data/app/ch.opengis.qfield_beta-zBASB7ynUhPKIRQALwEGGg==/lib/arm64/libqfield_core_arm64-v8a.so (LocatorModelSuperBridge::qt_metacall(QMetaObject::Call, int, void**)+68) (BuildId: 1eab66e6a992b858e72b2b6459b2b6bc05544f33)
10-02 14:29:07.887 11085 11085 F DEBUG   :       #11 pc 00000000002cc1c4  /data/app/ch.opengis.qfield_beta-zBASB7ynUhPKIRQALwEGGg==/lib/arm64/libQt5Qml_arm64-v8a.so (BuildId: 632b36899e4c84e30ad74d3fd75b87365cff929b)
```
