### PR TITLE
Fix multiline section header, revisit padding

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -164,7 +164,6 @@ Page {
       SwipeView {
         id: swipeView
         anchors.fill: parent
-        topPadding: 15
         currentIndex: tabRow.currentIndex
 
         Repeater {
@@ -188,12 +187,15 @@ Page {
                 // section header: group box name
                 Rectangle {
                   width: parent.width
-                  height: section === "" ? 0 : 30
+                  height: section === "" ? 0 : childrenRect.height + 10
                   color: 'lightGray'
 
                   Text {
-                    anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
+                    anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter; }
+                    leftPadding: 10
+                    rightPadding: 10
                     width: parent.width
+                    font.pointSize: 12
                     font.bold: true
                     text: section
                     wrapMode: Text.WordWrap
@@ -337,6 +339,7 @@ Page {
           wrapMode: Text.WordWrap
           font.pointSize: 12
           font.bold: true
+          topPadding: 10
           bottomPadding: 5
           color: ConstraintHardValid ? form.state === 'ReadOnly' || embedded && EditorWidget === 'RelationEditor' ? 'grey' : ConstraintSoftValid ? 'black' : Theme.warningColor : Theme.errorColor
         }


### PR DESCRIPTION
The feature form's section delegate had a fixed height, which means multiline strings would end up overlapping outside of the section rectangle, for e.g.:
![image](https://user-images.githubusercontent.com/1728657/96431810-3dd38500-122e-11eb-98cc-6b91292e5034.png)

The PR fixes that:
![image](https://user-images.githubusercontent.com/1728657/96431838-45932980-122e-11eb-95a2-9ca170ae61ca.png)
