### PR TITLE
Shorten java code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,8 @@ ENDIF ()
 SET (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${QFIELD_OUTPUT_DIRECTORY}/${QFIELD_BIN_SUBDIR})
 SET (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${QFIELD_OUTPUT_DIRECTORY}/${QFIELD_LIB_SUBDIR})
 
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/resources/ DESTINATION ${CMAKE_INSTALL_PREFIX}/share/qfield)
+
 IF (ANDROID)
   ADD_DEFINITIONS(-DQGIS_INSTALL_DIR="") # TODO: do we need osgeo4a/[lib]/files here? see qgis.pri
   SET (ANDROID_PACKAGE_SOURCE_DIR ${CMAKE_SOURCE_DIR}/android)
@@ -100,14 +102,14 @@ IF (ANDROID)
 
   INCLUDE(CreateZip)
 
-  FILE(COPY resources DESTINATION "${OSGEO4A_STAGE_DIR}/${ANDROID_ABI}/files/") # should we rather INSTALL everything and create the package from the installation instead?
-  FILE(COPY "${OSGEO4A_STAGE_DIR}/${ANDROID_ABI}/share/proj/" DESTINATION "${OSGEO4A_STAGE_DIR}/${ANDROID_ABI}/files/share/proj/") # should we rather INSTALL everything and create the package from the installation instead?
+  set(SHARE_PATH "${CMAKE_CURRENT_BINARY_DIR}/android-build/assets/share")
+  FILE(COPY "${OSGEO4A_STAGE_DIR}/${ANDROID_ABI}/share/proj/" DESTINATION "${SHARE_PATH}/proj/")
 
-  FILE(GLOB_RECURSE asset_files "${OSGEO4A_STAGE_DIR}/${ANDROID_ABI}/files/share/resources/*" "${OSGEO4A_STAGE_DIR}/${ANDROID_ABI}/files/share/svg/*" "${OSGEO4A_STAGE_DIR}/${ANDROID_ABI}/files/share/proj/*")
-  LIST(REMOVE_ITEM asset_files "${OSGEO4A_STAGE_DIR}/${ANDROID_ABI}/files/share/resources/data/world_map.gpkg")
-
-  CREATE_ZIP("${CMAKE_CURRENT_BINARY_DIR}/android-build/assets/assets.zip" "${asset_files}" "${OSGEO4A_STAGE_DIR}/${ANDROID_ABI}/files/")
-  ADD_CUSTOM_TARGET(assets ALL DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/android-build/assets/assets.zip")
+  FILE(COPY "${OSGEO4A_STAGE_DIR}/${ANDROID_ABI}/files/share/svg/" DESTINATION "${SHARE_PATH}/qgis/svg/")
+  FILE(COPY "${OSGEO4A_STAGE_DIR}/${ANDROID_ABI}/files/share/resources/" DESTINATION "${SHARE_PATH}/qgis/resources/")
+  # Remove world map to keep apk size a bit smaller
+  FILE(REMOVE "${SHARE_PATH}/qgis/resources/data/world_map.gpkg")
+  FILE(COPY resources/ DESTINATION "${SHARE_PATH}/qfield/")
 ENDIF (ANDROID)
 
 FIND_PACKAGE(Qt5 COMPONENTS Test Concurrent Core Qml Gui Xml Positioning Widgets PrintSupport Network Quick Svg OpenGL Sql PrintSupport Sensors WebView REQUIRED)

--- a/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -226,6 +226,7 @@ public class QFieldActivity extends Activity {
         intent.putExtra("SHARE_DIR", mShareDir);
         intent.putExtra("PACKAGE_PATH", getFilesDir().toString() + "/share");
         intent.putExtra("QFIELD_DATA_DIR", mQFieldDir);
+        intent.putExtra("GIT_REV", mActivityInfo.metaData.getString("android.app.git_rev"));
 
         Intent sourceIntent = getIntent();
         if (sourceIntent.getAction() == Intent.ACTION_VIEW) {

--- a/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -45,13 +45,8 @@ import java.util.zip.ZipInputStream;
 
 import android.app.Activity;
 import android.app.Application;
-import android.app.AlertDialog;
-import android.app.AlertDialog.Builder;
-import android.app.Dialog;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
@@ -59,11 +54,6 @@ import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Environment;
-import android.util.Log;
-import android.view.View;
-import android.view.LayoutInflater;
-import android.widget.ProgressBar;
-import android.widget.TextView;
 
 import org.qtproject.qt5.android.bindings.QtActivity;
 
@@ -72,291 +62,43 @@ import ch.opengis.qfield.QFieldUtils;
 
 
 public class QFieldActivity extends Activity {
-    private static final String QtTAG = "QField";
-    private static final int PROGRESS_DIALOG = 0;
-    private static final int NOEXTERNALSTORAGE_DIALOG = 1;
-    private UnzipTask mUnzipTask = new UnzipTask();
-    private ActivityInfo mActivityInfo = null; // activity info object, used to
-    private SharedPreferences mPrefs = null; // access the metadata
-    private String mThisRev = null; // the git_rev of qgis
-    private boolean mExternalStorageAvailable = false;
-    private boolean mExternalStorageWriteable = false;
-    private String mDotQgis2Dir;
-    private String mShareDir;
-    private String mQFieldDir;
-    private ProgressBar progressBar;
-    private TextView unpackingTitle;
-    private TextView unpackingMessage;
-    private static Application application;
-    private Dialog unpackingDialog;
-    private Dialog noExternalStorageDialog;
-    
-    public static Context getContext() {
-        return application.getApplicationContext();
-    }
-    
-    /** Called when the activity is first created. */
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        startQtActivity();
+    }
 
-        application = this.getApplication();
+    private void startQtActivity() {
+        String storagePath = Environment.getExternalStorageDirectory().getAbsolutePath();
 
-        // Put launch count and first launch values from parameters into AppRater properties
-        // to be used for test purposes
-        SharedPreferences appRaterSharedPreferences = getSharedPreferences("AppRater", Context.MODE_PRIVATE);
-        SharedPreferences.Editor editor = appRaterSharedPreferences.edit();
-        if (getIntent().hasExtra("LaunchCount")){
-            long launchCount = getIntent().getLongExtra("LaunchCount", 0);
-            editor.putLong("LaunchCount", launchCount);
-        }
-        if (getIntent().hasExtra("FirstLaunch")){
-            long firstLaunch = getIntent().getLongExtra("FirstLaunch", 0);
-            editor.putLong("FirstLaunch", firstLaunch);
-        }
-        if (getIntent().hasExtra("DontShowAgain")){
-            boolean dontShowAgain = getIntent().getBooleanExtra("DontShowAgain", false);
-            editor.putBoolean("DontShowAgain", dontShowAgain);
-        }
-        editor.commit();
+        String qFieldDir = storagePath + "/QField/";
+        new File(qFieldDir).mkdir();
 
-        // get preferences, 0 = mode private. only this app can read these
-        mPrefs = this.getApplicationContext().getSharedPreferences("qgisPrefs",0);
+        // create directories
+        new File(qFieldDir + "basemaps/").mkdir();
+        new File(qFieldDir + "fonts/").mkdir();
+        new File(qFieldDir + "proj/").mkdir();
+
+        Intent intent = new Intent();
+        intent.setClass(QFieldActivity.this, QtActivity.class);
         try {
-            mActivityInfo = getPackageManager().getActivityInfo(
-                                                                getComponentName(), PackageManager.GET_META_DATA);
+            ActivityInfo activityInfo = getPackageManager().getActivityInfo(getComponentName(), PackageManager.GET_META_DATA);
+            intent.putExtra("GIT_REV", activityInfo.metaData.getString("android.app.git_rev"));
         } catch (NameNotFoundException e) {
             e.printStackTrace();
             finish();
             return;
         }
 
-        unpackingDialog = createUnpackingDialog();
-        noExternalStorageDialog = createNoExternalStorageDialog();
-
-        String state = Environment.getExternalStorageState();
-        if (Environment.MEDIA_MOUNTED.equals(state)) {
-            mExternalStorageAvailable = mExternalStorageWriteable = true;
-        } else if (Environment.MEDIA_MOUNTED_READ_ONLY.equals(state)) {
-            mExternalStorageAvailable = true;
-            mExternalStorageWriteable = false;
-        } else {
-            mExternalStorageAvailable = mExternalStorageWriteable = false;
-        }
-
-        if (mExternalStorageAvailable) {
-            String storagePath = Environment.getExternalStorageDirectory().getAbsolutePath();
-            mQFieldDir = storagePath + "/QField/";
-        }
-
-        if (mExternalStorageWriteable) {
-            startFirstRun();
-        } else {
-            noExternalStorageDialog.show();
-        }
-    }
-
-    public void onDestroy() {
-        super.onDestroy();
-        mUnzipTask.cancel(true);
-
-        unpackingDialog.dismiss();
-        noExternalStorageDialog.dismiss();
-    }
-
-    private Dialog createUnpackingDialog(){
-        AlertDialog.Builder builder;
-
-        builder = new AlertDialog.Builder(this);
-        LayoutInflater inflater = getLayoutInflater();
-        View view = inflater.inflate(R.layout.unpacking_dialog, null);
-        builder.setView(view);
-
-        unpackingTitle = (TextView) view.findViewById(R.id.title);
-        unpackingTitle.setText(getString(R.string.unpacking_title));
-
-        unpackingMessage = (TextView) view.findViewById(R.id.message);
-        unpackingMessage.setText(getString(R.string.unpacking_msg));
-
-        progressBar = (ProgressBar) view.findViewById(R.id.progressBar);
-        return builder.create();
-    }
-
-    private Dialog createNoExternalStorageDialog(){
-        AlertDialog.Builder builder;
-        builder = new AlertDialog.Builder(QFieldActivity.this);
-        builder.setTitle(getString(R.string.external_storage_unavailable));
-        builder.setMessage(getString(R.string.noexternalstorage_dialog));
-        builder.setPositiveButton(getString(R.string.use_internal_storage),
-           new DialogInterface.OnClickListener() {
-               public void onClick(DialogInterface dialog, int whichButton) {
-                   dialog.cancel();
-                   startFirstRun();
-               }
-           });
-        builder.setNegativeButton(getString(android.R.string.no),
-            new DialogInterface.OnClickListener() {
-                public void onClick(DialogInterface dialog, int whichButton) {
-                    finish();
-                }
-            });
-        return builder.create();
-    }
-
-    private void startFirstRun() {
-        // get git_rev from the manifest metadata
-        mThisRev = mActivityInfo.metaData.getString("android.app.git_rev");
-        String lastRev = mPrefs.getString("lastRunGitRevision", "");
-        Log.i(QtTAG, "last git_rev:" + lastRev);
-        Log.i(QtTAG, "this git_rev:" + mThisRev);
-
-        if (lastRev.equals(mThisRev)) {
-            Log.i(QtTAG, "not first run, forwarding to QField");
-            startQtActivity();
-        } else {
-            // this is a first run after install or update
-            mUnzipTask.execute("assets.zip");
-        }
-    }
-
-    private void startQtActivity() {
-        // forward to startQtActivity and finish QFieldActivity
-        Intent intent = new Intent();
-        intent.setClass(QFieldActivity.this, QtActivity.class);
-        intent.putExtra("DOTQGIS2_DIR", mDotQgis2Dir);
-        intent.putExtra("SHARE_DIR", mShareDir);
-        intent.putExtra("PACKAGE_PATH", getFilesDir().toString() + "/share");
-        intent.putExtra("QFIELD_DATA_DIR", mQFieldDir);
-        intent.putExtra("GIT_REV", mActivityInfo.metaData.getString("android.app.git_rev"));
+        intent.putExtra("QFIELD_DATA_DIR", qFieldDir);
 
         Intent sourceIntent = getIntent();
         if (sourceIntent.getAction() == Intent.ACTION_VIEW) {
             Uri uri = sourceIntent.getData();
-            intent.putExtra("QGS_PROJECT", QFieldUtils.getPathFromUri(getContext(),uri));
+            Context context = getApplication().getApplicationContext();
+            intent.putExtra("QGS_PROJECT", QFieldUtils.getPathFromUri(context, uri));
         }
 
         startActivity(intent);
         finish();
-    }
-
-    private void makeSymlink(String path, String pathAlias) {
-        try {
-            String cmd = "rm -rf " + pathAlias;
-            Runtime.getRuntime().exec(cmd);
-            cmd = "ln -s " + path + " " + pathAlias;
-            Runtime.getRuntime().exec(cmd);
-
-            Log.i(QtTAG, "Symlinked '" + path + " to " + pathAlias + "'");
-
-        } catch (IOException e) {
-            Log.w(QtTAG, "Can't symlink '" + path + " to " + pathAlias + "'", e);
-        }
-    }
-
-    private class UnzipTask extends AsyncTask<String, Integer, String> {
-        protected String doInBackground(String... urlString) {
-            try{
-                extractZipFile(urlString[0]);
-            }catch (Exception e){
-                e.printStackTrace();
-            }
-            return null;
-        }
-
-        private void extractZipFile(String zipFile) throws IOException, InterruptedException{
-            Log.d(QtTAG, "Exctract zip file asset: "+zipFile);
-            InputStream is = getAssets().open(zipFile);
-            ZipInputStream zis = new ZipInputStream(new BufferedInputStream(is));
-            long totalSize = is.available();
-            float currentSize = 0;
-            float percent = 0;
-            try {
-                Thread.sleep(2500);
-                ZipEntry ze;
-                int count;
-                byte[] buffer = new byte[8192];
-                while ((ze = zis.getNextEntry()) != null) {
-                    File file = new File(getFilesDir(), ze.getName());
-                    File dir = ze.isDirectory() ? file : file.getParentFile();
-                    if (!dir.isDirectory() && !dir.mkdirs())
-                        throw new FileNotFoundException("Failed to ensure directory: " + dir.getAbsolutePath());
-                    if (ze.isDirectory())
-                        continue;
-                    FileOutputStream fout = new FileOutputStream(file);
-                    try {
-                        while ((count = zis.read(buffer)) != -1)
-                            fout.write(buffer, 0, count);
-                    } finally {
-                        fout.close();
-                    }
-                    currentSize = is.available();
-
-                    // 108 instead of 100 beacuse the is.available() is not accurate on large files and with
-                    // 108 we have a 100% when the unzip is finished
-                    percent = 108 - currentSize / totalSize * 100;
-                    publishProgress((int) percent);
-
-                    Log.d(QtTAG, "File unzipped: " + file.getPath());
-                    Log.d(QtTAG, "Exists: " + file.exists());
-                    Log.d(QtTAG, "Percent: " + percent);
-                }
-            } finally {
-                zis.close();
-            }
-        }
-
-        protected void onPreExecute() {
-            unpackingDialog.show();
-
-            // create symlink
-            // alias paths for storage dir (/sdcard or similar)
-            String storagePathAlias = getFilesDir() + "/storage";
-            String storagePath = Environment.getExternalStorageDirectory()
-                .getAbsolutePath();
-
-            if (mExternalStorageAvailable) {
-                mQFieldDir = storagePath + "/QField/";
-                if (mExternalStorageWriteable) {
-                    new File(mQFieldDir).mkdir();
-
-                    // create basemaps directory
-                    new File(mQFieldDir + "basemaps/").mkdir();
-
-                    String pathAlias;
-                    String externalFilesDir = getExternalFilesDir(null).getAbsolutePath();
-                    String filesDir = getFilesDir().getAbsolutePath();
-
-                    // put the share files to externalFilesDir
-                    pathAlias = filesDir + "/share";
-                    mShareDir = externalFilesDir + "/share";
-                    new File(mShareDir).mkdir();
-                    makeSymlink(mShareDir, pathAlias);
-
-                    // put .qgis to externalFilesDir
-                    pathAlias = filesDir + "/.qgis2";
-                    mDotQgis2Dir = externalFilesDir + "/.qgis2";
-                    new File(mDotQgis2Dir).mkdir();
-                    makeSymlink(mDotQgis2Dir, pathAlias);
-                } else {
-                    storagePathAlias = storagePathAlias + "ReadOnly";
-                }
-                makeSymlink(storagePath, storagePathAlias);
-            }
-        }
-
-        protected void onProgressUpdate(Integer... progress) {
-            super.onProgressUpdate(progress);
-            progressBar.setProgress(progress[0]);
-
-            if (progress[0] >= 60) {
-                unpackingMessage.setText(getString(R.string.unpacking_msg_following));
-            }
-        }
-
-        protected void onPostExecute(String result) {
-            SharedPreferences.Editor editor = mPrefs.edit();
-            editor.putString("lastRunGitRevision", mThisRev);
-            editor.commit();
-            startQtActivity();
-        }
     }
 }

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -17,6 +17,7 @@
  ***************************************************************************/
 
 #include "qgismobileapp.h"
+#include "fileutils.h"
 
 #include <QLocale>
 #include <QDir>
@@ -27,6 +28,7 @@
 #include <QDialog>
 #include <QApplication>
 #include <QtWebView/QtWebView>
+#include <QStandardPaths>
 
 #include "qgsapplication.h"
 #include "qgslogger.h"
@@ -88,12 +90,14 @@ int main( int argc, char **argv )
   delete dummyApp;
 #endif
 
+  PlatformUtilities::instance()->initSystem();
+
   QGuiApplication::setAttribute( Qt::AA_EnableHighDpiScaling );
   QtWebView::initialize();
 #ifdef ANDROID
-  QString projPath = AndroidPlatformUtilities().packagePath() + QStringLiteral( "/proj" );
+  QString projPath = AndroidPlatformUtilities().systemGenericDataLocation() + QStringLiteral( "/proj" );
   qputenv( "PROJ_LIB", projPath.toUtf8() );
-  QgsApplication app( argc, argv, true, AndroidPlatformUtilities().packagePath() + QStringLiteral( "/resources" ) );
+  QgsApplication app( argc, argv, true, AndroidPlatformUtilities().systemGenericDataLocation() + QStringLiteral( "/qgis" ) );
   qInstallMessageHandler( qfMessageHandler );
 
   QSettings settings;
@@ -101,7 +105,7 @@ int main( int argc, char **argv )
   app.setThemeName( settings.value( "/Themes", "default" ).toString() );
   app.setPrefixPath( "" QGIS_INSTALL_DIR, true );
   app.setPluginPath( QApplication::applicationDirPath() );
-  app.setPkgDataPath( AndroidPlatformUtilities().packagePath() );
+  app.setPkgDataPath( AndroidPlatformUtilities().systemGenericDataLocation() );
 #else
   QgsApplication app( argc, argv, true );
 

--- a/src/core/androidplatformutilities.cpp
+++ b/src/core/androidplatformutilities.cpp
@@ -20,6 +20,7 @@
 #include "androidpicturesource.h"
 #include "androidprojectsource.h"
 #include "androidviewstatus.h"
+#include "fileutils.h"
 
 #include <QMap>
 #include <QString>
@@ -27,10 +28,25 @@
 #include <QDebug>
 #include <QAndroidJniEnvironment>
 #include <QMimeDatabase>
+#include <QStandardPaths>
+#include <QFile>
 
 AndroidPlatformUtilities::AndroidPlatformUtilities()
   : mActivity( QtAndroid::androidActivity() )
 {
+}
+
+void AndroidPlatformUtilities::initSystem()
+{
+  QString appDataLocation = QStandardPaths::writableLocation( QStandardPaths::AppDataLocation );
+  mSystemGenericDataLocation = appDataLocation + QStringLiteral( "/share" );
+  QFile gitRevFile( appDataLocation + QStringLiteral( "/gitRev" ) );
+  QByteArray gitRev = getIntentExtra( "GIT_REV" ).toLocal8Bit();
+  if ( gitRevFile.readAll() != gitRev )
+  {
+    FileUtils::copyRecursively( "assets:/share", mSystemGenericDataLocation );
+    gitRevFile.write( gitRev );
+  }
 }
 
 QString AndroidPlatformUtilities::configDir() const
@@ -43,9 +59,9 @@ QString AndroidPlatformUtilities::shareDir() const
   return getIntentExtra( "SHARE_DIR" );
 }
 
-QString AndroidPlatformUtilities::packagePath() const
+QString AndroidPlatformUtilities::systemGenericDataLocation() const
 {
-  return getIntentExtra( "PACKAGE_PATH" );
+  return mSystemGenericDataLocation;
 }
 
 QString AndroidPlatformUtilities::qgsProject() const

--- a/src/core/androidplatformutilities.cpp
+++ b/src/core/androidplatformutilities.cpp
@@ -49,16 +49,6 @@ void AndroidPlatformUtilities::initSystem()
   }
 }
 
-QString AndroidPlatformUtilities::configDir() const
-{
-  return getIntentExtra( "DOTQGIS2_DIR" );
-}
-
-QString AndroidPlatformUtilities::shareDir() const
-{
-  return getIntentExtra( "SHARE_DIR" );
-}
-
 QString AndroidPlatformUtilities::systemGenericDataLocation() const
 {
   return mSystemGenericDataLocation;

--- a/src/core/androidplatformutilities.cpp
+++ b/src/core/androidplatformutilities.cpp
@@ -38,6 +38,7 @@ AndroidPlatformUtilities::AndroidPlatformUtilities()
 
 void AndroidPlatformUtilities::initSystem()
 {
+  // Copy data away from the virtual path `assets:/` to a path accessible also for non-qt-based libs
   QString appDataLocation = QStandardPaths::writableLocation( QStandardPaths::AppDataLocation );
   mSystemGenericDataLocation = appDataLocation + QStringLiteral( "/share" );
   QFile gitRevFile( appDataLocation + QStringLiteral( "/gitRev" ) );

--- a/src/core/androidplatformutilities.h
+++ b/src/core/androidplatformutilities.h
@@ -28,8 +28,6 @@ class AndroidPlatformUtilities : public PlatformUtilities
     AndroidPlatformUtilities();
 
     virtual void initSystem() override;
-    virtual QString configDir() const override;
-    virtual QString shareDir() const override;
     virtual QString systemGenericDataLocation() const override;
     virtual QString qgsProject() const override;
     virtual QString qfieldDataDir() const override;

--- a/src/core/androidplatformutilities.h
+++ b/src/core/androidplatformutilities.h
@@ -27,9 +27,10 @@ class AndroidPlatformUtilities : public PlatformUtilities
   public:
     AndroidPlatformUtilities();
 
+    virtual void initSystem() override;
     virtual QString configDir() const override;
     virtual QString shareDir() const override;
-    virtual QString packagePath() const override;
+    virtual QString systemGenericDataLocation() const override;
     virtual QString qgsProject() const override;
     virtual QString qfieldDataDir() const override;
     virtual PictureSource *getCameraPicture( const QString &prefix, const QString &pictureFilePath, const QString &suffix ) override;
@@ -53,6 +54,7 @@ class AndroidPlatformUtilities : public PlatformUtilities
     QAndroidJniObject getNativeIntent() const;
     QAndroidJniObject getNativeExtras() const;
     QAndroidJniObject mActivity;
+    QString mSystemGenericDataLocation;
 };
 
 #endif // ANDROIDPLATFORMUTILITIES_H

--- a/src/core/platformutilities.cpp
+++ b/src/core/platformutilities.cpp
@@ -39,6 +39,10 @@ PlatformUtilities::~PlatformUtilities()
 {
 }
 
+void PlatformUtilities::initSystem()
+{
+}
+
 QString PlatformUtilities::configDir() const
 {
   return QString();
@@ -49,9 +53,9 @@ QString PlatformUtilities::shareDir() const
   return QString();
 }
 
-QString PlatformUtilities::packagePath() const
+QString PlatformUtilities::systemGenericDataLocation() const
 {
-  return QString();
+  return QStandardPaths::standardLocations( QStandardPaths::GenericDataLocation ).first();
 }
 
 QString PlatformUtilities::qgsProject() const

--- a/src/core/platformutilities.cpp
+++ b/src/core/platformutilities.cpp
@@ -43,16 +43,6 @@ void PlatformUtilities::initSystem()
 {
 }
 
-QString PlatformUtilities::configDir() const
-{
-  return QString();
-}
-
-QString PlatformUtilities::shareDir() const
-{
-  return QString();
-}
-
 QString PlatformUtilities::systemGenericDataLocation() const
 {
   return QStandardPaths::standardLocations( QStandardPaths::GenericDataLocation ).first();

--- a/src/core/platformutilities.h
+++ b/src/core/platformutilities.h
@@ -30,15 +30,10 @@ class PlatformUtilities : public QObject
 {
     Q_OBJECT
 
-    Q_PROPERTY( QString configDir READ configDir CONSTANT )
-    Q_PROPERTY( QString shareDir READ shareDir CONSTANT )
-
   public:
     virtual ~PlatformUtilities();
 
     virtual void initSystem();
-    virtual QString configDir() const;
-    virtual QString shareDir() const;
 
     /**
      * The source path to generic data location.

--- a/src/core/platformutilities.h
+++ b/src/core/platformutilities.h
@@ -36,9 +36,16 @@ class PlatformUtilities : public QObject
   public:
     virtual ~PlatformUtilities();
 
+    virtual void initSystem();
     virtual QString configDir() const;
     virtual QString shareDir() const;
-    virtual QString packagePath() const;
+
+    /**
+     * The source path to generic data location.
+     * Under this path, there should be the app specific directories qgis/ proj/ qfield/ ...
+     * Refers to /share or /usr/share on Linux
+     */
+    virtual QString systemGenericDataLocation() const;
     virtual QString qgsProject() const;
     virtual QString qfieldDataDir() const;
     Q_INVOKABLE QStringList availableGrids() const;

--- a/src/core/recentprojectlistmodel.cpp
+++ b/src/core/recentprojectlistmodel.cpp
@@ -18,6 +18,7 @@
 
 #include <QSettings>
 #include <QFile>
+#include <QDir>
 
 RecentProjectListModel::RecentProjectListModel( QObject *parent )
   : QAbstractListModel( parent )
@@ -59,19 +60,19 @@ void RecentProjectListModel::reloadModel()
     settings.endGroup();
   }
   settings.endGroup();
-
+  
   // update demo projects
   const QList<RecentProject> demoProjects
   {
-    RecentProject( LocalProject, QStringLiteral( "Simple Bee Farming Demo" ), QStringLiteral( "/demo_projects/simple_bee_farming.qgs" ), true ),
-    RecentProject( LocalProject, QStringLiteral( "Advanced Bee Farming Demo" ), QStringLiteral( "/demo_projects/advanced_bee_farming.qgs" ), true ),
-    RecentProject( LocalProject, QStringLiteral( "Live QField Users Survey Demo" ), QStringLiteral( "/demo_projects/live_qfield_users_survey.qgs" ), true )
+    RecentProject( LocalProject, QStringLiteral( "Simple Bee Farming Demo" ), QStringLiteral( "/qfield/demo_projects/simple_bee_farming.qgs" ), true ),
+    RecentProject( LocalProject, QStringLiteral( "Advanced Bee Farming Demo" ), QStringLiteral( "/qfield/demo_projects/advanced_bee_farming.qgs" ), true ),
+    RecentProject( LocalProject, QStringLiteral( "Live QField Users Survey Demo" ), QStringLiteral( "/qfield/demo_projects/live_qfield_users_survey.qgs" ), true )
   };
   for ( const RecentProject &demoProject : demoProjects )
   {
     bool recentProjectsContainsDemoProject = false;
     QMutableListIterator<RecentProject> recentProject( mRecentProjects );
-    QString demoProjectPath( PlatformUtilities::instance()->packagePath() + demoProject.path );
+    QString demoProjectPath( PlatformUtilities::instance()->systemGenericDataLocation() + demoProject.path );
 
     while ( recentProject.hasNext() )
     {

--- a/src/core/utils/fileutils.cpp
+++ b/src/core/utils/fileutils.cpp
@@ -18,6 +18,7 @@
 #include <QMimeDatabase>
 #include <QDebug>
 #include <QFileInfo>
+#include <QDir>
 
 FileUtils::FileUtils( QObject *parent )
   : QObject( parent )
@@ -47,5 +48,39 @@ QString FileUtils::fileSuffix( const QString &filePath )
 bool FileUtils::fileExists( const QString &filePath )
 {
   QFileInfo fileInfo( filePath );
-  return (fileInfo.exists() && fileInfo.isFile() );
+  return ( fileInfo.exists() && fileInfo.isFile() );
+}
+
+bool FileUtils::copyRecursively( const QString &sourceFolder, const QString &destFolder )
+{
+  QDir sourceDir( sourceFolder );
+
+  if ( !sourceDir.exists() )
+    return false;
+
+  QDir destDir( destFolder );
+  if ( !destDir.exists() )
+    destDir.mkdir( destFolder );
+
+  const QStringList files = sourceDir.entryList( QDir::Files );
+  for ( const QString &file : files )
+  {
+    QString srcName = sourceFolder + QDir::separator() + file;
+    QString destName = destFolder + QDir::separator() + file;
+    bool success = QFile::copy( srcName, destName );
+    if ( !success )
+      return false;
+  }
+
+  const QStringList dirs = sourceDir.entryList( QDir::AllDirs | QDir::NoDotAndDotDot );
+  for ( const QString &dir : dirs )
+  {
+    QString srcName = sourceFolder + QDir::separator() + dir;
+    QString destName = destFolder + QDir::separator() + dir;
+    bool success = copyRecursively( srcName, destName );
+    if ( !success )
+      return false;
+  }
+
+  return true;
 }

--- a/src/core/utils/fileutils.h
+++ b/src/core/utils/fileutils.h
@@ -36,6 +36,7 @@ class FileUtils : public QObject
     Q_INVOKABLE static bool fileExists( const QString &filePath );
     //! returns the suffix (extension)
     Q_INVOKABLE static QString fileSuffix( const QString &filePath );
+    static bool copyRecursively( const QString &sourceFolder, const QString &destFolder );
 };
 
 #endif // FILEUTILS_H

--- a/src/qml/About.qml
+++ b/src/qml/About.qml
@@ -32,26 +32,7 @@ Item {
       wrapMode: Text.WordWrap
       text: qsTr( "QField Version: %1 (code: %2)").arg( version ).arg( versionCode )
     }
-    Label {
-      Layout.alignment: Qt.AlignCenter
-      Layout.maximumWidth: parent.width
-      horizontalAlignment: Text.AlignHCenter
-      color: Theme.light
-      font: Theme.strongFont
-      wrapMode: Text.WordWrap
 
-      text: qsTr( "QField Settings folder: %1" ).arg( '<br><font color="%1">'.arg(Theme.lightGray) + platformUtilities.configDir + '</font>' )
-    }
-    Label {
-      Layout.alignment: Qt.AlignCenter
-      Layout.maximumWidth: parent.width
-      horizontalAlignment: Text.AlignHCenter
-      color: Theme.light
-      font: Theme.strongFont
-      wrapMode: Text.WordWrap
-
-      text: qsTr( "QField Shared items folder: %1" ).arg( '<br><font color="%1">'.arg(Theme.lightGray) + platformUtilities.shareDir + '</font>' )
-    }
     Item{
       Layout.minimumHeight: 20
     }


### PR DESCRIPTION
This is a major change regarding

 - java bootstrap code
 - asset deployment

Almost all the initialization java code is gone. Java now does:

 - Creating the /QField/basemaps, /QField/proj, /QField/fonts directories
 - Obtaining some intent data for opening qgz files (to be tested)
 - Setting intent data for the app itself (version information, project file to open)

Assets are no longer zipped, they are delivered as files. They are copied from the original path to some user writable location on first run and when the version changes.