### PR TITLE
Fix usability issues with demo projects on desktop

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -514,6 +514,9 @@ void QgisMobileapp::loadProjectFile( const QString &path )
 
 void QgisMobileapp::reloadProjectFile( const QString &path )
 {
+  if ( ! QFile::exists( path ) )
+    QgsMessageLog::logMessage( tr( "Project file \"%1\" does not exist" ).arg( path ), QStringLiteral( "QField" ), Qgis::Warning );
+
   mProject->removeAllMapLayers();
   mTrackingModel->reset();
 

--- a/src/core/recentprojectlistmodel.cpp
+++ b/src/core/recentprojectlistmodel.cpp
@@ -17,6 +17,7 @@
 #include "platformutilities.h"
 
 #include <QSettings>
+#include <QFile>
 
 RecentProjectListModel::RecentProjectListModel( QObject *parent )
   : QAbstractListModel( parent )
@@ -70,6 +71,11 @@ void RecentProjectListModel::reloadModel()
   {
     bool recentProjectsContainsDemoProject = false;
     QMutableListIterator<RecentProject> recentProject( mRecentProjects );
+    QString demoProjectPath( PlatformUtilities::instance()->packagePath() + demoProject.path );
+
+    if ( ! QFile::exists( demoProjectPath ) )
+      continue;
+
     while ( recentProject.hasNext() )
     {
       recentProject.next();
@@ -77,7 +83,7 @@ void RecentProjectListModel::reloadModel()
       if ( recentProject.value().path.endsWith( demoProject.path ) )
       {
         // update path: on iOS the path seems to change at each run time
-        recentProject.value().path = PlatformUtilities::instance()->packagePath() + demoProject.path;
+        recentProject.value().path = demoProjectPath;
         recentProject.value().demo = true;
         recentProjectsContainsDemoProject = true;
         break;
@@ -86,7 +92,7 @@ void RecentProjectListModel::reloadModel()
     if ( !recentProjectsContainsDemoProject )
     {
       mRecentProjects << demoProject;
-      mRecentProjects.last().path = PlatformUtilities::instance()->packagePath() + demoProject.path;
+      mRecentProjects.last().path = demoProjectPath;
     }
   }
 

--- a/src/core/recentprojectlistmodel.cpp
+++ b/src/core/recentprojectlistmodel.cpp
@@ -73,9 +73,6 @@ void RecentProjectListModel::reloadModel()
     QMutableListIterator<RecentProject> recentProject( mRecentProjects );
     QString demoProjectPath( PlatformUtilities::instance()->packagePath() + demoProject.path );
 
-    if ( ! QFile::exists( demoProjectPath ) )
-      continue;
-
     while ( recentProject.hasNext() )
     {
       recentProject.next();
@@ -94,6 +91,15 @@ void RecentProjectListModel::reloadModel()
       mRecentProjects << demoProject;
       mRecentProjects.last().path = demoProjectPath;
     }
+  }
+
+  QMutableListIterator<RecentProject> recentProject( mRecentProjects );
+  while ( recentProject.hasNext() )
+  {
+    recentProject.next();
+
+    if ( ! QFile::exists( recentProject.value().path ) )
+      recentProject.remove();
   }
 
   endResetModel();


### PR DESCRIPTION
With the new approach for demo projects, it is impossible to use them during development, since their path is always reset to unusable path on desktop. So in that case, if the demo project file cannot be found, just don't add it at all.