### PR TITLE
Keep the digitizing ok/check button even when stylus is hovering the screen

### DIFF
--- a/src/qml/DigitizingToolbar.qml
+++ b/src/qml/DigitizingToolbar.qml
@@ -69,13 +69,15 @@ VisibilityFadingRow {
       }
       else
       {
-        !screenHovering && geometryValid
+        geometryValid
       }
     }
     round: true
     bgcolor: Theme.mainColor
 
     onClicked: {
+      // set coordinateLocator source location to undefined to avoid hover interferance
+      coordinateLocator.sourceLocation = undefined
       // remove editing vertex for lines and polygons
       removeVertex()
       confirm()

--- a/src/qml/DigitizingToolbar.qml
+++ b/src/qml/DigitizingToolbar.qml
@@ -76,10 +76,9 @@ VisibilityFadingRow {
     bgcolor: Theme.mainColor
 
     onClicked: {
-      // set coordinateLocator source location to undefined to avoid hover interferance
-      coordinateLocator.sourceLocation = undefined
       // remove editing vertex for lines and polygons
-      removeVertex()
+      rubberbandModel.frozen = true
+      rubberbandModel.removeVertex()
       confirm()
     }
   }

--- a/src/qml/DigitizingToolbar.qml
+++ b/src/qml/DigitizingToolbar.qml
@@ -102,7 +102,7 @@ VisibilityFadingRow {
     enabled: !screenHovering
     bgcolor: {
         if (screenHovering)
-          Qt.hsla(Theme.darkGray.hue,Theme.darkGray.saturation,Theme.darkGray.lightness,0.4)
+          Theme.darkGraySemiOpaque
         else if (!showConfirmButton)
           Theme.darkGray
         else if (Number( rubberbandModel ? rubberbandModel.geometryType : 0 ) === QgsWkbTypes.PointGeometry)

--- a/src/qml/DigitizingToolbar.qml
+++ b/src/qml/DigitizingToolbar.qml
@@ -97,19 +97,27 @@ VisibilityFadingRow {
 
   QfToolButton {
     id: addVertexButton
-    iconSource: !screenHovering ? Theme.getThemeIcon( "ic_add_white_24dp" ) : ''
+    iconSource: Theme.getThemeIcon( "ic_add_white_24dp" )
     round: true
     enabled: !screenHovering
     bgcolor: {
-        if (screenHovering)
-          Theme.darkGraySemiOpaque
-        else if (!showConfirmButton)
+        if (!showConfirmButton)
           Theme.darkGray
         else if (Number( rubberbandModel ? rubberbandModel.geometryType : 0 ) === QgsWkbTypes.PointGeometry)
           Theme.mainColor
         else
           Theme.darkGray
     }
+
+    states: [
+        State { when: addVertexButton.enabled;
+            PropertyChanges {   target: addVertexButton; opacity: 1.0    }
+        },
+        State { when: !addVertexButton.enabled;
+            PropertyChanges {   target: addVertexButton; opacity: 0.0    }
+        }
+    ]
+    transitions: [ Transition { NumberAnimation { property: "opacity"; duration: 200 } } ]
 
     onClicked: {
       if ( Number( rubberbandModel.geometryType ) === QgsWkbTypes.PointGeometry ||

--- a/src/qml/DigitizingToolbar.qml
+++ b/src/qml/DigitizingToolbar.qml
@@ -97,13 +97,13 @@ VisibilityFadingRow {
 
   QfToolButton {
     id: addVertexButton
-    iconSource: {
-        Theme.getThemeIcon( "ic_add_white_24dp" )
-    }
+    iconSource: !screenHovering ? Theme.getThemeIcon( "ic_add_white_24dp" ) : ''
     round: true
-    visible: !screenHovering
+    enabled: !screenHovering
     bgcolor: {
-        if (!showConfirmButton)
+        if (screenHovering)
+          Qt.hsla(Theme.darkGray.hue,Theme.darkGray.saturation,Theme.darkGray.lightness,0.4)
+        else if (!showConfirmButton)
           Theme.darkGray
         else if (Number( rubberbandModel ? rubberbandModel.geometryType : 0 ) === QgsWkbTypes.PointGeometry)
           Theme.mainColor

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -750,7 +750,7 @@ ApplicationWindow {
           PropertyChanges {
             target: gpsButton
             iconSource: Theme.getThemeIcon( "ic_location_disabled_white_24dp" )
-            bgcolor: "#88212121"
+            bgcolor: Theme.darkGraySemiOpaque
           }
         },
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -199,7 +199,6 @@ ApplicationWindow {
             else {
                 resetIsBeingTouchedTimer.restart()
             }
-
         }
     }
 


### PR DESCRIPTION
The long press on canvas to validate a new line/polygon is really hard to discover. Let's keep the ok/check button for users to touch / click on it to confirm the geometry.

@3nids , is that OK with you? I've tested this some more with freehand digitizing and I really thing we're better keeping the button here. 