### PR TITLE
Make use of dataset's default styles if present

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -177,7 +177,7 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   QFontDatabase::addApplicationFont( ":/fonts/CadastraSymbol-Regular.ttf" );
 
   mProject = QgsProject::instance();
-  mGpkgFlusher = qgis::make_unique<QgsGpkgFlusher>( mProject );
+  mGpkgFlusher = std::make_unique<QgsGpkgFlusher>( mProject );
   mFlatLayerTree = new FlatLayerTreeModel( mProject->layerTreeRoot(), mProject, this );
   mLegendImageProvider = new LegendImageProvider( mFlatLayerTree->layerTreeModel() );
   mTrackingModel = new TrackingModel;

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -660,11 +660,16 @@ void QgisMobileapp::readProjectFile()
       for( QgsMapLayer *l : vectorLayers )
       {
         QgsVectorLayer *vlayer = qobject_cast< QgsVectorLayer * >( l );
-        QgsSymbol *symbol = FeatureUtils::defaultSymbol( vlayer );
-        if ( symbol )
+        bool ok;
+        vlayer->loadDefaultStyle( ok );
+        if ( !ok )
         {
-          QgsSingleSymbolRenderer *renderer = new QgsSingleSymbolRenderer( symbol );
-          vlayer->setRenderer( renderer );
+          QgsSymbol *symbol = FeatureUtils::defaultSymbol( vlayer );
+          if ( symbol )
+          {
+            QgsSingleSymbolRenderer *renderer = new QgsSingleSymbolRenderer( symbol );
+            vlayer->setRenderer( renderer );
+          }
         }
       }
 
@@ -748,12 +753,14 @@ void QgisMobileapp::readProjectFile()
         rasterLayers << layer;
       }
 
-      // If the raster size is reasonably small, apply nicer resampling settings
-      if ( fi.size() < 50000000 )
+      for( QgsMapLayer *l : rasterLayers )
       {
-        for( QgsMapLayer *l : rasterLayers )
+        QgsRasterLayer *rlayer = qobject_cast< QgsRasterLayer * >( l );
+        bool ok;
+        rlayer->loadDefaultStyle( ok );
+        if ( !ok && fi.size() < 50000000 )
         {
-          QgsRasterLayer *rlayer = qobject_cast< QgsRasterLayer * >( l );
+          // If the raster size is reasonably small, apply nicer resampling settings
           rlayer->resampleFilter()->setZoomedInResampler( new QgsBilinearRasterResampler() );
           rlayer->resampleFilter()->setZoomedOutResampler( new QgsBilinearRasterResampler() );
           rlayer->resampleFilter()->setMaxOversampling( 2.0 );

--- a/src/core/qgsquick/qgsquickmapcanvasmap.cpp
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.cpp
@@ -32,7 +32,7 @@
 
 QgsQuickMapCanvasMap::QgsQuickMapCanvasMap( QQuickItem *parent )
   : QQuickItem( parent )
-  , mMapSettings( qgis::make_unique<QgsQuickMapSettings>() )
+  , mMapSettings( std::make_unique<QgsQuickMapSettings>() )
 {
   connect( this, &QQuickItem::windowChanged, this, &QgsQuickMapCanvasMap::onWindowChanged );
   connect( &mRefreshTimer, &QTimer::timeout, this, &QgsQuickMapCanvasMap::refreshMap );

--- a/src/core/utils/geometryutils.cpp
+++ b/src/core/utils/geometryutils.cpp
@@ -33,7 +33,7 @@ QgsGeometry GeometryUtils::polygonFromRubberband( RubberbandModel *rubberBandMod
 {
   QgsPointSequence ring = rubberBandModel->pointSequence( crs, QgsWkbTypes::Point, true );
   QgsLineString ext( ring );
-  std::unique_ptr< QgsPolygon > polygon = qgis::make_unique< QgsPolygon >( );
+  std::unique_ptr< QgsPolygon > polygon = std::make_unique< QgsPolygon >( );
   polygon->setExteriorRing( ext.clone() );
   QgsGeometry g( std::move( polygon ) );
   return g;

--- a/src/core/vertexmodel.cpp
+++ b/src/core/vertexmodel.cpp
@@ -354,12 +354,12 @@ QgsGeometry VertexModel::geometry() const
     }
     case QgsWkbTypes::PolygonGeometry:
     {
-      std::unique_ptr<QgsLineString> ls( qgis::make_unique<QgsLineString>( vertices ) );
-      std::unique_ptr<QgsPolygon> polygon( qgis::make_unique<QgsPolygon>() );
+      std::unique_ptr<QgsLineString> ls( std::make_unique<QgsLineString>( vertices ) );
+      std::unique_ptr<QgsPolygon> polygon( std::make_unique<QgsPolygon>() );
       polygon->setExteriorRing( ls.release() );
       for ( int r = 1; r <= ringCount(); r++ )
       {
-        std::unique_ptr<QgsLineString> ring( qgis::make_unique<QgsLineString>( flatVertices( r ) ) );
+        std::unique_ptr<QgsLineString> ring( std::make_unique<QgsLineString>( flatVertices( r ) ) );
         polygon->addInteriorRing( ring.release() );
       }
       geometry.set( polygon.release() );


### PR DESCRIPTION
This PR applies datasets' default style (i.e., embedded into a gpkg database or served through a side .qml file) when present. This means not only symbology but also customized feature form, etc.

https://user-images.githubusercontent.com/1728657/109104224-2ff2bb00-775e-11eb-8916-168b74d0b11c.mp4

