### PR TITLE
When freezing the map canvas, stop any rendering job in progress

### DIFF
--- a/src/core/qgsquick/qgsquickmapcanvasmap.cpp
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.cpp
@@ -140,6 +140,9 @@ void QgsQuickMapCanvasMap::refreshMap()
 
 void QgsQuickMapCanvasMap::renderJobUpdated()
 {
+  if ( !mJob )
+    return;
+
   mImage = mJob->renderedImage();
   mImageMapSettings = mJob->mapSettings();
   mDirty = true;
@@ -155,6 +158,9 @@ void QgsQuickMapCanvasMap::renderJobUpdated()
 
 void QgsQuickMapCanvasMap::renderJobFinished()
 {
+  if ( !mJob )
+    return;
+
   const QgsMapRendererJob::Errors errors = mJob->errors();
   for ( const QgsMapRendererJob::Error &error : errors )
   {
@@ -275,7 +281,9 @@ void QgsQuickMapCanvasMap::setFreeze( bool freeze )
 
   mFreeze = freeze;
 
-  if ( !mFreeze )
+  if ( mFreeze )
+    stopRendering();
+  else
     refresh();
 
   emit freezeChanged();


### PR DESCRIPTION
When the map canvas is frozen (when zooming / panning), any ongoing rendering job should be stopped to prevent "jaggy" panning / zooming of map. Thanks to the recent work by @nyalldawson , we can now do that without losing any of the progressively rendered layers' cache. 

The end result is a smooth panning without any visual cost. 