### PR TITLE
Message log improvements

### DIFF
--- a/src/core/messagelogmodel.cpp
+++ b/src/core/messagelogmodel.cpp
@@ -77,6 +77,13 @@ void MessageLogModel::unsuppressTags( const QList <QString> &tags )
   }
 }
 
+void MessageLogModel::clear()
+{
+  beginResetModel();
+  mMessages.clear();
+  endResetModel();
+}
+
 void MessageLogModel::onMessageReceived( const QString &message, const QString &tag, Qgis::MessageLevel level )
 {
   if ( mSuppressedTags.contains( tag ) )

--- a/src/core/messagelogmodel.h
+++ b/src/core/messagelogmodel.h
@@ -68,6 +68,8 @@ class MessageLogModel : public QAbstractListModel
     //! deactivates suppression of messages wit specific tags
     Q_INVOKABLE void unsuppressTags( const QList <QString> &tags );
 
+    Q_INVOKABLE void clear();
+
   private slots:
     void onMessageReceived( const QString &message, const QString &tag, Qgis::MessageLevel level );
 

--- a/src/core/messagelogmodel.h
+++ b/src/core/messagelogmodel.h
@@ -68,6 +68,7 @@ class MessageLogModel : public QAbstractListModel
     //! deactivates suppression of messages wit specific tags
     Q_INVOKABLE void unsuppressTags( const QList <QString> &tags );
 
+    //! Clears any messages from the log
     Q_INVOKABLE void clear();
 
   private slots:

--- a/src/qml/MessageLog.qml
+++ b/src/qml/MessageLog.qml
@@ -72,10 +72,37 @@ Page {
               text: Message
               wrapMode: Text.WordWrap
               textFormat: Text.RichText
+
+              MouseArea {
+                anchors.fill: parent
+                onClicked:
+                {
+                    copyHelper.text = messagetext.text
+                    copyHelper.selectAll()
+                    copyHelper.copy()
+                    displayToast(qsTr("Message text copied"))
+                }
+              }
             }
           }
         }
       }
+    }
+
+    TextEdit{
+        id: copyHelper
+        visible: false
+    }
+
+    QfButton {
+        text: qsTr("Clear message log")
+        anchors.left: parent.left
+        anchors.right: parent.right
+        onClicked:
+        {
+            table.model.clear()
+            displayToast(qsTr("Message log cleared"))
+        }
     }
   }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1356,6 +1356,21 @@ ApplicationWindow {
       }
     }
 
+    MenuItem {
+      text: qsTr( "Message Log" )
+
+      font: Theme.defaultFont
+      height: 48
+      leftPadding: 10
+
+      onTriggered: {
+        dashBoard.close()
+        messageLog.visible = true
+      }
+    }
+
+
+
     Connections {
         target: printMenu
 


### PR DESCRIPTION
- Button to clear the message log
- Button in the main menu to open the message log on demand
- Click on message log entry will copy the text
![Peek 2021-02-28 10-39](https://user-images.githubusercontent.com/588407/109414206-00d48780-79b2-11eb-89d1-8a1f1222c13d.gif)


Fixes #1723