### PR TITLE
Automatically close the features list when none are lefft after feature(s) deletion

### DIFF
--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -677,6 +677,8 @@ Rectangle {
           featureForm.selection.focusedItem = -1
           featureForm.state = "FeatureList"
         }
+        if ( featureForm.selection.model.count === 0 )
+          featureForm.state = "Hidden";
       } else {
         displayToast( qsTr( "Failed to delete %n feature(s)", "", selectedCount ) );
       }


### PR DESCRIPTION
@lindacamathias , that fixes the UX issue you spotted. 