### PR TITLE
Wrap the text input contents when its too long

### DIFF
--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -18,6 +18,7 @@ Item {
     anchors.right: parent.right
     font: Theme.defaultFont
     color: 'gray'
+    wrapMode: Text.Wrap
 
     text: value == null ? '' : stringUtilities.insertLinks(value)
 
@@ -26,7 +27,6 @@ Item {
 
   TextField {
     id: textField
-    height: textArea.height == 0 ? Math.max(fontMetrics.height, fontMetrics.boundingRect(text).height) + 20: 0
     topPadding: 10
     bottomPadding: 10
     visible: height !== 0 && isEnabled
@@ -34,6 +34,7 @@ Item {
     anchors.right: parent.right
     font: Theme.defaultFont
     color: 'black'
+    wrapMode: TextInput.Wrap
 
     text: value == null ? '' : value
 


### PR DESCRIPTION
There are few complaints that QField is quite inconvinient when the screen is not as wide as the text input contents. It is very hard to edit those attributes.

`TextField` supports wrap mode, so all should be good. I have remove the text input height, which was modified to support alphabets with very high characters, but it seems QML calculates the height automatically well enough.

![Peek 2020-12-21 12-34](https://user-images.githubusercontent.com/2820439/102768170-67716f80-4389-11eb-876f-1fa1362dda21.gif)
