### PR TITLE
Fix clang warning

### DIFF
--- a/src/core/qgsquick/qgsquickmapcanvasmap.cpp
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.cpp
@@ -17,8 +17,9 @@
 #include <QScreen>
 #include <QSGSimpleTextureNode>
 
+#include <qgslabelingresults.h>
 #include <qgsmaprendererparalleljob.h>
-#include "qgsmaprenderercache.h"
+#include <qgsmaprenderercache.h>
 #include <qgsmessagelog.h>
 #include <qgspallabeling.h>
 #include <qgsproject.h>


### PR DESCRIPTION
The missing `#include <qgslabelingresults.h>` line led my compiler to complaint about a risky delete (https://github.com/opengisch/QField/blob/fc7e61407eed3feaa34c40c85bb040cb94ff8dbc/src/core/qgsquick/qgsquickmapcanvasmap.cpp#L173) of undefined class.