### PR TITLE
Fix crash on reloading project while editing feature with value relation editor widget

### DIFF
--- a/src/core/featurelistmodel.cpp
+++ b/src/core/featurelistmodel.cpp
@@ -206,7 +206,7 @@ void FeatureListModel::processReloadLayer()
 {
   mEntries.clear();
 
-  if ( !mCurrentLayer )
+  if ( !mCurrentLayer || !mCurrentLayer->isValid() )
     return;
 
   QgsFeatureRequest request;


### PR DESCRIPTION
Steps to reproduce:
1) open a project
2) start editing a feature with relation editor widget
3) load a new project without closing the editing form
4) crash!

