### PR TITLE
Fields that aren't visible should always return valid constraints

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -500,9 +500,9 @@ void AttributeFormModelBase::updateVisibilityAndConstraints( int fieldIndex )
   for ( ; constraintIterator != mConstraints.constEnd(); ++constraintIterator )
   {
     QStandardItem *item = constraintIterator.key();
-
+    const bool isVisible = item->data( AttributeFormModel::CurrentlyVisible ).toBool();
     int fidx = item->data( AttributeFormModel::FieldIndex ).toInt();
-    if ( mFeatureModel->data( mFeatureModel->index( fidx ), FeatureModel::AttributeAllowEdit ) == true )
+    if ( isVisible && mFeatureModel->data( mFeatureModel->index( fidx ), FeatureModel::AttributeAllowEdit ) == true )
     {
       QStringList errors;
       bool hardConstraintSatisfied = QgsVectorLayerUtils::validateAttribute( mLayer, mFeatureModel->feature(), fidx, errors, QgsFieldConstraints::ConstraintStrengthHard );


### PR DESCRIPTION
This PR fixes #1326 . Thanks to @9ls1 for having provided a test project. His form configuration is a pretty good stress test for QField :smile: 

The bug being fixed here is that until now, QField - contrary to QGIS - would block feature form submission when hidden attributes wouldn't match their constraints. It makes no sense since those attributes can't be edited to begin with. 