### PR TITLE
Fix several textedit editor widget regressions

### DIFF
--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -13,7 +13,7 @@ EditorWidgetBase {
   // Due to QTextEdit::onLinkActivated does not work on Android & iOS, we need a separate `Text` element to support links https://bugreports.qt.io/browse/QTBUG-38487
   Label {
     id: textReadonlyValue
-    height: textArea.height == 0 ? fontMetrics.height + 20: 0
+    height: textArea.height == 0 ? textField.height : 0
     topPadding: 10
     bottomPadding: 10
     visible: height !== 0 && !isEnabled
@@ -69,10 +69,9 @@ EditorWidgetBase {
     inputMethodHints: field && field.isNumeric ? Qt.ImhFormattedNumbersOnly : Qt.ImhNone
 
     background: Rectangle {
-      y: textField.height - height - textField.bottomPadding / 2
-      implicitWidth: 120
-      height: textField.activeFocus ? 2: 1
-      color: textField.activeFocus ? "#4CAF50" : "#C8E6C9"
+        width: parent.width
+        height: parent.height
+        color: white;
     }
 
     onTextChanged: {
@@ -93,9 +92,24 @@ EditorWidgetBase {
     text: value !== undefined ? value : ''
     textFormat: config['UseHtml'] ? TextEdit.RichText : TextEdit.PlainText
 
+    background: Rectangle {
+        width: parent.width
+        height: parent.height
+        color: white;
+    }
+
     onEditingFinished: {
       valueChanged( text, text == '' )
     }
+  }
+
+  Rectangle {
+      anchors.left: parent.left
+      anchors.right: parent.right
+      y: Math.max( textField.height, textArea.height ) - height - textField.bottomPadding / 2
+      implicitWidth: 120
+      height: textField.activeFocus || textArea.activeFocus ? 2: 1
+      color: textField.activeFocus || textArea.activeFocus ? "#4CAF50" : "#C8E6C9"
   }
 
   FontMetrics {


### PR DESCRIPTION
This PR fixes several textedit editor widget regressions that slipped into QField since 1.6:
- missing bottom border line when not in edit mode in non-multiline mode
- wrong bottom border line color when in multiline mode for both edit and non-edit mode
- overlapping text + textarea when editing in multiline mode

Not sure how we missed the missing bottom border line for so long. When noticed, it can't be unseen.

Before vs. PR in read mode:
![image](https://user-images.githubusercontent.com/1728657/109448509-b1a55a00-7a78-11eb-9d5e-aae5bfd8a5aa.png)

Overlapping text + textarea in edit mode (there's no vs. after, it's just fixed :) )
![image](https://user-images.githubusercontent.com/1728657/109448577-def20800-7a78-11eb-8b06-ac825c7ee130.png)
