### PR TITLE
Respect project labeling engine settings when rendering canvas

### DIFF
--- a/src/core/qgsquick/qgsquickmapcanvasmap.cpp
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.cpp
@@ -103,6 +103,8 @@ void QgsQuickMapCanvasMap::refreshMap()
   if ( project )
   {
     expressionContext << QgsExpressionContextUtils::projectScope( project );
+
+    mapSettings.setLabelingEngineSettings( project->labelingEngineSettings() );
   }
 
   mapSettings.setExpressionContext( expressionContext );


### PR DESCRIPTION
QField should respect the project's labeling engine settings.