### PR TITLE
Respect maximum length in text edit widget

### DIFF
--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -37,6 +37,7 @@ EditorWidgetBase {
     anchors.right: parent.right
     font: Theme.defaultFont
     color: 'black'
+    maximumLength: field.length > 0 ? field.length : -1
     wrapMode: TextInput.Wrap
 
     text: value == null ? '' : value


### PR DESCRIPTION
Another UI/UX issue spotted while testing @suricactus client's project file: QField's text edit widget doesn't reflect the maximum length set by the field. If a field has a text has maximum length of 5 [characters], QField would allow entering more than 5 characters, only to silently chop its value when saving (and not immediately reflect the change in the UI).

This PR fixes that by setting the maximumLength property of the text edit widget's TextField to match that of the field. 