### PR TITLE
Avoid transforming empty geometry in LinePolygonHighlight

### DIFF
--- a/src/core/linepolygonhighlight.cpp
+++ b/src/core/linepolygonhighlight.cpp
@@ -37,18 +37,13 @@ QSGNode *LinePolygonHighlight::updatePaintNode( QSGNode *n, QQuickItem::UpdatePa
     delete n;
     n = new QSGNode;
 
-    QgsGeometry geometry;
-    if ( mGeometry )
+    QgsGeometry geometry( mGeometry ? mGeometry->qgsGeometry() : QgsGeometry() );
+    if ( mGeometry && !geometry.isEmpty() )
     {
-      Q_ASSERT( mGeometry->qgsGeometry().type() != QgsWkbTypes::PointGeometry );
+      Q_ASSERT( geometry.type() != QgsWkbTypes::PointGeometry );
 
-      geometry = QgsGeometry( mGeometry->qgsGeometry() );
-
-      if ( mMapSettings )
-      {
-        QgsCoordinateTransform ct( mGeometry->crs(), mMapSettings->destinationCrs(), QgsProject::instance()->transformContext() );
-        geometry.transform( ct );
-      }
+      QgsCoordinateTransform ct( mGeometry->crs(), mMapSettings->destinationCrs(), QgsProject::instance()->transformContext() );
+      geometry.transform( ct );
     }
 
     QgsSGGeometry *gn = new QgsSGGeometry( geometry, mColor, mWidth, mMapSettings->visibleExtent(), 1.0 / mMapSettings->mapUnitsPerPoint() );


### PR DESCRIPTION
@m-kuhn , I think this might fix / help avoid the crash you were witnessing yesterday. 