### PR TITLE
Fix and improve remembered values

### DIFF
--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -18,16 +18,18 @@
 #ifndef FEATUREMODEL_H
 #define FEATUREMODEL_H
 
+#include "snappingresult.h"
+#include "gnsspositioninformation.h"
+#include "qfieldcloudconnection.h"
+#include "geometry.h"
+
+#include <qgsfeature.h>
+
+#include <QMutex>
 #include <QAbstractListModel>
 #include <QtPositioning/QGeoPositionInfoSource>
 #include <qgsrelationmanager.h>
 #include <memory>
-#include <qgsfeature.h>
-#include "snappingresult.h"
-#include "gnsspositioninformation.h"
-#include "qfieldcloudconnection.h"
-
-#include "geometry.h"
 
 class VertexModel;
 
@@ -48,6 +50,8 @@ class FeatureModel : public QAbstractListModel
     Q_PROPERTY( bool positionLocked READ positionLocked WRITE setPositionLocked NOTIFY positionLockedChanged )
     Q_PROPERTY( CloudUserInformation cloudUserInformation WRITE setCloudUserInformation );
 
+  public:
+
     //! keeping the information what attributes are remembered and the last edited feature
     struct RememberValues
     {
@@ -55,7 +59,6 @@ class FeatureModel : public QAbstractListModel
       QVector<bool> rememberedAttributes;
     };
 
-  public:
     enum ModelModes
     {
       SingleFeatureModel = 1,
@@ -264,8 +267,9 @@ class FeatureModel : public QAbstractListModel
     SnappingResult mTopSnappingResult;
     CloudUserInformation mCloudUserInformation;
     QString mTempName;
-    QMap<QgsVectorLayer *, RememberValues> mRememberings;
     bool mPositionLocked = false;
+
+    static QMutex sMutex;
 };
 
 #endif // FEATUREMODEL_H


### PR DESCRIPTION
This fixes (at least) #1817 and #1823.

In addition to fixing the regression, there's a nice improvement buried in there: the remembrance settings are now shared across multiple feature forms (i.e. overlay feature form, embedded feature form, etc.).