### PR TITLE
Dismiss toast message when clicking on it

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2012,7 +2012,7 @@ ApplicationWindow {
       }
 
       Behavior on opacity {
-        NumberAnimation { duration: 500 }
+        NumberAnimation { duration: 250 }
       }
 
       Rectangle {
@@ -2044,14 +2044,6 @@ ApplicationWindow {
           horizontalAlignment: Text.AlignHCenter
           color: Theme.light
         }
-
-        MouseArea {
-          anchors.fill: parent
-          propagateComposedEvents: true
-          onClicked: {
-              mouse.accepted = false
-          }
-        }
       }
 
       FontMetrics {
@@ -2074,6 +2066,14 @@ ApplicationWindow {
               toastContent.visible = false
               toast.close()
           }
+      }
+
+      MouseArea {
+        anchors.fill: parent
+        onClicked: {
+            toast.close()
+            toast.opacity = 0
+        }
       }
   }
 


### PR DESCRIPTION
Once upon a time, QField's "toast" message container was an item which could be clicked through. That had to change to a popup to insure the message was displayed on top of everything else. However, it also led to clicks being blocked over that message area for the duration of the text (see e.g. #1611).

This PR tries to improve the situation by dismissing the message [popup] immediately when a click is detected. It's not perfect, but at least people can get rid of it before the 3 second timer runs out.