### PR TITLE
Further reduce number of scenarios where we force rebuild the flat tree

### DIFF
--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -94,7 +94,8 @@ void FlatLayerTreeModel::insertInMap( const QModelIndex &parent, int first, int 
 
     QMap<int, int> treeLevelMap;
     mIndexMap.clear();
-    for ( const auto &index : mRowMap.keys() )
+    const QList<QModelIndex> keys = mRowMap.keys();
+    for ( const auto &index : keys )
     {
       int row = mRowMap[index];
       int treeLevel = mTreeLevelMap[row];
@@ -177,7 +178,7 @@ void FlatLayerTreeModel::removeFromMap( const QModelIndex &parent, int first, in
 
     if ( resetNeeded )
     {
-      // Removed rows can't be handled, modle reset needed
+      // Removed rows can't be handled, model reset needed
       buildMap( mLayerTreeModel );
       return;
     }

--- a/src/core/layertreemodel.h
+++ b/src/core/layertreemodel.h
@@ -56,6 +56,9 @@ class FlatLayerTreeModel : public QAbstractProxyModel
     void updateMap( const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles );
     int buildMap( QgsLayerTreeModel *model, const QModelIndex &parent = QModelIndex(), int row = 0, int treeLevel = 0 );
 
+    void removeFromMap( const QModelIndex &parent, int first, int last );
+    void insertInMap( const QModelIndex &parent, int first, int last );
+
     void setSourceModel( QgsLayerTreeModel *sourceModel );
     QModelIndex mapToSource( const QModelIndex &proxyIndex ) const override;
     QModelIndex mapFromSource( const QModelIndex &sourceIndex ) const override;


### PR DESCRIPTION
This PR further optimizes the flat tree model by avoiding (as much as possible) model resets when rows are inserted and removed from the source model.

I was hoping we could avoid adding this level of complexity, but it turns out force rebuilding the proxy model on all row insertion deletion creates bad speed regressions.

For e.g., @RatInTheField reported a regression whereas adding a feature freezes QField for ~15 seconds. The reason why that is is that the layers he's using to add new features have [x] show feature count enabled, which in turn triggers _three_ pair of rows removed / inserted (the layer tree removes and re-add the layer's legend children to repopulate the count).

So, here we are.

Handling insertion of rows isn't too complex.  But for rows being deleted, it's slightly more complex. And in some instances, we simply have to reset the model as the stored QModelIndexes get out of sync. Eg.:

```
A
- 1
- 2
B
- 1
C
- 1
- 2
-- i
-- ii
- 3
```

If we remove A's children 1 and 2, that's easy enough, we merely have to adjust the flattened row count.

If we remove A's child 1, it's a bit more complex as we need to re-create the QModelIndex for A's child 2 (since it has moved from row() = 1 to row()  = 0. We can still handle this.

However, it we are to remove C's child 1, we enter in a scenario that becomes too complex to handle. We would not only have to re-create the QModelIndex for C's children 2 and 3, we would have to re-do the children of those too, etc. etc. In this scenario, we revert back to resetting the model.

With this in place, addition of features into a vector layer that has [x] show feature count is now amazingly fast. It also fixes a project load regression when projects include layer(s) with [x] show feature count enabled. 