### PR TITLE
When toggling digitizing on, insure an editable layer is selected

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -116,9 +116,12 @@ ApplicationWindow {
         break;
       case 'digitize':
         dashBoard.ensureEditableLayerSelected();
-        if (dashBoard.currentLayer) {
+        if (dashBoard.currentLayer)
+        {
           displayToast( qsTr( 'You are now in digitize mode on layer %1' ).arg( dashBoard.currentLayer.name ) );
-        } else {
+        }
+        else
+        {
           displayToast( qsTr( 'You are now in digitize mode' ) );
         }
         break;
@@ -678,21 +681,29 @@ ApplicationWindow {
     function ensureEditableLayerSelected() {
       var firstEditableLayer = null;
       var currentLayerLocked = false;
-      for(var i = 0; layerTree.rowCount(); i++) {
+      for (var i = 0; layerTree.rowCount(); i++)
+      {
         var index = layerTree.index(i,0)
-        if (firstEditableLayer === null) {
-          if (layerTree.data(index,FlatLayerTreeModel.Type) === 'layer' && layerTree.data(index, FlatLayerTreeModel.ReadOnly) === false && layerTree.data(index, FlatLayerTreeModel.GeometryLocked) === false) {
+        if (firstEditableLayer === null)
+        {
+          if (layerTree.data(index,FlatLayerTreeModel.Type) === 'layer' && layerTree.data(index, FlatLayerTreeModel.ReadOnly) === false && layerTree.data(index, FlatLayerTreeModel.GeometryLocked) === false)
+          {
              firstEditableLayer = layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer);
           }
         }
-        if (currentLayer != null && currentLayer === layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer)) {
-           if (layerTree.data(index, FlatLayerTreeModel.ReadOnly) === false || layerTree.data(index, FlatLayerTreeModel.GeometryLocked) === false) {
+        if (currentLayer != null && currentLayer === layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer))
+        {
+           if (layerTree.data(index, FlatLayerTreeModel.ReadOnly) === false || layerTree.data(index, FlatLayerTreeModel.GeometryLocked) === false)
+           {
              currentLayerLocked = true;
-           } else {
+           }
+           else
+           {
              break;
            }
         }
-        if (firstEditableLayer !== null && (currentLayer === null || currentLayerLocked === true)) {
+        if (firstEditableLayer !== null && (currentLayer === null || currentLayerLocked === true))
+        {
           currentLayer = firstEditableLayer;
           break;
         }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -115,7 +115,12 @@ ApplicationWindow {
         displayToast( qsTr( 'You are now in browse mode' ) );
         break;
       case 'digitize':
-        displayToast( qsTr( 'You are now in digitize mode' ) );
+        dashBoard.ensureEditableLayerSelected();
+        if (dashBoard.currentLayer) {
+          displayToast( qsTr( 'You are now in digitize mode on layer %1' ).arg( dashBoard.currentLayer.name ) );
+        } else {
+          displayToast( qsTr( 'You are now in digitize mode' ) );
+        }
         break;
       case 'measure':
         displayToast( qsTr( 'You are now in measure mode' ) );
@@ -668,6 +673,30 @@ ApplicationWindow {
     onOpenedChanged: {
       if ( !opened && featureForm.visible )
         featureForm.focus = true
+    }
+
+    function ensureEditableLayerSelected() {
+      var firstEditableLayer = null;
+      var currentLayerLocked = false;
+      for(var i = 0; layerTree.rowCount(); i++) {
+        var index = layerTree.index(i,0)
+        if (firstEditableLayer === null) {
+          if (layerTree.data(index,FlatLayerTreeModel.Type) === 'layer' && layerTree.data(index, FlatLayerTreeModel.ReadOnly) === false && layerTree.data(index, FlatLayerTreeModel.GeometryLocked) === false) {
+             firstEditableLayer = layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer);
+          }
+        }
+        if (currentLayer != null && currentLayer === layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer)) {
+           if (layerTree.data(index, FlatLayerTreeModel.ReadOnly) === false || layerTree.data(index, FlatLayerTreeModel.GeometryLocked) === false) {
+             currentLayerLocked = true;
+           } else {
+             break;
+           }
+        }
+        if (firstEditableLayer !== null && (currentLayer === null || currentLayerLocked === true)) {
+          currentLayer = firstEditableLayer;
+          break;
+        }
+      }
     }
   }
 
@@ -1228,6 +1257,9 @@ ApplicationWindow {
         welcomeScreen.focus = false
         recentProjectListModel.reloadModel()
         settings.setValue( "/QField/FirstRunFlag", false )
+        if (stateMachine.state === "digitize") {
+            dashBoard.ensureEditableLayerSelected();
+        }
       }
     }
   }


### PR DESCRIPTION
This fixes a UX issue I've heard by many people trying QField (from beginners all the way to pros). It goes like this: "Hey, I opened the demo bees project, toggled edit mode on, and I couldn't see any changes in the interface".

The PR adds a function to auto-select the first _editable_ layer when toggling digitizing on if no layer is selected or if the selected layer is locked (read-only or geometry locked). It's a _huge_ UX improvement. 

GIF:
![Peek 2020-12-25 20-12](https://user-images.githubusercontent.com/1728657/103135917-8efc6b00-46ee-11eb-80f0-14766106056e.gif)
