### PR TITLE
Update OSGeo4A SDK to grab latest GEOS and OpenSSL libs

### DIFF
--- a/sdk.conf
+++ b/sdk.conf
@@ -1,1 +1,1 @@
-osgeo4a_version=20210302
+osgeo4a_version=20210306


### PR DESCRIPTION
In preparation for 1.9 beta release, update libs.