### PR TITLE
Improve UI/UX of the fill ring tool

### DIFF
--- a/src/qml/geometry_editors/FillRingToolBar.qml
+++ b/src/qml/geometry_editors/FillRingToolBar.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.12
+import QtQuick.Controls 2.12
 
 import org.qgis 1.0
 import org.qfield 1.0
@@ -32,6 +33,19 @@ VisibilityFadingRow {
     return true // handled
   }
 
+  QfToolButton {
+    id: stopToolButton
+    iconSource: Theme.getThemeIcon( "ic_chevron_left_white_24dp" )
+    round: true
+    visible: !drawPolygonToolbar.rubberbandModel || drawPolygonToolbar.rubberbandModel.vertexCount < 2
+    bgcolor: Theme.darkGray
+
+    onClicked: {
+        cancel()
+        finished()
+    }
+  }
+
   DigitizingToolbar {
     id: drawPolygonToolbar
     showConfirmButton: true
@@ -62,22 +76,43 @@ VisibilityFadingRow {
           displayToast( qsTr( 'Unknown error when creating the ring' ) );
 
         featureModel.currentLayer.rollBack()
-        cancel()
-        finished()
       }
       else
       {
-        questionDialog.questionText = qsTr("Would you like to add a ring or rather fill a new polygon in the ring?")
-        questionDialog.nButtons = 3
-        questionDialog.button1Text = qsTr("Cancel")
-        questionDialog.button2Text = qsTr("Add ring")
-        questionDialog.button3Text = qsTr("Fill polygon")
-
-        questionDialog.button1Clicked.connect(rollbackRingAndCancel)
-        questionDialog.button2Clicked.connect(commitAndFinish)
-        questionDialog.button3Clicked.connect(fillPolygon)
-        questionDialog.open()
+        addPolygonDialog.show();
       }
+    }
+  }
+
+  Dialog {
+    id: addPolygonDialog
+    parent: mainWindow.contentItem
+
+    visible: false
+    modal: true
+
+    x: ( mainWindow.width - width ) / 2
+    y: ( mainWindow.height - height ) / 2
+
+    title: qsTr( "Fill ring" )
+    Label {
+      width: parent.width
+      wrapMode: Text.WordWrap
+      text: qsTr( "Would you like to fill the ring with a new polygon?" )
+    }
+
+    standardButtons: Dialog.Yes | Dialog.No
+
+    onAccepted: {
+        fillWithPolygon();
+    }
+
+    onRejected: {
+        commitRing();
+    }
+
+    function show() {
+        this.open();
     }
   }
 
@@ -95,27 +130,24 @@ VisibilityFadingRow {
     drawPolygonToolbar.cancel()
   }
 
-  function commitAndFinish(){
+  function commitRing() {
     featureModel.currentLayer.commitChanges()
-    cancel()
-    finished()
+    drawPolygonToolbar.rubberbandModel.reset()
   }
 
-  function rollbackRingAndCancel()
-  {
+  function cancelRing() {
     featureModel.currentLayer.rollBack()
-    cancel()
-    finished()
+    drawPolygonToolbar.rubberbandModel.reset()
   }
 
-  function fillPolygon()
+  function fillWithPolygon()
   {
     var polygonGeometry = GeometryUtils.polygonFromRubberband(drawPolygonToolbar.rubberbandModel, featureModel.currentLayer.crs)
     var feature = FeatureUtils.initFeature(featureModel.currentLayer, polygonGeometry)
 
     // Show form
-    formPopupLoader.onFeatureSaved.connect(commitAndFinish)
-    formPopupLoader.onFeatureCancelled.connect(rollbackRingAndCancel)
+    formPopupLoader.onFeatureSaved.connect(commitRing)
+    formPopupLoader.onFeatureCancelled.connect(cancelRing)
 
     formPopupLoader.feature = feature
     formPopupLoader.open()


### PR DESCRIPTION
While working on the reshape tool, it gave me the opportunity to look into the ring fill tool and do some UI/UX improvements.

The PR does the following:
- Let go of the question dialog in favor of a nicer looking Dialog item (which we use elsewhere)
- Decomplexify the question asked to the user after creating a ring in the feature being edited by a/ removing the [ cancel ] option (since the digitizing toolbar allows us to cancel), and b/ since we _always_ create a ring, merely ask whether the user wants to fill the created ring with a new polygon or not
- Allow for multiple rings to be crafted without the need to re-open the feature and re-edit the geometry (that's straight from doing some reshape testing)

How it looks now:
![Peek 2020-12-28 14-54](https://user-images.githubusercontent.com/1728657/103199411-65755680-491d-11eb-864e-a33a0edf5364.gif)

The whole question dialog revamp is IMHO needed as I will freely admit I was really confused as to what was being asked of me / happening there until now.

@3nids , that's your baby, is that correct? I'd love you review / approval.