### PR TITLE
Avoid prefixing the owner to the title of each cloud projects, use ListView section headers

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -193,7 +193,7 @@ Page {
                 Rectangle {
                   width: parent.width
                   height: section === "" ? 0 : childrenRect.height
-                  color: 'lightGray'
+                  color: Theme.lightestGray
 
                   Text {
                     leftPadding: 10

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -186,7 +186,7 @@ Rectangle {
       Rectangle {
         width: parent.width
         height: 30
-        color: "lightGray"
+        color: Theme.lightestGray
 
         Text {
           anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -137,13 +137,32 @@ Page {
             id: table
             property bool overshootRefresh: false
 
-            anchors.fill: parent
 
             model: QFieldCloudProjectsFilterModel {
                 projectsModel: cloudProjectsModel
                 filter: filterBar.currentIndex === 0
                     ? QFieldCloudProjectsFilterModel.PrivateProjects
                     : QFieldCloudProjectsFilterModel.PublicProjects
+            }
+
+            anchors.fill: parent
+            anchors.margins: 1
+            section.property: "Owner"
+            section.labelPositioning: ViewSection.CurrentLabelAtStart | ViewSection.InlineLabels
+            section.delegate: Component {
+              /* section header: layer name */
+              Rectangle {
+                width:parent.width
+                height: 30
+                color: Theme.lightestGray
+
+                Text {
+                  anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
+                  font.bold: true
+                  font.pointSize: Theme.resultFont.pointSize
+                  text: section
+                }
+              }
             }
             clip: true
 
@@ -188,8 +207,8 @@ Page {
                     Layout.fillWidth: true
                     leftPadding: 6
                     rightPadding: 10
-                    topPadding: 9
-                    bottomPadding: 3
+                    topPadding: 4
+                    bottomPadding: 8
                     spacing: 0
 
                     Image {
@@ -235,7 +254,7 @@ Page {
                             id: projectTitle
                             topPadding: 5
                             leftPadding: 3
-                            text: Owner + '/' + Name
+                            text: Name
                             font.pointSize: Theme.tipFont.pointSize
                             font.underline: true
                             color: Theme.mainColor

--- a/src/qml/imports/Theme/Theme.qml
+++ b/src/qml/imports/Theme/Theme.qml
@@ -8,6 +8,7 @@ QtObject {
     readonly property color darkGraySemiOpaque: "#88212121"
     readonly property color gray: "#888888"
     readonly property color lightGray: "#dddddd"
+    readonly property color lightestGray: "#eeeeee"
     readonly property color light: "#ffffff"
     readonly property color hyperlinkBlue: '#0000EE'
 


### PR DESCRIPTION
Having a redundant string prefix in the project titles makes it much harder to skip through a long list, and eats up valuable horizontal space. Let's make use of QML ListView's nifty section headers.

GIF:
![Peek 2021-04-14 20-55](https://user-images.githubusercontent.com/1728657/114722252-da04c180-9d63-11eb-9565-854495ad8d9a.gif)
