### PR TITLE
Improvement to ordering, location, and width of main menu and GPS menu

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -925,7 +925,10 @@ ApplicationWindow {
       }
 
       onPressAndHold: {
-        gpsMenu.popup()
+        console.log(locationToolbar.x)
+        console.log(width)
+        console.log(gpsMenu.width)
+        gpsMenu.popup(locationToolbar.x + locationToolbar.width - gpsMenu.width, locationToolbar.y + locationToolbar.height - gpsMenu.height)
       }
 
       function toggleGps() {
@@ -1275,22 +1278,30 @@ ApplicationWindow {
     id: gpsMenu
     title: qsTr( "Positioning Options" )
     font: Theme.defaultFont
-    width: Math.max(200, mainWindow.width/1.5)
+
+    width: {
+        var result = 0;
+        var padding = 0;
+        for (var i = 0; i < count; ++i) {
+            var item = itemAt(i);
+            result = Math.max(item.contentItem.implicitWidth, result);
+            padding = Math.max(item.padding, padding);
+        }
+        return Math.min( result + padding * 2,mainWindow.width - 20);
+    }
 
     MenuItem {
       id: positioningItem
       text: qsTr( "Enable Positioning" )
-
       height: 48
       font: Theme.defaultFont
-      width: parent.width
+
       checkable: true
       checked: positioningSettings.positioningActivated
       indicator.height: 20
       indicator.width: 20
       indicator.implicitHeight: 24
       indicator.implicitWidth: 24
-
       onCheckedChanged: {
         if ( checked ) {
             positioningSettings.positioningActivated = true
@@ -1300,30 +1311,13 @@ ApplicationWindow {
       }
     }
 
-    MenuSeparator { width: parent.width }
-
-    MenuItem {
-      text: qsTr( "Center to Current Location" )
-
-      height: 48
-      font: Theme.defaultFont
-      width: parent.width
-      onTriggered: {
-        mapCanvas.mapSettings.setCenter(positionSource.projectedPosition)
-      }
-    }
-
-    MenuSeparator { width: parent.width }
-
     MenuItem {
       text: qsTr( "Show Position Information" )
-
       height: 48
       font: Theme.defaultFont
-      width: parent.width
+
       checkable: true
       checked: settings.valueBool( "/QField/Positioning/ShowInformationView", false )
-
       indicator.height: 20
       indicator.width: 20
       indicator.implicitHeight: 24
@@ -1339,10 +1333,21 @@ ApplicationWindow {
       text: qsTr( "Configure Antenna Height" ) // Todo: rename to "Positioning Configuration" when there is more to configure
       height: 48
       font: Theme.defaultFont
-      width: parent.width
 
       onTriggered: {
         positioningSettingsPopup.visible = true
+      }
+    }
+
+    MenuSeparator { width: parent.width }
+
+    MenuItem {
+      text: qsTr( "Center to Current Location" )
+      height: 48
+      font: Theme.defaultFont
+
+      onTriggered: {
+        mapCanvas.mapSettings.setCenter(positionSource.projectedPosition)
       }
     }
   }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1061,13 +1061,51 @@ ApplicationWindow {
     id: mainMenu
     title: qsTr( "Main Menu" )
 
-    width: Math.max(200, mainWindow.width/4)
+    width: {
+        var result = 0;
+        var padding = 0;
+        for (var i = 0; i < count; ++i) {
+            var item = itemAt(i);
+            result = Math.max(item.contentItem.implicitWidth, result);
+            padding = Math.max(item.padding, padding);
+        }
+        return result + padding * 2;
+    }
+
+    MenuItem {
+      text: qsTr( 'Measure Tool' )
+
+      font: Theme.defaultFont
+      height: 48
+      leftPadding: 10
+
+      onTriggered: {
+        dashBoard.close()
+        changeMode( 'measure' )
+        highlighted = false
+      }
+    }
+
+    MenuItem {
+      id: printItem
+      text: qsTr( "Print to PDF" )
+
+      font: Theme.defaultFont
+      height: 48
+      leftPadding: 10
+
+      onTriggered: {
+        printMenu.popup( mainMenu.x, mainMenu.y + printItem.y )
+        highlighted = false
+      }
+    }
+
+    MenuSeparator { width: parent.width }
 
     MenuItem {
       id: openProjectMenuItem
 
       font: Theme.defaultFont
-      width: parent.width
       height: 48
       leftPadding: 10
 
@@ -1086,7 +1124,6 @@ ApplicationWindow {
       text: qsTr( "Settings" )
 
       font: Theme.defaultFont
-      width: parent.width
       height: 48
       leftPadding: 10
 
@@ -1098,25 +1135,9 @@ ApplicationWindow {
     }
 
     MenuItem {
-      text: qsTr( "About" )
+      text: qsTr( "View Log Messages" )
 
       font: Theme.defaultFont
-      width: parent.width
-      height: 48
-      leftPadding: 10
-
-      onTriggered: {
-        dashBoard.close()
-        aboutDialog.visible = true
-        highlighted = false
-      }
-    }
-
-    MenuItem {
-      text: qsTr( "Log" )
-
-      font: Theme.defaultFont
-      width: parent.width
       height: 48
       leftPadding: 10
 
@@ -1127,34 +1148,16 @@ ApplicationWindow {
       }
     }
 
-    MenuSeparator { width: parent.width }
-
     MenuItem {
-      text: qsTr( 'Measure Tool' )
+      text: qsTr( "About QField" )
 
       font: Theme.defaultFont
-      width: parent.width
       height: 48
       leftPadding: 10
 
       onTriggered: {
         dashBoard.close()
-        changeMode( 'measure' )
-        highlighted = false
-      }
-    }
-
-    MenuItem {
-      id: printItem
-      text: qsTr( "Print to PDF" )
-
-      font: Theme.defaultFont
-      width: parent.width
-      height: 48
-      leftPadding: 10
-
-      onTriggered: {
-        printMenu.popup( mainMenu.x, 2)
+        aboutDialog.visible = true
         highlighted = false
       }
     }
@@ -1192,8 +1195,16 @@ ApplicationWindow {
 
     signal enablePrintItem( int rows )
 
-    width: Math.max(200, mainWindow.width/3)
-    font: Theme.defaultFont
+    width: {
+        var result = 0;
+        var padding = 0;
+        for (var i = 0; i < count; ++i) {
+            var item = itemAt(i);
+            result = Math.max(item.contentItem.implicitWidth, result);
+            padding = Math.max(item.padding, padding);
+        }
+        return Math.min( result + padding * 2,mainWindow.width - 20);
+    }
 
     Instantiator {
 
@@ -1215,6 +1226,16 @@ ApplicationWindow {
       }
       onObjectAdded: printMenu.insertItem(index, object)
       onObjectRemoved: printMenu.removeItem(object)
+    }
+
+    MenuItem {
+      text: qsTr( '(Select template above)' )
+
+      font: Theme.defaultFont
+      height: 48
+      leftPadding: 10
+
+      enabled: false
     }
 
     Connections {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -925,9 +925,6 @@ ApplicationWindow {
       }
 
       onPressAndHold: {
-        console.log(locationToolbar.x)
-        console.log(width)
-        console.log(gpsMenu.width)
         gpsMenu.popup(locationToolbar.x + locationToolbar.width - gpsMenu.width, locationToolbar.y + locationToolbar.height - gpsMenu.height)
       }
 
@@ -1855,4 +1852,3 @@ ApplicationWindow {
       isHovering: hoverHandler.hovered
   }
 }
-


### PR DESCRIPTION
This addresses the suggestion in #1515 to re-order the main menu so project-specific actions appear at the top:
![image](https://user-images.githubusercontent.com/1728657/103122295-33ac8780-46b2-11eb-8dc9-ae7fce09f470.png)

The Print to PDF sub-menu now appears at a better location and will adjust its width to fit the longest print layout name. In addition, a disabled menu item was added to provide some advice to the user (a shortcut to address #1514):
![image](https://user-images.githubusercontent.com/1728657/103122365-825a2180-46b2-11eb-8ce2-b49e48a267ef.png)

The GPS menu got some attention too. I've regrouped the checkbox-enabled menu items together to improve the left alignment feel to the menu:
![image](https://user-images.githubusercontent.com/1728657/103122395-af0e3900-46b2-11eb-9d04-9e248ea6758e.png)
_No more label clipping!!_