### PR TITLE
Feature form container/tab constraints handling & general improvements

### DIFF
--- a/src/core/attributeformmodelbase.h
+++ b/src/core/attributeformmodelbase.h
@@ -83,7 +83,7 @@ class AttributeFormModelBase : public QStandardItemModel
 
     void flatten( QgsAttributeEditorContainer *container, QStandardItem *parent, const QString &parentVisibilityExpressions, QVector<QStandardItem *> &items, int currentTabIndex = 0 );
 
-    void updateVisibility( int fieldIndex = -1 );
+    void updateVisibilityAndConstraints( int fieldIndex = -1 );
 
     void setConstraintsHardValid( bool constraintsHardValid );
 

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -108,6 +108,7 @@ Page {
 
           TabButton {
             id: tabButton
+            property bool isCurrentIndex: index == tabRow.currentIndex
             text: Name
             topPadding: 0
             bottomPadding: 0
@@ -131,8 +132,8 @@ Page {
               text: tabButton.text
               // color: tabButton.down ? '#17a81a' : '#21be2b'
               color: !tabButton.enabled ? Theme.darkGray : !ConstraintHardValid ? Theme.errorColor : !ConstraintSoftValid ? Theme.warningColor :
-                                         tabButton.down || tabButton.checked ? Qt.darker(Theme.mainColor,1.5) : Theme.mainColor
-              font.weight: tabButton.checked ? Font.DemiBold : Font.Normal
+                                         tabButton.down || isCurrentIndex ? Qt.darker(Theme.mainColor,1.5) : Theme.mainColor
+              font.weight: isCurrentIndex ? Font.DemiBold : Font.Normal
 
               horizontalAlignment: Text.AlignHCenter
               verticalAlignment: Text.AlignVCenter

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -85,7 +85,7 @@ Page {
       TabBar {
         id: tabRow
         visible: model.hasTabs
-        height: 48
+        height: form.model.hasTabs ? 48 : 0
 
         Connections {
           target: master
@@ -142,72 +142,78 @@ Page {
       }
     }
 
-    SwipeView {
-      id: swipeView
-      currentIndex: tabRow.currentIndex
+    Rectangle {
       anchors {
         top: flickable.bottom
         left: parent.left
         right: parent.right
         bottom: parent.bottom
       }
+      color: "white"
 
-      Repeater {
-        // One page per tab in tabbed forms, 1 page in auto forms
-        model: form.model.hasTabs ? form.model : 1
+      SwipeView {
+        id: swipeView
+        anchors.fill: parent
+        topPadding: 15
+        currentIndex: tabRow.currentIndex
 
-        Item {
-          id: formPage
-          property int currentIndex: index
+        Repeater {
+          // One page per tab in tabbed forms, 1 page in auto forms
+          model: form.model.hasTabs ? form.model : 1
 
-          Rectangle {
-            anchors.fill: formPage
-            color: "white"
-          }
+          Item {
+            id: formPage
+            property int currentIndex: index
 
-          /**
+            Rectangle {
+              anchors.fill: formPage
+              color: "white"
+            }
+
+            /**
            * The main form content area
            */
-          ListView {
-            id: content
-            anchors.fill: parent
-            clip: true
-            section.property: 'Group'
-            section.labelPositioning: ViewSection.CurrentLabelAtStart | ViewSection.InlineLabels
-            section.delegate: Component {
-              // section header: group box name
-              Rectangle {
-                width: parent.width
-                height: section === "" ? 0 : 30
-                color: 'lightGray'
-
-                Text {
-                  anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
+            ListView {
+              id: content
+              anchors.fill: parent
+              clip: true
+              section.property: 'Group'
+              section.labelPositioning: ViewSection.CurrentLabelAtStart | ViewSection.InlineLabels
+              section.delegate: Component {
+                // section header: group box name
+                Rectangle {
                   width: parent.width
-                  font.bold: true
-                  text: section
-                  wrapMode: Text.WordWrap
+                  height: section === "" ? 0 : 30
+                  color: 'lightGray'
+
+                  Text {
+                    anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
+                    width: parent.width
+                    font.bold: true
+                    text: section
+                    wrapMode: Text.WordWrap
+                  }
                 }
               }
-            }
 
-            Connections {
-              target: master
+              Connections {
+                target: master
 
-              function onReset() {
-                content.contentY = 0
+                function onReset() {
+                  content.contentY = 0
+                }
               }
+
+              SubModel {
+                id: contentModel
+                model: form.model
+                rootIndex: form.model.index(currentIndex, 0)
+              }
+
+              model: form.model.hasTabs ? contentModel : form.model
+
+              delegate: fieldItem
             }
-
-            SubModel {
-              id: contentModel
-              model: form.model
-              rootIndex: form.model.index(currentIndex, 0)
-            }
-
-            model: form.model.hasTabs ? contentModel : form.model
-
-            delegate: fieldItem
           }
         }
       }

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -130,9 +130,8 @@ Page {
               width: paintedWidth
               height: parent.height
               text: tabButton.text
-              // color: tabButton.down ? '#17a81a' : '#21be2b'
               color: !tabButton.enabled ? Theme.darkGray : !ConstraintHardValid ? Theme.errorColor : !ConstraintSoftValid ? Theme.warningColor :
-                                         tabButton.down || isCurrentIndex ? Qt.darker(Theme.mainColor,1.5) : Theme.mainColor
+                                         tabButton.down ? Qt.darker(Theme.mainColor,1.5) : Theme.mainColor
               font.weight: isCurrentIndex ? Font.DemiBold : Font.Normal
 
               horizontalAlignment: Text.AlignHCenter

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -591,8 +591,6 @@ Page {
 
       Label {
         id: titleLabel
-        leftPadding: model.constraintsHardValid ? 0 : 48
-
         text:
         {
           var currentLayer = model.featureModel.currentLayer

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -112,7 +112,7 @@ Page {
             text: Name
             topPadding: 0
             bottomPadding: 0
-            leftPadding: 8
+            leftPadding: !ConstraintHardValid || !ConstraintSoftValid ? 22 : 8
             rightPadding: 8
 
             width: contentItem.width + leftPadding + rightPadding
@@ -122,6 +122,17 @@ Page {
               implicitWidth: parent.width
               implicitHeight: parent.height
               color: "transparent"
+
+              Rectangle {
+                anchors.left: parent.left
+                anchors.leftMargin: 8
+                anchors.verticalCenter: parent.verticalCenter
+                width: 10
+                height: 10
+                radius: 5
+                color: !ConstraintHardValid ? Theme.errorColor : Theme.warningColor
+                visible: !ConstraintHardValid || !ConstraintSoftValid
+              }
             }
 
             contentItem: Text {
@@ -130,8 +141,7 @@ Page {
               width: paintedWidth
               height: parent.height
               text: tabButton.text
-              color: !tabButton.enabled ? Theme.darkGray : !ConstraintHardValid ? Theme.errorColor : !ConstraintSoftValid ? Theme.warningColor :
-                                         tabButton.down ? Qt.darker(Theme.mainColor,1.5) : Theme.mainColor
+              color: !tabButton.enabled ? Theme.darkGray : tabButton.down ? Qt.darker(Theme.mainColor,1.5) : Theme.mainColor
               font.weight: isCurrentIndex ? Font.DemiBold : Font.Normal
 
               horizontalAlignment: Text.AlignHCenter

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -130,8 +130,8 @@ Page {
               height: parent.height
               text: tabButton.text
               // color: tabButton.down ? '#17a81a' : '#21be2b'
-              color: !tabButton.enabled ? '#999999' : tabButton.down ||
-                                        tabButton.checked ? '#1B5E20' : '#4CAF50'
+              color: !tabButton.enabled ? Theme.darkGray : !ConstraintHardValid ? Theme.errorColor : !ConstraintSoftValid ? Theme.warningColor :
+                                         tabButton.down || tabButton.checked ? Qt.darker(Theme.mainColor,1.5) : Theme.mainColor
               font.weight: tabButton.checked ? Font.DemiBold : Font.Normal
 
               horizontalAlignment: Text.AlignHCenter

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -165,14 +165,9 @@ Page {
             id: formPage
             property int currentIndex: index
 
-            Rectangle {
-              anchors.fill: formPage
-              color: "white"
-            }
-
             /**
-           * The main form content area
-           */
+            * The main form content area
+            */
             ListView {
               id: content
               anchors.fill: parent


### PR DESCRIPTION
Feature form tabs now reflect the status of failing soft/hard constraints by changing the color of the tab title:
![image](https://user-images.githubusercontent.com/1728657/96107704-e8823580-0f06-11eb-8a3a-7ed0f2260b66.png)

I took the time to improve other aspects of the feature form along the way.