### PR TITLE
Positioning accuracy indicator and digitizing accuracy requirement

### DIFF
--- a/src/qml/CoordinateLocator.qml
+++ b/src/qml/CoordinateLocator.qml
@@ -11,9 +11,15 @@ Item {
   property color highlightColor: "#CFD8DC"
 
   /**
-   * Set the current layer on which snapping should be performed
+   * Set the current layer on which snapping should be performed.
    */
   property alias currentLayer: snappingUtils.currentLayer
+
+  /**
+   * Returns whether the accuracy requirement is failing.
+   */
+  property bool accuracyRequirementFail: false
+
   /**
    * Overrides any possibility for the user to modify the coordinate.
    * There will be no user interaction or snapping if this is set to a QgsPoint.

--- a/src/qml/DigitizingToolbar.qml
+++ b/src/qml/DigitizingToolbar.qml
@@ -141,11 +141,16 @@ VisibilityFadingRow {
     transitions: [ Transition { NumberAnimation { property: "opacity"; duration: 200 } } ]
 
     onClicked: {
-      if ( Number( rubberbandModel.geometryType ) === QgsWkbTypes.PointGeometry ||
-           Number( rubberbandModel.geometryType ) === QgsWkbTypes.NullGeometry )
-        confirm()
-      else
-        addVertex()
+        if ( coordinateLocator && coordinateLocator.overrideLocation !== undefined && coordinateLocator.accuracyRequirementFail ) {
+            displayToast( qsTr( "Position accuracy doesn't meet the minimum requirement, vertex not added" ) )
+            return;
+        }
+
+        if ( Number( rubberbandModel.geometryType ) === QgsWkbTypes.PointGeometry ||
+                Number( rubberbandModel.geometryType ) === QgsWkbTypes.NullGeometry )
+            confirm()
+        else
+            addVertex()
     }
   }
 

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -7,4 +7,5 @@ LabSettings.Settings {
   property real antennaHeight: 0.0
   property bool antennaHeightActivated: false
   property bool skipAltitudeCorrection: false
+  property bool showPositionInformation: false
 }

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -4,8 +4,15 @@ import Qt.labs.settings 1.0 as LabSettings
 LabSettings.Settings {
   property bool positioningActivated: false
   property string positioningDeviceName: qsTr( "Internal device" )
+
+  property bool showPositionInformation: false
+
+  property bool accuracyIndicator: false
+  property real accuracyBad: 5.0
+  property real accuracyExcellent: 1.0
+  property bool accuracyRequirement: false
+
   property real antennaHeight: 0.0
   property bool antennaHeightActivated: false
   property bool skipAltitudeCorrection: false
-  property bool showPositionInformation: false
 }

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -516,9 +516,9 @@ Page {
 
                   Label {
                       text: qsTr( "When the accuracy indicator is enabled, a badge is attached to the location button and colored <span %1>red</span> if the accuracy value is below bad, <span %2>yellow</span> if it falls short of excellent, or <span %3>green</span>.<br><br>In addition, an accuracy restriction mode can be toggled on, which restricts vertex addition when locked to coordinate cursor to positions with an accuracy value above the bad threshold." )
-                                .arg( "style='color:rgb(%1,%2,%3)'".arg( Math.floor(Theme.errorColor.r * 255) ).arg( Math.floor(Theme.errorColor.g * 255) ).arg( Math.floor(Theme.errorColor.b * 255) ) )
-                                .arg( "style='color:rgb(%1,%2,%3)'".arg( Math.floor(Theme.warningColor.r * 255) ).arg( Math.floor(Theme.warningColor.g * 255) ).arg( Math.floor(Theme.warningColor.b * 255) ) )
-                                .arg( "style='color:rgb(%1,%2,%3)'".arg( Math.floor(Theme.mainColor.r * 255) ).arg( Math.floor(Theme.mainColor.g * 255) ).arg( Math.floor(Theme.mainColor.b * 255) ) )
+                                .arg("style='color:%1'".arg(Theme.colorToHtml(Theme.errorColor)))
+                                .arg("style='color:%1'".arg(Theme.colorToHtml(Theme.warningColor)))
+                                .arg("style='color:%1'".arg(Theme.colorToHtml(Theme.mainColor)))
                       font: Theme.tipFont
                       color: Theme.gray
                       textFormat: Qt.RichText

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -406,7 +406,7 @@ Page {
                   }
 
                   Label {
-                      text: qsTr("Bad accuracy below")
+                      text: qsTr("Bad accuracy below [m]")
                       font: Theme.defaultFont
                       enabled: accuracyIndicator.checked
                       visible: accuracyIndicator.checked
@@ -447,7 +447,7 @@ Page {
                   }
 
                   Label {
-                      text: qsTr("Excellent accuracy above")
+                      text: qsTr("Excellent accuracy above [m]")
                       font: Theme.defaultFont
                       enabled: accuracyIndicator.checked
                       visible: accuracyIndicator.checked
@@ -551,10 +551,11 @@ Page {
                   }
 
                   Label {
-                      text: qsTr("Antenna height")
+                      text: qsTr("Antenna height [m]")
                       enabled: antennaHeightActivated.checked
                       visible: antennaHeightActivated.checked
                       font: Theme.defaultFont
+                      textFormat: Text.RichText
                       Layout.leftMargin: 8
                   }
 

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -384,6 +384,151 @@ Page {
                   }
 
                   Label {
+                      text: qsTr("Activate accuracy indicator")
+                      font: Theme.defaultFont
+                      wrapMode: Text.WordWrap
+                      Layout.fillWidth: true
+
+                      MouseArea {
+                          anchors.fill: parent
+                          onClicked: accuracyIndicator.toggle()
+                      }
+                  }
+
+                  QfSwitch {
+                      id: accuracyIndicator
+                      Layout.preferredWidth: implicitContentWidth
+                      Layout.alignment: Qt.AlignTop
+                      checked: positioningSettings.accuracyIndicator
+                      onCheckedChanged: {
+                          positioningSettings.accuracyIndicator = checked
+                      }
+                  }
+
+                  Label {
+                      text: qsTr("Bad accuracy below")
+                      font: Theme.defaultFont
+                      enabled: accuracyIndicator.checked
+                      visible: accuracyIndicator.checked
+                      Layout.leftMargin: 8
+                  }
+
+                  TextField {
+                      id: accuracyBadInput
+                      width: antennaHeightActivated.width
+                      font: Theme.defaultFont
+                      enabled: accuracyIndicator.checked
+                      visible: accuracyIndicator.checked
+                      horizontalAlignment: TextInput.AlignHCenter
+                      Layout.preferredWidth: 60
+                      Layout.preferredHeight: font.height + 20
+
+                      inputMethodHints: Qt.ImhFormattedNumbersOnly
+                      validator: DoubleValidator {}
+
+                      background: Rectangle {
+                        y: parent.height - height - parent.bottomPadding / 2
+                        implicitWidth: 120
+                        height: parent.activeFocus ? 2: 1
+                        color: parent.activeFocus ? '#4CAF50' : '#C8E6C9'
+                      }
+
+                      Component.onCompleted: {
+                          text = isNaN( positioningSettings.accuracyBad ) ? '' : positioningSettings.accuracyBad
+                      }
+
+                      onTextChanged: {
+                          if( text.length === 0 || isNaN(text) ) {
+                              positioningSettings.accuracyBad = NaN
+                          } else {
+                              positioningSettings.accuracyBad = parseFloat( text )
+                          }
+                      }
+                  }
+
+                  Label {
+                      text: qsTr("Excellent accuracy above")
+                      font: Theme.defaultFont
+                      enabled: accuracyIndicator.checked
+                      visible: accuracyIndicator.checked
+                      Layout.leftMargin: 8
+                  }
+
+                  TextField {
+                      id: accuracyExcellentInput
+                      width: antennaHeightActivated.width
+                      font: Theme.defaultFont
+                      enabled: accuracyIndicator.checked
+                      visible: accuracyIndicator.checked
+                      horizontalAlignment: TextInput.AlignHCenter
+                      Layout.preferredWidth: 60
+                      Layout.preferredHeight: font.height + 20
+
+                      inputMethodHints: Qt.ImhFormattedNumbersOnly
+                      validator: DoubleValidator {}
+
+                      background: Rectangle {
+                        y: parent.height - height - parent.bottomPadding / 2
+                        implicitWidth: 120
+                        height: parent.activeFocus ? 2: 1
+                        color: parent.activeFocus ? '#4CAF50' : '#C8E6C9'
+                      }
+
+                      Component.onCompleted: {
+                          text = isNaN( positioningSettings.accuracyExcellent ) ? '' : positioningSettings.accuracyExcellent
+                      }
+
+                      onTextChanged: {
+                          if( text.length === 0 || isNaN(text) ) {
+                              positioningSettings.accuracyExcellent = NaN
+                          } else {
+                              positioningSettings.accuracyExcellent = parseFloat( text )
+                          }
+                      }
+                  }
+
+                  Label {
+                      text: qsTr("Enable accuracy requirement")
+                      font: Theme.defaultFont
+                      enabled: accuracyIndicator.checked
+                      visible: accuracyIndicator.checked
+                      wrapMode: Text.WordWrap
+                      Layout.fillWidth: true
+                      Layout.leftMargin: 8
+
+                      MouseArea {
+                          anchors.fill: parent
+                          onClicked: accuracyIndicator.toggle()
+                      }
+                  }
+
+                  QfSwitch {
+                      id: accuracyRequirement
+                      Layout.preferredWidth: implicitContentWidth
+                      Layout.alignment: Qt.AlignTop
+                      enabled: accuracyIndicator.checked
+                      visible: accuracyIndicator.checked
+                      checked: positioningSettings.accuracyRequirement
+                      onCheckedChanged: {
+                          positioningSettings.accuracyRequirement = checked
+                      }
+                  }
+
+                  Label {
+                      text: qsTr( "When the accuracy indicator is enabled, a badge is attached to the location button and colored red if the accuracy value is below bad, yellow if it falls short of excellent, or green.\n\nIn addition, an accuracy restriction mode can be toggled on, which restricts vertex addition when locked to coordinate cursor to positions with an accuracy value above the bad threshold." )
+                      font: Theme.tipFont
+                      color: Theme.gray
+
+                      wrapMode: Text.WordWrap
+                      Layout.fillWidth: true
+                  }
+
+                  Item {
+                      // empty cell in grid layout
+                      width: 1
+                  }
+
+                  Label {
                       text: qsTr("Antenna height compensation")
                       font: Theme.defaultFont
                       wrapMode: Text.WordWrap
@@ -410,6 +555,7 @@ Page {
                       enabled: antennaHeightActivated.checked
                       visible: antennaHeightActivated.checked
                       font: Theme.defaultFont
+                      Layout.leftMargin: 8
                   }
 
                   TextField {

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -515,10 +515,13 @@ Page {
                   }
 
                   Label {
-                      text: qsTr( "When the accuracy indicator is enabled, a badge is attached to the location button and colored red if the accuracy value is below bad, yellow if it falls short of excellent, or green.\n\nIn addition, an accuracy restriction mode can be toggled on, which restricts vertex addition when locked to coordinate cursor to positions with an accuracy value above the bad threshold." )
+                      text: qsTr( "When the accuracy indicator is enabled, a badge is attached to the location button and colored <span %1>red</span> if the accuracy value is below bad, <span %2>yellow</span> if it falls short of excellent, or <span %3>green</span>.<br><br>In addition, an accuracy restriction mode can be toggled on, which restricts vertex addition when locked to coordinate cursor to positions with an accuracy value above the bad threshold." )
+                                .arg( "style='color:rgb(%1,%2,%3)'".arg( Math.floor(Theme.errorColor.r * 255) ).arg( Math.floor(Theme.errorColor.g * 255) ).arg( Math.floor(Theme.errorColor.b * 255) ) )
+                                .arg( "style='color:rgb(%1,%2,%3)'".arg( Math.floor(Theme.warningColor.r * 255) ).arg( Math.floor(Theme.warningColor.g * 255) ).arg( Math.floor(Theme.warningColor.b * 255) ) )
+                                .arg( "style='color:rgb(%1,%2,%3)'".arg( Math.floor(Theme.mainColor.r * 255) ).arg( Math.floor(Theme.mainColor.g * 255) ).arg( Math.floor(Theme.mainColor.b * 255) ) )
                       font: Theme.tipFont
                       color: Theme.gray
-
+                      textFormat: Qt.RichText
                       wrapMode: Text.WordWrap
                       Layout.fillWidth: true
                   }

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -516,9 +516,9 @@ Page {
 
                   Label {
                       text: qsTr( "When the accuracy indicator is enabled, a badge is attached to the location button and colored <span %1>red</span> if the accuracy value is below bad, <span %2>yellow</span> if it falls short of excellent, or <span %3>green</span>.<br><br>In addition, an accuracy restriction mode can be toggled on, which restricts vertex addition when locked to coordinate cursor to positions with an accuracy value above the bad threshold." )
-                                .arg("style='color:%1'".arg(Theme.colorToHtml(Theme.errorColor)))
-                                .arg("style='color:%1'".arg(Theme.colorToHtml(Theme.warningColor)))
-                                .arg("style='color:%1'".arg(Theme.colorToHtml(Theme.mainColor)))
+                                .arg("style='%1'".arg(Theme.toInlineStyles({color:Theme.errorColor})))
+                                .arg("style='%1'".arg(Theme.toInlineStyles({color:Theme.warningColor})))
+                                .arg("style='%1'".arg(Theme.toInlineStyles({color:Theme.mainColor})))
                       font: Theme.tipFont
                       color: Theme.gray
                       textFormat: Qt.RichText

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -362,6 +362,28 @@ Page {
                   rowSpacing: 5
 
                   Label {
+                      text: qsTr("Show position information")
+                      font: Theme.defaultFont
+                      wrapMode: Text.WordWrap
+                      Layout.fillWidth: true
+
+                      MouseArea {
+                          anchors.fill: parent
+                          onClicked: showPositionInformation.toggle()
+                      }
+                  }
+
+                  QfSwitch {
+                      id: showPositionInformation
+                      Layout.preferredWidth: implicitContentWidth
+                      Layout.alignment: Qt.AlignTop
+                      checked: positioningSettings.showPositionInformation
+                      onCheckedChanged: {
+                          positioningSettings.showPositionInformation = checked
+                      }
+                  }
+
+                  Label {
                       text: qsTr("Antenna height compensation")
                       font: Theme.defaultFont
                       wrapMode: Text.WordWrap

--- a/src/qml/imports/Theme/Theme.qml
+++ b/src/qml/imports/Theme/Theme.qml
@@ -68,5 +68,21 @@ QtObject {
       return "rgba(%1,%2,%3,%4)".arg(Math.floor(Theme.errorColor.r * 255)).arg(Math.floor(Theme.errorColor.g * 255)).arg(Math.floor(Theme.errorColor.b * 255)).arg(Math.floor(Theme.errorColor.a * 255));
       
     }
+
+    function toInlineStyles(styleProperties) {
+      var styles = ''
+
+      for (var property in styleProperties) {
+        var value = styleProperties[property];
+        styles += property
+        styles += ': '
+        styles += typeof value == 'color'
+          ? colorToHtml(value)
+          : value
+        styles += ';'
+      }
+
+      return styles;
+    }
 }
 

--- a/src/qml/imports/Theme/Theme.qml
+++ b/src/qml/imports/Theme/Theme.qml
@@ -63,5 +63,9 @@ QtObject {
       var path = '/themes/' + theme + '/nodpi/' + name + '.svg';
       return path;
     }
+
+    function colorToHtml(color) {
+      return "rgba(%1,%2,%3,%4)".arg(Math.floor(Theme.errorColor.r * 255), Math.floor(Theme.errorColor.g * 255), Math.floor(Theme.errorColor.b * 255, Math.floor(Theme.errorColor.a * 255)));
+    }
 }
 

--- a/src/qml/imports/Theme/Theme.qml
+++ b/src/qml/imports/Theme/Theme.qml
@@ -65,7 +65,8 @@ QtObject {
     }
 
     function colorToHtml(color) {
-      return "rgba(%1,%2,%3,%4)".arg(Math.floor(Theme.errorColor.r * 255), Math.floor(Theme.errorColor.g * 255), Math.floor(Theme.errorColor.b * 255, Math.floor(Theme.errorColor.a * 255)));
+      return "rgba(%1,%2,%3,%4)".arg(Math.floor(Theme.errorColor.r * 255)).arg(Math.floor(Theme.errorColor.g * 255)).arg(Math.floor(Theme.errorColor.b * 255)).arg(Math.floor(Theme.errorColor.a * 255));
+      
     }
 }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -285,10 +285,10 @@ ApplicationWindow {
           else if ( type === "stylus" )
           {
               // Check if geometry editor is taking over
-              if ( geometryEditorsToolbar.canvasClicked(point) )
+              if ( !gpsLinkButton.linkActive && geometryEditorsToolbar.canvasClicked(point) )
                   return;
 
-              if ( ( ( stateMachine.state === "digitize" && dashBoard.currentLayer ) || stateMachine.state === 'measure' ) )
+              if ( !gpsLinkButton.linkActive && ( ( stateMachine.state === "digitize" && dashBoard.currentLayer ) || stateMachine.state === 'measure' ) )
               {
                   if ( Number( currentRubberband.model.geometryType ) === QgsWkbTypes.PointGeometry ||
                           Number( currentRubberband.model.geometryType ) === QgsWkbTypes.NullGeometry )
@@ -465,6 +465,13 @@ ApplicationWindow {
       mapSettings: mapCanvas.mapSettings
       currentLayer: dashBoard.currentLayer
       overrideLocation: gpsLinkButton.linkActive ? positionSource.projectedPosition : undefined
+      accuracyRequirementFail: {
+          if ( positioningSettings.accuracyIndicator && positioningSettings.accuracyRequirement )
+          {
+              return positioningSettings.accuracyBad > 0 && ( !positionSource.positionInfo || !positionSource.positionInfo.haccValid || !positionSource.positionInfo.hacc > badThreshold )
+          }
+          return false
+      }
     }
 
     /* GPS marker  */

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1050,6 +1050,22 @@ ApplicationWindow {
             break;
         }
       }
+
+      Rectangle {
+          anchors {
+              top: parent.top
+              right: parent.right
+              rightMargin: 2
+              topMargin: 2
+          }
+
+          width: 9
+          height: 9
+          radius: width / 2
+
+          visible: positioningSettings.accuracyIndicator && gpsButton.state === "On"
+          color: !positionSource.positionInfo || !positionSource.positionInfo.haccValid || positionSource.positionInfo.hacc > positioningSettings.accuracyBad ? "#e41a1c" : positionSource.positionInfo.hacc > positioningSettings.accuracyExcellent ? "#ff7f00" : "#4daf4a"
+      }
     }
 
     DigitizingToolbar {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1071,7 +1071,7 @@ ApplicationWindow {
           radius: width / 2
 
           visible: positioningSettings.accuracyIndicator && gpsButton.state === "On"
-          color: !positionSource.positionInfo || !positionSource.positionInfo.haccValid || positionSource.positionInfo.hacc > positioningSettings.accuracyBad ? "#e41a1c" : positionSource.positionInfo.hacc > positioningSettings.accuracyExcellent ? "#ff7f00" : "#4daf4a"
+          color: !positionSource.positionInfo || !positionSource.positionInfo.haccValid || positionSource.positionInfo.hacc > positioningSettings.accuracyBad ? Theme.errorColor : positionSource.positionInfo.hacc > positioningSettings.accuracyExcellent ? Theme.warningColor : Theme.mainColor
       }
     }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1066,12 +1066,21 @@ ApplicationWindow {
               topMargin: 2
           }
 
-          width: 9
-          height: 9
+          width: 12
+          height: 12
           radius: width / 2
 
+          border.width: 1.5
+          border.color: 'white'
+
           visible: positioningSettings.accuracyIndicator && gpsButton.state === "On"
-          color: !positionSource.positionInfo || !positionSource.positionInfo.haccValid || positionSource.positionInfo.hacc > positioningSettings.accuracyBad ? Theme.errorColor : positionSource.positionInfo.hacc > positioningSettings.accuracyExcellent ? Theme.warningColor : Theme.mainColor
+          color: !positionSource.positionInfo
+                 || !positionSource.positionInfo.haccValid
+                 || positionSource.positionInfo.hacc > positioningSettings.accuracyBad
+                     ? Theme.errorColor
+                     : positionSource.positionInfo.hacc > positioningSettings.accuracyExcellent
+                       ? Theme.warningColor
+                       : Theme.mainColor
       }
     }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -540,7 +540,7 @@ ApplicationWindow {
     anchors.bottom: parent.bottom
     anchors.left: parent.left
     anchors.right: parent.right
-    visible: settings.valueBool( "/QField/Positioning/ShowInformationView", false )
+    visible: positioningSettings.showPositionInformation
 
     height: childrenRect.height
     width: parent.width
@@ -1451,13 +1451,7 @@ ApplicationWindow {
       indicator.width: 20
       indicator.implicitHeight: 24
       indicator.implicitWidth: 24
-      onCheckedChanged: {
-        if ( checked ) {
-            positioningSettings.positioningActivated = true
-        } else {
-            positioningSettings.positioningActivated = false
-        }
-      }
+      onCheckedChanged: positioningSettings.positioningActivated = checked
     }
 
     MenuItem {
@@ -1466,16 +1460,12 @@ ApplicationWindow {
       font: Theme.defaultFont
 
       checkable: true
-      checked: settings.valueBool( "/QField/Positioning/ShowInformationView", false )
+      checked: positioningSettings.showPositionInformation
       indicator.height: 20
       indicator.width: 20
       indicator.implicitHeight: 24
       indicator.implicitWidth: 24
-      onCheckedChanged:
-      {
-        settings.setValue( "/QField/Positioning/ShowInformationView", checked )
-        positionInformationView.visible = checked
-      }
+      onCheckedChanged: positioningSettings.showPositionInformation = checked
     }
 
     MenuItem {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -468,7 +468,10 @@ ApplicationWindow {
       accuracyRequirementFail: {
           if ( positioningSettings.accuracyIndicator && positioningSettings.accuracyRequirement )
           {
-              return positioningSettings.accuracyBad > 0 && ( !positionSource.positionInfo || !positionSource.positionInfo.haccValid || !positionSource.positionInfo.hacc > badThreshold )
+              return positioningSettings.accuracyBad > 0 &&
+                     ( !positionSource.positionInfo ||
+                       !positionSource.positionInfo.haccValid ||
+                       positionSource.positionInfo.hacc >= badThreshold )
           }
           return false
       }


### PR DESCRIPTION
This PR adds a new accuracy indicator features as well as an accuracy requirement enforcement mechanism when digitizing features. 

When the accuracy indicator is enabled, a badge is attached to the location button and colored red if the accuracy value is below bad, yellow if it falls short of excellent, or green. The badge is subtle as to avoid obscuring the map area:
![image](https://user-images.githubusercontent.com/1728657/103437740-ea35dc80-4c5d-11eb-9ec6-561e5ef33c79.png)

In addition, an accuracy requirement mode can be toggled on alongside the indicator. The mode is active when the coordinate cursor to be locked to the GPS/NMEA position and prohibits vertex addition when the position accuracy value is below the bad accuracy value threshold. A toaster message is displayed for the user to understand he/she needs to wait for the device to gain a better accuracy:
![image](https://user-images.githubusercontent.com/1728657/103437778-4ac51980-4c5e-11eb-84aa-9736017e8763.png)

All of the above can be  toggled and tweaked in the QField settings' positioning panel:
![image](https://user-images.githubusercontent.com/1728657/103449917-8e149c00-4ce1-11eb-9f2b-1512f0fc8551.png)

