### PR TITLE
Fix use of relative paths by symbol layers during map canvas rendering

### DIFF
--- a/src/core/qgsquick/qgsquickmapsettings.cpp
+++ b/src/core/qgsquick/qgsquickmapsettings.cpp
@@ -54,6 +54,7 @@ void QgsQuickMapSettings::setProject( QgsProject *project )
     connect( mProject, &QgsProject::crsChanged, this, &QgsQuickMapSettings::onCrsChanged );
     setDestinationCrs( mProject->crs() );
     mMapSettings.setTransformContext( mProject->transformContext() );
+    mMapSettings.setPathResolver( mProject->pathResolver() );
   }
   else
   {
@@ -263,6 +264,7 @@ void QgsQuickMapSettings::onReadProject( const QDomDocument &doc )
   mMapSettings.setRotation( 0 );
 
   mMapSettings.setTransformContext( mProject->transformContext() );
+  mMapSettings.setPathResolver( mProject->pathResolver() );
 
   emit extentChanged();
   emit destinationCrsChanged();


### PR DESCRIPTION
This fixes #1854, whereas rendering  SVG and raster markers / fills symbol layers with relative paths (data defined or otherwise) resulted in broken renderings on QField.