### PR TITLE
Make the whole grey area of the relation editor clickable

### DIFF
--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -93,22 +93,24 @@ Rectangle{
                       source: Theme.getThemeIcon( 'ic_add_white_24dp' )
                     }
                 }
-
-                onClicked: {
-                  if( save() ) {
-                      //this has to be checked after buffering because the primary could be a value that has been created on creating featurer (e.g. fid)
-                      if( relationEditorModel.parentPrimariesAvailable ) {
-                          embeddedPopup.state = 'Add'
-                          embeddedPopup.currentLayer = relationEditorModel.relation.referencingLayer
-                          embeddedPopup.linkedParentFeature = relationEditorModel.feature
-                          embeddedPopup.linkedRelation = relationEditorModel.relation
-                          embeddedPopup.open()
-                      }
-                      else
-                      {
-                          displayToast(qsTr( 'Cannot add child. Parent primary keys are not available.' ) )
-                      }
-                  }
+            }
+          }
+          MouseArea {
+            anchors.fill: parent
+            onClicked: {
+              if( save() ) {
+                //this has to be checked after buffering because the primary could be a value that has been created on creating featurer (e.g. fid)
+                if( relationEditorModel.parentPrimariesAvailable ) {
+                    embeddedPopup.state = 'Add'
+                    embeddedPopup.currentLayer = relationEditorModel.relation.referencingLayer
+                    embeddedPopup.linkedParentFeature = relationEditorModel.feature
+                    embeddedPopup.linkedRelation = relationEditorModel.relation
+                    embeddedPopup.open()
+                }
+                else
+                {
+                    displayToast(qsTr( 'Cannot add child. Parent primary keys are not available.' ) )
+                }
               }
             }
           }


### PR DESCRIPTION
Currently the grey area of the new row in the relation editor is not active. Most of the time I end up clicking on it, since it is the biggest element in the widget. Now clicking on it or on the button has the same effect. Clickable gray area is already a thing for the the relation reference widget.

![image](https://user-images.githubusercontent.com/2820439/102554928-63fe8f80-40ce-11eb-987f-156eb6061db3.png)
