### PR TITLE
Fix QField crashing on exit (fixes #1505)

### DIFF
--- a/src/core/bluetoothreceiver.cpp
+++ b/src/core/bluetoothreceiver.cpp
@@ -20,11 +20,11 @@
 
 BluetoothReceiver::BluetoothReceiver( QObject *parent ) : QObject( parent ),
   mLocalDevice( std::make_unique<QBluetoothLocalDevice>() ),
-  mSocket( std::make_unique<QBluetoothSocket>( QBluetoothServiceInfo::RfcommProtocol ) ),
-  mGpsConnection( std::make_unique<QgsNmeaConnection>( mSocket.get() ) )
+  mSocket( new QBluetoothSocket( QBluetoothServiceInfo::RfcommProtocol ) ),
+  mGpsConnection( std::make_unique<QgsNmeaConnection>( mSocket ) )
 {
   //socket state changed
-  connect( mSocket.get(), &QBluetoothSocket::stateChanged, this, &BluetoothReceiver::setSocketState );
+  connect( mSocket, &QBluetoothSocket::stateChanged, this, &BluetoothReceiver::setSocketState );
 
   //QgsGpsConnection state changed (received location string)
   connect( mGpsConnection.get(), &QgsGpsConnection::stateChanged, this, &BluetoothReceiver::stateChanged );

--- a/src/core/bluetoothreceiver.h
+++ b/src/core/bluetoothreceiver.h
@@ -78,7 +78,7 @@ class BluetoothReceiver : public QObject
     void doConnectDevice( const QString &address );
 
     std::unique_ptr<QBluetoothLocalDevice> mLocalDevice;
-    std::unique_ptr<QBluetoothSocket> mSocket;
+    QBluetoothSocket *mSocket = nullptr;
     std::unique_ptr<QgsNmeaConnection> mGpsConnection;
     GnssPositionInformation mLastGnssPositionInformation;
 


### PR DESCRIPTION
Introduced in 1.8.0, we were destroying a destroyed QBluetoothSocket.