### PR TITLE
Refresh the vertex model when as feature is being reshaped

### DIFF
--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -396,6 +396,18 @@ void FeatureModel::reset()
   mLayer->rollBack();
 }
 
+void FeatureModel::refresh()
+{
+  if ( !mLayer || FID_IS_NEW( mFeature.id() ) )
+    return;
+
+  QgsFeature feat;
+  if ( mLayer->getFeatures( QgsFeatureRequest().setFilterFid( mFeature.id() ) ).nextFeature( feat ) )
+  {
+    setFeature( feat );
+  }
+}
+
 bool FeatureModel::suppressFeatureForm() const
 {
   if ( !mLayer )
@@ -729,6 +741,14 @@ void FeatureModel::applyVertexModelToGeometry()
     return;
 
   mFeature.setGeometry( mVertexModel->geometry() );
+}
+
+void FeatureModel::applyGeometryToVertexModel()
+{
+  if ( !mVertexModel )
+    return;
+
+  mVertexModel->setGeometry( mFeature.geometry() );
 }
 
 // a filter to gather all matches at the same place

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -147,6 +147,11 @@ class FeatureModel : public QAbstractListModel
     Q_INVOKABLE void reset();
 
     /**
+     * Will refresh the feature values and geometry from the data source.
+     */
+    Q_INVOKABLE void refresh();
+
+    /**
      * Will create this feature as a new feature on the data source
      */
     Q_INVOKABLE bool create();
@@ -185,6 +190,9 @@ class FeatureModel : public QAbstractListModel
     //! Apply the vertex model to the feature geometry.
     //! \note This shall be used if the feature model is used with the vertex model rather than the geometry and rubberband model
     Q_INVOKABLE void applyVertexModelToGeometry();
+
+    //! Apply the feature geometry to a vertex model if present.
+    Q_INVOKABLE void applyGeometryToVertexModel();
 
     //! Apply the vertex model changes to the layer topography.
     Q_INVOKABLE void applyVertexModelToLayerTopography();

--- a/src/qml/geometry_editors/GeometryEditorsToolbar.qml
+++ b/src/qml/geometry_editors/GeometryEditorsToolbar.qml
@@ -138,8 +138,8 @@ VisibilityFadingRow {
   Connections {
       target: toolbarRow.item
       onFinished: {
-        featureModel.vertexModel.clear()
-        toolbarRow.source = ''
+          featureModel.vertexModel.clear()
+          toolbarRow.source = ''
       }
   }
 

--- a/src/qml/geometry_editors/ReshapeToolBar.qml
+++ b/src/qml/geometry_editors/ReshapeToolBar.qml
@@ -66,6 +66,8 @@ VisibilityFadingRow {
             {
                 featureModel.currentLayer.commitChanges()
                 rubberbandModel.reset()
+                featureModel.refresh()
+                featureModel.applyGeometryToVertexModel()
             }
         }
     }


### PR DESCRIPTION
Without this, the red rubber band highlighting the feature doesn't get updated and is misleading to users.