### PR TITLE
Improvement on handling of attachments uploads to the cloud

### DIFF
--- a/src/core/platformutilities.cpp
+++ b/src/core/platformutilities.cpp
@@ -103,7 +103,6 @@ PictureSource *PlatformUtilities::getCameraPicture( const QString &prefix, const
 
 PictureSource *PlatformUtilities::getGalleryPicture( const QString &prefix, const QString &pictureFilePath )
 {
-  QString destinationFile = QStringLiteral( "%1/%2" ).arg( prefix, pictureFilePath );
   QString fileName = QFileDialog::getOpenFileName( nullptr, tr( "Select Media File" ), prefix, tr( "JPEG images (*.jpg *.jpeg)" ) );
 
   if ( QFileInfo::exists( fileName ) )
@@ -115,6 +114,7 @@ PictureSource *PlatformUtilities::getGalleryPicture( const QString &prefix, cons
     }
     else
     {
+      QString destinationFile = prefix + pictureFilePath;
       QFileInfo destinationInfo ( destinationFile );
       QDir prefixDir( prefix );
       if ( prefixDir.mkpath( destinationInfo.absolutePath() ) &&

--- a/src/core/platformutilities.cpp
+++ b/src/core/platformutilities.cpp
@@ -110,9 +110,19 @@ PictureSource *PlatformUtilities::getGalleryPicture( const QString &prefix, cons
   {
     // if the file is already in the prefixed path, no need to copy
     if ( fileName.startsWith( prefix ) )
+    {
       return new PictureSource( nullptr, prefix, fileName );
-    else if ( QFile::copy( fileName, destinationFile ) )
-      return new PictureSource( nullptr, prefix, destinationFile );
+    }
+    else
+    {
+      QFileInfo destinationInfo ( destinationFile );
+      QDir prefixDir( prefix );
+      if ( prefixDir.mkpath( destinationInfo.absolutePath() ) &&
+           QFile::copy( fileName, destinationFile ) )
+      {
+        return new PictureSource( nullptr, prefix, destinationFile );
+      }
+    }
 
     QgsMessageLog::logMessage( tr( "Failed to save gallery picture" ), "QField", Qgis::Critical );
   }

--- a/src/core/qfield.h
+++ b/src/core/qfield.h
@@ -36,8 +36,7 @@ namespace qfield
    * }
    * \endcode
    */
-  template <typename T>
-  class asKeyValueRange
+  template <typename T> class asKeyValueRange
   {
     public:
       explicit asKeyValueRange( T &data )

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -773,8 +773,12 @@ void QFieldCloudProjectsModel::uploadProject( const QString &projectId, const bo
   for ( QString &fileName : attachmentFileNames )
   {
     QFileInfo fileInfo( fileName );
-    if ( fileInfo.isRelative() )
+    if ( fileInfo.isRelative() || !fileInfo.exists() )
     {
+      // QField can end up storing relative paths starting with a slash, deal with it
+      if ( fileName.startsWith( '/' ) )
+        fileName = fileName.mid( 1 );
+
       fileName = projectDir.absoluteFilePath( fileName );
       fileInfo = QFileInfo( fileName );
     }

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -773,12 +773,8 @@ void QFieldCloudProjectsModel::uploadProject( const QString &projectId, const bo
   for ( QString &fileName : attachmentFileNames )
   {
     QFileInfo fileInfo( fileName );
-    if ( fileInfo.isRelative() || !fileInfo.exists() )
+    if ( fileInfo.isRelative() )
     {
-      // QField can end up storing relative paths starting with a slash, deal with it
-      if ( fileName.startsWith( '/' ) )
-        fileName = fileName.mid( 1 );
-
       fileName = projectDir.absoluteFilePath( fileName );
       fileInfo = QFileInfo( fileName );
     }

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -756,7 +756,7 @@ void QFieldCloudProjectsModel::uploadProject( const QString &projectId, const bo
 
   refreshProjectModification( projectId );
 
-  emit dataChanged( idx, idx,  QVector<int>() << StatusRole << UploadAttachmentsProgressRole << UploadDeltaProgressRole << UploadDeltaStatusRole << UploadDeltaStatusStringRole );
+  emit dataChanged( idx, idx,  QVector<int>() << StatusRole << UploadAttachmentsCountRole << UploadDeltaProgressRole << UploadDeltaStatusRole << UploadDeltaStatusStringRole );
 
   // //////////
   // prepare attachment files to be uploaded
@@ -1101,7 +1101,7 @@ void QFieldCloudProjectsModel::projectUploadAttachments( const QString &projectI
     {
       Q_UNUSED( bytesTotal )
       mCloudProjects[index].uploadAttachments[fileName].bytesTransferred = bytesSent;
-      emit dataChanged( idx, idx, QVector<int>() << UploadAttachmentsProgressRole );
+      emit dataChanged( idx, idx, QVector<int>() << UploadAttachmentsCountRole );
     } );
 
     connect( attachmentCloudReply, &NetworkReply::finished, this, [ = ]()
@@ -1126,12 +1126,10 @@ void QFieldCloudProjectsModel::projectUploadAttachments( const QString &projectI
         projectSetSetting( projectId, QStringLiteral( "uploadAttachments" ), QStringList( mCloudProjects[index].uploadAttachments.keys() ) );
       }
 
-      mCloudProjects[index].uploadAttachmentsProgress = ( attachmentFileNames.size() - mCloudProjects[index].uploadAttachments.size() ) / attachmentFileNames.size();
-
       if ( mCloudProjects[index].uploadAttachments.size() - mCloudProjects[index].uploadAttachmentsFailed == 0 )
         mCloudProjects[index].uploadAttachmentsStatus = UploadAttachmentsStatus::UploadAttachmentsDone;
 
-      emit dataChanged( idx, idx, QVector<int>() << UploadAttachmentsProgressRole );
+      emit dataChanged( idx, idx, QVector<int>() << UploadAttachmentsCountRole );
     } );
   }
 }
@@ -1439,7 +1437,7 @@ QHash<int, QByteArray> QFieldCloudProjectsModel::roleNames() const
   roles[ExportStatusRole] = "ExportStatus";
   roles[ExportedLayerErrorsRole] = "ExportedLayerErrors";
   roles[UploadAttachmentsStatusRole] = "UploadAttachmentsStatus";
-  roles[UploadAttachmentsProgressRole] = "UploadAttachmentsProgress";
+  roles[UploadAttachmentsCountRole] = "UploadAttachmentsCount";
   roles[UploadDeltaProgressRole] = "UploadDeltaProgress";
   roles[UploadDeltaStatusRole] = "UploadDeltaStatus";
   roles[UploadDeltaStatusStringRole] = "UploadDeltaStatusString";
@@ -1591,8 +1589,8 @@ QVariant QFieldCloudProjectsModel::data( const QModelIndex &index, int role ) co
       return mCloudProjects.at( index.row() ).downloadProgress;
     case UploadAttachmentsStatusRole:
       return mCloudProjects.at( index.row() ).uploadAttachmentsStatus;
-    case UploadAttachmentsProgressRole:
-      return mCloudProjects.at( index.row() ).uploadAttachmentsProgress;
+    case UploadAttachmentsCountRole:
+      return mCloudProjects.at( index.row() ).uploadAttachments.size() - mCloudProjects[ index.row() ].uploadAttachmentsFailed;
     case UploadDeltaProgressRole:
       return mCloudProjects.at( index.row() ).uploadDeltaProgress;
     case UploadDeltaStatusRole:

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -70,8 +70,8 @@ QFieldCloudProjectsModel::QFieldCloudProjectsModel() :
 
   connect( this, &QFieldCloudProjectsModel::dataChanged, this, [ = ]( const QModelIndex & topLeft, const QModelIndex & bottomRight, const QVector<int> &roles )
   {
-    Q_UNUSED( bottomRight );
-    Q_UNUSED( roles );
+    Q_UNUSED( bottomRight )
+    Q_UNUSED( roles )
 
     const int index = findProject( mCurrentProjectId );
 
@@ -483,8 +483,10 @@ void QFieldCloudProjectsModel::projectGetExportStatus( const QString &projectId 
         // download export job should be already started!!!
         Q_ASSERT( 0 );
         FALLTHROUGH
+
       case ExportAbortStatus:
         return;
+
       case ExportPendingStatus:
       case ExportBusyStatus:
         // infinite retry, there should be one day, when we can get the status!
@@ -493,6 +495,7 @@ void QFieldCloudProjectsModel::projectGetExportStatus( const QString &projectId 
           projectGetExportStatus( projectId );
         } );
         break;
+
       case ExportErrorStatus:
       {
         QString output = payload.value( QStringLiteral( "output" ) ).toString().split( '\n' ).last();
@@ -502,7 +505,7 @@ void QFieldCloudProjectsModel::projectGetExportStatus( const QString &projectId 
           projectDownloadFinishedWithError( projectId, tr( "Export failed" ) );
         return;
       }
-      break;
+
       case ExportFinishedStatus:
         QgsLogger::debug( QStringLiteral( "Export files list requested for \"%1\"" ).arg( projectId ) );
 
@@ -774,7 +777,7 @@ void QFieldCloudProjectsModel::uploadProject( const QString &projectId, const bo
       continue;
     }
 
-    const int fileSize = fileInfo.size();
+    const long long fileSize = fileInfo.size();
 
     // ? should we also check the checksums of the files being uploaded? they are available at deltaFile->attachmentFileNames()->values()
     mCloudProjects[index].uploadAttachments.insert( fileName, FileTransfer( fileName, fileSize ) );
@@ -1087,7 +1090,7 @@ void QFieldCloudProjectsModel::projectUploadAttachments( const QString &projectI
 
     connect( attachmentCloudReply, &NetworkReply::uploadProgress, this, [ = ]( int bytesSent, int bytesTotal )
     {
-      Q_UNUSED( bytesTotal );
+      Q_UNUSED( bytesTotal )
       mCloudProjects[index].uploadAttachments[fileName].bytesTransferred = bytesSent;
       emit dataChanged( idx, idx, QVector<int>() << UploadAttachmentsProgressRole );
     } );
@@ -1169,7 +1172,7 @@ void QFieldCloudProjectsModel::connectionStatusChanged()
 
 void QFieldCloudProjectsModel::layerObserverLayerEdited( const QString &layerId )
 {
-  Q_UNUSED( layerId );
+  Q_UNUSED( layerId )
 
   const int index = findProject( mCurrentProjectId );
 
@@ -1278,7 +1281,7 @@ void QFieldCloudProjectsModel::downloadFileConnections( const QString &projectId
 
   connect( reply, &NetworkReply::downloadProgress, reply, [ = ]( int bytesReceived, int bytesTotal )
   {
-    Q_UNUSED( bytesTotal );
+    Q_UNUSED( bytesTotal )
 
     // it means the NetworkReply has failed and retried
     mCloudProjects[index].downloadBytesReceived -= mCloudProjects[index].downloadFileTransfers[fileName].bytesTransferred;

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -767,8 +767,7 @@ void QFieldCloudProjectsModel::uploadProject( const QString &projectId, const bo
   }
   mCloudProjects[index].uploadAttachmentsFailed = 0;
 
-  QStringList attachmentFileNames = deltaFileWrapper->attachmentFileNames().keys();
-  attachmentFileNames << QString( "/home/webmaster/Desktop/transparent.png" );
+  const QStringList attachmentFileNames = deltaFileWrapper->attachmentFileNames().keys();
   for ( const QString &fileName : attachmentFileNames )
   {
     QFileInfo fileInfo( fileName );
@@ -1100,6 +1099,7 @@ void QFieldCloudProjectsModel::projectUploadAttachments( const QString &projectI
     connect( attachmentCloudReply, &NetworkReply::finished, this, [ = ]()
     {
       QNetworkReply *attachmentReply = attachmentCloudReply->reply();
+      attachmentCloudReply->deleteLater();
 
       Q_ASSERT( attachmentCloudReply->isFinished() );
       Q_ASSERT( attachmentReply );
@@ -1424,6 +1424,7 @@ QHash<int, QByteArray> QFieldCloudProjectsModel::roleNames() const
   roles[DownloadProgressRole] = "DownloadProgress";
   roles[ExportStatusRole] = "ExportStatus";
   roles[ExportedLayerErrorsRole] = "ExportedLayerErrors";
+  roles[UploadAttachmentsStatusRole] = "UploadAttachmentsStatus";
   roles[UploadAttachmentsProgressRole] = "UploadAttachmentsProgress";
   roles[UploadDeltaProgressRole] = "UploadDeltaProgress";
   roles[UploadDeltaStatusRole] = "UploadDeltaStatus";

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -767,11 +767,18 @@ void QFieldCloudProjectsModel::uploadProject( const QString &projectId, const bo
   }
   mCloudProjects[index].uploadAttachmentsFailed = 0;
 
+  const QFileInfo projectInfo( QFieldCloudUtils::localProjectFilePath( mUsername, projectId ) );
+  const QDir projectDir( projectInfo.absolutePath() );
   QStringList attachmentFileNames = deltaFileWrapper->attachmentFileNames().keys();
-  attachmentFileNames << QStringLiteral( "/home/webmaster/.local/share/qfield/profiles/default/cloud_projects/mathieu/a83a3b64-cdb4-4ed0-abb4-4a52a4c06135/test/ramps.xml" );
-  for ( const QString &fileName : attachmentFileNames )
+  for ( QString &fileName : attachmentFileNames )
   {
     QFileInfo fileInfo( fileName );
+    if ( fileInfo.isRelative() )
+    {
+      fileName = projectDir.absoluteFilePath( fileName );
+      fileInfo = QFileInfo( fileName );
+    }
+
     if ( !fileInfo.exists() )
     {
       QgsMessageLog::logMessage( QStringLiteral( "Attachment file '%1' does not exist" ).arg( fileName ) );
@@ -1407,7 +1414,9 @@ NetworkReply *QFieldCloudProjectsModel::uploadAttachment( const QString &project
 {
   QFileInfo projectInfo( QFieldCloudUtils::localProjectFilePath( mUsername, projectId ) );
   QDir projectDir( projectInfo.absolutePath() );
+
   const QString apiPath = projectDir.relativeFilePath( fileName );
+
   return mCloudConnection->post( QStringLiteral( "/api/v1/files/%1/%2/" ).arg( projectId, apiPath ), QVariantMap(), QStringList( { fileName } ) );
 }
 

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -345,6 +345,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
 
       UploadAttachmentsStatus uploadAttachmentsStatus = UploadAttachmentsStatus::UploadAttachmentsDone;
       QMap<QString, FileTransfer> uploadAttachments;
+      int uploadAttachmentsFailed = 0;
       double uploadAttachmentsProgress = 0.0; // range from 0.0 to 1.0
 
       double uploadDeltaProgress = 0.0; // range from 0.0 to 1.0

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -56,7 +56,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
       ExportStatusRole,
       ExportedLayerErrorsRole,
       UploadAttachmentsStatusRole,
-      UploadAttachmentsProgressRole,
+      UploadAttachmentsCountRole,
       UploadDeltaProgressRole,
       UploadDeltaStatusRole,
       UploadDeltaStatusStringRole,
@@ -346,7 +346,6 @@ class QFieldCloudProjectsModel : public QAbstractListModel
       UploadAttachmentsStatus uploadAttachmentsStatus = UploadAttachmentsStatus::UploadAttachmentsDone;
       QMap<QString, FileTransfer> uploadAttachments;
       int uploadAttachmentsFailed = 0;
-      double uploadAttachmentsProgress = 0.0; // range from 0.0 to 1.0
 
       double uploadDeltaProgress = 0.0; // range from 0.0 to 1.0
       int deltasCount = 0;

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -261,7 +261,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     void connectionStatusChanged();
     void projectListReceived();
 
-    NetworkReply *uploadFile( const QString &projectId, const QString &fileName );
+    NetworkReply *uploadAttachment( const QString &projectId, const QString &fileName );
 
     int findProject( const QString &projectId ) const;
 

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -55,6 +55,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
       DownloadProgressRole,
       ExportStatusRole,
       ExportedLayerErrorsRole,
+      UploadAttachmentsStatusRole,
       UploadAttachmentsProgressRole,
       UploadDeltaProgressRole,
       UploadDeltaStatusRole,
@@ -127,6 +128,15 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     };
 
     Q_ENUM( DeltaFileStatus )
+
+    //! The status of attachments uploading to server.
+    enum UploadAttachmentsStatus
+    {
+      UploadAttachmentsDone,
+      UploadAttachmentsInProgress,
+    };
+
+    Q_ENUM( UploadAttachmentsStatus )
 
     //! The status of the running server job for exporting a project.
     enum ExportStatus
@@ -333,9 +343,9 @@ class QFieldCloudProjectsModel : public QAbstractListModel
       int downloadBytesReceived = 0;
       double downloadProgress = 0.0; // range from 0.0 to 1.0
 
+      UploadAttachmentsStatus uploadAttachmentsStatus = UploadAttachmentsStatus::UploadAttachmentsDone;
       QMap<QString, FileTransfer> uploadAttachments;
       double uploadAttachmentsProgress = 0.0; // range from 0.0 to 1.0
-      bool uploadingAttachments;
 
       double uploadDeltaProgress = 0.0; // range from 0.0 to 1.0
       int deltasCount = 0;

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -334,12 +334,10 @@ class QFieldCloudProjectsModel : public QAbstractListModel
       double downloadProgress = 0.0; // range from 0.0 to 1.0
 
       QMap<QString, FileTransfer> uploadAttachments;
-      int uploadAttachmentsFinished = 0;
-      int uploadAttachmentsFailed = 0;
-      int uploadAttachmentsBytesTotal = 0;
       double uploadAttachmentsProgress = 0.0; // range from 0.0 to 1.0
-      double uploadDeltaProgress = 0.0; // range from 0.0 to 1.0
+      bool uploadingAttachments;
 
+      double uploadDeltaProgress = 0.0; // range from 0.0 to 1.0
       int deltasCount = 0;
 
       QString lastLocalExport;
@@ -359,6 +357,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     std::unique_ptr<DeltaStatusListModel> mDeltaStatusListModel;
 
     void projectCancelUpload( const QString &projectId );
+    void projectCancelUploadAttachments( const QString &projectId );
     void projectUploadAttachments( const QString &projectId );
     void projectApplyDeltas( const QString &projectId );
     void projectGetDeltaStatus( const QString &projectId );

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -273,7 +273,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     {
       FileTransfer(
         const QString &fileName,
-        const int bytesTotal,
+        const long long bytesTotal,
         NetworkReply *networkReply = nullptr,
         const QStringList &layerIds = QStringList()
       )
@@ -287,8 +287,8 @@ class QFieldCloudProjectsModel : public QAbstractListModel
 
       QString fileName;
       QString tmpFile;
-      int bytesTotal;
-      int bytesTransferred = 0;
+      long long bytesTotal;
+      long long bytesTransferred = 0;
       bool isFinished = false;
       NetworkReply *networkReply;
       QNetworkReply::NetworkError error = QNetworkReply::NoError;

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -438,7 +438,17 @@ Popup {
             }
             wrapMode: Text.WordWrap
             horizontalAlignment: Text.AlignHCenter
-            Layout.bottomMargin: 10
+            Layout.fillWidth: true
+          }
+
+          Text {
+            font: Theme.tipFont
+            color: Theme.mainColor
+            text: cloudProjectsModel.currentProjectData.UploadAttachmentsStatus === QFieldCloudProjectsModel.UploadAttachmentsInProgress
+                  ? qsTr( 'Attachments are currently uploaded in the background' )
+                  : ''
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
             Layout.fillWidth: true
           }
         }

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -445,7 +445,7 @@ Popup {
             font: Theme.tipFont
             color: Theme.mainColor
             text: cloudProjectsModel.currentProjectData.UploadAttachmentsStatus === QFieldCloudProjectsModel.UploadAttachmentsInProgress
-                  ? qsTr( 'Attachments are currently uploaded in the background' )
+                  ? qsTr( "%n attachment(s) are currently being uploaded in the background.", "", parseInt(cloudProjectsModel.currentProjectData.UploadAttachmentsCount) )
                   : ''
             wrapMode: Text.WordWrap
             horizontalAlignment: Text.AlignHCenter

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -161,21 +161,22 @@ Popup {
           id: statusText
           visible: cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Downloading ||
                    cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Uploading
-          font: Theme.defaultFont
+          font: Theme.tipFont
+          color: Theme.gray
           text: switch(cloudProjectsModel.currentProjectData.Status ) {
                   case QFieldCloudProjectsModel.Downloading:
                     switch ( cloudProjectsModel.currentProjectData.ExportStatus ) {
                       case QFieldCloudProjectsModel.ExportFinishedStatus:
                         return qsTr('Downloading %1%…').arg( parseInt(cloudProjectsModel.currentProjectData.DownloadProgress * 100) )
                       default:
-                        return qsTr('QFieldCloud is preparing the latest data just for you.\nThis might take some time, please hold tight…')
+                        return qsTr('QFieldCloud is preparing the latest data just for you. This might take some time, please hold tight…')
                     }
                   case QFieldCloudProjectsModel.Uploading:
                     switch ( cloudProjectsModel.currentProjectData.UploadDeltaStatus ) {
                       case QFieldCloudProjectsModel.DeltaFileLocalStatus:
                         return qsTr('Uploading %1%…').arg( parseInt(cloudProjectsModel.currentProjectData.UploadDeltaProgress * 100) );
                       default:
-                        return qsTr('QFieldCloud is applying the latest uploaded changes.\nThis might take some time, please hold tight…')
+                        return qsTr('QFieldCloud is applying the latest uploaded changes. This might take some time, please hold tight…')
                     }
                   default: '';
                 }
@@ -183,8 +184,7 @@ Popup {
           wrapMode: Text.WordWrap
           horizontalAlignment: Text.AlignHCenter
           Layout.fillWidth: true
-          Layout.leftMargin: 10
-          Layout.rightMargin: 10
+          Layout.margins: 10
         }
 
         Rectangle {


### PR DESCRIPTION
@suricactus , as discussed yesterday, this PR fixes and improves attachment uploads to the cloud.

First, there's a UI feedback informing people that attachments are being uploaded in the background:
![image](https://user-images.githubusercontent.com/1728657/114979210-a6857c80-9eb4-11eb-803d-e1cd0b2a3748.png)
_Feedback at the bottom of the cloud project panel_

Behind the scene, attachments uploads can be cancelled and resumed as well as new attachments appended during a session. If an attachment upload fails (network error, device gone offline, etc.), the failed attachment is keep in the list of attachments to upload and QField will retry the next time the user hits the [ Push changes ] button.

What's left to do is making that list of attachments 'permanent' across QField shutdown and restart.