### PR TITLE
Request external storage permission early

### DIFF
--- a/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -50,10 +50,13 @@ import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
+import android.Manifest;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Environment;
+import android.support.v4.app.ActivityCompat; 
+import android.support.v4.content.ContextCompat; 
 
 import org.qtproject.qt5.android.bindings.QtActivity;
 
@@ -74,6 +77,8 @@ public class QFieldActivity extends QtActivity {
     }
 
     private void prepareQtActivity() {
+		checkPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE, 101); 
+
         String storagePath = Environment.getExternalStorageDirectory().getAbsolutePath();
 
         String qFieldDir = storagePath + "/QField/";
@@ -104,5 +109,12 @@ public class QFieldActivity extends QtActivity {
             intent.putExtra("QGS_PROJECT", QFieldUtils.getPathFromUri(context, uri));
         }
         setIntent(intent);
+    }
+
+    public void checkPermission(String permission, int requestCode)
+    {
+        if (ContextCompat.checkSelfPermission(QFieldActivity.this, permission) == PackageManager.PERMISSION_DENIED) {
+            ActivityCompat.requestPermissions(QFieldActivity.this, new String[] { permission }, requestCode);
+        }
     }
 }

--- a/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -40,6 +40,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.Thread;
+import java.util.List;
+import java.util.ArrayList;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -77,7 +79,7 @@ public class QFieldActivity extends QtActivity {
     }
 
     private void prepareQtActivity() {
-		checkPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE, 101); 
+        checkPermissions(); 
 
         String storagePath = Environment.getExternalStorageDirectory().getAbsolutePath();
 
@@ -111,10 +113,19 @@ public class QFieldActivity extends QtActivity {
         setIntent(intent);
     }
 
-    public void checkPermission(String permission, int requestCode)
+    private void checkPermissions()
     {
-        if (ContextCompat.checkSelfPermission(QFieldActivity.this, permission) == PackageManager.PERMISSION_DENIED) {
-            ActivityCompat.requestPermissions(QFieldActivity.this, new String[] { permission }, requestCode);
+        List<String> permissionsList = new ArrayList<String>();
+        if (ContextCompat.checkSelfPermission(QFieldActivity.this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_DENIED) {
+            permissionsList.add(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+        }
+        if (ContextCompat.checkSelfPermission(QFieldActivity.this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_DENIED) {
+            permissionsList.add(Manifest.permission.ACCESS_FINE_LOCATION);
+        }
+        if ( permissionsList.size() > 0 ) {
+			String[] permissions = new String[ permissionsList.size() ];
+            permissionsList.toArray( permissions );
+            ActivityCompat.requestPermissions(QFieldActivity.this, permissions, 101);
         }
     }
 }


### PR DESCRIPTION
@m-kuhn , while slaying this blank screen issue, I stumbled on an android permission problem: while we now rely on a bunch of QField/sub-folders on the external storage to fetch additional projection grids, fonts, etc., that's all inactive/inaccessible until the user triggers an external storage permission request when manually opening a local project file using the welcome page button. 

This PR fixes that by checking and asking for the permission whenever we launch QField. 

This'll also have the effect of having the directory creation part of the QFieldActivity.java work on first launch. 