### PR TITLE
Add a filter proxy to the flat legend model to avoid freeze when hundreds of legend items are hidden

### DIFF
--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -28,9 +28,8 @@ ListView {
     property string layerType: LayerType
 
     id: rectangle
-    visible: !IsParentCollapsed
     width: parent ? parent.width : undefined
-    height: IsParentCollapsed ? 0 : line.height + 1
+    height: line.height + 1
     color: "#ffffff"
 
     Row {


### PR DESCRIPTION
So, it turns out that setting a large number of listview items to visible: false & height: 0 can lead to serious application freeze when the number of hidden items is very large (i.e. > 1,000 items). This becomes a problem for QField's legend when a project contains a number of layers with a large number of legend items (e.g. paletted/unique value rasters with 255 values each).

The solution is to do-the-right-thing(tm) and add a filter proxy model. This PR does that. 

The speed regression was spotted and reported by @monticola2 about a week ago.  