### PR TITLE
[backport release-1_9] OSGeo4A SDK update to QGIS 3.18.1 final

### DIFF
--- a/sdk.conf
+++ b/sdk.conf
@@ -1,1 +1,1 @@
-osgeo4a_version=20210306
+osgeo4a_version=20210322

--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -31,6 +31,8 @@
 #include <qgsattributeeditorrelation.h>
 #include <qgsmapthemecollection.h>
 
+#include <QRegularExpression>
+
 
 AttributeFormModelBase::AttributeFormModelBase( QObject *parent )
   : QStandardItemModel( 0, 1, parent )

--- a/src/core/bluetoothdevicemodel.cpp
+++ b/src/core/bluetoothdevicemodel.cpp
@@ -24,7 +24,7 @@ BluetoothDeviceModel::BluetoothDeviceModel( QObject *parent )
     mLocalDevice( std::make_unique<QBluetoothLocalDevice>() )
 {
   connect( &mServiceDiscoveryAgent, &QBluetoothServiceDiscoveryAgent::serviceDiscovered, this, &BluetoothDeviceModel::serviceDiscovered );
-  connect( &mServiceDiscoveryAgent, qgis::overload<QBluetoothServiceDiscoveryAgent::Error>::of( &QBluetoothServiceDiscoveryAgent::error ), this, [ = ]()
+  connect( &mServiceDiscoveryAgent, qOverload<QBluetoothServiceDiscoveryAgent::Error>( &QBluetoothServiceDiscoveryAgent::error ), this, [ = ]()
   {
     setLastError( mServiceDiscoveryAgent.errorString() );
     setScanningStatus( Failed );

--- a/src/core/featurelistmodel.cpp
+++ b/src/core/featurelistmodel.cpp
@@ -19,9 +19,12 @@
 #include "qgsvectorlayer.h"
 #include "stringutils.h"
 
+#include <QRegularExpression>
+
 #include <qgsproject.h>
 #include <qgsexpressioncontextutils.h>
 #include <qgsvaluerelationfieldformatter.h>
+
 
 FeatureListModel::FeatureListModel( QObject *parent )
   : QAbstractItemModel( parent )

--- a/src/core/gotolocatorfilter.cpp
+++ b/src/core/gotolocatorfilter.cpp
@@ -17,6 +17,7 @@
 #include "gotolocatorfilter.h"
 
 #include <QAction>
+#include <QRegularExpression>
 
 #include <qgscoordinateutils.h>
 #include <qgsexpressioncontextutils.h>

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -44,6 +44,7 @@
 #include <QFileInfo>
 #include <QFontDatabase>
 #include <QStyleHints>
+#include <QResource>
 
 #include <qgslayertreemodel.h>
 #include <qgslayoutatlas.h>

--- a/src/core/qgsgpkgflusher.cpp
+++ b/src/core/qgsgpkgflusher.cpp
@@ -17,13 +17,15 @@
 
 
 #include "qgsgpkgflusher.h"
+
 #include <qgsmessagelog.h>
 #include <qgsvectorlayer.h>
-
 #include <qgsproject.h>
-#include <sqlite3.h>
+
+#include <QRegularExpression>
 #include <QObject>
 #include <QTimer>
+#include <sqlite3.h>
 
 class Flusher : public QObject
 {


### PR DESCRIPTION
Needed to backport QGIS fixes to 1.9, including fixing feature addition on a CSV layer.