### PR TITLE
Remove locked from screenOrientation in QFieldActivity.

### DIFF
--- a/cmake/AndroidManifest.xml.in
+++ b/cmake/AndroidManifest.xml.in
@@ -10,7 +10,6 @@
       android:name="ch.opengis.@APP_PACKAGE_NAME@.QFieldActivity"
       android:icon="@drawable/qfield_logo"
       android:label="@string/app_name"
-      android:screenOrientation="locked"
       android:launchMode="singleTop"
       android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|locale|fontScale|keyboard|keyboardHidden|navigation">
       <intent-filter>


### PR DESCRIPTION
Before we allowed on QtActivity the orientation change  and on QFieldActivity we locket the orientation  Meanwhile QFieldActivity extends QtActivity and the orientation is locked and allowed in the changes for the  same activity. This leaded to the issue, that the screen does not rotate anymore.