### PR TITLE
When re-loadind a project, restore last viewed extent

### DIFF
--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -49,6 +49,11 @@ void AppInterface::readProject()
   return mApp->readProjectFile();
 }
 
+void AppInterface::saveProjectExtent( const QgsRectangle &extent )
+{
+  return mApp->saveProjectExtent( extent );
+}
+
 void AppInterface::print( int layoutIndex )
 {
   return mApp->print( layoutIndex );

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -44,6 +44,8 @@ class AppInterface : public QObject
     Q_INVOKABLE void readProject();
     Q_INVOKABLE void removeRecentProject( const QString &path );
 
+    Q_INVOKABLE void saveProjectExtent( const QgsRectangle &extent );
+
     Q_INVOKABLE void print( int layoutIndex );
 
   public slots:

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -800,10 +800,53 @@ void QgisMobileapp::readProjectFile()
 
   emit loadProjectEnded();
 
+  QgsRectangle projectExtent = getProjectExtent( mProjectFilePath );
+  if ( !projectExtent.isEmpty() )
+    extent = projectExtent;
+
   if ( !extent.isEmpty() && extent.width() != 0.0 )
   {
     // Add a bit of buffer so elements don't touch the map edges
     emit setMapExtent( extent.buffered( extent.width() * 0.02 ) );
+  }
+}
+
+QgsRectangle QgisMobileapp::getProjectExtent( const QString &path )
+{
+  QgsRectangle extent;
+
+  QFileInfo fi( path );
+  if ( fi.exists() )
+  {
+    QSettings settings;
+    QStringList parts = settings.value( QStringLiteral( "/qgis/projectExtent/%1/extent" ).arg( path ), QString() ).toString().split( '|' );
+    if ( parts.size() == 4 &&
+         ( SUPPORTED_PROJECT_EXTENSIONS.contains( fi.suffix().toLower() ) ||
+           fi.size() == settings.value( QStringLiteral( "/qgis/projectExtent/%1/filesize" ).arg( path ), 0 ).toLongLong() ) )
+    {
+      extent.setXMinimum( parts[0].toDouble() );
+      extent.setXMaximum( parts[1].toDouble() );
+      extent.setYMinimum( parts[2].toDouble() );
+      extent.setYMaximum( parts[3].toDouble() );
+    }
+  }
+
+  return extent;
+}
+
+void QgisMobileapp::saveProjectExtent( const QgsRectangle &extent )
+{
+  QFileInfo fi( mProjectFilePath );
+  if ( fi.exists() )
+  {
+    QSettings settings;
+    settings.beginGroup( QStringLiteral( "/qgis/projectExtent/%1" ).arg( mProjectFilePath ) );
+    settings.setValue( QStringLiteral( "filesize" ), fi.size() );
+    settings.setValue( QStringLiteral( "extent" ), QStringLiteral( "%1|%2|%3|%4" ).arg( qgsDoubleToString( extent.xMinimum() ),
+                                                                                        qgsDoubleToString( extent.xMaximum() ),
+                                                                                        qgsDoubleToString( extent.yMinimum() ),
+                                                                                        qgsDoubleToString( extent.yMaximum() ) ) );
+    settings.endGroup();
   }
 }
 

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -113,6 +113,10 @@ class QgisMobileapp : public QQmlApplicationEngine
      */
     void readProjectFile();
 
+    void saveProjectExtent( const QgsRectangle &extent );
+
+    QgsRectangle getProjectExtent( const QString &path );
+
     void print( int layoutIndex );
 
     bool event( QEvent *event ) override;

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1752,6 +1752,22 @@ ApplicationWindow {
     }
   }
 
+  Timer {
+    id: saveProjectExtentTimer
+
+    interval: 500
+    repeat: false
+    onTriggered: iface.saveProjectExtent(mapCanvas.mapSettings.extent)
+  }
+
+  Connections {
+      target: mapCanvas.mapSettings
+
+      function onExtentChanged() {
+          saveProjectExtentTimer.restart();
+      }
+  }
+
   BusyIndicator {
     id: busyIndicator
     anchors.left: mainMenuBar.left


### PR DESCRIPTION
Title says it all. With this PR, QField will restore the last viewed map extent when re-loading a project that was previously opened by QField. This improves quality of life by a lot.

The implementation is cloud-stored project friendly as it doesn't save the project itself but rather store the extent in the user settings. This means a large cloud-stored project can have many users focused on their own specific extents, remember those without interfering with others.

There's a project/dataset file size check here to reset extent whenever the file size has changed. That's to avoid restore an extent that would have been invalidated by changes to project/dataset.

