### PR TITLE
Fix zoom to layer extent broken on reprojected layers

### DIFF
--- a/src/qgsquick/qgsquickmapsettings.cpp
+++ b/src/qgsquick/qgsquickmapsettings.cpp
@@ -103,10 +103,11 @@ void QgsQuickMapSettings::setCenterToLayer( QgsMapLayer *layer, bool shouldZoom 
 {
   Q_ASSERT( layer );
 
+  const QgsRectangle extent = mapSettings().layerToMapCoordinates( layer, layer->extent() );
   if ( shouldZoom )
-    setExtent( layer->extent() );
+    setExtent( extent );
   else
-    setCenter( QgsPoint( layer->extent().center() ) );
+    setCenter( QgsPoint( extent.center() ) );
 }
 
 double QgsQuickMapSettings::mapUnitsPerPoint() const


### PR DESCRIPTION
_This should probably make its way into 1.7_

The QgsQuickMapSettings::setCenterToLayer() function didn't handle layers with a CRS that's not that of the project, leading to pain and tears. This fixes it.