### PR TITLE
Fix crashes on "What's new"

### DIFF
--- a/src/qml/Changelog.qml
+++ b/src/qml/Changelog.qml
@@ -139,7 +139,7 @@ Item {
             changelogBody.text = changelogPeffix + changelog
             changelogBody.isSuccess = true
           } catch (err) {
-            changelogBody.text = qsTr('Temporarily cannot retrieve the changelog. Please check your internet connection.')
+            changelogBody.text = qsTr('Cannot retrieve the changelog. Please check your internet connection.')
           }
         }
       }

--- a/src/qml/Changelog.qml
+++ b/src/qml/Changelog.qml
@@ -88,62 +88,67 @@ Item {
     if ( changelogBody.isSuccess )
       return
 
-    var RELEASES_URL = 'https://api.github.com/repos/opengisch/qfield/releases'
-    var xhr = new XMLHttpRequest()
+    try {
+      var RELEASES_URL = 'https://api.github.com/repos/opengisch/qfield/releases'
+      var xhr = new XMLHttpRequest()
 
-    xhr.open('GET', RELEASES_URL)
-    xhr.onreadystatechange = function() {
-      if (xhr.readyState === XMLHttpRequest.DONE) {
-        var resp = xhr.responseText
-        var qfieldVersion = parseVersion(version)
-        var versionNumbersOnly = ''
-        var changelog = ''
+      xhr.open('GET', RELEASES_URL)
+      xhr.onreadystatechange = function() {
+        if (xhr.readyState === XMLHttpRequest.DONE) {
+          var resp = xhr.responseText
+          var qfieldVersion = parseVersion(version)
+          var versionNumbersOnly = ''
+          var changelog = ''
 
-        try {
-          var releases = JSON.parse(resp)
+          try {
+            var releases = JSON.parse(resp)
 
-          for (var i = 0, l = releases.length; i < l; i++) {
-            var release = releases[i]
-            var releaseVersion = parseVersion(release['tag_name'])
+            for (var i = 0, l = releases.length; i < l; i++) {
+              var release = releases[i]
+              var releaseVersion = parseVersion(release['tag_name'])
 
-            if (releaseVersion.length === 0)
-              continue
+              if (releaseVersion.length === 0)
+                continue
 
-            // most probably developer version with no proper version set
-            if (qfieldVersion.length === 0)
-              qfieldVersion = releaseVersion
+              // most probably developer version with no proper version set
+              if (qfieldVersion.length === 0)
+                qfieldVersion = releaseVersion
 
-            if (qfieldVersion[0] !== releaseVersion[0] || qfieldVersion[1] !== releaseVersion[1])
-              continue
+              if (qfieldVersion[0] !== releaseVersion[0] || qfieldVersion[1] !== releaseVersion[1])
+                continue
 
-            if ( !versionNumbersOnly )
-              versionNumbersOnly = releaseVersion.join('.')
+              if ( !versionNumbersOnly )
+                versionNumbersOnly = releaseVersion.join('.')
 
-            var releaseChangelog = '\n#\n# ' + release['name'] + '\n\n' + release['body'] + '\n'
-            // prepend the current release
-            changelog = releaseChangelog + changelog
+              var releaseChangelog = '\n#\n# ' + release['name'] + '\n\n' + release['body'] + '\n'
+              // prepend the current release
+              changelog = releaseChangelog + changelog
+            }
+
+            if ( changelog.length === 0 )
+              throw new Error('Empty changelog!')
+
+            changelog += '\n' + '[' + qsTr('Previous releases on GitHub') + '](https://github.com/opengisch/qfield/releases)'
+            changelog = changelog.replace(/^##(.+)$/gm, function(full) {
+              return '\n###\n' + full + '\n\n\n'
+            })
+
+            var changelogPeffix = '';
+            changelogPeffix += 'Up to release **' + versionNumbersOnly + '**'
+
+            changelogBody.text = changelogPeffix + changelog
+            changelogBody.isSuccess = true
+          } catch (err) {
+            changelogBody.text = qsTr('Temporarily cannot retrieve the changelog. Please check your internet connection.')
           }
-
-          if ( changelog.length === 0 )
-            throw new Error('Empty changelog!')
-
-          changelog += '\n' + '[' + qsTr('Previous releases on GitHub') + '](https://github.com/opengisch/qfield/releases)'
-          changelog = changelog.replace(/^##(.+)$/gm, function(full) {
-            return '\n###\n' + full + '\n\n\n'
-          })
-
-          var changelogPeffix = '';
-          changelogPeffix += 'Up to release **' + versionNumbersOnly + '**'
-
-          changelogBody.text = changelogPeffix + changelog
-          changelogBody.isSuccess = true
-        } catch (err) {
-          changelogBody.text = qsTr('Temporarily cannot retrieve the changelog. Please check your internet connection.')
         }
       }
-    }
-    xhr.send()
+      xhr.send()
 
-    changelogBody.text = qsTr('Loading…')
+      changelogBody.text = qsTr('Loading…')
+    } catch (err) {
+      console.error(err)
+      close()
+    }
   }
 }


### PR DESCRIPTION
After this comment https://github.com/opengisch/QField/issues/1327#issuecomment-716383921 it seems it's something with the new implementation of the changelog. 

Maybe it's some kind of sandboxing on Galaxies on external resources?  That's why I wrapped `new XMLHttpRequest` in a try/catch.