### PR TITLE
Generate export headers for qfield_core

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -167,8 +167,12 @@ FIND_PACKAGE(Sqlite3)
 
 ADD_LIBRARY(qfield_core SHARED ${QFIELD_CORE_SRCS} ${QFIELD_CORE_HDRS})
 
+include(GenerateExportHeader)
+generate_export_header(qfield_core)
+
 TARGET_INCLUDE_DIRECTORIES(qfield_core SYSTEM PUBLIC 
-  ${QGIS_INCLUDE_DIR}  
+  ${QGIS_INCLUDE_DIR}
+  ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 TARGET_INCLUDE_DIRECTORIES(qfield_core SYSTEM PRIVATE 

--- a/src/core/platformutilities.h
+++ b/src/core/platformutilities.h
@@ -26,9 +26,11 @@
 #include "picturesource.h"
 #include "viewstatus.h"
 
+#include "qfield_core_export.h"
+
 class ProjectSource;
 
-class PlatformUtilities : public QObject
+class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
 {
     Q_OBJECT
 

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -38,6 +38,8 @@
 
 #include "qfieldappauthrequesthandler.h"
 
+#include "qfield_core_export.h"
+
 #include "platformutilities.h"
 #if defined(Q_OS_ANDROID)
 #include "androidplatformutilities.h"
@@ -61,8 +63,7 @@ class QgsProject;
 #define SUPPORTED_VECTOR_EXTENSIONS  QStringList( { QStringLiteral( "gpkg" ), QStringLiteral( "shp" ), QStringLiteral( "kml" ), QStringLiteral( "kmz" ), QStringLiteral( "geojson" ), QStringLiteral( "json" ), QStringLiteral( "pdf" ), QStringLiteral( "gpx" ), QStringLiteral( "zip" ) } )
 #define SUPPORTED_RASTER_EXTENSIONS  QStringList( { QStringLiteral( "tif" ), QStringLiteral( "pdf" ), QStringLiteral( "jpg" ), QStringLiteral( "png" ), QStringLiteral( "gpkg" ), QStringLiteral( "jp2" ), QStringLiteral( "webp" ), QStringLiteral( "zip" ) } )
 
-
-class QgisMobileapp : public QQmlApplicationEngine
+class QFIELD_CORE_EXPORT QgisMobileapp : public QQmlApplicationEngine
 {
     Q_OBJECT
   public:

--- a/src/core/qgsquick/qgsquickmapsettings.h
+++ b/src/core/qgsquick/qgsquickmapsettings.h
@@ -25,6 +25,7 @@
 #include <qgsmaplayer.h>
 #include <qgsrectangle.h>
 
+#include "qfield_core_export.h"
 
 class QgsProject;
 
@@ -41,7 +42,7 @@ class QgsProject;
  * \sa QgsMapCanvas
  *
  */
-class QgsQuickMapSettings : public QObject
+class QFIELD_CORE_EXPORT QgsQuickMapSettings : public QObject
 {
     Q_OBJECT
 

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -24,10 +24,12 @@
 //used for gatherer
 #include <QThread>
 
+#include "qfield_core_export.h"
+
 class QgsVectorLayer;
 class FeatureGatherer;
 
-class ReferencingFeatureListModel : public QAbstractItemModel
+class QFIELD_CORE_EXPORT ReferencingFeatureListModel : public QAbstractItemModel
 {
     Q_OBJECT
 

--- a/src/core/rubberbandmodel.h
+++ b/src/core/rubberbandmodel.h
@@ -25,6 +25,8 @@
 #include <qgsabstractgeometry.h>
 #include <qgsgeometry.h>
 
+#include "qfield_core_export.h"
+
 class QgsVectorLayer;
 
 /**
@@ -33,7 +35,7 @@ class QgsVectorLayer;
  * It can be used as a linestring or as a ring in a polygon.
  */
 
-class RubberbandModel : public QObject
+class QFIELD_CORE_EXPORT RubberbandModel : public QObject
 {
     Q_OBJECT
 

--- a/src/core/utils/featureutils.h
+++ b/src/core/utils/featureutils.h
@@ -21,10 +21,12 @@
 #include <qgsgeometry.h>
 #include <qgsfeature.h>
 
+#include "qfield_core_export.h"
+
 class QgsVectorLayer;
 class QgsSymbol;
 
-class FeatureUtils : public QObject
+class QFIELD_CORE_EXPORT FeatureUtils : public QObject
 {
   Q_OBJECT
 public:

--- a/src/core/utils/fileutils.h
+++ b/src/core/utils/fileutils.h
@@ -20,7 +20,9 @@
 #include <QObject>
 #include <qgsfeedback.h>
 
-class FileUtils : public QObject
+#include "qfield_core_export.h"
+
+class QFIELD_CORE_EXPORT FileUtils : public QObject
 {
     Q_OBJECT
 

--- a/src/core/utils/geometryutils.h
+++ b/src/core/utils/geometryutils.h
@@ -21,11 +21,13 @@
 #include <qgsgeometry.h>
 #include <qgsfeature.h>
 
+#include "qfield_core_export.h"
+
 class QgsVectorLayer;
 class RubberbandModel;
 
 
-class GeometryUtils : public QObject
+class QFIELD_CORE_EXPORT GeometryUtils : public QObject
 {
     Q_OBJECT
   public:

--- a/src/core/utils/stringutils.h
+++ b/src/core/utils/stringutils.h
@@ -20,8 +20,9 @@
 
 #include <QObject>
 
+#include "qfield_core_export.h"
 
-class StringUtils : public QObject
+class QFIELD_CORE_EXPORT StringUtils : public QObject
 {
     Q_OBJECT
 

--- a/src/core/utils/urlutils.h
+++ b/src/core/utils/urlutils.h
@@ -20,8 +20,10 @@
 
 #include <QObject>
 
+#include "qfield_core_export.h"
 
-class UrlUtils : public QObject
+
+class QFIELD_CORE_EXPORT UrlUtils : public QObject
 {
     Q_OBJECT
 

--- a/src/core/vertexmodel.h
+++ b/src/core/vertexmodel.h
@@ -24,6 +24,8 @@ class QgsQuickMapSettings;
 #include "qgsgeometry.h"
 #include "qgscoordinatetransform.h"
 
+#include "qfield_core_export.h"
+
 /**
  * The VertexModel class is a model to highlight and edit vertices.
  * The model is used in map coordinates.
@@ -31,7 +33,7 @@ class QgsQuickMapSettings;
  *
  * The model holds all vertices and the candidates for new vertices. If you need the existing nodes, use flatVertices().
  */
-class VertexModel : public QAbstractListModel
+class QFIELD_CORE_EXPORT VertexModel : public QAbstractListModel
 {
     Q_OBJECT
     //! The current mode


### PR DESCRIPTION
Properly define attribute visibility / dllexport the symbols needed by qfield app from qfield core.

@3nids in order to not mess too much with your current work, please let me know if you prefer to postpone this after the build chain work you are doing.