### PR TITLE
Do not use 0 for NULL in value relation widgets

### DIFF
--- a/src/core/featurelistmodel.cpp
+++ b/src/core/featurelistmodel.cpp
@@ -151,7 +151,7 @@ int FeatureListModel::findKey( const QVariant &key ) const
     ++idx;
   }
 
-  if ( addNull() )
+  if ( mAddNull )
     return 0;
 
   return -1;

--- a/src/core/featurelistmodel.cpp
+++ b/src/core/featurelistmodel.cpp
@@ -151,6 +151,9 @@ int FeatureListModel::findKey( const QVariant &key ) const
     ++idx;
   }
 
+  if ( addNull() )
+    return 0;
+
   return -1;
 }
 
@@ -212,7 +215,7 @@ void FeatureListModel::processReloadLayer()
   QList<Entry> entries;
 
   if ( mAddNull )
-    entries.append( Entry( QStringLiteral( "<i>NULL</i>" ), QVariant( QVariant::Int ) ) );
+    entries.append( Entry( QStringLiteral( "<i>NULL</i>" ), QVariant() ) );
 
   while ( iterator.nextFeature( feature ) )
   {


### PR DESCRIPTION
Set QVariant() as NULL for any kind of type to avoid that for integer values 0 has been set as NULL.
Return the first index (0) if the value has not been found (because NULL is not NULL) but allowNull is active.

fixes #1337 (leet)