### PR TITLE
Fix error response feedback

### DIFF
--- a/src/core/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloudconnection.cpp
@@ -102,8 +102,8 @@ QString QFieldCloudConnection::errorString( QNetworkReply *reply )
   }
 
   int httpCode = reply->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
-  QString httpErrorMessage = QStringLiteral( "[HTTP/%1] %2 %3 " ).arg( httpCode ).arg( reply->url().toString() ).arg( reply->errorString() );
-  httpErrorMessage += ( httpCode > 400 )
+  QString httpErrorMessage = QStringLiteral( "[HTTP/%1] %2 " ).arg( httpCode ).arg( reply->url().toString() );
+  httpErrorMessage += ( httpCode >= 400 )
       ? tr( "Server Error." )
       : tr( "Network Error." );
   httpErrorMessage += payload.left( 200 );
@@ -114,11 +114,11 @@ QString QFieldCloudConnection::errorString( QNetworkReply *reply )
   if ( errorMessage.isEmpty() )
   {
     errorMessage = httpErrorMessage;
-    QgsMessageLog::logMessage( QStringLiteral( "%1\n%2" ).arg( errorMessage, payload ) );
+    QgsMessageLog::logMessage( QStringLiteral( "%1\n%2\n%3" ).arg( errorMessage, payload ).arg( reply->errorString() ) );
   }
   else
   {
-    QgsMessageLog::logMessage( QStringLiteral( "%1\n%2\n%3" ).arg( errorMessage, httpErrorMessage, payload ) );
+    QgsMessageLog::logMessage( QStringLiteral( "%1\n%2\n%3\n%4" ).arg( errorMessage, httpErrorMessage, payload ).arg( reply->errorString() ) );
   }
 
   return errorMessage;

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -817,11 +817,10 @@ void QFieldCloudProjectsModel::uploadProject( const QString &projectId, const bo
     // if there is an error, cannot continue sync
     if ( deltasReply->error() != QNetworkReply::NoError )
     {
+      mCloudProjects[index].deltaFileUploadStatusString = QFieldCloudConnection::errorString( deltasReply );
       // TODO check why exactly we failed
       // maybe the project does not exist, then create it?
-      QgsMessageLog::logMessage( QStringLiteral( "Failed to upload delta file, reason:\n%1\n%2" ).arg( deltasReply->errorString(), QFieldCloudConnection::errorString( deltasReply ) ) );
-
-      mCloudProjects[index].deltaFileUploadStatusString = QFieldCloudConnection::errorString( deltasReply );
+      QgsMessageLog::logMessage( QStringLiteral( "Failed to upload delta file, reason:\n%1\n%2" ).arg( deltasReply->errorString(), mCloudProjects[index].deltaFileUploadStatusString ) );
       projectCancelUpload( projectId );
       return;
     }


### PR DESCRIPTION
Makes the error responses a bit more beautiful (no double URL).
Show "Server error" when the HTTP status code == 400.
Fix double reading the response payload (second time empty).