### PR TITLE
Resurrect QGIS project file association on Android

### DIFF
--- a/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -68,6 +68,7 @@ import android.widget.TextView;
 import org.qtproject.qt5.android.bindings.QtActivity;
 
 import ch.opengis.qfield.R;
+import ch.opengis.qfield.QFieldUtils;
 
 
 public class QFieldActivity extends Activity {
@@ -229,7 +230,9 @@ public class QFieldActivity extends Activity {
         Intent sourceIntent = getIntent();
         if (sourceIntent.getAction() == Intent.ACTION_VIEW) {
             Uri uri = sourceIntent.getData();
-            intent.putExtra("QGS_PROJECT", (uri.getPath()));
+            Log.i(QtTAG, "uri path:" + uri.getPath());
+            Log.i(QtTAG, "uri decode:" + uri.toString());
+            intent.putExtra("QGS_PROJECT", QFieldUtils.getPathFromUri(getContext(),uri));
         }
 
         startActivity(intent);

--- a/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -230,8 +230,6 @@ public class QFieldActivity extends Activity {
         Intent sourceIntent = getIntent();
         if (sourceIntent.getAction() == Intent.ACTION_VIEW) {
             Uri uri = sourceIntent.getData();
-            Log.i(QtTAG, "uri path:" + uri.getPath());
-            Log.i(QtTAG, "uri decode:" + uri.toString());
             intent.putExtra("QGS_PROJECT", QFieldUtils.getPathFromUri(getContext(),uri));
         }
 

--- a/android/src/ch/opengis/qfield/QFieldUtils.java
+++ b/android/src/ch/opengis/qfield/QFieldUtils.java
@@ -1,3 +1,20 @@
+/***************************************************************************
+                            QFieldUtils.java
+                            -------------------
+              begin                : December 6, 2020
+              copyright            : (C) 2020 by Mathieu Pellerin
+              email                : nirvn dot asia at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 package ch.opengis.qfield;
 
 import android.content.Context;

--- a/android/src/ch/opengis/qfield/QFieldUtils.java
+++ b/android/src/ch/opengis/qfield/QFieldUtils.java
@@ -1,0 +1,122 @@
+package ch.opengis.qfield;
+
+import android.content.Context;
+import android.content.ContentResolver;
+import android.content.ContentUris;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Environment;
+import android.provider.DocumentsContract;
+import android.provider.MediaStore;
+import android.database.Cursor;
+
+public class QFieldUtils {
+    // original script by SANJAY GUPTA (https://stackoverflow.com/questions/17546101/get-real-path-for-uri-android)
+    public static String getPathFromUri(final Context context, final Uri uri) {
+        final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
+        String path = null;
+
+        // DocumentProvider
+        if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
+            // ExternalStorageProvider
+            if (isExternalStorageDocument(uri)) {
+                final String docId = DocumentsContract.getDocumentId(uri);
+                final String[] split = docId.split(":");
+                final String type = split[0];
+
+                if ("primary".equalsIgnoreCase(type)) {
+                    return Environment.getExternalStorageDirectory() + "/" + split[1];
+                }
+                // TODO handle non-primary volumes
+            }
+            // DownloadsProvider
+            else if (isDownloadsDocument(uri)) {
+                final String id = DocumentsContract.getDocumentId(uri);
+                final Uri contentUri = ContentUris.withAppendedId(
+                    Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
+
+                path = getDataColumn(context, contentUri, null, null);
+            }
+            // MediaProvider
+            else if (isMediaDocument(uri)) {
+                final String docId = DocumentsContract.getDocumentId(uri);
+                final String[] split = docId.split(":");
+                final String type = split[0];
+
+                Uri contentUri = null;
+                if ("image".equals(type)) {
+                    contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+                } else if ("video".equals(type)) {
+                    contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
+                } else if ("audio".equals(type)) {
+                    contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
+                }
+
+                final String selection = "_id=?";
+                final String[] selectionArgs = new String[] {
+                    split[1]
+                };
+
+                path = getDataColumn(context, contentUri, selection, selectionArgs);
+            }
+        }
+        // MediaStore (and general)
+        else if ("content".equalsIgnoreCase(uri.getScheme())) {
+            // Return the remote address
+            if (isGooglePhotosUri(uri))
+                return uri.getLastPathSegment();
+
+            path = getDataColumn(context, uri, null, null);
+        }
+
+        if (path == null && ("content".equalsIgnoreCase(uri.getScheme()) || "file".equalsIgnoreCase(uri.getScheme()))) {
+            path = uri.getPath();
+            if ( path != null )
+                path = path.replaceFirst("^/storage_root", "");
+        }
+
+        return path;
+    }
+
+    public static String getDataColumn(Context context, Uri uri, String selection,
+        String[] selectionArgs) {
+
+        Cursor cursor = null;
+        final String column = "_data";
+        final String[] projection = {
+            column
+        };
+
+        try {
+            cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs,
+                null);
+            if (cursor != null && cursor.moveToFirst()) {
+                final int index = cursor.getColumnIndexOrThrow(column);
+                return cursor.getString(index);
+            }
+        } catch(Exception e) {
+            if (cursor != null)
+                cursor.close();
+        } finally {
+            if (cursor != null)
+                cursor.close();
+        }
+        return null;
+    }
+
+    public static boolean isExternalStorageDocument(Uri uri) {
+        return "com.android.externalstorage.documents".equals(uri.getAuthority());
+    }
+
+    public static boolean isDownloadsDocument(Uri uri) {
+        return "com.android.providers.downloads.documents".equals(uri.getAuthority());
+    }
+
+    public static boolean isMediaDocument(Uri uri) {
+        return "com.android.providers.media.documents".equals(uri.getAuthority());
+    }
+
+    public static boolean isGooglePhotosUri(Uri uri) {
+        return "com.google.android.apps.photos.content".equals(uri.getAuthority());
+    }
+}

--- a/cmake/AndroidManifest.xml.in
+++ b/cmake/AndroidManifest.xml.in
@@ -26,6 +26,7 @@
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE"/>
         <data android:scheme="file" />
+        <data android:scheme="content" />
         <data android:host="*" />
         <data android:mimeType="*/*" />
         <data android:pathPattern=".*\\.qgs" />
@@ -46,6 +47,9 @@
         <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\.qgz" />
       </intent-filter>
       <meta-data android:name="id" android:value="1"/>
+      <!-- Git Revision -->
+      <meta-data android:name="android.app.git_rev" android:value="@string/git_rev"/>
+      <!-- Git Revision -->
     </activity-alias>
 
     <activity android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|locale|fontScale|keyboard|keyboardHidden|navigation"

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -135,6 +135,7 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   handler.reset( mAuthRequestHandler );
   QgsNetworkAccessManager::instance()->setAuthHandler( std::move( handler ) );
 
+  qDebug() << PlatformUtilities::instance()->qfieldDataDir();
   if ( !PlatformUtilities::instance()->qfieldDataDir().isEmpty() )
   {
     //set localized data paths

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -135,7 +135,6 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   handler.reset( mAuthRequestHandler );
   QgsNetworkAccessManager::instance()->setAuthHandler( std::move( handler ) );
 
-  qDebug() << PlatformUtilities::instance()->qfieldDataDir();
   if ( !PlatformUtilities::instance()->qfieldDataDir().isEmpty() )
   {
     //set localized data paths


### PR DESCRIPTION
@signedav , @m-kuhn , this PR resurrects QGIS project file association for QField on Android. It allows QField to be launched & open a given project from a file manager such as Amaze again.

Fixing file association stuff opens the door for other interesting possibilities, such as opening of GeoPDFs, vector datasets like KML, etc. 