### PR TITLE
Support file association against _running_ QField instance

### DIFF
--- a/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -57,8 +57,8 @@ import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Environment;
-import android.support.v4.app.ActivityCompat; 
-import android.support.v4.content.ContextCompat; 
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 
 import org.qtproject.qt5.android.bindings.QtActivity;
 
@@ -67,6 +67,9 @@ import ch.opengis.qfield.QFieldUtils;
 
 
 public class QFieldActivity extends QtActivity {
+
+    public static native void openProject(String url);
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         prepareQtActivity();
@@ -76,6 +79,11 @@ public class QFieldActivity extends QtActivity {
     @Override
     public void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
+        if (intent.getAction() == Intent.ACTION_VIEW) {
+            Uri uri = intent.getData();
+            Context context = getApplication().getApplicationContext();
+            openProject(QFieldUtils.getPathFromUri(context, uri));
+        }
     }
 
     private void prepareQtActivity() {

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -62,7 +62,8 @@ if [[ -n ${APP_ICON} ]]; then
 fi
 if [[ "X${APP_PACKAGE_NAME}" != "Xqfield" ]]; then
   grep "ch.opengis.qfield" -l -r ${SOURCE_DIR}/android/ | xargs sed -i "s/ch.opengis.qfield/ch.opengis.${APP_PACKAGE_NAME}/g"
-  grep "ch.opengis.qfield" -l -r ${SOURCE_DIR}/src/ | xargs sed -i "s/ch.opengis.qfield/ch.opengis.${APP_PACKAGE_NAME}/g"
+  grep "ch\.opengis\.qfield" -l -r ${SOURCE_DIR}/src/ | xargs sed -i "s/ch\.opengis\.qfield/ch.opengis.${APP_PACKAGE_NAME}/g"
+  sed -i "s/ch_opengis_qfield/ch_opengis_${APP_PACKAGE_NAME//_/_1}/g" ${SOURCE_DIR}/src/core/androidplatformutilities.cpp
   mv ${SOURCE_DIR}/android/src/ch/opengis/qfield ${SOURCE_DIR}/android/src/ch/opengis/${APP_PACKAGE_NAME}
   sed -i "s|<string name=\"app_name\" translatable=\"false\">QField</string>|<string name=\"app_name\" translatable=\"false\">${APP_NAME}</string>|" ${SOURCE_DIR}/android/res/values/strings.xml
 fi

--- a/src/core/androidplatformutilities.cpp
+++ b/src/core/androidplatformutilities.cpp
@@ -20,6 +20,7 @@
 #include "androidpicturesource.h"
 #include "androidprojectsource.h"
 #include "androidviewstatus.h"
+#include "appinterface.h"
 #include "feedback.h"
 #include "fileutils.h"
 
@@ -35,6 +36,8 @@
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
 #include <QThread>
+
+#include <jni.h>
 
 AndroidPlatformUtilities::AndroidPlatformUtilities()
   : mActivity( QtAndroid::androidActivity() )
@@ -365,5 +368,24 @@ void AndroidPlatformUtilities::showRateThisApp() const
 
   QtAndroid::startActivity( intent.object<jobject>(), 104 );
 }
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+JNIEXPORT void JNICALL Java_ch_opengis_qfield_QFieldActivity_openProject( JNIEnv *env, jobject obj, jstring path )
+{
+  if ( AppInterface::instance() )
+  {
+    const char *pathStr = env->GetStringUTFChars( path, NULL );
+    AppInterface::instance()->loadFile( QString( pathStr ) );
+    env->ReleaseStringUTFChars( path, pathStr );
+  }
+  return;
+}
+
+#ifdef __cplusplus
+}
+#endif
 
 #include "androidplatformutilities.moc"

--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -18,6 +18,8 @@
 #include "appinterface.h"
 #include "qgismobileapp.h"
 
+AppInterface *AppInterface::sAppInterface = nullptr;
+
 AppInterface::AppInterface( QgisMobileapp *app )
   : mApp( app )
 {

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -43,8 +43,10 @@ class AppInterface : public QObject
     Q_INVOKABLE void reloadProject();
     Q_INVOKABLE void readProject();
     Q_INVOKABLE void removeRecentProject( const QString &path );
-
     Q_INVOKABLE void print( int layoutIndex );
+
+    static void setInstance( AppInterface *instance ) { sAppInterface = instance; }
+    static AppInterface *instance() { return sAppInterface; }
 
   public slots:
     void openFeatureForm();
@@ -59,6 +61,8 @@ class AppInterface : public QObject
     void setMapExtent( const QgsRectangle &extent );
 
   private:
+    static AppInterface *sAppInterface;
+
     QgisMobileapp *mApp = nullptr;
 };
 

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -139,6 +139,8 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   create();
 #endif
 
+  AppInterface::setInstance( mIface );
+
   //set the authHandler to qfield-handler
   std::unique_ptr<QgsNetworkAuthenticationHandler> handler;
   mAuthRequestHandler = new QFieldAppAuthRequestHandler();


### PR DESCRIPTION
If QField is already running, opening a QGIS project file via file association would bring QField in the foreground but fail to actually load the file.

This PR adds file association handling against a running QField instance :partying_face: .
