### PR TITLE
Improve UI/UX and user awareness of a broken local deltas file situation

### DIFF
--- a/src/core/deltafilewrapper.cpp
+++ b/src/core/deltafilewrapper.cpp
@@ -245,6 +245,9 @@ QString DeltaFileWrapper::errorString() const
 QByteArray DeltaFileWrapper::toJson( QJsonDocument::JsonFormat jsonFormat ) const
 {
   QJsonObject jsonRoot( mJsonRoot );
+  jsonRoot.insert( QStringLiteral( "version" ), DeltaFormatVersion );
+  jsonRoot.insert( QStringLiteral( "id" ), id() );
+  jsonRoot.insert( QStringLiteral( "project" ), mCloudProjectId );
   jsonRoot.insert( QStringLiteral( "deltas" ), mDeltas );
   jsonRoot.insert( QStringLiteral( "files" ), QJsonArray() );
 
@@ -262,7 +265,7 @@ bool DeltaFileWrapper::toFile()
 {
   QFile deltaFile( mFileName );
 
-  if ( ! deltaFile.open( QIODevice::WriteOnly | QIODevice::Unbuffered ) )
+  if ( !deltaFile.open( QIODevice::WriteOnly | QIODevice::Unbuffered ) )
   {
     mErrorType = DeltaFileWrapper::IOError;
     mErrorDetails = deltaFile.errorString();

--- a/src/core/deltafilewrapper.h
+++ b/src/core/deltafilewrapper.h
@@ -141,7 +141,7 @@ class DeltaFileWrapper : public QObject
      *
      * @return bool whether an error has been encountered
      */
-    bool hasError() const;
+    Q_INVOKABLE bool hasError() const;
 
 
     /**

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -365,7 +365,7 @@ void QFieldCloudProjectsModel::cancelDownloadProject( const QString &projectId )
   emit dataChanged( idx, idx, QVector<int>() << StatusRole << ExportStatusRole );
 }
 
-void QFieldCloudProjectsModel::downloadProject( const QString &projectId )
+void QFieldCloudProjectsModel::downloadProject( const QString &projectId, bool overwriteProject )
 {
   if ( !mCloudConnection )
     return;
@@ -379,7 +379,7 @@ void QFieldCloudProjectsModel::downloadProject( const QString &projectId )
     return;
 
   // before downloading, there should be no local modification, otherwise it will be overwritten
-  if ( mCloudProjects[index].modification & LocalModification )
+  if ( mCloudProjects[index].modification & LocalModification && !overwriteProject )
     return;
 
   mCloudProjects[index].exportStatus = ExportUnstartedStatus;
@@ -1698,7 +1698,6 @@ bool QFieldCloudProjectsModel::revertLocalChangesFromCurrentProject()
 bool QFieldCloudProjectsModel::discardLocalChangesFromCurrentProject()
 {
   const int index = findProject( mCurrentProjectId );
-
   if ( index == -1 || index >= mCloudProjects.size() )
     return false;
 
@@ -1712,7 +1711,7 @@ bool QFieldCloudProjectsModel::discardLocalChangesFromCurrentProject()
   deltaFileWrapper->reset();
   deltaFileWrapper->resetId();
 
-  if ( ! deltaFileWrapper->toFile() )
+  if ( !deltaFileWrapper->toFile() )
     return false;
 
   return true;

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -200,7 +200,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     Q_INVOKABLE void refreshProjectsList();
 
     //! Downloads a cloud project with given \a projectId and all of its files.
-    Q_INVOKABLE void downloadProject( const QString &projectId );    //! Downloads a cloud project with given \a projectId and all of its files.
+    Q_INVOKABLE void downloadProject( const QString &projectId, bool overwriteProject = false );    //! Downloads a cloud project with given \a projectId and all of its files.
 
     //! Cancels ongoing cloud project download with \a projectId.
     Q_INVOKABLE void cancelDownloadProject( const QString &projectId );

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -17,7 +17,7 @@ Popup {
       title: qsTr('QFieldCloud')
 
       showCancelButton: cloudProjectsModel.currentProjectData.Status !== QFieldCloudProjectsModel.Uploading
-                        || cloudConnection.status === QFieldCloudConnection.Disconnected
+                        && cloudConnection.status !== QFieldCloudConnection.Connecting
       showApplyButton: false
       busyIndicatorState: cloudConnection.status === QFieldCloudConnection.Connecting
             || cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Uploading

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -17,6 +17,7 @@ Popup {
       title: qsTr('QFieldCloud')
 
       showCancelButton: cloudProjectsModel.currentProjectData.Status !== QFieldCloudProjectsModel.Uploading
+                        || cloudProjectsModel.currentProjectData.Status !== QFieldCloudProjectsModel.Downloading
       showApplyButton: false
       busyIndicatorState: cloudConnection.status === QFieldCloudConnection.Connecting
             || cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Uploading
@@ -385,12 +386,8 @@ Popup {
               if (!cloudProjectsModel.layerObserver.deltaFileWrapper.hasError()) {
                 revertDialog.open();
               } else {
-                discardDialog.open();
+                resetDialog.open();
               }
-            }
-
-            onPressAndHold: {
-              discardDialog.open();
             }
           }
 
@@ -523,7 +520,7 @@ Popup {
   }
 
   Dialog {
-    id: discardDialog
+    id: resetDialog
     parent: mainWindow.contentItem
 
     property int selectedCount: 0
@@ -535,17 +532,17 @@ Popup {
     x: ( mainWindow.width - width ) / 2
     y: ( mainWindow.height - height ) / 2
 
-    title: qsTr( "Discard local changes" )
+    title: qsTr( "Reset cloud project" )
     Label {
       width: parent.width
       wrapMode: Text.WordWrap
-      text: qsTr( "Discarding local changes may result in QFieldCloud conflicts. Should local changes be discarded?" )
+      text: qsTr( "Last warning, resetting the cloud project will erase any local changes, are you sure you want to go ahead?" )
     }
 
     standardButtons: Dialog.Ok | Dialog.Cancel
 
     onAccepted: {
-      discardLocalChangesFromCurrentProject();
+      resetCurrentProject();
     }
     onRejected: {
       visible = false
@@ -585,16 +582,8 @@ Popup {
     displayToast(qsTr('No changes to revert'))
   }
 
-  function discardLocalChangesFromCurrentProject() {
-    if (cloudProjectsModel.currentProjectData && cloudProjectsModel.currentProjectData.CanSync) {
-      if ( cloudProjectsModel.discardLocalChangesFromCurrentProject(cloudProjectsModel.currentProjectId) )
-        displayToast(qsTr('Local changes discarded'))
-      else
-        displayToast(qsTr('Failed to discard changes'))
-
-      return
-    }
-
-    displayToast(qsTr('No changes to discard'))
+  function resetCurrentProject() {
+    cloudProjectsModel.discardLocalChangesFromCurrentProject(cloudProjectsModel.currentProjectId)
+    cloudProjectsModel.downloadProject(cloudProjectsModel.currentProjectId, true)
   }
 }

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -401,7 +401,7 @@ Popup {
             color: Theme.gray
             text: !cloudProjectsModel.layerObserver.deltaFileWrapper.hasError()
                   ? qsTr('Revert all modified features in the local cloud layers. You cannot restore those changes.')
-                  : qsTr('The local copy of this cloud project has been corrupted. Resetting the project will re-download the cloud version and will remove any local changes, make sure those were copied first if needed.')
+                  : qsTr('The local copy of this cloud project has been corrupted. Resetting the project will re-download the cloud version and will remove any local changes, make sure those were copied first if needed.\n\nWhile you can still view and use the project, it is strongly recommended to reset to avoid any accidental data loss as none of the changes made will be pushed back to the cloud.')
             wrapMode: Text.WordWrap
             horizontalAlignment: Text.AlignHCenter
             Layout.bottomMargin: 10

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -17,7 +17,6 @@ Popup {
       title: qsTr('QFieldCloud')
 
       showCancelButton: cloudProjectsModel.currentProjectData.Status !== QFieldCloudProjectsModel.Uploading
-                        && cloudConnection.status !== QFieldCloudConnection.Connecting
       showApplyButton: false
       busyIndicatorState: cloudConnection.status === QFieldCloudConnection.Connecting
             || cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Uploading

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1803,6 +1803,10 @@ ApplicationWindow {
               projectInfo.editRights = true
               break;
           }
+
+          if (cloudProjectsModel.layerObserver.deltaFileWrapper.hasError()) {
+            cloudPopup.show()
+          }
         } else {
           projectInfo.insertRights = true
           projectInfo.editRights = true


### PR DESCRIPTION
While we should aim at it being a one in a million chance to occur, we should still provide an helpful UI/UX for those who might end up with a broken local deltas file (phone crashed, etc. etc.). This PR does that.

Now, when a broken deltas file is detected upon loading a project, the cloud project popup will automatically appear with a customized UI to inform the user about his bad luck:
![image](https://user-images.githubusercontent.com/1728657/115538907-8eec3080-a2c6-11eb-9b55-60d62d512e2d.png)
