### PR TITLE
Relation editor widget UI/UX improvements

### DIFF
--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -246,6 +246,19 @@ bool ReferencingFeatureListModel::deleteFeature( QgsFeatureId referencingFeature
   return true;
 }
 
+int ReferencingFeatureListModel::getFeatureIdRow( QgsFeatureId featureId )
+{
+  int row = 0;
+  for ( const Entry &entry : mEntries )
+  {
+    if ( entry.referencingFeature.id() == featureId )
+      break;
+    row++;
+  }
+
+  return row < mEntries.size() ? row : -1;
+}
+
 bool ReferencingFeatureListModel::isLoading() const
 {
   return mGatherer;

--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -155,7 +155,7 @@ void ReferencingFeatureListModel::updateModel()
   if ( mGatherer )
     mEntries = mGatherer->entries();
 
-  std::sort( mEntries.begin(), mEntries.end(), []( Entry &e1, Entry &e2 ) {
+  std::sort( mEntries.begin(), mEntries.end(), []( const Entry &e1, const Entry &e2 ) {
     return e1.displayString < e2.displayString;
   } );
 

--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -155,6 +155,10 @@ void ReferencingFeatureListModel::updateModel()
   if ( mGatherer )
     mEntries = mGatherer->entries();
 
+  std::sort( mEntries.begin(), mEntries.end(), []( Entry &e1, Entry &e2 ) {
+    return e1.displayString < e2.displayString;
+  } );
+
   endResetModel();
   modelUpdated();
 }

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -141,6 +141,12 @@ class QFIELD_CORE_EXPORT ReferencingFeatureListModel : public QAbstractItemModel
     Q_INVOKABLE bool deleteFeature( QgsFeatureId referencingFeatureId );
 
     /**
+     * Returns the row number for a given feature id
+     * \param featureId the feature id
+     */
+    Q_INVOKABLE int getFeatureIdRow( QgsFeatureId featureId );
+
+    /**
      * Indicator if the model is currently performing any feature iteration in the background.
      */
     bool isLoading() const;

--- a/src/qml/EmbeddedFeatureForm.qml
+++ b/src/qml/EmbeddedFeatureForm.qml
@@ -37,7 +37,7 @@ Popup {
         }
     }
 
-    signal featureSaved
+    signal featureSaved(int id)
     signal featureCancelled
 
     parent: ApplicationWindow.overlay
@@ -72,7 +72,7 @@ Popup {
         anchors.fill: parent
 
         onConfirmed: {
-            formPopup.featureSaved()
+            formPopup.featureSaved(formFeatureModel.feature.id)
             closePopup()
         }
 

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -147,6 +147,7 @@ Page {
               height: parent.height
               text: tabButton.text
               color: !tabButton.enabled ? Theme.darkGray : tabButton.down ? Qt.darker(Theme.mainColor,1.5) : Theme.mainColor
+              font.pointSize: Theme.tipFont.pointSize
               font.weight: isCurrentIndex ? Font.DemiBold : Font.Normal
 
               horizontalAlignment: Text.AlignHCenter

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -40,7 +40,6 @@ EditorWidgetBase {
         property int featureFocus: -1
         onModelUpdated: {
           if (featureFocus > -1) {
-            console.log(relationEditorModel.getFeatureIdRow(featureFocus))
             referencingFeatureListView.currentIndex = relationEditorModel.getFeatureIdRow(featureFocus)
             featureFocus = -1
           }
@@ -52,7 +51,7 @@ EditorWidgetBase {
         id: referencingFeatureListView
         model: relationEditorModel
         width: parent.width
-        height: Math.min( 4 * itemHeight, referencingFeatureListView.count * itemHeight ) + ( referencingFeatureListView.count > 0 ? itemHeight / 2 : 0 )
+        height: Math.min( 4 * itemHeight, referencingFeatureListView.count * itemHeight ) + ( referencingFeatureListView.count > 4 ? itemHeight / 2 : 0 )
         delegate: referencingFeatureDelegate
         focus: true
         clip: true

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -36,6 +36,15 @@ EditorWidgetBase {
         currentRelationId: relationId
         currentNmRelationId: nmRelationId
         feature: currentFeature
+
+        property int featureFocus: -1
+        onModelUpdated: {
+          if (featureFocus > -1) {
+            console.log(relationEditorModel.getFeatureIdRow(featureFocus))
+            referencingFeatureListView.currentIndex = relationEditorModel.getFeatureIdRow(featureFocus)
+            featureFocus = -1
+          }
+        }
     }
 
     //the list
@@ -290,6 +299,7 @@ EditorWidgetBase {
         }
 
         onFeatureSaved: {
+            relationEditorModel.featureFocus = id
             relationEditorModel.reload()
         }
     }

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -13,7 +13,7 @@ import "."
 EditorWidgetBase {
     id: relationEditor
 
-    property int itemHeight: 32
+    property int itemHeight: 40
 
     // because no additional addEntry item on readOnly (isEnabled false)
     height: isEnabled
@@ -43,8 +43,8 @@ EditorWidgetBase {
         id: referencingFeatureListView
         model: relationEditorModel
         width: parent.width
-        height: Math.min( 5 * itemHeight, referencingFeatureListView.count * itemHeight ) + ( referencingFeatureListView.count > 0 ? itemHeight / 2 : 0 )
-        delegate:
+        height: Math.min( 4 * itemHeight, referencingFeatureListView.count * itemHeight ) + ( referencingFeatureListView.count > 0 ? itemHeight / 2 : 0 )
+        delegate: referencingFeatureDelegate
         focus: true
         clip: true
         highlightRangeMode: ListView.StrictlyEnforceRange
@@ -82,12 +82,13 @@ EditorWidgetBase {
               anchors { leftMargin: 10; left: parent.left; right: addButtonRow.left; verticalCenter: parent.verticalCenter }
               font.bold: true
               font.italic: true
+              font.pointSize: Theme.tipFont.pointSize
           }
 
           Row
           {
             id: addButtonRow
-            anchors { top: parent.top; right: parent.right }
+            anchors { top: parent.top; right: parent.right; rightMargin: 10 }
             height: parent.height
 
             ToolButton {
@@ -101,7 +102,7 @@ EditorWidgetBase {
                     color: parent.enabled ? nmRelationId ? 'blue' : 'black' : 'grey'
                     Image {
                       anchors.fill: parent
-                      anchors.margins: 4
+                      anchors.margins: 8
                       fillMode: Image.PreserveAspectFit
                       horizontalAlignment: Image.AlignHCenter
                       verticalAlignment: Image.AlignVCenter
@@ -150,7 +151,7 @@ EditorWidgetBase {
           Text {
             id: featureText
             anchors { leftMargin: 10; left: parent.left; right: deleteButtonRow.left; verticalCenter: parent.verticalCenter }
-            font.bold: true
+            font: Theme.defaultFont
             color: !isEnabled ? 'grey' : 'black'
             text: { text: nmRelationId ? model.nmDisplayString : model.displayString }
           }
@@ -182,10 +183,10 @@ EditorWidgetBase {
 
                 contentItem: Rectangle {
                     anchors.fill: parent
-                    color: nmRelationId ? 'blue' : '#900000'
+                    color: nmRelationId ? 'blue' : Theme.errorColor
                     Image {
                       anchors.fill: parent
-                      anchors.margins: 4
+                      anchors.margins: 8
                       fillMode: Image.PreserveAspectFit
                       horizontalAlignment: Image.AlignHCenter
                       verticalAlignment: Image.AlignVCenter

--- a/src/qml/editorwidgets/RelationEditor.qml
+++ b/src/qml/editorwidgets/RelationEditor.qml
@@ -43,11 +43,22 @@ EditorWidgetBase {
         id: referencingFeatureListView
         model: relationEditorModel
         width: parent.width
-        height: Math.min( 5 * itemHeight, referencingFeatureListView.count * itemHeight )
-        delegate: referencingFeatureDelegate
+        height: Math.min( 5 * itemHeight, referencingFeatureListView.count * itemHeight ) + ( referencingFeatureListView.count > 0 ? itemHeight / 2 : 0 )
+        delegate:
         focus: true
         clip: true
         highlightRangeMode: ListView.StrictlyEnforceRange
+
+        ScrollBar.vertical: ScrollBar {
+            width: 10
+            policy: ScrollBar.AlwaysOn
+
+            contentItem: Rectangle {
+                implicitWidth: 10
+                implicitHeight: itemHeight
+                color: Theme.mainColor
+            }
+        }
     }
 
     //the add entry "last row"
@@ -160,7 +171,7 @@ EditorWidgetBase {
           Row
           {
             id: deleteButtonRow
-            anchors { top: parent.top; right: parent.right }
+            anchors { top: parent.top; right: parent.right; rightMargin: 10 }
             height: listitem.height
 
             ToolButton {

--- a/test/test_referencingfeaturelistmodel.cpp
+++ b/test/test_referencingfeaturelistmodel.cpp
@@ -254,7 +254,7 @@ class TestReferencingFeatureListModel: public QObject
 
       //check display string of rohan
       QString displayString = mModel->data( mModel->index( 1, 0 ), ReferencingFeatureListModel::DisplayString ).toString();
-      QCOMPARE( displayString, QStringLiteral( "Rohan" ) );
+      QCOMPARE( displayString, QStringLiteral( "Gondor" ) );
 
       //delete Rohan
       mModel->deleteFeature( qvariant_cast<QgsFeature>( mModel->data( mModel->index( 1, 0 ), ReferencingFeatureListModel::ReferencingFeature ) ).id() );
@@ -293,7 +293,7 @@ class TestReferencingFeatureListModel: public QObject
 
       //check display string of Gollums Mordor share (80)
       QString displayString = mModel->data( mModel->index( 0, 0 ), ReferencingFeatureListModel::DisplayString ).toString();
-      QCOMPARE( displayString, QStringLiteral( "80" ) );
+      QCOMPARE( displayString, QStringLiteral( "40" ) );
 
       //delete Gollums share on Mordor
       mModel->deleteFeature( qvariant_cast<QgsFeature>( mModel->data( mModel->index( 0, 0 ), ReferencingFeatureListModel::ReferencingFeature ) ).id() );


### PR DESCRIPTION
Aimed at fixing #1850 .

Here's how it looks in real style:
![image](https://user-images.githubusercontent.com/1728657/115380429-c0002e80-a1fc-11eb-8030-d6e872b7b046.png)

Edit style:
![image](https://user-images.githubusercontent.com/1728657/115380516-d4dcc200-a1fc-11eb-98b1-63c122826049.png)

I've used a custom scroll bar and our QField green to have it pop out a bit more.