### PR TITLE
Support for geometry digitizing when adding a child feature via relation editor

### DIFF
--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -531,7 +531,7 @@ void FeatureModel::applyGeometry()
     }
   }
 
-  if ( mLayer && mLayer->geometryOptions()->geometryPrecision() == 0.0 )
+  if ( geometry.wkbType() != QgsWkbTypes::Unknown && mLayer && mLayer->geometryOptions()->geometryPrecision() == 0.0 )
   {
     // Still do a bit of node cleanup
     QgsGeometry deduplicatedGeometry = geometry;

--- a/src/qml/DigitizingToolbar.qml
+++ b/src/qml/DigitizingToolbar.qml
@@ -18,7 +18,13 @@ VisibilityFadingRow {
 
   spacing: 4
 
+  /* This signal is emitted when the user confirms the digitized geometry.
+   * The correspoding handler is \c onConfirm.
+   */
   signal confirm
+  /* This signal is emitted when the user cancels geometry digitizing.
+   * The correspoding handler is \c onCancel.
+   */
   signal cancel
   signal vertexCountChanged
 

--- a/src/qml/DigitizingToolbar.qml
+++ b/src/qml/DigitizingToolbar.qml
@@ -12,6 +12,10 @@ VisibilityFadingRow {
   property bool showConfirmButton: true //<! if the geometry type is point, it will never be shown
   property bool screenHovering: false //<! if the stylus pen is used, one should not use the add button
 
+  property bool geometryRequested: false
+  property var geometryRequestedItem
+  property VectorLayer geometryRequestedLayer
+
   readonly property bool isDigitizing: rubberbandModel ? rubberbandModel.vertexCount > 1 : false //!< Readonly
 
   property bool geometryValid: false

--- a/src/qml/DigitizingToolbar.qml
+++ b/src/qml/DigitizingToolbar.qml
@@ -135,7 +135,8 @@ VisibilityFadingRow {
     bgcolor: {
         if (!showConfirmButton)
           Theme.darkGray
-        else if (Number( rubberbandModel ? rubberbandModel.geometryType : 0 ) === QgsWkbTypes.PointGeometry)
+        else if (Number( rubberbandModel ? rubberbandModel.geometryType : 0 ) === QgsWkbTypes.PointGeometry ||
+                 Number( rubberbandModel.geometryType ) === QgsWkbTypes.NullGeometry)
           Theme.mainColor
         else
           Theme.darkGray

--- a/src/qml/DigitizingToolbar.qml
+++ b/src/qml/DigitizingToolbar.qml
@@ -51,6 +51,10 @@ VisibilityFadingRow {
             // Polygon: at least 3 points (last point not saved)
             geometryValid = rubberbandModel.vertexCount > 3
           }
+          else
+          {
+            geometryValid = false
+          }
 
           // emit the signal of digitizingToolbar
           vertexCountChanged()

--- a/src/qml/DigitizingToolbar.qml
+++ b/src/qml/DigitizingToolbar.qml
@@ -19,6 +19,7 @@ VisibilityFadingRow {
   spacing: 4
 
   signal confirm
+  signal cancel
   signal vertexCountChanged
 
   Connections {
@@ -173,6 +174,7 @@ VisibilityFadingRow {
 
     standardButtons: Dialog.Ok | Dialog.Cancel
     onAccepted: {
+      rubberbandModel.reset()
       cancel();
       visible = false;
     }
@@ -192,10 +194,5 @@ VisibilityFadingRow {
   {
     rubberbandModel.removeVertex()
     mapSettings.setCenter( rubberbandModel.currentCoordinate )
-  }
-
-  function cancel()
-  {
-    rubberbandModel.reset()
   }
 }

--- a/src/qml/EmbeddedFeatureForm.qml
+++ b/src/qml/EmbeddedFeatureForm.qml
@@ -79,4 +79,9 @@ Popup {
           form.isSaved = false
       }
     }
+
+    function applyGeometry(geometry) {
+        formFeatureModel.geometry = geometry;
+        formFeatureModel.applyGeometry();
+    }
 }

--- a/src/qml/EmbeddedFeatureForm.qml
+++ b/src/qml/EmbeddedFeatureForm.qml
@@ -7,12 +7,28 @@ Popup {
     id: formPopup
 
     property alias state: form.state
-
+    property alias embeddedLevel: form.embeddedLevel
     property alias currentLayer: formFeatureModel.currentLayer
     property alias linkedRelation: formFeatureModel.linkedRelation
     property alias linkedParentFeature: formFeatureModel.linkedParentFeature
     property alias feature: formFeatureModel.feature
     property alias attributeFormModel: formAttributeFormModel
+    property alias digitizingToolbar: form.digitizingToolbar
+
+    Connections {
+        target: digitizingToolbar
+
+        property bool wasVisible: false
+        onGeometryRequestedChanged: {
+            if ( digitizingToolbar.geometryRequested && formPopup.visible ) {
+                wasVisible = true
+                formPopup.visible = false
+            } else if ( !digitizingToolbar.geometryRequested && wasVisible ) {
+                wasVisible = false
+                formPopup.visible = true
+            }
+        }
+    }
 
     onAboutToShow: {
         if( state === 'Add' ) {
@@ -28,6 +44,7 @@ Popup {
 
     x: 24
     y: 24
+    z: 1000 + embeddedLevel
     padding: 0
     width: parent.width - 48
     height: parent.height - 48
@@ -73,11 +90,11 @@ Popup {
     }
 
     onClosed: {
-      if( !form.isSaved ){
-          form.confirm()
-      }else{
-          form.isSaved = false
-      }
+        if (!form.isSaved) {
+            form.confirm()
+        } else {
+            form.isSaved = false
+        }
     }
 
     function applyGeometry(geometry) {

--- a/src/qml/EmbeddedFeatureForm.qml
+++ b/src/qml/EmbeddedFeatureForm.qml
@@ -44,8 +44,7 @@ Popup {
 
     x: 24
     y: 24
-    //setting the z breaks combobox popup list, but not setting a z leads to random stacking behavior for child-of-child feature addition/editing
-    //z: 1000 + embeddedLevel
+    z: 1000 + embeddedLevel
     padding: 0
     width: parent.width - 48
     height: parent.height - 48

--- a/src/qml/EmbeddedFeatureForm.qml
+++ b/src/qml/EmbeddedFeatureForm.qml
@@ -44,7 +44,8 @@ Popup {
 
     x: 24
     y: 24
-    z: 1000 + embeddedLevel
+    //setting the z breaks combobox popup list, but not setting a z leads to random stacking behavior for child-of-child feature addition/editing
+    //z: 1000 + embeddedLevel
     padding: 0
     width: parent.width - 48
     height: parent.height - 48

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -13,6 +13,8 @@ import org.qfield 1.0
 import Theme 1.0
 
 Page {
+  id: form
+
   signal confirmed
   signal cancelled
   signal temporaryStored
@@ -34,8 +36,6 @@ Page {
   function reset() {
     master.reset()
   }
-
-  id: form
 
   states: [
     State {

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -29,6 +29,7 @@ Page {
   property alias toolbarVisible: toolbar.visible
   //! if embedded form called by RelationEditor or RelationReferenceWidget
   property bool embedded: false
+  property int embeddedLevel: 0
   //dontSave means data would be neither saved nor cleared (so feature data is handled elsewhere like e.g. in the tracking)
   property bool dontSave: false
   property bool featureCreated: false

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -17,6 +17,7 @@ Page {
   signal cancelled
   signal temporaryStored
   signal valueChanged(var field, var oldValue, var newValue)
+  signal requestGeometry(var item, var layer)
   signal aboutToSave
 
   property AttributeFormModel model
@@ -481,6 +482,10 @@ Page {
                     }
                   }
                 }
+
+                function onRequestGeometry(item, layer) {
+                    requestGeometry(item, layer)
+                }
               }
             }
 
@@ -544,7 +549,7 @@ Page {
       return
     }
 
-    if ( ! save() ) {
+    if ( !save() ) {
       displayToast( qsTr( 'Unable to save changes') )
       state = 'Edit'
       return

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -20,6 +20,8 @@ Page {
   signal requestGeometry(var item, var layer)
   signal aboutToSave
 
+  property DigitizingToolbar digitizingToolbar
+
   property AttributeFormModel model
   property alias currentTab: swipeView.currentIndex
   property alias toolbarVisible: toolbar.visible
@@ -482,9 +484,10 @@ Page {
                     }
                   }
                 }
-
                 function onRequestGeometry(item, layer) {
-                    requestGeometry(item, layer)
+                    form.digitizingToolbar.geometryRequested = true
+                    form.digitizingToolbar.geometryRequestedItem = item
+                    form.digitizingToolbar.geometryRequestedLayer = layer
                 }
               }
             }

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -47,25 +47,49 @@ Rectangle {
   signal requestGeometry(var item, var layer)
 
   width: {
-      if (props.isVisible) {
-          if (qfieldSettings.fullScreenIdentifyView || parent.width < parent.height || parent.width < 300) {
+      if ( props.isVisible || geometryRequested )
+      {
+          if (qfieldSettings.fullScreenIdentifyView || parent.width < parent.height || parent.width < 300)
+          {
               parent.width
-          } else {
+          }
+          else
+          {
               isVertical = false
               Math.min(Math.max( 200, parent.width / 2.6), parent.width)
           }
-      } else { 0 }
+      }
+      else
+      {
+
+          0
+      }
   }
   height: {
-     if (props.isVisible) {
-         if (fullScreenView || parent.width > parent.height) {
+     if ( props.isVisible || geometryRequested )
+     {
+         if (fullScreenView || parent.width > parent.height)
+         {
              parent.height
-         } else {
+         }
+         else
+         {
              isVertical = true
              Math.min(Math.max( 200, parent.height / 2 ), parent.height)
          }
-     } else { 0 }
+     }
+     else
+     {
+         0
+     }
   }
+
+  anchors.bottomMargin: geometryRequested ? featureForm.height : 0
+  anchors.rightMargin: geometryRequested ? -featureForm.width : 0
+  opacity: geometryRequested ? 0.5 : 1
+
+  enabled: !geometryRequested
+  visible: props.isVisible
 
   states: [
     State {
@@ -450,6 +474,34 @@ Rectangle {
   Behavior on height {
     PropertyAnimation {
       duration: parent.width < parent.height ? 250 : 0
+      easing.type: Easing.InQuart
+
+      onRunningChanged: {
+        if ( running )
+          mapCanvasMap.freeze('formresize')
+        else
+          mapCanvasMap.unfreeze('formresize')
+      }
+    }
+  }
+
+  Behavior on anchors.rightMargin {
+    PropertyAnimation {
+      duration: 250
+      easing.type: Easing.InQuart
+
+      onRunningChanged: {
+        if ( running )
+          mapCanvasMap.freeze('formresize')
+        else
+          mapCanvasMap.unfreeze('formresize')
+      }
+    }
+  }
+
+  Behavior on anchors.bottomMargin {
+    PropertyAnimation {
+      duration: 250
       easing.type: Easing.InQuart
 
       onRunningChanged: {

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -30,24 +30,21 @@ Rectangle {
 
   property FeatureListModelSelection selection
   property MapSettings mapSettings
+  property DigitizingToolbar digitizingToolbar
   property color selectionColor
   property alias model: globalFeaturesList.model
   property alias extentController: featureListToolBar.extentController
   property bool allowEdit
   property bool allowDelete
-  property bool geometryRequested: false
-  property var geometryRequestedItem
-  property VectorLayer geometryRequestedLayer
 
   property bool fullScreenView: qfieldSettings.fullScreenIdentifyView
   property bool isVertical: false
 
   signal showMessage(string message)
   signal editGeometry
-  signal requestGeometry(var item, var layer)
 
   width: {
-      if ( props.isVisible || geometryRequested )
+      if ( props.isVisible || digitizingToolbar.geometryRequested )
       {
           if (qfieldSettings.fullScreenIdentifyView || parent.width < parent.height || parent.width < 300)
           {
@@ -66,7 +63,7 @@ Rectangle {
       }
   }
   height: {
-     if ( props.isVisible || geometryRequested )
+     if ( props.isVisible || digitizingToolbar.geometryRequested )
      {
          if (fullScreenView || parent.width > parent.height)
          {
@@ -84,11 +81,11 @@ Rectangle {
      }
   }
 
-  anchors.bottomMargin: geometryRequested ? featureForm.height : 0
-  anchors.rightMargin: geometryRequested ? -featureForm.width : 0
-  opacity: geometryRequested ? 0.5 : 1
+  anchors.bottomMargin: digitizingToolbar.geometryRequested ? featureForm.height : 0
+  anchors.rightMargin: digitizingToolbar.geometryRequested ? -featureForm.width : 0
+  opacity: digitizingToolbar.geometryRequested ? 0.5 : 1
 
-  enabled: !geometryRequested
+  enabled: !digitizingToolbar.geometryRequested
   visible: props.isVisible
 
   states: [
@@ -315,6 +312,8 @@ Rectangle {
     anchors.bottom: parent.bottom
     height: parent.height - globalFeaturesList.height
 
+    digitizingToolbar: featureForm.digitizingToolbar
+
     model: AttributeFormModel {
       featureModel: FeatureModel {
         currentLayer: featureForm.selection.focusedLayer
@@ -326,13 +325,6 @@ Rectangle {
     focus: true
 
     visible: !globalFeaturesList.shown
-
-    onRequestGeometry: {
-        featureForm.geometryRequested = true
-        featureForm.geometryRequestedItem = item
-        featureForm.geometryRequestedLayer = layer
-        featureForm.requestGeometry(item, layer)
-    }
   }
 
   NavigationBar {
@@ -552,7 +544,7 @@ Rectangle {
     focus = false
     fullScreenView = qfieldSettings.fullScreenIdentifyView
 
-    if ( !geometryRequested )
+    if ( !digitizingToolbar.geometryRequested )
     {
       featureForm.selection.clear()
       if ( featureForm.selection.model )

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -35,11 +35,16 @@ Rectangle {
   property alias extentController: featureListToolBar.extentController
   property bool allowEdit
   property bool allowDelete
+  property bool geometryRequested: false
+  property var geometryRequestedItem
+  property VectorLayer geometryRequestedLayer
+
   property bool fullScreenView: qfieldSettings.fullScreenIdentifyView
   property bool isVertical: false
 
   signal showMessage(string message)
   signal editGeometry
+  signal requestGeometry(var item, var layer)
 
   width: {
       if (props.isVisible) {
@@ -298,6 +303,12 @@ Rectangle {
 
     visible: !globalFeaturesList.shown
 
+    onRequestGeometry: {
+        featureForm.geometryRequested = true
+        featureForm.geometryRequestedItem = item
+        featureForm.geometryRequestedLayer = layer
+        featureForm.requestGeometry(item, layer)
+    }
   }
 
   NavigationBar {
@@ -489,11 +500,13 @@ Rectangle {
     focus = false
     fullScreenView = qfieldSettings.fullScreenIdentifyView
 
-    featureForm.selection.clear()
-    if ( featureForm.selection.model )
-      featureForm.selection.model.clearSelection()
-
-    model.clear()
+    if ( !geometryRequested )
+    {
+      featureForm.selection.clear()
+      if ( featureForm.selection.model )
+        featureForm.selection.model.clearSelection()
+      model.clear()
+    }
   }
 
   Dialog {

--- a/src/qml/OverlayFeatureFormDrawer.qml
+++ b/src/qml/OverlayFeatureFormDrawer.qml
@@ -11,6 +11,7 @@ Drawer {
   property alias state: overlayFeatureForm.state
   property alias featureForm: overlayFeatureForm
   property DigitizingToolbar digitizingToolbar
+  property bool isAdding: false
 
   edge: parent.width < parent.height ? Qt.BottomEdge : Qt.RightEdge
   width: {
@@ -37,6 +38,10 @@ Drawer {
    * To make a difference between these scenarios we need position of the drawer and the isSaved flag of the FeatureForm
    */
 
+  onOpened: {
+      isAdding = true
+  }
+
   onClosed: {
       if ( !digitizingToolbar.geometryRequested ) {
           if( !overlayFeatureForm.isSaved ) {
@@ -45,21 +50,20 @@ Drawer {
               overlayFeatureForm.isSaved = false //reset
           }
           digitizingRubberband.model.reset()
+<<<<<<< HEAD
           featureModel.resetFeature()
+=======
+          isAdding = false
+>>>>>>> 40670e731 (Avoid child feature form showing under add feature drawer)
       }
   }
 
   Connections {
       target: digitizingToolbar
-      property bool wasAdding: false
 
-      function onGeometryRequestedChanged() {
-          if ( digitizingToolbar.geometryRequested && overlayFeatureFormDrawer.opened ) {
-              wasAdding = true
-              overlayFeatureFormDrawer.close()
-          } else if ( !digitizingToolbar.geometryRequested && wasAdding ) {
-              wasAdding = false
-              overlayFeatureFormDrawer.open()
+      onGeometryRequestedChanged: {
+          if ( digitizingToolbar.geometryRequested && overlayFeatureFormDrawer.isAdding ) {
+              overlayFeatureFormDrawer.close() // note: the digitizing toolbar will re-open the drawer to avoid panel stacking issues
           }
       }
   }

--- a/src/qml/OverlayFeatureFormDrawer.qml
+++ b/src/qml/OverlayFeatureFormDrawer.qml
@@ -50,18 +50,15 @@ Drawer {
               overlayFeatureForm.isSaved = false //reset
           }
           digitizingRubberband.model.reset()
-<<<<<<< HEAD
           featureModel.resetFeature()
-=======
           isAdding = false
->>>>>>> 40670e731 (Avoid child feature form showing under add feature drawer)
       }
   }
 
   Connections {
       target: digitizingToolbar
 
-      onGeometryRequestedChanged: {
+      function onGeometryRequestedChanged() {
           if ( digitizingToolbar.geometryRequested && overlayFeatureFormDrawer.isAdding ) {
               overlayFeatureFormDrawer.close() // note: the digitizing toolbar will re-open the drawer to avoid panel stacking issues
           }

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -277,6 +277,10 @@ Item {
         onPressAndHold: mouse.accepted = false;
       }
 
+      Component.onCompleted: {
+          comboBox.popup.z = 10000 // 1000s are embedded feature forms, use a higher value to insure popups always show above embedded feature formes
+      }
+
       contentItem: Text {
         id: textLabel
         height: fontMetrics.height + 20

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -58,6 +58,7 @@ Item {
     parent: ApplicationWindow.overlay
     x: 24
     y: 24
+    z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes
     width: parent.width - 48
     height: parent.height - 48
     padding: 0

--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.12
 
 Item {
   signal valueChanged( var value, bool isNull )
+  signal requestGeometry(var item, var layer)
 
   height: childrenRect.height
   enabled: isEnabled

--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -1,10 +1,9 @@
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 
-Item {
-  signal valueChanged( var value, bool isNull )
-  signal requestGeometry(var item, var layer)
+import "."
 
+EditorWidgetBase {
   height: childrenRect.height
   enabled: isEnabled
 

--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -6,6 +6,7 @@ import Qt.labs.calendar 1.0
 
 import Theme 1.0
 
+import "."
 
 /*
   Config:
@@ -21,10 +22,7 @@ import Theme 1.0
 
  */
 
-Item {
-  signal valueChanged(var value, bool isNull)
-  signal requestGeometry(var item, var layer)
-
+EditorWidgetBase {
   height: childrenRect.height
   enabled: isEnabled
 

--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -23,6 +23,7 @@ import Theme 1.0
 
 Item {
   signal valueChanged(var value, bool isNull)
+  signal requestGeometry(var item, var layer)
 
   height: childrenRect.height
   enabled: isEnabled

--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -235,7 +235,7 @@ EditorWidgetBase {
       parent: ApplicationWindow.overlay
       x: (parent.width - width) / 2
       y: (parent.height - height) / 2
-
+      z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes
 
       ColumnLayout {
           Rectangle {

--- a/src/qml/editorwidgets/EditorWidgetBase.qml
+++ b/src/qml/editorwidgets/EditorWidgetBase.qml
@@ -3,8 +3,10 @@ import QtQuick 2.12
 Item {
     signal valueChanged( var value, bool isNull )
 
-    /* The requested geometry will be returned through calling a requestedGeometry(geometry)
-     * function attached to an editor widget which signaled the request.
+    /* This signal is emitted when an editor widget is in need of a digitized geometry. The
+     * geometry will be returned through calling a requestedGeometry(geometry) function
+     * attached to editor widget which signaled the request. The corresponding
+     * handler is \c onRequestGeometry.
      */
     signal requestGeometry(var item, var layer)
 }

--- a/src/qml/editorwidgets/EditorWidgetBase.qml
+++ b/src/qml/editorwidgets/EditorWidgetBase.qml
@@ -2,5 +2,9 @@ import QtQuick 2.12
 
 Item {
     signal valueChanged( var value, bool isNull )
+
+    /* The requested geometry will be returned through calling a requestedGeometry(geometry)
+     * function attached to an editor widget which signaled the request.
+     */
     signal requestGeometry(var item, var layer)
 }

--- a/src/qml/editorwidgets/EditorWidgetBase.qml
+++ b/src/qml/editorwidgets/EditorWidgetBase.qml
@@ -1,0 +1,6 @@
+import QtQuick 2.12
+
+Item {
+    signal valueChanged( var value, bool isNull )
+    signal requestGeometry(var item, var layer)
+}

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -10,6 +10,7 @@ import ".." as QField
 
 Item {
   signal valueChanged(var value, bool isNull)
+  signal requestGeometry(var item, var layer)
 
   anchors.left: parent.left
   anchors.right: parent.right

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -6,12 +6,11 @@ import QtQuick.Window 2.12
 import org.qgis 1.0
 import org.qfield 1.0
 import Theme 1.0
+
+import "."
 import ".." as QField
 
-Item {
-  signal valueChanged(var value, bool isNull)
-  signal requestGeometry(var item, var layer)
-
+EditorWidgetBase {
   anchors.left: parent.left
   anchors.right: parent.right
 

--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -3,10 +3,9 @@ import QtQuick.Controls 2.12
 
 import Theme 1.0
 
-Item {
-  signal valueChanged(var value, bool isNull)
-  signal requestGeometry(var item, var layer)
+import "."
 
+EditorWidgetBase {
   height: childrenRect.height
   enabled: isEnabled
 

--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -5,6 +5,8 @@ import Theme 1.0
 
 Item {
   signal valueChanged(var value, bool isNull)
+  signal requestGeometry(var item, var layer)
+
   height: childrenRect.height
   enabled: isEnabled
 

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -9,10 +9,14 @@ import ".."
 import org.qfield 1.0
 import org.qgis 1.0
 
-Rectangle{
+Rectangle {
+    id: relationEditor
+
     // It is added as being part of the editors API, but it is never triggered!
     // Check commit cf963a38a6911db26e5cd463fd991c7d2ce425f4
     signal valueChanged(var value, bool isNull)
+    signal requestGeometry(var item, var layer)
+
     property int itemHeight: 32
 
     // because no additional addEntry item on readOnly (isEnabled false)
@@ -101,6 +105,12 @@ Rectangle{
               if( save() ) {
                 //this has to be checked after buffering because the primary could be a value that has been created on creating featurer (e.g. fid)
                 if( relationEditorModel.parentPrimariesAvailable ) {
+                    console.log(relationEditorModel.relation.referencingLayer.geometryType())
+                    if ( relationEditorModel.relation.referencingLayer.geometryType() !== QgsWkbTypes.NullGeometry )
+                    {
+                        requestGeometry(relationEditor, relationEditorModel.relation.referencingLayer);
+                        return;
+                    }
                     embeddedPopup.state = 'Add'
                     embeddedPopup.currentLayer = relationEditorModel.relation.referencingLayer
                     embeddedPopup.linkedParentFeature = relationEditorModel.feature
@@ -270,5 +280,14 @@ Rectangle{
         onFeatureSaved: {
             relationEditorModel.reload()
         }
+    }
+
+    function requestedGeometry(geometry) {
+        embeddedPopup.state = 'Add'
+        embeddedPopup.currentLayer = relationEditorModel.relation.referencingLayer
+        embeddedPopup.linkedParentFeature = relationEditorModel.feature
+        embeddedPopup.linkedRelation = relationEditorModel.relation
+        embeddedPopup.applyGeometry(geometry)
+        embeddedPopup.open()
     }
 }

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -105,17 +105,12 @@ EditorWidgetBase {
               if( save() ) {
                 //this has to be checked after buffering because the primary could be a value that has been created on creating featurer (e.g. fid)
                 if( relationEditorModel.parentPrimariesAvailable ) {
-                    console.log(relationEditorModel.relation.referencingLayer.geometryType())
                     if ( relationEditorModel.relation.referencingLayer.geometryType() !== QgsWkbTypes.NullGeometry )
                     {
                         requestGeometry(relationEditor, relationEditorModel.relation.referencingLayer);
                         return;
                     }
-                    embeddedPopup.state = 'Add'
-                    embeddedPopup.currentLayer = relationEditorModel.relation.referencingLayer
-                    embeddedPopup.linkedParentFeature = relationEditorModel.feature
-                    embeddedPopup.linkedRelation = relationEditorModel.relation
-                    embeddedPopup.open()
+                    showAddFeaturePopup()
                 }
                 else
                 {
@@ -283,11 +278,18 @@ EditorWidgetBase {
     }
 
     function requestedGeometry(geometry) {
+        showAddFeaturePopup(geometry)
+    }
+
+    function showAddFeaturePopup(geometry) {
         embeddedPopup.state = 'Add'
         embeddedPopup.currentLayer = relationEditorModel.relation.referencingLayer
         embeddedPopup.linkedParentFeature = relationEditorModel.feature
         embeddedPopup.linkedRelation = relationEditorModel.relation
-        embeddedPopup.applyGeometry(geometry)
+        if ( geometry !== undefined )
+        {
+            embeddedPopup.applyGeometry(geometry)
+        }
         embeddedPopup.open()
     }
 }

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -105,16 +105,17 @@ EditorWidgetBase {
               if( save() ) {
                 //this has to be checked after buffering because the primary could be a value that has been created on creating featurer (e.g. fid)
                 if( relationEditorModel.parentPrimariesAvailable ) {
+                    displayToast( qsTr( 'Adding child feature in layer %1' ).arg( relationEditorModel.relation.referencingLayer.name ) )
                     if ( relationEditorModel.relation.referencingLayer.geometryType() !== QgsWkbTypes.NullGeometry )
                     {
-                        requestGeometry(relationEditor, relationEditorModel.relation.referencingLayer);
+                        requestGeometry( relationEditor, relationEditorModel.relation.referencingLayer );
                         return;
                     }
                     showAddFeaturePopup()
                 }
                 else
                 {
-                    displayToast(qsTr( 'Cannot add child. Parent primary keys are not available.' ) )
+                    displayToast (qsTr( 'Cannot add child feature: parent primary keys are not available' ) )
                 }
               }
             }

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -268,6 +268,9 @@ EditorWidgetBase {
     EmbeddedFeatureForm{
         id: embeddedPopup
 
+        embeddedLevel: form.embeddedLevel + 1
+        digitizingToolbar: form.digitizingToolbar
+
         onFeatureCancelled: {
             if( autoSave )
                 relationEditorModel.reload()

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -3,19 +3,15 @@ import QtQuick.Controls 2.12
 import QtGraphicalEffects 1.0
 import QtQuick.Layouts 1.12
 
-import Theme 1.0
-import ".."
-
 import org.qfield 1.0
 import org.qgis 1.0
+import Theme 1.0
 
-Rectangle {
+import ".."
+import "."
+
+EditorWidgetBase {
     id: relationEditor
-
-    // It is added as being part of the editors API, but it is never triggered!
-    // Check commit cf963a38a6911db26e5cd463fd991c7d2ce425f4
-    signal valueChanged(var value, bool isNull)
-    signal requestGeometry(var item, var layer)
 
     property int itemHeight: 32
 
@@ -25,8 +21,12 @@ Rectangle {
             : Math.max( referencingFeatureListView.height, itemHeight)
     enabled: true
 
-    border.color: 'lightgray'
-    border.width: 1
+    Rectangle {
+        anchors.fill: parent
+        color: "transparent"
+        border.color: 'lightgray'
+        border.width: 1
+    }
 
     ReferencingFeatureListModel {
         //containing the current (parent) feature, the relation to the children

--- a/src/qml/editorwidgets/RelationReference.qml
+++ b/src/qml/editorwidgets/RelationReference.qml
@@ -14,6 +14,7 @@ Item {
   property bool showOpenFormButton: config['ShowOpenFormButton'] === undefined || config['ShowOpenFormButton'] === true
 
   signal valueChanged(var value, bool isNull)
+  signal requestGeometry(var item, var layer)
 
   RelationCombobox {
     id: relationReference

--- a/src/qml/editorwidgets/RelationReference.qml
+++ b/src/qml/editorwidgets/RelationReference.qml
@@ -6,15 +6,14 @@ import QtQuick.Layouts 1.12
 import org.qfield 1.0
 import org.qgis 1.0
 import Theme 1.0
-import ".."
 
-Item {
+import ".."
+import "."
+
+EditorWidgetBase {
   anchors { left: parent.left; right: parent.right; }
 
   property bool showOpenFormButton: config['ShowOpenFormButton'] === undefined || config['ShowOpenFormButton'] === true
-
-  signal valueChanged(var value, bool isNull)
-  signal requestGeometry(var item, var layer)
 
   RelationCombobox {
     id: relationReference

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -5,6 +5,8 @@ import Theme 1.0
 Item {
   id: topItem
   signal valueChanged(var value, bool isNull)
+  signal requestGeometry(var item, var layer)
+
   height: childrenRect.height
 
   // Due to QTextEdit::onLinkActivated does not work on Android & iOS, we need a separate `Text` element to support links https://bugreports.qt.io/browse/QTBUG-38487

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -1,11 +1,12 @@
 import QtQuick 2.14
 import QtQuick.Controls 2.12
+
 import Theme 1.0
 
-Item {
+import "."
+
+EditorWidgetBase {
   id: topItem
-  signal valueChanged(var value, bool isNull)
-  signal requestGeometry(var item, var layer)
 
   height: childrenRect.height
 

--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -7,6 +7,7 @@ import Theme 1.0
 Item {
   id: valueMap
   signal valueChanged(var value, bool isNull)
+  signal requestGeometry(var item, var layer)
 
   anchors {
     left: parent.left

--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -1,13 +1,14 @@
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtGraphicalEffects 1.0
+
 import org.qfield 1.0
 import Theme 1.0
 
-Item {
+import "."
+
+EditorWidgetBase {
   id: valueMap
-  signal valueChanged(var value, bool isNull)
-  signal requestGeometry(var item, var layer)
 
   anchors {
     left: parent.left

--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -65,27 +65,6 @@ EditorWidgetBase {
       onPressAndHold: mouse.accepted = false;
     }
 
-    // [hidpi fixes]
-    delegate: ItemDelegate {
-      width: comboBox.width
-      height: fontMetrics.height + 20
-      text: model.value
-      font.weight: comboBox.currentIndex === index ? Font.DemiBold : Font.Normal
-      font.pointSize: Theme.defaultFont.pointSize
-      highlighted: comboBox.highlightedIndex == index
-    }
-
-    contentItem: Text {
-      id: textLabel
-      height: fontMetrics.height + 20
-      text: comboBox.displayText
-      font: Theme.defaultFont
-      horizontalAlignment: Text.AlignLeft
-      verticalAlignment: Text.AlignVCenter
-      elide: Text.ElideRight
-      color: value === undefined || !enabled ? 'gray' : 'black'
-    }
-
     background: Item {
       implicitWidth: 120
       implicitHeight: 36
@@ -107,7 +86,6 @@ EditorWidgetBase {
         radius: 2
       }
     }
-    // [/hidpi fixes]
   }
 
   FontMetrics {

--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -43,6 +43,7 @@ EditorWidgetBase {
 
     Component.onCompleted:
     {
+      comboBox.popup.z = 10000 // 1000s are embedded feature forms, use a higher value to insure popups always show above embedded feature formes
       model.valueMap = config['map']
     }
 

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -6,14 +6,12 @@ import QtQuick.Layouts 1.12
 import org.qfield 1.0
 import org.qgis 1.0
 import Theme 1.0
+
 import ".."
+import "."
 
-
-Item {
+EditorWidgetBase {
   id: valueRelation
-
-  signal valueChanged(var value, bool isNull)
-  signal requestGeometry(var item, var layer)
 
   height: Number(config['AllowMulti']) !== 1 ? valueRelationCombobox.height : valueRelationList.height
   enabled: true

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -13,6 +13,7 @@ Item {
   id: valueRelation
 
   signal valueChanged(var value, bool isNull)
+  signal requestGeometry(var item, var layer)
 
   height: Number(config['AllowMulti']) !== 1 ? valueRelationCombobox.height : valueRelationList.height
   enabled: true

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -55,7 +55,7 @@ EditorWidgetBase {
     }
   }
 
-  Rectangle{
+  Rectangle {
     id: valueRelationList
 
     visible: Number(config['AllowMulti']) === 1
@@ -70,7 +70,7 @@ EditorWidgetBase {
     border.width: 1
 
     FeatureCheckListModel {
-      id: listModel
+        id: listModel
         attributeField: field
         //passing "" instead of undefined, so the model is cleared on adding new features
         attributeValue: value !== undefined ? value : ""
@@ -83,7 +83,7 @@ EditorWidgetBase {
         filterExpression: config['FilterExpression']
         allowMulti: true
         onListUpdated: {
-          valueRelation.valueChanged( attributeValue, false )
+            valueRelation.valueChanged( attributeValue, false )
         }
     }
 
@@ -113,17 +113,15 @@ EditorWidgetBase {
       Item {
         id: listItem
         anchors { left: parent ? parent.left : undefined; right: parent ? parent.right : undefined }
+        height: Math.max( valueRelationList.itemHeight, valueText.height )
 
         focus: true
 
-        height: Math.max( valueRelationList.itemHeight, valueText.height )
-
-        Row{
+        Row {
           id: checkBoxRow
-          anchors { top: parent.top; left: parent.left }
           height: listItem.height
 
-          CheckBox {
+          CheckDelegate {
             id: checkBox
             width: parent.height
             height: parent.height
@@ -140,21 +138,21 @@ EditorWidgetBase {
             indicator.implicitHeight: 24
             indicator.implicitWidth: 24
           }
-        }
 
-        Text {
-          id: valueText
-          anchors { leftMargin: 10; left: checkBoxRow.right; right: parent.right; verticalCenter: parent.verticalCenter }
-          font.bold: true
-          color: !isEnabled ? 'grey' : 'black'
-          text: { text: model.displayString }
+          Text {
+            id: valueText
+            anchors.verticalCenter: parent.verticalCenter
+            font: Theme.defaultFont
+            color: !isEnabled ? 'grey' : 'black'
+            text: { text: model.displayString }
+          }
         }
 
         MouseArea {
           anchors.fill: parent
 
           onClicked: {
-            if( isEnabled ){
+            if (isEnabled) {
               checkBox.checked = !checkBox.checked
             }
           }

--- a/src/qml/geometry_editors/GeometryEditorsToolbar.qml
+++ b/src/qml/geometry_editors/GeometryEditorsToolbar.qml
@@ -49,7 +49,7 @@ VisibilityFadingRow {
 
   function init() {
     var lastUsed = settings.value( "/QField/GeometryEditorLastUsed", -1 )
-    if (lastUsed >= 0)
+    if (lastUsed >= 0 && lastUsed < editors.rowCount())
     {
       selectorRow.stateVisible = false
       var toolbarQml = editors.data(editors.index(lastUsed, 0), GeometryEditorsModelSingleton.ToolbarRole)

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1129,6 +1129,7 @@ ApplicationWindow {
       property string previousStateMachineState: ''
       onGeometryRequestedChanged: {
           if ( geometryRequested ) {
+              digitizingRubberband.model.reset()
               previousStateMachineState = stateMachine.state
               stateMachine.state = "digitize"
           }
@@ -1153,21 +1154,25 @@ ApplicationWindow {
                 }
                 if( !overlayFeatureFormDrawer.featureForm.featureCreated )
                 {
-                    digitizingFeature.resetAttributes();
+                    overlayFeatureFormDrawer.featureForm.resetAttributes();
+                    overlayFeatureFormDrawer.featureModel.geometry = digitizingFeature.geometry
+                    overlayFeatureFormDrawer.featureModel.applyGeometry()
                     if( overlayFeatureFormDrawer.featureForm.model.constraintsHardValid ){
                       // when the constrainst are fulfilled
                       // indirect action, no need to check for success and display a toast, the log is enough
-                      overlayFeatureFormDrawer.featureForm.featureCreated = digitizingFeature.create()
+                      overlayFeatureFormDrawer.featureForm.featureCreated = overlayFeatureFormDrawer.featureForm.create()
                     }
                 } else {
                   // indirect action, no need to check for success and display a toast, the log is enough
-                  digitizingFeature.save()
+                  overlayFeatureFormDrawer.featureModel.geometry = digitizingFeature.geometry
+                  overlayFeatureFormDrawer.featureModel.applyGeometry()
+                  overlayFeatureFormDrawer.featureForm.save()
                 }
             } else {
               if( overlayFeatureFormDrawer.featureForm.featureCreated ) {
                 // delete the feature when the geometry gets invalid again
                 // indirect action, no need to check for success and display a toast, the log is enough
-                overlayFeatureFormDrawer.featureForm.featureCreated = !digitizingFeature.deleteFeature()
+                overlayFeatureFormDrawer.featureForm.featureCreated = !overlayFeatureFormDrawer.featureForm.deleteFeature()
               }
             }
         }
@@ -1206,7 +1211,9 @@ ApplicationWindow {
 
         if ( !digitizingFeature.suppressFeatureForm() )
         {
-          digitizingFeature.resetAttributes();
+          overlayFeatureFormDrawer.featureModel.resetAttributes()
+          overlayFeatureFormDrawer.featureModel.geometry = digitizingFeature.geometry
+          overlayFeatureFormDrawer.featureModel.applyGeometry()
           overlayFeatureFormDrawer.open()
           overlayFeatureFormDrawer.state = "Add"
           overlayFeatureFormDrawer.featureForm.reset()
@@ -1214,12 +1221,14 @@ ApplicationWindow {
         else
         {
           if ( !overlayFeatureFormDrawer.featureForm.featureCreated ) {
-              digitizingFeature.resetAttributes();
-              if ( !digitizingFeature.create() ) {
+              overlayFeatureFormDrawer.featureModel.resetAttributes();
+              overlayFeatureFormDrawer.featureModel.geometry = digitizingFeature.geometry
+              overlayFeatureFormDrawer.featureModel.applyGeometry()
+              if ( !overlayFeatureFormDrawer.featureModel.create() ) {
                 displayToast( qsTr( "Failed to create feature!" ) )
               }
           } else {
-              if ( !digitizingFeature.save() ) {
+              if ( !overlayFeatureFormDrawer.featureModel.save() ) {
                 displayToast( qsTr( "Failed to save feature!" ) )
               }
           }
@@ -1654,7 +1663,8 @@ ApplicationWindow {
 
   OverlayFeatureFormDrawer {
     id: overlayFeatureFormDrawer
-    featureModel: digitizingFeature
+    digitizingToolbar: digitizingToolbar
+    featureModel.currentLayer: dashBoard.currentLayer
   }
 
   function displayToast( message ) {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -315,7 +315,7 @@ ApplicationWindow {
       }
 
       onConfirmedClicked: {
-          if( !overlayFeatureFormDrawer.visible )
+          if( !featureForm.geometryRequested && !overlayFeatureFormDrawer.visible )
           {
               identifyTool.identify(point)
           }
@@ -1177,6 +1177,7 @@ ApplicationWindow {
             digitizingFeature.geometry.applyRubberband()
             featureForm.geometryRequestedItem.requestedGeometry(digitizingFeature.geometry)
             digitizingRubberband.model.reset()
+            stateMachine.state = featureForm.previousStateMachineState
             featureForm.geometryRequested = false
             featureForm.show()
             return;

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1188,11 +1188,14 @@ ApplicationWindow {
       onConfirm: {
         if ( geometryRequested )
         {
+            if ( overlayFeatureFormDrawer.isAdding )
+                overlayFeatureFormDrawer.open()
+
             coordinateLocator.flash()
             digitizingFeature.geometry.applyRubberband()
             geometryRequestedItem.requestedGeometry(digitizingFeature.geometry)
-            digitizingRubberband.model.reset()
             geometryRequested = false
+            digitizingRubberband.model.reset()
             return;
         }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -770,6 +770,13 @@ ApplicationWindow {
       toolText: qsTr( 'Stop editing' )
       onClosedTool: geometryEditorsToolbar.cancelEditors()
     }
+
+    CloseTool {
+      id: abortRequestGeometry
+      visible: featureForm.geometryRequested
+      toolText: qsTr( 'Cancel addition' )
+      onClosedTool: digitizingToolbar.cancel()
+    }
   }
 
   Column {

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -17,6 +17,7 @@
         <file>ScaleBar.qml</file>
         <file>VariableEditor.qml</file>
         <file>WelcomeScreen.qml</file>
+        <file>editorwidgets/EditorWidgetBase.qml</file>
         <file>editorwidgets/CheckBox.qml</file>
         <file>editorwidgets/DateTime.qml</file>
         <file>editorwidgets/ExternalResource.qml</file>


### PR DESCRIPTION
When adding a feature via the relation editor, if the referenced relation layer has a geometry, the user will jump into digitizing mode to add his/her point/line/polygon.

How it looks:
![Peek 2020-12-30 18-53](https://user-images.githubusercontent.com/1728657/103349814-7914ee80-4ad0-11eb-9c9e-669a34420be9.gif)

