### PR TITLE
Respect the null value in the value map widget

### DIFF
--- a/src/core/valuemapmodel.cpp
+++ b/src/core/valuemapmodel.cpp
@@ -17,6 +17,7 @@
  ***************************************************************************/
 
 #include "valuemapmodel.h"
+#include "qgsvaluemapfieldformatter.h"
 #include <QDebug>
 
 ValueMapModel::ValueMapModel( QObject *parent )
@@ -119,6 +120,9 @@ QVariant ValueMapModel::keyForValue( const QString &value ) const
 
   if ( match != mMap.end() )
     result = match->first;
+
+  if ( result == QgsValueMapFieldFormatter::NULL_VALUE )
+    result = QVariant();
 
   return result;
 }


### PR DESCRIPTION
TIL 
```
    /**
     * Will be saved in the configuration when a value is NULL.
     * It's the magic UUID {2839923C-8B7D-419E-B84B-CA2FE9B80EC7}
     */
const QString QgsValueMapFieldFormatter::NULL_VALUE = QStringLiteral( "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" );
```
Should fix #605 