### PR TITLE
Enable some form of jpg support to poppler to anvoid blank pages

### DIFF
--- a/sdk.conf
+++ b/sdk.conf
@@ -1,1 +1,1 @@
-osgeo4a_version=20210203
+osgeo4a_version=20210210


### PR DESCRIPTION
Without enabling one JPG decoder in poppler, GDAL ended up only rendering the vector elements. 

We can get away with enabling poppler's internal jpg decoder and get proper rendering. Sweet.