### PR TITLE
SDK update to gain georeferenced PDF support as well as rendering speed gains

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,8 @@ IF (ANDROID)
     ${OSGEO4A_LIB_DIR}/libqt5keychain_${ANDROID_ABI}.so
     ${OSGEO4A_LIB_DIR}/libzip.so
     ${OSGEO4A_LIB_DIR}/libzstd.so
+    ${OSGEO4A_LIB_DIR}/libpoppler_${ANDROID_ABI}.so
+    ${OSGEO4A_LIB_DIR}/libfreetype.so
   )
   FIND_PACKAGE(Qt5 COMPONENTS AndroidExtras REQUIRED)
 

--- a/sdk.conf
+++ b/sdk.conf
@@ -1,1 +1,1 @@
-osgeo4a_version=20210124
+osgeo4a_version=20210203


### PR DESCRIPTION
This PR updates the OSGeo4A SDK to catch a couple of _exciting_ updates:
- An updated GDAL build with its PDF driver enabled (georeferenced PDFs, GeoPDFs)
- An updated QGIS build with rendering speed improvements and fixes