### PR TITLE
Fix range editor widget not assigning slider value properly

### DIFF
--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -76,7 +76,7 @@ Item {
 
     Slider {
       id: slider
-      value: typeof rangeItem.parent.value === 'numeric' ? rangeItem.parent.value : slider.value
+      value: typeof rangeItem.parent.value === 'numeric' || typeof rangeItem.parent.value === 'number' ? rangeItem.parent.value : slider.value
       width: sliderRow.width - valueLabel.width
       height: fontMetrics.height + 20
       implicitWidth: width


### PR DESCRIPTION
 If the value is a digit, the typeof value is 'number', not 'numeric'. Not exactly sure what numeric vs number entails. But without this fix, our range slider is broken.