### PR TITLE
Fix canvas follow location interfering with jump to feature / go to coordinate

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -85,6 +85,7 @@ jobs:
         run: |
           df -h
           rm -rf /tmp/workspace
+          rm -rf /usr/share/dotnet/sdk
           sudo apt remove llvm-* ghc-* google-chrome-* dotnet-sdk-*
           dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
           du -a /usr/share | sort -n -r | head -n 10

--- a/src/qml/MapCanvas.qml
+++ b/src/qml/MapCanvas.qml
@@ -43,8 +43,6 @@ Item {
   //! Emitted when a release happens after a long press
   signal longPressReleased(var type)
 
-  signal panned
-
   /**
    * Freezes the map canvas refreshes.
    *
@@ -210,7 +208,6 @@ Item {
                 else
                 {
                     mapCanvasWrapper.pan(centroid.position, oldPos1)
-                    panned()
                 }
             }
         }
@@ -273,18 +270,15 @@ Item {
             if ( active )
             {
                 mapCanvasWrapper.pan(centroid.position, oldPos1)
-                panned()
             }
         }
 
         onActiveScaleChanged: {
             mapCanvasWrapper.zoom( pinch.centroid.position, oldScale / pinch.activeScale )
             mapCanvasWrapper.pan( pinch.centroid.position, oldPos )
-            panned()
             oldScale = pinch.activeScale
         }
     }
-
 
     WheelHandler {
         target: null


### PR DESCRIPTION
This PR improves the deactivation of the map canvas's follow location mode by not only listening to manual panning of the map via finger gesture but also deactivating the mode whenever a user uses to search bar to go to a X,Y location, or uses the search result's shortcut to jump to feature location, etc. etc.

This is what the bug looks like:

https://user-images.githubusercontent.com/1728657/111453897-a293fc80-8746-11eb-9f96-53f97bc4d629.mp4

