### PR TITLE
Avoid UI hang/freeze when opening the layer properties panel due to slow feature count

### DIFF
--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -692,6 +692,10 @@ QVariant FlatLayerTreeModelBase::data( const QModelIndex &index, int role ) cons
       if ( !layer ) // Group
         return -1;
 
+      // For now, do not count feature on WFS layers, it can lead to long hangs
+      if ( layer->dataProvider() && layer->dataProvider()->name() == QStringLiteral( "WFS" ) )
+        return QVariant();
+
       if ( layer->renderer() && layer->renderer()->legendSymbolItems().size() > 0 )
       {
         long count = layer->featureCount( layer->renderer()->legendSymbolItems().at( 0 ).ruleKey() );

--- a/src/core/layertreemodel.h
+++ b/src/core/layertreemodel.h
@@ -78,6 +78,8 @@ class FlatLayerTreeModelBase : public QAbstractProxyModel
     void mapThemeChanged();
 
   private:
+    void featureCountChanged();
+
     QMap<QModelIndex, int> mRowMap;
     QMap<int, QModelIndex> mIndexMap;
     QMap<int, int> mTreeLevelMap;
@@ -154,6 +156,7 @@ class FlatLayerTreeModel : public QSortFilterProxyModel
     virtual bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const override;
 
   private:
+
     FlatLayerTreeModelBase *mSourceModel = nullptr;
 };
 

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -30,18 +30,7 @@ Popup {
   padding: 0
 
   onIndexChanged: {
-    title = layerTree.data(index, Qt.DisplayName)
-    var vl = layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer)
-
-    if (vl && layerTree.data(index, FlatLayerTreeModel.IsValid) && layerTree.data( index, FlatLayerTreeModel.Type ) === 'layer') {
-      var count = layerTree.data(index, FlatLayerTreeModel.FeatureCount)
-      if (count != undefined) {
-        var countSuffix = ' [' + count + ']'
-
-        if ( !title.endsWith(countSuffix) )
-          title += countSuffix
-      }
-    }
+    updateTitle();
 
     itemVisibleCheckBox.checked = layerTree.data(index, FlatLayerTreeModel.Visible);
 
@@ -233,6 +222,27 @@ Popup {
         }
       }
     }
+  }
+
+  Connections {
+      target: layerTree
+
+      onDataChanged: updateTitle();
+  }
+
+  function updateTitle() {
+      title = layerTree.data(index, Qt.DisplayName)
+      var vl = layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer)
+
+      if (vl && layerTree.data(index, FlatLayerTreeModel.IsValid) && layerTree.data( index, FlatLayerTreeModel.Type ) === 'layer') {
+          var count = layerTree.data(index, FlatLayerTreeModel.FeatureCount)
+          if (count !== undefined && count >= 0) {
+              var countSuffix = ' [' + count + ']'
+
+              if ( !title.endsWith(countSuffix) )
+                  title += countSuffix
+          }
+      }
   }
 
   function isTrackingButtonVisible() {

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -34,10 +34,13 @@ Popup {
     var vl = layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer)
 
     if (vl && layerTree.data(index, FlatLayerTreeModel.IsValid) && layerTree.data( index, FlatLayerTreeModel.Type ) === 'layer') {
-      var countSuffix = ' [' + layerTree.data(index, FlatLayerTreeModel.FeatureCount) + ']'
+      var count = layerTree.data(index, FlatLayerTreeModel.FeatureCount)
+      if (count != undefined) {
+        var countSuffix = ' [' + count + ']'
 
-      if ( !title.endsWith(countSuffix) )
-        title += countSuffix
+        if ( !title.endsWith(countSuffix) )
+          title += countSuffix
+      }
     }
 
     itemVisibleCheckBox.checked = layerTree.data(index, FlatLayerTreeModel.Visible);

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -98,7 +98,7 @@ Popup {
         indicator.implicitHeight: 24
         indicator.implicitWidth: 24
 
-        onCheckStateChanged: {
+        onClicked: {
           layerTree.setData(index, checkState === Qt.Checked, FlatLayerTreeModel.Visible);
           close()
         }
@@ -111,7 +111,7 @@ Popup {
         font: Theme.defaultFont
         visible: expandCheckBoxVisible
 
-        onCheckStateChanged: {
+        onClicked: {
           layerTree.setData(index, checkState === Qt.Unchecked, FlatLayerTreeModel.IsCollapsed);
           close()
         }


### PR DESCRIPTION
On slow WFS servers, opening the layer properties panel (to refresh the data for e.g.) can hang QField for dozens of seconds while it's waiting a server reply on the main thread.

This PR improves the layer tree model feature count by relying on the countSymbolFeatures function whenever possible, and (for now) disable feature count on WFS layers.