### PR TITLE
Add a push history popup panel for cloud projects

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -77,7 +77,7 @@ set(QFIELD_CORE_SRCS
   qfieldcloudconnection.cpp
   qfieldcloudprojectsmodel.cpp
   deltafilewrapper.cpp
-  deltastatuslistmodel.cpp
+  deltalistmodel.cpp
   layerobserver.cpp
   networkreply.cpp
   networkmanager.cpp
@@ -164,7 +164,7 @@ set(QFIELD_CORE_HDRS
   qfieldcloudconnection.h
   qfieldcloudprojectsmodel.h
   deltafilewrapper.h
-  deltastatuslistmodel.h
+  deltalistmodel.h
   layerobserver.h
   networkreply.h
   networkmanager.h

--- a/src/core/deltalistmodel.h
+++ b/src/core/deltalistmodel.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-    deltastatuslistmodel.h
+    deltalistmodel.h
     ---------------------
     begin                : December 2020
     copyright            : (C) 2020 by Ivan Ivanov
@@ -13,14 +13,14 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef DELTASTATUSLISTMODEL_H
-#define DELTASTATUSLISTMODEL_H
+#ifndef DELTALISTMODEL_H
+#define DELTALISTMODEL_H
 
 #include <QAbstractListModel>
 #include <QUuid>
 #include <QJsonDocument>
 
-class DeltaStatusListModel : public QAbstractListModel
+class DeltaListModel : public QAbstractListModel
 {
   Q_OBJECT
 
@@ -49,7 +49,7 @@ public:
 
   Q_ENUM( ColumnRole )
 
-  struct DeltaStatus {
+  struct Delta {
     QUuid id;
     QUuid deltafileId;
     QString createdAt;
@@ -58,8 +58,8 @@ public:
     QString output;
   };
 
-  DeltaStatusListModel() = default;
-  explicit DeltaStatusListModel( QJsonDocument deltasStatusList );
+  DeltaListModel() = default;
+  explicit DeltaListModel( QJsonDocument deltasStatusList );
 
   //! Returns number of rows.
   int rowCount( const QModelIndex &parent ) const override;
@@ -89,7 +89,7 @@ private:
   QJsonDocument mJson;
   bool mIsValid = false;
   QString mErrorString;
-  QList<DeltaStatus> mDeltas;
+  QList<Delta> mDeltas;
 };
 
-#endif // DELTASTATUSLISTMODEL_H
+#endif // DELTALISTMODEL_H

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -933,8 +933,8 @@ void QFieldCloudProjectsModel::uploadProject( const QString &projectId, const bo
         mCloudProjects[index].status = ProjectStatus::Idle;
         mCloudProjects[index].modification ^= LocalModification;
         mCloudProjects[index].modification |= RemoteModification;
-        mCloudProjects[index].lastLocalPushDeltas = QDateTime::currentDateTimeUtc().toString( Qt::ISODate );
 
+        mCloudProjects[index].lastLocalPushDeltas = QDateTime::currentDateTimeUtc().toString( Qt::ISODate );
         projectSetSetting( projectId, QStringLiteral( "lastLocalPushDeltas" ), mCloudProjects[index].lastLocalPushDeltas );
 
         emit dataChanged( idx, idx, QVector<int>() << ModificationRole << LastLocalPushDeltasRole );
@@ -1430,7 +1430,6 @@ void QFieldCloudProjectsModel::downloadFileConnections( const QString &projectId
         mCloudProjects[index].checkout = ProjectCheckout::LocalAndRemoteCheckout;
         mCloudProjects[index].localPath = QFieldCloudUtils::localProjectFilePath( mUsername, projectId );
         mCloudProjects[index].lastLocalExport = QDateTime::currentDateTimeUtc().toString( Qt::ISODate );
-
         projectSetSetting( projectId, QStringLiteral( "lastLocalExport" ), mCloudProjects[index].lastLocalExport );
 
         emit projectDownloaded( projectId, mCloudProjects[index].name, false );

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -18,7 +18,7 @@
 
 #include "qgsnetworkaccessmanager.h"
 #include "qgsgpkgflusher.h"
-#include "deltastatuslistmodel.h"
+#include "deltalistmodel.h"
 
 #include <QAbstractListModel>
 #include <QSortFilterProxyModel>
@@ -66,6 +66,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
       LastLocalExportRole,
       LastLocalPushDeltasRole,
       UserRoleRole,
+      DeltaListRole,
     };
 
     Q_ENUM( ColumnRole )
@@ -207,6 +208,9 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     //! Pushes all local deltas for given \a projectId. If \a shouldDownloadUpdates is true, also calls `downloadProject`.
     Q_INVOKABLE void uploadProject( const QString &projectId, const bool shouldDownloadUpdates );
 
+    //! Retreives the delta list for a given \a projectId.
+    Q_INVOKABLE void refreshProjectDeltaList( const QString &projectId );
+
     //! Remove local cloud project with given \a projectId from the device storage
     Q_INVOKABLE void removeLocalProject( const QString &projectId );
 
@@ -312,6 +316,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
       {}
 
       CloudProject() = default;
+      ~CloudProject() { delete deltaListModel; }
 
       QString id;
       bool isPrivate = true;
@@ -349,6 +354,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
 
       double uploadDeltaProgress = 0.0; // range from 0.0 to 1.0
       int deltasCount = 0;
+      DeltaListModel *deltaListModel = nullptr;
 
       QString lastLocalExport;
       QString lastLocalPushDeltas;
@@ -363,8 +369,6 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     QgsProject *mProject = nullptr;
     QgsGpkgFlusher *mGpkgFlusher = nullptr;
     QString mUsername;
-
-    std::unique_ptr<DeltaStatusListModel> mDeltaStatusListModel;
 
     void projectCancelUpload( const QString &projectId );
     void projectCancelUploadAttachments( const QString &projectId );

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -139,6 +139,7 @@
 #include "qfieldcloudutils.h"
 #include "layerobserver.h"
 #include "deltafilewrapper.h"
+#include "deltalistmodel.h"
 
 
 #define QUOTE(string) _QUOTE(string)
@@ -407,6 +408,7 @@ void QgisMobileapp::initDeclarative()
   qmlRegisterType<QFieldCloudConnection>( "org.qfield", 1, 0, "QFieldCloudConnection" );
   qmlRegisterType<QFieldCloudProjectsModel>( "org.qfield", 1, 0, "QFieldCloudProjectsModel" );
   qmlRegisterType<QFieldCloudProjectsFilterModel>( "org.qfield", 1, 0, "QFieldCloudProjectsFilterModel" );
+  qmlRegisterType<DeltaListModel>( "org.qfield", 1, 0, "DeltaListModel" );
 
   qRegisterMetaType<GnssPositionInformation>( "GnssPositionInformation" );
 

--- a/src/qml/LocatorSettings.qml
+++ b/src/qml/LocatorSettings.qml
@@ -21,17 +21,41 @@ Popup {
     Page {
         id: page
         width: parent.width
-        height: locatorfiltersList.height
+        height: locatorfiltersList.height + 60
         padding: 10
-        header: Label {
-            padding: 10
-            topPadding: 15
-            bottomPadding: 0
+        header: ToolBar {
+          id: toolBar
+          height: 48
+
+          background: Rectangle {
+            color: "transparent"
+          }
+
+          Label {
+            anchors.centerIn: parent
+            leftPadding: 48
+            rightPadding: 48
             width: parent.width - 20
             text: qsTr( "Search Settings" )
             font: Theme.strongFont
+            color: Theme.mainColor
             horizontalAlignment: Text.AlignHCenter
             wrapMode: Text.WordWrap
+          }
+
+          QfToolButton {
+            id: closeButton
+            anchors {
+              top: parent.top
+              right: parent.right
+            }
+            iconSource: Theme.getThemeIcon( 'ic_close_black_24dp' )
+            bgcolor: "white"
+
+            onClicked: {
+              popup.close();
+            }
+          }
         }
 
         Column {
@@ -41,7 +65,7 @@ Popup {
             ListView {
                 id: locatorfiltersList
                 width: parent.width
-                height: Math.min( childrenRect.height, mainWindow.height - 80 );
+                height: Math.min( childrenRect.height, mainWindow.height - 160 );
                 clip: true
 
                 model: LocatorFiltersModel {

--- a/src/qml/QFieldCloudDeltaHistory.qml
+++ b/src/qml/QFieldCloudDeltaHistory.qml
@@ -10,27 +10,51 @@ import Theme 1.0
 Popup {
     id: popup
 
-    property alias model: deltasList.model
+    property alias model: deltaList.model
 
     width: Math.min( 400, mainWindow.width - 20 )
     x: (parent.width - width) / 2
-    y: (parent.height - height) / 2
+    y: (parent.height - page.height) / 2
     padding: 0
 
     Page {
         id: page
         width: parent.width
-        height: deltasList.height
+        height: deltaList.height + 60
         padding: 10
-        header: Label {
-            padding: 10
-            topPadding: 15
-            bottomPadding: 0
+        header: ToolBar {
+          id: toolBar;
+          height: 48
+
+          background: Rectangle {
+            color: "transparent"
+          }
+
+          Label {
+            anchors.centerIn: parent
+            leftPadding: 48
+            rightPadding: 48
             width: parent.width - 20
             text: qsTr( "Push History" )
             font: Theme.strongFont
+            color: Theme.mainColor
             horizontalAlignment: Text.AlignHCenter
             wrapMode: Text.WordWrap
+          }
+
+          QfToolButton {
+            id: closeButton
+            anchors {
+              top: parent.top
+              right: parent.right
+            }
+            iconSource: Theme.getThemeIcon( 'ic_close_black_24dp' )
+            bgcolor: "transparent"
+
+            onClicked: {
+              popup.close();
+            }
+          }
         }
 
         Column {
@@ -38,9 +62,9 @@ Popup {
             width: parent.width
 
             ListView {
-                id: deltasList
+                id: deltaList
                 width: parent.width
-                height: Math.min( childrenRect.height, mainWindow.height - 80 );
+                height: Math.min( deltaList.childrenRect.height, mainWindow.height - 160 )
                 clip: true
 
                 delegate: Rectangle {

--- a/src/qml/QFieldCloudDeltaHistory.qml
+++ b/src/qml/QFieldCloudDeltaHistory.qml
@@ -23,7 +23,7 @@ Popup {
         height: deltaList.height + 60
         padding: 10
         header: ToolBar {
-          id: toolBar;
+          id: toolBar
           height: 48
 
           background: Rectangle {
@@ -49,7 +49,7 @@ Popup {
               right: parent.right
             }
             iconSource: Theme.getThemeIcon( 'ic_close_black_24dp' )
-            bgcolor: "transparent"
+            bgcolor: "white"
 
             onClicked: {
               popup.close();

--- a/src/qml/QFieldCloudDeltaHistory.qml
+++ b/src/qml/QFieldCloudDeltaHistory.qml
@@ -1,0 +1,106 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.12
+
+import org.qgis 1.0
+import org.qfield 1.0
+
+import Theme 1.0
+
+Popup {
+    id: popup
+
+    property alias model: deltasList.model
+
+    width: Math.min( 400, mainWindow.width - 20 )
+    x: (parent.width - width) / 2
+    y: (parent.height - height) / 2
+    padding: 0
+
+    Page {
+        id: page
+        width: parent.width
+        height: deltasList.height
+        padding: 10
+        header: Label {
+            padding: 10
+            topPadding: 15
+            bottomPadding: 0
+            width: parent.width - 20
+            text: qsTr( "Push History" )
+            font: Theme.strongFont
+            horizontalAlignment: Text.AlignHCenter
+            wrapMode: Text.WordWrap
+        }
+
+        Column {
+            spacing: 4
+            width: parent.width
+
+            ListView {
+                id: deltasList
+                width: parent.width
+                height: Math.min( childrenRect.height, mainWindow.height - 80 );
+                clip: true
+
+                delegate: Rectangle {
+                    id: rectangle
+                    width: parent ? parent.width : undefined
+                    height: inner.height
+                    color: "transparent"
+
+                    ColumnLayout {
+                        id: inner
+                        width: parent.width
+
+                        Text {
+                            Layout.fillWidth: true
+                            topPadding: 5
+                            leftPadding: 5
+                            text: {
+                              var dt = new Date(CreatedAt)
+                              return dt.toLocaleString()
+                            }
+                            font: Theme.defaultFont
+                            color: "black"
+                            wrapMode: Text.WordWrap
+                        }
+
+                        Text {
+                            Layout.fillWidth: true
+                            leftPadding: 5
+                            bottomPadding: 5
+                            text: {
+                                var status = ''
+                                switch(Status) {
+                                  case DeltaListModel.PendingStatus:
+                                    status = 'pending'
+                                    break;
+                                  case DeltaListModel.BusyStatus:
+                                    status = 'busy'
+                                    break;
+                                  case DeltaListModel.AppliedStatus:
+                                    status = 'applied'
+                                    break;
+                                  case DeltaListModel.ConflictStatus:
+                                    status = 'conflict'
+                                    break;
+                                  case DeltaListModel.NotAppliedStatus:
+                                    status = 'not applied'
+                                    break;
+                                  case DeltaListModel.ErrorStatus:
+                                    status = 'error'
+                                    break;
+                                }
+                                return 'Status: ' + status + ( Output != '' ? ' (' + Output + ')' : '' )
+                              }
+                            font: Theme.tipFont
+                            color: Theme.gray
+                            wrapMode: Text.WordWrap
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -399,55 +399,35 @@ Popup {
           }
 
           Text {
-            id: lastExportText
+            id: lastExportPushText
             font: Theme.tipFont
             color: Theme.gray
             text: {
+              var exportText = ''
               var dt = cloudProjectsModel.currentProjectData.LastLocalExport
+              if (dt) {
+                dt = new Date(dt)
+                if (dt.toLocaleDateString() === new Date().toLocaleDateString())
+                  exportText = qsTr( 'Last synchronized at ' ) + dt.toLocaleTimeString()
+                else
+                  exportText = qsTr( 'Last synchronized on ' ) + dt.toLocaleString()
+              }
 
-              if (!dt)
-                return ''
+              var pushText = ''
+              dt = cloudProjectsModel.currentProjectData.LastLocalPushDeltas
 
-              dt = new Date(dt)
+              if (dt) {
+                dt = new Date(dt)
+                if (dt.toLocaleDateString() === new Date().toLocaleDateString())
+                  pushText = qsTr( 'Last changes pushed at ' ) + dt.toLocaleTimeString()
+                else
+                  pushText = qsTr( 'Last changes pushed on ' ) + dt.toLocaleString()
+              } else {
+                pushText = qsTr( 'No changes pushed yet' )
+              }
 
-              if (dt.toLocaleDateString() === new Date().toLocaleDateString())
-                return qsTr( 'Last cloud export at ' ) + dt.toLocaleTimeString()
-              else
-                return qsTr( 'Last cloud export on ' ) + dt.toLocaleString()
+              return exportText + '\n' + pushText
             }
-            wrapMode: Text.WordWrap
-            horizontalAlignment: Text.AlignHCenter
-            Layout.fillWidth: true
-          }
-
-          Text {
-            id: lastPushDeltasText
-            font: Theme.tipFont
-            color: Theme.gray
-            text: {
-              var dt = cloudProjectsModel.currentProjectData.LastLocalPushDeltas
-
-              if (!dt)
-                return qsTr( 'No changes pushed yet' )
-
-              dt = new Date(dt)
-
-              if (dt.toLocaleDateString() === new Date().toLocaleDateString())
-                return qsTr( 'Last changes push at ' ) + dt.toLocaleTimeString()
-              else
-                return qsTr( 'Last changes push on ' ) + dt.toLocaleString()
-            }
-            wrapMode: Text.WordWrap
-            horizontalAlignment: Text.AlignHCenter
-            Layout.fillWidth: true
-          }
-
-          Text {
-            font: Theme.tipFont
-            color: Theme.mainColor
-            text: cloudProjectsModel.currentProjectData.UploadAttachmentsStatus === QFieldCloudProjectsModel.UploadAttachmentsInProgress
-                  ? qsTr( "%n attachment(s) are currently being uploaded in the background.", "", parseInt(cloudProjectsModel.currentProjectData.UploadAttachmentsCount) )
-                  : ''
             wrapMode: Text.WordWrap
             horizontalAlignment: Text.AlignHCenter
             Layout.fillWidth: true
@@ -459,6 +439,17 @@ Popup {
                 qfieldCloudDeltaHistory.open()
               }
             }
+          }
+
+          Text {
+            font: Theme.tipFont
+            color: Theme.mainColor
+            text: cloudProjectsModel.currentProjectData.UploadAttachmentsStatus === QFieldCloudProjectsModel.UploadAttachmentsInProgress
+                  ? qsTr( "%n attachment(s) are currently being uploaded in the background.", "", parseInt(cloudProjectsModel.currentProjectData.UploadAttachmentsCount) )
+                  : ''
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
+            Layout.fillWidth: true
           }
         }
       }

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -451,6 +451,14 @@ Popup {
             wrapMode: Text.WordWrap
             horizontalAlignment: Text.AlignHCenter
             Layout.fillWidth: true
+
+            MouseArea {
+              anchors.fill: parent
+              onClicked: {
+                qfieldCloudDeltaHistory.model = cloudProjectsModel.currentProjectData.DeltaList
+                qfieldCloudDeltaHistory.open()
+              }
+            }
           }
         }
       }
@@ -467,6 +475,8 @@ Popup {
         displayToast(qsTr('Connecting...'))
       } else if (cloudConnection.status === QFieldCloudConnection.LoggedIn) {
         displayToast(qsTr('Logged in'))
+        if ( cloudProjectsModel.currentProjectId != '' )
+          cloudProjectsModel.refreshProjectDeltaList(cloudProjectsModel.currentProjectId)
       }
     }
   }
@@ -539,6 +549,8 @@ Popup {
 
     if ( cloudProjectsModel.currentProjectId && cloudConnection.hasToken && cloudConnection.status === QFieldCloudConnection.Disconnected )
       cloudConnection.login();
+    else if ( cloudProjectsModel.currentProjectId != '' )
+      cloudProjectsModel.refreshProjectDeltaList(cloudProjectsModel.currentProjectId)
 
     if ( cloudConnection.status === QFieldCloudConnection.Connectiong )
       displayToast(qsTr('Connecting cloud'))

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -16,9 +16,9 @@ Popup {
     header: PageHeader {
       title: qsTr('QFieldCloud')
 
-      showCancelButton: false
-      showApplyButton: cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Idle
-            || cloudConnection.status === QFieldCloudConnection.Disconnected
+      showCancelButton: cloudProjectsModel.currentProjectData.Status !== QFieldCloudProjectsModel.Uploading
+                        || cloudConnection.status === QFieldCloudConnection.Disconnected
+      showApplyButton: false
       busyIndicatorState: cloudConnection.status === QFieldCloudConnection.Connecting
             || cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Uploading
             || cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Downloading

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2025,6 +2025,14 @@ ApplicationWindow {
     onWarning: displayToast( message )
   }
 
+  QFieldCloudDeltaHistory {
+      id: qfieldCloudDeltaHistory
+
+      modal: true
+      closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+      parent: ApplicationWindow.overlay
+  }
+
   QFieldCloudScreen {
     id: qfieldCloudScreen
 

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -65,6 +65,7 @@
         <file>QFieldCloudLogin.qml</file>
         <file>QFieldCloudScreen.qml</file>
         <file>QFieldCloudPopup.qml</file>
+        <file>QFieldCloudDeltaHistory.qml</file>
         <file>QFieldCloudExportLayersFeedback.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
This PR adds a push history popup panel for cloud projects. The history gives a list of deltas pushed with a status:
![image](https://user-images.githubusercontent.com/1728657/115231530-e14f1500-a13f-11eb-9674-565111f11d54.png)

One thing that jumped at me while doing this: for projects edited by multiple users, we would definitively gain showing the user info alongside date and status.

The UI is not entirely finished (currently the panel is accessible via a hidden click on the 'no change pushed yet/last changed pushed on XXX' label, and there's a missing [X] to close the panel (you can do so by clicking on margins).

@suricactus , I renamed a class and a few members / structs to try and make things clearer, hope I achieved this.