### PR TITLE
QField should respect QFieldCloud permissions model

### DIFF
--- a/src/core/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloudconnection.cpp
@@ -32,6 +32,7 @@
 
 QFieldCloudConnection::QFieldCloudConnection()
   : mUrl( QSettings().value( QStringLiteral( "/QFieldCloud/url" ), defaultUrl() ).toString() )
+  , mUsername( QSettings().value( QStringLiteral( "/QFieldCloud/username" ) ).toString() )
   , mToken( QSettings().value( QStringLiteral( "/QFieldCloud/token" ) ).toByteArray() )
 {
   QgsNetworkAccessManager::instance()->setTimeout( 60 * 60 * 1000 );
@@ -256,7 +257,9 @@ void QFieldCloudConnection::login()
     }
 
     mUsername = resp.value( QStringLiteral( "username" ) ).toString();
+    QSettings().setValue( "/QFieldCloud/username", mUsername );
     emit usernameChanged();
+
     mAvatarUrl = resp.value( QStringLiteral( "avatar_url" ) ).toString();
     emit avatarUrlChanged();
     mUserInformation  = CloudUserInformation( mUsername, resp.value( QStringLiteral( "email" ) ).toString() );

--- a/src/core/qfieldcloudconnection.h
+++ b/src/core/qfieldcloudconnection.h
@@ -165,14 +165,16 @@ class QFieldCloudConnection : public QObject
     void setToken( const QByteArray &token );
     void invalidateToken();
 
-    QString mPassword;
+    QString mUrl;
+
     QString mUsername;
+    QString mPassword;
+    QByteArray mToken;
+
     QString mAvatarUrl;
     CloudUserInformation mUserInformation;
-    QString mUrl;
     ConnectionStatus mStatus = ConnectionStatus::Disconnected;
     ConnectionState mState = ConnectionState::Idle;
-    QByteArray mToken;
 
     int mPendingRequests = 0;
 

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -1446,7 +1446,7 @@ QHash<int, QByteArray> QFieldCloudProjectsModel::roleNames() const
   roles[CanSyncRole] = "CanSync";
   roles[LastLocalExportRole] = "LastLocalExport";
   roles[LastLocalPushDeltasRole] = "LastLocalPushDeltas";
-  roles[CollaboratorRole] = "CollaboratorRole";
+  roles[UserRoleRole] = "UserRole";
 
   return roles;
 }
@@ -1481,7 +1481,7 @@ void QFieldCloudProjectsModel::reload( const QJsonArray &remoteProjects )
                                projectDetails.value( "owner" ).toString(),
                                projectDetails.value( "name" ).toString(),
                                projectDetails.value( "description" ).toString(),
-                               projectDetails.value( "collaborators__role" ).toString(),
+                               projectDetails.value( "user_role" ).toString(),
                                QString(),
                                RemoteCheckout,
                                ProjectStatus::Idle );
@@ -1491,7 +1491,7 @@ void QFieldCloudProjectsModel::reload( const QJsonArray &remoteProjects )
     projectSetSetting( cloudProject.id, QStringLiteral( "name" ), cloudProject.name );
     projectSetSetting( cloudProject.id, QStringLiteral( "description" ), cloudProject.description );
     projectSetSetting( cloudProject.id, QStringLiteral( "updatedAt" ), cloudProject.updatedAt );
-    projectSetSetting( cloudProject.id, QStringLiteral( "collaboratorRole" ), cloudProject.collaboratorRole );
+    projectSetSetting( cloudProject.id, QStringLiteral( "userRole" ), cloudProject.userRole );
 
     if ( !mUsername.isEmpty() )
     {
@@ -1526,9 +1526,9 @@ void QFieldCloudProjectsModel::reload( const QJsonArray &remoteProjects )
       const QString name = projectSetting( projectId, QStringLiteral( "name" ) ).toString();
       const QString description = projectSetting( projectId, QStringLiteral( "description" ) ).toString();
       const QString updatedAt = projectSetting( projectId, QStringLiteral( "updatedAt" ) ).toString();
-      const QString collaboratorRole = projectSetting( projectId, QStringLiteral( "collaboratorRole" ) ).toString();
+      const QString userRole = projectSetting( projectId, QStringLiteral( "userRole" ) ).toString();
 
-      CloudProject cloudProject( projectId, true, owner, name, description, collaboratorRole, QString(), LocalCheckout, ProjectStatus::Idle );
+      CloudProject cloudProject( projectId, true, owner, name, description, userRole, QString(), LocalCheckout, ProjectStatus::Idle );
       QDir localPath( QStringLiteral( "%1/%2/%3" ).arg( QFieldCloudUtils::localCloudDirectory(), mUsername, cloudProject.id ) );
 
       restoreLocalSettings( cloudProject, localPath );
@@ -1607,8 +1607,8 @@ QVariant QFieldCloudProjectsModel::data( const QModelIndex &index, int role ) co
       return mCloudProjects.at( index.row() ).lastLocalExport;
     case LastLocalPushDeltasRole:
       return mCloudProjects.at( index.row() ).lastLocalPushDeltas;
-    case CollaboratorRole:
-      return mCloudProjects.at( index.row() ).collaboratorRole;
+    case UserRoleRole:
+      return mCloudProjects.at( index.row() ).userRole;
   }
 
   return QVariant();

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -1506,9 +1506,12 @@ void QFieldCloudProjectsModel::reload( const QJsonArray &remoteProjects )
     mCloudProjects << cloudProject;
   }
 
-  if ( !mUsername.isEmpty() )
+  QDirIterator userDirs( QFieldCloudUtils::localCloudDirectory(), QDir::Dirs | QDir::NoDotAndDotDot );
+  while( userDirs.hasNext() )
   {
-    QDirIterator projectDirs( QStringLiteral( "%1/%2" ).arg( QFieldCloudUtils::localCloudDirectory(), mUsername ), QDir::Dirs | QDir::NoDotAndDotDot );
+    userDirs.next();
+    const QString username = userDirs.fileName();
+    QDirIterator projectDirs( QStringLiteral( "%1/%2" ).arg( QFieldCloudUtils::localCloudDirectory(), username ), QDir::Dirs | QDir::NoDotAndDotDot );
     while ( projectDirs.hasNext() )
     {
       projectDirs.next();
@@ -1529,7 +1532,7 @@ void QFieldCloudProjectsModel::reload( const QJsonArray &remoteProjects )
       const QString userRole = projectSetting( projectId, QStringLiteral( "userRole" ) ).toString();
 
       CloudProject cloudProject( projectId, true, owner, name, description, userRole, QString(), LocalCheckout, ProjectStatus::Idle );
-      QDir localPath( QStringLiteral( "%1/%2/%3" ).arg( QFieldCloudUtils::localCloudDirectory(), mUsername, cloudProject.id ) );
+      QDir localPath( QStringLiteral( "%1/%2/%3" ).arg( QFieldCloudUtils::localCloudDirectory(), username, cloudProject.id ) );
 
       restoreLocalSettings( cloudProject, localPath );
 

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -65,7 +65,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
       CanSyncRole,
       LastLocalExportRole,
       LastLocalPushDeltasRole,
-      CollaboratorRole,
+      UserRoleRole,
     };
 
     Q_ENUM( ColumnRole )
@@ -299,13 +299,13 @@ class QFieldCloudProjectsModel : public QAbstractListModel
 
     struct CloudProject
     {
-      CloudProject( const QString &id, bool isPrivate, const QString &owner, const QString &name, const QString &description, const QString &collaboratorRole, const QString &updatedAt, const ProjectCheckouts &checkout, const ProjectStatus &status )
+      CloudProject( const QString &id, bool isPrivate, const QString &owner, const QString &name, const QString &description, const QString &userRole, const QString &updatedAt, const ProjectCheckouts &checkout, const ProjectStatus &status )
         : id( id )
         , isPrivate( isPrivate )
         , owner( owner )
         , name( name )
         , description( description )
-        , collaboratorRole( collaboratorRole )
+        , userRole( userRole )
         , updatedAt( updatedAt )
         , status( status )
         , checkout( checkout )
@@ -318,7 +318,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
       QString owner;
       QString name;
       QString description;
-      QString collaboratorRole;
+      QString userRole;
       QString updatedAt;
       ProjectStatus status;
       ProjectErrorStatus errorStatus = ProjectErrorStatus::NoErrorStatus;

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -81,8 +81,9 @@ Drawer {
 
       Switch {
         id: modeswitch
+        visible: projectInfo.insertRight
         height: 56
-        width: ( 56 + 36 ) 
+        width: ( 56 + 36 )
         anchors.right: parent.right
         indicator: Rectangle {
           implicitHeight: 36

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -81,7 +81,7 @@ Drawer {
 
       Switch {
         id: modeswitch
-        visible: projectInfo.insertRight
+        visible: projectInfo.insertRights
         height: 56
         width: ( 56 + 36 )
         anchors.right: parent.right

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -306,7 +306,7 @@ Rectangle {
 
     anchors.right: menuButton.left
 
-    width: ( parent.state == "Navigation" && supportsEditing ? 48: 0 )
+    width: ( parent.state == "Navigation" && supportsEditing && projectInfo.editRights ? 48: 0 )
     height: 48
     clip: true
 
@@ -385,13 +385,18 @@ Rectangle {
 
     anchors.right: menuButton.left
 
-    width: ( parent.state == "Indication" && toolBar.model && toolBar.model.canEditAttributesSelection && toolBar.model.selectedCount > 1 ? 48: 0 )
+    width: parent.state == "Indication"
+           && toolBar.model && toolBar.model.canEditAttributesSelection && toolBar.model.selectedCount > 1
+           && projectInfo.editRights
+           ? 48
+           : 0
     height: 48
     clip: true
 
     iconSource: Theme.getThemeIcon( "ic_edit_attributes_white" )
 
-    enabled: ( toolBar.model && toolBar.model.canEditAttributesSelection && toolBar.model.selectedCount > 1 )
+    enabled: toolBar.model && toolBar.model.canEditAttributesSelection && toolBar.model.selectedCount > 1
+             && projectInfo.editRights
 
     onClicked: {
       multiEditClicked();
@@ -451,15 +456,19 @@ Rectangle {
       }
     }
 
-    MenuSeparator { width: parent.width }
+    MenuSeparator {
+      visible: projectInfo.editRights
+      width: parent.width
+    }
 
     MenuItem {
       text: qsTr( 'Merge Selected Features' )
       icon.source: Theme.getThemeIcon( "ic_merge_features_white_24dp" )
-      enabled: toolBar.model && toolBar.model.canMergeSelection && toolBar.model.selectedCount > 1
+      enabled: toolBar.model && toolBar.model.canMergeSelection && toolBar.model.selectedCount > 1 && projectInfo.editRights
+      visible: projectInfo.editRights
 
       font: Theme.defaultFont
-      height: 48
+      height: visible ? 48 : 0
       leftPadding: 10
 
       onTriggered: multiMergeClicked();
@@ -468,10 +477,11 @@ Rectangle {
     MenuItem {
       text: qsTr( 'Delete Selected Feature(s)' )
       icon.source: Theme.getThemeIcon( "ic_delete_forever_white_24dp" )
-      enabled: toolBar.model && toolBar.model.canDeleteSelection
+      enabled: toolBar.model && toolBar.model.canDeleteSelection && projectInfo.editRights
+      visible: projectInfo.editRights
 
       font: Theme.defaultFont
-      height: 48
+      height: visible ? 48 : 0
       leftPadding: 10
 
       onTriggered: multiDeleteClicked();
@@ -534,14 +544,19 @@ Rectangle {
       onTriggered: extentController.autoZoom = !extentController.autoZoom
     }
 
-    MenuSeparator { width: parent.width }
+    MenuSeparator {
+      visible: projectInfo.editRights
+      width: parent.width
+    }
 
     MenuItem {
       text: qsTr( 'Delete Feature' )
       icon.source: Theme.getThemeIcon( "ic_delete_forever_white_24dp" )
+      enabled: projectInfo.editRights
+      visible: projectInfo.editRights
 
       font: Theme.defaultFont
-      height: 48
+      height: visible ? 48 : 0
       leftPadding: 10
 
       onTriggered: deleteClicked();

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1777,8 +1777,36 @@ ApplicationWindow {
         projectInfo.filePath = path;
 
         mapCanvasBackground.color = mapCanvas.mapSettings.backgroundColor
-        cloudProjectsModel.currentProjectId = QFieldCloudUtils.getProjectId(qgisProject)
-        cloudProjectsModel.refreshProjectModification( cloudProjectsModel.currentProjectId )
+
+        var cloudProjectId = QFieldCloudUtils.getProjectId(qgisProject)
+        cloudProjectsModel.currentProjectId = cloudProjectId
+        cloudProjectsModel.refreshProjectModification(cloudProjectId)
+        if (cloudProjectId != '') {
+          var cloudProjectData = cloudProjectsModel.getProjectData(cloudProjectId)
+          switch(cloudProjectData.UserRole) {
+            case 'reader':
+              projectInfo.insertRights = false
+              projectInfo.editRights = false
+              break;
+            case 'reporter':
+              projectInfo.insertRights = true
+              projectInfo.editRights = false
+              break;
+            case 'editor':
+            case 'manager':
+            case 'admin':
+              projectInfo.insertRights = true
+              projectInfo.editRights = true
+              break;
+            default:
+              projectInfo.insertRights = true
+              projectInfo.editRights = true
+              break;
+          }
+        } else {
+          projectInfo.insertRights = true
+          projectInfo.editRights = true
+        }
       }
 
       function onSetMapExtent(extent) {
@@ -1793,7 +1821,7 @@ ApplicationWindow {
     mapSettings: mapCanvas.mapSettings
     layerTree: dashBoard.layerTree
 
-    property bool insertRight: true
+    property bool insertRights: true
     property bool editRights: true
   }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1794,7 +1794,7 @@ ApplicationWindow {
     layerTree: dashBoard.layerTree
 
     property bool insertRight: true
-    property bool editRights: false
+    property bool editRights: true
   }
 
   BusyIndicator {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1792,6 +1792,9 @@ ApplicationWindow {
 
     mapSettings: mapCanvas.mapSettings
     layerTree: dashBoard.layerTree
+
+    property bool insertRight: true
+    property bool editRights: false
   }
 
   BusyIndicator {


### PR DESCRIPTION
@suricactus , as discussed over the chat, here comes the next piece: permissions handling.

It was a bit more involved than I initially thought it'd be as I had to do some logic updates for QField to remember the last successfully logged in user to unlock proper cloud project models reload while offline (or while connecting). This was working way back last year but along the way as we added more components and refined logics, we lost offline project list loading. All good now.