### PR TITLE
Qt Version 5.15.2 / more codecs / qtconnectivity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,6 @@ IF (ANDROID)
     ${OSGEO4A_LIB_DIR}/libiconv.so
     ${OSGEO4A_LIB_DIR}/libopenjp2.so
     ${OSGEO4A_LIB_DIR}/libfreexl.so
-    ${OSGEO4A_LIB_DIR}/libtiff.so
     ${OSGEO4A_LIB_DIR}/libpng16.so
     ${OSGEO4A_LIB_DIR}/libgdal.so
     ${OSGEO4A_LIB_DIR}/libproj.so

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ IF (ANDROID)
     ${OSGEO4A_LIB_DIR}/libqgis_native_${ANDROID_ABI}.so
     ${OSGEO4A_LIB_DIR}/libqt5keychain_${ANDROID_ABI}.so
     ${OSGEO4A_LIB_DIR}/libzip.so
+    ${OSGEO4A_LIB_DIR}/libzstd.so
   )
   FIND_PACKAGE(Qt5 COMPONENTS AndroidExtras REQUIRED)
 

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -112,9 +112,9 @@ cmake \
 	-DAPP_PACKAGE_NAME=${APP_PACKAGE_NAME} \
 	-DCMAKE_TOOLCHAIN_FILE=/opt/android-ndk/build/cmake/android.toolchain.cmake \
 	-DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
-	-DQt5_DIR:PATH=/opt/Qt/5.14.2/android/lib/cmake/Qt5 \
-	-DANDROID_DEPLOY_QT=/opt/Qt/5.14.2/android/bin/androiddeployqt \
-	-DCMAKE_FIND_ROOT_PATH:PATH=/opt/android-ndk\;/opt/Qt/5.14.2/android/\;/home/osgeo4a/${ANDROID_ARCH} \
+	-DQt5_DIR:PATH=${QT_ANDROID_BASE}/android/lib/cmake/Qt5 \
+	-DANDROID_DEPLOY_QT=${QT_ANDROID_BASE}/android/bin/androiddeployqt \
+	-DCMAKE_FIND_ROOT_PATH:PATH=/opt/android-ndk\;${QT_ANDROID_BASE}/android/\;/home/osgeo4a/${ANDROID_ARCH} \
 	-DANDROID_LINKER_FLAGS="${ANDROID_CMAKE_LINKER_FLAGS}" \
 	-DANDROID_ABI=${ANDROID_ARCH} \
 	-DANDROID_BUILD_ABI_${ANDROID_ARCH}=ON \

--- a/sdk.conf
+++ b/sdk.conf
@@ -1,1 +1,1 @@
-osgeo4a_version=latest
+osgeo4a_version=5_15_2

--- a/sdk.conf
+++ b/sdk.conf
@@ -1,1 +1,1 @@
-osgeo4a_version=5_15_2
+osgeo4a_version=20201214

--- a/sdk.conf
+++ b/sdk.conf
@@ -1,1 +1,1 @@
-osgeo4a_version=20201106
+osgeo4a_version=latest


### PR DESCRIPTION
My local build crashes with this. But so does `codex` built locally as well and the APK built on PR #1439 is fine.
So with this PR I want to check if it's just my local environment that does not work properly.

The `latest` image of the SDK is named like this because the tag 5.15.1 was invalid.
It contains:
- Qt 5.15.2 (2!)
- Changes for the codex (like the 20201126)
- qtconnectivity (to use QBluetooth stuff)