### PR TITLE
Remove need for extra click when in multi edit mode (fixes #1256)

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -381,8 +381,7 @@ Page {
             // - not set to editable in the widget configuration
             // - not in edit mode (ReadOnly)
             // - a relation in multi edit mode
-            property bool isEnabled: !!AttributeAllowEdit
-                                     && !!AttributeEditable
+            property bool isEnabled: !!AttributeEditable
                                      && form.state !== 'ReadOnly'
                                      && !( Type === 'relation' && form.model.featureModel.modelMode == FeatureModel.MultiFeatureModel )
             property var value: AttributeValue
@@ -440,6 +439,10 @@ Page {
                 AttributeValue = isNull ? undefined : value
 
                 valueChanged(Field, oldValue, AttributeValue)
+
+                if ( !AttributeAllowEdit && form.model.featureModel.modelMode == FeatureModel.MultiFeatureModel ) {
+                  AttributeAllowEdit = true;
+                }
 
                 if ( qfieldSettings.autoSave && !dontSave ) {
                   // indirect action, no need to check for success and display a toast, the log is enough


### PR DESCRIPTION
 As @m-kuhn mentioned, there's no real need for the current extra click needed to enable attribute editing when in multi-edit mode. This PR fixes that.