### PR TITLE
When applying a digitized geometry, insure invalid intersections are removed

### DIFF
--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -493,15 +493,9 @@ void FeatureModel::applyGeometry()
       geometry.avoidIntersections( intersectionLayers );
   }
 
-  if ( mLayer && mLayer->geometryOptions()->geometryPrecision() != 0.0 )
+  if ( mLayer && mLayer->geometryOptions()->geometryPrecision() == 0.0 )
   {
-    const double precision = mLayer->geometryOptions()->geometryPrecision();
-    QgsGeometry snappedGeometry = geometry.snappedToGrid( precision, precision );
-    if ( snappedGeometry.constGet()->isValid( error ) )
-      geometry = snappedGeometry;
-  }
-  else
-  {
+    // Still do a bit of node cleanup
     QgsGeometry deduplicatedGeometry = geometry;
     deduplicatedGeometry.removeDuplicateNodes( 0.00000001 );
     if ( deduplicatedGeometry.constGet()->isValid( error ) )

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -503,7 +503,7 @@ void FeatureModel::applyGeometry()
   // Extra steps to insure a valid geometry
   geometry = geometry.makeValid();
   QgsGeometry deduplicatedGeometry = geometry;
-  deduplicatedGeometry.removeDuplicateNodes( 7 );
+  deduplicatedGeometry.removeDuplicateNodes( 0.00000001 );
   if ( deduplicatedGeometry.constGet()->isValid( error ) )
     geometry = deduplicatedGeometry;
 

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -467,14 +467,14 @@ void FeatureModel::applyGeometry()
       while ( parts.hasNext() )
       {
         QgsGeometry part( parts.next() );
-        sanitizedGeometry.addPart( part.buffer( 0.0, 5 ).get()->clone(), QgsWkbTypes::PolygonGeometry );
+        sanitizedGeometry.addPart( part.buffer( 0.0, 5 ).constGet()->clone(), QgsWkbTypes::PolygonGeometry );
       }
     }
     else if ( QgsCurvePolygon *polygon = qgsgeometry_cast<QgsCurvePolygon *>( geometry.get() ) )
     {
       sanitizedGeometry = geometry.buffer( 0, 5 );
     }
-    if ( sanitizedGeometry.get()->isValid( error ) )
+    if ( sanitizedGeometry.constGet()->isValid( error ) )
       geometry = sanitizedGeometry;
 
     QList<QgsVectorLayer *> intersectionLayers;
@@ -504,7 +504,7 @@ void FeatureModel::applyGeometry()
   geometry = geometry.makeValid();
   QgsGeometry deduplicatedGeometry = geometry;
   deduplicatedGeometry.removeDuplicateNodes( 7 );
-  if ( deduplicatedGeometry.get()->isValid( error ) )
+  if ( deduplicatedGeometry.constGet()->isValid( error ) )
     geometry = deduplicatedGeometry;
 
   mFeature.setGeometry( geometry );

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -497,16 +497,18 @@ void FeatureModel::applyGeometry()
   {
     const double precision = mLayer->geometryOptions()->geometryPrecision();
     QgsGeometry snappedGeometry = geometry.snappedToGrid( precision, precision );
-    geometry = snappedGeometry;
+    if ( snappedGeometry.constGet()->isValid( error ) )
+      geometry = snappedGeometry;
+  }
+  else
+  {
+    QgsGeometry deduplicatedGeometry = geometry;
+    deduplicatedGeometry.removeDuplicateNodes( 0.00000001 );
+    if ( deduplicatedGeometry.constGet()->isValid( error ) )
+      geometry = deduplicatedGeometry;
   }
 
-  // Extra steps to insure a valid geometry
   geometry = geometry.makeValid();
-  QgsGeometry deduplicatedGeometry = geometry;
-  deduplicatedGeometry.removeDuplicateNodes( 0.00000001 );
-  if ( deduplicatedGeometry.constGet()->isValid( error ) )
-    geometry = deduplicatedGeometry;
-
   mFeature.setGeometry( geometry );
 }
 


### PR DESCRIPTION
Digitizing on mobile devices isn't always as precise or error free as on a workstation. Sometimes, users end up creating invalid polygon intersections as they are drawing/entering their polygon. The chances of that has increased now that QField supports stylus freehand drawing.

This PR aims at auto-fixing such issues in a non-destructive way. Example through GIF:
![Peek 2020-12-25 19-22](https://user-images.githubusercontent.com/1728657/103134883-e72f6f00-46e6-11eb-83ad-c04af046aaf7.gif)

It's pretty important to end up with a valid polygon as otherwise it fails to properly handle overlap interdiction and topology insertion.