### PR TITLE
Fix rubber band geometry not reprojected (when needed) in setDataFromGeometry

### DIFF
--- a/src/core/geometry.cpp
+++ b/src/core/geometry.cpp
@@ -93,7 +93,10 @@ void Geometry::updateRubberband( const QgsGeometry &geometry )
   if ( !mRubberbandModel )
     return;
 
-  mRubberbandModel->setDataFromGeometry( geometry );
+  if ( mVectorLayer )
+    mRubberbandModel->setDataFromGeometry( geometry, mVectorLayer->crs() );
+  else
+    mRubberbandModel->setDataFromGeometry( geometry );
 }
 
 QgsVectorLayer *Geometry::vectorLayer() const

--- a/src/core/rubberbandmodel.cpp
+++ b/src/core/rubberbandmodel.cpp
@@ -275,10 +275,13 @@ void RubberbandModel::reset()
   emit frozenChanged();
 }
 
-void RubberbandModel::setDataFromGeometry( const QgsGeometry &geometry )
+void RubberbandModel::setDataFromGeometry( QgsGeometry geometry, const QgsCoordinateReferenceSystem &crs )
 {
   if ( geometry.type() != mGeometryType )
     return;
+
+  QgsCoordinateTransform ct( crs, mCrs, QgsProject::instance()->transformContext() );
+  geometry.transform( ct );
 
   mPointList.clear();
   const QgsAbstractGeometry *abstractGeom = geometry.constGet();

--- a/src/core/rubberbandmodel.h
+++ b/src/core/rubberbandmodel.h
@@ -124,7 +124,7 @@ class RubberbandModel : public QObject
      * Sets the model data to match a given \a geometry
      * \note rings and multiparts are discarded
      */
-    void setDataFromGeometry( const QgsGeometry &geometry );
+    void setDataFromGeometry( QgsGeometry geometry, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() );
 
   signals:
     void vertexChanged( int index );


### PR DESCRIPTION
When confirming a new feature, the previewed geometry would disappear off the map due to the rubber band previewing the geometry not handling project vs layer projection difference in setDataFromGeometry.

While it'd be nice to have as a fix in the 1.7 branch, I don't think it's as needed as #1342. 