### PR TITLE
Add layer resolver

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -21,6 +21,7 @@ SET(QFIELD_CORE_SRCS
   identifytool.cpp
   layertreemapcanvasbridge.cpp
   layertreemodel.cpp
+  layerresolver.cpp
   legendimageprovider.cpp
   linepolygonhighlight.cpp
   locatormodelsuperbridge.cpp
@@ -94,6 +95,7 @@ SET(QFIELD_CORE_HDRS
   identifytool.h
   layertreemapcanvasbridge.h
   layertreemodel.h
+  layerresolver.h
   legendimageprovider.h
   linepolygonhighlight.h
   locatormodelsuperbridge.h

--- a/src/core/layerresolver.cpp
+++ b/src/core/layerresolver.cpp
@@ -1,0 +1,128 @@
+/***************************************************************************
+                            layerresolver.cpp
+
+                              -------------------
+              begin                : January 2021
+              copyright            : (C) 2011 by Matthias Kuhn
+              email                : matthias@opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "layerresolver.h"
+#include <qgsvectorlayerref.h>
+
+LayerResolver::LayerResolver( QObject *parent )
+  : QObject( parent )
+{
+
+}
+
+void LayerResolver::resolve()
+{
+  if ( !mProject )
+  {
+    setLayer( nullptr );
+    return;
+  }
+
+  QgsVectorLayerRef ref { mLayerId,
+                          mLayerName,
+                          mLayerSource,
+                          mLayerProviderName };
+  setLayer( ref.resolveByIdOrNameOnly( mProject ) );
+}
+
+QString LayerResolver::layerId() const
+{
+  return mLayerId;
+}
+
+void LayerResolver::setLayerId( const QString &layerId )
+{
+  if ( mLayerId == layerId )
+    return;
+
+  mLayerId = layerId;
+  resolve();
+  emit layerIdChanged();
+}
+
+QString LayerResolver::layerName() const
+{
+  return mLayerName;
+}
+
+void LayerResolver::setLayerName( const QString &layerName )
+{
+  if ( mLayerName == layerName )
+    return;
+
+  mLayerName = layerName;
+  resolve();
+  emit layerNameChanged();
+}
+
+QString LayerResolver::layerSource() const
+{
+  return mLayerSource;
+}
+
+void LayerResolver::setLayerSource( const QString &layerSource )
+{
+  if ( mLayerSource == layerSource )
+    return;
+
+  mLayerSource = layerSource;
+  emit layerSourceChanged();
+}
+
+QString LayerResolver::layerProviderName() const
+{
+  return mLayerProviderName;
+}
+
+void LayerResolver::setLayerProviderName( const QString &layerProviderName )
+{
+  if ( mLayerProviderName == layerProviderName )
+    return;
+
+  mLayerProviderName = layerProviderName;
+  resolve();
+  emit layerProviderNameChanged();
+}
+
+QgsVectorLayer *LayerResolver::currentLayer() const
+{
+  return mLayer;
+}
+
+void LayerResolver::setLayer( QgsVectorLayer *layer )
+{
+  if ( mLayer == layer )
+    return;
+
+  mLayer = layer;
+  emit currentLayerChanged();
+}
+
+QgsProject *LayerResolver::project() const
+{
+  return mProject;
+}
+
+void LayerResolver::setProject( QgsProject *project )
+{
+  if ( project == mProject )
+    return;
+
+  mProject = project;
+  resolve();
+  emit projectChanged();
+}

--- a/src/core/layerresolver.h
+++ b/src/core/layerresolver.h
@@ -1,0 +1,104 @@
+/***************************************************************************
+                            layerresolver.h
+
+                              -------------------
+              begin                : January 2021
+              copyright            : (C) 2011 by Matthias Kuhn
+              email                : matthias@opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef LAYERRESOLVER_H
+#define LAYERRESOLVER_H
+
+#include <QObject>
+
+class QgsVectorLayer;
+class QgsProject;
+
+/**
+ * Helper class to resolve layers by id, name, source and provider.
+ */
+class LayerResolver : public QObject
+{
+    Q_OBJECT
+
+    /**
+     * The layer id to resolve
+     */
+    Q_PROPERTY( QString layerId READ layerId WRITE setLayerId NOTIFY layerIdChanged )
+
+    /**
+     * The layer name to resolve
+     */
+    Q_PROPERTY( QString layerName READ layerName WRITE setLayerName NOTIFY layerNameChanged )
+
+    /**
+     * The layer source to resolve
+     */
+    Q_PROPERTY( QString layerSource READ layerSource WRITE setLayerSource NOTIFY layerSourceChanged )
+
+    /**
+     * The layer provider name to resolve
+     */
+    Q_PROPERTY( QString layerProviderName READ layerProviderName WRITE setLayerProviderName NOTIFY layerProviderNameChanged )
+
+    /**
+     * The qgis project from which layers will be acquired
+     */
+    Q_PROPERTY( QgsProject *project READ project WRITE setProject NOTIFY projectChanged )
+
+    /**
+     * Contains the layer after a successful resolving process
+     */
+    Q_PROPERTY( QgsVectorLayer *currentLayer READ currentLayer NOTIFY currentLayerChanged )
+
+  public:
+    LayerResolver( QObject *parent = nullptr );
+
+    void resolve();
+
+    QString layerId() const;
+    void setLayerId( const QString &layerId );
+
+    QString layerName() const;
+    void setLayerName( const QString &layerName );
+
+    QString layerSource() const;
+    void setLayerSource( const QString &layerSource );
+
+    QString layerProviderName() const;
+    void setLayerProviderName( const QString &layerProviderName );
+
+    QgsVectorLayer *currentLayer() const;
+
+    QgsProject *project() const;
+    void setProject( QgsProject *project );
+
+  signals:
+    void layerIdChanged();
+    void layerNameChanged();
+    void layerSourceChanged();
+    void layerProviderNameChanged();
+    void currentLayerChanged();
+    void projectChanged();
+
+  private:
+    void setLayer( QgsVectorLayer *layer );
+
+    QString mLayerId;
+    QString mLayerName;
+    QString mLayerSource;
+    QString mLayerProviderName;
+    QgsProject *mProject = nullptr;
+    QgsVectorLayer *mLayer = nullptr;
+};
+
+#endif // LAYERRESOLVER_H

--- a/src/core/layerresolver.h
+++ b/src/core/layerresolver.h
@@ -61,7 +61,7 @@ class LayerResolver : public QObject
     Q_PROPERTY( QgsVectorLayer *currentLayer READ currentLayer NOTIFY currentLayerChanged )
 
   public:
-    LayerResolver( QObject *parent = nullptr );
+    explicit LayerResolver( QObject *parent = nullptr );
 
     void resolve();
 

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -115,6 +115,7 @@
 #include "bluetoothdevicemodel.h"
 #include "gnsspositioninformation.h"
 #include "changelogcontents.h"
+#include "layerresolver.h"
 
 #define QUOTE(string) _QUOTE(string)
 #define _QUOTE(string) #string
@@ -345,6 +346,7 @@ void QgisMobileapp::initDeclarative()
   qmlRegisterType<BluetoothDeviceModel>( "org.qfield", 1, 0, "BluetoothDeviceModel" );
   qmlRegisterType<BluetoothReceiver>( "org.qfield", 1, 0, "BluetoothReceiver" );
   qmlRegisterType<ChangelogContents>( "org.qfield", 1, 0, "ChangelogContents" );
+  qmlRegisterType<LayerResolver>( "org.qfield", 1, 0, "LayerResolver" );
 
   qRegisterMetaType<GnssPositionInformation>( "GnssPositionInformation" );
 

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -17,6 +17,16 @@ Item {
   height: Number(config['AllowMulti']) !== 1 ? valueRelationCombobox.height : valueRelationList.height
   enabled: true
 
+  LayerResolver {
+      id: layerResolver
+
+      layerId: config['Layer']
+      layerName: config['LayerName']
+      layerSource: config['LayerSource']
+      layerProviderName: config['LayerProviderName']
+      project: qgisProject
+  }
+
   RelationCombobox {
     id: valueRelationCombobox
 
@@ -32,7 +42,7 @@ Item {
       attributeField: field
       //passing "" instead of undefined, so the model is cleared on adding new features
       attributeValue: value !== undefined ? value : ""
-      currentLayer: qgisProject.mapLayer(config['Layer'])
+      currentLayer: layerResolver.currentLayer
       currentFormFeature: currentFeature
       keyField: config['Key']
       displayValueField: config['Value']
@@ -65,7 +75,7 @@ Item {
         attributeField: field
         //passing "" instead of undefined, so the model is cleared on adding new features
         attributeValue: value !== undefined ? value : ""
-        currentLayer: qgisProject.mapLayer(config['Layer'])
+        currentLayer: layerResolver.currentLayer
         currentFormFeature: currentFeature
         keyField: config['Key']
         displayValueField: config['Value']


### PR DESCRIPTION
For reasons, layer ids configured in value relations do not always match with the id of the layer they refer to.
In these cases QGIS resorts to advanced detection techniques to resolve the layer anyway.
Let's do the same with a nice declarative approach.