### PR TITLE
Add the ability to see the password you entered

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -366,5 +366,7 @@
         <file>themes/qfield/nodpi/directions_walk_24dp.svg</file>
         <file>themes/qfield/nodpi/list_24dp.svg</file>
         <file>themes/qfield/nodpi/zoom_out_map_24dp.svg</file>
+        <file>themes/qfield/nodpi/ic_show_green_48dp.svg</file>
+        <file>themes/qfield/nodpi/ic_hide_green_48dp.svg</file>
     </qresource>
 </RCC>

--- a/images/themes/qfield/nodpi/ic_hide_green_48dp.svg
+++ b/images/themes/qfield/nodpi/ic_hide_green_48dp.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg6"
+   version="1.1"
+   height="48px"
+   width="48px"
+   fill="black"
+   viewBox="0 0 24 24">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <path
+     id="path2"
+     fill="none"
+     d="M0 0h24v24H0zm0 0h24v24H0zm0 0h24v24H0zm0 0h24v24H0z" />
+  <path
+     style="fill:#80cc28;fill-opacity:0.99215686"
+     id="path4"
+     d="M12 7c2.76 0 5 2.24 5 5 0 .65-.13 1.26-.36 1.83l2.92 2.92c1.51-1.26 2.7-2.89 3.43-4.75-1.73-4.39-6-7.5-11-7.5-1.4 0-2.74.25-3.98.7l2.16 2.16C10.74 7.13 11.35 7 12 7zM2 4.27l2.28 2.28.46.46C3.08 8.3 1.78 10.02 1 12c1.73 4.39 6 7.5 11 7.5 1.55 0 3.03-.3 4.38-.84l.42.42L19.73 22 21 20.73 3.27 3 2 4.27zM7.53 9.8l1.55 1.55c-.05.21-.08.43-.08.65 0 1.66 1.34 3 3 3 .22 0 .44-.03.65-.08l1.55 1.55c-.67.33-1.41.53-2.2.53-2.76 0-5-2.24-5-5 0-.79.2-1.53.53-2.2zm4.31-.78l3.15 3.15.02-.16c0-1.66-1.34-3-3-3l-.17.01z" />
+</svg>

--- a/images/themes/qfield/nodpi/ic_show_green_48dp.svg
+++ b/images/themes/qfield/nodpi/ic_show_green_48dp.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="48" height="48" version="1.1" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata>
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <path d="m24 13.733c6.8909 0 13.036 3.976 16.036 10.267-3 6.2907-9.1273 10.267-16.036 10.267s-13.036-3.976-16.036-10.267c3-6.2907 9.1455-10.267 16.036-10.267m0-3.7333c-9.0909 0-16.855 5.8053-20 14 3.1455 8.1947 10.909 14 20 14 9.0909 0 16.855-5.8053 20-14-3.1455-8.1947-10.909-14-20-14zm0 5.6c-4.5091 0-8.1818 3.7707-8.1818 8.4s3.6727 8.4 8.1818 8.4 8.1818-3.7707 8.1818-8.4-3.6727-8.4-8.1818-8.4z" fill="#80cc28" stroke-width="1.8422"/>
+</svg>

--- a/src/qml/LayerLoginDialog.qml
+++ b/src/qml/LayerLoginDialog.qml
@@ -81,7 +81,7 @@ Page {
 
     TextField {
       id: password
-      echoMode: TextInput.Password
+      echoMode: TextInput.PasswordEchoOnEdit
       Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
       Layout.preferredWidth: Math.max( parent.width / 2, usernamelabel.width )
       Layout.preferredHeight: font.height + 20

--- a/src/qml/LayerLoginDialog.qml
+++ b/src/qml/LayerLoginDialog.qml
@@ -53,18 +53,10 @@ Page {
       font: Theme.defaultFont
     }
 
-    TextField {
+    QfTextField {
       id: username
       Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
       Layout.preferredWidth: Math.max( parent.width / 2, usernamelabel.width )
-      font: Theme.defaultFont
-
-      background: Rectangle {
-        y: username.height - height - username.bottomPadding / 2
-        implicitWidth: 120
-        height: username.activeFocus ? 2: 1
-        color: username.activeFocus ? "#4CAF50" : "#C8E6C9"
-      }
     }
 
     Item {
@@ -79,21 +71,11 @@ Page {
       font: Theme.defaultFont
     }
 
-    TextField {
+    QfTextField {
       id: password
-      echoMode: TextInput.PasswordEchoOnEdit
       Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
       Layout.preferredWidth: Math.max( parent.width / 2, usernamelabel.width )
-      Layout.preferredHeight: font.height + 20
-      height: font.height + 20
-      font: Theme.defaultFont
-
-      background: Rectangle {
-        y: password.height - height - password.bottomPadding / 2
-        implicitWidth: 120
-        height: password.activeFocus ? 2: 1
-        color: password.activeFocus ? "#4CAF50" : "#C8E6C9"
-      }
+      echoMode: TextInput.Password
     }
 
     Item {

--- a/src/qml/imports/Theme/QfTextField.qml
+++ b/src/qml/imports/Theme/QfTextField.qml
@@ -1,0 +1,62 @@
+import QtQuick 2.0
+import QtQuick.Controls 2.0
+
+Item {
+  id: textFieldWrapper
+
+  property alias font: textField.font
+  property var echoMode: TextInput.Normal
+
+  width: textField.width
+  height: textField.height
+
+  TextField {
+    id: textField
+    echoMode: textFieldWrapper.echoMode
+    height: font.height + 20
+    width: textFieldWrapper.width
+    font: Theme.defaultFont
+    rightPadding: showPasswordButton.visible ? 2 * showPasswordButton.width : 0
+
+    background: Rectangle {
+      y: textField.height - height - textField.bottomPadding / 2
+      implicitWidth: 120
+      height: textField.activeFocus ? 2: 1
+      color: textField.activeFocus ? '#4CAF50' : '#C8E6C9'
+    }
+
+    onActiveFocusChanged: {
+      if ( !activeFocus ) {
+        echoMode = textFieldWrapper.echoMode
+      }
+    }
+  }
+
+  Image {
+    id: showPasswordButton
+    z: 1
+    visible: !!textFieldWrapper.echoMode && textFieldWrapper.echoMode !== TextInput.Normal
+    source: textField.echoMode === TextInput.Normal
+            ? Theme.getThemeVectorIcon('ic_hide_green_48dp')
+            : Theme.getThemeVectorIcon('ic_show_green_48dp')
+    sourceSize.width: 20 * screen.devicePixelRatio
+    sourceSize.height: 20 * screen.devicePixelRatio
+    fillMode: Image.PreserveAspectFit
+    anchors.top: textField.top
+    anchors.right: textField.right
+    anchors.topMargin: height - 7
+    anchors.rightMargin: height - 7
+    opacity: textField.text.length > 0 ? 1 : 0.25
+
+    MouseArea {
+      anchors.fill: parent
+      onClicked: {
+        textField.echoMode = textField.echoMode === TextInput.Normal
+            ? textFieldWrapper.echoMode
+            : TextInput.Normal
+      }
+    }
+  }
+
+
+}

--- a/src/qml/imports/Theme/qmldir
+++ b/src/qml/imports/Theme/qmldir
@@ -3,3 +3,4 @@ singleton Theme 1.0 Theme.qml
 QfSwitch 1.0 QfSwitch.qml
 QfButton 1.0 QfButton.qml
 QfToolButton 1.0 QfToolButton.qml
+QfTextField 1.0 QfTextField.qml

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -50,6 +50,7 @@
         <file>imports/Theme/QfToolButton.qml</file>
         <file>imports/Theme/QfButton.qml</file>
         <file>imports/Theme/QfSwitch.qml</file>
+        <file>imports/Theme/QfTextField.qml</file>
         <file>imports/Theme/qmldir</file>
         <file>PositioningSettingsPopup.qml</file>
         <file>PageHeader.qml</file>


### PR DESCRIPTION
As soon as the password field loses focus, the password is hidden.

Also, by adding a `QfTextField`, we can further easily modify text looks of the fields across QField.

![Peek 2020-12-18 00-45](https://user-images.githubusercontent.com/2820439/102553209-2ea47280-40cb-11eb-9f08-26c2a3473f5e.gif)
