### PR TITLE
Copy the QGIS behavior when min/max/step are not set

### DIFF
--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -10,9 +10,9 @@ Item {
 
   id: rangeItem
   property string widgetStyle: config["Style"] ? config["Style"] : "TextField"
-  property int precision: config["Precision"] ? config["Precision"] : 0
-  property real from: config["Min"] ? config["Min"] : 0
-  property real to: config["Max"] ? config["Max"] : 0
+  property int precision: config["Precision"] ? config["Precision"] : 1
+  property real from: config["Min"] ? config["Min"] : -Infinity
+  property real to: config["Max"] ? config["Max"] : Infinity
   property real step: config["Step"] ? config["Step"] : 1
   property string suffix: config["Suffix"] ? config["Suffix"] : ""
 


### PR DESCRIPTION
This is how the config looks in QGIS:
![image](https://user-images.githubusercontent.com/2820439/97999761-6ba2f700-1df4-11eb-9474-6a8e42937543.png)

But in QField one is not allowed to write more than a single digit.
See https://github.com/opengisch/QField/commit/0ba58d9febb30d6cc6f68b96e11ba35c8927159d#r43834696

