### PR TITLE
Always show feature count in layer properties popup

### DIFF
--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -651,6 +651,29 @@ QVariant FlatLayerTreeModelBase::data( const QModelIndex &index, int role ) cons
       return layer->isValid();
     }
 
+    case FlatLayerTreeModel::FeatureCount:
+    {
+      QgsVectorLayer *layer = nullptr;
+      QModelIndex sourceIndex = mapToSource( index );
+      if ( !sourceIndex.isValid() )
+        return -1;
+      QgsLayerTreeNode *node = mLayerTreeModel->index2node( sourceIndex );
+      if ( QgsLayerTree::isLayer( node ) )
+      {
+        QgsLayerTreeLayer *nodeLayer = QgsLayerTree::toLayer( node );
+        layer = qobject_cast<QgsVectorLayer *>( nodeLayer->layer() );
+      }
+      else if ( QgsLayerTreeModelLegendNode *sym = mLayerTreeModel->index2legendNode( mapToSource( index ) ) )
+      {
+        layer = qobject_cast<QgsVectorLayer *>( sym->layerNode()->layer() );
+      }
+
+      if ( !layer ) // Group
+        return -1;
+
+      return QVariant::fromValue<long>( layer->featureCount() );
+    }
+
     case FlatLayerTreeModel::IsCollapsed:
     {
       QModelIndex sourceIndex = mapToSource( index );
@@ -751,6 +774,7 @@ QHash<int, QByteArray> FlatLayerTreeModelBase::roleNames() const
   roleNames[FlatLayerTreeModel::TreeLevel] = "TreeLevel";
   roleNames[FlatLayerTreeModel::LayerType] = "LayerType";
   roleNames[FlatLayerTreeModel::IsValid] = "IsValid";
+  roleNames[FlatLayerTreeModel::FeatureCount] = "FeatureCount";
   roleNames[FlatLayerTreeModel::IsCollapsed] = "IsCollapsed";
   roleNames[FlatLayerTreeModel::IsParentCollapsed] = "IsParentCollapsed";
   roleNames[FlatLayerTreeModel::HasChildren] = "HasChildren";

--- a/src/core/layertreemodel.h
+++ b/src/core/layertreemodel.h
@@ -113,6 +113,7 @@ class FlatLayerTreeModel : public QSortFilterProxyModel
       TreeLevel,
       LayerType,
       IsValid,
+      FeatureCount,
       IsCollapsed,
       IsParentCollapsed,
       HasChildren

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -28,6 +28,14 @@ Popup {
 
   onIndexChanged: {
     title = layerTree.data(index, Qt.DisplayName)
+    var vl = layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer)
+
+    if (vl && layerTree.data(index, FlatLayerTreeModel.IsValid)) {
+      var countSuffix = ' [' + layerTree.data(index, FlatLayerTreeModel.FeatureCount) + ']'
+
+      if ( !title.endsWith(countSuffix) )
+        title += countSuffix
+    }
 
     itemVisibleCheckBox.checked = layerTree.data(index, FlatLayerTreeModel.Visible);
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/2820439/101321601-492a5080-386e-11eb-8d10-2d2115d5e9d1.png)

This is only valid for layer properties, the legend rendering remains the same. It renders the number of features the same way as it is from QGIS in square brackets.

