### PR TITLE
Fix number of warnings and errors in the RelationEditor

### DIFF
--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -98,14 +98,14 @@ QgsRelation ReferencingFeatureListModel::relation() const
   return mRelation;
 }
 
-QString ReferencingFeatureListModel::relationId() const
+QString ReferencingFeatureListModel::currentRelationId() const
 {
   return mRelation.isValid() ? mRelation.id() : QString();
 }
 
-void ReferencingFeatureListModel::setRelationId( const QString &relationId )
+void ReferencingFeatureListModel::setCurrentRelationId( const QString &relationId )
 {
-  if ( relationId == this->relationId() )
+  if ( relationId == currentRelationId() )
     return;
 
 
@@ -124,14 +124,14 @@ QgsRelation ReferencingFeatureListModel::nmRelation() const
   return mNmRelation;
 }
 
-QString ReferencingFeatureListModel::nmRelationId() const
+QString ReferencingFeatureListModel::currentNmRelationId() const
 {
   return mNmRelation.isValid() ? mNmRelation.id() : QString();
 }
 
-void ReferencingFeatureListModel::setNmRelationId( const QString &nmRelationId )
+void ReferencingFeatureListModel::setCurrentNmRelationId( const QString &nmRelationId )
 {
-  if ( nmRelationId == this->nmRelationId() )
+  if ( nmRelationId == currentNmRelationId() )
     return;
 
   mNmRelation = QgsProject::instance()->relationManager()->relation( nmRelationId );

--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -15,6 +15,7 @@
  ***************************************************************************/
 
 #include <qgsmessagelog.h>
+#include <qgsproject.h>
 
 #include "referencingfeaturelistmodel.h"
 
@@ -97,6 +98,21 @@ QgsRelation ReferencingFeatureListModel::relation() const
   return mRelation;
 }
 
+QString ReferencingFeatureListModel::relationId() const
+{
+  return mRelation.isValid() ? mRelation.id() : QString();
+}
+
+void ReferencingFeatureListModel::setRelationId( const QString &relationId )
+{
+  if ( relationId == this->relationId() )
+    return;
+
+
+  mRelation = QgsProject::instance()->relationManager()->relation( relationId );
+  reload();
+}
+
 void ReferencingFeatureListModel::setNmRelation( const QgsRelation &relation )
 {
   mNmRelation = relation;
@@ -106,6 +122,20 @@ void ReferencingFeatureListModel::setNmRelation( const QgsRelation &relation )
 QgsRelation ReferencingFeatureListModel::nmRelation() const
 {
   return mNmRelation;
+}
+
+QString ReferencingFeatureListModel::nmRelationId() const
+{
+  return mNmRelation.isValid() ? mNmRelation.id() : QString();
+}
+
+void ReferencingFeatureListModel::setNmRelationId( const QString &nmRelationId )
+{
+  if ( nmRelationId == this->nmRelationId() )
+    return;
+
+  mNmRelation = QgsProject::instance()->relationManager()->relation( nmRelationId );
+  reload();
 }
 
 void ReferencingFeatureListModel::setParentPrimariesAvailable( const bool parentPrimariesAvailable )

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -57,7 +57,7 @@ class ReferencingFeatureListModel : public QAbstractItemModel
     int columnCount( const QModelIndex &parent = QModelIndex() ) const override;
     QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
 
-    //! Returns the relation id connecting the parent feature with the children in this model
+    //! Returns the id of the relation connecting the parent feature with the children in this model
     QString currentRelationId() const;
 
     //! Sets the relation connecting the parent feature with the children in this model

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -33,6 +33,8 @@ class ReferencingFeatureListModel : public QAbstractItemModel
 
     Q_PROPERTY( QgsFeature feature WRITE setFeature READ feature NOTIFY featureChanged )
     Q_PROPERTY( QgsRelation relation WRITE setRelation READ relation NOTIFY relationChanged )
+    Q_PROPERTY( QString currentRelationId WRITE setRelationId READ relationId NOTIFY relationChanged )
+    Q_PROPERTY( QString currentNmRelationId WRITE setNmRelationId READ nmRelationId NOTIFY nmRelationChanged )
     Q_PROPERTY( QgsRelation nmRelation WRITE setNmRelation READ nmRelation NOTIFY nmRelationChanged )
     Q_PROPERTY( bool parentPrimariesAvailable WRITE setParentPrimariesAvailable READ parentPrimariesAvailable NOTIFY parentPrimariesAvailableChanged )
     Q_PROPERTY( bool isLoading READ isLoading NOTIFY isLoadingChanged )
@@ -55,6 +57,18 @@ class ReferencingFeatureListModel : public QAbstractItemModel
     int columnCount( const QModelIndex &parent = QModelIndex() ) const override;
     QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
 
+    //! Returns the relation id of the connection to the parent feature with the children in this model
+    QString relationId() const;
+
+    //! Sets the relation id of the connection to the parent feature with the children in this model
+    void setRelationId( const QString &relationId );
+
+    //! On many-to-many relations returns the second relation id connecting the children in the association table to their other parent
+    QString nmRelationId() const;
+
+    //! On many-to-many relations sets the second relation id connecting the children in the association table to their other parent
+    void setNmRelationId( const QString &nmRelationId );
+
     /**
      * The parent feature for which this model contains the children
      * \param feature
@@ -70,14 +84,14 @@ class ReferencingFeatureListModel : public QAbstractItemModel
     QgsFeature feature() const;
 
     /**
-     * The relation connectiong the parent feature with the children in this model
+     * The relation connection to the parent feature with the children in this model
      * \param relation
      * \see relation
      */
     void setRelation( const QgsRelation &relation );
 
     /**
-     * The relation connectiong the parent feature with the children in this model
+     * The relation connection to the parent feature with the children in this model
      * \return relation
      * \see setRelation
      */

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -33,8 +33,8 @@ class ReferencingFeatureListModel : public QAbstractItemModel
 
     Q_PROPERTY( QgsFeature feature WRITE setFeature READ feature NOTIFY featureChanged )
     Q_PROPERTY( QgsRelation relation WRITE setRelation READ relation NOTIFY relationChanged )
-    Q_PROPERTY( QString currentRelationId WRITE setRelationId READ relationId NOTIFY relationChanged )
-    Q_PROPERTY( QString currentNmRelationId WRITE setNmRelationId READ nmRelationId NOTIFY nmRelationChanged )
+    Q_PROPERTY( QString currentRelationId WRITE setCurrentRelationId READ currentRelationId NOTIFY relationChanged )
+    Q_PROPERTY( QString currentNmRelationId WRITE setCurrentNmRelationId READ currentNmRelationId NOTIFY nmRelationChanged )
     Q_PROPERTY( QgsRelation nmRelation WRITE setNmRelation READ nmRelation NOTIFY nmRelationChanged )
     Q_PROPERTY( bool parentPrimariesAvailable WRITE setParentPrimariesAvailable READ parentPrimariesAvailable NOTIFY parentPrimariesAvailableChanged )
     Q_PROPERTY( bool isLoading READ isLoading NOTIFY isLoadingChanged )
@@ -57,17 +57,17 @@ class ReferencingFeatureListModel : public QAbstractItemModel
     int columnCount( const QModelIndex &parent = QModelIndex() ) const override;
     QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
 
-    //! Returns the relation id of the connection to the parent feature with the children in this model
-    QString relationId() const;
+    //! Returns the relation id connecting the parent feature with the children in this model
+    QString currentRelationId() const;
 
-    //! Sets the relation id of the connection to the parent feature with the children in this model
-    void setRelationId( const QString &relationId );
+    //! Sets the relation connecting the parent feature with the children in this model
+    void setCurrentRelationId( const QString &relationId );
 
     //! On many-to-many relations returns the second relation id connecting the children in the association table to their other parent
-    QString nmRelationId() const;
+    QString currentNmRelationId() const;
 
-    //! On many-to-many relations sets the second relation id connecting the children in the association table to their other parent
-    void setNmRelationId( const QString &nmRelationId );
+    //! On many-to-many relations sets the second relation connecting the children in the association table to their other parent
+    void setCurrentNmRelationId( const QString &nmRelationId );
 
     /**
      * The parent feature for which this model contains the children
@@ -84,14 +84,14 @@ class ReferencingFeatureListModel : public QAbstractItemModel
     QgsFeature feature() const;
 
     /**
-     * The relation connection to the parent feature with the children in this model
+     * The relation connecting the parent feature with the children in this model
      * \param relation
      * \see relation
      */
     void setRelation( const QgsRelation &relation );
 
     /**
-     * The relation connection to the parent feature with the children in this model
+     * The relation connecting the parent feature with the children in this model
      * \return relation
      * \see setRelation
      */

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -22,8 +22,8 @@ Rectangle{
         //and the relation from the children to the other parent (if it's nm and cardinality is set)
         //if cardinality is not set, the nmRelationId is empty
         id: relationEditorModel
-        relation: qgisProject.relationManager.relation(relationId)
-        nmRelation: qgisProject.relationManager.relation(nmRelationId)
+        currentRelationId: relationId
+        currentNmRelationId: nmRelationId
         feature: currentFeature
     }
 
@@ -57,7 +57,7 @@ Rectangle{
               visible: isEnabled
               color: 'grey'
               text: isEnabled && !constraintsHardValid ? qsTr( 'Ensure contraints') : ''
-              anchors { leftMargin: 10; left: parent.left; right: addButton.left; verticalCenter: parent.verticalCenter }
+              anchors { leftMargin: 10; left: parent.left; right: addButtonRow.left; verticalCenter: parent.verticalCenter }
               font.bold: true
               font.italic: true
           }
@@ -194,21 +194,37 @@ Rectangle{
 
       property int referencingFeatureId
       property string referencingFeatureDisplayMessage
+      property string referencingLayerName: relationEditorModel.relation.referencingLayer ? relationEditorModel.relation.referencingLayer.name : ''
       property int nmReferencedFeatureId
       property string nmReferencedFeatureDisplayMessage
+      property string nmReferencedLayerName: relationEditorModel.nmRelation.referencedLayer ? relationEditorModel.nmRelation.referencedLayer.name : ''
+      property string nmReferencingLayerName
 
       visible: false
-      modal: yes
+      modal: true
 
-      title: nmRelationId ?
-               qsTr( 'Unlink feature %1 (%2) of %3' ).arg( nmReferencedFeatureDisplayMessage ).arg( nmReferencedFeatureId ).arg( relationEditorModel.nmRelation.referencedLayer.name ) :
-               qsTr( 'Delete feature %1 (%2) on %3' ).arg( referencingFeatureDisplayMessage ).arg( referencingFeatureId ).arg( relationEditorModel.relation.referencingLayer.name )
+      title: nmRelationId
+              ? qsTr( 'Unlink feature %1 (%2) of %3' )
+                .arg( nmReferencedFeatureDisplayMessage )
+                .arg( nmReferencedFeatureId )
+                .arg( nmReferencedLayerName )
+              : qsTr( 'Delete feature %1 (%2) on %3' )
+                .arg( referencingFeatureDisplayMessage )
+                .arg( referencingFeatureId )
+                .arg( referencingLayerName )
       Label {
         width: parent.width
         wrapMode: Text.WordWrap
-        text:  nmRelationId ?
-               qsTr( 'Should the feature <b>%1 (%2)</b> of layer <b>%3</b> be unlinked?<br><i>(The connection will be deleted on layer <b>%4</b>)</i>').arg( nmReferencedFeatureDisplayMessage ).arg( nmReferencedFeatureId ).arg( relationEditorModel.nmRelation.referencedLayer.name ).arg( relationEditorModel.relation.referencingLayer.name ) :
-               qsTr( 'Should the feature <b>%1 (%2)</b> on layer <b>%3</b> be deleted?').arg( referencingFeatureDisplayMessage ).arg( referencingFeatureId ).arg( relationEditorModel.relation.referencingLayer.name )
+        text:  nmRelationId
+                ? qsTr( 'Should the feature <b>%1 (%2)</b> of layer <b>%3</b> be unlinked?<br><i>(The connection will be deleted on layer <b>%4</b>)</i>')
+                  .arg( parent.nmReferencedFeatureDisplayMessage )
+                  .arg( parent.nmReferencedFeatureId )
+                  .arg( parent.nmReferencedLayerName )
+                  .arg( parent.referencingLayerName )
+                : qsTr( 'Should the feature <b>%1 (%2)</b> on layer <b>%3</b> be deleted?')
+                  .arg( parent.referencingFeatureDisplayMessage )
+                  .arg( parent.referencingFeatureId )
+                  .arg( parent.referencingLayerName )
       }
 
       standardButtons: Dialog.Ok | Dialog.Cancel

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -114,7 +114,8 @@ Rectangle{
 
         Item {
           id: listitem
-          anchors { left: parent.left; right: parent.right }
+          anchors.left: parent ? parent.left : undefined
+          anchors.right: parent ? parent.right : undefined
 
           focus: true
 


### PR DESCRIPTION
All of these should be gone:
```
qrc:/qml/FeatureForm.qml:578:3: QML ToolBar (parent or ancestor of Material): Binding loop detected for property "foreground"
QQmlExpression: Expression qrc:/qml/editorwidgets/RelationEditor.qml:25:9 depends on non-NOTIFYable properties:
    QgsProject::relationManager
qrc:/qml/editorwidgets/RelationEditor.qml:56:11: QML QQuickText: Cannot anchor to an item that isn't a parent or sibling.
QQmlExpression: Expression qrc:/qml/editorwidgets/RelationEditor.qml:26:9 depends on non-NOTIFYable properties:
    QgsProject::relationManager
qrc:/qml/FeatureForm.qml:446:11: QML Connections: Detected function "onValueChanged" in Connections element. This is probably intended to be a signal handler but no signal of the target matches the name.
qrc:/qml/editorwidgets/RelationEditor.qml:201: ReferenceError: yes is not defined
qrc:/qml/editorwidgets/RelationEditor.qml:209: ReferenceError: referencingFeatureDisplayMessage is not defined
qrc:/qml/FeatureForm.qml:578:3: QML ToolBar (parent or ancestor of Material): Binding loop detected for property "foreground"
QQmlExpression: Expression qrc:/qml/editorwidgets/RelationEditor.qml:25:9 depends on non-NOTIFYable properties:
    QgsProject::relationManager
qrc:/qml/editorwidgets/RelationEditor.qml:56:11: QML QQuickText: Cannot anchor to an item that isn't a parent or sibling.
QQmlExpression: Expression qrc:/qml/editorwidgets/RelationEditor.qml:26:9 depends on non-NOTIFYable properties:
    QgsProject::relationManager
qrc:/qml/FeatureForm.qml:446:11: QML Connections: Detected function "onValueChanged" in Connections element. This is probably intended to be a signal handler but no signal of the target matches the name.
qrc:/qml/editorwidgets/RelationEditor.qml:201: ReferenceError: yes is not defined
qrc:/qml/editorwidgets/RelationEditor.qml:209: ReferenceError: referencingFeatureDisplayMessage is not defined
```