### PR TITLE
When an expression constraint lacks a description, add a generic tip to users

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -374,9 +374,11 @@ void AttributeFormModelBase::flatten( QgsAttributeEditorContainer *container, QS
 
         // create constraint description
         QStringList descriptions;
-        if ( !field.constraints().constraintDescription().isEmpty() )
+        if ( field.constraints().constraints() & QgsFieldConstraints::ConstraintExpression )
         {
-          descriptions << field.constraints().constraintDescription();
+          descriptions << ( !field.constraints().constraintDescription().isEmpty()
+                            ? field.constraints().constraintDescription()
+                            : tr( "Expression constraint" ) );
         }
         if ( field.constraints().constraints() & QgsFieldConstraints::ConstraintNotNull )
         {


### PR DESCRIPTION
@signedav , while testing your client's parcel demo prototype (GCK-Rto), I noticed a confusing part of our UI/UX, whereas one field would keep being red even though I had fulfilled the constraints _QField was showing me_ (namely non NULL and unique). Turns out the field also had an expression constraint with an empty description.

This PR reduces the confusion by adding a default "Expression constraint" when no description is available, to let users know why a field would remain red. 

![image](https://user-images.githubusercontent.com/1728657/110263406-26344780-7fe9-11eb-8efc-99087031798b.png)


