### PR TITLE
 Say hello to QFieldCloud's community projects 

### DIFF
--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -1748,6 +1748,7 @@ bool QFieldCloudProjectsFilterModel::filterAcceptsRow( int source_row, const QMo
   switch( mFilter )
   {
     case PrivateProjects:
+      // the list will include public "community" projects that are present locally so they can appear in the "My projects" list
       ok = mSourceModel->data( mSourceModel->index( source_row, 0, source_parent ), QFieldCloudProjectsModel::PrivateRole ).toBool() ||
            !mSourceModel->data( mSourceModel->index( source_row, 0, source_parent ), QFieldCloudProjectsModel::LocalPathRole ).toString().isEmpty();
       break;

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -1728,13 +1728,11 @@ QFieldCloudProjectsModel *QFieldCloudProjectsFilterModel::projectsModel() const
 
 void QFieldCloudProjectsFilterModel::setFilter( ProjectsFilter filter )
 {
-  qDebug() << "invalidated";
   if ( mFilter == filter )
     return;
 
   mFilter = filter;
   invalidateFilter();
-  qDebug() << "invalidated";
 
   emit filterChanged();
 }

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -185,7 +185,7 @@ void QFieldCloudProjectsModel::refreshProjectsList()
   {
     case QFieldCloudConnection::ConnectionStatus::LoggedIn:
     {
-      NetworkReply *reply = mCloudConnection->get( QStringLiteral( "/api/v1/projects/" ) );
+      NetworkReply *reply = mCloudConnection->get( QStringLiteral( "/api/v1/projects/?include-public=true" ) );
       connect( reply, &NetworkReply::finished, this, &QFieldCloudProjectsModel::projectListReceived );
       break;
     }
@@ -1393,6 +1393,7 @@ QHash<int, QByteArray> QFieldCloudProjectsModel::roleNames() const
 {
   QHash<int, QByteArray> roles;
   roles[IdRole] = "Id";
+  roles[PrivateRole] = "Private";
   roles[OwnerRole] = "Owner";
   roles[NameRole] = "Name";
   roles[DescriptionRole] = "Description";
@@ -1429,6 +1430,7 @@ void QFieldCloudProjectsModel::reload( const QJsonArray &remoteProjects )
   {
     QVariantHash projectDetails = project.toObject().toVariantHash();
     CloudProject cloudProject( projectDetails.value( "id" ).toString(),
+                               projectDetails.value( "private" ).toBool(),
                                projectDetails.value( "owner" ).toString(),
                                projectDetails.value( "name" ).toString(),
                                projectDetails.value( "description" ).toString(),
@@ -1482,7 +1484,7 @@ void QFieldCloudProjectsModel::reload( const QJsonArray &remoteProjects )
       const QString updatedAt = projectSetting( projectId, QStringLiteral( "updatedAt" ) ).toString();
       const QString collaboratorRole = projectSetting( projectId, QStringLiteral( "collaboratorRole" ) ).toString();
 
-      CloudProject cloudProject( projectId, owner, name, description, collaboratorRole, QString(), LocalCheckout, ProjectStatus::Idle );
+      CloudProject cloudProject( projectId, true, owner, name, description, collaboratorRole, QString(), LocalCheckout, ProjectStatus::Idle );
       QDir localPath( QStringLiteral( "%1/%2/%3" ).arg( QFieldCloudUtils::localCloudDirectory(), mUsername, cloudProject.id ) );
       cloudProject.localPath = QFieldCloudUtils::localProjectFilePath( mUsername, cloudProject.id );
       cloudProject.deltasCount = DeltaFileWrapper( qgisProject, QStringLiteral( "%1/deltafile.json" ).arg( localPath.absolutePath() ) ).count();
@@ -1496,21 +1498,6 @@ void QFieldCloudProjectsModel::reload( const QJsonArray &remoteProjects )
   }
 
   endResetModel();
-}
-
-QVariantMap QFieldCloudProjectsModel::getEntry( int row )
-{
-  QHash<int, QByteArray> names = roleNames();
-  QHashIterator<int, QByteArray> i( names );
-  QVariantMap res;
-  while ( i.hasNext() )
-  {
-    i.next();
-    QModelIndex idx = index( row, 0 );
-    QVariant data = idx.data( i.key() );
-    res[i.value()] = data;
-  }
-  return res;
 }
 
 int QFieldCloudProjectsModel::rowCount( const QModelIndex &parent ) const
@@ -1530,6 +1517,8 @@ QVariant QFieldCloudProjectsModel::data( const QModelIndex &index, int role ) co
   {
     case IdRole:
       return mCloudProjects.at( index.row() ).id;
+    case PrivateRole:
+      return mCloudProjects.at( index.row() ).isPrivate;
     case OwnerRole:
       return mCloudProjects.at( index.row() ).owner;
     case NameRole:
@@ -1712,4 +1701,61 @@ QVariant QFieldCloudProjectsModel::projectSetting( const QString &projectId, con
 {
   const QString projectPrefix = QStringLiteral( "QFieldCloud/projects/%1" ).arg( projectId );
   return QSettings().value( QStringLiteral( "%1/%2" ).arg( projectPrefix, setting ), defaultValue );
+}
+
+// --
+
+QFieldCloudProjectsFilterModel::QFieldCloudProjectsFilterModel( QObject *parent )
+  : QSortFilterProxyModel( parent )
+{
+}
+
+void QFieldCloudProjectsFilterModel::setProjectsModel( QFieldCloudProjectsModel *projectsModel )
+{
+  if ( mSourceModel == projectsModel )
+    return;
+
+  mSourceModel = projectsModel;
+  setSourceModel( mSourceModel );
+
+  emit projectsModelChanged();
+}
+
+QFieldCloudProjectsModel *QFieldCloudProjectsFilterModel::projectsModel() const
+{
+  return mSourceModel;
+}
+
+void QFieldCloudProjectsFilterModel::setFilter( ProjectsFilter filter )
+{
+  qDebug() << "invalidated";
+  if ( mFilter == filter )
+    return;
+
+  mFilter = filter;
+  invalidateFilter();
+  qDebug() << "invalidated";
+
+  emit filterChanged();
+}
+
+QFieldCloudProjectsFilterModel::ProjectsFilter QFieldCloudProjectsFilterModel::filter() const
+{
+  return mFilter;
+}
+
+bool QFieldCloudProjectsFilterModel::filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const
+{
+  bool ok = false;
+  switch( mFilter )
+  {
+    case PrivateProjects:
+      ok = mSourceModel->data( mSourceModel->index( source_row, 0, source_parent ), QFieldCloudProjectsModel::PrivateRole ).toBool() ||
+           !mSourceModel->data( mSourceModel->index( source_row, 0, source_parent ), QFieldCloudProjectsModel::LocalPathRole ).toString().isEmpty();
+      break;
+    case PublicProjects:
+      ok = !mSourceModel->data( mSourceModel->index( source_row, 0, source_parent ), QFieldCloudProjectsModel::PrivateRole ).toBool();
+      break;
+  }
+  return ok;
 }

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -410,10 +410,25 @@ class QFieldCloudProjectsFilterModel : public QSortFilterProxyModel
 
     explicit QFieldCloudProjectsFilterModel( QObject *parent = nullptr );
 
+    /**
+     * Returns the source cloud projects model from which the filtered list is derived.
+     */
     QFieldCloudProjectsModel *projectsModel() const;
+
+    /**
+     * Sets the source cloud projects model from which the filtered list is derived.
+     * \param projectsModel the source cloud project model
+     */
     void setProjectsModel( QFieldCloudProjectsModel *projectsModel );
 
+    /**
+     * Returns the current cloud projects filter.
+     */
     ProjectsFilter filter() const;
+
+    /**
+     * Sets the the cloud project \a filter.
+     */
     void setFilter( ProjectsFilter filter );
 
   signals:

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -21,6 +21,7 @@
 #include "deltastatuslistmodel.h"
 
 #include <QAbstractListModel>
+#include <QSortFilterProxyModel>
 #include <QNetworkReply>
 #include <QTimer>
 
@@ -43,6 +44,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     {
       IdRole = Qt::UserRole + 1,
       OwnerRole,
+      PrivateRole,
       NameRole,
       DescriptionRole,
       ModificationRole,
@@ -225,9 +227,6 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     //! Reloads the list of cloud projects with the given list of \a remoteProjects.
     Q_INVOKABLE void reload( const QJsonArray &remoteProjects );
 
-    //! Returns an entry as a variant map to provide it the the QML DelegateModel
-    Q_INVOKABLE QVariantMap getEntry( int row );
-
   signals:
     void cloudConnectionChanged();
     void layerObserverChanged();
@@ -290,8 +289,9 @@ class QFieldCloudProjectsModel : public QAbstractListModel
 
     struct CloudProject
     {
-      CloudProject( const QString &id, const QString &owner, const QString &name, const QString &description, const QString &collaboratorRole, const QString &updatedAt, const ProjectCheckouts &checkout, const ProjectStatus &status )
+      CloudProject( const QString &id, bool isPrivate, const QString &owner, const QString &name, const QString &description, const QString &collaboratorRole, const QString &updatedAt, const ProjectCheckouts &checkout, const ProjectStatus &status )
         : id( id )
+        , isPrivate( isPrivate )
         , owner( owner )
         , name( name )
         , description( description )
@@ -304,6 +304,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
       CloudProject() = default;
 
       QString id;
+      bool isPrivate = true;
       QString owner;
       QString name;
       QString description;
@@ -312,6 +313,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
       ProjectStatus status;
       ProjectErrorStatus errorStatus = ProjectErrorStatus::NoErrorStatus;
       ProjectCheckouts checkout;
+
       ProjectModifications modification = ProjectModification::NoModification;
       QString localPath;
 
@@ -388,5 +390,47 @@ Q_DECLARE_OPERATORS_FOR_FLAGS( QFieldCloudProjectsModel::ProjectCheckouts )
 Q_DECLARE_METATYPE( QFieldCloudProjectsModel::ProjectModification )
 Q_DECLARE_METATYPE( QFieldCloudProjectsModel::ProjectModifications )
 Q_DECLARE_OPERATORS_FOR_FLAGS( QFieldCloudProjectsModel::ProjectModifications )
+
+
+class QFieldCloudProjectsFilterModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+
+    Q_PROPERTY( QFieldCloudProjectsModel *projectsModel READ projectsModel WRITE setProjectsModel NOTIFY projectsModelChanged )
+    Q_PROPERTY( ProjectsFilter filter READ filter WRITE setFilter NOTIFY filterChanged )
+
+  public:
+
+    enum ProjectsFilter
+    {
+      PrivateProjects,
+      PublicProjects,
+    };
+    Q_ENUM( ProjectsFilter )
+
+    explicit QFieldCloudProjectsFilterModel( QObject *parent = nullptr );
+
+    QFieldCloudProjectsModel *projectsModel() const;
+    void setProjectsModel( QFieldCloudProjectsModel *projectsModel );
+
+    ProjectsFilter filter() const;
+    void setFilter( ProjectsFilter filter );
+
+  signals:
+
+    void projectsModelChanged();
+    void filterChanged();
+
+  protected:
+
+    virtual bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const override;
+
+  private:
+
+    QFieldCloudProjectsModel *mSourceModel = nullptr;
+    ProjectsFilter mFilter = PrivateProjects;
+};
+
+Q_DECLARE_METATYPE( QFieldCloudProjectsFilterModel::ProjectsFilter )
 
 #endif // QFIELDCLOUDPROJECTSMODEL_H

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -406,6 +406,7 @@ void QgisMobileapp::initDeclarative()
   qmlRegisterType<LayerResolver>( "org.qfield", 1, 0, "LayerResolver" );
   qmlRegisterType<QFieldCloudConnection>( "org.qfield", 1, 0, "QFieldCloudConnection" );
   qmlRegisterType<QFieldCloudProjectsModel>( "org.qfield", 1, 0, "QFieldCloudProjectsModel" );
+  qmlRegisterType<QFieldCloudProjectsFilterModel>( "org.qfield", 1, 0, "QFieldCloudProjectsFilterModel" );
 
   qRegisterMetaType<GnssPositionInformation>( "GnssPositionInformation" );
 

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -141,7 +141,9 @@ Page {
 
             model: QFieldCloudProjectsFilterModel {
                 projectsModel: cloudProjectsModel
-                filter: filterBar.currentIndex === 1 ? QFieldCloudProjectsFilterModel.PublicProjects : QFieldCloudProjectsFilterModel.PrivateProjects
+                filter: filterBar.currentIndex === 0
+                    ? QFieldCloudProjectsFilterModel.PrivateProjects
+                    : QFieldCloudProjectsFilterModel.PublicProjects
             }
             clip: true
 

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -107,14 +107,10 @@ Page {
       spacing: 2
 
       TabBar {
-        id: bar
+        id: filterBar
         currentIndex: 0
         Layout.fillWidth: true
         Layout.preferredHeight: 48
-
-        onCurrentIndexChanged: {
-          swipeView.currentIndex = bar.currentIndex
-        }
 
         TabButton {
           text: qsTr("My Projects")
@@ -127,7 +123,6 @@ Page {
           height: 48
           font: Theme.defaultFont
           anchors.verticalCenter : parent.verticalCenter
-          enabled: false
         }
       }
 
@@ -144,7 +139,10 @@ Page {
 
             anchors.fill: parent
 
-            model: cloudProjectsModel
+            model: QFieldCloudProjectsFilterModel {
+                projectsModel: cloudProjectsModel
+                filter: filterBar.currentIndex === 1 ? QFieldCloudProjectsFilterModel.PublicProjects : QFieldCloudProjectsFilterModel.PrivateProjects
+            }
             clip: true
 
             onMovingChanged: {


### PR DESCRIPTION
The cloud community tab is back in force.

A GIF worth a 100 word description:
![Peek 2021-04-14 18-37](https://user-images.githubusercontent.com/1728657/114706362-0ebc4d00-9d53-11eb-81cf-77596a7bad2b.gif)

Some food for thoughts while I was implementing this:
- _Not for 2.0_, but eventually, we'll need to break down this mammoth QFieldCloudProjectsModel into a QFieldCloudProjects vs a leaner model class that doesn't act as a swiss army knife.
- I'm not entirely sure what will go int the community tab, but if the list expands beyond a dozen curated (and maybe geofensed?) projects, we should avoid fetching a large public list when the user logs in and instead only to that whenever he/she clicks on the community tab
  