### PR TITLE
Add a ENABLE_BLUETOOTH switch, TRUE by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,8 @@ ENDIF (ANDROID)
 
 FIND_PACKAGE(Qt5 COMPONENTS Test Concurrent Core Qml Gui Xml Positioning Widgets PrintSupport Network Quick Svg OpenGL Sql PrintSupport Sensors WebView Bluetooth REQUIRED)
 
+SET(ENABLE_BLUETOOTH TRUE CACHE BOOL "Determines whether bluetooth scanning and connectivity will be enabled")
+
 ADD_SUBDIRECTORY(3rdparty/tessellate)
 ADD_SUBDIRECTORY(src/core)
 ADD_SUBDIRECTORY(src/app)

--- a/src/core/bluetoothdevicemodel.h
+++ b/src/core/bluetoothdevicemodel.h
@@ -78,7 +78,7 @@ class BluetoothDeviceModel : public QAbstractListModel
 
   private:
     std::unique_ptr<QBluetoothLocalDevice> mLocalDevice;
-    QBluetoothServiceDiscoveryAgent mServiceDiscoveryAgent;
+    std::unique_ptr<QBluetoothServiceDiscoveryAgent> mServiceDiscoveryAgent;
     QList<QPair<QString, QString>> mDiscoveredDevices;
     ScanningStatus mScanningStatus = NoStatus;
     QString mLastError;


### PR DESCRIPTION
This PR adds a switch to enable/disable bluetooth scanning and connectivity. This allows for QField to run without app launch freeze on bluetooth-less devices / workstations.