### PR TITLE
Fix empty numeric fields saved as 0 instead of NULL

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -260,7 +260,7 @@ void AttributeFormModelBase::updateAttributeValue( QStandardItem *item )
   {
     int fieldIndex = item->data( AttributeFormModel::FieldIndex ).toInt();
     QVariant attributeValue = mFeatureModel->data( mFeatureModel->index( fieldIndex ), FeatureModel::AttributeValue );
-    item->setData( attributeValue, AttributeFormModel::AttributeValue );
+    item->setData( attributeValue.isNull() ? QVariant() : attributeValue, AttributeFormModel::AttributeValue );
     item->setData( mFeatureModel->data( mFeatureModel->index( fieldIndex ), FeatureModel::AttributeAllowEdit ), AttributeFormModel::AttributeAllowEdit);
     //set item visibility to false in case it's a linked attribute
     item->setData( !mFeatureModel->data( mFeatureModel->index( fieldIndex ), FeatureModel::LinkedAttribute ).toBool(), AttributeFormModel::CurrentlyVisible );

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -289,7 +289,7 @@ bool FeatureModel::setData( const QModelIndex &index, const QVariant &value, int
   if ( index.row() < 0 )
     return false;
 
-  if ( data( index, role ) == value )
+  if ( qgsVariantEqual( data( index, role ), value ) )
     return true;
 
   switch ( role )

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -455,7 +455,8 @@ Page {
                 target: attributeEditorLoader.item
 
                 function onValueChanged(value, isNull) {
-                  if( AttributeValue != value && !( AttributeValue === undefined && isNull ) ) //do not compare AttributeValue and value with strict comparison operators
+                  //do not compare AttributeValue and value with strict comparison operators
+                  if( ( AttributeValue != value || ( AttributeValue !== undefined && isNull ) ) && !( AttributeValue === undefined && isNull ) )
                   {
                     var oldValue = AttributeValue
                     AttributeValue = isNull ? undefined : value


### PR DESCRIPTION
This PR partially fixes #1624 -- a fix is also needed in QGIS, which I will submit in a minute.

This was caused by the following commit in QGIS (https://github.com/qgis/QGIS/commit/b078be618520f925e07e40599036f00f806fbc3e), which modified null values from OGR provider datasets (see this line https://github.com/qgis/QGIS/commit/b078be618520f925e07e40599036f00f806fbc3e#diff-e49c5ac0cde677bf01e13a0838f8f37ea2dffe73c4b8def4f9f7679d920984a0R326).

This caused two issues in QField itself:
- QML models don't handle QVariant( QVariant::Type ) properly, and shows the default value while ignoring the fact that the QVariant itself is set to null
- Also - and somewhat stupidly? - QVariant( 0 ) == QVariant( QVariant::Int ), which let to feature model not updating when switching from null to zero and vice versa
