### PR TITLE
Fix white line in feature form

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -602,6 +602,7 @@ Page {
       top: parent.top
       left: parent.left
       right: parent.right
+      topMargin: -1 // fix scene rounding issue leading to a white line
     }
 
     background: Rectangle {


### PR DESCRIPTION
This "attacked" me while testing the geometry addition child feature PR:
![image](https://user-images.githubusercontent.com/1728657/105705047-38c75580-5f42-11eb-8fd3-56505566c1ab.png)
_Left, white line, right, fixed_
