### PR TITLE
For 'static' rubber band, we need to listen to extent change

### DIFF
--- a/src/core/rubberband.cpp
+++ b/src/core/rubberband.cpp
@@ -108,10 +108,23 @@ void Rubberband::setMapSettings( QgsQuickMapSettings *mapSettings )
   if ( mMapSettings == mapSettings )
     return;
 
+  if ( mMapSettings )
+  {
+    disconnect( mMapSettings, &QgsQuickMapSettings::visibleExtentChanged, this, &Rubberband::visibleExtentChanged );
+  }
+
   mMapSettings = mapSettings;
+  connect( mMapSettings, &QgsQuickMapSettings::visibleExtentChanged, this, &Rubberband::visibleExtentChanged );
+
   markDirty();
 
   emit mapSettingsChanged();
+}
+
+void Rubberband::visibleExtentChanged()
+{
+  mDirty = true;
+  update();
 }
 
 void Rubberband::markDirty()

--- a/src/core/rubberband.h
+++ b/src/core/rubberband.h
@@ -91,6 +91,7 @@ class Rubberband : public QQuickItem
 
   private slots:
     void markDirty();
+    void visibleExtentChanged();
 
   private:
     QSGNode *updatePaintNode( QSGNode *n, QQuickItem::UpdatePaintNodeData * );


### PR DESCRIPTION
This fixes a regression  from the rubber band precision work done and merged yesterday. For 'static' rubber band (i.e. those who don't have a moving vertex following the location indicator), we need to listen to visible extent change to update the SGRubberband.