### PR TITLE
Add new gnss_* variables next to position_* variables

### DIFF
--- a/src/core/expressioncontextutils.cpp
+++ b/src/core/expressioncontextutils.cpp
@@ -23,7 +23,7 @@
 
 void addVar( QgsExpressionContextScope *scope, const QString &name, const QVariant &value, bool positionLocked, const QVariant &defaultValue = QVariant() )
 {
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "sensor_%1" ).arg( name ), value, true, true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "gnss_%1" ).arg( name ), value, true, true ) );
   if ( positionLocked )
     scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "position_%1" ).arg( name ), value, true, true ) );
   else

--- a/src/core/expressioncontextutils.cpp
+++ b/src/core/expressioncontextutils.cpp
@@ -20,10 +20,21 @@
 #include "qgsgeometry.h"
 #include <QtPositioning/QGeoPositionInfoSource>
 
-QgsExpressionContextScope *ExpressionContextUtils::positionScope( const GnssPositionInformation &positionInformation )
+
+void addVar( QgsExpressionContextScope *scope, const QString &name, const QVariant &value, bool positionLocked, const QVariant &defaultValue = QVariant() )
+{
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "sensor_%1" ).arg( name ), value, true, true ) );
+  if ( positionLocked )
+    scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "position_%1" ).arg( name ), value, true, true ) );
+  else
+    scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "position_%1" ).arg( name ), defaultValue, true, true ) );
+}
+
+
+QgsExpressionContextScope *ExpressionContextUtils::positionScope( const GnssPositionInformation &positionInformation, bool positionLocked )
 {
   QgsExpressionContextScope *scope = new QgsExpressionContextScope( QObject::tr( "Position" ) );
-  ;
+
   const QgsGeometry point = QgsGeometry( new QgsPoint( positionInformation.longitude(), positionInformation.latitude(), positionInformation.elevation() ) );
   const QDateTime timestamp = positionInformation.utcDateTime();
   const qreal direction = positionInformation.direction();
@@ -43,27 +54,27 @@ QgsExpressionContextScope *ExpressionContextUtils::positionScope( const GnssPosi
   const QString fixMode = positionInformation.fixMode();
   const QString sourceName = positionInformation.sourceName();
 
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "position_coordinate" ), QVariant::fromValue<QgsGeometry>( point ), true, true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "position_timestamp" ), timestamp, true, true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "position_direction" ), direction, true, true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "position_ground_speed" ), groundSpeed, true, true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "position_magnetic_variation" ), magneticVariation, true, true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "position_horizontal_accuracy" ), horizontalAccuracy, true, true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "position_vertical_accuracy" ), verticalAccuracy, true, true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "position_3d_accuracy" ), horizontalVerticalAccuracy, true, true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "position_vertical_speed" ), verticalSpeed, true, true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "position_source_name" ), sourceName, true, true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "position_horizontal_accuracy" ), horizontalAccuracy, true, true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "position_vertical_accuracy" ), verticalAccuracy, true, true ) );
+  addVar( scope, QStringLiteral( "coordinate" ), QVariant::fromValue<QgsGeometry>( point ), positionLocked );
+  addVar( scope, QStringLiteral( "timestamp" ), timestamp, positionLocked );
+  addVar( scope, QStringLiteral( "direction" ), direction, positionLocked );
+  addVar( scope, QStringLiteral( "ground_speed" ), groundSpeed, positionLocked );
+  addVar( scope, QStringLiteral( "magnetic_variation" ), magneticVariation, positionLocked );
+  addVar( scope, QStringLiteral( "horizontal_accuracy" ), horizontalAccuracy, positionLocked );
+  addVar( scope, QStringLiteral( "vertical_accuracy" ), verticalAccuracy, positionLocked );
+  addVar( scope, QStringLiteral( "3d_accuracy" ), horizontalVerticalAccuracy, positionLocked );
+  addVar( scope, QStringLiteral( "vertical_speed" ), verticalSpeed, positionLocked );
+  addVar( scope, QStringLiteral( "source_name" ), sourceName, positionLocked, QStringLiteral( "manual" ) );
+  addVar( scope, QStringLiteral( "horizontal_accuracy" ), horizontalAccuracy, positionLocked );
+  addVar( scope, QStringLiteral( "vertical_accuracy" ), verticalAccuracy, positionLocked );
 
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "position_pdop" ), precisionDilution, true, true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "position_hdop" ), horizontalDilution, true, true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "position_vdop" ), verticalDilution, true, true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "position_number_of_used_satellites" ), numberOfUsedSatelites, true, true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "position_used_satellites" ),  QVariant::fromValue( usedSatelites ), true, true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "position_quality_description" ), qualityDescription, true, true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "position_fix_status_description" ), fixStatusDescription, true, true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "position_fix_mode" ), fixMode, true, true ) );
+  addVar( scope, QStringLiteral( "pdop" ), precisionDilution, positionLocked );
+  addVar( scope, QStringLiteral( "hdop" ), horizontalDilution, positionLocked );
+  addVar( scope, QStringLiteral( "vdop" ), verticalDilution, positionLocked );
+  addVar( scope, QStringLiteral( "number_of_used_satellites" ), numberOfUsedSatelites, positionLocked );
+  addVar( scope, QStringLiteral( "used_satellites" ),  QVariant::fromValue( usedSatelites ), positionLocked );
+  addVar( scope, QStringLiteral( "quality_description" ), qualityDescription, positionLocked );
+  addVar( scope, QStringLiteral( "fix_status_description" ), fixStatusDescription, positionLocked );
+  addVar( scope, QStringLiteral( "fix_mode" ), fixMode, positionLocked );
 
   return scope;
 }

--- a/src/core/expressioncontextutils.cpp
+++ b/src/core/expressioncontextutils.cpp
@@ -21,7 +21,7 @@
 #include <QtPositioning/QGeoPositionInfoSource>
 
 
-void addVar( QgsExpressionContextScope *scope, const QString &name, const QVariant &value, bool positionLocked, const QVariant &defaultValue = QVariant() )
+void addPositionVariable( QgsExpressionContextScope *scope, const QString &name, const QVariant &value, bool positionLocked, const QVariant &defaultValue = QVariant() )
 {
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "gnss_%1" ).arg( name ), value, true, true ) );
   if ( positionLocked )
@@ -54,27 +54,27 @@ QgsExpressionContextScope *ExpressionContextUtils::positionScope( const GnssPosi
   const QString fixMode = positionInformation.fixMode();
   const QString sourceName = positionInformation.sourceName();
 
-  addVar( scope, QStringLiteral( "coordinate" ), QVariant::fromValue<QgsGeometry>( point ), positionLocked );
-  addVar( scope, QStringLiteral( "timestamp" ), timestamp, positionLocked );
-  addVar( scope, QStringLiteral( "direction" ), direction, positionLocked );
-  addVar( scope, QStringLiteral( "ground_speed" ), groundSpeed, positionLocked );
-  addVar( scope, QStringLiteral( "magnetic_variation" ), magneticVariation, positionLocked );
-  addVar( scope, QStringLiteral( "horizontal_accuracy" ), horizontalAccuracy, positionLocked );
-  addVar( scope, QStringLiteral( "vertical_accuracy" ), verticalAccuracy, positionLocked );
-  addVar( scope, QStringLiteral( "3d_accuracy" ), horizontalVerticalAccuracy, positionLocked );
-  addVar( scope, QStringLiteral( "vertical_speed" ), verticalSpeed, positionLocked );
-  addVar( scope, QStringLiteral( "source_name" ), sourceName, positionLocked, QStringLiteral( "manual" ) );
-  addVar( scope, QStringLiteral( "horizontal_accuracy" ), horizontalAccuracy, positionLocked );
-  addVar( scope, QStringLiteral( "vertical_accuracy" ), verticalAccuracy, positionLocked );
+  addPositionVariable( scope, QStringLiteral( "coordinate" ), QVariant::fromValue<QgsGeometry>( point ), positionLocked );
+  addPositionVariable( scope, QStringLiteral( "timestamp" ), timestamp, positionLocked );
+  addPositionVariable( scope, QStringLiteral( "direction" ), direction, positionLocked );
+  addPositionVariable( scope, QStringLiteral( "ground_speed" ), groundSpeed, positionLocked );
+  addPositionVariable( scope, QStringLiteral( "magnetic_variation" ), magneticVariation, positionLocked );
+  addPositionVariable( scope, QStringLiteral( "horizontal_accuracy" ), horizontalAccuracy, positionLocked );
+  addPositionVariable( scope, QStringLiteral( "vertical_accuracy" ), verticalAccuracy, positionLocked );
+  addPositionVariable( scope, QStringLiteral( "3d_accuracy" ), horizontalVerticalAccuracy, positionLocked );
+  addPositionVariable( scope, QStringLiteral( "vertical_speed" ), verticalSpeed, positionLocked );
+  addPositionVariable( scope, QStringLiteral( "source_name" ), sourceName, positionLocked, QStringLiteral( "manual" ) );
+  addPositionVariable( scope, QStringLiteral( "horizontal_accuracy" ), horizontalAccuracy, positionLocked );
+  addPositionVariable( scope, QStringLiteral( "vertical_accuracy" ), verticalAccuracy, positionLocked );
 
-  addVar( scope, QStringLiteral( "pdop" ), precisionDilution, positionLocked );
-  addVar( scope, QStringLiteral( "hdop" ), horizontalDilution, positionLocked );
-  addVar( scope, QStringLiteral( "vdop" ), verticalDilution, positionLocked );
-  addVar( scope, QStringLiteral( "number_of_used_satellites" ), numberOfUsedSatelites, positionLocked );
-  addVar( scope, QStringLiteral( "used_satellites" ),  QVariant::fromValue( usedSatelites ), positionLocked );
-  addVar( scope, QStringLiteral( "quality_description" ), qualityDescription, positionLocked );
-  addVar( scope, QStringLiteral( "fix_status_description" ), fixStatusDescription, positionLocked );
-  addVar( scope, QStringLiteral( "fix_mode" ), fixMode, positionLocked );
+  addPositionVariable( scope, QStringLiteral( "pdop" ), precisionDilution, positionLocked );
+  addPositionVariable( scope, QStringLiteral( "hdop" ), horizontalDilution, positionLocked );
+  addPositionVariable( scope, QStringLiteral( "vdop" ), verticalDilution, positionLocked );
+  addPositionVariable( scope, QStringLiteral( "number_of_used_satellites" ), numberOfUsedSatelites, positionLocked );
+  addPositionVariable( scope, QStringLiteral( "used_satellites" ),  QVariant::fromValue( usedSatelites ), positionLocked );
+  addPositionVariable( scope, QStringLiteral( "quality_description" ), qualityDescription, positionLocked );
+  addPositionVariable( scope, QStringLiteral( "fix_status_description" ), fixStatusDescription, positionLocked );
+  addPositionVariable( scope, QStringLiteral( "fix_mode" ), fixMode, positionLocked );
 
   return scope;
 }

--- a/src/core/expressioncontextutils.h
+++ b/src/core/expressioncontextutils.h
@@ -26,7 +26,7 @@
 class ExpressionContextUtils
 {
   public:
-    static QgsExpressionContextScope *positionScope( const GnssPositionInformation &positionInformation );
+    static QgsExpressionContextScope *positionScope( const GnssPositionInformation &positionInformation, bool positionLocked );
     static QgsExpressionContextScope *mapToolCaptureScope( const SnappingResult &topSnappingResult );
 
   private:

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -182,6 +182,19 @@ void FeatureModel::setLinkedFeatureValues()
   emit featureChanged();
 }
 
+bool FeatureModel::positionLocked() const
+{
+  return mPositionLocked;
+}
+
+void FeatureModel::setPositionLocked( bool positionLocked )
+{
+  if ( mPositionLocked == positionLocked )
+    return;
+  mPositionLocked = positionLocked;
+  emit positionLockedChanged();
+}
+
 void FeatureModel::setLinkedParentFeature( const QgsFeature &feature )
 {
   if ( mLinkedParentFeature == feature )
@@ -423,7 +436,7 @@ void FeatureModel::resetAttributes()
 
   QgsExpressionContext expressionContext = mLayer->createExpressionContext();
   if ( mPositionInformation.isValid() )
-    expressionContext << ExpressionContextUtils::positionScope( mPositionInformation );
+    expressionContext << ExpressionContextUtils::positionScope( mPositionInformation, mPositionLocked );
 
   //set snapping_results to ExpressionScope...
   if ( mTopSnappingResult.isValid() )

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -44,6 +44,7 @@ class FeatureModel : public QAbstractListModel
     Q_PROPERTY( QgsVectorLayer *currentLayer READ layer WRITE setCurrentLayer NOTIFY currentLayerChanged )
     Q_PROPERTY( GnssPositionInformation positionInformation READ positionInformation WRITE setPositionInformation NOTIFY positionInformationChanged )
     Q_PROPERTY( SnappingResult topSnappingResult READ topSnappingResult WRITE setTopSnappingResult NOTIFY topSnappingResultChanged )
+    Q_PROPERTY( bool positionLocked READ positionLocked WRITE setPositionLocked NOTIFY positionLockedChanged )
 
     //! keeping the information what attributes are remembered and the last edited feature
     struct RememberValues
@@ -200,6 +201,16 @@ class FeatureModel : public QAbstractListModel
     //! Update the linked geometry rubber band to match the feature's geometry
     Q_INVOKABLE void updateRubberband() const;
 
+    /**
+     * Determines if the position is locked to the GNSS
+     */
+    bool positionLocked() const;
+
+    /**
+     * Determines if the position is locked to the GNSS
+     */
+    void setPositionLocked( bool positionLocked );
+
   public slots:
     void applyGeometry();
     void removeLayer( QObject *layer );
@@ -221,6 +232,7 @@ class FeatureModel : public QAbstractListModel
     void currentLayerChanged();
     void positionInformationChanged();
     void topSnappingResultChanged();
+    void positionLockedChanged();
 
     void warning( const QString &text );
 
@@ -246,6 +258,7 @@ class FeatureModel : public QAbstractListModel
     SnappingResult mTopSnappingResult;
     QString mTempName;
     QMap<QgsVectorLayer *, RememberValues> mRememberings;
+    bool mPositionLocked = false;
 };
 
 #endif // FEATUREMODEL_H

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1110,6 +1110,7 @@ ApplicationWindow {
         currentLayer: dashBoard.currentLayer
         positionInformation: positionSource.positionInfo
         topSnappingResult: coordinateLocator.topSnappingResult
+        positionLocked: gpsLinkButton.checked
         geometry: Geometry {
           id: digitizingGeometry
           rubberbandModel: digitizingRubberband.model


### PR DESCRIPTION
The position variables are only set when the digitizing crosshair is locked to the current positioning device location.
The gnss variables are always set.

The `position_source_name` will be set to `manual` when digitizing features with the position not locked

Fixes https://github.com/opengisch/QField/issues/1607