### PR TITLE
Set TX_TOKEN in github workflow and assume it's set in pull_translations

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -27,6 +27,8 @@ jobs:
           ./scripts/ci/env_gh.sh
           ./scripts/ci/setup_signing_key.sh
       - name: Test
+        env:
+          TX_TOKEN: ${{ secrets.TX_TOKEN }}
         run: |
           ./test/test_version_number.sh
           ./scripts/ci/pull_translations.sh
@@ -63,6 +65,7 @@ jobs:
           KEYNAME: qfield
           KEYPASS: ${{ secrets.KEYPASS }}
           STOREPASS: ${{ secrets.STOREPASS }}
+          TX_TOKEN: ${{ secrets.TX_TOKEN }}
         run: |
           export QFIELD_SDK_VERSION=$(awk -F "=" '/osgeo4a_version/{print $2}' sdk.conf)
           ./scripts/ci/docker_pull.sh

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -57,7 +57,7 @@ jobs:
           git submodule update --init --recursive
           ./scripts/ci/env_gh.sh
           pip install wheel
-          pip install transifex-client
+          apt install -y transifex-client
       - name: Build
         env:
           ARCH: ${{ matrix.arch }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -25,7 +25,7 @@ jobs:
           echo "" # NOTE missing newline from the GitHub event file
           echo "::endgroup::"
           ./scripts/ci/env_gh.sh
-          ./scripts/ci/setup_signing_key.sh
+
       - name: Test
         env:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
@@ -56,7 +56,6 @@ jobs:
           sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
           git submodule update --init --recursive
           ./scripts/ci/env_gh.sh
-          ./scripts/ci/setup_signing_key.sh
           pip install wheel
           pip install transifex-client
       - name: Build

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup build environment
         run: |
+          sudo apt install -y transifex-client
           sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
           git submodule update --init --recursive
           echo "::group::GitHub Event"

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup build environment
         run: |
-          sudo apt install -y transifex-client
+          sudo apt update && sudo apt install -y qttools5-dev-tools qt5-default transifex-client
           sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
           git submodule update --init --recursive
           echo "::group::GitHub Event"
@@ -54,11 +54,11 @@ jobs:
           echo "$SIGNINGKEY" | base64 --decode > ./keystore.p12
       - name: Setup build environment
         run: |
+          sudo apt update && sudo apt install -y qttools5-dev-tools qt5-default transifex-client
           sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
           git submodule update --init --recursive
           ./scripts/ci/env_gh.sh
           pip install wheel
-          sudo apt install -y transifex-client
       - name: Build
         env:
           ARCH: ${{ matrix.arch }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -57,7 +57,7 @@ jobs:
           git submodule update --init --recursive
           ./scripts/ci/env_gh.sh
           pip install wheel
-          apt install -y transifex-client
+          sudo apt install -y transifex-client
       - name: Build
         env:
           ARCH: ${{ matrix.arch }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -40,7 +40,7 @@ jobs:
 
   # Build Android packages
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         arch: [armv7, arm64_v8a, x86, x86_64]

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup siging key
+      - name: Setup signing key
         env:
           SIGNINGKEY: ${{ secrets.PLAYSTORE_SIGNINGKEY }}
         run: |

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -82,6 +82,7 @@ jobs:
   comment:
     runs-on: ubuntu-latest
     needs: build
+    if: ${{ ! startsWith( github.ref, 'refs/heads' ) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -81,7 +81,7 @@ jobs:
           ARCH: ${{ matrix.arch }}
 
   comment:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: build
     if: ${{ github.event_name == 'pull_request' }}
     steps:
@@ -106,7 +106,7 @@ jobs:
               - [x86](https://download.opengis.ch/qfield/ci-builds/qfield-dev-${{ steps.vars.outputs.CI_UPLOAD_ARTIFACT_ID}}-${{ steps.vars.outputs.CI_COMMIT }}-x86.apk)
 
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: build
     steps:
       - name: Spring Cleaning

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -82,7 +82,7 @@ jobs:
   comment:
     runs-on: ubuntu-latest
     needs: build
-    if: ${{ ! startsWith( github.ref, 'refs/heads' ) }}
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/scripts/ci/pull_translations.sh
+++ b/scripts/ci/pull_translations.sh
@@ -2,15 +2,13 @@
 
 echo "::group::tx-pull"
 
-if [[ ${CI_SECURE_ENV_VARS} = true ]]; then
-  DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-  source ${DIR}/../version_number.sh
-  
-  tx pull --all --force
-  
-  for x in android/res/values-*_*;do mv $x $(echo $x | sed -e 's/_/-r/') ;done
-  
-  find ${DIR}/i18n -type f -name "*.ts" -exec lrelease "{}" \;
-fi
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+source ${DIR}/../version_number.sh
+
+tx pull --all --force
+
+for x in android/res/values-*_*;do mv $x $(echo $x | sed -e 's/_/-r/') ;done
+
+find ${DIR}/i18n -type f -name "*.ts" -exec lrelease "{}" \;
 
 echo "::endgroup::"

--- a/scripts/ci/pull_translations.sh
+++ b/scripts/ci/pull_translations.sh
@@ -11,6 +11,6 @@ tx pull --all --force
 
 for x in android/res/values-*_*;do mv $x $(echo $x | sed -e 's/_/-r/') ;done
 
-find ${DIR}/i18n -type f -name "*.ts" -exec lrelease "{}" \;
+find ${DIR}/../../i18n -type f -name "*.ts" -exec lrelease "{}" \;
 
 echo "::endgroup::"

--- a/scripts/ci/pull_translations.sh
+++ b/scripts/ci/pull_translations.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 echo "::group::tx-pull"
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"

--- a/scripts/ci/setup_signing_key.sh
+++ b/scripts/ci/setup_signing_key.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -e
-
-if [[ ${CI_SECURE_ENV_VARS} = true ]]; then
-  echo "With signing key"
-  openssl aes-256-cbc -K $encrypted_c158cd588669_key -iv $encrypted_c158cd588669_iv -in keystore.p12.enc -out keystore.p12 -d
-else
-  echo "Without signing key"
-fi


### PR DESCRIPTION
There is one last use of `CI_SECURE_ENV_VARS`, but I don't know whether these secrets are present in GitHub:
 $encrypted_c158cd588669_key -iv $encrypted_c158cd588669_iv 

They are used in this script:
https://github.com/opengisch/QField/blob/a7e4e95cb4e652763a4baddd7119b5400984e877/scripts/ci/setup_signing_key.sh#L4-L6

Which is called from here:
https://github.com/opengisch/QField/blob/a7e4e95cb4e652763a4baddd7119b5400984e877/.github/workflows/continuous_integration.yml#L21

@m-kuhn help?

Fixes https://github.com/opengisch/QField/issues/1381
