### PR TITLE
Hide keyboard on list view move started

### DIFF
--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -240,6 +240,10 @@ Item {
               }
             }
           }
+
+          onMovementStarted: {
+            Qt.inputMethod.hide()
+          }
         }
       }
     }


### PR DESCRIPTION
The trouble of selecting values under the android keyboard should be gone and fix #1579. If one tries to scroll, the keyboard disappears.