### PR TITLE
Fix crippled range editor

### DIFF
--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -76,7 +76,7 @@ Item {
 
     Slider {
       id: slider
-      value: typeof rangeItem.parent.value === 'numeric' ? rangeItem.parent.value : rangeItem.from
+      value: typeof rangeItem.parent.value === 'numeric' ? rangeItem.parent.value : slider.value
       width: sliderRow.width - valueLabel.width
       height: fontMetrics.height + 20
       implicitWidth: width


### PR DESCRIPTION
Bug introduced by "Fix: editorwidgets/Range.qml:76:7: Unable to assign [undefined] to double"

https://github.com/opengisch/QField/commit/ee45e74db93e85790ac34959bbbab4d782b3bd21

When the range editor is clicked, it initialy resets to 0 and then goes to the current value.