### PR TITLE
Proper way to handle ZIP container, unlock mixed vector / raster dataset loading

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -631,7 +631,7 @@ void QgisMobileapp::readProjectFile()
     files << mProjectFilePath;
   }
 
-  for ( auto filePath : files )
+  for ( auto filePath : std::as_const( files ) )
   {
     // Load vector dataset
     if ( SUPPORTED_VECTOR_EXTENSIONS.contains( suffix ) )
@@ -698,7 +698,7 @@ void QgisMobileapp::readProjectFile()
           vectorLayers << layer;
         }
 
-        for( QgsMapLayer *l : vectorLayers )
+        for( QgsMapLayer *l : std::as_const( vectorLayers ) )
         {
           QgsVectorLayer *vlayer = qobject_cast< QgsVectorLayer * >( l );
           bool ok;
@@ -794,7 +794,7 @@ void QgisMobileapp::readProjectFile()
           rasterLayers << layer;
         }
 
-        for( QgsMapLayer *l : rasterLayers )
+        for( QgsMapLayer *l : std::as_const( rasterLayers ) )
         {
           QgsRasterLayer *rlayer = qobject_cast< QgsRasterLayer * >( l );
           bool ok;

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -24,8 +24,9 @@
 
 // use GDAL VSI mechanism
 #define CPL_SUPRESS_CPLUSPLUS  //#spellok
-#include "cpl_vsi.h"
+#include "cpl_conv.h"
 #include "cpl_string.h"
+#include "cpl_vsi.h"
 
 #include <QFontDatabase>
 #include <QStandardPaths>
@@ -267,6 +268,9 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   mSettings.setValue( "/Map/searchRadiusMM", 5 );
 
   mAppMissingGridHandler = new AppMissingGridHandler( this );
+
+  // Set GDAL option to fix loading of datasets within ZIP containers
+  CPLSetConfigOption( "CPL_ZIP_ENCODING", "UTF-8" );
 }
 
 void QgisMobileapp::initDeclarative()


### PR DESCRIPTION
@m-kuhn , I pushed the merge button a bit too quickly here.

The PR is changing ZIP handling so we can open both vector and raster datasets. The actual vector / raster dataset opening is _only indent changes_, the part added is line 606 to 630 (which has been tested in QGIS's browser panel for ages (see QgsZipItem class).