### PR TITLE
Fix missing @snapping_results variable content (fixes #1871)

### DIFF
--- a/src/qml/EmbeddedFeatureForm.qml
+++ b/src/qml/EmbeddedFeatureForm.qml
@@ -61,6 +61,7 @@ Popup {
                 id: formFeatureModel
                 positionInformation: digitizingToolbar.coordinateLocator.positionInformation
                 positionLocked: digitizingToolbar.coordinateLocator.overrideLocation !== undefined
+                topSnappingResult: coordinateLocator.topSnappingResult
             }
         }
 

--- a/src/qml/OverlayFeatureFormDrawer.qml
+++ b/src/qml/OverlayFeatureFormDrawer.qml
@@ -79,6 +79,7 @@ Drawer {
         featureModel: FeatureModel {
             positionInformation: overlayFeatureFormDrawer.digitizingToolbar.coordinateLocator.positionInformation
             positionLocked: overlayFeatureFormDrawer.digitizingToolbar.coordinateLocator.overrideLocation !== undefined
+            topSnappingResult: coordinateLocator.topSnappingResult
         }
     }
 


### PR DESCRIPTION
This PR fixes #1871 , whereas the @snapping_results variable was not properly populated when adding features.