### PR TITLE
Editor widgets improvements

### DIFF
--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -40,14 +40,23 @@ EditorWidgetBase {
   onCurrentValueChanged: {
       if ( isImage ) {
           if ( value === undefined || FileUtils.fileName( qgisProject.homePath + '/' + value ) === '' ) {
-              image.source=Theme.getThemeIcon("ic_photo_notavailable_black_24dp")
+              image.width = 24
+              image.opacity = 0.25
+              image.anchors.topMargin = 11
+              image.source = Theme.getThemeIcon("ic_photo_notavailable_black_24dp")
               geoTagBadge.visible = false
           } else if ( image.status === Image.Error || !FileUtils.fileExists( qgisProject.homePath + '/' + value ) ) {
+              image.width = 24
+              image.opacity = 0.25
+              image.anchors.topMargin = 11
               image.source=Theme.getThemeIcon("ic_broken_image_black_24dp")
               geoTagBadge.visible = false
           } else {
-              geoTagBadge.hasGeoTag = ExifTools.hasGeoTag(qgisProject.homePath + '/' + value)
+              image.width = 220
+              image.opacity = 1
+              image.anchors.topMargin = 0
               image.source= 'file://' + qgisProject.homePath + '/' + value
+              geoTagBadge.hasGeoTag = ExifTools.hasGeoTag(qgisProject.homePath + '/' + value)
               geoTagBadge.visible = true
           }
       } else {
@@ -145,7 +154,11 @@ EditorWidgetBase {
     id: image
     visible: isImage
     enabled: isImage
-    width: 200
+    anchors.left: parent.left
+    anchors.top: parent.top
+    anchors.topMargin: 11
+    width: 24
+    opacity: 0.25
     autoTransform: true
     fillMode: Image.PreserveAspectFit
     horizontalAlignment: Image.AlignLeft
@@ -168,7 +181,8 @@ EditorWidgetBase {
     visible: false
     anchors.bottom: image.bottom
     anchors.right: image.right
-    anchors.margins: 4
+    anchors.rightMargin: 10
+    anchors.bottomMargin: 12
     fillMode: Image.PreserveAspectFit
     width: 24
     height: 24
@@ -191,8 +205,8 @@ EditorWidgetBase {
 
   QfToolButton {
     id: button_camera
-    width: 36
-    height: 36
+    width: 48
+    height: 48
 
     anchors.right: button_gallery.left
     anchors.bottom: parent.bottom
@@ -215,8 +229,8 @@ EditorWidgetBase {
 
   QfToolButton {
     id: button_gallery
-    width: 36
-    height: 36
+    width: 48
+    height: 48
 
     anchors.right: parent.right
     anchors.bottom: parent.bottom

--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -66,13 +66,25 @@ EditorWidgetBase {
       onPressAndHold: mouse.accepted = false;
     }
 
+    font: Theme.defaultFont
+    contentItem: Text {
+        leftPadding: enabled ? 5 : 0
+
+        text: comboBox.displayText
+        font: comboBox.font
+        color: enabled ? 'black' : 'gray'
+        verticalAlignment: Text.AlignVCenter
+        horizontalAlignment: Text.AlignLeft
+        elide: Text.ElideRight
+    }
+
     background: Item {
       implicitWidth: 120
       implicitHeight: 36
 
       Rectangle {
         visible: !enabled
-        y: comboBox.height - 8
+        y: comboBox.height - 12
         width: comboBox.width
         height: comboBox.activeFocus ? 2: 1
         color: comboBox.activeFocus ? "#4CAF50" : "#C8E6C9"

--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -71,7 +71,8 @@ EditorWidgetBase {
       implicitHeight: 36
 
       Rectangle {
-        y: textLabel.height - 8
+        visible: !enabled
+        y: comboBox.height - 8
         width: comboBox.width
         height: comboBox.activeFocus ? 2: 1
         color: comboBox.activeFocus ? "#4CAF50" : "#C8E6C9"


### PR DESCRIPTION
This PR (dramatically?) improvements the looks of the picture-mode external resources editor widget by:
- avoiding a super-sized missing/broken image icon and making that icon semi-opaque
- aligning various icons on an invisible horizontal plane
- enlarging the tiny action buttons in edit mode

I've also fixed the value map editor widget's bottom border line in read mode:
![image](https://user-images.githubusercontent.com/1728657/109645464-7181cc80-7b89-11eb-8387-9dafb9c6f5f7.png)


