### PR TITLE
qgis::as_const -> std::as_const

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -485,7 +485,7 @@ void AttributeFormModelBase::updateVisibilityAndConstraints( int fieldIndex )
   mExpressionContext.setFields( fields );
   mExpressionContext.setFeature( mFeatureModel->feature() );
 
-  for ( const VisibilityExpression &it : qgis::as_const( mVisibilityExpressions ) )
+  for ( const VisibilityExpression &it : std::as_const( mVisibilityExpressions ) )
   {
     if ( fieldIndex == -1 || it.first.referencedAttributeIndexes( fields ).contains( fieldIndex ) )
     {
@@ -493,7 +493,7 @@ void AttributeFormModelBase::updateVisibilityAndConstraints( int fieldIndex )
       exp.prepare( &mExpressionContext );
 
       bool visible = exp.evaluate( &mExpressionContext ).toInt();
-      for ( QStandardItem *item : qgis::as_const( it.second ) )
+      for ( QStandardItem *item : std::as_const( it.second ) )
       {
         if ( item->data( AttributeFormModel::CurrentlyVisible ).toBool() != visible )
         {

--- a/src/core/deltafilewrapper.cpp
+++ b/src/core/deltafilewrapper.cpp
@@ -377,7 +377,7 @@ QMap<QString, QString> DeltaFileWrapper::attachmentFileNames() const
   QMap<QString, QString> fileNames;
   QMap<QString, QString> fileChecksums;
 
-  for ( const QJsonValue &deltaJson : qgis::as_const( mDeltas ) )
+  for ( const QJsonValue &deltaJson : std::as_const( mDeltas ) )
   {
     QVariantMap delta = deltaJson.toObject().toVariantMap();
     const QString localLayerId = delta.value( QStringLiteral( "localLayerId" ) ).toString();
@@ -724,7 +724,7 @@ QStringList DeltaFileWrapper::deltaLayerIds() const
 {
   QStringList layerIds;
 
-  for ( const QJsonValue &v : qgis::as_const( mDeltas ) )
+  for ( const QJsonValue &v : std::as_const( mDeltas ) )
   {
     QJsonObject deltaItem = v.toObject();
     const QString layerId = deltaItem.value( QStringLiteral( "layerId" ) ).toString();
@@ -766,7 +766,7 @@ bool DeltaFileWrapper::applyInternal( bool shouldApplyInReverse )
 
   // 1) get all vector layers referenced in the delta file and make them editable
   QHash<QString, QgsVectorLayer *> vectorLayers;
-  for ( const QJsonValue &deltaJson : qgis::as_const( mDeltas ) )
+  for ( const QJsonValue &deltaJson : std::as_const( mDeltas ) )
   {
     const QVariantMap delta = deltaJson.toObject().toVariantMap();
     const QString layerId = delta.value( QStringLiteral( "localLayerId" ) ).toString();
@@ -835,7 +835,7 @@ bool DeltaFileWrapper::applyDeltasOnLayers( QHash<QString, QgsVectorLayer *> &ve
   else
     deltas = QJsonArray( mDeltas );
 
-  for ( const QJsonValue &deltaJson : qgis::as_const( deltas ) )
+  for ( const QJsonValue &deltaJson : std::as_const( deltas ) )
   {
     const QVariantMap delta = deltaJson.toObject().toVariantMap();
     const QString layerId = delta.value( QStringLiteral( "localLayerId" ) ).toString();

--- a/src/core/featurechecklistmodel.cpp
+++ b/src/core/featurechecklistmodel.cpp
@@ -66,7 +66,7 @@ QVariant FeatureCheckListModel::attributeValue() const
 
   QVariantList vl;
   //store as QVariantList because the field type supports data structure
-  for ( const QString &s : qgis::as_const( mCheckedEntries ) )
+  for ( const QString &s : std::as_const( mCheckedEntries ) )
   {
     // Convert to proper type
     const QVariant::Type type {fkType()};

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -668,7 +668,7 @@ bool FeatureModel::deleteFeature()
   }
 
   // we need to either commit or rollback the child layers that have experienced any modification
-  for ( QgsVectorLayer *childLayer : qgis::as_const( childLayersEdited ) )
+  for ( QgsVectorLayer *childLayer : std::as_const( childLayersEdited ) )
   {
     if ( isSuccess )
     {

--- a/src/core/featureslocatorfilter.cpp
+++ b/src/core/featureslocatorfilter.cpp
@@ -95,7 +95,7 @@ void FeaturesLocatorFilter::fetchResults( const QString &string, const QgsLocato
   QgsFeature f;
 
   // we cannot used const loop since iterator::nextFeature is not const
-  for ( auto preparedLayer : qgis::as_const( mPreparedLayers ) )
+  for ( auto preparedLayer : std::as_const( mPreparedLayers ) )
   {
     int foundInCurrentLayer = 0;
     QgsFeatureIterator it = preparedLayer->featureSource->getFeatures( preparedLayer->request );

--- a/src/core/fieldexpressionvaluesgatherer.h
+++ b/src/core/fieldexpressionvaluesgatherer.h
@@ -96,7 +96,7 @@ class FeatureExpressionValuesGatherer: public QThread
 
       QgsFeature feature;
       QList<int> attributeIndexes;
-      for ( const QString &fieldName : qgis::as_const( mIdentifierFields ) )
+      for ( const QString &fieldName : std::as_const( mIdentifierFields ) )
         attributeIndexes << mSource->fields().indexOf( fieldName );
 
       while ( iterator.nextFeature( feature ) )

--- a/src/core/identifytool.cpp
+++ b/src/core/identifytool.cpp
@@ -131,7 +131,7 @@ QList<IdentifyTool::IdentifyResult> IdentifyTool::identifyVectorLayer( QgsVector
     filter = renderer->capabilities() & QgsFeatureRenderer::Filter;
   }
 
-  for ( const QgsFeature &feature : qgis::as_const( featureList ) )
+  for ( const QgsFeature &feature : std::as_const( featureList ) )
   {
     context.expressionContext().setFeature( feature );
 

--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -370,7 +370,7 @@ bool MultiFeatureListModelBase::mergeSelection()
     if ( isSuccess )
     {
       selectedFeatures.removeFirst();
-      for ( const auto &pair : qgis::as_const( selectedFeatures ) )
+      for ( const auto &pair : std::as_const( selectedFeatures ) )
       {
         isSuccess = deleteFeature( pair.first, pair.second.id(), true );
         if ( !isSuccess )
@@ -454,7 +454,7 @@ bool MultiFeatureListModelBase::deleteFeature( QgsVectorLayer *layer, QgsFeature
   }
 
   // we need to either commit or rollback the child layers that have experienced any modification
-  for ( QgsVectorLayer *childLayer : qgis::as_const( childLayersEdited ) )
+  for ( QgsVectorLayer *childLayer : std::as_const( childLayersEdited ) )
   {
     // if everything went well so far, we try to commit
     if ( isSuccess )

--- a/src/core/qgsquick/qgsquickmapcanvasmap.cpp
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.cpp
@@ -352,7 +352,7 @@ void QgsQuickMapCanvasMap::onLayersChanged()
   if ( mMapSettings->extent().isEmpty() )
     zoomToFullExtent();
 
-  for ( const QMetaObject::Connection &conn : qgis::as_const( mLayerConnections ) )
+  for ( const QMetaObject::Connection &conn : std::as_const( mLayerConnections ) )
   {
     disconnect( conn );
   }

--- a/src/core/utils/fileutils.cpp
+++ b/src/core/utils/fileutils.cpp
@@ -60,7 +60,7 @@ bool FileUtils::copyRecursively( const QString &sourceFolder, const QString &des
   int fileCount = copyRecursivelyPrepare( sourceFolder, destFolder, mapping );
 
   int current = 0;
-  for ( QPair<QString, QString> srcDestFilePair : qgis::as_const( mapping ) )
+  for ( QPair<QString, QString> srcDestFilePair : std::as_const( mapping ) )
   {
 
     QString srcName = srcDestFilePair.first;

--- a/src/core/vertexmodel.cpp
+++ b/src/core/vertexmodel.cpp
@@ -668,7 +668,7 @@ QVector<QgsPoint> VertexModel::flatVertices( int ringId ) const
   }
 
   QVector<QgsPoint> vertices = QVector<QgsPoint>();
-  for ( const Vertex &vertex : qgis::as_const( mVertices ) )
+  for ( const Vertex &vertex : std::as_const( mVertices ) )
   {
     if ( vertex.type != ExistingVertex || vertex.ring != ringId )
       continue;
@@ -685,7 +685,7 @@ QVector<QgsPoint> VertexModel::flatVertices( int ringId ) const
 QVector<QPair<QgsPoint, QgsPoint>> VertexModel::verticesMoved() const
 {
   QVector<QPair<QgsPoint, QgsPoint>> vertices;
-  for ( const Vertex &vertex : qgis::as_const( mVertices ) )
+  for ( const Vertex &vertex : std::as_const( mVertices ) )
   {
     if ( vertex.type != ExistingVertex )
       continue;

--- a/test/test_layerobserver.cpp
+++ b/test/test_layerobserver.cpp
@@ -220,7 +220,7 @@ class TestLayerObserver: public QObject
 
       QJsonArray deltasJsonArray = doc.object().value( QStringLiteral( "deltas" ) ).toArray();
 
-      for ( const QJsonValue &v : qgis::as_const( deltasJsonArray ) )
+      for ( const QJsonValue &v : std::as_const( deltasJsonArray ) )
         operations.append( v.toObject().value( QStringLiteral( "method" ) ).toString() );
 
       return operations;


### PR DESCRIPTION
Because it's the right thing to do, and because QGIS is getting rid of qgis::as_const.