### PR TITLE
Improve project extent saving and add map theme saving

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -33,6 +33,7 @@ SET(QFIELD_CORE_SRCS
   picturesource.cpp
   platformutilities.cpp
   printlayoutlistmodel.cpp
+  projectinfo.cpp
   projectsource.cpp
   qfieldappauthrequesthandler.cpp
   qgismobileapp.cpp
@@ -108,6 +109,7 @@ SET(QFIELD_CORE_HDRS
   picturesource.h
   platformutilities.h
   printlayoutlistmodel.h
+  projectinfo.h
   projectsource.h
   qfieldappauthrequesthandler.h
   qgismobileapp.h

--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -49,11 +49,6 @@ void AppInterface::readProject()
   return mApp->readProjectFile();
 }
 
-void AppInterface::saveProjectExtent( const QgsRectangle &extent )
-{
-  return mApp->saveProjectExtent( extent );
-}
-
 void AppInterface::print( int layoutIndex )
 {
   return mApp->print( layoutIndex );

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -44,8 +44,6 @@ class AppInterface : public QObject
     Q_INVOKABLE void readProject();
     Q_INVOKABLE void removeRecentProject( const QString &path );
 
-    Q_INVOKABLE void saveProjectExtent( const QgsRectangle &extent );
-
     Q_INVOKABLE void print( int layoutIndex );
 
   public slots:

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -54,7 +54,7 @@ class AppInterface : public QObject
 
     void loadProjectTriggered( const QString &path, const QString &name );
 
-    void loadProjectEnded();
+    void loadProjectEnded( const QString &path, const QString &name );
 
     void setMapExtent( const QgsRectangle &extent );
 

--- a/src/core/projectinfo.cpp
+++ b/src/core/projectinfo.cpp
@@ -1,0 +1,120 @@
+/***************************************************************************
+  projectinfo.cpp - ProjectInfo
+
+ ---------------------
+ begin                : 14.2.2021
+ copyright            : (C) 2021 by Mathieu Pellerin
+ email                : nirvn dot asia at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "projectinfo.h"
+
+#include <QFileInfo>
+#include <QSettings>
+#include <QString>
+
+ProjectInfo::ProjectInfo( QObject *parent ) : QObject( parent )
+{
+  mSaveExtentTimer.setSingleShot( true );
+  connect( &mSaveExtentTimer, &QTimer::timeout, this, &ProjectInfo::extentChanged );
+}
+
+void ProjectInfo::setFilePath( const QString &filePath )
+{
+  if ( mFilePath == filePath )
+    return;
+  
+  mFilePath = filePath;
+  
+  emit filePathChanged();
+}
+
+QString ProjectInfo::filePath() const
+{
+  return mFilePath;
+}
+
+void ProjectInfo::setMapSettings( QgsQuickMapSettings *mapSettings )
+{
+  if ( !mapSettings )
+    return;
+
+  if ( mMapSettings )
+  {
+    disconnect( mMapSettings, &QgsQuickMapSettings::extentChanged, this, &ProjectInfo::extentChanged );
+  }
+  
+  mMapSettings = mapSettings;
+  connect( mMapSettings, &QgsQuickMapSettings::extentChanged, this, [=] { mSaveExtentTimer.start( 750 ); } );
+  
+  emit mapSettingsChanged();
+}
+
+QgsQuickMapSettings *ProjectInfo::mapSettings() const
+{
+  return mMapSettings;
+}
+
+void ProjectInfo::setLayerTree( FlatLayerTreeModel *layerTree )
+{
+  if ( !layerTree )
+    return;
+
+  if ( mLayerTree )
+  {
+    disconnect( mLayerTree, &FlatLayerTreeModel::mapThemeChanged, this, &ProjectInfo::mapThemeChanged );
+  }
+
+  mLayerTree = layerTree;
+  connect( mLayerTree, &FlatLayerTreeModel::mapThemeChanged, this, &ProjectInfo::mapThemeChanged );
+
+  emit layerTreeChanged();
+}
+
+FlatLayerTreeModel *ProjectInfo::layerTree() const
+{
+  return mLayerTree;
+}
+
+void ProjectInfo::extentChanged()
+{
+  if ( mFilePath.isEmpty() )
+    return;
+
+  QFileInfo fi( mFilePath );
+  if ( fi.exists() )
+  {
+    QSettings settings;
+    const QgsRectangle extent = mMapSettings->extent();
+    settings.beginGroup( QStringLiteral( "/qgis/projectInfo/%1" ).arg( mFilePath ) );
+    settings.setValue( QStringLiteral( "filesize" ), fi.size() );
+    settings.setValue( QStringLiteral( "extent" ), QStringLiteral( "%1|%2|%3|%4" ).arg( qgsDoubleToString( extent.xMinimum() ),
+                                                                                        qgsDoubleToString( extent.xMaximum() ),
+                                                                                        qgsDoubleToString( extent.yMinimum() ),
+                                                                                        qgsDoubleToString( extent.yMaximum() ) ) );
+    settings.endGroup();
+  }
+}
+
+void ProjectInfo::mapThemeChanged()
+{
+  if ( mFilePath.isEmpty() )
+    return;
+
+  QFileInfo fi( mFilePath );
+  if ( fi.exists() )
+  {
+    QSettings settings;
+    settings.beginGroup( QStringLiteral( "/qgis/projectInfo/%1" ).arg( mFilePath ) );
+    settings.setValue( QStringLiteral( "maptheme" ), mLayerTree->mapTheme() );
+    settings.endGroup();
+  }
+}

--- a/src/core/projectinfo.h
+++ b/src/core/projectinfo.h
@@ -1,0 +1,83 @@
+/***************************************************************************
+  projectinfo.h - ProjectInfo
+
+ ---------------------
+ begin                : 14.2.2021
+ copyright            : (C) 2021 by Mathieu Pellerin
+ email                : nirvn dot asia at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef PROJECTINFO_H
+#define PROJECTINFO_H
+
+#include "qgsquickmapsettings.h"
+#include "layertreemodel.h"
+
+#include <QObject>
+
+/**
+ * This class stores current projection information such as
+ * extent and map theme in order for those to be saved and
+ * afterwards restored when the project is re-opened
+ */
+class ProjectInfo : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY( QString filePath READ filePath WRITE setFilePath NOTIFY filePathChanged )
+    
+    Q_PROPERTY( QgsQuickMapSettings *mapSettings READ mapSettings WRITE setMapSettings NOTIFY mapSettingsChanged )
+
+    Q_PROPERTY( FlatLayerTreeModel *layerTree READ layerTree WRITE setLayerTree NOTIFY layerTreeChanged )
+
+  public:
+  
+    explicit ProjectInfo( QObject *parent = nullptr );
+
+    virtual ~ProjectInfo() = default;
+
+    void setFilePath( const QString &filePath );
+    
+    QString filePath() const;
+
+    void setMapSettings( QgsQuickMapSettings *mapSettings );
+    
+    QgsQuickMapSettings *mapSettings() const;
+
+    void setLayerTree( FlatLayerTreeModel *layerTree );
+
+    FlatLayerTreeModel *layerTree() const;
+
+  signals:
+  
+    void filePathChanged();
+    
+    void mapSettingsChanged();
+
+    void layerTreeChanged();
+
+  private slots:
+
+    void extentChanged();
+
+    void mapThemeChanged();
+
+  private:
+  
+    QString mFilePath;
+
+    QgsQuickMapSettings *mMapSettings = nullptr;
+    QTimer mSaveExtentTimer;
+
+    FlatLayerTreeModel *mLayerTree = nullptr;
+};
+
+#endif // PROJECTINFO_H

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -824,7 +824,7 @@ void QgisMobileapp::readProjectFile()
   if ( !mapTheme.isEmpty() )
     mFlatLayerTree->setMapTheme( mapTheme );
 
-  emit loadProjectEnded();
+  emit loadProjectEnded( mProjectFilePath, mProjectFileName );
 }
 
 void QgisMobileapp::print( int layoutIndex )

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -129,7 +129,7 @@ class QgisMobileapp : public QQmlApplicationEngine
     /**
      * Emitted when the project is fully loaded
      */
-    void loadProjectEnded();
+    void loadProjectEnded( const QString &filename, const QString &name );
 
     /**
      * Emitted when a map canvas extent change is needed

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -113,10 +113,6 @@ class QgisMobileapp : public QQmlApplicationEngine
      */
     void readProjectFile();
 
-    void saveProjectExtent( const QgsRectangle &extent );
-
-    QgsRectangle getProjectExtent( const QString &path );
-
     void print( int layoutIndex );
 
     bool event( QEvent *event ) override;

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1733,10 +1733,14 @@ ApplicationWindow {
 
       function onLoadProjectTriggered(path,name) {
         welcomeScreen.visible = false
+
         dashBoard.layerTree.freeze()
         mapCanvasMap.freeze('projectload')
+
         busyMessageText.text = qsTr( "Loading %1" ).arg( name !== '' ? name : path )
         busyMessage.state = "visible"
+
+        projectInfo.filePath = path;
         readProjectTimer.start()
       }
 
@@ -1752,20 +1756,11 @@ ApplicationWindow {
     }
   }
 
-  Timer {
-    id: saveProjectExtentTimer
+  ProjectInfo {
+    id: projectInfo
 
-    interval: 500
-    repeat: false
-    onTriggered: iface.saveProjectExtent(mapCanvas.mapSettings.extent)
-  }
-
-  Connections {
-      target: mapCanvas.mapSettings
-
-      function onExtentChanged() {
-          saveProjectExtentTimer.restart();
-      }
+    mapSettings: mapCanvas.mapSettings
+    layerTree: dashBoard.layerTree
   }
 
   BusyIndicator {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1740,13 +1740,16 @@ ApplicationWindow {
         busyMessageText.text = qsTr( "Loading %1" ).arg( name !== '' ? name : path )
         busyMessage.state = "visible"
 
-        projectInfo.filePath = path;
+        projectInfo.filePath = '';
         readProjectTimer.start()
       }
 
-      function onLoadProjectEnded() {
+      function onLoadProjectEnded(path,name) {
         mapCanvasMap.unfreeze('projectload')
         busyMessage.state = "hidden"
+
+        projectInfo.filePath = path;
+
         mapCanvasBackground.color = mapCanvas.mapSettings.backgroundColor
       }
 


### PR DESCRIPTION
@m-kuhn , OK, I give up, I'll do the right thing (tm) :wink: and while doing so, add restore last used map theme when reloading project :tada: 

Note: I'm using a pointer to the layer tree property here (instead of say a map theme string) as it unlocks more doors for the future, e.g. saving / restoring visibility of individual layers. Full disclosure: I'm not going to go there now, just stating it as a possibility for the future.