### PR TITLE
Smarter progressive rendering

### DIFF
--- a/src/core/qgsquick/qgsquickmapcanvasmap.h
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.h
@@ -88,7 +88,7 @@ class QgsQuickMapCanvasMap : public QQuickItem
   public:
     //! Create map canvas map
     explicit QgsQuickMapCanvasMap( QQuickItem *parent = nullptr );
-    ~QgsQuickMapCanvasMap() = default;
+    ~QgsQuickMapCanvasMap();
 
     QSGNode *updatePaintNode( QSGNode *oldNode, QQuickItem::UpdatePaintNodeData * ) override;
 

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -16,7 +16,6 @@ Page {
   property alias showScaleBar: registry.showScaleBar
   property alias fullScreenIdentifyView: registry.fullScreenIdentifyView
   property alias locatorKeepScale: registry.locatorKeepScale
-  property alias incrementalRendering: registry.incrementalRendering
   property alias numericalDigitizingInformation: registry.numericalDigitizingInformation
   property alias nativeCamera: registry.nativeCamera
   property alias autoSave: registry.autoSave
@@ -30,7 +29,6 @@ Page {
     property bool showScaleBar
     property bool fullScreenIdentifyView
     property bool locatorKeepScale
-    property bool incrementalRendering
     property bool numericalDigitizingInformation
     property bool nativeCamera: true
     property bool autoSave
@@ -54,11 +52,6 @@ Page {
           title: qsTr( "Fixed scale navigation" )
           description: qsTr( "When fixed scale navigation is active, focusing on a search result will pan to the feature. With fixed scale navigation disabled it will pan and zoom to the feature." )
           settingAlias: "locatorKeepScale"
-      }
-      ListElement {
-          title: qsTr( "Progressive rendering" )
-          description: qsTr( "When progressive rendering is enabled, the map will be drawn every 250 milliseconds while rendering." )
-          settingAlias: "incrementalRendering"
       }
       ListElement {
           title: qsTr( "Show digitizing information" )

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -275,7 +275,7 @@ ApplicationWindow {
     /* The base map */
     MapCanvas {
       id: mapCanvasMap
-      incrementalRendering: qfieldSettings.incrementalRendering
+      incrementalRendering: true
       freehandDigitizing: freehandButton.freehandDigitizing && freehandHandler.active
 
       anchors.fill: parent


### PR DESCRIPTION
This PR improves progressive rendering by:
- adding a map renderer cache, which in used by raster layers to _greatly_ improve intermediate rendering by using a transformed cache image as temporary placeholder during progressive rendering
- switching the RenderPartialOutput on when progressive rendering is on

The end result is a much, much smoother progressive rendering experience:
![Peek 2021-01-26 14-33](https://user-images.githubusercontent.com/1728657/105817413-256ec580-5fe8-11eb-96fd-acfeb71e3811.gif)
_Note the raster topo basemap here has its old image cache transformed and rendered onto the canvas prior to its new image being rendered_

**UPDATE** With @nyalldawson 's fantastic follow up work adding smart labels and vector caching, the progressive rendering looks _even better_:
![Peek 2021-01-27 13-00](https://user-images.githubusercontent.com/1728657/105949805-e8660a00-609f-11eb-9262-f50d1ceca917.gif)

The updated SDK on QField master also contains the recent tile download manager work, which also speeds up progressive rendering of XYZ layers. 

Based on all these improvements, I believe we've reached a point where when can turn progressive rendering _on_ by default. I've done so here by renaming the settings variable so that pre-existing users can also be wow'ed.

Having progressive rendering on by default is a great service to users who rely on WFS layers.

Instead of this:
![eternity](https://user-images.githubusercontent.com/1728657/105817687-89918980-5fe8-11eb-9cf1-ff6ba2f1f7b8.jpg)

they can enjoy being presented with a progressive rendering of the WFS layer as features are retrieved
![Peek 2021-01-26 14-25](https://user-images.githubusercontent.com/1728657/105817780-a3cb6780-5fe8-11eb-84da-1d99696136ab.gif)
 from the remote server:
