### PR TITLE
Fix remembered values regression (fixes #1673)

### DIFF
--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -431,8 +431,15 @@ bool FeatureModel::suppressFeatureForm() const
 
 void FeatureModel::resetFeature()
 {
-    mFeature = mLayer ? QgsFeature( mLayer->fields() ) : QgsFeature();
-    mRememberings[mLayer].rememberedAttributes.fill( false, mLayer->fields().size() );
+  if ( !mLayer )
+    return;
+
+  if ( mRememberings.contains( mLayer ) )
+  {
+    mRememberings[mLayer].rememberedFeature = mFeature;
+  }
+
+  mFeature = QgsFeature( mLayer->fields() );
 }
 
 void FeatureModel::resetAttributes()
@@ -478,6 +485,10 @@ void FeatureModel::resetAttributes()
       {
         mFeature.setAttribute( i, QVariant() );
       }
+    }
+    else if ( mRememberings[mLayer].rememberedAttributes.at( i ) )
+    {
+      mFeature.setAttribute( i, mRememberings[mLayer].rememberedFeature.attribute( i ) );
     }
   }
   endResetModel();

--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -51,9 +51,6 @@ EditorWidgetBase {
     }
 
     onTextChanged: {
-      if ( value != undefined && value != text )
-        value = text
-
       valueChanged( text, text == '' )
     }
   }


### PR DESCRIPTION
@m-kuhn , as  discussed.

While debugging this, I've spotted another issue whereas _range_ widgets (i.e. numbers) don't reset values across feature addition when values are set to _not_ be remembered. 

Couldn't figure out why that is happening. The underlying model properly resets the value. 