### PR TITLE
Fix missing translations

### DIFF
--- a/src/core/finlandlocatorfilter.cpp
+++ b/src/core/finlandlocatorfilter.cpp
@@ -25,7 +25,7 @@
 
 
 FinlandLocatorFilter::FinlandLocatorFilter( QgsGeocoderInterface *geocoder, LocatorModelSuperBridge *locatorBridge )
-  : QgsAbstractGeocoderLocatorFilter( QStringLiteral( "pelias-finland" ), QStringLiteral( "Finnish address search" ), QStringLiteral( "fia" ), geocoder )
+  : QgsAbstractGeocoderLocatorFilter( QStringLiteral( "pelias-finland" ), tr( "Finnish address search" ), QStringLiteral( "fia" ), geocoder )
   , mLocatorBridge( locatorBridge )
 {
   setBoundingBox( QgsRectangle( 19.0832098, 59.4541578, 31.5867071, 70.0922939) );

--- a/src/core/locatormodelsuperbridge.cpp
+++ b/src/core/locatormodelsuperbridge.cpp
@@ -30,14 +30,6 @@
 #include <qgslocator.h>
 #include <qgssettings.h>
 
-static QMap<QString, QString> locatorFilterDescriptionValues() {
-  QMap<QString, QString> map;
-  map.insert( QStringLiteral("allfeatures"), QObject::tr( "Returns a list of features accross all searchable layers with matching attributes" ) );
-  map.insert( QStringLiteral("goto"), QObject::tr( "Returns a point from a pair of X and Y coordinates typed in the search bar" ) );
-  map.insert( QStringLiteral("pelias-finland"), QObject::tr( "Returns a list of locations and addresses within Finland with matching terms" ) );
-  return map;
-}
-static const QMap<QString, QString>  locatorFilterDescriptions = locatorFilterDescriptionValues();
 
 LocatorModelSuperBridge::LocatorModelSuperBridge( QObject *parent )
   : QgsLocatorModelBridge( parent )
@@ -199,6 +191,12 @@ QHash<int, QByteArray> LocatorFiltersModel::roleNames() const
 
 QVariant LocatorFiltersModel::data( const QModelIndex &index, int role ) const
 {
+  const static QMap<QString, QString> sLocatorFilterDescriptions = {
+    { QStringLiteral("allfeatures"), tr( "Returns a list of features accross all searchable layers with matching attributes" ) },
+    { QStringLiteral("goto"), ( "Returns a point from a pair of X and Y coordinates typed in the search bar" ) },
+    { QStringLiteral("pelias-finland"), tr( "Returns a list of locations and addresses within Finland with matching terms" ) }
+  };
+
   if ( !mLocatorModelSuperBridge->locator() || !index.isValid() || index.parent().isValid() ||
        index.row() < 0 || index.row() >= rowCount( QModelIndex() ) )
     return QVariant();
@@ -210,7 +208,7 @@ QVariant LocatorFiltersModel::data( const QModelIndex &index, int role ) const
       return filterForIndex( index )->displayName();
 
     case DescriptionRole:
-      return locatorFilterDescriptions.value( filterForIndex( index )->name() );
+      return sLocatorFilterDescriptions.value( filterForIndex( index )->name() );
 
     case PrefixRole:
       return filterForIndex( index )->activePrefix();

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -401,7 +401,6 @@ void QgisMobileapp::initDeclarative()
   rootContext()->setContextProperty( "ppi", dpi );
   rootContext()->setContextProperty( "mouseDoubleClickInterval", QApplication::styleHints()->mouseDoubleClickInterval() );
   rootContext()->setContextProperty( "qgisProject", mProject );
-  rootContext()->setContextProperty( "qgisProjet", mProject );
   rootContext()->setContextProperty( "iface", mIface );
   rootContext()->setContextProperty( "settings", &mSettings );
   rootContext()->setContextProperty( "appVersion", QString( "" APP_VERSION ) );


### PR DESCRIPTION
Hopefully fixes issue #1754.

@m-kuhn , as you hinted, it seems QObject::tr() doesn't work out in providing translatable strings here. The hopeful part is me hoping QCoreApplication::translate() will work better :smile: 