### PR TITLE
Additional safeguards to avoid crash when loading a project with a project already opened

### DIFF
--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -392,6 +392,9 @@ QModelIndex FlatLayerTreeModelBase::index( int row, int column, const QModelInde
 
 QVariant FlatLayerTreeModelBase::data( const QModelIndex &index, int role ) const
 {
+  if ( mFrozen )
+    return QVariant();
+
   switch ( role )
   {
     case FlatLayerTreeModel::VectorLayerPointer:

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1733,12 +1733,14 @@ ApplicationWindow {
       function onLoadProjectTriggered(path,name) {
         welcomeScreen.visible = false
         dashBoard.layerTree.freeze()
+        mapCanvasMap.freeze('projectload')
         busyMessageText.text = qsTr( "Loading %1" ).arg( name !== '' ? name : path )
         busyMessage.state = "visible"
         readProjectTimer.start()
       }
 
       function onLoadProjectEnded() {
+        mapCanvasMap.unfreeze('projectload')
         busyMessage.state = "hidden"
         mapCanvasBackground.color = mapCanvas.mapSettings.backgroundColor
       }


### PR DESCRIPTION
This fixes a couple of corner case crashers.