### PR TITLE
Allow users to define postgresql services in a pg_service.conf on their devices

### DIFF
--- a/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -82,7 +82,7 @@ public class QFieldActivity extends Activity {
     private boolean mExternalStorageWriteable = false;
     private String mDotQgis2Dir;
     private String mShareDir;
-    private String mLocalizedDataPathsDir;
+    private String mQFieldDir;
     private ProgressBar progressBar;
     private TextView unpackingTitle;
     private TextView unpackingMessage;
@@ -144,7 +144,7 @@ public class QFieldActivity extends Activity {
 
         if (mExternalStorageAvailable) {
             String storagePath = Environment.getExternalStorageDirectory().getAbsolutePath();
-            mLocalizedDataPathsDir = storagePath + "/QField/basemaps/";
+            mQFieldDir = storagePath + "/QField/";
         }
 
         if (mExternalStorageWriteable) {
@@ -224,7 +224,7 @@ public class QFieldActivity extends Activity {
         intent.putExtra("DOTQGIS2_DIR", mDotQgis2Dir);
         intent.putExtra("SHARE_DIR", mShareDir);
         intent.putExtra("PACKAGE_PATH", getFilesDir().toString() + "/share");
-        intent.putExtra("LOCALIZED_DATA_PATHS", mLocalizedDataPathsDir);
+        intent.putExtra("QFIELD_DATA_DIR", mQFieldDir);
 
         Intent sourceIntent = getIntent();
         if (sourceIntent.getAction() == Intent.ACTION_VIEW) {
@@ -312,9 +312,12 @@ public class QFieldActivity extends Activity {
                 .getAbsolutePath();
 
             if (mExternalStorageAvailable) {
-                mLocalizedDataPathsDir = storagePath + "/QField/basemaps/";
+                mQFieldDir = storagePath + "/QField/";
                 if (mExternalStorageWriteable) {
-                    new File(mLocalizedDataPathsDir).mkdir();
+                    new File(mQFieldDir).mkdir();
+
+                    // create basemaps directory
+                    new File(mQFieldDir + "basemaps/").mkdir();
 
                     String pathAlias;
                     String externalFilesDir = getExternalFilesDir(null).getAbsolutePath();

--- a/src/core/androidplatformutilities.cpp
+++ b/src/core/androidplatformutilities.cpp
@@ -53,9 +53,9 @@ QString AndroidPlatformUtilities::qgsProject() const
   return getIntentExtra( "QGS_PROJECT" );
 }
 
-QString AndroidPlatformUtilities::localizedDataPaths() const
+QString AndroidPlatformUtilities::qfieldDataDir() const
 {
-  return getIntentExtra( "LOCALIZED_DATA_PATHS" );
+  return getIntentExtra( "QFIELD_DATA_DIR" );
 }
 
 QString AndroidPlatformUtilities::getIntentExtra( const QString &extra, QAndroidJniObject extras ) const

--- a/src/core/androidplatformutilities.h
+++ b/src/core/androidplatformutilities.h
@@ -31,7 +31,7 @@ class AndroidPlatformUtilities : public PlatformUtilities
     virtual QString shareDir() const override;
     virtual QString packagePath() const override;
     virtual QString qgsProject() const override;
-    virtual QString localizedDataPaths() const override;
+    virtual QString qfieldDataDir() const override;
     virtual PictureSource *getCameraPicture( const QString &prefix, const QString &pictureFilePath, const QString &suffix ) override;
     virtual PictureSource *getGalleryPicture( const QString &prefix, const QString &pictureFilePath ) override;
     virtual ViewStatus *open( const QString &uri ) override;

--- a/src/core/platformutilities.cpp
+++ b/src/core/platformutilities.cpp
@@ -51,7 +51,7 @@ QString PlatformUtilities::qgsProject() const
   return QString();
 }
 
-QString PlatformUtilities::localizedDataPaths() const
+QString PlatformUtilities::qfieldDataDir() const
 {
   return QString();
 }

--- a/src/core/platformutilities.h
+++ b/src/core/platformutilities.h
@@ -40,7 +40,7 @@ class PlatformUtilities : public QObject
     virtual QString shareDir() const;
     virtual QString packagePath() const;
     virtual QString qgsProject() const;
-    virtual QString localizedDataPaths() const;
+    virtual QString qfieldDataDir() const;
     Q_INVOKABLE bool createDir( const QString &path, const QString &dirname ) const;
     Q_INVOKABLE bool rmFile( const QString &filename ) const;
     Q_INVOKABLE bool renameFile( const QString &filename, const QString &newname ) const;

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -18,6 +18,7 @@
 #include <QApplication>
 
 #include <unistd.h>
+#include <stdlib.h>
 
 #include <QStandardPaths>
 #include <QtQml/QQmlEngine>
@@ -129,9 +130,10 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   QgsNetworkAccessManager::instance()->setAuthHandler( std::move( handler ) );
 
   //set localized data paths
-  QStringList localizedDataPaths = mPlatformUtils.localizedDataPaths().split( ';' );
-  if ( localizedDataPaths.size() != 0 )
+  if ( !mPlatformUtils.qfieldDataDir().isEmpty() )
   {
+    QStringList localizedDataPaths;
+    localizedDataPaths << mPlatformUtils.qfieldDataDir() + QStringLiteral( "basemaps/" );
     QgsApplication::instance()->localizedDataPathRegistry()->setPaths( localizedDataPaths );
   }
 
@@ -152,6 +154,11 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
 
   // cppcheck-suppress leakReturnValNotUsed
   initDeclarative();
+
+  if ( !mPlatformUtils.qfieldDataDir().isEmpty() )
+  {
+    setenv( "PGSYSCONFDIR", mPlatformUtils.qfieldDataDir().toUtf8(), true );
+  }
 
   QSettings settings;
   const bool firstRunFlag = settings.value( QStringLiteral( "/QField/FirstRunFlag" ), QString() ).toString().isEmpty();


### PR DESCRIPTION
This PR enables QField users to define postgresql services via a pg_service.conf file inside their mobile device's <external_drive>/QField/ directory.

Note that <external_drive> is NOT the sd card but the internal storage.

For the non-geek users, this means adding a QField directory in the root of the external drive you see popping up on your laptop/workstation when connecting the mobile device via a USB cable.

Services are defined as follow in the pg_service.conf file:

```
[qfield_db]
host=demo.qfield.org
port=8080
dbname=qfielddemo
user=qfielduser
password=qfielduser
sslmode=disable
```

You can add as many of those as you want. Lastly, you have to make sure your postgresql layers are using the service (vs. manually defining the host,port,dbname, etc.) for those to rely on the service file to connect to the right server.

