### PR TITLE
Improve project loading feedback

### DIFF
--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -39,10 +39,14 @@ void AppInterface::loadProject( const QString &path, const QString &name )
   return mApp->loadProjectFile( url.isLocalFile() ? url.toLocalFile() : url.path(), name );
 }
 
-void AppInterface::reloadProject( const QString &path )
+void AppInterface::reloadProject()
 {
-  const QUrl url( path );
-  return mApp->reloadProjectFile( url.isLocalFile() ? url.toLocalFile() : url.path() );
+  return mApp->reloadProjectFile();
+}
+
+void AppInterface::readProject()
+{
+  return mApp->readProjectFile();
 }
 
 void AppInterface::print( int layoutIndex )

--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -33,10 +33,10 @@ void AppInterface::loadLastProject()
   return mApp->loadLastProject();
 }
 
-void AppInterface::loadProject( const QString &path )
+void AppInterface::loadProject( const QString &path, const QString &name )
 {
   const QUrl url( path );
-  return mApp->loadProjectFile( url.isLocalFile() ? url.toLocalFile() : url.path() );
+  return mApp->loadProjectFile( url.isLocalFile() ? url.toLocalFile() : url.path(), name );
 }
 
 void AppInterface::reloadProject( const QString &path )

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -38,7 +38,7 @@ class AppInterface : public QObject
     }
 
     Q_INVOKABLE void loadLastProject();
-    Q_INVOKABLE void loadProject( const QString &path );
+    Q_INVOKABLE void loadProject( const QString &path, const QString &name = QString() );
     Q_INVOKABLE void reloadProject( const QString &path );
     Q_INVOKABLE void removeRecentProject( const QString &path );
 
@@ -50,7 +50,7 @@ class AppInterface : public QObject
   signals:
     void openFeatureFormRequested();
 
-    void loadProjectStarted( const QString &path );
+    void loadProjectStarted( const QString &path, const QString &name );
 
     void loadProjectEnded();
 

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -39,7 +39,8 @@ class AppInterface : public QObject
 
     Q_INVOKABLE void loadLastProject();
     Q_INVOKABLE void loadProject( const QString &path, const QString &name = QString() );
-    Q_INVOKABLE void reloadProject( const QString &path );
+    Q_INVOKABLE void reloadProject();
+    Q_INVOKABLE void readProject();
     Q_INVOKABLE void removeRecentProject( const QString &path );
 
     Q_INVOKABLE void print( int layoutIndex );
@@ -50,7 +51,7 @@ class AppInterface : public QObject
   signals:
     void openFeatureFormRequested();
 
-    void loadProjectStarted( const QString &path, const QString &name );
+    void loadProjectTriggered( const QString &path, const QString &name );
 
     void loadProjectEnded();
 

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -242,7 +242,7 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   connect( mProject, &QgsProject::readProject, this, &QgisMobileapp::onReadProject );
 
   mLayerTreeCanvasBridge = new LayerTreeMapCanvasBridge( mFlatLayerTree, mMapCanvas->mapSettings(), mTrackingModel, this );
-  connect( this, &QgisMobileapp::loadProjectStarted, mIface, &AppInterface::loadProjectStarted );
+  connect( this, &QgisMobileapp::loadProjectTriggered, mIface, &AppInterface::loadProjectTriggered );
   connect( this, &QgisMobileapp::loadProjectEnded, mIface, &AppInterface::loadProjectEnded );
   QTimer::singleShot( 1, this, &QgisMobileapp::onAfterFirstRendering );
 
@@ -526,35 +526,41 @@ void QgisMobileapp::loadLastProject()
 
 void QgisMobileapp::loadProjectFile( const QString &path, const QString &name )
 {
-// Check QGIS Version
-#if VERSION_INT >= 30600
-  mAuthRequestHandler->clearStoredRealms();
-#endif
-  reloadProjectFile( path, name );
-}
-
-void QgisMobileapp::reloadProjectFile( const QString &path, const QString &name )
-{
   QFileInfo fi( path );
   if ( !fi.exists() )
     QgsMessageLog::logMessage( tr( "Project file \"%1\" does not exist" ).arg( path ), QStringLiteral( "QField" ), Qgis::Warning );
 
+// Check QGIS Version
+#if VERSION_INT >= 30600
+  mAuthRequestHandler->clearStoredRealms();
+#endif
+  mProjectPath = path;
+  mProjectName = name.isEmpty() ? name : fi.completeBaseName();
+
+  emit loadProjectTriggered( mProjectPath, mProjectName );
+}
+
+void QgisMobileapp::reloadProjectFile()
+{
+  if ( mProjectPath.isEmpty() )
+    QgsMessageLog::logMessage( tr( "No project file currently opened" ), QStringLiteral( "QField" ), Qgis::Warning );
+
+  emit loadProjectTriggered( mProjectPath, mProjectName );
+}
+
+void QgisMobileapp::readProjectFile()
+{
+  QFileInfo fi( mProjectPath );
+  if ( !fi.exists() )
+    QgsMessageLog::logMessage( tr( "Project file \"%1\" does not exist" ).arg( mProjectPath ), QStringLiteral( "QField" ), Qgis::Warning );
+
   mProject->removeAllMapLayers();
   mTrackingModel->reset();
 
-  emit loadProjectStarted( path, !name.isEmpty() ? name : fi.baseName() );
-
-  // Process events to insure the QML scene is setup for project loading
-  const QTime dieTime = QTime::currentTime().addMSecs(100);
-  while ( QTime::currentTime() < dieTime )
-  {
-    QApplication::processEvents(QEventLoop::AllEvents, 50);
-  }
-
-  mProject->read( path );
+  mProject->read( mProjectPath );
 
   // load fonts in same directory
-  QDir fontDir = QDir::cleanPath( QFileInfo( path ).absoluteDir().path() + QDir::separator() + ".fonts" );
+  QDir fontDir = QDir::cleanPath( QFileInfo( mProjectPath ).absoluteDir().path() + QDir::separator() + ".fonts" );
   QStringList fontExts = QStringList() << "*.ttf" << "*.TTF" << "*.otf" << "*.OTF";
   const QStringList fontFiles = fontDir.entryList( fontExts, QDir::Files );
   for ( const QString &fontFile : fontFiles )

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -107,7 +107,7 @@ class QgisMobileapp : public QQmlApplicationEngine
     void reloadProjectFile();
 
     /**
-     * Reads and o pen the project file set in the loadProjectFile function
+     * Reads and opens the project file set in the loadProjectFile function
      */
     void readProjectFile();
 

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -88,20 +88,29 @@ class QgisMobileapp : public QQmlApplicationEngine
     void loadLastProject();
 
     /**
-     * When called loads the project file found at path.
+     * Set the project file path to be loaded.
      *
-     * @param path The project file to load
-     * @param name The project name
+     * \param path The project file to load
+     * \param name The project name
+     * \note The actual loading is done in readProjectFile
      */
     void loadProjectFile( const QString &path, const QString &name = QString() );
+
     /**
-     * Loads the project file found at path.
-     * It does not reset the Auth Request Handler.
+     * Reloads the current project
      *
-     * @param path The project file to load
-     * @param name The project name
+     * \param path The project file to load
+     * \param name The project name
+     * \note It does not reset the Auth Request Handler.
+     * \note The actual loading is done in readProjectFile
      */
-    void reloadProjectFile( const QString &path, const QString &name = QString() );
+    void reloadProjectFile();
+
+    /**
+     * Reads and o pen the project file set in the loadProjectFile function
+     */
+    void readProjectFile();
+
     void print( int layoutIndex );
 
     bool event( QEvent *event ) override;
@@ -113,7 +122,7 @@ class QgisMobileapp : public QQmlApplicationEngine
      * @param filename The filename of the project that is being loaded
      * @param projectname The project name that is being loaded
      */
-    void loadProjectStarted( const QString &filename, const QString &name );
+    void loadProjectTriggered( const QString &filename, const QString &name );
 
     /**
      * Emitted when the project is fully loaded
@@ -147,6 +156,9 @@ class QgisMobileapp : public QQmlApplicationEngine
     LegendImageProvider *mLegendImageProvider = nullptr;
 
     QgsProject *mProject = nullptr;
+    QString mProjectPath;
+    QString mProjectName;
+
     std::unique_ptr<QgsGpkgFlusher> mGpkgFlusher;
 #if VERSION_INT >= 30600
     QFieldAppAuthRequestHandler *mAuthRequestHandler = nullptr;

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -91,15 +91,17 @@ class QgisMobileapp : public QQmlApplicationEngine
      * When called loads the project file found at path.
      *
      * @param path The project file to load
+     * @param name The project name
      */
-    void loadProjectFile( const QString &path );
+    void loadProjectFile( const QString &path, const QString &name = QString() );
     /**
      * Loads the project file found at path.
      * It does not reset the Auth Request Handler.
      *
      * @param path The project file to load
+     * @param name The project name
      */
-    void reloadProjectFile( const QString &path );
+    void reloadProjectFile( const QString &path, const QString &name = QString() );
     void print( int layoutIndex );
 
     bool event( QEvent *event ) override;
@@ -109,8 +111,9 @@ class QgisMobileapp : public QQmlApplicationEngine
      * Emitted when a project file is being loaded
      *
      * @param filename The filename of the project that is being loaded
+     * @param projectname The project name that is being loaded
      */
-    void loadProjectStarted( const QString &filename );
+    void loadProjectStarted( const QString &filename, const QString &name );
 
     /**
      * Emitted when the project is fully loaded

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -6,6 +6,8 @@ import QtQuick.Particles 2.0
 import Theme 1.0
 
 Page {
+  id: welcomeScreen
+
   property alias model: table.model
   signal showOpenProjectDialog
 
@@ -128,6 +130,7 @@ Page {
           delegate: Rectangle {
             id: rectangle
             property string path: ProjectPath
+            property string title: ProjectTitle
             width: parent ? parent.width : undefined
             height: line.height
             color: "transparent"
@@ -191,7 +194,7 @@ Page {
             onClicked: {
               var item = table.itemAt(mouse.x, mouse.y)
               if (item)
-                iface.loadProject(item.path)
+                iface.loadProject(item.path,item.title)
             }
             onPressed: {
               var item = table.itemAt(mouse.x, mouse.y)

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1666,7 +1666,7 @@ ApplicationWindow {
     id: busyMessage
     anchors.fill: parent
     color: Theme.darkGray
-    opacity: 0.5
+    opacity: 0.75
     visible: false
 
     BusyIndicator {
@@ -1681,14 +1681,18 @@ ApplicationWindow {
       id: busyMessageText
       anchors.top: busyMessageIndicator.bottom
       anchors.horizontalCenter: parent.horizontalCenter
-      text: qsTr( "Loading Project" )
+      horizontalAlignment: Text.AlignHCenter
+      font: Theme.tipFont
+      color: Theme.mainColor
+      text: qsTr( "" )
     }
 
     Connections {
       target: iface
 
-      function onLoadProjectStarted(path) {
-        busyMessageText.text = qsTr( "Loading Project: %1" ).arg( path )
+      function onLoadProjectStarted(path,name) {
+        welcomeScreen.visible = false
+        busyMessageText.text = qsTr( "Loading %1" ).arg( name !== '' ? name : path )
         busyMessage.visible = true
       }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1716,7 +1716,7 @@ ApplicationWindow {
       horizontalAlignment: Text.AlignHCenter
       font: Theme.tipFont
       color: Theme.mainColor
-      text: qsTr( "" )
+      text: ''
     }
 
     Timer {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1666,8 +1666,40 @@ ApplicationWindow {
     id: busyMessage
     anchors.fill: parent
     color: Theme.darkGray
-    opacity: 0.75
+    opacity: 0
     visible: false
+
+    state: "hidden"
+    states: [
+        State {
+            name: "hidden"
+            PropertyChanges { target: busyMessage; opacity: 0 }
+            PropertyChanges { target: busyMessage; visible: false }
+        },
+
+        State {
+            name: "visible"
+            PropertyChanges { target: busyMessage; visible: true }
+            PropertyChanges { target: busyMessage; opacity: 0.75 }
+        }]
+    transitions: [
+        Transition {
+            from: "hidden"
+            to: "visible"
+            SequentialAnimation {
+                PropertyAnimation { target: busyMessage; property: "visible"; duration: 0 }
+                NumberAnimation { target: busyMessage; easing.type: Easing.InOutQuad; properties: "opacity"; duration: 250 }
+            }
+        },
+        Transition {
+            from: "visible"
+            to: "hidden"
+            SequentialAnimation {
+                PropertyAnimation { target: busyMessage; easing.type: Easing.InOutQuad; property: "opacity"; duration: 250 }
+                PropertyAnimation { target: busyMessage; property: "visible"; duration: 0 }
+            }
+        }
+    ]
 
     BusyIndicator {
       id: busyMessageIndicator
@@ -1687,17 +1719,27 @@ ApplicationWindow {
       text: qsTr( "" )
     }
 
+    Timer {
+      id: readProjectTimer
+
+      interval: 250
+      repeat: false
+      onTriggered: iface.readProject()
+    }
+
     Connections {
       target: iface
 
-      function onLoadProjectStarted(path,name) {
+      function onLoadProjectTriggered(path,name) {
         welcomeScreen.visible = false
+        dashBoard.layerTree.freeze()
         busyMessageText.text = qsTr( "Loading %1" ).arg( name !== '' ? name : path )
-        busyMessage.visible = true
+        busyMessage.state = "visible"
+        readProjectTimer.start()
       }
 
       function onLoadProjectEnded() {
-        busyMessage.visible = false
+        busyMessage.state = "hidden"
         mapCanvasBackground.color = mapCanvas.mapSettings.backgroundColor
       }
     }
@@ -1774,8 +1816,7 @@ ApplicationWindow {
     Connections {
         target: iface
 
-        function onLoadProjectStarted(path) {
-          dashBoard.layerTree.freeze()
+        function onLoadProjectTriggered(path) {
           messageLogModel.suppressTags(["WFS","WMS"])
         }
     }
@@ -1790,7 +1831,7 @@ ApplicationWindow {
       }
 
       function onReloadEverything() {
-        iface.reloadProject( qgisProject.fileName )
+        iface.reloadProject()
       }
     }
 


### PR DESCRIPTION
A screencast worth a thousand words:

https://user-images.githubusercontent.com/1728657/106242968-1cc1fd80-623b-11eb-8925-9bc1f494b620.mp4

Because UI feedback > UI freeze. The MP4 doesn't render the fade in / out loading screen that well, but it's there, and it makes for a really nice transition.

~~@m-kuhn , I did just use processEvents here literally 48 hours after you said "NOOOOOOOOOOOO" :) I however think this specific use is actually safe here. It merely allows for the QML scene to reflect the changes done in the signal onLoadProjectStarted signal. Without it, the loading items randomly fail to show.~~ 

@m-kuhn , you will be happy to know no processEvents were used in the production of this feature :wink: 