### PR TITLE
Make sure legend images are drawn at device dpi, avoid blur and size issue

### DIFF
--- a/src/core/layertreemapcanvasbridge.cpp
+++ b/src/core/layertreemapcanvasbridge.cpp
@@ -42,7 +42,15 @@ LayerTreeMapCanvasBridge::LayerTreeMapCanvasBridge( FlatLayerTreeModel *model, Q
 
   connect( mTrackingModel, &TrackingModel::layerInTrackingChanged, this, &LayerTreeMapCanvasBridge::layerInTrackingChanged );
 
+  connect( mMapSettings, &QgsQuickMapSettings::extentChanged, this, &LayerTreeMapCanvasBridge::extentChanged );
   setCanvasLayers();
+}
+
+void LayerTreeMapCanvasBridge::extentChanged()
+{
+  // allow symbols in the legend update their preview if they use map units
+  mModel->layerTreeModel()->setLegendMapViewData( mMapSettings->mapSettings().mapUnitsPerPixel(),
+      static_cast< int >( std::round( mMapSettings->outputDpi() ) ), mMapSettings->mapSettings().scale() );
 }
 
 void LayerTreeMapCanvasBridge::setCanvasLayers()

--- a/src/core/layertreemapcanvasbridge.h
+++ b/src/core/layertreemapcanvasbridge.h
@@ -77,6 +77,7 @@ class LayerTreeMapCanvasBridge : public QObject
     Q_INVOKABLE void setCanvasLayers();
 
   private slots:
+    void extentChanged();
     void nodeVisibilityChanged();
     void mapThemeChanged();
     void layerInTrackingChanged( QgsVectorLayer *layer, bool tracking );

--- a/src/core/legendimageprovider.cpp
+++ b/src/core/legendimageprovider.cpp
@@ -32,6 +32,7 @@ LegendImageProvider::LegendImageProvider( QgsLayerTreeModel *layerTreeModel )
 QPixmap LegendImageProvider::requestPixmap( const QString &id, QSize *size, const QSize &requestedSize )
 {
   Q_UNUSED( size )
+  const int iconSize = mLayerTreeModel->scaleIconSize( 16 );
 
   // the id is passed on as an encoded URL string which needs decoding
   const QString decodedId = QUrl::fromPercentEncoding( id.toUtf8() );
@@ -54,11 +55,11 @@ QPixmap LegendImageProvider::requestPixmap( const QString &id, QSize *size, cons
         {
           QIcon icon = mLayerTreeModel->data( index, Qt::DecorationRole ).value<QIcon>();
           if ( !icon.isNull() )
-            pixmap = icon.pixmap( 24, 24 );
+            pixmap = icon.pixmap( iconSize, iconSize );
         }
         if ( pixmap.isNull() )
         {
-          pixmap = QPixmap( 24, 24 );
+          pixmap = QPixmap( iconSize, iconSize );
           pixmap.fill( QColor( 255, 255, 255 ) );
         }
         return pixmap;
@@ -99,18 +100,18 @@ QPixmap LegendImageProvider::requestPixmap( const QString &id, QSize *size, cons
         {
          QIcon icon = legendNode->data( Qt::DecorationRole ).value<QIcon>();
          if ( !icon.isNull() )
-           pixmap = icon.pixmap( 24, 24 );
+           pixmap = icon.pixmap( iconSize, iconSize );
         }
         if ( pixmap.isNull() )
         {
-          pixmap = QPixmap( 24, 24 );
+          pixmap = QPixmap( iconSize, iconSize );
           pixmap.fill( QColor( 255, 255, 255 ) );
         }
         return pixmap;
       }
       else
       {
-        QPixmap pixmap( 24, 24 );
+        QPixmap pixmap( iconSize, iconSize );
         pixmap.fill( QColor( 255, 255, 255 ) );
         return pixmap;
       }

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -175,6 +175,9 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   mMapCanvas = rootObjects().first()->findChild<QgsQuickMapCanvasMap *>();
   mMapCanvas->mapSettings()->setProject( mProject );
 
+  mFlatLayerTree->layerTreeModel()->setLegendMapViewData( mMapCanvas->mapSettings()->mapSettings().mapUnitsPerPixel(),
+      static_cast< int >( std::round( mMapCanvas->mapSettings()->outputDpi() ) ), mMapCanvas->mapSettings()->mapSettings().scale() );
+
   Q_ASSERT_X( mMapCanvas, "QML Init", "QgsQuickMapCanvasMap not found. It is likely that we failed to load the QML files. Check debug output for related messages." );
 
   connect( mProject, &QgsProject::readProject, this, &QgisMobileapp::onReadProject );


### PR DESCRIPTION
This and https://github.com/qgis/QGIS/pull/39341 fix blurry QField legend preview images on HiDPI screens.