### PR TITLE
Lower QtBluetooth import to 5.14

### DIFF
--- a/src/qml/TransformedPositionSource.qml
+++ b/src/qml/TransformedPositionSource.qml
@@ -3,7 +3,7 @@ import QtPositioning 5.3
 import org.qfield 1.0
 import org.qgis 1.0
 import Utils 1.0
-import QtBluetooth 5.15
+import QtBluetooth 5.14
 
 Item{
     id: positionSource


### PR DESCRIPTION
Everything works just fine with Qt 5.14 too, and that allows me to code QField again :wink: