### PR TITLE
Use QgsLayoutExporter's exportToPdf instead of a QPrinter

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -817,24 +817,25 @@ void QgisMobileapp::print( int layoutIndex )
     return;
 
   layoutToPrint->referenceMap()->zoomToExtent( mMapCanvas->mapSettings()->visibleExtent() );
+  layoutToPrint->refresh();
 
-  QPrinter printer;
   QString documentsLocation = QStringLiteral( "%1/QField" ).arg( QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) );
   QDir documentsDir( documentsLocation );
   if ( !documentsDir.exists() )
     documentsDir.mkpath( "." );
+  const QString destination = documentsLocation  + '/' + layoutToPrint->name() + QStringLiteral( ".pdf" );
 
-  printer.setOutputFileName( documentsLocation  + '/' + layoutToPrint->name() + QStringLiteral( ".pdf" ) );
-
-  QgsLayoutExporter::PrintExportSettings printSettings;
-  printSettings.rasterizeWholeImage = layoutToPrint->customProperty( QStringLiteral( "rasterize" ), false ).toBool();
-
-  layoutToPrint->refresh();
+  QgsLayoutExporter::PdfExportSettings pdfSettings;
+  pdfSettings.rasterizeWholeImage = layoutToPrint->customProperty( QStringLiteral( "rasterize" ), false ).toBool();
+  pdfSettings.dpi = layoutToPrint->renderContext().dpi();
+  pdfSettings.appendGeoreference = true;
+  pdfSettings.exportMetadata = true;
+  pdfSettings.simplifyGeometries = true;
 
   QgsLayoutExporter exporter = QgsLayoutExporter( layoutToPrint );
-  exporter.print( printer, printSettings );
+  exporter.exportToPdf( destination, pdfSettings );
 
-  PlatformUtilities::instance()->open( printer.outputFileName() );
+  PlatformUtilities::instance()->open( destination );
 }
 
 bool QgisMobileapp::event( QEvent *event )


### PR DESCRIPTION
Instant gratification:
- Exported PDFs will have project metadata added (a few clients should be happy about that)
- Georeferenced PDFs out of the box (possible since the addition of the PDF driver to the OSGeo4A GDAL library)
- Geometry simplification for smaller file sizes

It's also future-proof and far more tested in QGIS than its old QPrinter alternative.