### PR TITLE
Let QML trigger the connection

### DIFF
--- a/src/core/bluetoothreceiver.cpp
+++ b/src/core/bluetoothreceiver.cpp
@@ -28,16 +28,6 @@ BluetoothReceiver::BluetoothReceiver( QObject *parent ) : QObject( parent ),
 
   //QgsGpsConnection state changed (received location string)
   connect( mGpsConnection.get(), &QgsGpsConnection::stateChanged, this, &BluetoothReceiver::stateChanged );
-
-  //connect on create
-  QSettings settings;
-  bool positioningActivated = settings.value( QStringLiteral( "positioningActivated" ), false ).toBool();
-  if ( positioningActivated )
-  {
-    const QString deviceAddress = settings.value( QStringLiteral( "positioningDevice" ), QString() ).toString();
-    if ( !deviceAddress.isEmpty() )
-      connectDevice( deviceAddress );
-  }
 }
 
 void BluetoothReceiver::disconnectDevice()

--- a/src/qml/TransformedPositionSource.qml
+++ b/src/qml/TransformedPositionSource.qml
@@ -23,8 +23,8 @@ Item{
     property string device: ''
 
     // proxy variables
-    property bool active
-    property string name
+    property bool active: false
+    property string name: ''
     property bool valid: qtPositionSource.valid || bluetoothPositionSource.valid
     property alias bluetoothSocketState: bluetoothPositionSource.socketState
     property bool currentness: false


### PR DESCRIPTION
QML already triggers a connection via the onActiveChanged trigger (https://github.com/opengisch/QField/blob/master/src/qml/TransformedPositionSource.qml#L55) -- it increases the chance of a successful connect on app launch and avoid a duplicate connection call.