### PR TITLE
Fix QField _always_ ignoring project transformation settings

### DIFF
--- a/src/qgsquick/qgsquickmapsettings.cpp
+++ b/src/qgsquick/qgsquickmapsettings.cpp
@@ -252,6 +252,8 @@ void QgsQuickMapSettings::onReadProject( const QDomDocument &doc )
 
   mMapSettings.setRotation( 0 );
 
+  mMapSettings.setTransformContext( mProject->transformContext() );
+
   emit extentChanged();
   emit destinationCrsChanged();
   emit outputSizeChanged();


### PR DESCRIPTION
Went deep down the rabbit whole to figure this one out. A good example of the number of lines not being so representative of the amount of energy spent figure things out :wink: 

