### PR TITLE
Support for opening individual vector/raster dataset in QField

### DIFF
--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -14,8 +14,8 @@
     <string name="secondary_storage_read_only">External storage (read only)</string>
     <string name="inaccessible">inaccessible</string>
     <string name="loading">Loading</string>
-    <string name="select_project">Select a QGIS project</string>
-    <string name="recent_projects">Recent projects</string>
+    <string name="select_project">Select a QGIS project or dataset</string>
+    <string name="recent_projects">Recent projects and datasets</string>
     <string name="rate_title">Rate QField</string>
     <string name="rate_message">If you enjoy using QField, please take a moment to rate it. Thanks for your support!</string>
     <string name="rate_now">Rate</string>

--- a/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -140,7 +140,11 @@ public class QFieldProjectActivity extends Activity {
                 for (File file : list) {
                     if (file.getName().startsWith(".")) {
                         continue;
-                    }else if (file.getName().toLowerCase().endsWith(".qgs") || file.getName().toLowerCase().endsWith(".qgz")){
+                    }else if (file.getName().toLowerCase().endsWith(".qgs") || file.getName().toLowerCase().endsWith(".qgz") ||
+                              file.getName().toLowerCase().endsWith(".gpkg") || file.getName().toLowerCase().endsWith(".shp") || 
+                              file.getName().toLowerCase().endsWith(".kml") || file.getName().toLowerCase().endsWith(".kmz") || 
+                              file.getName().toLowerCase().endsWith(".tif") || file.getName().toLowerCase().endsWith(".jpg") || 
+                              file.getName().toLowerCase().endsWith(".png") || file.getName().toLowerCase().endsWith(".pdf")){
                         values.add(new QFieldProjectListItem(file, file.getName(), R.drawable.qfield_logo, QFieldProjectListItem.TYPE_ITEM));
                     }else if (file.isDirectory()){
                         values.add(new QFieldProjectListItem(file, file.getName(), R.drawable.directory, QFieldProjectListItem.TYPE_ITEM));

--- a/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -140,11 +140,16 @@ public class QFieldProjectActivity extends Activity {
                 for (File file : list) {
                     if (file.getName().startsWith(".")) {
                         continue;
-                    }else if (file.getName().toLowerCase().endsWith(".qgs") || file.getName().toLowerCase().endsWith(".qgz") ||
-                              file.getName().toLowerCase().endsWith(".gpkg") || file.getName().toLowerCase().endsWith(".shp") || 
-                              file.getName().toLowerCase().endsWith(".kml") || file.getName().toLowerCase().endsWith(".kmz") || 
-                              file.getName().toLowerCase().endsWith(".tif") || file.getName().toLowerCase().endsWith(".jpg") || 
-                              file.getName().toLowerCase().endsWith(".png") || file.getName().toLowerCase().endsWith(".pdf") ||
+                    }else if (file.getName().toLowerCase().endsWith(".qgs") ||
+                              file.getName().toLowerCase().endsWith(".qgz") ||
+                              file.getName().toLowerCase().endsWith(".gpkg") || 
+                              file.getName().toLowerCase().endsWith(".shp") || 
+                              file.getName().toLowerCase().endsWith(".kml") || 
+                              file.getName().toLowerCase().endsWith(".kmz") || 
+                              file.getName().toLowerCase().endsWith(".tif") || 
+                              file.getName().toLowerCase().endsWith(".jpg") || 
+                              file.getName().toLowerCase().endsWith(".png") || 
+                              file.getName().toLowerCase().endsWith(".pdf") ||
                               file.getName().toLowerCase().endsWith(".gpx")){
                         values.add(new QFieldProjectListItem(file, file.getName(), R.drawable.qfield_logo, QFieldProjectListItem.TYPE_ITEM));
                     }else if (file.isDirectory()){

--- a/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -146,6 +146,8 @@ public class QFieldProjectActivity extends Activity {
                               file.getName().toLowerCase().endsWith(".shp") || 
                               file.getName().toLowerCase().endsWith(".kml") || 
                               file.getName().toLowerCase().endsWith(".kmz") || 
+                              file.getName().toLowerCase().endsWith(".gepjson") || 
+                              file.getName().toLowerCase().endsWith(".json") || 
                               file.getName().toLowerCase().endsWith(".tif") || 
                               file.getName().toLowerCase().endsWith(".jpg") || 
                               file.getName().toLowerCase().endsWith(".png") || 

--- a/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -144,7 +144,8 @@ public class QFieldProjectActivity extends Activity {
                               file.getName().toLowerCase().endsWith(".gpkg") || file.getName().toLowerCase().endsWith(".shp") || 
                               file.getName().toLowerCase().endsWith(".kml") || file.getName().toLowerCase().endsWith(".kmz") || 
                               file.getName().toLowerCase().endsWith(".tif") || file.getName().toLowerCase().endsWith(".jpg") || 
-                              file.getName().toLowerCase().endsWith(".png") || file.getName().toLowerCase().endsWith(".pdf")){
+                              file.getName().toLowerCase().endsWith(".png") || file.getName().toLowerCase().endsWith(".pdf") ||
+                              file.getName().toLowerCase().endsWith(".gpx")){
                         values.add(new QFieldProjectListItem(file, file.getName(), R.drawable.qfield_logo, QFieldProjectListItem.TYPE_ITEM));
                     }else if (file.isDirectory()){
                         values.add(new QFieldProjectListItem(file, file.getName(), R.drawable.directory, QFieldProjectListItem.TYPE_ITEM));

--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -33,7 +33,7 @@ void AppInterface::loadLastProject()
   return mApp->loadLastProject();
 }
 
-void AppInterface::loadProject( const QString &path, const QString &name )
+void AppInterface::loadFile( const QString &path, const QString &name )
 {
   const QUrl url( path );
   return mApp->loadProjectFile( url.isLocalFile() ? url.toLocalFile() : url.path(), name );

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -24,6 +24,7 @@
 #include <QStandardItemModel>
 
 class QgisMobileapp;
+class QgsRectangle;
 
 class AppInterface : public QObject
 {
@@ -38,7 +39,7 @@ class AppInterface : public QObject
     }
 
     Q_INVOKABLE void loadLastProject();
-    Q_INVOKABLE void loadProject( const QString &path, const QString &name = QString() );
+    Q_INVOKABLE void loadFile( const QString &path, const QString &name = QString() );
     Q_INVOKABLE void reloadProject();
     Q_INVOKABLE void readProject();
     Q_INVOKABLE void removeRecentProject( const QString &path );
@@ -54,6 +55,8 @@ class AppInterface : public QObject
     void loadProjectTriggered( const QString &path, const QString &name );
 
     void loadProjectEnded();
+
+    void setMapExtent( const QgsRectangle &extent );
 
   private:
     QgisMobileapp *mApp = nullptr;

--- a/src/core/platformutilities.cpp
+++ b/src/core/platformutilities.cpp
@@ -130,7 +130,7 @@ QString PlatformUtilities::fieldType( const QgsField &field ) const
 ProjectSource *PlatformUtilities::openProject()
 {
   ProjectSource *source = new ProjectSource( );
-  QString path { QFileDialog::getOpenFileName( nullptr, tr( "Open QGIS Project File" ), QString(), tr( "QGIS Project Files (*.qgs *.qgz)" ) ) };
+  QString path { QFileDialog::getOpenFileName( nullptr, tr( "Open QGIS Project File" ), QString(), tr( "QGIS Project Files (*.qgs *.qgz);;Vector Datasets (*.gpkg *.shp *.kml *.kmz);;Raster Datasets (*.tif *.pdf *.jpg *.png)" ) ) };
   if ( ! path.isEmpty() )
   {
     QTimer::singleShot( 0, this, [source, path]() { emit source->projectOpened( path ); } );

--- a/src/core/platformutilities.cpp
+++ b/src/core/platformutilities.cpp
@@ -20,6 +20,7 @@
 
 #include "platformutilities.h"
 #include "projectsource.h"
+#include "qgismobileapp.h"
 
 #include <QDebug>
 #include <QDir>
@@ -130,7 +131,15 @@ QString PlatformUtilities::fieldType( const QgsField &field ) const
 ProjectSource *PlatformUtilities::openProject()
 {
   ProjectSource *source = new ProjectSource( );
-  QString path { QFileDialog::getOpenFileName( nullptr, tr( "Open QGIS Project File" ), QString(), tr( "QGIS Project Files (*.qgs *.qgz);;Vector Datasets (*.gpkg *.shp *.kml *.kmz *.gpx);;Raster Datasets (*.tif *.pdf *.jpg *.png)" ) ) };
+  QString path { QFileDialog::getOpenFileName( nullptr,
+                                               tr( "Open QGIS Project File" ),
+                                               QString(),
+                                               QStringLiteral( "%1 (*.%2);;%3 (*.%4);;%5 (*.%6)" ).arg( tr( "QGIS Project Files" ),
+                                                                                                        SUPPORTED_PROJECT_EXTENSIONS.join( QStringLiteral( " *." ) ),
+                                                                                                        tr( "Vector Datasets" ),
+                                                                                                        SUPPORTED_VECTOR_EXTENSIONS.join( QStringLiteral( " *." ) ),
+                                                                                                        tr( "Raster Datasets" ),
+                                                                                                        SUPPORTED_RASTER_EXTENSIONS.join( QStringLiteral( " *." ) ) ) ) };
   if ( ! path.isEmpty() )
   {
     QTimer::singleShot( 0, this, [source, path]() { emit source->projectOpened( path ); } );

--- a/src/core/platformutilities.cpp
+++ b/src/core/platformutilities.cpp
@@ -130,7 +130,7 @@ QString PlatformUtilities::fieldType( const QgsField &field ) const
 ProjectSource *PlatformUtilities::openProject()
 {
   ProjectSource *source = new ProjectSource( );
-  QString path { QFileDialog::getOpenFileName( nullptr, tr( "Open QGIS Project File" ), QString(), tr( "QGIS Project Files (*.qgs *.qgz);;Vector Datasets (*.gpkg *.shp *.kml *.kmz);;Raster Datasets (*.tif *.pdf *.jpg *.png)" ) ) };
+  QString path { QFileDialog::getOpenFileName( nullptr, tr( "Open QGIS Project File" ), QString(), tr( "QGIS Project Files (*.qgs *.qgz);;Vector Datasets (*.gpkg *.shp *.kml *.kmz *.gpx);;Raster Datasets (*.tif *.pdf *.jpg *.png)" ) ) };
   if ( ! path.isEmpty() )
   {
     QTimer::singleShot( 0, this, [source, path]() { emit source->projectOpened( path ); } );

--- a/src/core/platformutilities.h
+++ b/src/core/platformutilities.h
@@ -20,7 +20,9 @@
 #define PLATFORMUTILITIES_H
 
 #include <QObject>
+
 #include <qgsfield.h>
+
 #include "picturesource.h"
 #include "viewstatus.h"
 

--- a/src/core/projectsource.h
+++ b/src/core/projectsource.h
@@ -24,6 +24,11 @@
  * It will notify the system with the projectOpened() signal
  * once the user has selected a project to open.
  *
+ * The path can either be a QGIS project file (.qgs, .qgz) or
+ * a supported vector/raster dataset. The latter will trigger
+ * the creation of a project within which the dataset will
+ * be loaded.
+ *
  * The default implementation does nothing. You probably
  * want to have a look at the AndroidProjectSource subclass.
  */

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -765,11 +765,9 @@ void QgisMobileapp::readProjectFile()
     if ( crs.isValid() )
       mProject->setCrs( crs );
 
-    if ( rasterLayers.size() == 0 )
-    {
-      QgsRasterLayer *layer = new QgsRasterLayer( QStringLiteral( "type=xyz&url=http://a.tile.openstreetmap.org/%7Bz%7D/%7Bx%7D/%7By%7D.png&zmax=19&zmin=0&crs=EPSG3857" ), QStringLiteral( "OpenStreetMap" ), QLatin1String( "wms" ) );
-      vectorLayers << layer;
-    }
+    // Add a basemap
+    QgsRasterLayer *layer = new QgsRasterLayer( QStringLiteral( "type=xyz&url=https://a.tile.openstreetmap.org/%7Bz%7D/%7Bx%7D/%7By%7D.png&zmax=19&zmin=0&crs=EPSG3857" ), QStringLiteral( "OpenStreetMap" ), QLatin1String( "wms" ) );
+    mProject->addMapLayers( QList<QgsMapLayer *>() << layer );
 
     mProject->addMapLayers( rasterLayers );
     mProject->addMapLayers( vectorLayers );

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -528,17 +528,10 @@ void QgisMobileapp::loadProjectFile( const QString &path, const QString &name )
   if ( !fi.exists() )
     QgsMessageLog::logMessage( tr( "Project file \"%1\" does not exist" ).arg( path ), QStringLiteral( "QField" ), Qgis::Warning );
 
-  const QString suffix = fi.suffix();
-  if ( suffix.compare( QLatin1String( "qgs"), Qt::CaseInsensitive ) == 0 ||
-       suffix.compare( QLatin1String( "qgz"), Qt::CaseInsensitive ) == 0 ||
-       suffix.compare( QLatin1String( "gpkg" ), Qt::CaseInsensitive ) == 0 ||
-       suffix.compare( QLatin1String( "shp" ), Qt::CaseInsensitive ) == 0 ||
-       suffix.compare( QLatin1String( "kml" ), Qt::CaseInsensitive ) == 0 ||
-       suffix.compare( QLatin1String( "kmz" ), Qt::CaseInsensitive ) == 0 ||
-       suffix.compare( QLatin1String( "tif" ), Qt::CaseInsensitive ) == 0 ||
-       suffix.compare( QLatin1String( "pdf" ), Qt::CaseInsensitive ) == 0 ||
-       suffix.compare( QLatin1String( "jpg" ), Qt::CaseInsensitive ) == 0 ||
-       suffix.compare( QLatin1String( "png" ), Qt::CaseInsensitive ) == 0 )
+  const QString suffix = fi.suffix().toLower();
+  if ( suffix == QLatin1String( "qgs") || suffix == QLatin1String( "qgz") ||
+       suffix == QLatin1String( "gpkg" ) || suffix == QLatin1String( "shp" ) || suffix == QLatin1String( "kml" ) || suffix == QLatin1String( "kmz" ) ||
+       suffix == QLatin1String( "tif" ) || suffix == QLatin1String( "pdf" ) || suffix == QLatin1String( "jpg" ) || suffix == QLatin1String( "png" ) )
   {
     mAuthRequestHandler->clearStoredRealms();
 
@@ -563,14 +556,13 @@ void QgisMobileapp::readProjectFile()
   if ( !fi.exists() )
     QgsMessageLog::logMessage( tr( "Project file \"%1\" does not exist" ).arg( mProjectFilePath ), QStringLiteral( "QField" ), Qgis::Warning );
 
-  const QString suffix = fi.suffix();
+  const QString suffix = fi.suffix().toLower();
 
   mProject->removeAllMapLayers();
   mTrackingModel->reset();
 
   // Load project file
-  if ( suffix.compare( QLatin1String( "qgs"), Qt::CaseInsensitive ) == 0 ||
-       suffix.compare( QLatin1String( "qgz"), Qt::CaseInsensitive ) == 0 )
+  if ( suffix == QLatin1String( "qgs") || suffix == QLatin1String( "qgz") )
   {
     mProject->read( mProjectFilePath );
 
@@ -605,11 +597,7 @@ void QgisMobileapp::readProjectFile()
   QgsRectangle extent;
 
   // Load vector dataset
-  if ( suffix.compare( QLatin1String( "gpkg" ), Qt::CaseInsensitive ) == 0 ||
-       suffix.compare( QLatin1String( "shp" ), Qt::CaseInsensitive ) == 0 ||
-       suffix.compare( QLatin1String( "kml" ), Qt::CaseInsensitive ) == 0 ||
-       suffix.compare( QLatin1String( "kmz" ), Qt::CaseInsensitive ) == 0 ||
-       suffix.compare( QLatin1String( "pdf" ), Qt::CaseInsensitive ) == 0 )
+  if ( suffix == QLatin1String( "gpkg" ) || suffix == QLatin1String( "shp" ) || suffix == QLatin1String( "kml" ) || suffix == QLatin1String( "kmz" ) || suffix == QLatin1String( "pdf" ) )
   {
     QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
     options.loadDefaultStyle = true;
@@ -685,11 +673,7 @@ void QgisMobileapp::readProjectFile()
   }
 
   // Load raster dataset
-  if ( suffix.compare( QLatin1String( "tif" ), Qt::CaseInsensitive ) == 0 ||
-       suffix.compare( QLatin1String( "pdf" ), Qt::CaseInsensitive ) == 0 ||
-       suffix.compare( QLatin1String( "jpg" ), Qt::CaseInsensitive ) == 0 ||
-       suffix.compare( QLatin1String( "png" ), Qt::CaseInsensitive ) == 0 )
-  {
+  if ( suffix == QLatin1String( "tif" ) || suffix == QLatin1String( "pdf" ) || suffix == QLatin1String( "jpg" ) || suffix == QLatin1String( "png" ) ) {
     QgsRasterLayer *layer = new QgsRasterLayer( mProjectFilePath, mProjectFileName, QLatin1String( "gdal" ) );
     if ( layer->isValid() )
     {

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -530,7 +530,7 @@ void QgisMobileapp::loadProjectFile( const QString &path, const QString &name )
 
   const QString suffix = fi.suffix().toLower();
   if ( suffix == QLatin1String( "qgs") || suffix == QLatin1String( "qgz") ||
-       suffix == QLatin1String( "gpkg" ) || suffix == QLatin1String( "shp" ) || suffix == QLatin1String( "kml" ) || suffix == QLatin1String( "kmz" ) ||
+       suffix == QLatin1String( "gpkg" ) || suffix == QLatin1String( "shp" ) || suffix == QLatin1String( "kml" ) || suffix == QLatin1String( "kmz" ) || suffix == QLatin1String( "gpx" ) ||
        suffix == QLatin1String( "tif" ) || suffix == QLatin1String( "pdf" ) || suffix == QLatin1String( "jpg" ) || suffix == QLatin1String( "png" ) )
   {
     mAuthRequestHandler->clearStoredRealms();
@@ -597,7 +597,8 @@ void QgisMobileapp::readProjectFile()
   QgsRectangle extent;
 
   // Load vector dataset
-  if ( suffix == QLatin1String( "gpkg" ) || suffix == QLatin1String( "shp" ) || suffix == QLatin1String( "kml" ) || suffix == QLatin1String( "kmz" ) || suffix == QLatin1String( "pdf" ) )
+  if ( suffix == QLatin1String( "gpkg" ) || suffix == QLatin1String( "shp" ) || suffix == QLatin1String( "kml" ) || suffix == QLatin1String( "kmz" ) ||
+       suffix == QLatin1String( "gpx" ) || suffix == QLatin1String( "pdf" ) )
   {
     QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
     options.loadDefaultStyle = true;

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -581,7 +581,19 @@ void QgisMobileapp::readProjectFile()
   }
   else
   {
-    mProject->clear();
+    if ( QFile::exists( PlatformUtilities::instance()->qfieldDataDir() + QStringLiteral( "basemap.qgs" ) ) )
+    {
+      mProject->read( PlatformUtilities::instance()->qfieldDataDir() + QStringLiteral( "basemap.qgs" ) );
+    }
+    else if ( QFile::exists( PlatformUtilities::instance()->qfieldDataDir() + QStringLiteral( "basemap.qgz" ) ) )
+    {
+      mProject->read( PlatformUtilities::instance()->qfieldDataDir() + QStringLiteral( "basemap.qgz" ) );
+    }
+    else
+    {
+      mProject->clear();
+    }
+    mProject->setTitle( mProjectFileName );
   }
 
   QList<QPair<QString, QString>> projects = recentProjects();
@@ -766,9 +778,12 @@ void QgisMobileapp::readProjectFile()
     if ( crs.isValid() )
       mProject->setCrs( crs );
 
-    // Add a basemap
-    QgsRasterLayer *layer = new QgsRasterLayer( QStringLiteral( "type=xyz&url=https://a.tile.openstreetmap.org/%7Bz%7D/%7Bx%7D/%7By%7D.png&zmax=19&zmin=0&crs=EPSG3857" ), QStringLiteral( "OpenStreetMap" ), QLatin1String( "wms" ) );
-    mProject->addMapLayers( QList<QgsMapLayer *>() << layer );
+    if ( mProject->fileName().isEmpty() )
+    {
+      // Add a default basemap
+      QgsRasterLayer *layer = new QgsRasterLayer( QStringLiteral( "type=xyz&url=https://a.tile.openstreetmap.org/%7Bz%7D/%7Bx%7D/%7By%7D.png&zmax=19&zmin=0&crs=EPSG3857" ), QStringLiteral( "OpenStreetMap" ), QLatin1String( "wms" ) );
+      mProject->addMapLayers( QList<QgsMapLayer *>() << layer );
+    }
 
     mProject->addMapLayers( rasterLayers );
     mProject->addMapLayers( vectorLayers );

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -790,8 +790,11 @@ void QgisMobileapp::readProjectFile()
 
   emit loadProjectEnded();
 
-  if ( !extent.isEmpty() )
-    emit setMapExtent( extent );
+  if ( !extent.isEmpty() && extent.width() != 0.0 )
+  {
+    // Add a bit of buffer so elements don't touch the map edges
+    emit setMapExtent( extent.buffered( extent.width() * 0.02 ) );
+  }
 }
 
 void QgisMobileapp::print( int layoutIndex )

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -473,14 +473,6 @@ void QgisMobileapp::onReadProject( const QDomDocument &doc )
   Q_UNUSED( doc )
   QMap<QgsVectorLayer *, QgsFeatureRequest> requests;
 
-  QList<QPair<QString, QString>> projects = recentProjects();
-  QFileInfo fi( mProject->fileName() );
-  QPair<QString, QString> project = qMakePair( mProject->title().isEmpty() ? fi.completeBaseName() : mProject->title(), mProject->fileName() );
-  if ( projects.contains( project ) )
-    projects.removeAt( projects.indexOf( project ) );
-  projects.insert( 0, project );
-  saveRecentProjects( projects );
-
   const QList<QgsMapLayer *> mapLayers { mProject->mapLayers().values() };
   for ( QgsMapLayer *layer : mapLayers )
   {
@@ -597,6 +589,13 @@ void QgisMobileapp::readProjectFile()
   {
     mProject->clear();
   }
+
+  QList<QPair<QString, QString>> projects = recentProjects();
+  QPair<QString, QString> project = qMakePair( mProject->title().isEmpty() ? mProjectFileName : mProject->title(), mProjectFilePath );
+  if ( projects.contains( project ) )
+    projects.removeAt( projects.indexOf( project ) );
+  projects.insert( 0, project );
+  saveRecentProjects( projects );
 
   QList<QgsMapLayer *> vectorLayers;
   QList<QgsMapLayer *> rasterLayers;

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -668,9 +668,9 @@ void QgisMobileapp::readProjectFile()
         vectorLayers << layer;
       }
 
-      for( QgsMapLayer *layer : vectorLayers )
+      for( QgsMapLayer *l : vectorLayers )
       {
-        QgsVectorLayer *vlayer = qobject_cast< QgsVectorLayer * >( layer );
+        QgsVectorLayer *vlayer = qobject_cast< QgsVectorLayer * >( l );
         QgsSymbol *symbol = FeatureUtils::defaultSymbol( vlayer );
         if ( symbol )
         {
@@ -762,9 +762,9 @@ void QgisMobileapp::readProjectFile()
       // If the raster size is reasonably small, apply nicer resampling settings
       if ( fi.size() < 50000000 )
       {
-        for( QgsMapLayer *layer : rasterLayers )
+        for( QgsMapLayer *l : rasterLayers )
         {
-          QgsRasterLayer *rlayer = qobject_cast< QgsRasterLayer * >( layer );
+          QgsRasterLayer *rlayer = qobject_cast< QgsRasterLayer * >( l );
           rlayer->resampleFilter()->setZoomedInResampler( new QgsBilinearRasterResampler() );
           rlayer->resampleFilter()->setZoomedOutResampler( new QgsBilinearRasterResampler() );
           rlayer->resampleFilter()->setMaxOversampling( 2.0 );

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -529,9 +529,9 @@ void QgisMobileapp::loadProjectFile( const QString &path, const QString &name )
     QgsMessageLog::logMessage( tr( "Project file \"%1\" does not exist" ).arg( path ), QStringLiteral( "QField" ), Qgis::Warning );
 
   const QString suffix = fi.suffix().toLower();
-  if ( suffix == QLatin1String( "qgs") || suffix == QLatin1String( "qgz") ||
-       suffix == QLatin1String( "gpkg" ) || suffix == QLatin1String( "shp" ) || suffix == QLatin1String( "kml" ) || suffix == QLatin1String( "kmz" ) || suffix == QLatin1String( "gpx" ) ||
-       suffix == QLatin1String( "tif" ) || suffix == QLatin1String( "pdf" ) || suffix == QLatin1String( "jpg" ) || suffix == QLatin1String( "png" ) )
+  if ( SUPPORTED_PROJECT_EXTENSIONS.contains( suffix ) ||
+       SUPPORTED_VECTOR_EXTENSIONS.contains( suffix ) ||
+       SUPPORTED_RASTER_EXTENSIONS.contains( suffix ) )
   {
     mAuthRequestHandler->clearStoredRealms();
 
@@ -562,7 +562,7 @@ void QgisMobileapp::readProjectFile()
   mTrackingModel->reset();
 
   // Load project file
-  if ( suffix == QLatin1String( "qgs") || suffix == QLatin1String( "qgz") )
+  if ( SUPPORTED_PROJECT_EXTENSIONS.contains( suffix ) )
   {
     mProject->read( mProjectFilePath );
 
@@ -609,8 +609,7 @@ void QgisMobileapp::readProjectFile()
   QgsRectangle extent;
 
   // Load vector dataset
-  if ( suffix == QLatin1String( "gpkg" ) || suffix == QLatin1String( "shp" ) || suffix == QLatin1String( "kml" ) || suffix == QLatin1String( "kmz" ) ||
-       suffix == QLatin1String( "gpx" ) || suffix == QLatin1String( "pdf" ) )
+  if ( SUPPORTED_VECTOR_EXTENSIONS.contains( suffix ) )
   {
     QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
     options.loadDefaultStyle = true;
@@ -705,7 +704,7 @@ void QgisMobileapp::readProjectFile()
   }
 
   // Load raster dataset
-  if ( suffix == QLatin1String( "tif" ) || suffix == QLatin1String( "pdf" ) || suffix == QLatin1String( "jpg" ) || suffix == QLatin1String( "png" ) ) {
+  if ( SUPPORTED_RASTER_EXTENSIONS.contains( suffix ) ) {
     QgsRasterLayer *layer = new QgsRasterLayer( mProjectFilePath, mProjectFileName, QLatin1String( "gdal" ) );
     if ( layer->isValid() )
     {

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -665,6 +665,25 @@ void QgisMobileapp::readProjectFile()
           vlayer->setRenderer( renderer );
         }
       }
+
+      if ( vectorLayers.size() > 1 )
+      {
+        std::sort( vectorLayers.begin(), vectorLayers.end(), []( QgsMapLayer *a, QgsMapLayer *b ) {
+         QgsVectorLayer *alayer = qobject_cast< QgsVectorLayer * >( a );
+         QgsVectorLayer *blayer = qobject_cast< QgsVectorLayer * >( b );
+         if ( alayer->geometryType() == QgsWkbTypes::PointGeometry && blayer->geometryType() != QgsWkbTypes::PointGeometry )
+         {
+           return true;
+         } else if ( alayer->geometryType() == QgsWkbTypes::LineGeometry && blayer->geometryType() == QgsWkbTypes::PolygonGeometry )
+         {
+           return true;
+         }
+         else
+         {
+           return false;
+         }
+        } );
+      }
     }
     else
     {
@@ -752,21 +771,15 @@ void QgisMobileapp::readProjectFile()
       vectorLayers << layer;
     }
 
+    mProject->addMapLayers( rasterLayers );
+    mProject->addMapLayers( vectorLayers );
     if ( suffix.compare( QLatin1String( "pdf" ) ) == 0 )
     {
-      // GeoPDFs should have vector layers (if any) _below_ the raster layer and hidden by default
-      mProject->addMapLayers( vectorLayers );
-      mProject->addMapLayers( rasterLayers );
-
+      // GeoPDFs should have vector layers hidden by default
       for ( QgsMapLayer *layer : vectorLayers )
       {
         mProject->layerTreeRoot()->findLayer( layer->id() )->setItemVisibilityChecked( false );
       }
-    }
-    else
-    {
-      mProject->addMapLayers( rasterLayers );
-      mProject->addMapLayers( vectorLayers );
     }
   }
 

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -57,6 +57,10 @@ class QgsProject;
 
 #define REGISTER_SINGLETON(uri, _class, name) qmlRegisterSingletonType<_class>( uri, 1, 0, name, [] ( QQmlEngine *engine, QJSEngine *scriptEngine ) -> QObject * { Q_UNUSED(engine); Q_UNUSED(scriptEngine); return new _class(); } )
 
+#define SUPPORTED_PROJECT_EXTENSIONS QStringList( { QStringLiteral( "qgs" ), QStringLiteral( "qgz" ) } )
+#define SUPPORTED_VECTOR_EXTENSIONS    QStringList( { QStringLiteral( "gpkg" ), QStringLiteral( "shp" ), QStringLiteral( "kml" ), QStringLiteral( "kmz" ), QStringLiteral( "geojson" ), QStringLiteral( "json" ), QStringLiteral( "pdf" ) } )
+#define SUPPORTED_RASTER_EXTENSIONS    QStringList( { QStringLiteral( "tif" ), QStringLiteral( "pdf" ), QStringLiteral( "jpg" ), QStringLiteral( "png" ), QStringLiteral( "gpkg" ) } )
+
 
 class QgisMobileapp : public QQmlApplicationEngine
 {

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -86,9 +86,9 @@ class QgisMobileapp : public QQmlApplicationEngine
     void loadLastProject();
 
     /**
-     * Set the project file path to be loaded.
+     * Set the project or dataset file path to be loaded.
      *
-     * \param path The project file to load
+     * \param path The project or dataset file to load
      * \param name The project name
      * \note The actual loading is done in readProjectFile
      */
@@ -127,6 +127,11 @@ class QgisMobileapp : public QQmlApplicationEngine
      */
     void loadProjectEnded();
 
+    /**
+     * Emitted when a map canvas extent change is needed
+     */
+    void setMapExtent( const QgsRectangle &extent );
+
   private slots:
 
     /**
@@ -154,8 +159,8 @@ class QgisMobileapp : public QQmlApplicationEngine
     LegendImageProvider *mLegendImageProvider = nullptr;
 
     QgsProject *mProject = nullptr;
-    QString mProjectPath;
-    QString mProjectName;
+    QString mProjectFilePath;
+    QString mProjectFileName;
 
     std::unique_ptr<QgsGpkgFlusher> mGpkgFlusher;
     QFieldAppAuthRequestHandler *mAuthRequestHandler = nullptr;

--- a/src/core/qgsquick/qgsquickmapsettings.cpp
+++ b/src/core/qgsquick/qgsquickmapsettings.cpp
@@ -51,6 +51,7 @@ void QgsQuickMapSettings::setProject( QgsProject *project )
   if ( mProject )
   {
     connect( mProject, &QgsProject::readProject, this, &QgsQuickMapSettings::onReadProject );
+    connect( mProject, &QgsProject::crsChanged, this, &QgsQuickMapSettings::onCrsChanged );
     setDestinationCrs( mProject->crs() );
     mMapSettings.setTransformContext( mProject->transformContext() );
   }
@@ -216,6 +217,11 @@ void MapSettings::setMapTheme( QgsProject *project, const QString &mapThemeName 
   emit layersChanged();
 }
 #endif
+
+void QgsQuickMapSettings::onCrsChanged()
+{
+  setDestinationCrs( mProject->crs() );
+}
 
 void QgsQuickMapSettings::onReadProject( const QDomDocument &doc )
 {

--- a/src/core/qgsquick/qgsquickmapsettings.h
+++ b/src/core/qgsquick/qgsquickmapsettings.h
@@ -248,6 +248,11 @@ class QgsQuickMapSettings : public QObject
      */
     void onReadProject( const QDomDocument &doc );
 
+    /**
+     * Sets the destination CRS to match the changed project CRS
+     */
+    void onCrsChanged();
+
   private:
     QgsProject *mProject = nullptr;
     QgsMapSettings mMapSettings;

--- a/src/core/utils/featureutils.cpp
+++ b/src/core/utils/featureutils.cpp
@@ -19,6 +19,13 @@
 #include <qgsexpressioncontextutils.h>
 #include <qgsproject.h>
 #include <qgsvectorlayer.h>
+#include <qgssymbol.h>
+#include <qgssymbollayer.h>
+#include <qgsmarkersymbollayer.h>
+#include <qgslinesymbollayer.h>
+#include <qgsfillsymbollayer.h>
+#include <qgswkbtypes.h>
+#include "qgssinglesymbolrenderer.h"
 
 
 FeatureUtils::FeatureUtils(QObject *parent) : QObject(parent)
@@ -49,4 +56,42 @@ QString FeatureUtils::displayName( QgsVectorLayer *layer, const QgsFeature &feat
     name = QString::number( feature.id() );
 
   return name;
+}
+
+QgsSymbol *FeatureUtils::defaultSymbol( QgsVectorLayer *layer )
+{
+  QgsSymbol *symbol = nullptr;
+  QgsSymbolLayerList layers;
+  switch ( layer->geometryType() )
+  {
+    case QgsWkbTypes::PointGeometry:
+    {
+      QgsSimpleMarkerSymbolLayer *layer = new QgsSimpleMarkerSymbolLayer( QgsSimpleMarkerSymbolLayerBase::Circle, 2.6, 0.0, DEFAULT_SCALE_METHOD, QColor( 255, 0, 0, 100 ), QColor( 255, 0, 0 ) );
+      layer->setStrokeWidth( 0.6 );
+      layers << layer;
+      symbol = new QgsMarkerSymbol( layers );
+      break;
+    }
+
+    case QgsWkbTypes::LineGeometry:
+    {
+      QgsSimpleLineSymbolLayer *layer = new QgsSimpleLineSymbolLayer( QColor( 255, 0, 0 ), 0.6 );
+      layers << layer;
+      symbol = new QgsLineSymbol( layers );
+      break;
+    }
+
+    case QgsWkbTypes::PolygonGeometry:
+    {
+      QgsSimpleFillSymbolLayer *layer = new QgsSimpleFillSymbolLayer( QColor( 255, 0, 0, 100), DEFAULT_SIMPLEFILL_STYLE, QColor( 255, 0, 0), DEFAULT_SIMPLEFILL_BORDERSTYLE, 0.6 );
+      layers << layer;
+      symbol = new QgsFillSymbol( layers );
+      break;
+    }
+
+    case QgsWkbTypes::UnknownGeometry:
+    case QgsWkbTypes::NullGeometry:
+      break;
+  }
+  return symbol;
 }

--- a/src/core/utils/featureutils.cpp
+++ b/src/core/utils/featureutils.cpp
@@ -61,31 +61,31 @@ QString FeatureUtils::displayName( QgsVectorLayer *layer, const QgsFeature &feat
 QgsSymbol *FeatureUtils::defaultSymbol( QgsVectorLayer *layer )
 {
   QgsSymbol *symbol = nullptr;
-  QgsSymbolLayerList layers;
+  QgsSymbolLayerList symbolLayers;
   switch ( layer->geometryType() )
   {
     case QgsWkbTypes::PointGeometry:
     {
-      QgsSimpleMarkerSymbolLayer *layer = new QgsSimpleMarkerSymbolLayer( QgsSimpleMarkerSymbolLayerBase::Circle, 2.6, 0.0, DEFAULT_SCALE_METHOD, QColor( 255, 0, 0, 100 ), QColor( 255, 0, 0 ) );
-      layer->setStrokeWidth( 0.6 );
-      layers << layer;
-      symbol = new QgsMarkerSymbol( layers );
+      QgsSimpleMarkerSymbolLayer *symbolLayer = new QgsSimpleMarkerSymbolLayer( QgsSimpleMarkerSymbolLayerBase::Circle, 2.6, 0.0, DEFAULT_SCALE_METHOD, QColor( 255, 0, 0, 100 ), QColor( 255, 0, 0 ) );
+      symbolLayer->setStrokeWidth( 0.6 );
+      symbolLayers << symbolLayer;
+      symbol = new QgsMarkerSymbol( symbolLayers );
       break;
     }
 
     case QgsWkbTypes::LineGeometry:
     {
-      QgsSimpleLineSymbolLayer *layer = new QgsSimpleLineSymbolLayer( QColor( 255, 0, 0 ), 0.6 );
-      layers << layer;
-      symbol = new QgsLineSymbol( layers );
+      QgsSimpleLineSymbolLayer *symbolLayer = new QgsSimpleLineSymbolLayer( QColor( 255, 0, 0 ), 0.6 );
+      symbolLayers << symbolLayer;
+      symbol = new QgsLineSymbol( symbolLayers );
       break;
     }
 
     case QgsWkbTypes::PolygonGeometry:
     {
-      QgsSimpleFillSymbolLayer *layer = new QgsSimpleFillSymbolLayer( QColor( 255, 0, 0, 100), DEFAULT_SIMPLEFILL_STYLE, QColor( 255, 0, 0), DEFAULT_SIMPLEFILL_BORDERSTYLE, 0.6 );
-      layers << layer;
-      symbol = new QgsFillSymbol( layers );
+      QgsSimpleFillSymbolLayer *symbolLayer = new QgsSimpleFillSymbolLayer( QColor( 255, 0, 0, 100), DEFAULT_SIMPLEFILL_STYLE, QColor( 255, 0, 0), DEFAULT_SIMPLEFILL_BORDERSTYLE, 0.6 );
+      symbolLayers << symbolLayer;
+      symbol = new QgsFillSymbol( symbolLayers );
       break;
     }
 

--- a/src/core/utils/featureutils.h
+++ b/src/core/utils/featureutils.h
@@ -22,7 +22,7 @@
 #include <qgsfeature.h>
 
 class QgsVectorLayer;
-
+class QgsSymbol;
 
 class FeatureUtils : public QObject
 {
@@ -38,6 +38,8 @@ public:
    * \param feature the feature to be named
    */
   static Q_INVOKABLE QString displayName( QgsVectorLayer *layer, const QgsFeature &feature );
+
+  static QgsSymbol *defaultSymbol( QgsVectorLayer *layer );
 };
 
 #endif // FEATUREUTILS_H

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -174,7 +174,7 @@ Page {
                   text: {
                     if (index == 0) {
                         var firstRun = !settings.value( "/QField/FirstRunFlag", false )
-                        return !firstRun && firstShown == '' ? qsTr( "Last session" ) : ""
+                        return !firstRun && firstShown === false ? qsTr( "Last session" ) : ""
                     }
                     else
                     {

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -8,6 +8,8 @@ import Theme 1.0
 Page {
   id: welcomeScreen
 
+  property bool firstShown: false
+
   property alias model: table.model
   signal showOpenProjectDialog
 
@@ -172,7 +174,7 @@ Page {
                   text: {
                     if (index == 0) {
                         var firstRun = !settings.value( "/QField/FirstRunFlag", false )
-                        return !firstRun && qgisProject.fileName == '' ? qsTr( "Last session" ) : ""
+                        return !firstRun && firstShown == '' ? qsTr( "Last session" ) : ""
                     }
                     else
                     {
@@ -374,7 +376,7 @@ Page {
 
   function adjustWelcomeScreen() {
     if (visible) {
-      if (qgisProject.fileName != '') {
+      if (firstShown) {
         welcomeText.text = " ";
         currentProjectButton.visible = true
       } else {
@@ -385,6 +387,7 @@ Page {
           welcomeText.text = qsTr( "Welcome back to QField." )
         }
         currentProjectButton.visible = false
+        firstShown = true
       }
     }
   }

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -89,7 +89,7 @@ Page {
         QfButton {
           id: localProjectButton
           Layout.fillWidth: true
-          text: qsTr( "Open local project" )
+          text: qsTr( "Open local file" )
           onClicked: {
             showOpenProjectDialog()
           }
@@ -194,7 +194,7 @@ Page {
             onClicked: {
               var item = table.itemAt(mouse.x, mouse.y)
               if (item)
-                iface.loadProject(item.path,item.title)
+                iface.loadFile(item.path,item.title)
             }
             onPressed: {
               var item = table.itemAt(mouse.x, mouse.y)

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1742,6 +1742,10 @@ ApplicationWindow {
         busyMessage.state = "hidden"
         mapCanvasBackground.color = mapCanvas.mapSettings.backgroundColor
       }
+
+      function onSetMapExtent(extent) {
+          mapCanvas.mapSettings.extent = extent;
+      }
     }
   }
 
@@ -2053,7 +2057,7 @@ ApplicationWindow {
       }
     }
     onDropped: {
-      iface.loadProject( drop.urls[0] )
+      iface.loadFile( drop.urls[0] )
     }
 
     function validateFileExtension(filePath) {
@@ -2089,7 +2093,7 @@ ApplicationWindow {
     target: welcomeScreen.__projectSource
 
     function onProjectOpened(path) {
-      iface.loadProject( path )
+      iface.loadFile(path)
     }
   }
 


### PR DESCRIPTION
This PR adds support for opening individual vector / raster datasets in QField without the need for a QGIS project file. Opening such a file in QField will automatically create a temporary project to display the dataset. If the dataset supports writing, users can use the great QField digitizing tools to add and save features into the dataset.

Here's how it looks:

https://user-images.githubusercontent.com/1728657/106351430-af7f9c80-630e-11eb-9903-c206cf78a707.mp4


Off the box, when opening individual datasets, QField will automatically add a openstreetmap layer as basemap on top of which the dataset is displayed. Users can add a custom basemap.qgs (or basemap.qgz) QGIS project file in their device's <storage>/QField/ directory to customize the layer(s) that will be used as basemap.

E.g. of a basemap project that contains a couple of XYZ basemap layers (satellite and osm):

https://user-images.githubusercontent.com/1728657/106351700-35501780-6310-11eb-9a95-c5aa5821816b.mp4


For datasets containing more than one layer (say a geopackage), all layers will be added and their stacking sorted. The logic is: points on top, then lines, then polygons, then rasters, then the basemap (an OSM layer or the layer(s) from basemap.qgs.

GeoPDFs have specific handling whereas by default, any vector feature layers from the GeoPDF are hidden to allow for the raster map to display. While the features are hidden by default, they can still be identified via the search bar, which is pretty cool:

https://user-images.githubusercontent.com/1728657/106351367-6deef180-630e-11eb-96bf-b56641b96da8.mp4

