### PR TITLE
Implement the changelog request and parsing in C++

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -51,6 +51,7 @@ SET(QFIELD_CORE_SRCS
   trackingmodel.cpp
   tracker.cpp
   viewstatus.cpp
+  changelogcontents.cpp
   utils/fileutils.cpp
   utils/geometryutils.cpp
   utils/featureutils.cpp
@@ -119,6 +120,7 @@ SET(QFIELD_CORE_HDRS
   trackingmodel.h
   tracker.h
   viewstatus.h
+  changelogcontents.h
   utils/fileutils.h
   utils/geometryutils.h
   utils/featureutils.h

--- a/src/core/changelogcontents.cpp
+++ b/src/core/changelogcontents.cpp
@@ -79,8 +79,10 @@ void ChangelogContents::request()
 
     changelog += QStringLiteral("\n") + QStringLiteral("[") + tr("Previous releases on GitHub") + QStringLiteral("](https://github.com/opengisch/qfield/releases)");
 
-    QRegularExpression regexp( "^##(.+)$", QRegularExpression::MultilineOption );
-    changelog = changelog.replace(regexp, QStringLiteral("\n###\n##\\1\n\n\n") );
+    QRegularExpression regexpFirstTitle( QStringLiteral( "^\n#\n# " ) );
+    changelog = changelog.replace( regexpFirstTitle, QStringLiteral("\n# ") );
+    QRegularExpression regexpAllTitles( QStringLiteral( "^##(.+)$" ), QRegularExpression::MultilineOption );
+    changelog = changelog.replace( regexpAllTitles, QStringLiteral("\n###\n##\\1\n\n\n") );
     changelog = "Up to release **" + versionNumbersOnly + "**" + changelog;
 
     mStatus = SuccessStatus;

--- a/src/core/changelogcontents.cpp
+++ b/src/core/changelogcontents.cpp
@@ -1,0 +1,106 @@
+/***************************************************************************
+  changelogcontents.h - Changelog
+
+ ---------------------
+ begin                : Nov 2020
+ copyright            : (C) 2020 by Ivan Ivanov
+ email                : ivan@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "changelogcontents.h"
+#include "qregularexpression.h"
+#include "qgsnetworkaccessmanager.h"
+#include "qjsondocument.h"
+#include "qjsonarray.h"
+#include "qjsonobject.h"
+
+ChangelogContents::ChangelogContents( QObject *parent ):
+    QObject( parent )
+{
+}
+
+
+void ChangelogContents::request()
+{
+  QgsNetworkAccessManager *manager = new QgsNetworkAccessManager(this);
+  connect(manager, &QNetworkAccessManager::finished, this, [ = ]( QNetworkReply *reply ) {
+    manager->deleteLater();
+
+    QJsonParseError error;
+    QJsonDocument json = QJsonDocument::fromJson( reply->readAll(), &error );
+
+    if ( error.error != QJsonParseError::NoError )
+    {
+      emit changelogFetchFinished(false);
+      return;
+    }
+
+    QString changelog;
+    QString versionNumbersOnly;
+    QList<int> qfieldVersion = parseVersion( VERSTR );
+    const QJsonArray releases = json.array();
+
+    for ( const QJsonValue &releaseValue : releases )
+    {
+      QVariantMap release = releaseValue.toObject().toVariantMap();
+      QList<int> releaseVersion = parseVersion( release.value( QStringLiteral( "tag_name" ) ).toString() );
+
+      if (releaseVersion.isEmpty())
+        continue;
+
+      // most probably developer version with no proper version set
+      if (qfieldVersion.isEmpty())
+        qfieldVersion = releaseVersion;
+
+      if (qfieldVersion[0] != releaseVersion[0] || qfieldVersion[1] != releaseVersion[1])
+        continue;
+
+      if ( versionNumbersOnly.isEmpty() )
+      {
+        versionNumbersOnly = QStringLiteral("%1.%2.%3").arg( releaseVersion[0] ).arg( releaseVersion[1] ).arg( releaseVersion[2] );
+      }
+
+      const QString releaseChangelog = QStringLiteral("\n#\n# ") + release["name"].toString() + QStringLiteral("\n\n") + release["body"].toString() + QStringLiteral("\n");
+      changelog = releaseChangelog + changelog;
+    }
+
+    changelog += QStringLiteral("\n") + QStringLiteral("[") + tr("Previous releases on GitHub") + QStringLiteral("](https://github.com/opengisch/qfield/releases)");
+
+    QRegularExpression regexp( "^##(.+)$", QRegularExpression::MultilineOption );
+    changelog = changelog.replace(regexp, QStringLiteral("\n###\n##\\1\n\n\n") );
+    changelog = "Up to release **" + versionNumbersOnly + "**" + changelog;
+
+    mMarkdown = changelog;
+
+    emit changelogFetchFinished( true );
+  });
+
+  manager->get( QNetworkRequest( QUrl( QStringLiteral( "https://api.github.com/repos/opengisch/qfield/releases" ) ) ) );
+}
+
+QString ChangelogContents::markdown()
+{
+  return mMarkdown;
+}
+
+QList<int> ChangelogContents::parseVersion( const QString &version )
+{
+  QRegularExpression regexp( "^[a-z]*" );
+  QString cleanVersion = QString( version ).replace( regexp, "" );
+  QStringList parts = cleanVersion.split( QStringLiteral( "." ) );
+
+  if ( parts.size() != 3 )
+    return QList<int>();
+
+  if (parts[0].toInt() >= 0 && parts[1].toInt() >= 0 && parts[2].toInt() >= 0)
+    return QList<int>({parts[0].toInt(), parts[1].toInt(), parts[2].toInt()});
+
+  return QList<int>();
+}

--- a/src/core/changelogcontents.h
+++ b/src/core/changelogcontents.h
@@ -1,0 +1,41 @@
+/***************************************************************************
+  changelogcontents.h - Changelog
+
+ ---------------------
+ begin                : Nov 2020
+ copyright            : (C) 2020 by Ivan Ivanov
+ email                : ivan@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef CHANGELOGCONTENTS_H
+#define CHANGELOGCONTENTS_H
+
+#include <QObject>
+
+class ChangelogContents : public QObject
+{
+    Q_OBJECT
+
+  public:
+    explicit ChangelogContents( QObject *parent = nullptr );
+
+    Q_INVOKABLE void request();
+
+    Q_INVOKABLE QString markdown();
+
+  signals:
+    void changelogFetchFinished( bool isSuccess );
+
+  private:
+    QList<int> parseVersion( const QString &version );
+
+    QString mMarkdown;
+};
+
+#endif // CHANGELOGCONTENTS_H

--- a/src/core/changelogcontents.h
+++ b/src/core/changelogcontents.h
@@ -18,24 +18,66 @@
 
 #include <QObject>
 
+//! Obtain the QField changelog contents from the GitHub releases API.
 class ChangelogContents : public QObject
 {
     Q_OBJECT
 
+  //! Holds the current changelog contents formatted as markdown.
+  Q_PROPERTY( QString markdown READ markdown NOTIFY markdownChanged )
+
+  //! Holds the current changelog contents status.
+  Q_PROPERTY( Status status READ status NOTIFY statusChanged )
+
   public:
+    //! Constructor
     explicit ChangelogContents( QObject *parent = nullptr );
 
+    //! Changelog contents status.
+    enum Status
+    {
+      //! Changelog has not been requested
+      IdleStatus,
+      //! Changelog has been requested, but still not received
+      LoadingStatus,
+      //! Changelog has been successfully generated
+      SuccessStatus,
+      //! Changelog has been requested, but failed to be generated
+      ErrorStatus,
+    };
+
+    Q_ENUM( Status )
+
+    /**
+     * Initiates a HTTP request to obtain the changelog contents.
+     * @see markdownChanged()
+     * @see statusChanged()
+     */
     Q_INVOKABLE void request();
 
-    Q_INVOKABLE QString markdown();
+    //! Returns the current changelog contents formatted as markdown. Null string if no changelog.
+    QString markdown();
+
+    //! Returns the current changelog contents status.
+    Status status();
 
   signals:
-    void changelogFetchFinished( bool isSuccess );
+
+    //! Emitted when the markdown contents has been changed.
+    void markdownChanged();
+
+    //! Emitted when the status has been changed.
+    void statusChanged();
 
   private:
+    //! Parses a given \a version string into a list of three numbers, e.g. 'v1.5.6-dev' to [1, 5, 6]. Returns an empty list if cannot be parsed.
     QList<int> parseVersion( const QString &version );
 
+    //! Holds the current changelog contents formatted as markdown. Null string if no changelog.
     QString mMarkdown;
+
+    //! Holds the current status.
+    Status mStatus = Status::IdleStatus;
 };
 
 #endif // CHANGELOGCONTENTS_H

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -109,6 +109,7 @@
 #include "expressionevaluator.h"
 #include "stringutils.h"
 #include "urlutils.h"
+#include "changelogcontents.h"
 
 #define QUOTE(string) _QUOTE(string)
 #define _QUOTE(string) #string
@@ -329,6 +330,7 @@ void QgisMobileapp::initDeclarative()
   qmlRegisterType<FeatureCheckListModel>( "org.qgis", 1, 0, "FeatureCheckListModel" );
   qmlRegisterType<GeometryEditorsModel>( "org.qfield", 1, 0, "GeometryEditorsModel" );
   qmlRegisterType<ExpressionEvaluator>( "org.qfield", 1, 0, "ExpressionEvaluator" );
+  qmlRegisterType<ChangelogContents>( "org.qfield", 1, 0, "ChangelogContents" );
   REGISTER_SINGLETON( "org.qfield", GeometryEditorsModel, "GeometryEditorsModelSingleton" );
   REGISTER_SINGLETON( "org.qfield", GeometryUtils, "GeometryUtils" );
   REGISTER_SINGLETON( "org.qfield", FeatureUtils, "FeatureUtils" );

--- a/src/qml/Changelog.qml
+++ b/src/qml/Changelog.qml
@@ -6,149 +6,126 @@ import QtGraphicalEffects 1.0
 import Theme 1.0
 import org.qfield 1.0
 
-Item {
-  signal close()
-
-  height: childrenRect.height
-  width: parent.width
-
-  GridLayout {
-    id: mainGrid
-
-    anchors.left: parent.left
-    anchors.right: parent.right
-    anchors.margins: 20
-
-    columns: 1
-
-    Item {
-        // top margin
-        height: 20
-    }
-
-    Text {
-      id: title
-      text: qsTr( "What's new in the latest QField" )
-      color: Theme.mainColor
-      font: Theme.titleFont
-      minimumPixelSize: 12
 
 
-      fontSizeMode: Text.VerticalFit
-      wrapMode: Text.WordWrap
-      Layout.fillWidth: true
-      Layout.fillHeight: true
-      Layout.minimumHeight: contentHeight
-      Layout.maximumHeight: contentHeight
-    }
+Popup {
+  id: changelogPopup
 
-    Text {
-      id: changelogBody
-      property bool isSuccess: false
-      color: '#95000000'
-      font: Theme.tipFont
+  parent: ApplicationWindow.overlay
+  x: 24
+  y: 24
+  width: parent.width - 48
+  height: parent.height - 48
+  padding: 0
+  modal: true
+  closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+  focus: visible
 
-      fontSizeMode: Text.VerticalFit
-      textFormat: Text.MarkdownText
-      wrapMode: Text.WordWrap
-      Layout.fillWidth: true
-      Layout.fillHeight: true
-      Layout.minimumHeight: contentHeight
-      Layout.maximumHeight: contentHeight
+  Flickable {
+    id: changelogFlickable
+    anchors.fill: parent
+    flickableDirection: Flickable.VerticalFlick
+    interactive: true
+    contentWidth: parent.width; contentHeight: changelogGrid.height
+    clip: true
 
-      onLinkActivated: Qt.openUrlExternally(link)
-    }
+    GridLayout {
+      id: changelogGrid
 
-    QfButton {
-      id: closeButton
-      Layout.fillWidth: true
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.margins: 20
 
-      text: qsTr( 'OK' )
-      onClicked: close()
-    }
+      columns: 1
 
-    Item {
-        // bottom
-        height: 20
+      Item {
+          // top margin
+          height: 20
+      }
+
+      Text {
+        id: title
+        text: qsTr( "What's new in the latest QField" )
+        color: Theme.mainColor
+        font: Theme.titleFont
+        minimumPixelSize: 12
+
+
+        fontSizeMode: Text.VerticalFit
+        wrapMode: Text.WordWrap
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        Layout.minimumHeight: contentHeight
+        Layout.maximumHeight: contentHeight
+      }
+
+      Text {
+        id: changelogBody
+        property bool isSuccess: false
+        color: '#95000000'
+        font: Theme.tipFont
+
+        fontSizeMode: Text.VerticalFit
+        textFormat: Text.MarkdownText
+        wrapMode: Text.WordWrap
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        Layout.minimumHeight: contentHeight
+        Layout.maximumHeight: contentHeight
+
+        onLinkActivated: Qt.openUrlExternally(link)
+      }
+
+      QfButton {
+        id: closeButton
+        Layout.fillWidth: true
+
+        text: qsTr( 'OK' )
+        onClicked: changelogPopup.close()
+      }
+
+      Item {
+          // bottom
+          height: 20
+      }
     }
   }
 
-  function parseVersion(str) {
-    str = str.replace(/^[a-z]*/, '')
+  ChangelogContents {
+    id: changelogContents
+    property bool isSuccess: false
 
-    var parts = str.split('.')
+    onChangelogFetchFinished: function(isSuccess) {
+      changelogContents.isSuccess = isSuccess
 
-    if (parts[0] >= 0 && parts[1] >= 0 && parts[2] >= 0)
-      return [parts[0], parts[1], parts[2]]
-
-    return []
+      if ( isSuccess ) {
+        changelogBody.text = changelogContents.markdown()
+      } else {
+        changelogBody.text = qsTr( 'Error while fetching changelog. Try again later.' )
+      }
+    }
   }
 
-  function refreshChangelog() {
-    if ( changelogBody.isSuccess )
+  onClosed: {
+    if ( changelogContents.isSuccess ) {
+      settings.setValue( "/QField/ChangelogVersion", versionCode )
+    }
+
+    changelogFlickable.contentY = 0
+  }
+
+  onOpened: {
+    if ( changelogContents.isSuccess )
       return
 
-    try {
-      var RELEASES_URL = 'https://api.github.com/repos/opengisch/qfield/releases'
-      var xhr = new XMLHttpRequest()
+    changelogBody.text = qsTr( 'Loading...' )
+    changelogContents.request()
+  }
 
-      xhr.open('GET', RELEASES_URL)
-      xhr.onreadystatechange = function() {
-        if (xhr.readyState === XMLHttpRequest.DONE) {
-          var resp = xhr.responseText
-          var qfieldVersion = parseVersion(version)
-          var versionNumbersOnly = ''
-          var changelog = ''
-
-          try {
-            var releases = JSON.parse(resp)
-
-            for (var i = 0, l = releases.length; i < l; i++) {
-              var release = releases[i]
-              var releaseVersion = parseVersion(release['tag_name'])
-
-              if (releaseVersion.length === 0)
-                continue
-
-              // most probably developer version with no proper version set
-              if (qfieldVersion.length === 0)
-                qfieldVersion = releaseVersion
-
-              if (qfieldVersion[0] !== releaseVersion[0] || qfieldVersion[1] !== releaseVersion[1])
-                continue
-
-              if ( !versionNumbersOnly )
-                versionNumbersOnly = releaseVersion.join('.')
-
-              var releaseChangelog = '\n#\n# ' + release['name'] + '\n\n' + release['body'] + '\n'
-              // prepend the current release
-              changelog = releaseChangelog + changelog
-            }
-
-            if ( changelog.length === 0 )
-              throw new Error('Empty changelog!')
-
-            changelog += '\n' + '[' + qsTr('Previous releases on GitHub') + '](https://github.com/opengisch/qfield/releases)'
-            changelog = changelog.replace(/^##(.+)$/gm, function(full) {
-              return '\n###\n' + full + '\n\n\n'
-            })
-
-            var changelogPeffix = '';
-            changelogPeffix += 'Up to release **' + versionNumbersOnly + '**'
-
-            changelogBody.text = changelogPeffix + changelog
-            changelogBody.isSuccess = true
-          } catch (err) {
-            changelogBody.text = qsTr('Cannot retrieve the changelog. Please check your internet connection.')
-          }
-        }
-      }
-      xhr.send()
-
-      changelogBody.text = qsTr('Loading…')
-    } catch (err) {
-      console.error(err)
-      close()
+  Keys.onReleased: {
+    if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
+      event.accepted = true
+      visible = false
     }
   }
 }

--- a/src/qml/Changelog.qml
+++ b/src/qml/Changelog.qml
@@ -63,6 +63,7 @@ Popup {
         id: changelogBody
         color: '#95000000'
         font: Theme.tipFont
+        visible: changelogContents.status != ChangelogContents.LoadingStatus
 
         fontSizeMode: Text.VerticalFit
         textFormat: Text.MarkdownText
@@ -76,7 +77,7 @@ Popup {
           switch ( changelogContents.status ) {
             case ChangelogContents.IdleStatus:
             case ChangelogContents.LoadingStatus:
-              return qsTr('Loading...')
+              return ''
             case ChangelogContents.SuccessStatus:
               return changelogContents.markdown
             case ChangelogContents.ErrorStatus:
@@ -85,6 +86,13 @@ Popup {
         }
 
         onLinkActivated: Qt.openUrlExternally(link)
+      }
+
+      BusyIndicator {
+        anchors.horizontalCenter: parent.horizontalCenter
+
+        visible: changelogContents.status == ChangelogContents.LoadingStatus
+        running: visible
       }
 
       QfButton {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1622,56 +1622,14 @@ ApplicationWindow {
     }
   }
 
-  Popup {
+  Changelog {
     id: changelogPopup
     parent: ApplicationWindow.overlay
 
     property var expireDate: new Date(2038,1,19)
     visible: settings.value( "/QField/ChangelogVersion", "" ) !== versionCode
                && expireDate > new Date()
-
-    x: 24
-    y: 24
-    width: parent.width - 48
-    height: parent.height - 48
-    padding: 0
-    modal: true
-    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
-    focus: visible
-
-    Flickable {
-      id: changelogFlickable
-      anchors.fill: parent
-      flickableDirection: Flickable.VerticalFlick
-      interactive: true
-      contentWidth: changelog.width; contentHeight: changelog.height
-      clip: true
-
-      Changelog {
-        id: changelog
-        width: changelogFlickable.width
-
-        onClose: {
-          changelogPopup.close()
-        }
-      }
-    }
-
-    onClosed: {
-      settings.setValue( "/QField/ChangelogVersion", versionCode )
-      changelogFlickable.contentY = 0
-    }
-
-    onOpened: {
-      changelog.refreshChangelog()
-    }
-
-    Keys.onReleased: {
-      if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
-        event.accepted = true
-        visible = false
-      }
-    }
+//               || true
   }
 
   // Toast


### PR DESCRIPTION
This is an attempt to revive the changelog removed in https://github.com/opengisch/QField/pull/1375 , due to crashes on some devices, as described in https://github.com/opengisch/QField/issues/1327 and https://github.com/opengisch/QField/issues/1369 .

Now the implementation uses `QgsNetworkAccessManager` to connect to the outside world, after the lessons learned by making network requests from QML. 

sudo fairy make-apks