### PR TITLE
Astyle check

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -65,6 +65,7 @@ IncludeCategories:
     Priority:        1
 IncludeIsMainRegex: false
 IncludeBlocks: Regroup
+IndentAccessModifiers: true
 IndentCaseLabels: true
 IndentWidth: 2
 IndentWrappedFunctionNames: true

--- a/.github/workflows/astyle.yml
+++ b/.github/workflows/astyle.yml
@@ -1,0 +1,58 @@
+---
+name: 🕴️ Style check
+
+on:
+  push:
+    branches:
+      - master
+      - release-**
+  pull_request:
+    branches:
+      - master
+      - release-**
+  issue_comment:
+    types: [created]
+
+jobs:
+  astyle-check:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: khan/pull-request-comment-trigger@master
+        id: indent-check
+        with:
+          trigger: 'style police please'
+          reaction: rocket
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Check astyle
+        run: |
+          sudo apt install -y astyle
+          find src/ -name '*.cpp' -o -name '*.h' | xargs ./scripts/astyle.sh
+          find test/ -name '*.cpp' -o -name '*.h' | xargs ./scripts/astyle.sh
+          if [ ! -z "$(git status --porcelain)" ]; then
+            echo "::error::Indentation errors found (astyle)"
+            echo "::group::Indentation changes"
+            git diff
+            echo "::endgroup"
+          fi
+
+      - uses: getsentry/action-git-diff-suggestions@main
+        if: steps.indent-check.outputs.triggered != 'true'
+        with:
+          message: |
+            Astyle suggested changes
+
+            Accept them manually or add a comment with `style police please` to invoke some magic 🪄.
+
+      - uses: EndBug/add-and-commit@v4
+        if: steps.indent-check.outputs.triggered == 'true'
+        with:
+          author_name: Style police
+          author_email: fairy@qfield.org
+          message: 'Committing astyle changes'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/code_layout.yml
+++ b/.github/workflows/code_layout.yml
@@ -87,19 +87,3 @@ jobs:
       - name: Check sdk pattern
         run: |
           grep -E 'osgeo4a_version=2[0-9]{7}' sdk.conf
-
-  astyle-check:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Check astyle
-        run: |
-          sudo apt install -y astyle
-          find src/ -name '*.cpp' -o -name '*.h' | xargs ./scripts/astyle.sh
-          find test/ -name '*.cpp' -o -name '*.h' | xargs ./scripts/astyle.sh
-          if [ ! -z "$(git status --porcelain)" ]; then
-            git diff
-            false
-          fi

--- a/.github/workflows/code_layout.yml
+++ b/.github/workflows/code_layout.yml
@@ -87,3 +87,16 @@ jobs:
       - name: Check sdk pattern
         run: |
           grep -E 'osgeo4a_version=2[0-9]{7}' sdk.conf
+
+  astyle-check:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Check astyle
+        run: |
+          sudo apt install -y astyle
+          find src/ -name '*.cpp' -o -name '*.h' | xargs ./scripts/astyle.sh
+          find test/ -name '*.cpp' -o -name '*.h' | xargs ./scripts/astyle.sh
+          [ -z "$(git status --porcelain)" ]

--- a/.github/workflows/code_layout.yml
+++ b/.github/workflows/code_layout.yml
@@ -99,4 +99,7 @@ jobs:
           sudo apt install -y astyle
           find src/ -name '*.cpp' -o -name '*.h' | xargs ./scripts/astyle.sh
           find test/ -name '*.cpp' -o -name '*.h' | xargs ./scripts/astyle.sh
-          [ -z "$(git status --porcelain)" ]
+          if [ ! -z "$(git status --porcelain)" ]; then
+            git diff
+            false
+          fi

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -16,22 +16,21 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgismobileapp.h"
 #include "fileutils.h"
-
-#include <QLocale>
-#include <QDir>
-#include <QSettings>
-#include <QTranslator>
-#include <QMainWindow>
-#include <QLabel>
-#include <QDialog>
-#include <QApplication>
-#include <QtWebView/QtWebView>
-#include <QStandardPaths>
-
+#include "qgismobileapp.h"
 #include "qgsapplication.h"
 #include "qgslogger.h"
+
+#include <QApplication>
+#include <QDialog>
+#include <QDir>
+#include <QLabel>
+#include <QLocale>
+#include <QMainWindow>
+#include <QSettings>
+#include <QStandardPaths>
+#include <QTranslator>
+#include <QtWebView/QtWebView>
 
 #ifdef ANDROID
 #include <android/log.h>
@@ -94,7 +93,7 @@ int main( int argc, char **argv )
 
   QGuiApplication::setAttribute( Qt::AA_EnableHighDpiScaling );
   QtWebView::initialize();
-#if defined(Q_OS_ANDROID)
+#if defined( Q_OS_ANDROID )
   QString projPath = PlatformUtilities::instance()->systemGenericDataLocation() + QStringLiteral( "/proj" );
   qputenv( "PROJ_LIB", projPath.toUtf8() );
   QgsApplication app( argc, argv, true, PlatformUtilities::instance()->systemGenericDataLocation() + QStringLiteral( "/qgis/resources" ) );
@@ -106,7 +105,7 @@ int main( int argc, char **argv )
   app.setPrefixPath( "" QGIS_INSTALL_DIR, true );
   app.setPluginPath( QApplication::applicationDirPath() );
   app.setPkgDataPath( PlatformUtilities::instance()->systemGenericDataLocation() + QStringLiteral( "/qgis" ) );
-#elif defined(Q_OS_IOS)
+#elif defined( Q_OS_IOS )
   QString projPath = IosPlatformUtilities().systemGenericDataLocation() + QStringLiteral( "/proj" );
   qputenv( "PROJ_LIB", projPath.toUtf8() );
   QgsApplication app( argc, argv, true, PlatformUtilities::instance()->systemGenericDataLocation() + QStringLiteral( "/qgis/resources" ) );
@@ -116,13 +115,13 @@ int main( int argc, char **argv )
   QSettings settings;
   app.setThemeName( settings.value( "/Themes", "default" ).toString() );
 
-#  if defined( Q_OS_WIN )
+#if defined( Q_OS_WIN )
   qputenv( "GDAL_DATA", QDir::toNativeSeparators( app.applicationDirPath() + "/gdal" ).toLocal8Bit() );
   qputenv( "PROJ_LIB", QDir::toNativeSeparators( app.applicationDirPath() + "/proj" ).toLocal8Bit() );
   app.setPrefixPath( app.applicationDirPath() + "/qgis", true );
-#  else
+#else
   app.setPrefixPath( CMAKE_INSTALL_PREFIX, true );
-#  endif
+#endif
 #endif
 
   app.initQgis();

--- a/src/core/androidpicturesource.cpp
+++ b/src/core/androidpicturesource.cpp
@@ -14,27 +14,26 @@
  *                                                                         *
  ***************************************************************************/
 #include "androidpicturesource.h"
-#include "qgsmessagelog.h"
 #include "qgsapplication.h"
+#include "qgsmessagelog.h"
+
 #include <QAndroidJniEnvironment>
-#include <QtAndroid>
+#include <QDebug>
 #include <QDir>
 #include <QFile>
-#include <QDebug>
+#include <QtAndroid>
 
 AndroidPictureSource::AndroidPictureSource( const QString &prefix )
   : PictureSource( nullptr, prefix )
   , QAndroidActivityResultReceiver()
   , mPrefix( prefix )
 {
-
 }
 
 void AndroidPictureSource::handleActivityResult( int receiverRequestCode, int resultCode, const QAndroidJniObject &data )
 {
   if ( receiverRequestCode == 171 )
   {
-
     jint RESULT_OK = QAndroidJniObject::getStaticField<jint>( "android/app/Activity", "RESULT_OK" );
     if ( resultCode == RESULT_OK )
     {
@@ -54,5 +53,4 @@ void AndroidPictureSource::handleActivityResult( int receiverRequestCode, int re
       emit pictureReceived( QString() );
     }
   }
-
 }

--- a/src/core/androidpicturesource.h
+++ b/src/core/androidpicturesource.h
@@ -16,9 +16,9 @@
 #ifndef ANDROIDPICTURESOURCE_H
 #define ANDROIDPICTURESOURCE_H
 
-#include <QAndroidActivityResultReceiver>
-
 #include "picturesource.h"
+
+#include <QAndroidActivityResultReceiver>
 
 
 class AndroidPictureSource : public PictureSource, public QAndroidActivityResultReceiver

--- a/src/core/androidplatformutilities.cpp
+++ b/src/core/androidplatformutilities.cpp
@@ -16,26 +16,26 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "androidplatformutilities.h"
 #include "androidpicturesource.h"
+#include "androidplatformutilities.h"
 #include "androidprojectsource.h"
 #include "androidviewstatus.h"
 #include "appinterface.h"
 #include "feedback.h"
 #include "fileutils.h"
 
-#include <QMap>
-#include <QString>
-#include <QtAndroid>
-#include <QDebug>
 #include <QAndroidJniEnvironment>
-#include <QMimeDatabase>
-#include <QStandardPaths>
-#include <QFile>
 #include <QApplication>
+#include <QDebug>
+#include <QFile>
+#include <QMap>
+#include <QMimeDatabase>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
+#include <QStandardPaths>
+#include <QString>
 #include <QThread>
+#include <QtAndroid>
 
 #include <jni.h>
 
@@ -58,7 +58,6 @@ class FileCopyThread : public QThread
     }
 
   private:
-
     void run() override
     {
       FileUtils::copyRecursively( mSource, mDestination, mFeedback );
@@ -329,8 +328,7 @@ void AndroidPlatformUtilities::setScreenLockPermission( const bool allowLock )
       QAndroidJniObject activity = QtAndroid::androidActivity();
       if ( activity.isValid() )
       {
-        QAndroidJniObject window =
-        activity.callObjectMethod( "getWindow", "()Landroid/view/Window;" );
+        QAndroidJniObject window = activity.callObjectMethod( "getWindow", "()Landroid/view/Window;" );
 
         if ( window.isValid() )
         {

--- a/src/core/androidplatformutilities.h
+++ b/src/core/androidplatformutilities.h
@@ -20,6 +20,7 @@
 #define ANDROIDPLATFORMUTILITIES_H
 
 #include "platformutilities.h"
+
 #include <QAndroidJniObject>
 
 class AndroidPlatformUtilities : public PlatformUtilities

--- a/src/core/androidprojectsource.cpp
+++ b/src/core/androidprojectsource.cpp
@@ -14,8 +14,9 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgsmessagelog.h"
 #include "androidprojectsource.h"
+#include "qgsmessagelog.h"
+
 #include <QFile>
 #include <QtAndroid>
 
@@ -30,10 +31,10 @@ void AndroidProjectSource::handleActivityResult( int receiverRequestCode, int re
   jint RESULT_OK = QAndroidJniObject::getStaticField<jint>( "android/app/Activity", "RESULT_OK" );
   if ( receiverRequestCode == 103 && resultCode == RESULT_OK )
   {
-    QAndroidJniObject uri = data.callObjectMethod( "getData", "()Landroid/net/Uri;");
+    QAndroidJniObject uri = data.callObjectMethod( "getData", "()Landroid/net/Uri;" );
 
-    QString path = uri.callObjectMethod("getPath", "()Ljava/lang/String;").toString();
-    
+    QString path = uri.callObjectMethod( "getPath", "()Ljava/lang/String;" ).toString();
+
     if ( !QFile( path ).exists() )
     {
       QgsMessageLog::logMessage( tr( "File %1 does not exist" ).arg( path ), QStringLiteral( "QField" ), Qgis::Warning );

--- a/src/core/androidprojectsource.h
+++ b/src/core/androidprojectsource.h
@@ -18,8 +18,9 @@
 #ifndef ANDROIDPROJECTSOURCE_H
 #define ANDROIDPROJECTSOURCE_H
 
-#include <QAndroidActivityResultReceiver>
 #include "projectsource.h"
+
+#include <QAndroidActivityResultReceiver>
 
 class AndroidProjectSource : public ProjectSource, public QAndroidActivityResultReceiver
 {
@@ -29,7 +30,6 @@ class AndroidProjectSource : public ProjectSource, public QAndroidActivityResult
     AndroidProjectSource();
 
     void handleActivityResult( int receiverRequestCode, int resultCode, const QAndroidJniObject &data ) override;
-
 };
 
 #endif // ANDROIDPROJECTSOURCE_H

--- a/src/core/androidviewstatus.h
+++ b/src/core/androidviewstatus.h
@@ -17,8 +17,9 @@
 #ifndef ANDROIDVIEWSTATUS_H
 #define ANDROIDVIEWSTATUS_H
 
-#include <QAndroidActivityResultReceiver>
 #include "viewstatus.h"
+
+#include <QAndroidActivityResultReceiver>
 
 class AndroidViewStatus : public ViewStatus, public QAndroidActivityResultReceiver
 {

--- a/src/core/appcoordinateoperationhandlers.cpp
+++ b/src/core/appcoordinateoperationhandlers.cpp
@@ -79,8 +79,7 @@ void AppMissingGridHandler::onMissingRequiredGrid( const QgsCoordinateReferenceS
   if ( !shouldWarnAboutPair( sourceCrs, destinationCrs ) )
     return;
 
-  const QString shortMessage = tr( "No transform available between %1 and %2" ).arg( sourceCrs.userFriendlyIdentifier( QgsCoordinateReferenceSystem::ShortString ),
-                               destinationCrs.userFriendlyIdentifier( QgsCoordinateReferenceSystem::ShortString ) );
+  const QString shortMessage = tr( "No transform available between %1 and %2" ).arg( sourceCrs.userFriendlyIdentifier( QgsCoordinateReferenceSystem::ShortString ), destinationCrs.userFriendlyIdentifier( QgsCoordinateReferenceSystem::ShortString ) );
 
   QString downloadMessage;
   if ( !grid.url.isEmpty() )
@@ -94,7 +93,7 @@ void AppMissingGridHandler::onMissingRequiredGrid( const QgsCoordinateReferenceS
       downloadMessage = tr( "This grid is available for download from <a href=\"%1\">%1</a>." ).arg( grid.url );
     }
   }
-  QgsMessageLog::logMessage( QStringLiteral( "%1\n%2"  ).arg( shortMessage, downloadMessage ), tr( "projection" ) );
+  QgsMessageLog::logMessage( QStringLiteral( "%1\n%2" ).arg( shortMessage, downloadMessage ), tr( "projection" ) );
 }
 
 void AppMissingGridHandler::onMissingPreferredGrid( const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs, const QgsDatumTransform::TransformDetails &preferredOperation, const QgsDatumTransform::TransformDetails &availableOperation )
@@ -130,14 +129,11 @@ void AppMissingGridHandler::onMissingPreferredGrid( const QgsCoordinateReference
 
   QString accuracyMessage;
   if ( availableOperation.accuracy >= 0 && preferredOperation.accuracy >= 0 )
-    accuracyMessage = tr( "<p>Current transform “<i>%1</i>” has an accuracy of %2 meters, while the preferred transformation “<i>%3</i>” has accuracy %4 meters.</p>" ).arg( availableOperation.name )
-                      .arg( availableOperation.accuracy ).arg( preferredOperation.name ).arg( preferredOperation.accuracy );
+    accuracyMessage = tr( "<p>Current transform “<i>%1</i>” has an accuracy of %2 meters, while the preferred transformation “<i>%3</i>” has accuracy %4 meters.</p>" ).arg( availableOperation.name ).arg( availableOperation.accuracy ).arg( preferredOperation.name ).arg( preferredOperation.accuracy );
   else if ( preferredOperation.accuracy >= 0 )
-    accuracyMessage = tr( "<p>Current transform “<i>%1</i>” has an unknown accuracy, while the preferred transformation “<i>%2</i>” has accuracy %3 meters.</p>" ).arg( availableOperation.name )
-                      .arg( preferredOperation.name ).arg( preferredOperation.accuracy );
+    accuracyMessage = tr( "<p>Current transform “<i>%1</i>” has an unknown accuracy, while the preferred transformation “<i>%2</i>” has accuracy %3 meters.</p>" ).arg( availableOperation.name ).arg( preferredOperation.name ).arg( preferredOperation.accuracy );
 
-  const QString longMessage = tr( "<p>The preferred transform between <i>%1</i> and <i>%2</i> is not available for use on the system.</p>" ).arg( sourceCrs.userFriendlyIdentifier(),
-                              destinationCrs.userFriendlyIdentifier() )
+  const QString longMessage = tr( "<p>The preferred transform between <i>%1</i> and <i>%2</i> is not available for use on the system.</p>" ).arg( sourceCrs.userFriendlyIdentifier(), destinationCrs.userFriendlyIdentifier() )
                               + gridMessage + accuracyMessage;
 
   QgsMessageLog::logMessage( QStringLiteral( "%1\n%2" ).arg( longMessage, downloadMessage ), tr( "projection" ) );
@@ -158,8 +154,7 @@ void AppMissingGridHandler::onMissingGridUsedByContextHandler( const QgsCoordina
   if ( !shouldWarnAboutPairForCurrentProject( sourceCrs, destinationCrs ) )
     return;
 
-  const QString shortMessage = tr( "Cannot use project transform between %1 and %2" ).arg( sourceCrs.userFriendlyIdentifier( QgsCoordinateReferenceSystem::ShortString ),
-                               destinationCrs.userFriendlyIdentifier( QgsCoordinateReferenceSystem::ShortString ) );
+  const QString shortMessage = tr( "Cannot use project transform between %1 and %2" ).arg( sourceCrs.userFriendlyIdentifier( QgsCoordinateReferenceSystem::ShortString ), destinationCrs.userFriendlyIdentifier( QgsCoordinateReferenceSystem::ShortString ) );
 
   QString gridMessage;
   QString downloadMessage;
@@ -194,7 +189,7 @@ void AppMissingGridHandler::onFallbackOperationOccurred( const QgsCoordinateRefe
 
   const QString shortMessage = tr( "Used a ballpark transform from %1 to %2" ).arg( sourceCrs.userFriendlyIdentifier( QgsCoordinateReferenceSystem::ShortString ), destinationCrs.userFriendlyIdentifier( QgsCoordinateReferenceSystem::ShortString ) );
 
-  QgsMessageLog::logMessage( shortMessage, tr( "projection" ) ) ;
+  QgsMessageLog::logMessage( shortMessage, tr( "projection" ) );
 }
 
 bool AppMissingGridHandler::shouldWarnAboutPair( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &dest )

--- a/src/core/appcoordinateoperationhandlers.h
+++ b/src/core/appcoordinateoperationhandlers.h
@@ -17,7 +17,6 @@
 #define APPCOORDINATEOPERATIONHANDLERS_H
 
 #include <QObject>
-
 #include <qgscoordinatereferencesystem.h>
 #include <qgsdatumtransform.h>
 
@@ -30,7 +29,6 @@ class AppMissingGridHandler : public QObject
 {
     Q_OBJECT
   public:
-
     explicit AppMissingGridHandler( QObject *parent );
 
   signals:
@@ -80,14 +78,13 @@ class AppMissingGridHandler : public QObject
                                       const QString &desired );
 
   private:
-
     bool shouldWarnAboutPair( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &dest );
     bool shouldWarnAboutPairForCurrentProject( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &dest );
     bool shouldWarnAboutBallparkPairForCurrentProject( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &dest );
 
-    QList< QPair< QgsCoordinateReferenceSystem, QgsCoordinateReferenceSystem > > mAlreadyWarnedPairs;
-    QList< QPair< QgsCoordinateReferenceSystem, QgsCoordinateReferenceSystem > > mAlreadyWarnedPairsForProject;
-    QList< QPair< QgsCoordinateReferenceSystem, QgsCoordinateReferenceSystem > > mAlreadyWarnedBallparkPairsForProject;
+    QList<QPair<QgsCoordinateReferenceSystem, QgsCoordinateReferenceSystem>> mAlreadyWarnedPairs;
+    QList<QPair<QgsCoordinateReferenceSystem, QgsCoordinateReferenceSystem>> mAlreadyWarnedPairsForProject;
+    QList<QPair<QgsCoordinateReferenceSystem, QgsCoordinateReferenceSystem>> mAlreadyWarnedBallparkPairsForProject;
 };
 
 #endif // QGSAPPCOORDINATEOPERATIONHANDLERS_H

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -20,7 +20,6 @@
 
 #include <QObject>
 #include <QPointF>
-
 #include <QStandardItemModel>
 
 class QgisMobileapp;

--- a/src/core/attributeformmodel.h
+++ b/src/core/attributeformmodel.h
@@ -16,9 +16,9 @@
 #ifndef ATTRIBUTEFORMMODEL_H
 #define ATTRIBUTEFORMMODEL_H
 
-#include <QSortFilterProxyModel>
-
 #include "attributeformmodelbase.h"
+
+#include <QSortFilterProxyModel>
 
 class FeatureModel;
 

--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -14,24 +14,23 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "attributeformmodelbase.h"
 #include "attributeformmodel.h"
+#include "attributeformmodelbase.h"
 
-#include <qgsvectorlayer.h>
-#include <qgseditorwidgetsetup.h>
-#include <qgsproject.h>
-#include <qgsrelationmanager.h>
-#include <qgsdatetimefieldformatter.h>
-#include <qgsvectorlayerutils.h>
+#include <QRegularExpression>
 #include <qgsattributeeditorcontainer.h>
 #include <qgsattributeeditorelement.h>
 #include <qgsattributeeditorfield.h>
 #include <qgsattributeeditorhtmlelement.h>
 #include <qgsattributeeditorqmlelement.h>
 #include <qgsattributeeditorrelation.h>
+#include <qgsdatetimefieldformatter.h>
+#include <qgseditorwidgetsetup.h>
 #include <qgsmapthemecollection.h>
-
-#include <QRegularExpression>
+#include <qgsproject.h>
+#include <qgsrelationmanager.h>
+#include <qgsvectorlayer.h>
+#include <qgsvectorlayerutils.h>
 
 
 AttributeFormModelBase::AttributeFormModelBase( QObject *parent )
@@ -49,15 +48,15 @@ AttributeFormModelBase::~AttributeFormModelBase()
 
 void AttributeFormModelBase::onMapThemeCollectionChanged()
 {
-  connect( QgsProject::instance()->mapThemeCollection(), &QgsMapThemeCollection::mapThemeChanged, this, [=] { resetModel(); applyFeatureModel(); } );
+  connect( QgsProject::instance()->mapThemeCollection(), &QgsMapThemeCollection::mapThemeChanged, this, [ = ] { resetModel(); applyFeatureModel(); } );
 }
 
 QHash<int, QByteArray> AttributeFormModelBase::roleNames() const
 {
   QHash<int, QByteArray> roles = QAbstractItemModel::roleNames();
 
-  roles[AttributeFormModel::ElementType]  = "Type";
-  roles[AttributeFormModel::Name]  = "Name";
+  roles[AttributeFormModel::ElementType] = "Type";
+  roles[AttributeFormModel::Name] = "Name";
   roles[AttributeFormModel::AttributeValue] = "AttributeValue";
   roles[AttributeFormModel::AttributeEditable] = "AttributeEditable";
   roles[AttributeFormModel::EditorWidget] = "EditorWidget";
@@ -219,7 +218,7 @@ void AttributeFormModelBase::resetModel()
 
 void AttributeFormModelBase::applyFeatureModel()
 {
-  for ( int i = 0 ; i < invisibleRootItem()->rowCount(); ++i )
+  for ( int i = 0; i < invisibleRootItem()->rowCount(); ++i )
   {
     updateAttributeValue( invisibleRootItem()->child( i ) );
   }
@@ -261,18 +260,17 @@ void AttributeFormModelBase::updateAttributeValue( QStandardItem *item )
     int fieldIndex = item->data( AttributeFormModel::FieldIndex ).toInt();
     QVariant attributeValue = mFeatureModel->data( mFeatureModel->index( fieldIndex ), FeatureModel::AttributeValue );
     item->setData( attributeValue.isNull() ? QVariant() : attributeValue, AttributeFormModel::AttributeValue );
-    item->setData( mFeatureModel->data( mFeatureModel->index( fieldIndex ), FeatureModel::AttributeAllowEdit ), AttributeFormModel::AttributeAllowEdit);
+    item->setData( mFeatureModel->data( mFeatureModel->index( fieldIndex ), FeatureModel::AttributeAllowEdit ), AttributeFormModel::AttributeAllowEdit );
     //set item visibility to false in case it's a linked attribute
     item->setData( !mFeatureModel->data( mFeatureModel->index( fieldIndex ), FeatureModel::LinkedAttribute ).toBool(), AttributeFormModel::CurrentlyVisible );
   }
-  else if ( item->data( AttributeFormModel::ElementType ) == QStringLiteral( "qml" ) ||
-            item->data( AttributeFormModel::ElementType ) == QStringLiteral( "html" ) )
+  else if ( item->data( AttributeFormModel::ElementType ) == QStringLiteral( "qml" ) || item->data( AttributeFormModel::ElementType ) == QStringLiteral( "html" ) )
   {
     QString code = mEditorWidgetCodes[item];
 
     QRegularExpression re( "expression\\.evaluate\\(\\s*\\\"(.*?[^\\\\])\\\"\\s*\\)" );
     QRegularExpressionMatch match = re.match( code );
-    while( match.hasMatch() )
+    while ( match.hasMatch() )
     {
       QString expression = match.captured( 1 );
       expression = expression.replace( QStringLiteral( "\\\"" ), QStringLiteral( "\"" ) );
@@ -285,7 +283,7 @@ void AttributeFormModelBase::updateAttributeValue( QStandardItem *item )
       QVariant result = exp.evaluate( &expressionContext );
 
       QString resultString;
-      switch( static_cast<QMetaType::Type>( result.type() ) )
+      switch ( static_cast<QMetaType::Type>( result.type() ) )
       {
         case QMetaType::Int:
         case QMetaType::UInt:
@@ -372,7 +370,7 @@ void AttributeFormModelBase::flatten( QgsAttributeEditorContainer *container, QS
         item->setData( true, AttributeFormModel::ConstraintSoftValid );
         item->setData( mFeatureModel->data( mFeatureModel->index( fieldIndex ), FeatureModel::AttributeAllowEdit ), AttributeFormModel::AttributeAllowEdit );
         if ( color.isValid() )
-            item->setData( color, AttributeFormModel::Color );
+          item->setData( color, AttributeFormModel::Color );
 
         // create constraint description
         QStringList descriptions;
@@ -417,7 +415,7 @@ void AttributeFormModelBase::flatten( QgsAttributeEditorContainer *container, QS
         item->setData( "relation", AttributeFormModel::ElementType );
         item->setData( "RelationEditor", AttributeFormModel::EditorWidget );
         item->setData( relation.id(), AttributeFormModel::RelationId );
-        item->setData( mLayer->editFormConfig().widgetConfig( relation.id() )[ QStringLiteral( "nm-rel" ) ].toString(), AttributeFormModel::NmRelationId );
+        item->setData( mLayer->editFormConfig().widgetConfig( relation.id() )[QStringLiteral( "nm-rel" )].toString(), AttributeFormModel::NmRelationId );
         item->setData( container->isGroupBox() ? container->name() : QString(), AttributeFormModel::Group );
         item->setData( true, AttributeFormModel::CurrentlyVisible );
         item->setData( true, AttributeFormModel::ConstraintHardValid );

--- a/src/core/attributeformmodelbase.h
+++ b/src/core/attributeformmodelbase.h
@@ -16,13 +16,12 @@
 #ifndef ATTRIBUTEFORMMODELBASE_H
 #define ATTRIBUTEFORMMODELBASE_H
 
-#include <QStandardItemModel>
-#include<QStack>
+#include "featuremodel.h"
 
+#include <QStack>
+#include <QStandardItemModel>
 #include <qgseditformconfig.h>
 #include <qgsexpressioncontext.h>
-
-#include "featuremodel.h"
 
 class AttributeFormModelBase : public QStandardItemModel
 {
@@ -35,7 +34,7 @@ class AttributeFormModelBase : public QStandardItemModel
 
   public:
     explicit AttributeFormModelBase( QObject *parent = nullptr );
-    ~AttributeFormModelBase() override ;
+    ~AttributeFormModelBase() override;
 
     QHash<int, QByteArray> roleNames() const override;
 
@@ -77,7 +76,7 @@ class AttributeFormModelBase : public QStandardItemModel
 
     void updateAttributeValue( QStandardItem *item );
 
-    void flatten(QgsAttributeEditorContainer *container, QStandardItem *parent, const QString &parentVisibilityExpressions, QVector<QStandardItem *> &items, int currentTabIndex = 0 , const QColor &color = QColor() );
+    void flatten( QgsAttributeEditorContainer *container, QStandardItem *parent, const QString &parentVisibilityExpressions, QVector<QStandardItem *> &items, int currentTabIndex = 0, const QColor &color = QColor() );
 
     void updateVisibilityAndConstraints( int fieldIndex = -1 );
 
@@ -106,7 +105,7 @@ class AttributeFormModelBase : public QStandardItemModel
     QgsAttributeEditorContainer *mTemporaryContainer = nullptr;
     bool mHasTabs = false;
 
-    typedef QPair<QgsExpression, QVector<QStandardItem *> > VisibilityExpression;
+    typedef QPair<QgsExpression, QVector<QStandardItem *>> VisibilityExpression;
     QList<VisibilityExpression> mVisibilityExpressions;
     QMap<QStandardItem *, QgsFieldConstraints> mConstraints;
     QMap<QStandardItem *, QString> mEditorWidgetCodes;

--- a/src/core/badlayerhandler.cpp
+++ b/src/core/badlayerhandler.cpp
@@ -14,12 +14,12 @@
  *                                                                         *
  ***************************************************************************/
 #include "badlayerhandler.h"
+
 #include <qgsproject.h>
 
 BadLayerHandler::BadLayerHandler( QObject *parent )
   : QStandardItemModel( parent )
 {
-
 }
 
 QHash<int, QByteArray> BadLayerHandler::roleNames() const

--- a/src/core/bluetoothdevicemodel.cpp
+++ b/src/core/bluetoothdevicemodel.cpp
@@ -16,12 +16,12 @@
 
 #include "bluetoothdevicemodel.h"
 #include "qgis.h"
-#include <QSettings>
+
 #include <QDebug>
+#include <QSettings>
 
 BluetoothDeviceModel::BluetoothDeviceModel( QObject *parent )
-  : QAbstractListModel( parent ),
-    mLocalDevice( std::make_unique<QBluetoothLocalDevice>() )
+  : QAbstractListModel( parent ), mLocalDevice( std::make_unique<QBluetoothLocalDevice>() )
 {
   connect( &mServiceDiscoveryAgent, &QBluetoothServiceDiscoveryAgent::serviceDiscovered, this, &BluetoothDeviceModel::serviceDiscovered );
   connect( &mServiceDiscoveryAgent, qOverload<QBluetoothServiceDiscoveryAgent::Error>( &QBluetoothServiceDiscoveryAgent::error ), this, [ = ]()
@@ -113,7 +113,7 @@ QVariant BluetoothDeviceModel::data( const QModelIndex &index, int role ) const
   {
     case Qt::DisplayRole:
       return QStringLiteral( "%1%2" ).arg( mDiscoveredDevices.at( index.row() ).first,
-                                            index.row() > 0 ? QStringLiteral( " (%2)" ).arg ( mDiscoveredDevices.at( index.row() ).second ) : QString() );
+                                           index.row() > 0 ? QStringLiteral( " (%2)" ).arg( mDiscoveredDevices.at( index.row() ).second ) : QString() );
       break;
 
     case DeviceAddressRole:

--- a/src/core/bluetoothdevicemodel.h
+++ b/src/core/bluetoothdevicemodel.h
@@ -18,9 +18,9 @@
 #define BLUETOOTHDEVICEMODEL_H
 
 #include <QAbstractListModel>
+#include <QtBluetooth/QBluetoothLocalDevice>
 #include <QtBluetooth/QBluetoothServiceDiscoveryAgent>
 #include <QtBluetooth/QBluetoothServiceInfo>
-#include <QtBluetooth/QBluetoothLocalDevice>
 
 /**
  * A model that provides all paired bluetooth devices name/address that are accessible over the serial port

--- a/src/core/bluetoothreceiver.cpp
+++ b/src/core/bluetoothreceiver.cpp
@@ -15,13 +15,12 @@
  ***************************************************************************/
 
 #include "bluetoothreceiver.h"
-#include <QSettings>
-#include <QDebug>
 
-BluetoothReceiver::BluetoothReceiver( QObject *parent ) : QObject( parent ),
-  mLocalDevice( std::make_unique<QBluetoothLocalDevice>() ),
-  mSocket( new QBluetoothSocket( QBluetoothServiceInfo::RfcommProtocol ) ),
-  mGpsConnection( std::make_unique<QgsNmeaConnection>( mSocket ) )
+#include <QDebug>
+#include <QSettings>
+
+BluetoothReceiver::BluetoothReceiver( QObject *parent )
+  : QObject( parent ), mLocalDevice( std::make_unique<QBluetoothLocalDevice>() ), mSocket( new QBluetoothSocket( QBluetoothServiceInfo::RfcommProtocol ) ), mGpsConnection( std::make_unique<QgsNmeaConnection>( mSocket ) )
 {
   //socket state changed
   connect( mSocket, &QBluetoothSocket::stateChanged, this, &BluetoothReceiver::setSocketState );
@@ -146,7 +145,7 @@ void BluetoothReceiver::repairDevice( const QBluetoothAddress &address )
 {
   connect( mLocalDevice.get(), &QBluetoothLocalDevice::pairingFinished, this, &BluetoothReceiver::pairingFinished, Qt::UniqueConnection );
   connect( mLocalDevice.get(), &QBluetoothLocalDevice::pairingDisplayConfirmation, this, &BluetoothReceiver::confirmPairing, Qt::UniqueConnection );
-  connect( mLocalDevice.get(),  &QBluetoothLocalDevice::error, [ = ]( QBluetoothLocalDevice::Error error )
+  connect( mLocalDevice.get(), &QBluetoothLocalDevice::error, [ = ]( QBluetoothLocalDevice::Error error )
   {
     qDebug() << "BluetoothReceiver (not android): Re-pairing device " << address.toString() << " failed:" << error;
   } );

--- a/src/core/bluetoothreceiver.h
+++ b/src/core/bluetoothreceiver.h
@@ -16,11 +16,12 @@
 #ifndef BLUETOOTHRECEIVER_H
 #define BLUETOOTHRECEIVER_H
 
+#include "gnsspositioninformation.h"
+#include "qgsnmeaconnection.h"
+
 #include <QObject>
 #include <QtBluetooth/QBluetoothLocalDevice>
 #include <QtBluetooth/QBluetoothSocket>
-#include "qgsnmeaconnection.h"
-#include "gnsspositioninformation.h"
 
 /**
  * The bluetoothreceiver connects to a device and feeds the QgsNmeaConnection over QBluetoothSocket.
@@ -42,7 +43,7 @@ class BluetoothReceiver : public QObject
     Q_INVOKABLE void connectDevice( const QString &address );
 
     GnssPositionInformation lastGnssPositionInformation() const { return mLastGnssPositionInformation; }
-    QBluetoothSocket::SocketState socketState() const { return mSocketState;}
+    QBluetoothSocket::SocketState socketState() const { return mSocketState; }
     QString socketStateString() const { return mSocketStateString; }
 
     /**
@@ -102,7 +103,6 @@ class BluetoothReceiver : public QObject
     QString mAddressToConnect;
 
     bool mEllipsoidalElevation = true;
-
 };
 
 #endif // BLUETOOTHRECEIVER_H

--- a/src/core/changelogcontents.cpp
+++ b/src/core/changelogcontents.cpp
@@ -16,16 +16,15 @@
 
 #include "changelogcontents.h"
 
-#include <qgsnetworkaccessmanager.h>
-
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QRegularExpression>
+#include <qgsnetworkaccessmanager.h>
 
 
-ChangelogContents::ChangelogContents( QObject *parent ):
-    QObject( parent )
+ChangelogContents::ChangelogContents( QObject *parent )
+  : QObject( parent )
 {
 }
 
@@ -40,7 +39,8 @@ void ChangelogContents::request()
   mStatus = LoadingStatus;
   emit statusChanged();
 
-  connect(manager, &QNetworkAccessManager::finished, this, [ = ]( QNetworkReply *reply ) {
+  connect( manager, &QNetworkAccessManager::finished, this, [ = ]( QNetworkReply * reply )
+  {
     QJsonParseError error;
     QJsonDocument json = QJsonDocument::fromJson( reply->readAll(), &error );
 
@@ -61,31 +61,31 @@ void ChangelogContents::request()
       QVariantMap release = releaseValue.toObject().toVariantMap();
       QList<int> releaseVersion = parseVersion( release.value( QStringLiteral( "tag_name" ) ).toString() );
 
-      if (releaseVersion.isEmpty())
+      if ( releaseVersion.isEmpty() )
         continue;
 
       // most probably developer version with no proper version set
-      if (qfieldVersion.isEmpty())
+      if ( qfieldVersion.isEmpty() )
         qfieldVersion = releaseVersion;
 
-      if (qfieldVersion[0] != releaseVersion[0] || qfieldVersion[1] != releaseVersion[1])
+      if ( qfieldVersion[0] != releaseVersion[0] || qfieldVersion[1] != releaseVersion[1] )
         continue;
 
       if ( versionNumbersOnly.isEmpty() )
       {
-        versionNumbersOnly = QStringLiteral("%1.%2.%3").arg( releaseVersion[0] ).arg( releaseVersion[1] ).arg( releaseVersion[2] );
+        versionNumbersOnly = QStringLiteral( "%1.%2.%3" ).arg( releaseVersion[0] ).arg( releaseVersion[1] ).arg( releaseVersion[2] );
       }
 
-      const QString releaseChangelog = QStringLiteral("\n#\n# ") + release["name"].toString() + QStringLiteral("\n\n") + release["body"].toString() + QStringLiteral("\n");
+      const QString releaseChangelog = QStringLiteral( "\n#\n# " ) + release["name"].toString() + QStringLiteral( "\n\n" ) + release["body"].toString() + QStringLiteral( "\n" );
       changelog = releaseChangelog + changelog;
     }
 
-    changelog += QStringLiteral("\n") + QStringLiteral("[") + tr("Previous releases on GitHub") + QStringLiteral("](https://github.com/opengisch/qfield/releases)");
+    changelog += QStringLiteral( "\n" ) + QStringLiteral( "[" ) + tr( "Previous releases on GitHub" ) + QStringLiteral( "](https://github.com/opengisch/qfield/releases)" );
 
     QRegularExpression regexpFirstTitle( QStringLiteral( "^\n#\n# " ) );
-    changelog = changelog.replace( regexpFirstTitle, QStringLiteral("\n# ") );
+    changelog = changelog.replace( regexpFirstTitle, QStringLiteral( "\n# " ) );
     QRegularExpression regexpAllTitles( QStringLiteral( "^##(.+)$" ), QRegularExpression::MultilineOption );
-    changelog = changelog.replace( regexpAllTitles, QStringLiteral("\n###\n##\\1\n\n\n") );
+    changelog = changelog.replace( regexpAllTitles, QStringLiteral( "\n###\n##\\1\n\n\n" ) );
     changelog = "Up to release **" + versionNumbersOnly + "**" + changelog;
 
     mStatus = SuccessStatus;
@@ -93,7 +93,7 @@ void ChangelogContents::request()
 
     emit statusChanged();
     emit markdownChanged();
-  });
+  } );
 
   manager->get( QNetworkRequest( QUrl( QStringLiteral( "https://api.github.com/repos/opengisch/qfield/releases" ) ) ) );
 }
@@ -117,8 +117,8 @@ QList<int> ChangelogContents::parseVersion( const QString &version )
   if ( parts.size() != 3 )
     return QList<int>();
 
-  if (parts[0].toInt() >= 0 && parts[1].toInt() >= 0 && parts[2].toInt() >= 0)
-    return QList<int>({parts[0].toInt(), parts[1].toInt(), parts[2].toInt()});
+  if ( parts[0].toInt() >= 0 && parts[1].toInt() >= 0 && parts[2].toInt() >= 0 )
+    return QList<int>( { parts[0].toInt(), parts[1].toInt(), parts[2].toInt() } );
 
   return QList<int>();
 }

--- a/src/core/changelogcontents.h
+++ b/src/core/changelogcontents.h
@@ -23,11 +23,11 @@ class ChangelogContents : public QObject
 {
     Q_OBJECT
 
-  //! Holds the current changelog contents formatted as markdown.
-  Q_PROPERTY( QString markdown READ markdown NOTIFY markdownChanged )
+    //! Holds the current changelog contents formatted as markdown.
+    Q_PROPERTY( QString markdown READ markdown NOTIFY markdownChanged )
 
-  //! Holds the current changelog contents status.
-  Q_PROPERTY( Status status READ status NOTIFY statusChanged )
+    //! Holds the current changelog contents status.
+    Q_PROPERTY( Status status READ status NOTIFY statusChanged )
 
   public:
     //! Constructor

--- a/src/core/deltafilewrapper.cpp
+++ b/src/core/deltafilewrapper.cpp
@@ -20,13 +20,12 @@
 #include "utils/fileutils.h"
 #include "utils/qfieldcloudutils.h"
 
-#include <QFileInfo>
 #include <QFile>
+#include <QFileInfo>
 #include <QUuid>
-
+#include <qgsmessagelog.h>
 #include <qgsproject.h>
 #include <qgsvectorlayerutils.h>
-#include <qgsmessagelog.h>
 
 
 /**
@@ -73,7 +72,7 @@ DeltaFileWrapper::DeltaFileWrapper( const QgsProject *project, const QString &fi
 
     QgsLogger::debug( QStringLiteral( "Loading deltas from %1" ).arg( mFileName ) );
 
-    if ( mErrorType == DeltaFileWrapper::NoError && ! deltaFile.open( QIODevice::ReadWrite ) )
+    if ( mErrorType == DeltaFileWrapper::NoError && !deltaFile.open( QIODevice::ReadWrite ) )
     {
       mErrorType = DeltaFileWrapper::IOError;
       mErrorDetails = deltaFile.errorString();
@@ -88,16 +87,16 @@ DeltaFileWrapper::DeltaFileWrapper( const QgsProject *project, const QString &fi
       mErrorDetails = jsonError.errorString();
     }
 
-    if ( mErrorType == DeltaFileWrapper::NoError && ( ! mJsonRoot.value( QStringLiteral( "id" ) ).isString() || mJsonRoot.value( QStringLiteral( "id" ) ).toString().isEmpty() ) )
+    if ( mErrorType == DeltaFileWrapper::NoError && ( !mJsonRoot.value( QStringLiteral( "id" ) ).isString() || mJsonRoot.value( QStringLiteral( "id" ) ).toString().isEmpty() ) )
       mErrorType = DeltaFileWrapper::JsonFormatIdError;
 
-    if ( mErrorType == DeltaFileWrapper::NoError && ( ! mJsonRoot.value( QStringLiteral( "project" ) ).isString() || mJsonRoot.value( QStringLiteral( "project" ) ).toString().isEmpty() ) )
+    if ( mErrorType == DeltaFileWrapper::NoError && ( !mJsonRoot.value( QStringLiteral( "project" ) ).isString() || mJsonRoot.value( QStringLiteral( "project" ) ).toString().isEmpty() ) )
       mErrorType = DeltaFileWrapper::JsonFormatProjectIdError;
 
-    if ( mErrorType == DeltaFileWrapper::NoError && ! mJsonRoot.value( QStringLiteral( "deltas" ) ).isArray() )
+    if ( mErrorType == DeltaFileWrapper::NoError && !mJsonRoot.value( QStringLiteral( "deltas" ) ).isArray() )
       mErrorType = DeltaFileWrapper::JsonFormatDeltasError;
 
-    if ( mErrorType == DeltaFileWrapper::NoError && ( ! mJsonRoot.value( QStringLiteral( "version" ) ).isString() || mJsonRoot.value( QStringLiteral( "version" ) ).toString().isEmpty() ) )
+    if ( mErrorType == DeltaFileWrapper::NoError && ( !mJsonRoot.value( QStringLiteral( "version" ) ).isString() || mJsonRoot.value( QStringLiteral( "version" ) ).toString().isEmpty() ) )
       mErrorType = DeltaFileWrapper::JsonFormatVersionError;
 
     if ( mErrorType == DeltaFileWrapper::NoError && mJsonRoot.value( QStringLiteral( "version" ) ) != DeltaFormatVersion )
@@ -109,7 +108,7 @@ DeltaFileWrapper::DeltaFileWrapper( const QgsProject *project, const QString &fi
 
       for ( const QJsonValue &v : deltasJsonArray )
       {
-        if ( ! v.isObject() )
+        if ( !v.isObject() )
         {
           mErrorType = DeltaFileWrapper::JsonFormatDeltaItemError;
           continue;
@@ -123,12 +122,12 @@ DeltaFileWrapper::DeltaFileWrapper( const QgsProject *project, const QString &fi
   }
   else if ( mErrorType == DeltaFileWrapper::NoError )
   {
-    mJsonRoot = QJsonObject( {{"version", DeltaFormatVersion},
-      {"id", QUuid::createUuid().toString( QUuid::WithoutBraces )},
-      {"project", mCloudProjectId},
-      {"deltas", mDeltas}} );
+    mJsonRoot = QJsonObject( { { "version", DeltaFormatVersion },
+      { "id", QUuid::createUuid().toString( QUuid::WithoutBraces ) },
+      { "project", mCloudProjectId },
+      { "deltas", mDeltas } } );
 
-    if ( ! deltaFile.open( QIODevice::ReadWrite ) )
+    if ( !deltaFile.open( QIODevice::ReadWrite ) )
     {
       mErrorType = DeltaFileWrapper::IOError;
       mErrorDetails = deltaFile.errorString();
@@ -172,7 +171,7 @@ QString DeltaFileWrapper::projectId() const
 
 void DeltaFileWrapper::reset()
 {
-  if ( ! mIsDirty && mDeltas.size() == 0 )
+  if ( !mIsDirty && mDeltas.size() == 0 )
     return;
 
   mIsDirty = true;
@@ -223,18 +222,17 @@ QString DeltaFileWrapper::errorString() const
 {
   const QHash<DeltaFileWrapper::ErrorTypes, QString> errorMessages(
   {
-    {DeltaFileWrapper::NoError, QString()},
-    {DeltaFileWrapper::LockError, QStringLiteral( "Delta file is already opened" )},
-    {DeltaFileWrapper::NotCloudProjectError, QStringLiteral( "The current project is not a cloud project" ) },
-    {DeltaFileWrapper::IOError, QStringLiteral( "Cannot open file for read and write" ) },
-    {DeltaFileWrapper::JsonParseError, QStringLiteral( "Unable to parse JSON" ) },
-    {DeltaFileWrapper::JsonFormatIdError, QStringLiteral( "Delta file is missing a valid id" ) },
-    {DeltaFileWrapper::JsonFormatProjectIdError, QStringLiteral( "Delta file is missing a valid project id" ) },
-    {DeltaFileWrapper::JsonFormatVersionError, QStringLiteral( "Delta file is missing a valid version" ) },
-    {DeltaFileWrapper::JsonFormatDeltasError, QStringLiteral( "Delta file is missing a valid deltas" ) },
-    {DeltaFileWrapper::JsonFormatDeltaItemError, QStringLiteral( "Delta file is missing a valid delta item" ) },
-    {DeltaFileWrapper::JsonIncompatibleVersionError, QStringLiteral( "Delta file has incompatible version" ) }
-  } );
+    { DeltaFileWrapper::NoError, QString() },
+    { DeltaFileWrapper::LockError, QStringLiteral( "Delta file is already opened" ) },
+    { DeltaFileWrapper::NotCloudProjectError, QStringLiteral( "The current project is not a cloud project" ) },
+    { DeltaFileWrapper::IOError, QStringLiteral( "Cannot open file for read and write" ) },
+    { DeltaFileWrapper::JsonParseError, QStringLiteral( "Unable to parse JSON" ) },
+    { DeltaFileWrapper::JsonFormatIdError, QStringLiteral( "Delta file is missing a valid id" ) },
+    { DeltaFileWrapper::JsonFormatProjectIdError, QStringLiteral( "Delta file is missing a valid project id" ) },
+    { DeltaFileWrapper::JsonFormatVersionError, QStringLiteral( "Delta file is missing a valid version" ) },
+    { DeltaFileWrapper::JsonFormatDeltasError, QStringLiteral( "Delta file is missing a valid deltas" ) },
+    { DeltaFileWrapper::JsonFormatDeltaItemError, QStringLiteral( "Delta file is missing a valid delta item" ) },
+    { DeltaFileWrapper::JsonIncompatibleVersionError, QStringLiteral( "Delta file has incompatible version" ) } } );
 
   Q_ASSERT( errorMessages.contains( mErrorType ) );
 
@@ -274,7 +272,7 @@ bool DeltaFileWrapper::toFile()
     return false;
   }
 
-  if ( deltaFile.write( toJson() )  == -1 )
+  if ( deltaFile.write( toJson() ) == -1 )
   {
     mErrorType = DeltaFileWrapper::IOError;
     mErrorDetails = deltaFile.errorString();
@@ -294,39 +292,39 @@ bool DeltaFileWrapper::toFile()
 
 QString DeltaFileWrapper::toFileForUpload( const QString &outFileName ) const
 {
-    QString fileName = outFileName;
+  QString fileName = outFileName;
 
-    if ( fileName.isEmpty() )
-    {
-        QTemporaryFile tempFile;
+  if ( fileName.isEmpty() )
+  {
+    QTemporaryFile tempFile;
 
-        if ( !tempFile.open() )
-            return QString();
-
-        fileName = tempFile.fileName();
-    }
-
-    QJsonArray resultDeltas;
-    QJsonObject jsonRoot( mJsonRoot );
-
-    jsonRoot.insert( QStringLiteral( "deltas" ), deltas() );
-    jsonRoot.insert( QStringLiteral( "files" ), QJsonArray() );
-
-    QFile deltaFile( fileName );
-
-    if ( ! deltaFile.open( QIODevice::WriteOnly | QIODevice::Unbuffered ) )
+    if ( !tempFile.open() )
       return QString();
 
-    if ( deltaFile.write( QJsonDocument( jsonRoot ).toJson( QJsonDocument::Indented ) )  == -1 )
-      return QString();
+    fileName = tempFile.fileName();
+  }
 
-    return fileName;
+  QJsonArray resultDeltas;
+  QJsonObject jsonRoot( mJsonRoot );
+
+  jsonRoot.insert( QStringLiteral( "deltas" ), deltas() );
+  jsonRoot.insert( QStringLiteral( "files" ), QJsonArray() );
+
+  QFile deltaFile( fileName );
+
+  if ( !deltaFile.open( QIODevice::WriteOnly | QIODevice::Unbuffered ) )
+    return QString();
+
+  if ( deltaFile.write( QJsonDocument( jsonRoot ).toJson( QJsonDocument::Indented ) ) == -1 )
+    return QString();
+
+  return fileName;
 }
 
 
 bool DeltaFileWrapper::append( const DeltaFileWrapper *deltaFileWrapper )
 {
-  if ( ! deltaFileWrapper )
+  if ( !deltaFileWrapper )
     return false;
 
   if ( deltaFileWrapper->hasError() )
@@ -347,7 +345,7 @@ QStringList DeltaFileWrapper::attachmentFieldNames( const QgsProject *project, c
 {
   QStringList attachmentFieldNames;
 
-  if ( ! project )
+  if ( !project )
     return attachmentFieldNames;
 
   if ( sCacheAttachmentFieldNames()->contains( layerId ) )
@@ -355,7 +353,7 @@ QStringList DeltaFileWrapper::attachmentFieldNames( const QgsProject *project, c
 
   const QgsVectorLayer *vl = static_cast<QgsVectorLayer *>( project->mapLayer( layerId ) );
 
-  if ( ! vl )
+  if ( !vl )
     return attachmentFieldNames;
 
   const QgsFields fields = vl->fields();
@@ -392,27 +390,27 @@ QMap<QString, QString> DeltaFileWrapper::attachmentFileNames() const
     {
       const QVariantMap oldData = delta.value( QStringLiteral( "old" ) ).toMap();
 
-      Q_ASSERT( ! oldData.isEmpty() );
+      Q_ASSERT( !oldData.isEmpty() );
     }
 
     if ( method == QStringLiteral( "create" ) || method == QStringLiteral( "patch" ) )
     {
       const QVariantMap newData = delta.value( QStringLiteral( "new" ) ).toMap();
 
-      Q_ASSERT( ! newData.isEmpty() );
+      Q_ASSERT( !newData.isEmpty() );
 
       if ( newData.contains( QStringLiteral( "files_sha256" ) ) )
       {
         const QVariantMap filesChecksum = newData.value( QStringLiteral( "files_sha256" ) ).toMap();
 
-        Q_ASSERT( ! filesChecksum.isEmpty() );
+        Q_ASSERT( !filesChecksum.isEmpty() );
 
         const QVariantMap attributes = newData.value( QStringLiteral( "attributes" ) ).toMap();
         const QStringList attributeNames = attributes.keys();
 
         for ( const QString &fieldName : attributeNames )
         {
-          if ( ! attachmentFieldNamesList.contains( fieldName ) )
+          if ( !attachmentFieldNamesList.contains( fieldName ) )
             continue;
 
           const QString fileName = attributes.value( fieldName ).toString();
@@ -451,12 +449,12 @@ void DeltaFileWrapper::addPatch( const QString &localLayerId, const QString &sou
 {
   QJsonObject delta(
   {
-    {"localPk", oldFeature.attribute( localPkAttrName ).toString()},
-    {"localLayerId", localLayerId},
-    {"method", "patch"},
-    {"sourcePk", oldFeature.attribute( sourcePkAttrName ).toString()},
-    {"sourceLayerId", sourceLayerId},
-    {"uuid", QUuid::createUuid().toString( QUuid::WithoutBraces )},
+    { "localPk", oldFeature.attribute( localPkAttrName ).toString() },
+    { "localLayerId", localLayerId },
+    { "method", "patch" },
+    { "sourcePk", oldFeature.attribute( sourcePkAttrName ).toString() },
+    { "sourceLayerId", sourceLayerId },
+    { "uuid", QUuid::createUuid().toString( QUuid::WithoutBraces ) },
   } );
 
   const QStringList attachmentFieldsList = attachmentFieldNames( mProject, localLayerId );
@@ -468,7 +466,7 @@ void DeltaFileWrapper::addPatch( const QString &localLayerId, const QString &sou
   QJsonObject newData;
   bool areFeaturesEqual = false;
 
-  if ( ! oldGeom.equals( newGeom ) )
+  if ( !oldGeom.equals( newGeom ) )
   {
     oldData.insert( QStringLiteral( "geometry" ), geometryToJsonValue( oldGeom ) );
     newData.insert( QStringLiteral( "geometry" ), geometryToJsonValue( newGeom ) );
@@ -504,7 +502,7 @@ void DeltaFileWrapper::addPatch( const QString &localLayerId, const QString &sou
         const QString newFileName = newVal.toString();
 
         // if the file name is an empty or null string, there is not much we can do
-        if ( ! oldFileName.isEmpty() )
+        if ( !oldFileName.isEmpty() )
         {
           const QString oldFullFileName = QFileInfo( oldFileName ).isAbsolute() ? oldFileName : QStringLiteral( "%1/%2" ).arg( homeDir, oldFileName );
           const QByteArray oldFileChecksum = FileUtils::fileChecksum( oldFullFileName, QCryptographicHash::Sha256 );
@@ -512,7 +510,7 @@ void DeltaFileWrapper::addPatch( const QString &localLayerId, const QString &sou
           tmpOldFileChecksums.insert( oldFullFileName, oldFileChecksumJson );
         }
 
-        if ( ! newFileName.isEmpty() )
+        if ( !newFileName.isEmpty() )
         {
           const QString newFullFileName = QFileInfo( newFileName ).isAbsolute() ? newFileName : QStringLiteral( "%1/%2" ).arg( homeDir, newFileName );
           const QByteArray newFileChecksum = FileUtils::fileChecksum( newFullFileName, QCryptographicHash::Sha256 );
@@ -524,7 +522,7 @@ void DeltaFileWrapper::addPatch( const QString &localLayerId, const QString &sou
   }
 
   // if features are completely equal, there is no need to change the JSON
-  if ( ! areFeaturesEqual )
+  if ( !areFeaturesEqual )
     return;
 
   if ( tmpOldAttrs.length() > 0 || tmpNewAttrs.length() > 0 )
@@ -559,7 +557,7 @@ void DeltaFileWrapper::addPatch( const QString &localLayerId, const QString &sou
     QJsonObject newCreate = deltaCreate.value( QStringLiteral( "new" ) ).toObject();
     QJsonObject attributesCreate = newCreate.value( QStringLiteral( "attributes" ) ).toObject();
 
-    if ( ! newData.value( QStringLiteral( "geometry" ) ).isUndefined() )
+    if ( !newData.value( QStringLiteral( "geometry" ) ).isUndefined() )
     {
       newCreate.insert( QStringLiteral( "geometry" ), newData.value( QStringLiteral( "geometry" ) ) );
     }
@@ -590,13 +588,14 @@ void DeltaFileWrapper::addPatch( const QString &localLayerId, const QString &sou
 
 void DeltaFileWrapper::addDelete( const QString &localLayerId, const QString &sourceLayerId, const QString &localPkAttrName, const QString &sourcePkAttrName, const QgsFeature &oldFeature )
 {
-  QJsonObject delta( {
-    {"localPk", oldFeature.attribute( localPkAttrName ).toString()},
-    {"localLayerId", localLayerId},
-    {"method", "delete"},
-    {"sourcePk", oldFeature.attribute( sourcePkAttrName ).toString()},
-    {"sourceLayerId", sourceLayerId},
-    {"uuid", QUuid::createUuid().toString( QUuid::WithoutBraces )},
+  QJsonObject delta(
+  {
+    { "localPk", oldFeature.attribute( localPkAttrName ).toString() },
+    { "localLayerId", localLayerId },
+    { "method", "delete" },
+    { "sourcePk", oldFeature.attribute( sourcePkAttrName ).toString() },
+    { "sourceLayerId", sourceLayerId },
+    { "uuid", QUuid::createUuid().toString( QUuid::WithoutBraces ) },
   } );
 
   QMap<QString, int> layerPkDeltaIdx = mLocalPkDeltaIdx.value( localLayerId );
@@ -613,7 +612,7 @@ void DeltaFileWrapper::addDelete( const QString &localLayerId, const QString &so
 
   const QStringList attachmentFieldsList = attachmentFieldNames( mProject, localLayerId );
   const QgsAttributes oldAttrs = oldFeature.attributes();
-  QJsonObject oldData( {{"geometry", geometryToJsonValue( oldFeature.geometry() )}} );
+  QJsonObject oldData( { { "geometry", geometryToJsonValue( oldFeature.geometry() ) } } );
   QJsonObject tmpOldAttrs;
   QJsonObject tmpOldFileChecksums;
 
@@ -623,7 +622,7 @@ void DeltaFileWrapper::addDelete( const QString &localLayerId, const QString &so
     const QString name = oldFeature.fields().at( idx ).name();
     tmpOldAttrs.insert( name, oldVal.isNull() ? QJsonValue::Null : QJsonValue::fromVariant( oldVal ) );
 
-    if ( attachmentFieldsList.contains( name ) && ! oldVal.isNull() )
+    if ( attachmentFieldsList.contains( name ) && !oldVal.isNull() )
     {
       const QString oldFileName = oldVal.toString();
       const QByteArray oldFileChecksum = FileUtils::fileChecksum( oldFileName, QCryptographicHash::Sha256 );
@@ -656,19 +655,20 @@ void DeltaFileWrapper::addDelete( const QString &localLayerId, const QString &so
 }
 
 
-void DeltaFileWrapper::addCreate(  const QString &localLayerId, const QString &sourceLayerId, const QString &localPkAttrName, const QString &sourcePkAttrName, const QgsFeature &newFeature )
+void DeltaFileWrapper::addCreate( const QString &localLayerId, const QString &sourceLayerId, const QString &localPkAttrName, const QString &sourcePkAttrName, const QgsFeature &newFeature )
 {
-  QJsonObject delta( {
-    {"localPk", newFeature.attribute( localPkAttrName ).toString()},
-    {"localLayerId", localLayerId},
-    {"method", "create"},
-    {"sourcePk", newFeature.attribute( sourcePkAttrName ).toString()},
-    {"sourceLayerId", sourceLayerId},
-    {"uuid", QUuid::createUuid().toString( QUuid::WithoutBraces )},
+  QJsonObject delta(
+  {
+    { "localPk", newFeature.attribute( localPkAttrName ).toString() },
+    { "localLayerId", localLayerId },
+    { "method", "create" },
+    { "sourcePk", newFeature.attribute( sourcePkAttrName ).toString() },
+    { "sourceLayerId", sourceLayerId },
+    { "uuid", QUuid::createUuid().toString( QUuid::WithoutBraces ) },
   } );
   const QStringList attachmentFieldsList = attachmentFieldNames( mProject, localLayerId );
   const QgsAttributes newAttrs = newFeature.attributes();
-  QJsonObject newData( {{"geometry", geometryToJsonValue( newFeature.geometry() )}} );
+  QJsonObject newData( { { "geometry", geometryToJsonValue( newFeature.geometry() ) } } );
   QJsonObject tmpNewAttrs;
   QJsonObject tmpNewFileChecksums;
 
@@ -732,7 +732,7 @@ QStringList DeltaFileWrapper::deltaLayerIds() const
     QJsonObject deltaItem = v.toObject();
     const QString layerId = deltaItem.value( QStringLiteral( "layerId" ) ).toString();
 
-    if ( ! layerIds.contains( layerId ) )
+    if ( !layerIds.contains( layerId ) )
       layerIds.append( layerId );
   }
 
@@ -760,7 +760,7 @@ bool DeltaFileWrapper::applyReversed()
 
 bool DeltaFileWrapper::applyInternal( bool shouldApplyInReverse )
 {
-  if ( ! toFile() )
+  if ( !toFile() )
     return false;
 
   mIsDeltaFileBeingApplied = true;
@@ -776,7 +776,7 @@ bool DeltaFileWrapper::applyInternal( bool shouldApplyInReverse )
 
     QgsVectorLayer *vl = static_cast<QgsVectorLayer *>( mProject->mapLayer( layerId ) );
 
-    if ( ! vl || ( ! vl->isEditable() && ! vl->startEditing() ) )
+    if ( !vl || ( !vl->isEditable() && !vl->startEditing() ) )
     {
       isSuccess = false;
       break;
@@ -792,7 +792,7 @@ bool DeltaFileWrapper::applyInternal( bool shouldApplyInReverse )
   // 3) commit the changes, if fails, revert the rest of the layers
   if ( isSuccess )
   {
-    for ( auto [ layerId, vl ] : qfield::asKeyValueRange( vectorLayers ) )
+    for ( auto [layerId, vl] : qfield::asKeyValueRange( vectorLayers ) )
     {
       // despite the error, try to rollback all the changes so far
       if ( vl->commitChanges() )
@@ -807,16 +807,16 @@ bool DeltaFileWrapper::applyInternal( bool shouldApplyInReverse )
   }
 
   // 4) revert the changes that didn't manage to be applied
-  if ( ! isSuccess )
+  if ( !isSuccess )
   {
-    for ( auto [ layerId, vl ] : qfield::asKeyValueRange( vectorLayers ) )
+    for ( auto [layerId, vl] : qfield::asKeyValueRange( vectorLayers ) )
     {
       // the layer has already been committed
-      if ( ! vl )
+      if ( !vl )
         continue;
 
       // despite the error, try to rollback all the changes so far
-      if ( ! vl->rollBack() )
+      if ( !vl->rollBack() )
         QgsMessageLog::logMessage( QStringLiteral( "Failed to rollback layer with id \"%1\"" ).arg( layerId ) );
     }
   }
@@ -865,7 +865,7 @@ bool DeltaFileWrapper::applyDeltasOnLayers( QHash<QString, QgsVectorLayer *> &ve
 
     Q_ASSERT( vectorLayers[layerId] );
 
-    if ( ! vectorLayers[layerId] )
+    if ( !vectorLayers[layerId] )
       return false;
 
     if ( method != QStringLiteral( "create" ) )
@@ -873,21 +873,21 @@ bool DeltaFileWrapper::applyDeltasOnLayers( QHash<QString, QgsVectorLayer *> &ve
       QgsExpression expr( QStringLiteral( " %1 = %2 " ).arg( QgsExpression::quotedColumnRef( pkAttrPair.second ), QgsExpression::quotedString( localPk ) ) );
       QgsFeatureIterator it = vectorLayers[layerId]->getFeatures( QgsFeatureRequest( expr ) );
 
-      if ( ! it.nextFeature( f ) )
+      if ( !it.nextFeature( f ) )
         return false;
 
       QgsFeature tempFeature;
       if ( it.nextFeature( tempFeature ) )
         return false;
 
-      if ( ! f.isValid() )
+      if ( !f.isValid() )
         return false;
     }
 
     if ( method == QStringLiteral( "create" ) )
     {
       Q_ASSERT( oldValues.isEmpty() );
-      Q_ASSERT( ! newValues.isEmpty() );
+      Q_ASSERT( !newValues.isEmpty() );
 
       const QString geomWkt = newValues.value( QStringLiteral( "geometry" ) ).toString();
       const QVariantMap attributes = newValues.value( QStringLiteral( "attributes" ) ).toMap();
@@ -895,46 +895,46 @@ bool DeltaFileWrapper::applyDeltasOnLayers( QHash<QString, QgsVectorLayer *> &ve
       QgsGeometry geom;
       QgsAttributeMap qgsAttributeMap;
 
-      if ( ! geomWkt.isEmpty() )
+      if ( !geomWkt.isEmpty() )
         geom = QgsGeometry::fromWkt( geomWkt );
 
-      for ( auto [ attrName, attrValue ] : qfield::asKeyValueRange( attributes ) )
+      for ( auto [attrName, attrValue] : qfield::asKeyValueRange( attributes ) )
         qgsAttributeMap.insert( fields.indexFromName( attrName ), attrValue );
 
       QgsFeature createdFeature = QgsVectorLayerUtils::createFeature( vectorLayers[layerId], geom, qgsAttributeMap );
 
       Q_ASSERT( createdFeature.isValid() );
 
-      if ( ! vectorLayers[layerId]->addFeature( createdFeature ) )
+      if ( !vectorLayers[layerId]->addFeature( createdFeature ) )
         return false;
     }
     else if ( method == QStringLiteral( "delete" ) )
     {
       Q_ASSERT( newValues.isEmpty() );
-      Q_ASSERT( ! oldValues.isEmpty() );
+      Q_ASSERT( !oldValues.isEmpty() );
       Q_ASSERT( f.isValid() );
 
-      if ( ! vectorLayers[layerId]->deleteFeature( f.id() ) )
+      if ( !vectorLayers[layerId]->deleteFeature( f.id() ) )
         return false;
     }
     else if ( method == QStringLiteral( "patch" ) )
     {
-      Q_ASSERT( ! newValues.isEmpty() );
-      Q_ASSERT( ! oldValues.isEmpty() );
+      Q_ASSERT( !newValues.isEmpty() );
+      Q_ASSERT( !oldValues.isEmpty() );
       Q_ASSERT( f.isValid() );
 
       const QString geomWkt = newValues.value( QStringLiteral( "geometry" ) ).toString();
       const QVariantMap attributes = newValues.value( QStringLiteral( "attributes" ) ).toMap();
 
-      if ( ! geomWkt.isEmpty() )
+      if ( !geomWkt.isEmpty() )
       {
         QgsGeometry geom = QgsGeometry::fromWkt( geomWkt );
         vectorLayers[layerId]->changeGeometry( f.id(), geom );
       }
 
-      for ( auto [ attrName, attrValue ] : qfield::asKeyValueRange( attributes ) )
+      for ( auto [attrName, attrValue] : qfield::asKeyValueRange( attributes ) )
       {
-        if ( ! vectorLayers[layerId]->changeAttributeValue( f.id(), fields.indexOf( attrName ), attrValue ) )
+        if ( !vectorLayers[layerId]->changeAttributeValue( f.id(), fields.indexOf( attrName ), attrValue ) )
           return false;
       }
     }

--- a/src/core/deltafilewrapper.h
+++ b/src/core/deltafilewrapper.h
@@ -18,13 +18,12 @@
 #ifndef FEATUREDELTAS_H
 #define FEATUREDELTAS_H
 
-#include <qgsfeature.h>
-#include <qgsvectorlayer.h>
-#include <qgslogger.h>
-
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <qgsfeature.h>
+#include <qgslogger.h>
+#include <qgsvectorlayer.h>
 
 
 const QString DeltaFormatVersion = QStringLiteral( "1.0" );
@@ -322,7 +321,6 @@ class DeltaFileWrapper : public QObject
 
 
   private:
-
     /**
      * Converts geometry to QJsonValue string in WKT format.
      * Returns null if the geometry is null, or WKT string of the geometry

--- a/src/core/deltalistmodel.cpp
+++ b/src/core/deltalistmodel.cpp
@@ -14,14 +14,15 @@
  ***************************************************************************/
 
 #include "deltalistmodel.h"
-#include <QJsonObject>
+
 #include <QJsonArray>
+#include <QJsonObject>
 
 
 DeltaListModel::DeltaListModel( QJsonDocument deltasStatusList )
   : mJson( deltasStatusList )
 {
-  if ( ! mJson.isArray() )
+  if ( !mJson.isArray() )
   {
     mIsValid = false;
     mErrorString = tr( "Expected the json document to be an array of delta status" );
@@ -33,7 +34,7 @@ DeltaListModel::DeltaListModel( QJsonDocument deltasStatusList )
 
   for ( const QJsonValue &deltaJson : deltas )
   {
-    if ( ! deltaJson.isObject() )
+    if ( !deltaJson.isObject() )
     {
       mIsValid = false;
       mErrorString = tr( "Expected all array elements to be an object, but the element at #%1 is not" ).arg( mDeltas.size() );
@@ -41,7 +42,7 @@ DeltaListModel::DeltaListModel( QJsonDocument deltasStatusList )
     }
 
     const QJsonObject deltaObject = deltaJson.toObject();
-    const QStringList requiredKeys({"id", "deltafile_id", "created_at", "updated_at", "status"});
+    const QStringList requiredKeys( { "id", "deltafile_id", "created_at", "updated_at", "status" } );
     for ( const QString &requiredKey : requiredKeys )
     {
       if ( deltaObject.value( requiredKey ).isNull() || deltaObject.value( requiredKey ).isUndefined() )
@@ -164,7 +165,7 @@ bool DeltaListModel::allHaveFinalStatus() const
         break;
     }
 
-    if ( ! isFinalForAll )
+    if ( !isFinalForAll )
       break;
   }
 

--- a/src/core/deltalistmodel.h
+++ b/src/core/deltalistmodel.h
@@ -17,79 +17,80 @@
 #define DELTALISTMODEL_H
 
 #include <QAbstractListModel>
-#include <QUuid>
 #include <QJsonDocument>
+#include <QUuid>
 
 class DeltaListModel : public QAbstractListModel
 {
-  Q_OBJECT
+    Q_OBJECT
 
-public:
-  enum Status
-  {
-    PendingStatus,
-    BusyStatus,
-    AppliedStatus,
-    ConflictStatus,
-    NotAppliedStatus,
-    ErrorStatus,
-  };
+  public:
+    enum Status
+    {
+      PendingStatus,
+      BusyStatus,
+      AppliedStatus,
+      ConflictStatus,
+      NotAppliedStatus,
+      ErrorStatus,
+    };
 
-  Q_ENUM( Status )
+    Q_ENUM( Status )
 
-  enum ColumnRole
-  {
-    IdRole,
-    DeltafileIdRole,
-    CreatedAtRole,
-    UpdatedAtRole,
-    StatusRole,
-    OutputRole,
-  };
+    enum ColumnRole
+    {
+      IdRole,
+      DeltafileIdRole,
+      CreatedAtRole,
+      UpdatedAtRole,
+      StatusRole,
+      OutputRole,
+    };
 
-  Q_ENUM( ColumnRole )
+    Q_ENUM( ColumnRole )
 
-  struct Delta {
-    QUuid id;
-    QUuid deltafileId;
-    QString createdAt;
-    QString updatedAt;
-    Status status;
-    QString output;
-  };
+    struct Delta
+    {
+      QUuid id;
+      QUuid deltafileId;
+      QString createdAt;
+      QString updatedAt;
+      Status status;
+      QString output;
+    };
 
-  DeltaListModel() = default;
-  explicit DeltaListModel( QJsonDocument deltasStatusList );
+    DeltaListModel() = default;
+    explicit DeltaListModel( QJsonDocument deltasStatusList );
 
-  //! Returns number of rows.
-  int rowCount( const QModelIndex &parent ) const override;
+    //! Returns number of rows.
+    int rowCount( const QModelIndex &parent ) const override;
 
-  //! Returns the data at given \a index with given \a role.
-  QVariant data( const QModelIndex &index, int role ) const override;
+    //! Returns the data at given \a index with given \a role.
+    QVariant data( const QModelIndex &index, int role ) const override;
 
-  //! Returns the model role names.
-  QHash<int, QByteArray> roleNames() const override;
+    //! Returns the model role names.
+    QHash<int, QByteArray> roleNames() const override;
 
-  //! Returns the json document used to initialize the model.
-  QJsonDocument json() const;
+    //! Returns the json document used to initialize the model.
+    QJsonDocument json() const;
 
-  //! Whether the model is valid and can be used.
-  bool isValid() const;
+    //! Whether the model is valid and can be used.
+    bool isValid() const;
 
-  //! Holds the reason why it is invalid. Null string if not invalid.
-  QString errorString() const;
+    //! Holds the reason why it is invalid. Null string if not invalid.
+    QString errorString() const;
 
-  //! Whether all the deltas are in final status.
-  bool allHaveFinalStatus() const;
+    //! Whether all the deltas are in final status.
+    bool allHaveFinalStatus() const;
 
-  //! Returns a combined output for all deltas, separated by a new line.
-  QString combinedOutput() const;
+    //! Returns a combined output for all deltas, separated by a new line.
+    QString combinedOutput() const;
 
-private:
-  QJsonDocument mJson;
-  bool mIsValid = false;
-  QString mErrorString;
-  QList<Delta> mDeltas;
+  private:
+    QJsonDocument mJson;
+    bool mIsValid = false;
+    QString mErrorString;
+    QList<Delta> mDeltas;
 };
 
 #endif // DELTALISTMODEL_H

--- a/src/core/distancearea.cpp
+++ b/src/core/distancearea.cpp
@@ -15,9 +15,9 @@
  ***************************************************************************/
 #include "distancearea.h"
 #include "geometry.h"
-#include "rubberband.h"
-#include "qgsvectorlayer.h"
 #include "qgsproject.h"
+#include "qgsvectorlayer.h"
+#include "rubberband.h"
 
 DistanceArea::DistanceArea( QObject *parent )
   : QObject( parent )

--- a/src/core/distancearea.h
+++ b/src/core/distancearea.h
@@ -17,7 +17,6 @@
 #define DISTANCEAREA_H
 
 #include <QObject>
-
 #include <qgsdistancearea.h>
 
 class Geometry;

--- a/src/core/expressioncontextutils.cpp
+++ b/src/core/expressioncontextutils.cpp
@@ -18,6 +18,7 @@
 
 #include "expressioncontextutils.h"
 #include "qgsgeometry.h"
+
 #include <QtPositioning/QGeoPositionInfoSource>
 
 
@@ -71,7 +72,7 @@ QgsExpressionContextScope *ExpressionContextUtils::positionScope( const GnssPosi
   addPositionVariable( scope, QStringLiteral( "hdop" ), horizontalDilution, positionLocked );
   addPositionVariable( scope, QStringLiteral( "vdop" ), verticalDilution, positionLocked );
   addPositionVariable( scope, QStringLiteral( "number_of_used_satellites" ), numberOfUsedSatelites, positionLocked );
-  addPositionVariable( scope, QStringLiteral( "used_satellites" ),  QVariant::fromValue( usedSatelites ), positionLocked );
+  addPositionVariable( scope, QStringLiteral( "used_satellites" ), QVariant::fromValue( usedSatelites ), positionLocked );
   addPositionVariable( scope, QStringLiteral( "quality_description" ), qualityDescription, positionLocked );
   addPositionVariable( scope, QStringLiteral( "fix_status_description" ), fixStatusDescription, positionLocked );
   addPositionVariable( scope, QStringLiteral( "fix_mode" ), fixMode, positionLocked );
@@ -100,11 +101,11 @@ QgsExpressionContextScope *ExpressionContextUtils::mapToolCaptureScope( const Sn
   return scope;
 }
 
-QgsExpressionContextScope *ExpressionContextUtils::cloudUserScope(const CloudUserInformation &cloudUserInformation)
+QgsExpressionContextScope *ExpressionContextUtils::cloudUserScope( const CloudUserInformation &cloudUserInformation )
 {
-    QgsExpressionContextScope *scope = new QgsExpressionContextScope( QObject::tr( "Cloud User Info" ) );
+  QgsExpressionContextScope *scope = new QgsExpressionContextScope( QObject::tr( "Cloud User Info" ) );
 
-    scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "cloud_username" ), cloudUserInformation.username, true, true ) );
-    scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "cloud_useremail" ), cloudUserInformation.email, true, true ) );
-    return scope;
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "cloud_username" ), cloudUserInformation.username, true, true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "cloud_useremail" ), cloudUserInformation.email, true, true ) );
+  return scope;
 }

--- a/src/core/expressioncontextutils.h
+++ b/src/core/expressioncontextutils.h
@@ -19,10 +19,11 @@
 #ifndef EXPRESSIONCONTEXTUTILS_H
 #define EXPRESSIONCONTEXTUTILS_H
 
-#include <qgsexpressioncontext.h>
-#include "snappingresult.h"
 #include "gnsspositioninformation.h"
 #include "qfieldcloudconnection.h"
+#include "snappingresult.h"
+
+#include <qgsexpressioncontext.h>
 
 class ExpressionContextUtils
 {

--- a/src/core/expressionevaluator.cpp
+++ b/src/core/expressionevaluator.cpp
@@ -16,8 +16,8 @@
  ***************************************************************************/
 
 #include "expressionevaluator.h"
-#include "qgsproject.h"
 #include "qgsexpressioncontextutils.h"
+#include "qgsproject.h"
 
 ExpressionEvaluator::ExpressionEvaluator( QObject *parent )
   : QObject( parent )

--- a/src/core/expressionevaluator.h
+++ b/src/core/expressionevaluator.h
@@ -18,9 +18,9 @@
 #ifndef EXPRESSIONEVALUATOR_H
 #define EXPRESSIONEVALUATOR_H
 
+#include <QObject>
 #include <qgsexpression.h>
 #include <qgsexpressioncontext.h>
-#include <QObject>
 
 class ExpressionEvaluator : public QObject
 {
@@ -53,6 +53,5 @@ class ExpressionEvaluator : public QObject
     QString mExpressionText;
     QgsFeature mFeature;
     QgsMapLayer *mLayer = nullptr;
-
 };
 #endif // EXPRESSIONEVALUATOR_H

--- a/src/core/expressionvariablemodel.cpp
+++ b/src/core/expressionvariablemodel.cpp
@@ -15,12 +15,11 @@
  ***************************************************************************/
 
 #include "expressionvariablemodel.h"
+
+#include <QDebug>
+#include <QSettings>
 #include <qgsexpressioncontext.h>
 #include <qgsexpressioncontextutils.h>
-
-
-#include <QSettings>
-#include <QDebug>
 
 ExpressionVariableModel::ExpressionVariableModel( QObject *parent )
   : QStandardItemModel( parent )
@@ -113,7 +112,7 @@ void ExpressionVariableModel::setName( int row, const QString &name )
 {
   QStandardItem *rowItem = item( row );
 
-  if ( ! rowItem )
+  if ( !rowItem )
     return;
 
   if ( rowItem->data( VariableName ).toString() == name )
@@ -126,7 +125,7 @@ void ExpressionVariableModel::setValue( int row, const QString &value )
 {
   QStandardItem *rowItem = item( row );
 
-  if ( ! rowItem )
+  if ( !rowItem )
     return;
 
   if ( rowItem->data( VariableValue ).toString() == value )

--- a/src/core/featurechecklistmodel.cpp
+++ b/src/core/featurechecklistmodel.cpp
@@ -16,8 +16,8 @@
 
 #include "featurechecklistmodel.h"
 #include "qgsmessagelog.h"
-#include "qgsvaluerelationfieldformatter.h"
 #include "qgspostgresstringutils.h"
+#include "qgsvaluerelationfieldformatter.h"
 
 FeatureCheckListModel::FeatureCheckListModel( QObject *parent )
   : FeatureListModel( parent )
@@ -69,7 +69,7 @@ QVariant FeatureCheckListModel::attributeValue() const
   for ( const QString &s : std::as_const( mCheckedEntries ) )
   {
     // Convert to proper type
-    const QVariant::Type type {fkType()};
+    const QVariant::Type type { fkType() };
     switch ( type )
     {
       case QVariant::Type::Int:
@@ -127,7 +127,7 @@ void FeatureCheckListModel::setAttributeValue( const QVariant &attributeValue )
     {
       QString value = attributeValue.value<QString>();
 
-      if ( ! value.isEmpty() )
+      if ( !value.isEmpty() )
         checkedEntries << value;
     }
 
@@ -193,14 +193,13 @@ void FeatureCheckListModel::toggleCheckAll( const bool toggleChecked )
   }
   else
   {
-    if ( ! mCheckedEntries.isEmpty() )
+    if ( !mCheckedEntries.isEmpty() )
     {
       beginResetModel();
       mCheckedEntries = QStringList();
       endResetModel();
     }
   }
-
 }
 
 void FeatureCheckListModel::setChecked( const QModelIndex &index )
@@ -230,7 +229,7 @@ QVariant::Type FeatureCheckListModel::fkType() const
   if ( currentLayer() )
   {
     QgsFields fields = currentLayer()->fields();
-    int idx {fields.indexOf( keyField() )};
+    int idx { fields.indexOf( keyField() ) };
     if ( idx >= 0 )
     {
       return fields.at( idx ).type();

--- a/src/core/featurelistextentcontroller.cpp
+++ b/src/core/featurelistextentcontroller.cpp
@@ -15,13 +15,13 @@
 
 #include "featurelistextentcontroller.h"
 
-#include <qgsvectorlayer.h>
 #include <qgsgeometry.h>
+#include <qgsvectorlayer.h>
 
 FeatureListExtentController::FeatureListExtentController( QObject *parent )
   : QObject( parent )
 {
-  connect( this, &FeatureListExtentController::autoZoomChanged, this, [ = ]() {zoomToSelected();} );
+  connect( this, &FeatureListExtentController::autoZoomChanged, this, [ = ]() { zoomToSelected(); } );
   connect( this, &FeatureListExtentController::modelChanged, this, &FeatureListExtentController::onModelChanged );
   connect( this, &FeatureListExtentController::selectionChanged, this, &FeatureListExtentController::onModelChanged );
 }

--- a/src/core/featurelistextentcontroller.h
+++ b/src/core/featurelistextentcontroller.h
@@ -16,11 +16,11 @@
 #ifndef FEATURELISTEXTENTCONTROLLER_H
 #define FEATURELISTEXTENTCONTROLLER_H
 
-#include <QObject>
-
-#include "multifeaturelistmodel.h"
 #include "featurelistmodelselection.h"
+#include "multifeaturelistmodel.h"
 #include "qgsquickmapsettings.h"
+
+#include <QObject>
 
 class FeatureListExtentController : public QObject
 {

--- a/src/core/featurelistmodel.cpp
+++ b/src/core/featurelistmodel.cpp
@@ -20,9 +20,8 @@
 #include "stringutils.h"
 
 #include <QRegularExpression>
-
-#include <qgsproject.h>
 #include <qgsexpressioncontextutils.h>
+#include <qgsproject.h>
 #include <qgsvaluerelationfieldformatter.h>
 
 
@@ -230,15 +229,14 @@ void FeatureListModel::gatherFeatureList()
 
   request.setSubsetOfAttributes( referencedColumns, fields );
 
-  if ( ! mFilterExpression.isEmpty()
-       && ( ! QgsValueRelationFieldFormatter::expressionRequiresFormScope( mFilterExpression )
-            || QgsValueRelationFieldFormatter::expressionIsUsable( mFilterExpression, mCurrentFormFeature )
-          ) )
+  if ( !mFilterExpression.isEmpty()
+       && ( !QgsValueRelationFieldFormatter::expressionRequiresFormScope( mFilterExpression )
+            || QgsValueRelationFieldFormatter::expressionIsUsable( mFilterExpression, mCurrentFormFeature ) ) )
   {
     QgsExpression exp( mFilterExpression );
     QgsExpressionContext filterContext = QgsExpressionContext( QgsExpressionContextUtils::globalProjectLayerScopes( mCurrentLayer ) );
 
-    if ( mCurrentFormFeature.isValid( ) && QgsValueRelationFieldFormatter::expressionRequiresFormScope( mFilterExpression ) )
+    if ( mCurrentFormFeature.isValid() && QgsValueRelationFieldFormatter::expressionRequiresFormScope( mFilterExpression ) )
       filterContext.appendScope( QgsExpressionContextUtils::formScope( mCurrentFormFeature ) );
 
     request.setExpressionContext( filterContext );
@@ -246,14 +244,14 @@ void FeatureListModel::gatherFeatureList()
   }
 
   QString fieldDisplayString = displayValueIndex >= 0
-    ? QgsExpression::quotedColumnRef( mDisplayValueField )
-    : QStringLiteral( " ( %1 ) " ).arg( mCurrentLayer->displayExpression() );
+                               ? QgsExpression::quotedColumnRef( mDisplayValueField )
+                               : QStringLiteral( " ( %1 ) " ).arg( mCurrentLayer->displayExpression() );
 
   if ( !mSearchTerm.isEmpty() )
   {
     QString escapedSearchTerm = QgsExpression::quotedValue( mSearchTerm ).replace( QRegularExpression( QStringLiteral( "^'|'$" ) ), QString( "" ) );
     QString searchTermExpression = QStringLiteral( " %1 ILIKE '%%2%' " )
-        .arg( fieldDisplayString, escapedSearchTerm );
+                                   .arg( fieldDisplayString, escapedSearchTerm );
 
     QStringList searchTermParts = escapedSearchTerm.split( QRegularExpression( QStringLiteral( "\\s+" ) ) );
 
@@ -297,7 +295,7 @@ void FeatureListModel::processFeatureList()
 
     entry = Entry( gatheredEntry.value, gatheredEntry.identifierFields.at( 0 ), gatheredEntry.featureId );
 
-    if ( ! mSearchTerm.isEmpty() )
+    if ( !mSearchTerm.isEmpty() )
     {
       entry.calcFuzzyScore( mSearchTerm );
 
@@ -320,7 +318,7 @@ void FeatureListModel::processFeatureList()
       return entry1.displayString.toLower() < entry2.displayString.toLower();
     } );
   }
-  else if ( ! mSearchTerm.isEmpty() )
+  else if ( !mSearchTerm.isEmpty() )
   {
     std::sort( entries.begin(), entries.end(), []( const Entry & entry1, const Entry & entry2 )
     {

--- a/src/core/featurelistmodel.h
+++ b/src/core/featurelistmodel.h
@@ -19,13 +19,12 @@
 
 #include "fieldexpressionvaluesgatherer.h"
 
-#include <stringutils.h>
-
 #include <QAbstractItemModel>
 #include <QTimer>
-
 #include <qgsfeature.h>
 #include <qgsstringutils.h>
+
+#include <stringutils.h>
 
 class QgsVectorLayer;
 

--- a/src/core/featurelistmodelselection.cpp
+++ b/src/core/featurelistmodelselection.cpp
@@ -15,10 +15,10 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <QDebug>
-
-#include <qgsvectorlayer.h>
 #include "featurelistmodelselection.h"
+
+#include <QDebug>
+#include <qgsvectorlayer.h>
 
 FeatureListModelSelection::FeatureListModelSelection( QObject *parent )
   : QObject( parent )

--- a/src/core/featurelistmodelselection.h
+++ b/src/core/featurelistmodelselection.h
@@ -18,9 +18,9 @@
 #ifndef FEATURELISTMODELSELECTION_H
 #define FEATURELISTMODELSELECTION_H
 
-#include <QObject>
-
 #include "multifeaturelistmodel.h"
+
+#include <QObject>
 
 class FeatureListModelSelection : public QObject
 {

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -15,21 +15,20 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "featuremodel.h"
 #include "expressioncontextutils.h"
+#include "featuremodel.h"
 #include "vertexmodel.h"
-
-#include <qgsproject.h>
-#include <qgsmessagelog.h>
-#include <qgsvectorlayer.h>
-#include <qgsgeometryoptions.h>
-#include <qgsgeometrycollection.h>
-#include <qgscurvepolygon.h>
-#include <qgsrelationmanager.h>
-#include <qgsvectorlayerutils.h>
 
 #include <QGeoPositionInfoSource>
 #include <QMutex>
+#include <qgscurvepolygon.h>
+#include <qgsgeometrycollection.h>
+#include <qgsgeometryoptions.h>
+#include <qgsmessagelog.h>
+#include <qgsproject.h>
+#include <qgsrelationmanager.h>
+#include <qgsvectorlayer.h>
+#include <qgsvectorlayerutils.h>
 
 typedef QMap<QgsVectorLayer *, FeatureModel::RememberValues> Rememberings;
 Q_GLOBAL_STATIC( Rememberings, sRememberings )
@@ -89,7 +88,8 @@ void FeatureModel::setFeatures( const QList<QgsFeature> &features )
       {
         const int attributeIndex;
         const QgsFeature &feature;
-        AttributeNotEqual( const QgsFeature &feature, int attributeIndex ) : attributeIndex( attributeIndex ), feature( feature ) {}
+        AttributeNotEqual( const QgsFeature &feature, int attributeIndex )
+          : attributeIndex( attributeIndex ), feature( feature ) {}
         bool operator()( const QgsFeature &f ) const { return f.attributes().size() > attributeIndex && feature.attributes().at( attributeIndex ) != f.attributes().at( attributeIndex ); }
       };
 
@@ -132,8 +132,8 @@ void FeatureModel::setCurrentLayer( QgsVectorLayer *layer )
     {
       mFeature = QgsFeature( mLayer->fields() );
       QMutexLocker locker( sMutex );
-      (*sRememberings)[mLayer].rememberedFeature = mFeature;
-      (*sRememberings)[mLayer].rememberedAttributes.fill( false, layer->fields().size() );
+      ( *sRememberings )[mLayer].rememberedFeature = mFeature;
+      ( *sRememberings )[mLayer].rememberedAttributes.fill( false, layer->fields().size() );
     }
   }
   emit currentLayerChanged();
@@ -198,7 +198,7 @@ void FeatureModel::setPositionLocked( bool positionLocked )
 
 void FeatureModel::setCloudUserInformation( const CloudUserInformation &cloudUserInformation )
 {
-    mCloudUserInformation = cloudUserInformation;
+  mCloudUserInformation = cloudUserInformation;
 }
 
 void FeatureModel::setLinkedParentFeature( const QgsFeature &feature )
@@ -233,7 +233,7 @@ QgsRelation FeatureModel::linkedRelation() const
 QHash<int, QByteArray> FeatureModel::roleNames() const
 {
   QHash<int, QByteArray> roles = QAbstractListModel::roleNames();
-  roles[AttributeName]  = "AttributeName";
+  roles[AttributeName] = "AttributeName";
   roles[AttributeValue] = "AttributeValue";
   roles[Field] = "Field";
   roles[RememberAttribute] = "RememberAttribute";
@@ -315,7 +315,7 @@ bool FeatureModel::setData( const QModelIndex &index, const QVariant &value, int
     case RememberAttribute:
     {
       QMutexLocker locker( sMutex );
-      (*sRememberings)[mLayer].rememberedAttributes[index.row()] = value.toBool();
+      ( *sRememberings )[mLayer].rememberedAttributes[index.row()] = value.toBool();
       emit dataChanged( index, index, QVector<int>() << role );
       break;
     }
@@ -444,7 +444,7 @@ void FeatureModel::resetFeature()
   if ( sRememberings->contains( mLayer ) )
   {
     QMutexLocker locker( sMutex );
-    (*sRememberings)[mLayer].rememberedFeature = mFeature;
+    ( *sRememberings )[mLayer].rememberedFeature = mFeature;
   }
 
   mFeature = QgsFeature( mLayer->fields() );
@@ -474,8 +474,7 @@ void FeatureModel::resetAttributes()
   for ( int i = 0; i < fields.count(); ++i )
   {
     //if the value does not need to be remembered and it's not prefilled by the linked parent feature
-    if ( !sRememberings->value( mLayer ).rememberedAttributes.at( i ) &&
-         !mLinkedAttributeIndexes.contains( i ) )
+    if ( !sRememberings->value( mLayer ).rememberedAttributes.at( i ) && !mLinkedAttributeIndexes.contains( i ) )
     {
       if ( fields.at( i ).defaultValueDefinition().isValid() )
       {
@@ -568,7 +567,7 @@ void FeatureModel::applyGeometry()
 
 void FeatureModel::removeLayer( QObject *layer )
 {
-  sRememberings->remove( static_cast< QgsVectorLayer * >( layer ) );
+  sRememberings->remove( static_cast<QgsVectorLayer *>( layer ) );
 }
 
 void FeatureModel::featureAdded( QgsFeatureId fid )
@@ -581,7 +580,7 @@ bool FeatureModel::create()
   if ( !mLayer )
     return false;
 
-  if ( ! startEditing() )
+  if ( !startEditing() )
   {
     QgsMessageLog::logMessage( tr( "Cannot start editing on layer \"%1\" to create feature %2" ).arg( mLayer->name() ).arg( mFeature.id() ), QStringLiteral( "QField" ), Qgis::Critical );
     return false;
@@ -626,7 +625,7 @@ bool FeatureModel::create()
   if ( isSuccess && sRememberings->contains( mLayer ) )
   {
     QMutexLocker locker( sMutex );
-    (*sRememberings)[mLayer].rememberedFeature = mFeature;
+    ( *sRememberings )[mLayer].rememberedFeature = mFeature;
   }
 
   disconnect( mLayer, &QgsVectorLayer::featureAdded, this, &FeatureModel::featureAdded );
@@ -635,7 +634,7 @@ bool FeatureModel::create()
 
 bool FeatureModel::deleteFeature()
 {
-  if ( ! startEditing() )
+  if ( !startEditing() )
   {
     QgsMessageLog::logMessage( tr( "Cannot start editing on layer \"%1\" to delete feature %2" ).arg( mLayer->name() ).arg( mFeature.id() ), QStringLiteral( "QField" ), Qgis::Critical );
     return false;
@@ -657,7 +656,7 @@ bool FeatureModel::deleteFeature()
         QgsFeature childFeature;
         while ( relatedFeaturesIt.nextFeature( childFeature ) )
         {
-          if ( ! childLayer->deleteFeature( childFeature.id() ) )
+          if ( !childLayer->deleteFeature( childFeature.id() ) )
           {
             QgsMessageLog::logMessage( tr( "Cannot delete feature %2 from child layer \"%1\"" ).arg( childLayer->name() ).arg( childFeature.id() ), QStringLiteral( "QField" ), Qgis::Critical );
             isSuccess = false;
@@ -683,7 +682,7 @@ bool FeatureModel::deleteFeature()
   {
     if ( isSuccess )
     {
-      if ( ! childLayer->commitChanges() )
+      if ( !childLayer->commitChanges() )
       {
         const QString msgs = childLayer->commitErrors().join( QStringLiteral( "\n" ) );
         QgsMessageLog::logMessage( tr( "Cannot commit child layer deletions in layer \"%1\". Reason:\n%2" ).arg( childLayer->name(), msgs ), QStringLiteral( "QField" ), Qgis::Critical );
@@ -691,9 +690,9 @@ bool FeatureModel::deleteFeature()
       }
     }
 
-    if ( ! isSuccess )
+    if ( !isSuccess )
     {
-      if ( ! childLayer->rollBack() )
+      if ( !childLayer->rollBack() )
         QgsMessageLog::logMessage( tr( "Cannot rollback layer deletions in layer \"%1\"" ).arg( childLayer->name() ), QStringLiteral( "QField" ), Qgis::Critical );
     }
   }
@@ -704,7 +703,7 @@ bool FeatureModel::deleteFeature()
     if ( mLayer->deleteFeature( mFeature.id() ) )
     {
       // commit parent changes
-      if ( ! mLayer->commitChanges() )
+      if ( !mLayer->commitChanges() )
       {
         const QString msgs = mLayer->commitErrors().join( QStringLiteral( "\n" ) );
         QgsMessageLog::logMessage( tr( "Cannot commit deletion of feature %2 in layer \"%1\". Reason:\n%3" ).arg( mLayer->name() ).arg( mFeature.id() ).arg( msgs ), QStringLiteral( "QField" ), Qgis::Warning );
@@ -719,7 +718,7 @@ bool FeatureModel::deleteFeature()
     }
   }
 
-  if ( ! isSuccess )
+  if ( !isSuccess )
   {
     if ( mLayer->rollBack() )
       QgsMessageLog::logMessage( tr( "Successfully rolled back changes in layer \"%1\" while attempting to delete feature %2" ).arg( mLayer->name() ).arg( mFeature.id() ), QStringLiteral( "QField" ), Qgis::Critical );
@@ -816,7 +815,7 @@ class MatchCollectingFilter : public QgsPointLocator::MatchFilter
       // result... the locator API needs a new method verticesInRect()
       QgsFeature f;
       match.layer()->getFeatures( QgsFeatureRequest( match.featureId() ).setNoAttributes() ).nextFeature( f );
-      QgsGeometry matchGeom  = f.geometry();
+      QgsGeometry matchGeom = f.geometry();
       bool isPolygon = matchGeom.type() == QgsWkbTypes::PolygonGeometry;
       QgsVertexId polygonRingVid;
       QgsVertexId vid;

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -18,16 +18,16 @@
 #ifndef FEATUREMODEL_H
 #define FEATUREMODEL_H
 
-#include "snappingresult.h"
+#include "geometry.h"
 #include "gnsspositioninformation.h"
 #include "qfieldcloudconnection.h"
-#include "geometry.h"
-
-#include <qgsfeature.h>
+#include "snappingresult.h"
 
 #include <QAbstractListModel>
 #include <QtPositioning/QGeoPositionInfoSource>
+#include <qgsfeature.h>
 #include <qgsrelationmanager.h>
+
 #include <memory>
 
 class VertexModel;
@@ -50,7 +50,6 @@ class FeatureModel : public QAbstractListModel
     Q_PROPERTY( CloudUserInformation cloudUserInformation WRITE setCloudUserInformation );
 
   public:
-
     //! keeping the information what attributes are remembered and the last edited feature
     struct RememberValues
     {
@@ -71,7 +70,7 @@ class FeatureModel : public QAbstractListModel
       AttributeValue,
       Field,
       RememberAttribute,
-      LinkedAttribute,  //! value of this attribute is given by the parent feature and does not to be available for editing in the form
+      LinkedAttribute,    //! value of this attribute is given by the parent feature and does not to be available for editing in the form
       AttributeAllowEdit, //! value of this attribute is equal across features being edited
     };
     Q_ENUM( FeatureRoles )

--- a/src/core/featureslocatorfilter.cpp
+++ b/src/core/featureslocatorfilter.cpp
@@ -14,21 +14,20 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "featurelistextentcontroller.h"
 #include "featureslocatorfilter.h"
+#include "locatormodelsuperbridge.h"
+#include "qgsgeometrywrapper.h"
+#include "qgsquickmapsettings.h"
 
-#include <math.h>
 #include <QAction>
-
+#include <qgsexpressioncontextutils.h>
+#include <qgsfeedback.h>
+#include <qgsmaplayermodel.h>
 #include <qgsproject.h>
 #include <qgsvectorlayer.h>
-#include <qgsmaplayermodel.h>
-#include <qgsfeedback.h>
-#include <qgsexpressioncontextutils.h>
 
-#include "locatormodelsuperbridge.h"
-#include "qgsquickmapsettings.h"
-#include "featurelistextentcontroller.h"
-#include "qgsgeometrywrapper.h"
+#include <math.h>
 
 
 FeaturesLocatorFilter::FeaturesLocatorFilter( LocatorModelSuperBridge *locatorBridge, QObject *parent )
@@ -54,7 +53,7 @@ QStringList FeaturesLocatorFilter::prepare( const QString &string, const QgsLoca
   const QMap<QString, QgsMapLayer *> layers = QgsProject::instance()->mapLayers();
   for ( auto it = layers.constBegin(); it != layers.constEnd(); ++it )
   {
-    QgsVectorLayer *layer = qobject_cast< QgsVectorLayer *>( it.value() );
+    QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( it.value() );
     if ( !layer || !layer->dataProvider() || !layer->flags().testFlag( QgsMapLayer::Searchable ) )
       continue;
 
@@ -113,7 +112,7 @@ void FeaturesLocatorFilter::fetchResults( const QString &string, const QgsLocato
 
       result.userData = QVariantList() << f.id() << preparedLayer->layerId;
       result.icon = preparedLayer->layerIcon;
-      result.score = static_cast< double >( string.length() ) / result.displayString.size();
+      result.score = static_cast<double>( string.length() ) / result.displayString.size();
       result.actions << QgsLocatorResult::ResultAction( OpenForm, tr( "Open form" ), QStringLiteral( "ic_baseline-list_alt-24px" ) );
 
       emit resultFetched( result );
@@ -138,7 +137,7 @@ void FeaturesLocatorFilter::triggerResultFromAction( const QgsLocatorResult &res
   QVariantList dataList = result.userData.toList();
   QgsFeatureId fid = dataList.at( 0 ).toLongLong();
   QString layerId = dataList.at( 1 ).toString();
-  QgsVectorLayer *layer = qobject_cast< QgsVectorLayer *>( QgsProject::instance()->mapLayer( layerId ) );
+  QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( layerId ) );
   if ( !layer )
     return;
 

--- a/src/core/featureslocatorfilter.h
+++ b/src/core/featureslocatorfilter.h
@@ -19,9 +19,8 @@
 #define FEATURESLOCATORFILTER_H
 
 #include <QObject>
-
-#include <qgslocatorfilter.h>
 #include <qgsexpressioncontext.h>
+#include <qgslocatorfilter.h>
 #include <qgsvectorlayerfeatureiterator.h>
 
 
@@ -37,7 +36,6 @@ class FeaturesLocatorFilter : public QgsLocatorFilter
     Q_OBJECT
 
   public:
-
     //! Origin of the action which triggers the result
     enum ActionOrigin
     {
@@ -55,7 +53,7 @@ class FeaturesLocatorFilter : public QgsLocatorFilter
         QString layerName;
         QString layerId;
         QIcon layerIcon;
-    } ;
+    };
 
     explicit FeaturesLocatorFilter( LocatorModelSuperBridge *locatorBridge, QObject *parent = nullptr );
     FeaturesLocatorFilter *clone() const override;

--- a/src/core/fieldexpressionvaluesgatherer.h
+++ b/src/core/fieldexpressionvaluesgatherer.h
@@ -18,26 +18,24 @@
 #ifndef FIELDEXPRESSIONVALUESGATHERER_H
 #define FIELDEXPRESSIONVALUESGATHERER_H
 
-#include <QThread>
 #include <QMutex>
-
+#include <QThread>
 #include <qgsapplication.h>
+#include <qgsfeature.h>
 #include <qgslogger.h>
 #include <qgsvectorlayer.h>
 #include <qgsvectorlayerfeatureiterator.h>
-#include <qgsfeature.h>
 
 /**
  * \class FieldExpressionValuesGatherer
  * Gathers features with substring matching on an expression.
  * \note This is a is an exact copy of QGIS' QgsFieldExpressionValuesGatherer
  */
-class FeatureExpressionValuesGatherer: public QThread
+class FeatureExpressionValuesGatherer : public QThread
 {
     Q_OBJECT
 
   public:
-
     /**
        * Constructor
        * \param layer the vector layer
@@ -46,9 +44,9 @@ class FeatureExpressionValuesGatherer: public QThread
        * \param identifierFields an optional list of fields name to be save in a variant list for an easier reuse
        */
     explicit FeatureExpressionValuesGatherer( QgsVectorLayer *layer,
-                                        const QString &displayExpression = QString(),
-                                        const QgsFeatureRequest &request = QgsFeatureRequest(),
-                                        const QStringList &identifierFields = QStringList() )
+        const QString &displayExpression = QString(),
+        const QgsFeatureRequest &request = QgsFeatureRequest(),
+        const QStringList &identifierFields = QStringList() )
       : mSource( new QgsVectorLayerFeatureSource( layer ) )
       , mDisplayExpression( displayExpression.isEmpty() ? layer->displayExpression() : displayExpression )
       , mRequest( request )

--- a/src/core/finlandlocatorfilter.cpp
+++ b/src/core/finlandlocatorfilter.cpp
@@ -18,17 +18,16 @@
 #include "locatormodelsuperbridge.h"
 #include "qgsquickmapsettings.h"
 
+#include <QAction>
 #include <qgsgeocoderresult.h>
 #include <qgsproject.h>
-
-#include <QAction>
 
 
 FinlandLocatorFilter::FinlandLocatorFilter( QgsGeocoderInterface *geocoder, LocatorModelSuperBridge *locatorBridge )
   : QgsAbstractGeocoderLocatorFilter( QStringLiteral( "pelias-finland" ), tr( "Finnish address search" ), QStringLiteral( "fia" ), geocoder )
   , mLocatorBridge( locatorBridge )
 {
-  setBoundingBox( QgsRectangle( 19.0832098, 59.4541578, 31.5867071, 70.0922939) );
+  setBoundingBox( QgsRectangle( 19.0832098, 59.4541578, 31.5867071, 70.0922939 ) );
   setFetchResultsDelay( 1000 );
   setUseWithoutPrefix( false );
 }
@@ -54,7 +53,7 @@ void FinlandLocatorFilter::handleGeocodeResult( const QgsGeocoderResult &result 
     Q_UNUSED( e )
     return;
   }
-  catch(...)
+  catch ( ... )
   {
     // catch any other errors
     return;

--- a/src/core/finlandlocatorfilter.h
+++ b/src/core/finlandlocatorfilter.h
@@ -19,7 +19,6 @@
 #define FINLANDLOCATORFILTER_H
 
 #include <QObject>
-
 #include <qgsabstractgeocoderlocatorfilter.h>
 
 
@@ -34,7 +33,6 @@ class FinlandLocatorFilter : public QgsAbstractGeocoderLocatorFilter
     Q_OBJECT
 
   public:
-
     explicit FinlandLocatorFilter( QgsGeocoderInterface *geocoder, LocatorModelSuperBridge *locatorBridge );
     FinlandLocatorFilter *clone() const override;
 

--- a/src/core/focusstack.h
+++ b/src/core/focusstack.h
@@ -36,4 +36,3 @@ class FocusStack : public QObject
 };
 
 #endif // FOCUSSTACK_H
-

--- a/src/core/geometry.cpp
+++ b/src/core/geometry.cpp
@@ -14,15 +14,14 @@
  ***************************************************************************/
 #include "geometry.h"
 
-#include <qgspoint.h>
 #include <qgslinestring.h>
+#include <qgspoint.h>
 #include <qgspolygon.h>
 #include <qgsvectorlayer.h>
 
 Geometry::Geometry( QObject *parent )
   : QObject( parent )
 {
-
 }
 
 QgsGeometry Geometry::asQgsGeometry() const
@@ -60,7 +59,6 @@ QgsGeometry Geometry::asQgsGeometry() const
       break;
     case QgsWkbTypes::NullGeometry:
       break;
-
   }
 
   // QgsCoordinateTransform ct( mRubberbandModel->crs(), mVectorLayer->crs() );

--- a/src/core/geometry.h
+++ b/src/core/geometry.h
@@ -15,10 +15,10 @@
 #ifndef GEOMETRY_H
 #define GEOMETRY_H
 
-#include <qgsgeometry.h>
 #include "rubberbandmodel.h"
 
 #include <QtPositioning/QGeoCoordinate>
+#include <qgsgeometry.h>
 
 class Geometry : public QObject
 {

--- a/src/core/geometryeditorsmodel.cpp
+++ b/src/core/geometryeditorsmodel.cpp
@@ -14,9 +14,9 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <qgswkbtypes.h>
-
 #include "geometryeditorsmodel.h"
+
+#include <qgswkbtypes.h>
 
 GeometryEditorsModel::GeometryEditorsModel( QObject *parent )
   : QStandardItemModel( parent )
@@ -70,4 +70,3 @@ void GeometryEditorsModel::setVertexModel( VertexModel *vertexModel )
   mVertexModel = vertexModel;
   emit vertexModelChanged();
 }
-

--- a/src/core/geometryeditorsmodel.h
+++ b/src/core/geometryeditorsmodel.h
@@ -18,11 +18,10 @@
 #define GEOMETRYEDITORSMODEL_H
 
 
-
-#include <QStandardItemModel>
-#include <QQuickItem>
-
 #include "vertexmodel.h"
+
+#include <QQuickItem>
+#include <QStandardItemModel>
 
 
 class GeometryEditorsModel : public QStandardItemModel
@@ -59,11 +58,12 @@ class GeometryEditorsModel : public QStandardItemModel
 
     Q_INVOKABLE static bool supportsGeometry( const QgsGeometry &geometry, const SupportedGeometries &supportedGeometries );
 
-    VertexModel *vertexModel() const {return mVertexModel;}
+    VertexModel *vertexModel() const { return mVertexModel; }
     void setVertexModel( VertexModel *vertexModel );
 
   signals:
     void vertexModelChanged();
+
   private:
     VertexModel *mVertexModel = nullptr;
 };

--- a/src/core/gnsspositioninformation.cpp
+++ b/src/core/gnsspositioninformation.cpp
@@ -14,44 +14,20 @@
  ***************************************************************************/
 
 #include "gnsspositioninformation.h"
+#include "qgslogger.h"
+#include "qgsnmeaconnection.h"
 
 #include <QCoreApplication>
-#include <QTime>
+#include <QFileInfo>
 #include <QIODevice>
 #include <QStringList>
-#include <QFileInfo>
-
-#include "qgsnmeaconnection.h"
-#include "qgslogger.h"
+#include <QTime>
 
 
 GnssPositionInformation::GnssPositionInformation( double latitude, double longitude, double elevation, double speed, double direction, const QList<QgsSatelliteInfo> &satellitesInView, double pdop, double hdop, double vdop, double hacc, double vacc,
     QDateTime utcDateTime, QChar fixMode, int fixType, int quality, int satellitesUsed, QChar status, const QList<int> &satPrn, bool satInfoComplete, double verticalSpeed, double magneticVariation, const QString &sourceName )
-  : mLatitude( latitude ),
-    mLongitude( longitude ),
-    mElevation( elevation ),
-    mSpeed( speed ),
-    mDirection( direction ),
-    mSatellitesInView( satellitesInView ),
-    mPdop( pdop ),
-    mHdop( hdop ),
-    mVdop( vdop ),
-    mHacc( hacc ),
-    mVacc( vacc ),
-    mHvacc( sqrt( ( pow( hacc, 2 ) + pow( hacc, 2 ) + pow( vacc, 2 ) ) / 3 ) ),
-    mUtcDateTime( utcDateTime ),
-    mFixMode( fixMode ),
-    mFixType( fixType ),
-    mQuality( quality ),
-    mSatellitesUsed( satellitesUsed ),
-    mStatus( status ),
-    mSatPrn( satPrn ),
-    mSatInfoComplete( satInfoComplete ),
-    mVerticalSpeed( verticalSpeed ),
-    mMagneticVariation( magneticVariation ),
-    mSourceName( sourceName )
+  : mLatitude( latitude ), mLongitude( longitude ), mElevation( elevation ), mSpeed( speed ), mDirection( direction ), mSatellitesInView( satellitesInView ), mPdop( pdop ), mHdop( hdop ), mVdop( vdop ), mHacc( hacc ), mVacc( vacc ), mHvacc( sqrt( ( pow( hacc, 2 ) + pow( hacc, 2 ) + pow( vacc, 2 ) ) / 3 ) ), mUtcDateTime( utcDateTime ), mFixMode( fixMode ), mFixType( fixType ), mQuality( quality ), mSatellitesUsed( satellitesUsed ), mStatus( status ), mSatPrn( satPrn ), mSatInfoComplete( satInfoComplete ), mVerticalSpeed( verticalSpeed ), mMagneticVariation( magneticVariation ), mSourceName( sourceName )
 {
-
 }
 
 bool GnssPositionInformation::isValid() const

--- a/src/core/gnsspositioninformation.h
+++ b/src/core/gnsspositioninformation.h
@@ -16,30 +16,30 @@
 #ifndef GNSSPOSITIONINFORMATION_H
 #define GNSSPOSITIONINFORMATION_H
 
-#include <QDateTime>
 #include "qgis.h"
+#include "qgsgpsconnection.h"
+
+#include <QDateTime>
 #include <QObject>
 #include <QString>
-
-#include "qgsgpsconnection.h"
 #include <QtPositioning/QGeoPositionInfoSource>
 
 /* Statics from external/nmea/info.h:*/
-#define NMEA_SIG_BAD        (0)
-#define NMEA_SIG_LOW        (1)
-#define NMEA_SIG_MID        (2)
-#define NMEA_SIG_HIGH       (3)
+#define NMEA_SIG_BAD ( 0 )
+#define NMEA_SIG_LOW ( 1 )
+#define NMEA_SIG_MID ( 2 )
+#define NMEA_SIG_HIGH ( 3 )
 
-#define NMEA_FIX_BAD        (1)
-#define NMEA_FIX_2D         (2)
-#define NMEA_FIX_3D         (3)
+#define NMEA_FIX_BAD ( 1 )
+#define NMEA_FIX_2D ( 2 )
+#define NMEA_FIX_3D ( 3 )
 
-#define NMEA_MAXSAT         (12)
-#define NMEA_SATINPACK      (4)
-#define NMEA_NSATPACKS      (NMEA_MAXSAT / NMEA_SATINPACK)
+#define NMEA_MAXSAT ( 12 )
+#define NMEA_SATINPACK ( 4 )
+#define NMEA_NSATPACKS ( NMEA_MAXSAT / NMEA_SATINPACK )
 
-#define NMEA_DEF_LAT        (5001.2621)
-#define NMEA_DEF_LON        (3613.0595)
+#define NMEA_DEF_LAT ( 5001.2621 )
+#define NMEA_DEF_LON ( 3613.0595 )
 
 class GnssPositionInformation
 {
@@ -82,7 +82,6 @@ class GnssPositionInformation
     Q_PROPERTY( QString sourceName READ sourceName )
 
   public:
-
     /**
      * GPS fix status
      */
@@ -96,11 +95,11 @@ class GnssPositionInformation
 
     Q_ENUM( FixStatus )
 
-    GnssPositionInformation( double latitude = std::numeric_limits< double >::quiet_NaN(), double longitude = std::numeric_limits< double >::quiet_NaN(), double elevation = std::numeric_limits< double >::quiet_NaN(),
-                             double speed = std::numeric_limits< double >::quiet_NaN(), double direction = std::numeric_limits< double >::quiet_NaN(), const QList<QgsSatelliteInfo> &satellitesInView = QList<QgsSatelliteInfo>(),
-                             double pdop = 0, double hdop = 0, double vdop = 0, double hacc = std::numeric_limits< double >::quiet_NaN(), double vacc = std::numeric_limits< double >::quiet_NaN(), QDateTime utcDateTime = QDateTime(),
+    GnssPositionInformation( double latitude = std::numeric_limits<double>::quiet_NaN(), double longitude = std::numeric_limits<double>::quiet_NaN(), double elevation = std::numeric_limits<double>::quiet_NaN(),
+                             double speed = std::numeric_limits<double>::quiet_NaN(), double direction = std::numeric_limits<double>::quiet_NaN(), const QList<QgsSatelliteInfo> &satellitesInView = QList<QgsSatelliteInfo>(),
+                             double pdop = 0, double hdop = 0, double vdop = 0, double hacc = std::numeric_limits<double>::quiet_NaN(), double vacc = std::numeric_limits<double>::quiet_NaN(), QDateTime utcDateTime = QDateTime(),
                              QChar fixMode = QChar(), int fixType = 0, int quality = -1, int satellitesUsed = 0, QChar status = QChar(), const QList<int> &satPrn = QList<int>(), bool satInfoComplete = false,
-                             double verticalSpeed = std::numeric_limits< double >::quiet_NaN(), double magneticVariation = std::numeric_limits< double >::quiet_NaN(), const QString &sourceName = QString() );
+                             double verticalSpeed = std::numeric_limits<double>::quiet_NaN(), double magneticVariation = std::numeric_limits<double>::quiet_NaN(), const QString &sourceName = QString() );
 
     /**
      * Latitude in decimal degrees, using the WGS84 datum. A positive value indicates the Northern Hemisphere, and
@@ -174,7 +173,7 @@ class GnssPositionInformation
      * 3DRMS
      */
     double hvacc() const { return mHvacc; }
-    bool hvaccValid() const  { return !std::isnan( mHvacc ); }
+    bool hvaccValid() const { return !std::isnan( mHvacc ); }
 
     /**
      * The date and time at which this position was reported, in UTC time.
@@ -252,18 +251,18 @@ class GnssPositionInformation
     QString fixStatusDescription() const;
 
   private:
-    double mLatitude = std::numeric_limits< double >::quiet_NaN();
-    double mLongitude = std::numeric_limits< double >::quiet_NaN();
-    double mElevation = std::numeric_limits< double >::quiet_NaN();
-    double mSpeed = std::numeric_limits< double >::quiet_NaN();
-    double mDirection = std::numeric_limits< double >::quiet_NaN();
+    double mLatitude = std::numeric_limits<double>::quiet_NaN();
+    double mLongitude = std::numeric_limits<double>::quiet_NaN();
+    double mElevation = std::numeric_limits<double>::quiet_NaN();
+    double mSpeed = std::numeric_limits<double>::quiet_NaN();
+    double mDirection = std::numeric_limits<double>::quiet_NaN();
     QList<QgsSatelliteInfo> mSatellitesInView;
     double mPdop = 0;
     double mHdop = 0;
     double mVdop = 0;
-    double mHacc = std::numeric_limits< double >::quiet_NaN();
-    double mVacc = std::numeric_limits< double >::quiet_NaN();
-    double mHvacc = std::numeric_limits< double >::quiet_NaN();
+    double mHacc = std::numeric_limits<double>::quiet_NaN();
+    double mVacc = std::numeric_limits<double>::quiet_NaN();
+    double mHvacc = std::numeric_limits<double>::quiet_NaN();
     QDateTime mUtcDateTime;
     QChar mFixMode;
     int mFixType = 0;
@@ -272,8 +271,8 @@ class GnssPositionInformation
     QChar mStatus;
     QList<int> mSatPrn;
     bool mSatInfoComplete = false;
-    double mVerticalSpeed = std::numeric_limits< double >::quiet_NaN();
-    double mMagneticVariation = std::numeric_limits< double >::quiet_NaN();
+    double mVerticalSpeed = std::numeric_limits<double>::quiet_NaN();
+    double mMagneticVariation = std::numeric_limits<double>::quiet_NaN();
     QString mSourceName;
 };
 

--- a/src/core/gotolocatorfilter.cpp
+++ b/src/core/gotolocatorfilter.cpp
@@ -15,18 +15,16 @@
  ***************************************************************************/
 
 #include "gotolocatorfilter.h"
+#include "locatormodelsuperbridge.h"
+#include "qgsquickmapsettings.h"
 
 #include <QAction>
 #include <QRegularExpression>
-
 #include <qgscoordinateutils.h>
 #include <qgsexpressioncontextutils.h>
 #include <qgsfeedback.h>
 #include <qgspoint.h>
 #include <qgsproject.h>
-
-#include "locatormodelsuperbridge.h"
-#include "qgsquickmapsettings.h"
 
 
 GotoLocatorFilter::GotoLocatorFilter( LocatorModelSuperBridge *locatorBridge, QObject *parent )
@@ -55,9 +53,7 @@ void GotoLocatorFilter::fetchResults( const QString &string, const QgsLocatorCon
   QLocale locale;
 
   // Coordinates such as 106.8468,-6.3804
-  QRegularExpression separatorRx( QStringLiteral( "^([0-9\\-\\%1\\%2]*)[\\s%3]*([0-9\\-\\%1\\%2]*)$" ).arg( locale.decimalPoint(),
-                                  locale.groupSeparator(),
-                                  locale.decimalPoint() != ',' && locale.groupSeparator() != ',' ? QStringLiteral( "\\," ) : QString() ) );
+  QRegularExpression separatorRx( QStringLiteral( "^([0-9\\-\\%1\\%2]*)[\\s%3]*([0-9\\-\\%1\\%2]*)$" ).arg( locale.decimalPoint(), locale.groupSeparator(), locale.decimalPoint() != ',' && locale.groupSeparator() != ',' ? QStringLiteral( "\\," ) : QString() ) );
   QRegularExpressionMatch match = separatorRx.match( string.trimmed() );
   if ( match.hasMatch() )
   {
@@ -122,7 +118,7 @@ void GotoLocatorFilter::fetchResults( const QString &string, const QgsLocatorCon
           Q_UNUSED( e )
           return;
         }
-        catch(...)
+        catch ( ... )
         {
           // catch any other errors
           return;

--- a/src/core/gotolocatorfilter.h
+++ b/src/core/gotolocatorfilter.h
@@ -19,9 +19,8 @@
 #define GOTOLOCATORFILTER_H
 
 #include <QObject>
-
-#include <qgslocatorfilter.h>
 #include <qgsexpressioncontext.h>
+#include <qgslocatorfilter.h>
 
 
 class LocatorModelSuperBridge;
@@ -35,7 +34,6 @@ class GotoLocatorFilter : public QgsLocatorFilter
     Q_OBJECT
 
   public:
-
     //! Origin of the action which triggers the result
     enum ActionOrigin
     {

--- a/src/core/identifytool.cpp
+++ b/src/core/identifytool.cpp
@@ -14,21 +14,19 @@
  *                                                                         *
  ***************************************************************************/
 #include "identifytool.h"
-
-#include "qgsquickmapsettings.h"
 #include "multifeaturelistmodel.h"
+#include "qgsquickmapsettings.h"
 
-#include <qgsvectorlayer.h>
+#include <qgsexpressioncontextutils.h>
 #include <qgsproject.h>
 #include <qgsrenderer.h>
-#include <qgsexpressioncontextutils.h>
+#include <qgsvectorlayer.h>
 
 IdentifyTool::IdentifyTool( QObject *parent )
   : QObject( parent )
   , mMapSettings( nullptr )
   , mSearchRadiusMm( 8 )
 {
-
 }
 
 QgsQuickMapSettings *IdentifyTool::mapSettings() const

--- a/src/core/identifytool.h
+++ b/src/core/identifytool.h
@@ -17,10 +17,9 @@
 #define IDENTIFYTOOL_H
 
 #include <QObject>
-
 #include <qgsfeature.h>
-#include <qgspoint.h>
 #include <qgsmapsettings.h>
+#include <qgspoint.h>
 #include <qgsrendercontext.h>
 
 class QgsMapLayer;

--- a/src/core/ios/iosplatformutilities.h
+++ b/src/core/ios/iosplatformutilities.h
@@ -29,7 +29,6 @@ class IosPlatformUtilities : public PlatformUtilities
     bool checkPositioningPermissions() const override;
     bool checkCameraPermissions() const override;
     virtual PictureSource *getCameraPicture( const QString &prefix, const QString &pictureFilePath, const QString &suffix ) override;
-
 };
 
 #endif

--- a/src/core/layerobserver.cpp
+++ b/src/core/layerobserver.cpp
@@ -18,13 +18,12 @@
 #include "layerobserver.h"
 #include "qfieldcloudutils.h"
 
+#include <QDir>
 #include <qgsfeature.h>
 #include <qgsfeatureiterator.h>
 #include <qgsfeaturerequest.h>
-#include <qgsvectorlayereditbuffer.h>
 #include <qgsmessagelog.h>
-
-#include <QDir>
+#include <qgsvectorlayereditbuffer.h>
 
 
 LayerObserver::LayerObserver( const QgsProject *project )
@@ -57,7 +56,7 @@ void LayerObserver::onHomePathChanged()
   if ( mProject->homePath().isNull() )
     return;
 
-  Q_ASSERT( mDeltaFileWrapper->hasError() || ! mDeltaFileWrapper->isDirty() );
+  Q_ASSERT( mDeltaFileWrapper->hasError() || !mDeltaFileWrapper->isDirty() );
 
   // we should make deltas only on cloud projects
   if ( QFieldCloudUtils::getProjectId( mProject ).isEmpty() )
@@ -88,7 +87,7 @@ void LayerObserver::onBeforeCommitChanges()
   QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( sender() );
   QgsVectorLayerEditBuffer *eb = vl->editBuffer();
 
-  if ( ! eb )
+  if ( !eb )
     return;
 
   const QgsFeatureIds deletedFids = eb->deletedFeatureIds();
@@ -227,7 +226,7 @@ void LayerObserver::onCommittedGeometriesChanges( const QString &localLayerId, c
 }
 
 
-void LayerObserver::onEditingStopped( )
+void LayerObserver::onEditingStopped()
 {
   const QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( sender() );
   const QString layerId = vl->id();
@@ -235,7 +234,7 @@ void LayerObserver::onEditingStopped( )
   mPatchedFids.take( layerId );
   mChangedFeatures.take( layerId );
 
-  if ( ! mDeltaFileWrapper->toFile() )
+  if ( !mDeltaFileWrapper->toFile() )
   {
     // TODO somehow indicate the user that writing failed
     QgsMessageLog::logMessage( QStringLiteral( "Failed writing JSON file" ) );

--- a/src/core/layerobserver.h
+++ b/src/core/layerobserver.h
@@ -176,7 +176,6 @@ class LayerObserver : public QObject
      * Assigns listeners only for layer actions of `cloud` and `offline`.
      */
     void addLayerListeners();
-
 };
 
 #endif // LAYEROBSERVER_H

--- a/src/core/layerresolver.cpp
+++ b/src/core/layerresolver.cpp
@@ -16,12 +16,12 @@
  *                                                                         *
  ***************************************************************************/
 #include "layerresolver.h"
+
 #include <qgsvectorlayerref.h>
 
 LayerResolver::LayerResolver( QObject *parent )
   : QObject( parent )
 {
-
 }
 
 void LayerResolver::resolve()

--- a/src/core/layertreemapcanvasbridge.cpp
+++ b/src/core/layertreemapcanvasbridge.cpp
@@ -18,12 +18,12 @@
 #include "qgsquickmapcanvasmap.h"
 #include "qgsquickmapsettings.h"
 
-#include <qgslayertreegroup.h>
 #include <qgslayertree.h>
-#include <qgsmaplayer.h>
-#include <qgslayertreeutils.h>
-#include <qgsmaplayerstylemanager.h>
+#include <qgslayertreegroup.h>
 #include <qgslayertreemodel.h>
+#include <qgslayertreeutils.h>
+#include <qgsmaplayer.h>
+#include <qgsmaplayerstylemanager.h>
 
 LayerTreeMapCanvasBridge::LayerTreeMapCanvasBridge( FlatLayerTreeModel *model, QgsQuickMapSettings *mapSettings, TrackingModel *trackingModel, QObject *parent )
   : QObject( parent )
@@ -50,7 +50,7 @@ void LayerTreeMapCanvasBridge::extentChanged()
 {
   // allow symbols in the legend update their preview if they use map units
   mModel->layerTreeModel()->setLegendMapViewData( mMapSettings->mapSettings().mapUnitsPerPixel(),
-      static_cast< int >( std::round( mMapSettings->outputDpi() ) ), mMapSettings->mapSettings().scale() );
+      static_cast<int>( std::round( mMapSettings->outputDpi() ) ), mMapSettings->mapSettings().scale() );
 }
 
 void LayerTreeMapCanvasBridge::setCanvasLayers()
@@ -166,7 +166,3 @@ void LayerTreeMapCanvasBridge::layerInTrackingChanged( QgsVectorLayer *layer, bo
   QgsLayerTreeLayer *nodeLayer = mRoot->findLayer( layer->id() );
   mModel->setLayerInTracking( nodeLayer, tracking );
 }
-
-
-
-

--- a/src/core/layertreemapcanvasbridge.h
+++ b/src/core/layertreemapcanvasbridge.h
@@ -16,15 +16,13 @@
 #ifndef LAYERTREEMAPCANVASBRIDGE_H
 #define LAYERTREEMAPCANVASBRIDGE_H
 
+#include "layertreemodel.h"
+#include "trackingmodel.h"
+
 #include <QObject>
 #include <QStringList>
-
 #include <qgscoordinatereferencesystem.h>
 #include <qgsmapthemecollection.h>
-
-#include "layertreemodel.h"
-
-#include "trackingmodel.h"
 
 class QgsLayerTreeGroup;
 class QgsLayerTreeNode;
@@ -59,8 +57,8 @@ class LayerTreeMapCanvasBridge : public QObject
 
     //! if enabled, will automatically set full canvas extent and destination CRS + map units
     //! when first layer(s) are added
-    void setAutoSetupOnFirstLayer( bool enabled ) {  mAutoSetupOnFirstLayer = enabled; }
-    bool autoSetupOnFirstLayer() const    {  return mAutoSetupOnFirstLayer;  }
+    void setAutoSetupOnFirstLayer( bool enabled ) { mAutoSetupOnFirstLayer = enabled; }
+    bool autoSetupOnFirstLayer() const { return mAutoSetupOnFirstLayer; }
 
     //! if enabled, will automatically turn on on-the-fly reprojection of layers if a layer
     //! with different source CRS is added
@@ -83,7 +81,6 @@ class LayerTreeMapCanvasBridge : public QObject
     void layerInTrackingChanged( QgsVectorLayer *layer, bool tracking );
 
   private:
-
     void setCanvasLayers( QgsLayerTreeNode *node, QList<QgsMapLayer *> &canvasLayers, QList<QgsMapLayer *> &allLayers );
 
     void deferredSetCanvasLayers();

--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -15,10 +15,10 @@
  ***************************************************************************/
 #include "layertreemodel.h"
 
-#include <qgslayertreemodel.h>
-#include <qgslayertreenode.h>
 #include <qgslayertree.h>
+#include <qgslayertreemodel.h>
 #include <qgslayertreemodellegendnode.h>
+#include <qgslayertreenode.h>
 #include <qgsmapthemecollection.h>
 #include <qgsrasterlayer.h>
 #include <qgsvectorlayer.h>
@@ -157,7 +157,7 @@ void FlatLayerTreeModelBase::insertInMap( const QModelIndex &parent, int first, 
     }
   }
 
-  if ( insertedAt >  -1 )
+  if ( insertedAt > -1 )
   {
     beginInsertRows( QModelIndex(), insertedAt, insertedAt + ( last - first ) );
 
@@ -236,7 +236,7 @@ void FlatLayerTreeModelBase::removeFromMap( const QModelIndex &parent, int first
     const int treeLevelRemovedAt = mTreeLevelMap[removedAt];
     while ( modifiedUntil < mTreeLevelMap.size() && mTreeLevelMap[modifiedUntil] >= treeLevelRemovedAt )
     {
-      if ( mTreeLevelMap[modifiedUntil]  > treeLevelRemovedAt )
+      if ( mTreeLevelMap[modifiedUntil] > treeLevelRemovedAt )
       {
         resetNeeded = true;
         break;
@@ -262,7 +262,7 @@ void FlatLayerTreeModelBase::removeFromMap( const QModelIndex &parent, int first
       int row = mRowMap[index];
       int treeLevel = mTreeLevelMap[row];
 
-      if ( row >= removedAt  && row <= removedAt + ( last - first ) )
+      if ( row >= removedAt && row <= removedAt + ( last - first ) )
       {
         mRowMap.remove( index );
         continue;
@@ -470,7 +470,7 @@ QVariant FlatLayerTreeModelBase::data( const QModelIndex &index, int role ) cons
             if ( vectorLayer && vectorLayer->geometryType() != QgsWkbTypes::NullGeometry )
             {
               id += QStringLiteral( "layer" );
-              id += '/' +  nodeLayer->layerId();
+              id += '/' + nodeLayer->layerId();
             }
           }
         }
@@ -702,7 +702,7 @@ QVariant FlatLayerTreeModelBase::data( const QModelIndex &index, int role ) cons
       if ( layer->renderer() && layer->renderer()->legendSymbolItems().size() > 0 )
       {
         const long count = layer->featureCount( layer->renderer()->legendSymbolItems().at( 0 ).ruleKey() );
-        if (  count == -1 )
+        if ( count == -1 )
         {
           connect( layer, &QgsVectorLayer::symbolFeatureCountMapChanged, this, &FlatLayerTreeModelBase::featureCountChanged, Qt::UniqueConnection );
           layer->countSymbolFeatures();

--- a/src/core/layertreemodel.h
+++ b/src/core/layertreemodel.h
@@ -18,7 +18,6 @@
 #define LAYERTREEMODEL_H
 
 #include <QSortFilterProxyModel>
-
 #include <qgslayertreelayer.h>
 
 class QgsLayerTree;
@@ -156,7 +155,6 @@ class FlatLayerTreeModel : public QSortFilterProxyModel
     virtual bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const override;
 
   private:
-
     FlatLayerTreeModelBase *mSourceModel = nullptr;
 };
 

--- a/src/core/legendimageprovider.cpp
+++ b/src/core/legendimageprovider.cpp
@@ -15,11 +15,11 @@
  ***************************************************************************/
 #include "legendimageprovider.h"
 
-#include <qgsproject.h>
 #include <qgslayertree.h>
 #include <qgslayertreelayer.h>
 #include <qgslayertreemodel.h>
 #include <qgslayertreemodellegendnode.h>
+#include <qgsproject.h>
 
 LegendImageProvider::LegendImageProvider( QgsLayerTreeModel *layerTreeModel )
   : QQuickImageProvider( Pixmap )
@@ -45,7 +45,7 @@ QPixmap LegendImageProvider::requestPixmap( const QString &id, QSize *size, cons
     QModelIndex layerIndex = mLayerTreeModel->node2index( layerNode );
     QModelIndex index = mLayerTreeModel->index( 0, 0, layerIndex );
     QStringList legendParts;
-    while( index.isValid() )
+    while ( index.isValid() )
     {
       legendParts << mLayerTreeModel->data( index ).toString();
       if ( idParts.value( 2 ) == legendParts.join( QStringLiteral( "~__~" ) ) )
@@ -98,9 +98,9 @@ QPixmap LegendImageProvider::requestPixmap( const QString &id, QSize *size, cons
         QPixmap pixmap = legendNode->data( Qt::DecorationRole ).value<QPixmap>();
         if ( pixmap.isNull() )
         {
-         QIcon icon = legendNode->data( Qt::DecorationRole ).value<QIcon>();
-         if ( !icon.isNull() )
-           pixmap = icon.pixmap( iconSize, iconSize );
+          QIcon icon = legendNode->data( Qt::DecorationRole ).value<QIcon>();
+          if ( !icon.isNull() )
+            pixmap = icon.pixmap( iconSize, iconSize );
         }
         if ( pixmap.isNull() )
         {

--- a/src/core/linepolygonhighlight.cpp
+++ b/src/core/linepolygonhighlight.cpp
@@ -13,14 +13,13 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <qgsgeometry.h>
-#include <qgscoordinatereferencesystem.h>
-#include <qgsproject.h>
-
 #include "linepolygonhighlight.h"
-
 #include "qgsgeometrywrapper.h"
 #include "qgssggeometry.h"
+
+#include <qgscoordinatereferencesystem.h>
+#include <qgsgeometry.h>
+#include <qgsproject.h>
 
 
 LinePolygonHighlight::LinePolygonHighlight( QQuickItem *parent )

--- a/src/core/linepolygonhighlight.h
+++ b/src/core/linepolygonhighlight.h
@@ -16,9 +16,9 @@
 #ifndef LOCATORHIGHLIGHT_H
 #define LOCATORHIGHLIGHT_H
 
-#include <QtQuick/QQuickItem>
-
 #include "qgsquickmapsettings.h"
+
+#include <QtQuick/QQuickItem>
 
 class QgsGeometryWrapper;
 class QgsGeometry;

--- a/src/core/locatormodelsuperbridge.cpp
+++ b/src/core/locatormodelsuperbridge.cpp
@@ -15,19 +15,18 @@
  ***************************************************************************/
 
 
-#include "locatormodelsuperbridge.h"
-#include "qgsquickmapsettings.h"
 #include "featurelistextentcontroller.h"
 #include "featureslocatorfilter.h"
-#include "gotolocatorfilter.h"
-#include "peliasgeocoder.h"
 #include "finlandlocatorfilter.h"
 #include "gnsspositioninformation.h"
+#include "gotolocatorfilter.h"
+#include "locatormodelsuperbridge.h"
+#include "peliasgeocoder.h"
+#include "qgsquickmapsettings.h"
 
 #include <QStandardItem>
-
-#include <qgslocatormodel.h>
 #include <qgslocator.h>
+#include <qgslocatormodel.h>
 #include <qgssettings.h>
 
 
@@ -57,8 +56,8 @@ void LocatorModelSuperBridge::setMapSettings( QgsQuickMapSettings *mapSettings )
   updateCanvasExtent( mMapSettings->extent() );
   updateCanvasCrs( mMapSettings->destinationCrs() );
 
-  connect( mMapSettings, &QgsQuickMapSettings::visibleExtentChanged, this, [ = ]() {updateCanvasExtent( mMapSettings->visibleExtent() );} );
-  connect( mMapSettings, &QgsQuickMapSettings::destinationCrsChanged, this, [ = ]() {updateCanvasCrs( mMapSettings->destinationCrs() );} ) ;
+  connect( mMapSettings, &QgsQuickMapSettings::visibleExtentChanged, this, [ = ]() { updateCanvasExtent( mMapSettings->visibleExtent() ); } );
+  connect( mMapSettings, &QgsQuickMapSettings::destinationCrsChanged, this, [ = ]() { updateCanvasCrs( mMapSettings->destinationCrs() ); } );
 
   emit mapSettingsChanged();
 }
@@ -164,7 +163,8 @@ QHash<int, QByteArray> LocatorActionsModel::roleNames() const
 // LocatorFiltersModel
 //
 
-LocatorFiltersModel::LocatorFiltersModel() : QAbstractListModel()
+LocatorFiltersModel::LocatorFiltersModel()
+  : QAbstractListModel()
 {
 }
 
@@ -191,14 +191,14 @@ QHash<int, QByteArray> LocatorFiltersModel::roleNames() const
 
 QVariant LocatorFiltersModel::data( const QModelIndex &index, int role ) const
 {
-  const static QMap<QString, QString> sLocatorFilterDescriptions = {
-    { QStringLiteral("allfeatures"), tr( "Returns a list of features accross all searchable layers with matching attributes" ) },
-    { QStringLiteral("goto"), tr( "Returns a point from a pair of X and Y coordinates typed in the search bar" ) },
-    { QStringLiteral("pelias-finland"), tr( "Returns a list of locations and addresses within Finland with matching terms" ) }
+  const static QMap<QString, QString> sLocatorFilterDescriptions =
+  {
+    { QStringLiteral( "allfeatures" ), tr( "Returns a list of features accross all searchable layers with matching attributes" ) },
+    { QStringLiteral( "goto" ), tr( "Returns a point from a pair of X and Y coordinates typed in the search bar" ) },
+    { QStringLiteral( "pelias-finland" ), tr( "Returns a list of locations and addresses within Finland with matching terms" ) }
   };
 
-  if ( !mLocatorModelSuperBridge->locator() || !index.isValid() || index.parent().isValid() ||
-       index.row() < 0 || index.row() >= rowCount( QModelIndex() ) )
+  if ( !mLocatorModelSuperBridge->locator() || !index.isValid() || index.parent().isValid() || index.row() < 0 || index.row() >= rowCount( QModelIndex() ) )
     return QVariant();
 
   switch ( role )
@@ -225,8 +225,7 @@ QVariant LocatorFiltersModel::data( const QModelIndex &index, int role ) const
 
 bool LocatorFiltersModel::setData( const QModelIndex &index, const QVariant &value, int role )
 {
-  if ( !mLocatorModelSuperBridge->locator() || !index.isValid() || index.parent().isValid() ||
-       index.row() < 0 || index.row() >= rowCount( QModelIndex() ) )
+  if ( !mLocatorModelSuperBridge->locator() || !index.isValid() || index.parent().isValid() || index.row() < 0 || index.row() >= rowCount( QModelIndex() ) )
     return false;
 
   switch ( role )

--- a/src/core/locatormodelsuperbridge.h
+++ b/src/core/locatormodelsuperbridge.h
@@ -18,8 +18,8 @@
 #define LOCATORMODELSUPERBRIDGE_H
 
 #include <QStandardItemModel>
-#include <qgslocatormodelbridge.h>
 #include <qgslocatorfilter.h>
+#include <qgslocatormodelbridge.h>
 
 class QgsQuickMapSettings;
 class FeatureListExtentController;
@@ -105,7 +105,6 @@ class LocatorFiltersModel : public QAbstractListModel
     Q_PROPERTY( LocatorModelSuperBridge *locatorModelSuperBridge READ locatorModelSuperBridge WRITE setLocatorModelSuperBridge NOTIFY locatorModelSuperBridgeChanged )
 
   public:
-
     //! Custom model roles
     enum Role
     {
@@ -139,8 +138,6 @@ class LocatorFiltersModel : public QAbstractListModel
     void locatorModelSuperBridgeChanged();
 
   private:
-
     LocatorModelSuperBridge *mLocatorModelSuperBridge = nullptr;
-
 };
 #endif // LOCATORMODELSUPERBRIDGE_H

--- a/src/core/maptoscreen.cpp
+++ b/src/core/maptoscreen.cpp
@@ -16,8 +16,8 @@
 #include "maptoscreen.h"
 #include "qgspoint.h"
 
-MapToScreen::MapToScreen( QObject *parent ) :
-  QObject( parent )
+MapToScreen::MapToScreen( QObject *parent )
+  : QObject( parent )
 {
 }
 
@@ -57,7 +57,7 @@ void MapToScreen::setMapPoint( const QgsPoint &point )
 
 QgsPoint MapToScreen::mapPoint()
 {
-  return  mMapPoint;
+  return mMapPoint;
 }
 
 QPointF MapToScreen::screenPoint()
@@ -77,5 +77,3 @@ void MapToScreen::transformPoint()
   }
   emit screenPointChanged();
 }
-
-

--- a/src/core/maptoscreen.h
+++ b/src/core/maptoscreen.h
@@ -16,11 +16,11 @@
 #ifndef MAPTOSCREEN_H
 #define MAPTOSCREEN_H
 
+#include "qgsquickmapsettings.h"
+
 #include <QObject>
 #include <QPointF>
 #include <qgspoint.h>
-
-#include "qgsquickmapsettings.h"
 
 /**
  * @brief The MapToScreen class transform a map point to screen coordinates.

--- a/src/core/messagelogmodel.cpp
+++ b/src/core/messagelogmodel.cpp
@@ -15,8 +15,8 @@
  ***************************************************************************/
 #include "messagelogmodel.h"
 
-#include <qgsapplication.h>
 #include <QDebug>
+#include <qgsapplication.h>
 
 MessageLogModel::MessageLogModel( QObject *parent )
   : QAbstractListModel( parent )
@@ -28,7 +28,7 @@ MessageLogModel::MessageLogModel( QObject *parent )
 QHash<int, QByteArray> MessageLogModel::roleNames() const
 {
   QHash<int, QByteArray> roles = QAbstractListModel::roleNames();
-  roles[MessageRole]  = "Message";
+  roles[MessageRole] = "Message";
   roles[MessageTagRole] = "MessageTag";
   roles[MessageLevelRole] = "MessageLevel";
   roles[MessageDateTimeRole] = "MessageDateTime";
@@ -59,7 +59,7 @@ QVariant MessageLogModel::data( const QModelIndex &index, int role ) const
   return QVariant();
 }
 
-void MessageLogModel::suppressTags( const QList <QString> &tags )
+void MessageLogModel::suppressTags( const QList<QString> &tags )
 {
   for ( const QString &tag : tags )
   {
@@ -68,7 +68,7 @@ void MessageLogModel::suppressTags( const QList <QString> &tags )
   }
 }
 
-void MessageLogModel::unsuppressTags( const QList <QString> &tags )
+void MessageLogModel::unsuppressTags( const QList<QString> &tags )
 {
   for ( const QString &tag : tags )
   {

--- a/src/core/messagelogmodel.h
+++ b/src/core/messagelogmodel.h
@@ -64,9 +64,9 @@ class MessageLogModel : public QAbstractListModel
     QVariant data( const QModelIndex &index, int role ) const override;
 
     //! activates suppression of messages wit specific tags
-    Q_INVOKABLE void suppressTags( const QList <QString> &tags );
+    Q_INVOKABLE void suppressTags( const QList<QString> &tags );
     //! deactivates suppression of messages wit specific tags
-    Q_INVOKABLE void unsuppressTags( const QList <QString> &tags );
+    Q_INVOKABLE void unsuppressTags( const QList<QString> &tags );
 
     //! Clears any messages from the log
     Q_INVOKABLE void clear();
@@ -77,7 +77,7 @@ class MessageLogModel : public QAbstractListModel
   private:
     QgsMessageLog *mMessageLog = nullptr;
     QVector<LogMessage> mMessages;
-    QList< QString > mSuppressedTags;
+    QList<QString> mSuppressedTags;
 };
 
 #endif // MESSAGELOGMODEL_H

--- a/src/core/modelhelper.cpp
+++ b/src/core/modelhelper.cpp
@@ -19,7 +19,6 @@ ModelHelper::ModelHelper( QObject *parent )
   : QObject( parent )
   , mModel( nullptr )
 {
-
 }
 
 QModelIndex ModelHelper::index( int row, int column )

--- a/src/core/modelhelper.h
+++ b/src/core/modelhelper.h
@@ -16,8 +16,8 @@
 #ifndef MODELHELPER_H
 #define MODELHELPER_H
 
-#include <QObject>
 #include <QAbstractItemModel>
+#include <QObject>
 
 class ModelHelper : public QObject
 {

--- a/src/core/multifeaturelistmodel.cpp
+++ b/src/core/multifeaturelistmodel.cpp
@@ -15,18 +15,17 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <qgsvectorlayer.h>
-#include <qgsvectordataprovider.h>
-#include <qgsproject.h>
-#include <qgsgeometry.h>
-#include <qgscoordinatereferencesystem.h>
-#include <qgsexpressioncontextutils.h>
-#include <qgsrelationmanager.h>
-#include <qgsmessagelog.h>
-
 #include "multifeaturelistmodel.h"
 
 #include <QDebug>
+#include <qgscoordinatereferencesystem.h>
+#include <qgsexpressioncontextutils.h>
+#include <qgsgeometry.h>
+#include <qgsmessagelog.h>
+#include <qgsproject.h>
+#include <qgsrelationmanager.h>
+#include <qgsvectordataprovider.h>
+#include <qgsvectorlayer.h>
 
 MultiFeatureListModel::MultiFeatureListModel( QObject *parent )
   : QSortFilterProxyModel( parent )
@@ -35,7 +34,7 @@ MultiFeatureListModel::MultiFeatureListModel( QObject *parent )
   setSourceModel( mSourceModel );
   connect( mSourceModel, &MultiFeatureListModelBase::modelReset, this, &MultiFeatureListModel::countChanged );
   connect( mSourceModel, &MultiFeatureListModelBase::countChanged, this, &MultiFeatureListModel::countChanged );
-  connect( mSourceModel, &MultiFeatureListModelBase::selectedCountChanged, this, &MultiFeatureListModel::adjustFilterToSelectedCount);
+  connect( mSourceModel, &MultiFeatureListModelBase::selectedCountChanged, this, &MultiFeatureListModel::adjustFilterToSelectedCount );
 }
 
 void MultiFeatureListModel::setFeatures( const QMap<QgsVectorLayer *, QgsFeatureRequest> requests )
@@ -45,7 +44,7 @@ void MultiFeatureListModel::setFeatures( const QMap<QgsVectorLayer *, QgsFeature
 
 void MultiFeatureListModel::setFeatures( QgsVectorLayer *vl )
 {
-  QMap<QgsVectorLayer *, QgsFeatureRequest> requests({{vl, QgsFeatureRequest()}});
+  QMap<QgsVectorLayer *, QgsFeatureRequest> requests( { { vl, QgsFeatureRequest() } } );
   mSourceModel->setFeatures( requests );
 }
 
@@ -115,7 +114,7 @@ void MultiFeatureListModel::toggleSelectedItem( int item )
   mSourceModel->toggleSelectedItem( sourceItem.row() );
   if ( mSourceModel->selectedCount() > 0 && mFilterLayer == nullptr )
   {
-    mFilterLayer =  mSourceModel->data( sourceItem, MultiFeatureListModel::LayerRole ).value<QgsVectorLayer *>();
+    mFilterLayer = mSourceModel->data( sourceItem, MultiFeatureListModel::LayerRole ).value<QgsVectorLayer *>();
     emit selectedLayerChanged();
     invalidateFilter();
   }

--- a/src/core/multifeaturelistmodel.h
+++ b/src/core/multifeaturelistmodel.h
@@ -18,13 +18,12 @@
 #ifndef MULTIFEATURELISTMODEL_H
 #define MULTIFEATURELISTMODEL_H
 
-#include <QAbstractItemModel>
-#include <QSortFilterProxyModel>
-
-#include <qgsfeaturerequest.h>
-
 #include "identifytool.h"
 #include "multifeaturelistmodelbase.h"
+
+#include <QAbstractItemModel>
+#include <QSortFilterProxyModel>
+#include <qgsfeaturerequest.h>
 
 class MultiFeatureListModel : public QSortFilterProxyModel
 {
@@ -34,9 +33,9 @@ class MultiFeatureListModel : public QSortFilterProxyModel
     Q_PROPERTY( QList<QgsFeature> selectedFeatures READ selectedFeatures NOTIFY selectedCountChanged )
     Q_PROPERTY( QgsVectorLayer *selectedLayer READ selectedLayer NOTIFY selectedLayerChanged )
     Q_PROPERTY( int selectedCount READ selectedCount NOTIFY selectedCountChanged )
-    Q_PROPERTY( bool canEditAttributesSelection READ canEditAttributesSelection NOTIFY selectedCountChanged  )
-    Q_PROPERTY( bool canMergeSelection READ canMergeSelection NOTIFY selectedCountChanged  )
-    Q_PROPERTY( bool canDeleteSelection READ canDeleteSelection NOTIFY selectedCountChanged  )
+    Q_PROPERTY( bool canEditAttributesSelection READ canEditAttributesSelection NOTIFY selectedCountChanged )
+    Q_PROPERTY( bool canMergeSelection READ canMergeSelection NOTIFY selectedCountChanged )
+    Q_PROPERTY( bool canDeleteSelection READ canDeleteSelection NOTIFY selectedCountChanged )
 
   public:
     enum FeatureListRoles
@@ -144,13 +143,11 @@ class MultiFeatureListModel : public QSortFilterProxyModel
     void selectedLayerChanged();
 
   protected:
-
     virtual bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const override;
 
     void adjustFilterToSelectedCount();
 
   private:
-
     MultiFeatureListModelBase *mSourceModel = nullptr;
 
     QgsVectorLayer *mFilterLayer = nullptr;

--- a/src/core/multifeaturelistmodelbase.h
+++ b/src/core/multifeaturelistmodelbase.h
@@ -18,18 +18,16 @@
 #ifndef MULTIFEATURELISTMODELBASE_H
 #define MULTIFEATURELISTMODELBASE_H
 
-#include <QAbstractItemModel>
-
-#include <qgsfeaturerequest.h>
-
 #include "identifytool.h"
+
+#include <QAbstractItemModel>
+#include <qgsfeaturerequest.h>
 
 class MultiFeatureListModelBase : public QAbstractItemModel
 {
     Q_OBJECT
 
   public:
-
     explicit MultiFeatureListModelBase( QObject *parent = nullptr );
 
     /**
@@ -137,14 +135,13 @@ class MultiFeatureListModelBase : public QAbstractItemModel
     void geometryChanged( QgsFeatureId fid, const QgsGeometry &geometry );
 
   private:
-
-    inline QPair< QgsVectorLayer *, QgsFeature > *toFeature( const QModelIndex &index ) const
+    inline QPair<QgsVectorLayer *, QgsFeature> *toFeature( const QModelIndex &index ) const
     {
-      return static_cast<QPair< QgsVectorLayer *, QgsFeature >*>( index.internalPointer() );
+      return static_cast<QPair<QgsVectorLayer *, QgsFeature> *>( index.internalPointer() );
     }
 
-    QList< QPair< QgsVectorLayer *, QgsFeature > > mFeatures;
-    QList< QPair< QgsVectorLayer *, QgsFeature > > mSelectedFeatures;
+    QList<QPair<QgsVectorLayer *, QgsFeature>> mFeatures;
+    QList<QPair<QgsVectorLayer *, QgsFeature>> mSelectedFeatures;
 };
 
 #endif // MULTIFEATURELISTMODELBASE_H

--- a/src/core/networkmanager.cpp
+++ b/src/core/networkmanager.cpp
@@ -15,7 +15,6 @@
 
 #include "networkmanager.h"
 #include "networkreply.h"
-
 #include "qgsnetworkaccessmanager.h"
 
 

--- a/src/core/networkmanager.h
+++ b/src/core/networkmanager.h
@@ -33,9 +33,7 @@ class QgsNetworkAccessManager;
  */
 class NetworkManager
 {
-
   public:
-
     /**
      * makes HTTP GET \a request and returns a reply.
      */
@@ -70,7 +68,6 @@ class NetworkManager
      * makes HTTP DELETE \a request with an optional \a payload and returns a reply
      */
     static NetworkReply *deleteResource( const QNetworkRequest &request, const QByteArray &payload = QByteArray() );
-
 };
 
 

--- a/src/core/networkreply.cpp
+++ b/src/core/networkreply.cpp
@@ -18,21 +18,15 @@
 #include <QTimer>
 
 
-NetworkReply::NetworkReply( const QNetworkAccessManager::Operation operation, const QNetworkRequest &request, const QByteArray &payloadByteArray = QByteArray() ):
-  mOperation( operation ),
-  mIsMultiPartPayload( false ),
-  mRequest( request ),
-  mPayloadByteArray( payloadByteArray )
+NetworkReply::NetworkReply( const QNetworkAccessManager::Operation operation, const QNetworkRequest &request, const QByteArray &payloadByteArray = QByteArray() )
+  : mOperation( operation ), mIsMultiPartPayload( false ), mRequest( request ), mPayloadByteArray( payloadByteArray )
 {
   initiateRequest();
 };
 
 
-NetworkReply::NetworkReply( const QNetworkAccessManager::Operation operation, const QNetworkRequest &request, QHttpMultiPart *payloadMultiPart ):
-  mOperation( operation ),
-  mIsMultiPartPayload( true ),
-  mRequest( request ),
-  mPayloadMultiPart( payloadMultiPart )
+NetworkReply::NetworkReply( const QNetworkAccessManager::Operation operation, const QNetworkRequest &request, QHttpMultiPart *payloadMultiPart )
+  : mOperation( operation ), mIsMultiPartPayload( true ), mRequest( request ), mPayloadMultiPart( payloadMultiPart )
 {
   initiateRequest();
 };
@@ -167,7 +161,7 @@ void NetworkReply::onFinished()
       break;
   }
 
-  if ( ! canRetry || mRetriesLeft == 0 )
+  if ( !canRetry || mRetriesLeft == 0 )
   {
     mIsFinished = true;
 
@@ -180,7 +174,7 @@ void NetworkReply::onFinished()
   emit temporaryErrorOccurred( error );
 
   // wait random time before the retry is sent
-//  QTimer::singleShot( mRNG.bounded( sMaxTimeoutBetweenRetriesMs ), this, [ = ]()
+  //  QTimer::singleShot( mRNG.bounded( sMaxTimeoutBetweenRetriesMs ), this, [ = ]()
   QTimer::singleShot( 100, this, [ = ]()
   {
     emit retry();

--- a/src/core/networkreply.h
+++ b/src/core/networkreply.h
@@ -17,11 +17,10 @@
 #ifndef NETWORKREPLY_H
 #define NETWORKREPLY_H
 
-#include <qgsnetworkaccessmanager.h>
-
-#include <QObject>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
+#include <QObject>
+#include <qgsnetworkaccessmanager.h>
 //#include <QRandomGenerator>
 
 
@@ -30,12 +29,9 @@
  */
 class NetworkReply : public QObject
 {
-
     Q_OBJECT
 
   public:
-
-
     /**
      * A wrapper around QNetworkReply that allows retriable requests.
      * @param op HTTP method
@@ -151,8 +147,6 @@ class NetworkReply : public QObject
     void temporaryErrorOccurred( QNetworkReply::NetworkError code );
 
   private:
-
-
     /**
      * Upper bound of the delay between retries in milliseconds.
      */
@@ -192,7 +186,7 @@ class NetworkReply : public QObject
     /**
      * Random number generator instance. Used to create random delay bettween retries.
      */
-//    QRandomGenerator mRNG;
+    //    QRandomGenerator mRNG;
 
 
     /**

--- a/src/core/peliasgeocoder.cpp
+++ b/src/core/peliasgeocoder.cpp
@@ -20,14 +20,14 @@
 #include "qgsnetworkaccessmanager.h"
 
 #include <QDateTime>
-#include <QUrl>
-#include <QUrlQuery>
+#include <QJsonArray>
+#include <QJsonDocument>
 #include <QMutex>
 #include <QNetworkRequest>
-#include <QJsonDocument>
-#include <QJsonArray>
+#include <QUrl>
+#include <QUrlQuery>
 
-typedef QMap< QUrl, QList< QgsGeocoderResult > > CachedGeocodeResult;
+typedef QMap<QUrl, QList<QgsGeocoderResult>> CachedGeocodeResult;
 Q_GLOBAL_STATIC( CachedGeocodeResult, sCachedResults )
 qint64 PeliasGeocoder::sLastRequestTimestamp = 0;
 
@@ -130,7 +130,7 @@ QList<QgsGeocoderResult> PeliasGeocoder::geocodeString( const QString &string, c
     return QList<QgsGeocoderResult>();
   }
 
-  QList< QgsGeocoderResult > matches;
+  QList<QgsGeocoderResult> matches;
   matches.reserve( results.size() );
   for ( const QVariant &result : results )
   {

--- a/src/core/peliasgeocoder.h
+++ b/src/core/peliasgeocoder.h
@@ -33,9 +33,7 @@
 */
 class QFIELD_CORE_EXPORT PeliasGeocoder : public QgsGeocoderInterface
 {
-
   public:
-
     /**
      * Constructor for PeliasGeocoder.
      *
@@ -46,7 +44,7 @@ class QFIELD_CORE_EXPORT PeliasGeocoder : public QgsGeocoderInterface
     Flags flags() const override;
     QgsFields appendedFields() const override;
     QgsWkbTypes::Type wkbType() const override;
-    QList< QgsGeocoderResult > geocodeString( const QString &string, const QgsGeocoderContext &context, QgsFeedback *feedback = nullptr ) const override;
+    QList<QgsGeocoderResult> geocodeString( const QString &string, const QgsGeocoderContext &context, QgsFeedback *feedback = nullptr ) const override;
 
     /**
      * Returns the URL generated for geocoding the specified \a address.
@@ -87,12 +85,10 @@ class QFIELD_CORE_EXPORT PeliasGeocoder : public QgsGeocoderInterface
     void setRequestsPerSecond( double number ) { mRequestsPerSecond = number; }
 
   private:
-
     QString mEndpoint;
     double mRequestsPerSecond = 10;
 
     static qint64 sLastRequestTimestamp;
-
 };
 
 #endif // PELIASGEOCODER_H

--- a/src/core/picturesource.cpp
+++ b/src/core/picturesource.cpp
@@ -29,12 +29,12 @@ PictureSource::PictureSource( QObject *parent, const QString &prefix, const QStr
   if ( mPictureFilePath.startsWith( mPrefix ) )
     mPictureFilePath = mPictureFilePath.remove( mPrefix );
 
-  QTimer::singleShot(0, this, [ = ] () {
+  QTimer::singleShot( 0, this, [ = ]()
+  {
     emit pictureReceived( mPictureFilePath );
-  });
+  } );
 }
 
 PictureSource::~PictureSource()
 {
-
 }

--- a/src/core/picturesource.h
+++ b/src/core/picturesource.h
@@ -28,7 +28,7 @@ class PictureSource : public QObject
   public:
     /**
      * Construct a new Picture Source object.
-     * 
+     *
      * @note Subclasses which implement their own file dialog should provide an empty string for \a pictureFilePath and emit \a pictureReceived when appropriate.
      * @param parent Parent object
      * @param prefix The project folder. Base directory path for all relative paths.
@@ -42,16 +42,15 @@ class PictureSource : public QObject
     virtual ~PictureSource();
 
   signals:
-  
+
     /**
-     * Emit this signal when a picture really has been received. 
-     * 
+     * Emit this signal when a picture really has been received.
+     *
      * @note When the constructor received a non-empty \a pictureFilePath, the signal is emitted in the constructor.
      */
     void pictureReceived( const QString &path );
-  
-  private:
 
+  private:
     /**
      * Base directory path for all relative paths.
      */

--- a/src/core/platformutilities.cpp
+++ b/src/core/platformutilities.cpp
@@ -16,27 +16,26 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgsmessagelog.h"
-
 #include "platformutilities.h"
 #include "projectsource.h"
 #include "qgismobileapp.h"
+#include "qgsmessagelog.h"
 
 #include <QDebug>
-#include <QDir>
 #include <QDesktopServices>
-#include <QUrl>
+#include <QDir>
 #include <QFileDialog>
 #include <QTimer>
+#include <QUrl>
 
-#if defined (Q_OS_ANDROID)
+#if defined( Q_OS_ANDROID )
 #include "androidplatformutilities.h"
-Q_GLOBAL_STATIC(AndroidPlatformUtilities, sPlatformUtils)
-#elif defined (Q_OS_IOS)
+Q_GLOBAL_STATIC( AndroidPlatformUtilities, sPlatformUtils )
+#elif defined( Q_OS_IOS )
 #include "ios/iosplatformutilities.h"
-Q_GLOBAL_STATIC(IosPlatformUtilities, sPlatformUtils)
+Q_GLOBAL_STATIC( IosPlatformUtilities, sPlatformUtils )
 #else
-Q_GLOBAL_STATIC(PlatformUtilities, sPlatformUtils)
+Q_GLOBAL_STATIC( PlatformUtilities, sPlatformUtils )
 #endif
 
 PlatformUtilities::~PlatformUtilities()
@@ -115,10 +114,9 @@ PictureSource *PlatformUtilities::getGalleryPicture( const QString &prefix, cons
     else
     {
       QString destinationFile = prefix + pictureFilePath;
-      QFileInfo destinationInfo ( destinationFile );
+      QFileInfo destinationInfo( destinationFile );
       QDir prefixDir( prefix );
-      if ( prefixDir.mkpath( destinationInfo.absolutePath() ) &&
-           QFile::copy( fileName, destinationFile ) )
+      if ( prefixDir.mkpath( destinationInfo.absolutePath() ) && QFile::copy( fileName, destinationFile ) )
       {
         return new PictureSource( nullptr, prefix, destinationFile );
       }
@@ -144,20 +142,11 @@ QString PlatformUtilities::fieldType( const QgsField &field ) const
 ProjectSource *PlatformUtilities::openProject()
 {
   QSettings settings;
-  ProjectSource *source = new ProjectSource( );
+  ProjectSource *source = new ProjectSource();
   QString fileName { QFileDialog::getOpenFileName( nullptr,
-                                               tr( "Open File" ),
-                                               settings.value( QStringLiteral( "QField/lastOpenDir" ), QString() ).toString(),
-                                               QStringLiteral( "%1 (*.%2);;%3 (*.%4);;%5 (*.%6);;%7 (*.%8)" ).arg( tr( "All Supported Files" ),
-                                                                                                                   ( SUPPORTED_PROJECT_EXTENSIONS +
-                                                                                                                     SUPPORTED_VECTOR_EXTENSIONS +
-                                                                                                                     SUPPORTED_RASTER_EXTENSIONS ).join( QStringLiteral( " *." ) ),
-                                                                                                                   tr( "QGIS Project Files" ),
-                                                                                                                   SUPPORTED_PROJECT_EXTENSIONS.join( QStringLiteral( " *." ) ),
-                                                                                                                   tr( "Vector Datasets" ),
-                                                                                                                   SUPPORTED_VECTOR_EXTENSIONS.join( QStringLiteral( " *." ) ),
-                                                                                                                   tr( "Raster Datasets" ),
-                                                                                                                   SUPPORTED_RASTER_EXTENSIONS.join( QStringLiteral( " *." ) ) ) ) };
+                     tr( "Open File" ),
+                     settings.value( QStringLiteral( "QField/lastOpenDir" ), QString() ).toString(),
+                     QStringLiteral( "%1 (*.%2);;%3 (*.%4);;%5 (*.%6);;%7 (*.%8)" ).arg( tr( "All Supported Files" ), ( SUPPORTED_PROJECT_EXTENSIONS + SUPPORTED_VECTOR_EXTENSIONS + SUPPORTED_RASTER_EXTENSIONS ).join( QStringLiteral( " *." ) ), tr( "QGIS Project Files" ), SUPPORTED_PROJECT_EXTENSIONS.join( QStringLiteral( " *." ) ), tr( "Vector Datasets" ), SUPPORTED_VECTOR_EXTENSIONS.join( QStringLiteral( " *." ) ), tr( "Raster Datasets" ), SUPPORTED_RASTER_EXTENSIONS.join( QStringLiteral( " *." ) ) ) ) };
   if ( !fileName.isEmpty() )
   {
     settings.setValue( QStringLiteral( "/QField/lastOpenDir" ), QFileInfo( fileName ).absolutePath() );

--- a/src/core/platformutilities.h
+++ b/src/core/platformutilities.h
@@ -19,14 +19,12 @@
 #ifndef PLATFORMUTILITIES_H
 #define PLATFORMUTILITIES_H
 
-#include <QObject>
-
-#include <qgsfield.h>
-
 #include "picturesource.h"
+#include "qfield_core_export.h"
 #include "viewstatus.h"
 
-#include "qfield_core_export.h"
+#include <QObject>
+#include <qgsfield.h>
 
 class ProjectSource;
 
@@ -120,6 +118,5 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
     Q_INVOKABLE virtual void setScreenLockPermission( const bool allowLock ) { Q_UNUSED( allowLock ); }
 
     static PlatformUtilities *instance();
-
 };
 #endif // PLATFORMUTILITIES_H

--- a/src/core/printlayoutlistmodel.cpp
+++ b/src/core/printlayoutlistmodel.cpp
@@ -26,7 +26,7 @@ PrintLayoutListModel::PrintLayoutListModel( QObject *parent )
 QHash<int, QByteArray> PrintLayoutListModel::roleNames() const
 {
   QHash<int, QByteArray> roles = QAbstractListModel::roleNames();
-  roles[TitleRow]  = "Title";
+  roles[TitleRow] = "Title";
   roles[IndexRow] = "Index";
 
   return roles;
@@ -67,7 +67,7 @@ void PrintLayoutListModel::reloadModel()
   beginResetModel();
   mPrintLayouts.clear();
 
-  const QList< QgsPrintLayout * > layouts( mProject->layoutManager()->printLayouts() );
+  const QList<QgsPrintLayout *> layouts( mProject->layoutManager()->printLayouts() );
   for ( const auto &layout : layouts )
   {
     if ( mAtlasCoverageLayr )
@@ -86,7 +86,6 @@ void PrintLayoutListModel::reloadModel()
     }
   }
   endResetModel();
-
 }
 
 int PrintLayoutListModel::rowCount( const QModelIndex &parent ) const
@@ -105,7 +104,7 @@ QVariant PrintLayoutListModel::data( const QModelIndex &index, int role ) const
   if ( role == TitleRow )
     return mPrintLayouts.at( index.row() ).title;
   else if ( role == IndexRow )
-    return  index.row();
+    return index.row();
 
   return QVariant();
 }

--- a/src/core/printlayoutlistmodel.h
+++ b/src/core/printlayoutlistmodel.h
@@ -17,10 +17,9 @@
 #define PRINTLAYOUTLISTMODEL_H
 
 #include <QAbstractListModel>
-
-#include <qgsprintlayout.h>
 #include <qgslayoutmanager.h>
 #include <qgslayoutpagecollection.h>
+#include <qgsprintlayout.h>
 
 class QStringList;
 class QgsProject;

--- a/src/core/projectinfo.cpp
+++ b/src/core/projectinfo.cpp
@@ -21,7 +21,8 @@
 #include <QSettings>
 #include <QString>
 
-ProjectInfo::ProjectInfo( QObject *parent ) : QObject( parent )
+ProjectInfo::ProjectInfo( QObject *parent )
+  : QObject( parent )
 {
   mSaveExtentTimer.setSingleShot( true );
   connect( &mSaveExtentTimer, &QTimer::timeout, this, &ProjectInfo::extentChanged );
@@ -31,9 +32,9 @@ void ProjectInfo::setFilePath( const QString &filePath )
 {
   if ( mFilePath == filePath )
     return;
-  
+
   mFilePath = filePath;
-  
+
   emit filePathChanged();
 }
 
@@ -51,10 +52,10 @@ void ProjectInfo::setMapSettings( QgsQuickMapSettings *mapSettings )
   {
     disconnect( mMapSettings, &QgsQuickMapSettings::extentChanged, this, &ProjectInfo::extentChanged );
   }
-  
+
   mMapSettings = mapSettings;
-  connect( mMapSettings, &QgsQuickMapSettings::extentChanged, this, [=] { mSaveExtentTimer.start( 750 ); } );
-  
+  connect( mMapSettings, &QgsQuickMapSettings::extentChanged, this, [ = ] { mSaveExtentTimer.start( 750 ); } );
+
   emit mapSettingsChanged();
 }
 
@@ -96,10 +97,7 @@ void ProjectInfo::extentChanged()
     const QgsRectangle extent = mMapSettings->extent();
     settings.beginGroup( QStringLiteral( "/qgis/projectInfo/%1" ).arg( mFilePath ) );
     settings.setValue( QStringLiteral( "filesize" ), fi.size() );
-    settings.setValue( QStringLiteral( "extent" ), QStringLiteral( "%1|%2|%3|%4" ).arg( qgsDoubleToString( extent.xMinimum() ),
-                                                                                        qgsDoubleToString( extent.xMaximum() ),
-                                                                                        qgsDoubleToString( extent.yMinimum() ),
-                                                                                        qgsDoubleToString( extent.yMaximum() ) ) );
+    settings.setValue( QStringLiteral( "extent" ), QStringLiteral( "%1|%2|%3|%4" ).arg( qgsDoubleToString( extent.xMinimum() ), qgsDoubleToString( extent.xMaximum() ), qgsDoubleToString( extent.yMinimum() ), qgsDoubleToString( extent.yMaximum() ) ) );
     settings.endGroup();
   }
 }

--- a/src/core/projectinfo.h
+++ b/src/core/projectinfo.h
@@ -18,8 +18,8 @@
 #ifndef PROJECTINFO_H
 #define PROJECTINFO_H
 
-#include "qgsquickmapsettings.h"
 #include "layertreemodel.h"
+#include "qgsquickmapsettings.h"
 
 #include <QObject>
 #include <QTimer>
@@ -34,23 +34,22 @@ class ProjectInfo : public QObject
     Q_OBJECT
 
     Q_PROPERTY( QString filePath READ filePath WRITE setFilePath NOTIFY filePathChanged )
-    
+
     Q_PROPERTY( QgsQuickMapSettings *mapSettings READ mapSettings WRITE setMapSettings NOTIFY mapSettingsChanged )
 
     Q_PROPERTY( FlatLayerTreeModel *layerTree READ layerTree WRITE setLayerTree NOTIFY layerTreeChanged )
 
   public:
-  
     explicit ProjectInfo( QObject *parent = nullptr );
 
     virtual ~ProjectInfo() = default;
 
     void setFilePath( const QString &filePath );
-    
+
     QString filePath() const;
 
     void setMapSettings( QgsQuickMapSettings *mapSettings );
-    
+
     QgsQuickMapSettings *mapSettings() const;
 
     void setLayerTree( FlatLayerTreeModel *layerTree );
@@ -58,9 +57,9 @@ class ProjectInfo : public QObject
     FlatLayerTreeModel *layerTree() const;
 
   signals:
-  
+
     void filePathChanged();
-    
+
     void mapSettingsChanged();
 
     void layerTreeChanged();
@@ -72,7 +71,6 @@ class ProjectInfo : public QObject
     void mapThemeChanged();
 
   private:
-  
     QString mFilePath;
 
     QgsQuickMapSettings *mMapSettings = nullptr;

--- a/src/core/projectsource.cpp
+++ b/src/core/projectsource.cpp
@@ -15,8 +15,10 @@
  ***************************************************************************/
 
 #include "projectsource.h"
+
 #include <QDebug>
 
-ProjectSource::ProjectSource( QObject *parent ) : QObject( parent )
+ProjectSource::ProjectSource( QObject *parent )
+  : QObject( parent )
 {
 }

--- a/src/core/qfield.h
+++ b/src/core/qfield.h
@@ -25,10 +25,9 @@
  */
 namespace qfield
 {
-
   /**
    * Can be used to iterate over `QMap`s in a convenient way.
-   * 
+   *
    * \code{.cpp}
    * for (auto [key, value]: asKeyValueRange(map))
    * {
@@ -36,11 +35,11 @@ namespace qfield
    * }
    * \endcode
    */
-  template <typename T> class asKeyValueRange
+  template<typename T> class asKeyValueRange
   {
     public:
       explicit asKeyValueRange( T &data )
-        : mData{data}
+        : mData { data }
       {
       }
 
@@ -51,6 +50,6 @@ namespace qfield
     private:
       T &mData;
   };
-};
+}; // namespace qfield
 
 #endif // QFIELD_H

--- a/src/core/qfieldappauthrequesthandler.cpp
+++ b/src/core/qfieldappauthrequesthandler.cpp
@@ -19,13 +19,11 @@
 
 #include <QAuthenticator>
 #include <QThread>
-#include <qgsmessagelog.h>
-
 #include <qgscredentials.h>
+#include <qgsmessagelog.h>
 
 QFieldAppAuthRequestHandler::QFieldAppAuthRequestHandler()
 {
-
 }
 
 void QFieldAppAuthRequestHandler::enterCredentials( const QString &realm, const QString &username, const QString &password )
@@ -35,7 +33,7 @@ void QFieldAppAuthRequestHandler::enterCredentials( const QString &realm, const 
 
 QString QFieldAppAuthRequestHandler::getFirstUnhandledRealm() const
 {
-  auto entry = std::find_if( mRealms.begin(), mRealms.end(), []( const RealmEntry &entry ) { return !entry.canceled; } );
+  auto entry = std::find_if( mRealms.begin(), mRealms.end(), []( const RealmEntry & entry ) { return !entry.canceled; } );
   return entry != mRealms.end() ? entry->realm : QString();
 }
 
@@ -97,7 +95,7 @@ void QFieldAppAuthRequestHandler::clearStoredRealms()
 
 void QFieldAppAuthRequestHandler::authNeeded( const QString &realm )
 {
-  if ( std::any_of( mRealms.begin(), mRealms.end(), [&realm]( const RealmEntry &entry ) { return entry.realm == realm; } ) )
+  if ( std::any_of( mRealms.begin(), mRealms.end(), [&realm]( const RealmEntry & entry ) { return entry.realm == realm; } ) )
   {
     //realm already in list
     return;
@@ -147,8 +145,7 @@ void QFieldAppAuthRequestHandler::handleAuthRequest( QNetworkReply *reply, QAuth
       // save credentials
       QgsCredentials::instance()->put(
         QStringLiteral( "%1 at %2" ).arg( auth->realm(), reply->url().host() ),
-        username, password
-      );
+        username, password );
       break;
     }
     else

--- a/src/core/qfieldappauthrequesthandler.h
+++ b/src/core/qfieldappauthrequesthandler.h
@@ -38,7 +38,6 @@ class QFieldAppAuthRequestHandler : public QObject, public QgsNetworkAuthenticat
     Q_OBJECT
 
   public:
-
     QFieldAppAuthRequestHandler();
 
     //! handles the auth request - triggered by the authRequestOccurred signal
@@ -60,7 +59,6 @@ class QFieldAppAuthRequestHandler : public QObject, public QgsNetworkAuthenticat
     void reloadEverything();
 
   private:
-
     //! adds the realm to the list on loading the project
     void authNeeded( const QString &realm );
 

--- a/src/core/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloudconnection.cpp
@@ -15,19 +15,20 @@
 
 #include "qfield.h"
 #include "qfieldcloudconnection.h"
-#include <qgsnetworkaccessmanager.h>
-#include <qgsapplication.h>
-#include <qgsmessagelog.h>
-#include <qgssettings.h>
-#include <QJsonObject>
-#include <QJsonDocument>
-#include <QNetworkCookieJar>
-#include <QNetworkCookie>
+
+#include <QFile>
 #include <QHttpMultiPart>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkCookie>
+#include <QNetworkCookieJar>
 #include <QSettings>
 #include <QTimer>
 #include <QUrlQuery>
-#include <QFile>
+#include <qgsapplication.h>
+#include <qgsmessagelog.h>
+#include <qgsnetworkaccessmanager.h>
+#include <qgssettings.h>
 
 
 QFieldCloudConnection::QFieldCloudConnection()
@@ -36,7 +37,7 @@ QFieldCloudConnection::QFieldCloudConnection()
   , mToken( QSettings().value( QStringLiteral( "/QFieldCloud/token" ) ).toByteArray() )
 {
   QgsNetworkAccessManager::instance()->setTimeout( 60 * 60 * 1000 );
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
   QgsNetworkAccessManager::instance()->setTransferTimeout( 5 * 60 * 1000 );
 #endif
   // we cannot use "/" as separator, since QGIS puts a suffix QGIS/31700 anyway
@@ -44,20 +45,21 @@ QFieldCloudConnection::QFieldCloudConnection()
   QgsSettings().setValue( QStringLiteral( "/qgis/networkAndProxy/userAgent" ), userAgent );
 }
 
-QMap<QString, QString> QFieldCloudConnection::sErrors = QMap<QString, QString>({
-{"unknown_error", QObject::tr( "QFieldCloud Unknown Error" )},
-{"status_not_ok", QObject::tr( "Status not ok" )},
-{"empty_content", QObject::tr( "Empty content" )},
-{"object_not_found", QObject::tr( "Object not found" )},
-{"api_error", QObject::tr( "API Error" )},
-{"validation_error", QObject::tr( "Validation Error" )},
-{"multiple_projects", QObject::tr( "Multiple Projects" )},
-{"invalid_deltafile", QObject::tr( "Invalid delta file" )},
-{"no_qgis_project", QObject::tr( "The project does not contain a valid QGIS project file" )},
-{"invalid_job", QObject::tr( "Invalid job" )},
-{"qgis_export_error", QObject::tr( "QGIS export failed" )},
-{"qgis_cannot_open_project", QObject::tr( "QGIS is unable to open the QGIS project" )},
-});
+QMap<QString, QString> QFieldCloudConnection::sErrors = QMap<QString, QString>(
+{
+  { "unknown_error", QObject::tr( "QFieldCloud Unknown Error" ) },
+  { "status_not_ok", QObject::tr( "Status not ok" ) },
+  { "empty_content", QObject::tr( "Empty content" ) },
+  { "object_not_found", QObject::tr( "Object not found" ) },
+  { "api_error", QObject::tr( "API Error" ) },
+  { "validation_error", QObject::tr( "Validation Error" ) },
+  { "multiple_projects", QObject::tr( "Multiple Projects" ) },
+  { "invalid_deltafile", QObject::tr( "Invalid delta file" ) },
+  { "no_qgis_project", QObject::tr( "The project does not contain a valid QGIS project file" ) },
+  { "invalid_job", QObject::tr( "Invalid job" ) },
+  { "qgis_export_error", QObject::tr( "QGIS export failed" ) },
+  { "qgis_cannot_open_project", QObject::tr( "QGIS is unable to open the QGIS project" ) },
+} );
 
 QString QFieldCloudConnection::errorString( QNetworkReply *reply )
 {
@@ -105,8 +107,8 @@ QString QFieldCloudConnection::errorString( QNetworkReply *reply )
   int httpCode = reply->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
   QString httpErrorMessage = QStringLiteral( "[HTTP/%1] %2 " ).arg( httpCode ).arg( reply->url().toString() );
   httpErrorMessage += ( httpCode >= 400 )
-      ? tr( "Server Error." )
-      : tr( "Network Error." );
+                      ? tr( "Server Error." )
+                      : tr( "Network Error." );
   httpErrorMessage += payload.left( 200 );
 
   if ( payload.size() > 200 )
@@ -180,22 +182,22 @@ void QFieldCloudConnection::setPassword( const QString &password )
 
   mPassword = password;
   emit passwordChanged();
-
 }
 
 CloudUserInformation QFieldCloudConnection::userInformation() const
 {
-    return mUserInformation;
+  return mUserInformation;
 }
 
 void QFieldCloudConnection::login()
 {
   NetworkReply *reply = ( !mToken.isEmpty() && ( mPassword.isEmpty() || mUsername.isEmpty() ) )
-        ? get( QStringLiteral( "/api/v1/auth/user/" ) )
-        : post( QStringLiteral( "/api/v1/auth/token/" ), QVariantMap({
-                         {"username", mUsername},
-                         {"password", mPassword},
-                       }) );
+                        ? get( QStringLiteral( "/api/v1/auth/user/" ) )
+                        : post( QStringLiteral( "/api/v1/auth/token/" ), QVariantMap(
+  {
+    { "username", mUsername },
+    { "password", mPassword },
+  } ) );
 
   setStatus( ConnectionStatus::Connecting );
 
@@ -262,7 +264,7 @@ void QFieldCloudConnection::login()
 
     mAvatarUrl = resp.value( QStringLiteral( "avatar_url" ) ).toString();
     emit avatarUrlChanged();
-    mUserInformation  = CloudUserInformation( mUsername, resp.value( QStringLiteral( "email" ) ).toString() );
+    mUserInformation = CloudUserInformation( mUsername, resp.value( QStringLiteral( "email" ) ).toString() );
     emit userInformationChanged();
 
     setStatus( ConnectionStatus::LoggedIn );
@@ -331,7 +333,7 @@ NetworkReply *QFieldCloudConnection::post( const QString &endpoint, const QVaria
     QHttpPart filePart;
     QFile *file = new QFile( fileName, multiPart );
 
-    if ( ! file->open( QIODevice::ReadOnly ) )
+    if ( !file->open( QIODevice::ReadOnly ) )
       return nullptr;
 
     const QString header = QStringLiteral( "form-data; name=\"file\"; filename=\"%1\"" ).arg( fileName );
@@ -350,7 +352,8 @@ NetworkReply *QFieldCloudConnection::post( const QString &endpoint, const QVaria
 
   mPendingRequests++;
   setState( ConnectionState::Busy );
-  connect( reply, &NetworkReply::finished, this, [=]() {
+  connect( reply, &NetworkReply::finished, this, [ = ]()
+  {
     QNetworkReply *rawReply = reply->reply();
     if ( --mPendingRequests == 0 )
     {
@@ -397,7 +400,7 @@ NetworkReply *QFieldCloudConnection::get( QNetworkRequest &request, const QUrl &
 {
   QUrlQuery urlQuery = QUrlQuery( url.query() );
 
-  for ( auto [ key, value ] : qfield::asKeyValueRange( params ) )
+  for ( auto [key, value] : qfield::asKeyValueRange( params ) )
     urlQuery.addQueryItem( key, value.toString() );
 
   QUrl requestUrl = url;
@@ -411,7 +414,8 @@ NetworkReply *QFieldCloudConnection::get( QNetworkRequest &request, const QUrl &
 
   mPendingRequests++;
   setState( ConnectionState::Busy );
-  connect( reply, &NetworkReply::finished, this, [=]() {
+  connect( reply, &NetworkReply::finished, this, [ = ]()
+  {
     QNetworkReply *rawReply = reply->reply();
     if ( --mPendingRequests == 0 )
     {

--- a/src/core/qfieldcloudconnection.h
+++ b/src/core/qfieldcloudconnection.h
@@ -27,18 +27,18 @@ class QNetworkRequest;
 
 struct CloudUserInformation
 {
-  Q_GADGET
+    Q_GADGET
 
   public:
-  CloudUserInformation() = default;
+    CloudUserInformation() = default;
 
-  CloudUserInformation(const QString &username, const QString &email )
-    : username( username )
-    , email( email )
-  {}
+    CloudUserInformation( const QString &username, const QString &email )
+      : username( username )
+      , email( email )
+    {}
 
-  QString username;
-  QString email;
+    QString username;
+    QString email;
 };
 
 class QFieldCloudConnection : public QObject

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -13,34 +13,33 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qfieldcloudprojectsmodel.h"
-#include "qfieldcloudconnection.h"
-#include "qfieldcloudutils.h"
-#include "layerobserver.h"
 #include "deltafilewrapper.h"
 #include "fileutils.h"
+#include "layerobserver.h"
 #include "qfield.h"
+#include "qfieldcloudconnection.h"
+#include "qfieldcloudprojectsmodel.h"
+#include "qfieldcloudutils.h"
 
-#include <qgis.h>
-#include <qgsnetworkaccessmanager.h>
-#include <qgsapplication.h>
-#include <qgsproject.h>
-#include <qgsproviderregistry.h>
-#include <qgsmessagelog.h>
-
-#include <QNetworkReply>
-#include <QTemporaryFile>
-#include <QJsonDocument>
-#include <QJsonArray>
-#include <QJsonObject>
 #include <QDir>
 #include <QDirIterator>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkReply>
 #include <QSettings>
+#include <QTemporaryFile>
+#include <qgis.h>
+#include <qgsapplication.h>
+#include <qgsmessagelog.h>
+#include <qgsnetworkaccessmanager.h>
+#include <qgsproject.h>
+#include <qgsproviderregistry.h>
 
 #define MAX_REDIRECTS_ALLOWED 10
 
-QFieldCloudProjectsModel::QFieldCloudProjectsModel() :
-  mProject( QgsProject::instance() )
+QFieldCloudProjectsModel::QFieldCloudProjectsModel()
+  : mProject( QgsProject::instance() )
 {
   QJsonArray projects;
   reload( projects );
@@ -132,7 +131,7 @@ void QFieldCloudProjectsModel::setLayerObserver( LayerObserver *layerObserver )
 
   mLayerObserver = layerObserver;
 
-  if ( ! layerObserver )
+  if ( !layerObserver )
     return;
 
   connect( layerObserver, &LayerObserver::layerEdited, this, &QFieldCloudProjectsModel::layerObserverLayerEdited );
@@ -177,7 +176,7 @@ QVariantMap QFieldCloudProjectsModel::getProjectData( const QString &projectId )
 
   const QHash<int, QByteArray> rn = this->roleNames();
 
-  for ( auto [ key, value ] : qfield::asKeyValueRange( rn ) )
+  for ( auto [key, value] : qfield::asKeyValueRange( rn ) )
   {
     data[value] = idx.data( key );
   }
@@ -237,7 +236,7 @@ void QFieldCloudProjectsModel::removeLocalProject( const QString &projectId )
         mCloudProjects[index].checkout = RemoteCheckout;
         mCloudProjects[index].modification = NoModification;
         QModelIndex idx = createIndex( index, 0 );
-        emit dataChanged( idx, idx,  QVector<int>() << StatusRole << LocalPathRole << CheckoutRole );
+        emit dataChanged( idx, idx, QVector<int>() << StatusRole << LocalPathRole << CheckoutRole );
       }
       else
       {
@@ -424,7 +423,7 @@ void QFieldCloudProjectsModel::downloadProject( const QString &projectId, bool o
     QgsLogger::debug( QStringLiteral( "Export request for \"%1\" finished with no error" ).arg( projectId ) );
 
     const QJsonObject payload = QJsonDocument::fromJson( rawReply->readAll() ).object();
-    Q_ASSERT( ! payload.isEmpty() );
+    Q_ASSERT( !payload.isEmpty() );
     mCloudProjects[index].exportStatus = exportStatus( payload.value( QStringLiteral( "status" ) ).toString() );
 
     emit dataChanged( idx, idx, QVector<int>() << ExportStatusRole );
@@ -475,7 +474,7 @@ void QFieldCloudProjectsModel::projectGetExportStatus( const QString &projectId 
     }
 
     const QJsonObject payload = QJsonDocument::fromJson( rawReply->readAll() ).object();
-    Q_ASSERT( ! payload.isEmpty() );
+    Q_ASSERT( !payload.isEmpty() );
 
     mCloudProjects[index].exportStatus = exportStatus( payload.value( QStringLiteral( "status" ) ).toString() );
 
@@ -541,10 +540,7 @@ void QFieldCloudProjectsModel::projectGetExportStatus( const QString &projectId 
 
           const QJsonObject exportedFilesPayload = QJsonDocument::fromJson( exportedFilesRawReply->readAll() ).object();
 
-          QgsLogger::debug( QStringLiteral( "Export files list request finished for \"%1\" with no error and response: %2" ).arg(
-                              projectId,
-                              QString::fromUtf8( QJsonDocument( exportedFilesPayload ).toJson( QJsonDocument::Indented ) )
-                              ) );
+          QgsLogger::debug( QStringLiteral( "Export files list request finished for \"%1\" with no error and response: %2" ).arg( projectId, QString::fromUtf8( QJsonDocument( exportedFilesPayload ).toJson( QJsonDocument::Indented ) ) ) );
 
           const QJsonArray files = exportedFilesPayload.value( QStringLiteral( "files" ) ).toArray();
           for ( const QJsonValue file : files )
@@ -576,8 +572,8 @@ void QFieldCloudProjectsModel::projectGetExportStatus( const QString &projectId 
               QString layerStatus = layer.value( QStringLiteral( "status" ) ).toString();
 
               mCloudProjects[index].exportedLayerErrors.append( tr( "Exported layer '%1' is not valid: '%2'" )
-                                                                .arg( layerName )
-                                                                .arg( layerStatus ) );
+                  .arg( layerName )
+                  .arg( layerStatus ) );
               QgsMessageLog::logMessage( mCloudProjects[index].exportedLayerErrors.last() );
 
               hasLayerExportErrror = true;
@@ -586,11 +582,8 @@ void QFieldCloudProjectsModel::projectGetExportStatus( const QString &projectId 
 
           if ( hasLayerExportErrror )
           {
-            QgsLogger::debug( QStringLiteral( "Export files list request finished for \"%1\" with some failed layers:\n%2" ).arg(
-                                projectId,
-                                mCloudProjects[index].exportedLayerErrors.join( QStringLiteral( "\n" ) )
-                                ) );
-            emit dataChanged( idx, idx,  QVector<int>() << ExportedLayerErrorsRole );
+            QgsLogger::debug( QStringLiteral( "Export files list request finished for \"%1\" with some failed layers:\n%2" ).arg( projectId, mCloudProjects[index].exportedLayerErrors.join( QStringLiteral( "\n" ) ) ) );
+            emit dataChanged( idx, idx, QVector<int>() << ExportedLayerErrorsRole );
           }
 
           projectDownloadFiles( projectId );
@@ -620,7 +613,7 @@ void QFieldCloudProjectsModel::projectDownloadFiles( const QString &projectId )
     mCloudProjects[index].status = ProjectStatus::Idle;
     mCloudProjects[index].downloadProgress = 1;
 
-    emit dataChanged( idx, idx,  QVector<int>() << StatusRole << DownloadProgressRole );
+    emit dataChanged( idx, idx, QVector<int>() << StatusRole << DownloadProgressRole );
 
     return;
   }
@@ -632,10 +625,10 @@ void QFieldCloudProjectsModel::projectDownloadFiles( const QString &projectId )
 
     file->setAutoRemove( false );
 
-    if ( ! file->open() )
+    if ( !file->open() )
     {
       mCloudProjects[index].downloadFilesFailed++;
-      projectDownloadFinishedWithError( projectId, tr("Failed to open temporary file for \"%1\", reason:\n%2")
+      projectDownloadFinishedWithError( projectId, tr( "Failed to open temporary file for \"%1\", reason:\n%2" )
                                         .arg( fileName )
                                         .arg( file->errorString() ) );
       return;
@@ -665,7 +658,7 @@ void QFieldCloudProjectsModel::projectDownloadFinishedWithError( const QString &
   mCloudProjects[index].errorStatus = DownloadErrorStatus;
   mCloudProjects[index].exportStatusString = errorString;
   QgsMessageLog::logMessage( QStringLiteral( "Download of project id \"%1\" finished with error: %2" ).arg( projectId ).arg( mCloudProjects[index].exportStatusString ) );
-  emit dataChanged( idx, idx, QVector<int>() << StatusRole << ExportStatusRole << ErrorStatusRole << ErrorStringRole);
+  emit dataChanged( idx, idx, QVector<int>() << StatusRole << ExportStatusRole << ErrorStatusRole << ErrorStringRole );
   emit projectDownloaded( projectId, mCloudProjects[index].name, true, errorString );
 }
 
@@ -687,7 +680,7 @@ bool QFieldCloudProjectsModel::projectMoveDownloadedFilesToPermanentStorage( con
     QFile file( mCloudProjects[index].downloadFileTransfers[fileName].tmpFile );
     QDir dir( QStringLiteral( "%1/%2/%3/%4" ).arg( QFieldCloudUtils::localCloudDirectory(), mUsername, projectId, fileInfo.path() ) );
 
-    if ( ! hasError && ! dir.exists() && ! dir.mkpath( QStringLiteral( "." ) ) )
+    if ( !hasError && !dir.exists() && !dir.mkpath( QStringLiteral( "." ) ) )
     {
       hasError = true;
       QgsMessageLog::logMessage( QStringLiteral( "Failed to create directory at \"%1\"" ).arg( dir.path() ) );
@@ -697,26 +690,26 @@ bool QFieldCloudProjectsModel::projectMoveDownloadedFilesToPermanentStorage( con
 
     // if the file already exists, we need to delete it first, as QT does not support overwriting
     // NOTE: it is possible that someone creates the file in the meantime between this and the next if statement
-    if ( ! hasError && QFile::exists( destinationFileName ) && ! file.remove( destinationFileName ) )
+    if ( !hasError && QFile::exists( destinationFileName ) && !file.remove( destinationFileName ) )
     {
       hasError = true;
       QgsMessageLog::logMessage( QStringLiteral( "Failed to remove file before overwriting stored at \"%1\", reason:\n%2" ).arg( fileName ).arg( file.errorString() ) );
     }
 
-    if ( ! hasError && ! file.copy( destinationFileName ) )
+    if ( !hasError && !file.copy( destinationFileName ) )
     {
       hasError = true;
       QgsMessageLog::logMessage( QStringLiteral( "Failed to write downloaded file stored at \"%1\", reason:\n%2" ).arg( fileName ).arg( file.errorString() ) );
 
-      if ( ! QFile::remove( dir.filePath( fileName ) ) )
+      if ( !QFile::remove( dir.filePath( fileName ) ) )
         QgsMessageLog::logMessage( QStringLiteral( "Failed to remove partly overwritten file stored at \"%1\"" ).arg( fileName ) );
     }
 
-    if ( ! file.remove() )
+    if ( !file.remove() )
       QgsMessageLog::logMessage( QStringLiteral( "Failed to remove temporary file \"%1\"" ).arg( fileName ) );
   }
 
-  return ! hasError;
+  return !hasError;
 }
 
 
@@ -744,7 +737,7 @@ void QFieldCloudProjectsModel::uploadProject( const QString &projectId, const bo
   if ( !( mCloudProjects[index].modification & LocalModification ) )
     return;
 
-  if ( ! mLayerObserver->deltaFileWrapper()->toFile() )
+  if ( !mLayerObserver->deltaFileWrapper()->toFile() )
     return;
 
   QModelIndex idx = createIndex( index, 0 );
@@ -762,7 +755,7 @@ void QFieldCloudProjectsModel::uploadProject( const QString &projectId, const bo
 
   refreshProjectModification( projectId );
 
-  emit dataChanged( idx, idx,  QVector<int>() << StatusRole << UploadAttachmentsCountRole << UploadDeltaProgressRole << UploadDeltaStatusRole << UploadDeltaStatusStringRole );
+  emit dataChanged( idx, idx, QVector<int>() << StatusRole << UploadAttachmentsCountRole << UploadDeltaProgressRole << UploadDeltaStatusRole << UploadDeltaStatusStringRole );
 
   // //////////
   // prepare attachment files to be uploaded
@@ -803,7 +796,7 @@ void QFieldCloudProjectsModel::uploadProject( const QString &projectId, const bo
   if ( deltaFileToUpload.isEmpty() )
   {
     mCloudProjects[index].status = ProjectStatus::Idle;
-    emit dataChanged( idx, idx,  QVector<int>() << StatusRole );
+    emit dataChanged( idx, idx, QVector<int>() << StatusRole );
     return;
   }
 
@@ -813,7 +806,7 @@ void QFieldCloudProjectsModel::uploadProject( const QString &projectId, const bo
   NetworkReply *deltasCloudReply = mCloudConnection->post(
                                      QStringLiteral( "/api/v1/deltas/%1/" ).arg( projectId ),
                                      QVariantMap(),
-                                     QStringList( {deltaFileToUpload} ) );
+                                     QStringList( { deltaFileToUpload } ) );
 
   Q_ASSERT( deltasCloudReply );
 
@@ -821,7 +814,7 @@ void QFieldCloudProjectsModel::uploadProject( const QString &projectId, const bo
   {
     mCloudProjects[index].uploadDeltaProgress = std::clamp( ( static_cast<double>( bytesSent ) / bytesTotal ), 0., 1. );
 
-    emit dataChanged( idx, idx,  QVector<int>() << UploadDeltaProgressRole );
+    emit dataChanged( idx, idx, QVector<int>() << UploadDeltaProgressRole );
   } );
   connect( deltasCloudReply, &NetworkReply::finished, this, [ = ]()
   {
@@ -846,7 +839,7 @@ void QFieldCloudProjectsModel::uploadProject( const QString &projectId, const bo
     mCloudProjects[index].deltaFileUploadStatus = DeltaPendingStatus;
     mCloudProjects[index].deltaLayersToDownload = deltaFileWrapper->deltaLayerIds();
 
-    emit dataChanged( idx, idx,  QVector<int>() << UploadDeltaProgressRole << UploadDeltaStatusRole );
+    emit dataChanged( idx, idx, QVector<int>() << UploadDeltaProgressRole << UploadDeltaStatusRole );
     emit networkDeltaUploaded( projectId );
   } );
 
@@ -877,7 +870,7 @@ void QFieldCloudProjectsModel::uploadProject( const QString &projectId, const bo
       deltaFileWrapper->reset();
       deltaFileWrapper->resetId();
 
-      if ( ! deltaFileWrapper->toFile() )
+      if ( !deltaFileWrapper->toFile() )
         QgsMessageLog::logMessage( QStringLiteral( "Failed to reset delta file after delta push. %1" ).arg( deltaFileWrapper->errorString() ) );
 
       QModelIndex idx = createIndex( index, 0 );
@@ -914,7 +907,7 @@ void QFieldCloudProjectsModel::uploadProject( const QString &projectId, const bo
         delete networkDeltaStatusCheckedParent;
         deltaFileWrapper->resetId();
 
-        if ( ! deltaFileWrapper->toFile() )
+        if ( !deltaFileWrapper->toFile() )
           QgsMessageLog::logMessage( QStringLiteral( "Failed update committed delta file." ) );
 
         projectCancelUpload( projectId );
@@ -927,7 +920,7 @@ void QFieldCloudProjectsModel::uploadProject( const QString &projectId, const bo
         deltaFileWrapper->reset();
         deltaFileWrapper->resetId();
 
-        if ( ! deltaFileWrapper->toFile() )
+        if ( !deltaFileWrapper->toFile() )
           QgsMessageLog::logMessage( QStringLiteral( "Failed to reset delta file. %1" ).arg( deltaFileWrapper->errorString() ) );
 
         mCloudProjects[index].status = ProjectStatus::Idle;
@@ -955,36 +948,36 @@ void QFieldCloudProjectsModel::uploadProject( const QString &projectId, const bo
   } );
 
 
-// this code is no longer needed, as we do not upload or download files selectively
-// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-//  // //////////
-//  // 4) project downloaded, if all done, then reload the project and sync done!
-//  // //////////
-//  connect( this, &QFieldCloudProjectsModel::networkAllLayersDownloaded, this, [ = ]( const QString & callerProjectId )
-//  {
-//    if ( projectId != callerProjectId )
-//      return;
+  // this code is no longer needed, as we do not upload or download files selectively
+  // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  //  // //////////
+  //  // 4) project downloaded, if all done, then reload the project and sync done!
+  //  // //////////
+  //  connect( this, &QFieldCloudProjectsModel::networkAllLayersDownloaded, this, [ = ]( const QString & callerProjectId )
+  //  {
+  //    if ( projectId != callerProjectId )
+  //      return;
 
-//    // wait until all layers are downloaded
-//    if ( mCloudProjects[index].downloadLayersFinished < mCloudProjects[index].deltaLayersToDownload.size() )
-//      return;
+  //    // wait until all layers are downloaded
+  //    if ( mCloudProjects[index].downloadLayersFinished < mCloudProjects[index].deltaLayersToDownload.size() )
+  //      return;
 
-//    // there are some files that failed to download
-//    if ( mCloudProjects[index].downloadLayersFailed > 0 )
-//    {
-//      // TODO translate this message
-//      mCloudProjects[index].deltaFileUploadStatusString = QStringLiteral( "Failed to retrieve some of the updated layers, but changes are committed on the server. "
-//                            "Try to reload the project from the cloud." );
-//      projectCancelUpload( projectId );
+  //    // there are some files that failed to download
+  //    if ( mCloudProjects[index].downloadLayersFailed > 0 )
+  //    {
+  //      // TODO translate this message
+  //      mCloudProjects[index].deltaFileUploadStatusString = QStringLiteral( "Failed to retrieve some of the updated layers, but changes are committed on the server. "
+  //                            "Try to reload the project from the cloud." );
+  //      projectCancelUpload( projectId );
 
-//      return;
-//    }
+  //      return;
+  //    }
 
-//    QgsProject::instance()->reloadAllLayers();
+  //    QgsProject::instance()->reloadAllLayers();
 
-//    emit dataChanged( idx, idx, QVector<int>() << StatusRole );
-//    emit syncFinished( projectId, false );
-//  } );
+  //    emit dataChanged( idx, idx, QVector<int>() << StatusRole );
+  //    emit syncFinished( projectId, false );
+  //  } );
 }
 
 
@@ -1011,7 +1004,7 @@ void QFieldCloudProjectsModel::projectApplyDeltas( const QString &projectId )
       mCloudProjects[index].deltaFileUploadStatus = DeltaErrorStatus;
       mCloudProjects[index].deltaFileUploadStatusString = QFieldCloudConnection::errorString( rawReply );
 
-      emit dataChanged( idx, idx,  QVector<int>() << UploadDeltaStatusRole << UploadDeltaStatusStringRole );
+      emit dataChanged( idx, idx, QVector<int>() << UploadDeltaStatusRole << UploadDeltaStatusStringRole );
       emit networkDeltaStatusChecked( projectId );
       return;
     }
@@ -1051,7 +1044,7 @@ void QFieldCloudProjectsModel::refreshProjectDeltaList( const QString &projectId
 
     mCloudProjects[index].deltaListModel = new DeltaListModel( doc );
 
-    emit dataChanged( idx, idx,  QVector<int>() << DeltaListRole );
+    emit dataChanged( idx, idx, QVector<int>() << DeltaListRole );
     emit networkDeltaStatusChecked( projectId );
   } );
 }
@@ -1082,7 +1075,7 @@ void QFieldCloudProjectsModel::projectGetDeltaStatus( const QString &projectId )
       // TODO this is oversimplification. e.g. 404 error is when the requested delta file id is not existant
       mCloudProjects[index].deltaFileUploadStatusString = QFieldCloudConnection::errorString( rawReply );
 
-      emit dataChanged( idx, idx,  QVector<int>() << UploadDeltaStatusRole << UploadDeltaStatusStringRole );
+      emit dataChanged( idx, idx, QVector<int>() << UploadDeltaStatusRole << UploadDeltaStatusStringRole );
       emit networkDeltaStatusChecked( projectId );
 
       return;
@@ -1098,7 +1091,7 @@ void QFieldCloudProjectsModel::projectGetDeltaStatus( const QString &projectId )
     {
       mCloudProjects[index].deltaFileUploadStatus = DeltaErrorStatus;
       mCloudProjects[index].deltaFileUploadStatusString = deltaListModel.errorString();
-      emit dataChanged( idx, idx,  QVector<int>() << UploadDeltaStatusRole << UploadDeltaStatusStringRole );
+      emit dataChanged( idx, idx, QVector<int>() << UploadDeltaStatusRole << UploadDeltaStatusStringRole );
       emit networkDeltaStatusChecked( projectId );
       return;
     }
@@ -1108,14 +1101,14 @@ void QFieldCloudProjectsModel::projectGetDeltaStatus( const QString &projectId )
     if ( !deltaListModel.allHaveFinalStatus() )
     {
       mCloudProjects[index].deltaFileUploadStatus = DeltaPendingStatus;
-      emit dataChanged( idx, idx,  QVector<int>() << UploadDeltaStatusRole << UploadDeltaStatusStringRole );
+      emit dataChanged( idx, idx, QVector<int>() << UploadDeltaStatusRole << UploadDeltaStatusStringRole );
       emit networkDeltaStatusChecked( projectId );
       return;
     }
 
     mCloudProjects[index].deltaFileUploadStatus = DeltaAppliedStatus;
 
-    emit dataChanged( idx, idx,  QVector<int>() << UploadDeltaStatusRole << UploadDeltaStatusStringRole );
+    emit dataChanged( idx, idx, QVector<int>() << UploadDeltaStatusRole << UploadDeltaStatusStringRole );
     emit networkDeltaStatusChecked( projectId );
   } );
 }
@@ -1132,7 +1125,7 @@ void QFieldCloudProjectsModel::projectUploadAttachments( const QString &projectI
   // start uploading the attachments
   const QStringList attachmentFileNames = mCloudProjects[index].uploadAttachments.keys();
   mCloudProjects[index].uploadAttachmentsStatus = UploadAttachmentsStatus::UploadAttachmentsInProgress;
-  emit dataChanged( idx, idx, QVector<int>() << UploadAttachmentsStatusRole);
+  emit dataChanged( idx, idx, QVector<int>() << UploadAttachmentsStatusRole );
   for ( const QString &fileName : attachmentFileNames )
   {
     NetworkReply *attachmentCloudReply = uploadAttachment( projectId, fileName );
@@ -1216,7 +1209,7 @@ void QFieldCloudProjectsModel::projectCancelUploadAttachments( const QString &pr
   }
   mCloudProjects[index].uploadAttachmentsStatus = UploadAttachmentsStatus::UploadAttachmentsDone;
   QModelIndex idx = createIndex( index, 0 );
-  emit dataChanged( idx, idx, QVector<int>() << UploadAttachmentsStatusRole);
+  emit dataChanged( idx, idx, QVector<int>() << UploadAttachmentsStatusRole );
 }
 
 void QFieldCloudProjectsModel::connectionStatusChanged()
@@ -1303,7 +1296,7 @@ void QFieldCloudProjectsModel::downloadFileConnections( const QString &projectId
 
   QStringList fileNames = mCloudProjects[index].downloadFileTransfers.keys();
 
-  connect( reply, &NetworkReply::redirected, reply, [ = ] ( const QUrl &url )
+  connect( reply, &NetworkReply::redirected, reply, [ = ]( const QUrl & url )
   {
     QUrl oldUrl = mCloudProjects[index].downloadFileTransfers[fileName].lastRedirectUrl;
 
@@ -1331,7 +1324,7 @@ void QFieldCloudProjectsModel::downloadFileConnections( const QString &projectId
     emit reply->abort();
 
     downloadFileConnections( projectId, fileName );
-  });
+  } );
 
   connect( reply, &NetworkReply::downloadProgress, reply, [ = ]( int bytesReceived, int bytesTotal )
   {
@@ -1345,7 +1338,7 @@ void QFieldCloudProjectsModel::downloadFileConnections( const QString &projectId
 
     QModelIndex idx = createIndex( index, 0 );
 
-    emit dataChanged( idx, idx,  QVector<int>() << DownloadProgressRole );
+    emit dataChanged( idx, idx, QVector<int>() << DownloadProgressRole );
   } );
 
   connect( reply, &NetworkReply::finished, reply, [ = ]()
@@ -1380,7 +1373,7 @@ void QFieldCloudProjectsModel::downloadFileConnections( const QString &projectId
 
     file.open( QIODevice::ReadWrite );
 
-    if ( ! hasError && ! file.write( rawReply->readAll() ) )
+    if ( !hasError && !file.write( rawReply->readAll() ) )
     {
       hasError = true;
       errorMessageDetail = file.errorString();
@@ -1406,7 +1399,7 @@ void QFieldCloudProjectsModel::downloadFileConnections( const QString &projectId
 
     if ( mCloudProjects[index].downloadFilesFinished == fileNames.count() )
     {
-      if ( ! hasError )
+      if ( !hasError )
       {
         const QStringList unprefixedGpkgFileNames = filterGpkgFileNames( fileNames );
         const QStringList gpkgFileNames = projectFileNames( mProject->homePath(), unprefixedGpkgFileNames );
@@ -1417,7 +1410,7 @@ void QFieldCloudProjectsModel::downloadFileConnections( const QString &projectId
           mGpkgFlusher->stop( fileName );
 
         // move the files from their temporary location to their permanent one
-        if ( ! projectMoveDownloadedFilesToPermanentStorage( projectId ) )
+        if ( !projectMoveDownloadedFilesToPermanentStorage( projectId ) )
           mCloudProjects[index].errorStatus = DownloadErrorStatus;
 
         deleteGpkgShmAndWal( gpkgFileNames );
@@ -1499,7 +1492,8 @@ void QFieldCloudProjectsModel::reload( const QJsonArray &remoteProjects )
 
   QgsProject *qgisProject = QgsProject::instance();
 
-  auto restoreLocalSettings = [=]( CloudProject &cloudProject, const QDir &localPath ) {
+  auto restoreLocalSettings = [ = ]( CloudProject & cloudProject, const QDir & localPath )
+  {
     cloudProject.deltasCount = DeltaFileWrapper( qgisProject, QStringLiteral( "%1/deltafile.json" ).arg( localPath.absolutePath() ) ).count();
     cloudProject.lastLocalExport = projectSetting( cloudProject.id, QStringLiteral( "lastLocalExport" ) ).toString();
     cloudProject.lastLocalPushDeltas = projectSetting( cloudProject.id, QStringLiteral( "lastLocalPushDeltas" ) ).toString();
@@ -1548,7 +1542,7 @@ void QFieldCloudProjectsModel::reload( const QJsonArray &remoteProjects )
   }
 
   QDirIterator userDirs( QFieldCloudUtils::localCloudDirectory(), QDir::Dirs | QDir::NoDotAndDotDot );
-  while( userDirs.hasNext() )
+  while ( userDirs.hasNext() )
   {
     userDirs.next();
     const QString username = userDirs.fileName();
@@ -1640,7 +1634,7 @@ QVariant QFieldCloudProjectsModel::data( const QModelIndex &index, int role ) co
     case UploadAttachmentsStatusRole:
       return mCloudProjects.at( index.row() ).uploadAttachmentsStatus;
     case UploadAttachmentsCountRole:
-      return mCloudProjects.at( index.row() ).uploadAttachments.size() - mCloudProjects[ index.row() ].uploadAttachmentsFailed;
+      return mCloudProjects.at( index.row() ).uploadAttachments.size() - mCloudProjects[index.row()].uploadAttachmentsFailed;
     case UploadDeltaProgressRole:
       return mCloudProjects.at( index.row() ).uploadDeltaProgress;
     case UploadDeltaStatusRole:
@@ -1675,10 +1669,10 @@ bool QFieldCloudProjectsModel::revertLocalChangesFromCurrentProject()
 
   DeltaFileWrapper *deltaFileWrapper = mLayerObserver->deltaFileWrapper();
 
-  if ( ! deltaFileWrapper->toFile() )
+  if ( !deltaFileWrapper->toFile() )
     return false;
 
-  if ( ! deltaFileWrapper->applyReversed() )
+  if ( !deltaFileWrapper->applyReversed() )
   {
     QgsMessageLog::logMessage( QStringLiteral( "Failed to apply reversed" ) );
     return false;
@@ -1689,7 +1683,7 @@ bool QFieldCloudProjectsModel::revertLocalChangesFromCurrentProject()
   deltaFileWrapper->reset();
   deltaFileWrapper->resetId();
 
-  if ( ! deltaFileWrapper->toFile() )
+  if ( !deltaFileWrapper->toFile() )
     return false;
 
   return true;
@@ -1703,7 +1697,7 @@ bool QFieldCloudProjectsModel::discardLocalChangesFromCurrentProject()
 
   DeltaFileWrapper *deltaFileWrapper = mLayerObserver->deltaFileWrapper();
 
-  if ( ! deltaFileWrapper->toFile() )
+  if ( !deltaFileWrapper->toFile() )
     QgsMessageLog::logMessage( QStringLiteral( "Failed to write deltas." ) );
 
   mCloudProjects[index].modification ^= LocalModification;
@@ -1736,7 +1730,7 @@ bool QFieldCloudProjectsModel::deleteGpkgShmAndWal( const QStringList &gpkgFileN
     QFile shmFile( QStringLiteral( "%1-shm" ).arg( fileName ) );
     if ( shmFile.exists() )
     {
-      if ( ! shmFile.remove() )
+      if ( !shmFile.remove() )
       {
         QgsMessageLog::logMessage( QStringLiteral( "Failed to remove -shm file '%1' " ).arg( shmFile.fileName() ) );
         isSuccess = false;
@@ -1747,7 +1741,7 @@ bool QFieldCloudProjectsModel::deleteGpkgShmAndWal( const QStringList &gpkgFileN
 
     if ( walFile.exists() )
     {
-      if ( ! walFile.remove() )
+      if ( !walFile.remove() )
       {
         QgsMessageLog::logMessage( QStringLiteral( "Failed to remove -wal file '%1' " ).arg( walFile.fileName() ) );
         isSuccess = false;
@@ -1838,7 +1832,7 @@ QFieldCloudProjectsFilterModel::ProjectsFilter QFieldCloudProjectsFilterModel::f
 
 void QFieldCloudProjectsFilterModel::setShowLocalOnly( bool showLocalOnly )
 {
-  if ( mShowLocalOnly == showLocalOnly)
+  if ( mShowLocalOnly == showLocalOnly )
     return;
 
   mShowLocalOnly = showLocalOnly;
@@ -1854,19 +1848,17 @@ bool QFieldCloudProjectsFilterModel::showLocalOnly() const
 
 bool QFieldCloudProjectsFilterModel::filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const
 {
-  if ( mShowLocalOnly &&
-       mSourceModel->data( mSourceModel->index( source_row, 0, source_parent ), QFieldCloudProjectsModel::LocalPathRole ).toString().isEmpty() )
+  if ( mShowLocalOnly && mSourceModel->data( mSourceModel->index( source_row, 0, source_parent ), QFieldCloudProjectsModel::LocalPathRole ).toString().isEmpty() )
   {
     return false;
   }
 
   bool ok = false;
-  switch( mFilter )
+  switch ( mFilter )
   {
     case PrivateProjects:
       // the list will include public "community" projects that are present locally so they can appear in the "My projects" list
-      ok = mSourceModel->data( mSourceModel->index( source_row, 0, source_parent ), QFieldCloudProjectsModel::PrivateRole ).toBool() ||
-           !mSourceModel->data( mSourceModel->index( source_row, 0, source_parent ), QFieldCloudProjectsModel::LocalPathRole ).toString().isEmpty();
+      ok = mSourceModel->data( mSourceModel->index( source_row, 0, source_parent ), QFieldCloudProjectsModel::PrivateRole ).toBool() || !mSourceModel->data( mSourceModel->index( source_row, 0, source_parent ), QFieldCloudProjectsModel::LocalPathRole ).toString().isEmpty();
       break;
     case PublicProjects:
       ok = !mSourceModel->data( mSourceModel->index( source_row, 0, source_parent ), QFieldCloudProjectsModel::PrivateRole ).toBool();

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -16,13 +16,13 @@
 #ifndef QFIELDCLOUDPROJECTSMODEL_H
 #define QFIELDCLOUDPROJECTSMODEL_H
 
-#include "qgsnetworkaccessmanager.h"
-#include "qgsgpkgflusher.h"
 #include "deltalistmodel.h"
+#include "qgsgpkgflusher.h"
+#include "qgsnetworkaccessmanager.h"
 
 #include <QAbstractListModel>
-#include <QSortFilterProxyModel>
 #include <QNetworkReply>
+#include <QSortFilterProxyModel>
 #include <QTimer>
 
 
@@ -39,7 +39,6 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     Q_OBJECT
 
   public:
-
     enum ColumnRole
     {
       IdRole = Qt::UserRole + 1,
@@ -200,7 +199,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     Q_INVOKABLE void refreshProjectsList();
 
     //! Downloads a cloud project with given \a projectId and all of its files.
-    Q_INVOKABLE void downloadProject( const QString &projectId, bool overwriteProject = false );    //! Downloads a cloud project with given \a projectId and all of its files.
+    Q_INVOKABLE void downloadProject( const QString &projectId, bool overwriteProject = false ); //! Downloads a cloud project with given \a projectId and all of its files.
 
     //! Cancels ongoing cloud project download with \a projectId.
     Q_INVOKABLE void cancelDownloadProject( const QString &projectId );
@@ -249,7 +248,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     void canSyncCurrentProjectChanged();
     void gpkgFlusherChanged();
     void warning( const QString &message );
-    void projectDownloaded( const QString &projectId, const QString &projectName, const bool hasError, const QString &errorString = QString());
+    void projectDownloaded( const QString &projectId, const QString &projectName, const bool hasError, const QString &errorString = QString() );
     void projectStatusChanged( const QString &projectId, const ProjectStatus &projectStatus );
 
     //
@@ -270,6 +269,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     int findProject( const QString &projectId ) const;
 
     void layerObserverLayerEdited( const QString &layerId );
+
   private:
     static const int sDelayBeforeStatusRetry = 1000;
 
@@ -279,13 +279,8 @@ class QFieldCloudProjectsModel : public QAbstractListModel
         const QString &fileName,
         const long long bytesTotal,
         NetworkReply *networkReply = nullptr,
-        const QStringList &layerIds = QStringList()
-      )
-        : fileName( fileName ),
-          bytesTotal( bytesTotal ),
-          networkReply( networkReply ),
-          layerIds( layerIds )
-      {};
+        const QStringList &layerIds = QStringList() )
+        : fileName( fileName ), bytesTotal( bytesTotal ), networkReply( networkReply ), layerIds( layerIds ) {};
 
       FileTransfer() = default;
 
@@ -414,7 +409,6 @@ class QFieldCloudProjectsFilterModel : public QSortFilterProxyModel
     Q_PROPERTY( bool showLocalOnly READ showLocalOnly WRITE setShowLocalOnly NOTIFY showLocalOnlyChanged )
 
   public:
-
     enum ProjectsFilter
     {
       PrivateProjects,
@@ -462,11 +456,9 @@ class QFieldCloudProjectsFilterModel : public QSortFilterProxyModel
     void showLocalOnlyChanged();
 
   protected:
-
     virtual bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const override;
 
   private:
-
     QFieldCloudProjectsModel *mSourceModel = nullptr;
     ProjectsFilter mFilter = PrivateProjects;
     bool mShowLocalOnly = false;

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -20,132 +20,127 @@
 #ifndef _MSC_VER
 #include <unistd.h>
 #endif
+#include <proj.h>
 #include <stdlib.h>
 
-#include <proj.h>
-
 // use GDAL VSI mechanism
-#define CPL_SUPRESS_CPLUSPLUS  //#spellok
+#define CPL_SUPRESS_CPLUSPLUS //#spellok
 #include "cpl_conv.h"
 #include "cpl_string.h"
 #include "cpl_vsi.h"
 
 #include <QFontDatabase>
+#include <QStandardItemModel>
 #include <QStandardPaths>
-#include <QtQml/QQmlEngine>
-#include <QtQml/QQmlContext>
 #include <QtQml/QQmlApplicationEngine>
+#include <QtQml/QQmlContext>
+#include <QtQml/QQmlEngine>
 #include <QtWidgets/QDesktopWidget>
 #include <QtWidgets/QFileDialog> // Until native looking QML dialogs are implemented (Qt5.4?)
-#include <QtWidgets/QMenu> // Until native looking QML dialogs are implemented (Qt5.4?)
+#include <QtWidgets/QMenu>       // Until native looking QML dialogs are implemented (Qt5.4?)
 #include <QtWidgets/QMenuBar>
-#include <QStandardItemModel>
 #ifndef QT_NO_PRINTER
-#include <QPrinter>
 #include <QPrintDialog>
+#include <QPrinter>
 #endif
-#include <QTemporaryFile>
-#include <QFileInfo>
-#include <QFontDatabase>
-#include <QStyleHints>
-#include <QResource>
-
-#include <qgslayertreemodel.h>
-#include <qgslayoutatlas.h>
-#include <qgslocalizeddatapathregistry.h>
-#include <qgsproject.h>
-#include <qgsprojectviewsettings.h>
-#include <qgsfeature.h>
-#include <qgsvectorlayer.h>
-#include <qgsrasterlayer.h>
-#include <qgsrasterresamplefilter.h>
-#include <qgsbilinearrasterresampler.h>
-#include <qgssnappingutils.h>
-#include <qgsunittypes.h>
-#include <qgscoordinatereferencesystem.h>
-#include <qgsmapthemecollection.h>
-#include <qgsprintlayout.h>
-#include <qgslayoutmanager.h>
-#include <qgslayoutpagecollection.h>
-#include <qgslayoutitemmap.h>
-#include <qgslocator.h>
-#include <qgslocatormodel.h>
-#include <qgsfield.h>
-#include <qgsfieldconstraints.h>
-#include <qgsmaplayer.h>
-#include <qgsvectorlayereditbuffer.h>
-#include <qgsexpressionfunction.h>
-#include <qgslayertree.h>
-#include <qgssinglesymbolrenderer.h>
-
-#include "qgsquickmapsettings.h"
-#include "qgsquickmapcanvasmap.h"
-#include "qgsquickcoordinatetransformer.h"
-#include "qgsquickmaptransform.h"
-
-#include "qgsnetworkaccessmanager.h"
-
-#include "qgismobileapp.h"
-
 #include "appinterface.h"
-#include "featurelistmodelselection.h"
-#include "featurelistextentcontroller.h"
-#include "modelhelper.h"
-#include "rubberband.h"
-#include "rubberbandmodel.h"
-#include "qgsofflineediting.h"
-#include "messagelogmodel.h"
 #include "attributeformmodel.h"
-#include "geometry.h"
-#include "featuremodel.h"
-#include "layertreemapcanvasbridge.h"
-#include "identifytool.h"
-#include "submodel.h"
-#include "expressionvariablemodel.h"
 #include "badlayerhandler.h"
-#include "snappingutils.h"
-#include "snappingresult.h"
-#include "layertreemodel.h"
-#include "legendimageprovider.h"
-#include "featurelistmodel.h"
-#include "qgsrelationmanager.h"
+#include "bluetoothdevicemodel.h"
+#include "bluetoothreceiver.h"
+#include "changelogcontents.h"
+#include "deltafilewrapper.h"
+#include "deltalistmodel.h"
 #include "distancearea.h"
-#include "printlayoutlistmodel.h"
-#include "vertexmodel.h"
-#include "maptoscreen.h"
-#include "projectinfo.h"
-#include "projectsource.h"
-#include "locatormodelsuperbridge.h"
-#include "qgsgeometrywrapper.h"
-#include "linepolygonhighlight.h"
-#include "valuemapmodel.h"
-#include "recentprojectlistmodel.h"
-#include "referencingfeaturelistmodel.h"
+#include "expressionevaluator.h"
+#include "expressionvariablemodel.h"
 #include "featurechecklistmodel.h"
+#include "featurelistextentcontroller.h"
+#include "featurelistmodel.h"
+#include "featurelistmodelselection.h"
+#include "featuremodel.h"
+#include "featureutils.h"
+#include "fileutils.h"
+#include "geometry.h"
 #include "geometryeditorsmodel.h"
 #include "geometryutils.h"
-#include "trackingmodel.h"
-#include "fileutils.h"
-#include "featureutils.h"
-#include "layerutils.h"
-#include "expressionevaluator.h"
-#include "stringutils.h"
-#include "urlutils.h"
-#include "bluetoothreceiver.h"
-#include "bluetoothdevicemodel.h"
 #include "gnsspositioninformation.h"
-#include "changelogcontents.h"
+#include "identifytool.h"
+#include "layerobserver.h"
 #include "layerresolver.h"
+#include "layertreemapcanvasbridge.h"
+#include "layertreemodel.h"
+#include "layerutils.h"
+#include "legendimageprovider.h"
+#include "linepolygonhighlight.h"
+#include "locatormodelsuperbridge.h"
+#include "maptoscreen.h"
+#include "messagelogmodel.h"
+#include "modelhelper.h"
+#include "printlayoutlistmodel.h"
+#include "projectinfo.h"
+#include "projectsource.h"
 #include "qfieldcloudconnection.h"
 #include "qfieldcloudprojectsmodel.h"
 #include "qfieldcloudutils.h"
-#include "layerobserver.h"
-#include "deltafilewrapper.h"
-#include "deltalistmodel.h"
+#include "qgismobileapp.h"
+#include "qgsgeometrywrapper.h"
+#include "qgsnetworkaccessmanager.h"
+#include "qgsofflineediting.h"
+#include "qgsquickcoordinatetransformer.h"
+#include "qgsquickmapcanvasmap.h"
+#include "qgsquickmapsettings.h"
+#include "qgsquickmaptransform.h"
+#include "qgsrelationmanager.h"
+#include "recentprojectlistmodel.h"
+#include "referencingfeaturelistmodel.h"
+#include "rubberband.h"
+#include "rubberbandmodel.h"
+#include "snappingresult.h"
+#include "snappingutils.h"
+#include "stringutils.h"
+#include "submodel.h"
+#include "trackingmodel.h"
+#include "urlutils.h"
+#include "valuemapmodel.h"
+#include "vertexmodel.h"
+
+#include <QFileInfo>
+#include <QFontDatabase>
+#include <QResource>
+#include <QStyleHints>
+#include <QTemporaryFile>
+#include <qgsbilinearrasterresampler.h>
+#include <qgscoordinatereferencesystem.h>
+#include <qgsexpressionfunction.h>
+#include <qgsfeature.h>
+#include <qgsfield.h>
+#include <qgsfieldconstraints.h>
+#include <qgslayertree.h>
+#include <qgslayertreemodel.h>
+#include <qgslayoutatlas.h>
+#include <qgslayoutitemmap.h>
+#include <qgslayoutmanager.h>
+#include <qgslayoutpagecollection.h>
+#include <qgslocalizeddatapathregistry.h>
+#include <qgslocator.h>
+#include <qgslocatormodel.h>
+#include <qgsmaplayer.h>
+#include <qgsmapthemecollection.h>
+#include <qgsprintlayout.h>
+#include <qgsproject.h>
+#include <qgsprojectviewsettings.h>
+#include <qgsrasterlayer.h>
+#include <qgsrasterresamplefilter.h>
+#include <qgssinglesymbolrenderer.h>
+#include <qgssnappingutils.h>
+#include <qgsunittypes.h>
+#include <qgsvectorlayer.h>
+#include <qgsvectorlayereditbuffer.h>
 
 
-#define QUOTE(string) _QUOTE(string)
-#define _QUOTE(string) #string
+#define QUOTE( string ) _QUOTE( string )
+#define _QUOTE( string ) #string
 
 
 QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
@@ -176,11 +171,15 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
     QgsApplication::instance()->localizedDataPathRegistry()->setPaths( localizedDataPaths );
 
     // set fonts
-    const QString fontsPath  = PlatformUtilities::instance()->qfieldDataDir() + QStringLiteral( "fonts/" );
+    const QString fontsPath = PlatformUtilities::instance()->qfieldDataDir() + QStringLiteral( "fonts/" );
     QDir fontsDir( fontsPath );
     if ( fontsDir.exists() )
     {
-      const QStringList fonts = fontsDir.entryList( QStringList() << "*.ttf" << "*.TTF" << "*.otf" << "*.OTF", QDir::Files );
+      const QStringList fonts = fontsDir.entryList( QStringList() << "*.ttf"
+                                << "*.TTF"
+                                << "*.otf"
+                                << "*.OTF",
+                                QDir::Files );
       for ( auto font : fonts )
       {
         QFontDatabase::addApplicationFont( fontsPath + font );
@@ -250,7 +249,7 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
     {
       free( newPaths[i] );
     }
-    delete [] newPaths;
+    delete[] newPaths;
 
 #ifdef Q_OS_ANDROID
     setenv( "PGSYSCONFDIR", PlatformUtilities::instance()->qfieldDataDir().toUtf8(), true );
@@ -272,7 +271,7 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   {
     Q_UNUSED( projectName );
     Q_UNUSED( errorString );
-    if ( ! hasError )
+    if ( !hasError )
     {
       if ( projectId == QFieldCloudUtils::getProjectId( mProject ) )
       {
@@ -282,7 +281,7 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   } );
 
   mFlatLayerTree->layerTreeModel()->setLegendMapViewData( mMapCanvas->mapSettings()->mapSettings().mapUnitsPerPixel(),
-      static_cast< int >( std::round( mMapCanvas->mapSettings()->outputDpi() ) ), mMapCanvas->mapSettings()->mapSettings().scale() );
+      static_cast<int>( std::round( mMapCanvas->mapSettings()->outputDpi() ) ), mMapCanvas->mapSettings()->mapSettings().scale() );
 
   Q_ASSERT_X( mMapCanvas, "QML Init", "QgsQuickMapCanvasMap not found. It is likely that we failed to load the QML files. Check debug output for related messages." );
 
@@ -308,8 +307,7 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
 
 void QgisMobileapp::initDeclarative()
 {
-
-#if defined(Q_OS_ANDROID) && QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+#if defined( Q_OS_ANDROID ) && QT_VERSION >= QT_VERSION_CHECK( 5, 14, 0 )
   QResource::registerResource( QStringLiteral( "assets:/android_rcc_bundle.rcc" ) );
 #endif
   addImportPath( QStringLiteral( "qrc:/qml/imports" ) );
@@ -329,8 +327,8 @@ void QgisMobileapp::initDeclarative()
   qRegisterMetaType<QgsPointSequence>( "QgsPointSequence" );
   qRegisterMetaType<QgsCoordinateTransformContext>( "QgsCoordinateTransformContext" );
   qRegisterMetaType<QgsWkbTypes::GeometryType>( "QgsWkbTypes::GeometryType" ); // could be removed since we have now qmlRegisterUncreatableType<QgsWkbTypes> ?
-  qRegisterMetaType<QgsWkbTypes::Type>( "QgsWkbTypes::Type" ); // could be removed since we have now qmlRegisterUncreatableType<QgsWkbTypes> ?
-  qRegisterMetaType<QgsMapLayerType>( "QgsMapLayerType" ); // could be removed since we have now qmlRegisterUncreatableType<QgsWkbTypes> ?
+  qRegisterMetaType<QgsWkbTypes::Type>( "QgsWkbTypes::Type" );                 // could be removed since we have now qmlRegisterUncreatableType<QgsWkbTypes> ?
+  qRegisterMetaType<QgsMapLayerType>( "QgsMapLayerType" );                     // could be removed since we have now qmlRegisterUncreatableType<QgsWkbTypes> ?
   qRegisterMetaType<QgsFeatureId>( "QgsFeatureId" );
   qRegisterMetaType<QgsAttributes>( "QgsAttributes" );
   qRegisterMetaType<QgsSnappingConfig>( "QgsSnappingConfig" );
@@ -590,9 +588,7 @@ void QgisMobileapp::loadProjectFile( const QString &path, const QString &name )
     QgsMessageLog::logMessage( tr( "Project file \"%1\" does not exist" ).arg( path ), QStringLiteral( "QField" ), Qgis::Warning );
 
   const QString suffix = fi.suffix().toLower();
-  if ( SUPPORTED_PROJECT_EXTENSIONS.contains( suffix ) ||
-       SUPPORTED_VECTOR_EXTENSIONS.contains( suffix ) ||
-       SUPPORTED_RASTER_EXTENSIONS.contains( suffix ) )
+  if ( SUPPORTED_PROJECT_EXTENSIONS.contains( suffix ) || SUPPORTED_VECTOR_EXTENSIONS.contains( suffix ) || SUPPORTED_RASTER_EXTENSIONS.contains( suffix ) )
   {
     mAuthRequestHandler->clearStoredRealms();
 
@@ -631,7 +627,10 @@ void QgisMobileapp::readProjectFile()
 
     // load fonts in same directory
     QDir fontDir = QDir::cleanPath( QFileInfo( mProjectFilePath ).absoluteDir().path() + QDir::separator() + ".fonts" );
-    QStringList fontExts = QStringList() << "*.ttf" << "*.TTF" << "*.otf" << "*.OTF";
+    QStringList fontExts = QStringList() << "*.ttf"
+                           << "*.TTF"
+                           << "*.otf"
+                           << "*.OTF";
     const QStringList fontFiles = fontDir.entryList( fontExts, QDir::Files );
     for ( const QString &fontFile : fontFiles )
     {
@@ -682,8 +681,7 @@ void QgisMobileapp::readProjectFile()
         if ( tmpPath.right( 1 ) != QLatin1String( "/" ) )
         {
           const QFileInfo tmpFi( tmpPath );
-          if ( SUPPORTED_VECTOR_EXTENSIONS.contains( tmpFi.suffix().toLower() ) ||
-               SUPPORTED_RASTER_EXTENSIONS.contains( tmpFi.suffix().toLower() ) )
+          if ( SUPPORTED_VECTOR_EXTENSIONS.contains( tmpFi.suffix().toLower() ) || SUPPORTED_RASTER_EXTENSIONS.contains( tmpFi.suffix().toLower() ) )
             files << QStringLiteral( "/vsizip/%1/%2" ).arg( mProjectFilePath, tmpPath );
         }
       }
@@ -772,7 +770,7 @@ void QgisMobileapp::readProjectFile()
 
         for ( QgsMapLayer *l : std::as_const( vectorLayers ) )
         {
-          QgsVectorLayer *vlayer = qobject_cast< QgsVectorLayer * >( l );
+          QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( l );
           bool ok;
           vlayer->loadDefaultStyle( ok );
           if ( !ok )
@@ -790,8 +788,8 @@ void QgisMobileapp::readProjectFile()
         {
           std::sort( vectorLayers.begin(), vectorLayers.end(), []( QgsMapLayer * a, QgsMapLayer * b )
           {
-            QgsVectorLayer *alayer = qobject_cast< QgsVectorLayer * >( a );
-            QgsVectorLayer *blayer = qobject_cast< QgsVectorLayer * >( b );
+            QgsVectorLayer *alayer = qobject_cast<QgsVectorLayer *>( a );
+            QgsVectorLayer *blayer = qobject_cast<QgsVectorLayer *>( b );
             if ( alayer->geometryType() == QgsWkbTypes::PointGeometry && blayer->geometryType() != QgsWkbTypes::PointGeometry )
             {
               return true;
@@ -878,7 +876,7 @@ void QgisMobileapp::readProjectFile()
 
         for ( QgsMapLayer *l : std::as_const( rasterLayers ) )
         {
-          QgsRasterLayer *rlayer = qobject_cast< QgsRasterLayer * >( l );
+          QgsRasterLayer *rlayer = qobject_cast<QgsRasterLayer *>( l );
           bool ok;
           rlayer->loadDefaultStyle( ok );
           if ( !ok && fi.size() < 50000000 )
@@ -939,9 +937,7 @@ void QgisMobileapp::readProjectFile()
   // Restore last extent if present
   QSettings settings;
   const QStringList parts = settings.value( QStringLiteral( "/qgis/projectInfo/%1/extent" ).arg( mProjectFilePath ), QString() ).toString().split( '|' );
-  if ( parts.size() == 4 &&
-       ( SUPPORTED_PROJECT_EXTENSIONS.contains( fi.suffix().toLower() ) ||
-         fi.size() == settings.value( QStringLiteral( "/qgis/projectInfo/%1/filesize" ).arg( mProjectFilePath ), 0 ).toLongLong() ) )
+  if ( parts.size() == 4 && ( SUPPORTED_PROJECT_EXTENSIONS.contains( fi.suffix().toLower() ) || fi.size() == settings.value( QStringLiteral( "/qgis/projectInfo/%1/filesize" ).arg( mProjectFilePath ), 0 ).toLongLong() ) )
   {
     extent.setXMinimum( parts[0].toDouble() );
     extent.setXMaximum( parts[1].toDouble() );
@@ -988,7 +984,7 @@ bool QgisMobileapp::print( const QString &layoutName )
   QDir documentsDir( documentsLocation );
   if ( !documentsDir.exists() )
     documentsDir.mkpath( "." );
-  const QString destination = documentsLocation  + '/' + layoutToPrint->name() + QStringLiteral( ".pdf" );
+  const QString destination = documentsLocation + '/' + layoutToPrint->name() + QStringLiteral( ".pdf" );
 
   QgsLayoutExporter::PdfExportSettings pdfSettings;
   pdfSettings.rasterizeWholeImage = layoutToPrint->customProperty( QStringLiteral( "rasterize" ), false ).toBool();
@@ -1050,7 +1046,7 @@ bool QgisMobileapp::printAtlasFeatures( const QString &layoutName, const QList<l
   pdfSettings.exportMetadata = true;
   pdfSettings.simplifyGeometries = true;
 
-  QVector< double > mapScales = layoutToPrint->project()->viewSettings()->mapScales();
+  QVector<double> mapScales = layoutToPrint->project()->viewSettings()->mapScales();
   bool hasProjectScales( layoutToPrint->project()->viewSettings()->useProjectScales() );
   if ( !hasProjectScales || mapScales.isEmpty() )
   {
@@ -1111,4 +1107,3 @@ QgisMobileapp::~QgisMobileapp()
   delete mProject;
   delete mAppMissingGridHandler;
 }
-

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -23,27 +23,24 @@
 
 // QGIS includes
 #include <qgsapplication.h>
+#include <qgsconfig.h>
 #include <qgsexiftools.h>
 #include <qgsmaplayerproxymodel.h>
-#include <qgsconfig.h>
 
 // QGIS mobile includes
 #include "appcoordinateoperationhandlers.h"
-#include "multifeaturelistmodel.h"
-#include "settings.h"
 #include "focusstack.h"
-#include "qgsquickutils.h"
-#include "qgsgpkgflusher.h"
 #include "geometryeditorsmodel.h"
-
-#include "qfieldappauthrequesthandler.h"
-
-#include "qfield_core_export.h"
-
+#include "multifeaturelistmodel.h"
 #include "platformutilities.h"
-#if defined(Q_OS_ANDROID)
+#include "qfield_core_export.h"
+#include "qfieldappauthrequesthandler.h"
+#include "qgsgpkgflusher.h"
+#include "qgsquickutils.h"
+#include "settings.h"
+#if defined( Q_OS_ANDROID )
 #include "androidplatformutilities.h"
-#elif defined(Q_OS_IOS)
+#elif defined( Q_OS_IOS )
 #include "ios/iosplatformutilities.h"
 #endif
 
@@ -61,11 +58,11 @@ class QgsProject;
 class LayerObserver;
 
 
-#define REGISTER_SINGLETON(uri, _class, name) qmlRegisterSingletonType<_class>( uri, 1, 0, name, [] ( QQmlEngine *engine, QJSEngine *scriptEngine ) -> QObject * { Q_UNUSED(engine); Q_UNUSED(scriptEngine); return new _class(); } )
+#define REGISTER_SINGLETON( uri, _class, name ) qmlRegisterSingletonType<_class>( uri, 1, 0, name, []( QQmlEngine *engine, QJSEngine *scriptEngine ) -> QObject * { Q_UNUSED(engine); Q_UNUSED(scriptEngine); return new _class(); } )
 
 #define SUPPORTED_PROJECT_EXTENSIONS QStringList( { QStringLiteral( "qgs" ), QStringLiteral( "qgz" ) } )
-#define SUPPORTED_VECTOR_EXTENSIONS  QStringList( { QStringLiteral( "gpkg" ), QStringLiteral( "shp" ), QStringLiteral( "kml" ), QStringLiteral( "kmz" ), QStringLiteral( "geojson" ), QStringLiteral( "json" ), QStringLiteral( "pdf" ), QStringLiteral( "gpx" ), QStringLiteral( "zip" ) } )
-#define SUPPORTED_RASTER_EXTENSIONS  QStringList( { QStringLiteral( "tif" ), QStringLiteral( "pdf" ), QStringLiteral( "jpg" ), QStringLiteral( "png" ), QStringLiteral( "gpkg" ), QStringLiteral( "jp2" ), QStringLiteral( "webp" ), QStringLiteral( "zip" ) } )
+#define SUPPORTED_VECTOR_EXTENSIONS QStringList( { QStringLiteral( "gpkg" ), QStringLiteral( "shp" ), QStringLiteral( "kml" ), QStringLiteral( "kmz" ), QStringLiteral( "geojson" ), QStringLiteral( "json" ), QStringLiteral( "pdf" ), QStringLiteral( "gpx" ), QStringLiteral( "zip" ) } )
+#define SUPPORTED_RASTER_EXTENSIONS QStringList( { QStringLiteral( "tif" ), QStringLiteral( "pdf" ), QStringLiteral( "jpg" ), QStringLiteral( "png" ), QStringLiteral( "gpkg" ), QStringLiteral( "jp2" ), QStringLiteral( "webp" ), QStringLiteral( "zip" ) } )
 
 class QFIELD_CORE_EXPORT QgisMobileapp : public QQmlApplicationEngine
 {

--- a/src/core/qgsgeometrywrapper.cpp
+++ b/src/core/qgsgeometrywrapper.cpp
@@ -34,8 +34,8 @@ QVariantList QgsGeometryWrapper::pointList() const
 
 void QgsGeometryWrapper::clear()
 {
-  setQgsGeometry(QgsGeometry());
-  setCrs(QgsCoordinateReferenceSystem());
+  setQgsGeometry( QgsGeometry() );
+  setCrs( QgsCoordinateReferenceSystem() );
 }
 
 QgsGeometry QgsGeometryWrapper::qgsGeometry() const

--- a/src/core/qgsgeometrywrapper.h
+++ b/src/core/qgsgeometrywrapper.h
@@ -19,9 +19,8 @@
 
 #include <QObject>
 #include <QStandardItemModel>
-
-#include <qgsgeometry.h>
 #include <qgscoordinatereferencesystem.h>
+#include <qgsgeometry.h>
 
 /**
  * @brief The QgsGeometryWrapper class wraps QGIS geometry and CRS classes
@@ -64,9 +63,6 @@ class QgsGeometryWrapper : public QObject
     QgsGeometry mQgsGeometry;
     QgsCoordinateReferenceSystem mCrs;
 };
-
-
-
 
 
 Q_DECLARE_METATYPE( QgsGeometryWrapper * )

--- a/src/core/qgsgpkgflusher.cpp
+++ b/src/core/qgsgpkgflusher.cpp
@@ -18,13 +18,13 @@
 
 #include "qgsgpkgflusher.h"
 
-#include <qgsmessagelog.h>
-#include <qgsvectorlayer.h>
-#include <qgsproject.h>
-
-#include <QRegularExpression>
 #include <QObject>
+#include <QRegularExpression>
 #include <QTimer>
+#include <qgsmessagelog.h>
+#include <qgsproject.h>
+#include <qgsvectorlayer.h>
+
 #include <sqlite3.h>
 
 class Flusher : public QObject
@@ -184,7 +184,7 @@ void Flusher::flush( const QString &filename )
 
 void Flusher::stop( const QString &fileName )
 {
-  if ( ! mScheduledFlushes.contains( fileName ) )
+  if ( !mScheduledFlushes.contains( fileName ) )
     return;
 
   mScheduledFlushes.value( fileName )->stop();

--- a/src/core/qgsquick/qgsquickcoordinatetransformer.cpp
+++ b/src/core/qgsquick/qgsquickcoordinatetransformer.cpp
@@ -13,23 +13,21 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgsquickcoordinatetransformer.h"
 #include "platformutilities.h"
-#if defined(Q_OS_ANDROID)
+#include "qgsquickcoordinatetransformer.h"
+#if defined( Q_OS_ANDROID )
 #include "androidplatformutilities.h"
 #endif
 
 #include <QFile>
 #include <QSettings>
-
-#include <vector>
-
-#include <proj.h>
-#include <gdal.h>
-#include <cpl_conv.h>
-#include <ogr_srs_api.h>
-
 #include <qgslogger.h>
+
+#include <cpl_conv.h>
+#include <gdal.h>
+#include <ogr_srs_api.h>
+#include <proj.h>
+#include <vector>
 
 QgsQuickCoordinateTransformer::QgsQuickCoordinateTransformer( QObject *parent )
   : QObject( parent )
@@ -153,7 +151,7 @@ void QgsQuickCoordinateTransformer::updatePosition()
       mVerticalGridName = verticalGridName;
       if ( !PlatformUtilities::instance()->qfieldDataDir().isEmpty() )
       {
-        const QString verticalGridPath = QStringLiteral( "%1proj/%2" ).arg( PlatformUtilities::instance()->qfieldDataDir(),  verticalGridName );
+        const QString verticalGridPath = QStringLiteral( "%1proj/%2" ).arg( PlatformUtilities::instance()->qfieldDataDir(), verticalGridName );
         if ( QFile::exists( verticalGridPath ) )
         {
           GDALDatasetH hDataset;
@@ -165,7 +163,7 @@ void QgsQuickCoordinateTransformer::updatePosition()
             char *pszWkt = nullptr;
             const QByteArray multiLineOption = QStringLiteral( "MULTILINE=NO" ).toLocal8Bit();
             const QByteArray formatOption = QStringLiteral( "FORMAT=WKT2" ).toLocal8Bit();
-            const char *const options[] = {multiLineOption.constData(), formatOption.constData(), nullptr};
+            const char *const options[] = { multiLineOption.constData(), formatOption.constData(), nullptr };
             OSRExportToWktEx( spatialRef, &pszWkt, options );
             mCoordinateVerticalGridTransform.setDestinationCrs( QgsCoordinateReferenceSystem::fromWkt( QString( pszWkt ) ) );
             mCoordinateVerticalGridTransform.setContext( mCoordinateTransform.context() );
@@ -176,9 +174,9 @@ void QgsQuickCoordinateTransformer::updatePosition()
       }
     }
 
-    std::vector< double > xVector = { mSourcePosition.x() };
-    std::vector< double > yVector = { mSourcePosition.y() };
-    std::vector< double > zVector = { !std::isnan( mSourcePosition.z() ) ? mSourcePosition.z() : 0 };
+    std::vector<double> xVector = { mSourcePosition.x() };
+    std::vector<double> yVector = { mSourcePosition.y() };
+    std::vector<double> zVector = { !std::isnan( mSourcePosition.z() ) ? mSourcePosition.z() : 0 };
     double zDummy = 0.0; // we don't want to manipulate the elevation data yet, use a dummy z value to transform coordinates first
     mCoordinateVerticalGridTransform.transformInPlace( xVector[0], yVector[0], zDummy );
 
@@ -224,8 +222,7 @@ void QgsQuickCoordinateTransformer::setSourceCoordinate( const QGeoCoordinate &s
 {
   if ( qgsDoubleNear( sourceCoordinate.latitude(), mSourcePosition.y() )
        && qgsDoubleNear( sourceCoordinate.longitude(), mSourcePosition.x() )
-       && qgsDoubleNear( sourceCoordinate.altitude(), mSourcePosition.z() )
-     )
+       && qgsDoubleNear( sourceCoordinate.altitude(), mSourcePosition.z() ) )
     return;
 
   mSourcePosition = QgsPoint( sourceCoordinate.longitude(), sourceCoordinate.latitude(), sourceCoordinate.altitude() );

--- a/src/core/qgsquick/qgsquickcoordinatetransformer.h
+++ b/src/core/qgsquick/qgsquickcoordinatetransformer.h
@@ -16,13 +16,10 @@
 #ifndef QGSQUICKCOORDINATETRANSFORMER_H
 #define QGSQUICKCOORDINATETRANSFORMER_H
 
-#include <QObject>
 #include <QGeoCoordinate>
-
-#include <qgspoint.h>
-
-#include <qgscoordinatetransformcontext.h>
+#include <QObject>
 #include <qgscoordinatereferencesystem.h>
+#include <qgscoordinatetransformcontext.h>
 #include <qgspoint.h>
 
 /**

--- a/src/core/qgsquick/qgsquickfeaturelayerpair.cpp
+++ b/src/core/qgsquick/qgsquickfeaturelayerpair.cpp
@@ -13,10 +13,10 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <qgsvectorlayer.h>
-#include <qgsfeature.h>
-
 #include "qgsquickfeaturelayerpair.h"
+
+#include <qgsfeature.h>
+#include <qgsvectorlayer.h>
 
 QgsQuickFeatureLayerPair::QgsQuickFeatureLayerPair() = default;
 

--- a/src/core/qgsquick/qgsquickfeaturelayerpair.h
+++ b/src/core/qgsquick/qgsquickfeaturelayerpair.h
@@ -17,7 +17,6 @@
 #define QGSQUICKFEATURELAYERPAIR_H
 
 #include <QObject>
-
 #include <qgsfeature.h>
 
 

--- a/src/core/qgsquick/qgsquickmapcanvasmap.cpp
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.cpp
@@ -14,17 +14,16 @@
  ***************************************************************************/
 
 #include <QQuickWindow>
-#include <QScreen>
 #include <QSGSimpleTextureNode>
-
-#include <qgsmaprendererparalleljob.h>
+#include <QScreen>
+#include <qgis.h>
+#include <qgsexpressioncontextutils.h>
 #include <qgsmaprenderercache.h>
+#include <qgsmaprendererparalleljob.h>
 #include <qgsmessagelog.h>
 #include <qgspallabeling.h>
 #include <qgsproject.h>
 #include <qgsvectorlayer.h>
-#include <qgsexpressioncontextutils.h>
-#include <qgis.h>
 #if _QGIS_VERSION_INT >= 31900
 #include <qgslabelingresults.h>
 #endif
@@ -321,9 +320,7 @@ QSGNode *QgsQuickMapCanvasMap::updatePaintNode( QSGNode *oldNode, QQuickItem::Up
     size /= mMapSettings->devicePixelRatio();
 
   // Check for resizes that change the w/h ratio
-  if ( !rect.isEmpty() &&
-       !size.isEmpty() &&
-       !qgsDoubleNear( rect.width() / rect.height(), ( size.width() ) / static_cast<double>( size.height() ), 3 ) )
+  if ( !rect.isEmpty() && !size.isEmpty() && !qgsDoubleNear( rect.width() / rect.height(), ( size.width() ) / static_cast<double>( size.height() ), 3 ) )
   {
     if ( qgsDoubleNear( rect.height(), mImage.height() ) )
     {
@@ -419,7 +416,7 @@ void QgsQuickMapCanvasMap::zoomToFullExtent()
 void QgsQuickMapCanvasMap::refresh()
 {
   if ( mMapSettings->outputSize().isNull() )
-    return;  // the map image size has not been set yet
+    return; // the map image size has not been set yet
 
   if ( !mFreeze )
     mRefreshTimer.start( 1 );

--- a/src/core/qgsquick/qgsquickmapcanvasmap.h
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.h
@@ -16,16 +16,15 @@
 #ifndef QGSQUICKMAPCANVASMAP_H
 #define QGSQUICKMAPCANVASMAP_H
 
-#include <memory>
+#include "qgsquickmapsettings.h"
 
-#include <QtQuick/QQuickItem>
 #include <QFutureSynchronizer>
 #include <QTimer>
-
+#include <QtQuick/QQuickItem>
 #include <qgsmapsettings.h>
 #include <qgspoint.h>
 
-#include "qgsquickmapsettings.h"
+#include <memory>
 
 class QgsMapRendererParallelJob;
 class QgsMapRendererCache;
@@ -173,7 +172,6 @@ class QgsQuickMapCanvasMap : public QQuickItem
     void onLayersChanged();
 
   private:
-
     /**
      * Should only be called by stopRendering()!
      */

--- a/src/core/qgsquick/qgsquickmapsettings.cpp
+++ b/src/core/qgsquick/qgsquickmapsettings.cpp
@@ -14,13 +14,13 @@
  ***************************************************************************/
 
 
+#include "qgis.h"
+#include "qgsquickmapsettings.h"
+
 #include <qgsmaplayer.h>
 #include <qgsmaplayerstylemanager.h>
 #include <qgsmessagelog.h>
 #include <qgsproject.h>
-#include "qgis.h"
-
-#include "qgsquickmapsettings.h"
 
 QgsQuickMapSettings::QgsQuickMapSettings( QObject *parent )
   : QObject( parent )
@@ -245,8 +245,7 @@ void QgsQuickMapSettings::onReadProject( const QDomDocument &doc )
     QDomNode node = nodes.item( 0 );
     QDomElement element = node.toElement();
 
-    if ( element.hasAttribute( QStringLiteral( "name" ) ) &&
-         element.attribute( QStringLiteral( "name" ) ) == QStringLiteral( "theMapCanvas" ) )
+    if ( element.hasAttribute( QStringLiteral( "name" ) ) && element.attribute( QStringLiteral( "name" ) ) == QStringLiteral( "theMapCanvas" ) )
     {
       foundTheMapCanvas = true;
       mMapSettings.readXml( node );

--- a/src/core/qgsquick/qgsquickmapsettings.h
+++ b/src/core/qgsquick/qgsquickmapsettings.h
@@ -16,16 +16,15 @@
 #ifndef QGSQUICKMAPSETTINGS_H
 #define QGSQUICKMAPSETTINGS_H
 
-#include <QObject>
+#include "qfield_core_export.h"
 
+#include <QObject>
 #include <qgscoordinatetransformcontext.h>
+#include <qgsmaplayer.h>
 #include <qgsmapsettings.h>
 #include <qgsmapthemecollection.h>
 #include <qgspoint.h>
-#include <qgsmaplayer.h>
 #include <qgsrectangle.h>
-
-#include "qfield_core_export.h"
 
 class QgsProject;
 
@@ -258,7 +257,6 @@ class QFIELD_CORE_EXPORT QgsQuickMapSettings : public QObject
     QgsProject *mProject = nullptr;
     QgsMapSettings mMapSettings;
     qreal mDevicePixelRatio = 1.0;
-
 };
 
 #endif // QGSQUICKMAPSETTINGS_H

--- a/src/core/qgsquick/qgsquickmaptransform.cpp
+++ b/src/core/qgsquick/qgsquickmaptransform.cpp
@@ -13,8 +13,8 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgsquickmaptransform.h"
 #include "qgsquickmapsettings.h"
+#include "qgsquickmaptransform.h"
 
 void QgsQuickMapTransform::applyTo( QMatrix4x4 *matrix ) const
 {
@@ -51,7 +51,7 @@ void QgsQuickMapTransform::updateMatrix()
   float scaleFactor = static_cast<float>( 1.0 / mMapSettings->mapUnitsPerPoint() );
 
   matrix.scale( scaleFactor, -scaleFactor );
-  matrix.translate( static_cast<float>( -mMapSettings->visibleExtent().xMinimum( ) ),
+  matrix.translate( static_cast<float>( -mMapSettings->visibleExtent().xMinimum() ),
                     static_cast<float>( -mMapSettings->visibleExtent().yMaximum() ) );
 
   mMatrix = matrix;

--- a/src/core/qgsquick/qgsquickmaptransform.h
+++ b/src/core/qgsquick/qgsquickmaptransform.h
@@ -16,8 +16,8 @@
 #ifndef QGSQUICKMAPTRANSFORM_H
 #define QGSQUICKMAPTRANSFORM_H
 
-#include <QQuickItem>
 #include <QMatrix4x4>
+#include <QQuickItem>
 
 
 class QgsQuickMapSettings;

--- a/src/core/qgsquick/qgsquickutils.cpp
+++ b/src/core/qgsquick/qgsquickutils.cpp
@@ -13,24 +13,22 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <QGuiApplication>
-#include <QScreen>
-#include <QString>
-#include <QWindow>
-#include <QFileInfo>
-
-#include <qgscoordinatereferencesystem.h>
-#include <qgscoordinatetransform.h>
-#include <qgsdistancearea.h>
-#include <qgslogger.h>
-#include <qgsvectorlayer.h>
-#include <qgsfeature.h>
-#include <qgsunittypes.h>
-
 #include "qgsquickfeaturelayerpair.h"
 #include "qgsquickmapsettings.h"
 #include "qgsquickutils.h"
 
+#include <QFileInfo>
+#include <QGuiApplication>
+#include <QScreen>
+#include <QString>
+#include <QWindow>
+#include <qgscoordinatereferencesystem.h>
+#include <qgscoordinatetransform.h>
+#include <qgsdistancearea.h>
+#include <qgsfeature.h>
+#include <qgslogger.h>
+#include <qgsunittypes.h>
+#include <qgsvectorlayer.h>
 
 
 QgsQuickUtils::QgsQuickUtils( QObject *parent )
@@ -79,7 +77,8 @@ double QgsQuickUtils::distanceFromUnitToUnitFactor( const QgsUnitTypes::Distance
 
 double QgsQuickUtils::screenUnitsToMeters( QgsQuickMapSettings *mapSettings, int baseLengthPixels )
 {
-  if ( mapSettings == nullptr ) return 0.0;
+  if ( mapSettings == nullptr )
+    return 0.0;
 
   QgsDistanceArea mDistanceArea;
   mDistanceArea.setEllipsoid( QStringLiteral( "WGS84" ) );
@@ -333,7 +332,7 @@ qreal QgsQuickUtils::calculateScreenDensity()
   double dpiX = screen->physicalDotsPerInchX();
   double dpiY = screen->physicalDotsPerInchY();
   double dpi = dpiX < dpiY ? dpiX : dpiY; // In case of asymmetrical DPI. Improbable
-  return dpi / 160.;  // 160 DPI is baseline for density-independent pixels in Android
+  return dpi / 160.;                      // 160 DPI is baseline for density-independent pixels in Android
 }
 
 void QgsQuickUtils::selectFeaturesInLayer( QgsVectorLayer *layer, const QList<int> &fids, QgsVectorLayer::SelectBehavior behavior )

--- a/src/core/qgsquick/qgsquickutils.h
+++ b/src/core/qgsquick/qgsquickutils.h
@@ -17,22 +17,21 @@
 #define QGSQUICKUTILS_H
 
 
+#include "qgsquickfeaturelayerpair.h"
+#include "qgsquickmapsettings.h"
+
 #include <QObject>
 #include <QString>
 #include <QUrl>
 #include <QtPositioning/QGeoCoordinate>
-
-#include <limits>
-
+#include <qgscoordinateformatter.h>
 #include <qgsmessagelog.h>
 #include <qgspoint.h>
 #include <qgspointxy.h>
 #include <qgsunittypes.h>
-#include <qgscoordinateformatter.h>
 #include <qgsvectorlayer.h>
 
-#include "qgsquickmapsettings.h"
-#include "qgsquickfeaturelayerpair.h"
+#include <limits>
 
 
 class QgsFeature;
@@ -46,7 +45,7 @@ class QgsCoordinateReferenceSystem;
  * \note QML Type: Utils (Singleton)
  *
  */
-class QgsQuickUtils: public QObject
+class QgsQuickUtils : public QObject
 {
     Q_OBJECT
 

--- a/src/core/qgssggeometry.cpp
+++ b/src/core/qgssggeometry.cpp
@@ -13,7 +13,6 @@
  *                                                                         *
  ***************************************************************************/
 #include "math.h"
-
 #include "qgssggeometry.h"
 extern "C" {
 #include "tessellate.h"
@@ -145,7 +144,7 @@ QSGGeometry *QgsSGGeometry::qgsPolygonToQSGGeometry( const QgsPolygonXY &polygon
 
   const QgsPolylineXY &ring = *it;
 
-  double *vertices_in = ( double * )malloc( ring.size() * 2 * sizeof( double ) );
+  double *vertices_in = ( double * ) malloc( ring.size() * 2 * sizeof( double ) );
   const double *contours_array[] = { vertices_in, vertices_in + ring.size() * 2 };
   int i = 0;
 

--- a/src/core/qgssggeometry.h
+++ b/src/core/qgssggeometry.h
@@ -15,10 +15,10 @@
 #ifndef QGSSGGEOMETRY_H
 #define QGSSGGEOMETRY_H
 
-#include <QtQuick/QSGGeometryNode>
-#include <QtQuick/QSGFlatColorMaterial>
-
 #include "qgsgeometry.h"
+
+#include <QtQuick/QSGFlatColorMaterial>
+#include <QtQuick/QSGGeometryNode>
 
 class QgsSGGeometry : public QSGNode
 {

--- a/src/core/recentprojectlistmodel.cpp
+++ b/src/core/recentprojectlistmodel.cpp
@@ -14,14 +14,14 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "recentprojectlistmodel.h"
 #include "platformutilities.h"
-#include "qgismobileapp.h"
 #include "qfieldcloudutils.h"
+#include "qgismobileapp.h"
+#include "recentprojectlistmodel.h"
 
-#include <QSettings>
-#include <QFile>
 #include <QDir>
+#include <QFile>
+#include <QSettings>
 
 RecentProjectListModel::RecentProjectListModel( QObject *parent )
   : QAbstractListModel( parent )
@@ -32,10 +32,10 @@ RecentProjectListModel::RecentProjectListModel( QObject *parent )
 QHash<int, QByteArray> RecentProjectListModel::roleNames() const
 {
   QHash<int, QByteArray> roles = QAbstractListModel::roleNames();
-  roles[ProjectTypeRole]  = "ProjectType";
-  roles[ProjectTitleRole]  = "ProjectTitle";
-  roles[ProjectPathRole]  = "ProjectPath";
-  roles[ProjectDemoRole]  = "ProjectDemo";
+  roles[ProjectTypeRole] = "ProjectType";
+  roles[ProjectTitleRole] = "ProjectTitle";
+  roles[ProjectPathRole] = "ProjectPath";
+  roles[ProjectDemoRole] = "ProjectDemo";
 
   return roles;
 }
@@ -62,10 +62,10 @@ void RecentProjectListModel::reloadModel()
     if ( fi.exists() )
     {
       ProjectType projectType = path.startsWith( QFieldCloudUtils::localCloudDirectory() )
-        ? CloudProject
-        : SUPPORTED_PROJECT_EXTENSIONS.contains( fi.suffix() )
-          ? LocalProject
-          : LocalDataset;
+                                ? CloudProject
+                                : SUPPORTED_PROJECT_EXTENSIONS.contains( fi.suffix() )
+                                ? LocalProject
+                                : LocalDataset;
       mRecentProjects.append( RecentProject( projectType,
                                              settings.value( QStringLiteral( "title" ) ).toString(),
                                              path,
@@ -81,8 +81,7 @@ void RecentProjectListModel::reloadModel()
   {
     RecentProject( LocalProject, QStringLiteral( "Simple Bee Farming Demo" ), QStringLiteral( "/qfield/demo_projects/simple_bee_farming.qgs" ), true ),
     RecentProject( LocalProject, QStringLiteral( "Advanced Bee Farming Demo" ), QStringLiteral( "/qfield/demo_projects/advanced_bee_farming.qgs" ), true ),
-    RecentProject( LocalProject, QStringLiteral( "Live QField Users Survey Demo" ), QStringLiteral( "/qfield/demo_projects/live_qfield_users_survey.qgs" ), true )
-  };
+    RecentProject( LocalProject, QStringLiteral( "Live QField Users Survey Demo" ), QStringLiteral( "/qfield/demo_projects/live_qfield_users_survey.qgs" ), true ) };
   for ( const RecentProject &demoProject : demoProjects )
   {
     bool recentProjectsContainsDemoProject = false;
@@ -114,7 +113,7 @@ void RecentProjectListModel::reloadModel()
   {
     recentProject.next();
 
-    if ( ! QFile::exists( recentProject.value().path ) )
+    if ( !QFile::exists( recentProject.value().path ) )
       recentProject.remove();
   }
 

--- a/src/core/recentprojectlistmodel.h
+++ b/src/core/recentprojectlistmodel.h
@@ -23,7 +23,6 @@ class RecentProjectListModel : public QAbstractListModel
     Q_OBJECT
 
   public:
-
     enum ProjectType
     {
       LocalProject,
@@ -54,9 +53,9 @@ class RecentProjectListModel : public QAbstractListModel
     enum Role
     {
       ProjectTypeRole = Qt::UserRole, //! the project type (e.g., local, cloud, etc.)
-      ProjectTitleRole, //! the project title
-      ProjectPathRole, //! the project path
-      ProjectDemoRole, //! if the project is a demo project
+      ProjectTitleRole,               //! the project title
+      ProjectPathRole,                //! the project path
+      ProjectDemoRole,                //! if the project is a demo project
     };
     Q_ENUM( Role )
 

--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -14,10 +14,10 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "referencingfeaturelistmodel.h"
+
 #include <qgsmessagelog.h>
 #include <qgsproject.h>
-
-#include "referencingfeaturelistmodel.h"
 
 ReferencingFeatureListModel::ReferencingFeatureListModel( QObject *parent )
   : QAbstractItemModel( parent )
@@ -155,7 +155,8 @@ void ReferencingFeatureListModel::updateModel()
   if ( mGatherer )
     mEntries = mGatherer->entries();
 
-  std::sort( mEntries.begin(), mEntries.end(), []( const Entry &e1, const Entry &e2 ) {
+  std::sort( mEntries.begin(), mEntries.end(), []( const Entry & e1, const Entry & e2 )
+  {
     return e1.displayString < e2.displayString;
   } );
 
@@ -218,24 +219,24 @@ void ReferencingFeatureListModel::reload()
 bool ReferencingFeatureListModel::deleteFeature( QgsFeatureId referencingFeatureId )
 {
   QgsVectorLayer *vl = mRelation.referencingLayer();
-  
-  if ( ! vl->startEditing() )
+
+  if ( !vl->startEditing() )
   {
     QgsMessageLog::logMessage( tr( "Cannot start editing" ), "QField", Qgis::Critical );
     return false;
   }
 
-  if ( ! vl->deleteFeature( referencingFeatureId ) )
+  if ( !vl->deleteFeature( referencingFeatureId ) )
   {
     QgsMessageLog::logMessage( tr( "Cannot delete feature" ), "QField", Qgis::Critical );
     return false;
   }
 
-  if ( ! vl->commitChanges() )
+  if ( !vl->commitChanges() )
   {
     QgsMessageLog::logMessage( tr( "Cannot commit layer changes in layer %1." ).arg( vl->name() ), "QField", Qgis::Critical );
 
-    if ( ! vl->rollBack() )
+    if ( !vl->rollBack() )
       QgsMessageLog::logMessage( tr( "Cannot rollback layer changes in layer %1" ).arg( vl->name() ), "QField", Qgis::Critical );
 
     return false;

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -16,15 +16,16 @@
 #ifndef REFERENCINGFEATURELISTMODEL_H
 #define REFERENCINGFEATURELISTMODEL_H
 
+#include "attributeformmodel.h"
+#include "qgsvectorlayer.h"
+
 #include <QAbstractItemModel>
 #include <QPair>
-#include "qgsvectorlayer.h"
-#include "attributeformmodel.h"
 
 //used for gatherer
-#include <QThread>
-
 #include "qfield_core_export.h"
+
+#include <QThread>
 
 class QgsVectorLayer;
 class FeatureGatherer;
@@ -197,7 +198,7 @@ class QFIELD_CORE_EXPORT ReferencingFeatureListModel : public QAbstractItemModel
     friend class TestReferencingFeatureListModel;
 };
 
-class FeatureGatherer: public QThread
+class FeatureGatherer : public QThread
 {
     Q_OBJECT
 
@@ -267,7 +268,6 @@ class FeatureGatherer: public QThread
     void collectedValues();
 
   private:
-
     QList<ReferencingFeatureListModel::Entry> mEntries;
 
     QgsFeature mFeature;

--- a/src/core/rubberband.cpp
+++ b/src/core/rubberband.cpp
@@ -15,11 +15,11 @@
  ***************************************************************************/
 
 
-#include "vertexmodel.h"
+#include "qgsquickmapsettings.h"
 #include "rubberband.h"
 #include "rubberbandmodel.h"
 #include "sgrubberband.h"
-#include "qgsquickmapsettings.h"
+#include "vertexmodel.h"
 
 Rubberband::Rubberband( QQuickItem *parent )
   : QQuickItem( parent )
@@ -133,12 +133,12 @@ void Rubberband::markDirty()
   update();
 }
 
-void Rubberband::transformPoints( QVector<QgsPoint> & points )
+void Rubberband::transformPoints( QVector<QgsPoint> &points )
 {
   const QgsRectangle visibleExtent = mMapSettings->visibleExtent();
   const double scaleFactor = 1.0 / mMapSettings->mapUnitsPerPoint();
 
-  for( QgsPoint &point : points )
+  for ( QgsPoint &point : points )
   {
     point.setX( ( point.x() - visibleExtent.xMinimum() ) * scaleFactor );
     point.setY( ( point.y() - visibleExtent.yMaximum() ) * -scaleFactor );
@@ -251,4 +251,3 @@ void Rubberband::setColorCurrentPoint( const QColor &color )
 
   emit colorCurrentPointChanged();
 }
-

--- a/src/core/rubberbandmodel.cpp
+++ b/src/core/rubberbandmodel.cpp
@@ -16,9 +16,9 @@
 #include "rubberbandmodel.h"
 #include "snappingutils.h"
 
-#include <qgsvectorlayer.h>
-#include <qgsproject.h>
 #include <qgslogger.h>
+#include <qgsproject.h>
+#include <qgsvectorlayer.h>
 
 RubberbandModel::RubberbandModel( QObject *parent )
   : QObject( parent )

--- a/src/core/rubberbandmodel.h
+++ b/src/core/rubberbandmodel.h
@@ -16,16 +16,16 @@
 #ifndef RUBBERBANDMODEL_H
 #define RUBBERBANDMODEL_H
 
-#include <QVector>
+#include "qfield_core_export.h"
+
+#include <QDateTime>
 #include <QObject>
 #include <QPointF>
-#include <QDateTime>
+#include <QVector>
 #include <qgis.h>
-#include <qgspoint.h>
 #include <qgsabstractgeometry.h>
 #include <qgsgeometry.h>
-
-#include "qfield_core_export.h"
+#include <qgspoint.h>
 
 class QgsVectorLayer;
 
@@ -103,7 +103,7 @@ class QFIELD_CORE_EXPORT RubberbandModel : public QObject
     Q_INVOKABLE void addVertex();
 
     //! Add vertex with a given point
-    Q_INVOKABLE void addVertexFromPoint(const QgsPoint &point );
+    Q_INVOKABLE void addVertexFromPoint( const QgsPoint &point );
 
     Q_INVOKABLE void removeVertex();
 

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -18,8 +18,8 @@
 
 #include <QDebug>
 
-Settings::Settings( QObject *parent ) :
-  QSettings( parent )
+Settings::Settings( QObject *parent )
+  : QSettings( parent )
 {
 }
 

--- a/src/core/sgrubberband.cpp
+++ b/src/core/sgrubberband.cpp
@@ -77,7 +77,7 @@ QSGGeometryNode *SGRubberband::createPolygonGeometry( const QVector<QgsPoint> &p
   int *tris_out;
   int nverts, ntris;
 
-  double *vertices_in = ( double * )malloc( points.size() * 2 * sizeof( double ) );
+  double *vertices_in = ( double * ) malloc( points.size() * 2 * sizeof( double ) );
   const double *contours_array[] = { vertices_in, vertices_in + points.size() * 2 };
   int i = 0;
 

--- a/src/core/sgrubberband.h
+++ b/src/core/sgrubberband.h
@@ -15,9 +15,8 @@
 #ifndef QGSSGRUBBERBAND_H
 #define QGSSGRUBBERBAND_H
 
-#include <QtQuick/QSGNode>
 #include <QtQuick/QSGFlatColorMaterial>
-
+#include <QtQuick/QSGNode>
 #include <qgspoint.h>
 #include <qgswkbtypes.h>
 

--- a/src/core/snappingresult.cpp
+++ b/src/core/snappingresult.cpp
@@ -114,4 +114,3 @@ void SnappingResult::edgePoints( QgsPoint &pt1, QgsPoint &pt2 ) const
   pt1 = mEdgePoints[0];
   pt2 = mEdgePoints[1];
 }
-

--- a/src/core/snappingresult.h
+++ b/src/core/snappingresult.h
@@ -17,8 +17,8 @@
 #define SNAPPINGRESULT_H
 
 #include <qgspoint.h>
-#include <qgsvectorlayer.h>
 #include <qgspointlocator.h>
+#include <qgsvectorlayer.h>
 
 class SnappingResult
 {
@@ -32,10 +32,10 @@ class SnappingResult
      */
     enum Type
     {
-      Invalid = 0, //!< Invalid
-      Vertex  = 1, //!< Snapped to a vertex. Can be a vertex of the geometry or an intersection.
-      Edge    = 2, //!< Snapped to an edge
-      Area    = 4, //!< Snapped to an area
+      Invalid = 0,               //!< Invalid
+      Vertex = 1,                //!< Snapped to a vertex. Can be a vertex of the geometry or an intersection.
+      Edge = 2,                  //!< Snapped to an edge
+      Area = 4,                  //!< Snapped to an area
       All = Vertex | Edge | Area //!< Combination of vertex, edge and area
     };
 

--- a/src/core/snappingutils.cpp
+++ b/src/core/snappingutils.cpp
@@ -14,11 +14,11 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "snappingutils.h"
 #include "qgsquickmapsettings.h"
+#include "snappingutils.h"
 
-#include <qgsvectorlayer.h>
 #include <qgsproject.h>
+#include <qgsvectorlayer.h>
 
 SnappingUtils::SnappingUtils( QObject *parent )
   : QgsSnappingUtils( parent, false /*enableSnappingForInvisibleFeature*/ )
@@ -36,7 +36,6 @@ void SnappingUtils::onMapSettingsUpdated()
 
 void SnappingUtils::removeOutdatedLocators()
 {
-
   clearAllLocators();
 }
 
@@ -89,7 +88,8 @@ void SnappingUtils::snap()
     if ( vlayer->crs() != mapSettings()->destinationCrs() )
     {
       QgsCoordinateTransform transform( vlayer->crs(), mapSettings()->destinationCrs(), QgsProject::instance()->transformContext() );
-      try {
+      try
+      {
         snappedPoint.transform( transform );
       }
       catch ( const QgsException &e )
@@ -97,7 +97,7 @@ void SnappingUtils::snap()
         Q_UNUSED( e )
         return;
       }
-      catch(...)
+      catch ( ... )
       {
         // catch any other errors
         return;

--- a/src/core/snappingutils.h
+++ b/src/core/snappingutils.h
@@ -19,9 +19,9 @@
 
 class QgsQuickMapSettings;
 
-#include <qgssnappingutils.h>
-
 #include "snappingresult.h"
+
+#include <qgssnappingutils.h>
 
 class SnappingUtils : public QgsSnappingUtils
 {

--- a/src/core/submodel.cpp
+++ b/src/core/submodel.cpp
@@ -14,12 +14,12 @@
  *                                                                         *
  ***************************************************************************/
 #include "submodel.h"
+
 #include <QDebug>
 
 SubModel::SubModel( QObject *parent )
   : QAbstractItemModel( parent )
 {
-
 }
 
 QModelIndex SubModel::index( int row, int column, const QModelIndex &parent ) const
@@ -139,7 +139,7 @@ bool SubModel::isInSubModel( const QModelIndex &sourceIndex ) const
 
   QModelIndex idx = sourceIndex;
   bool foundRootIndex = false;
-  while( idx.isValid() )
+  while ( idx.isValid() )
   {
     if ( mModel->parent( idx ) == mRootIndex )
     {

--- a/src/core/submodel.h
+++ b/src/core/submodel.h
@@ -62,7 +62,6 @@ class SubModel : public QAbstractItemModel
 
     // Map internal id to parent index
     mutable QHash<qintptr, QModelIndex> mMappings;
-
 };
 
 #endif // SUBMODEL_H

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -13,16 +13,14 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <QTimer>
-
+#include "qgsproject.h"
+#include "rubberbandmodel.h"
 #include "tracker.h"
 
-#include "rubberbandmodel.h"
-#include "qgsproject.h"
+#include <QTimer>
 
 Tracker::Tracker( QgsVectorLayer *layer, bool visible )
-  : mLayer( layer ),
-    mVisible( visible )
+  : mLayer( layer ), mVisible( visible )
 {
 }
 
@@ -63,7 +61,7 @@ QDateTime Tracker::startPositionTimestamp() const
   return mStartPositionTimestamp;
 }
 
-void Tracker::setStartPositionTimestamp(const QDateTime &startPositionTimestamp)
+void Tracker::setStartPositionTimestamp( const QDateTime &startPositionTimestamp )
 {
   mStartPositionTimestamp = startPositionTimestamp;
 }
@@ -92,7 +90,6 @@ void Tracker::trackPosition()
 
 void Tracker::positionReceived()
 {
-
   QVector<QgsPointXY> points = mRubberbandModel->flatPointSequence( QgsProject::instance()->crs() );
 
   auto pointIt = points.constEnd() - 1;
@@ -136,7 +133,7 @@ void Tracker::start()
 
   //set the start time
   setStartPositionTimestamp( QDateTime::currentDateTime() );
-  model()->setMeasureValue(0);
+  model()->setMeasureValue( 0 );
 
   //track first position
   trackPosition();
@@ -151,6 +148,6 @@ void Tracker::stop()
   }
   if ( mMinimumDistance > 0 )
   {
-    disconnect( mRubberbandModel,  &RubberbandModel::currentCoordinateChanged, this, &Tracker::positionReceived );
+    disconnect( mRubberbandModel, &RubberbandModel::currentCoordinateChanged, this, &Tracker::positionReceived );
   }
 }

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -16,8 +16,9 @@
 #ifndef TRACKER_H
 #define TRACKER_H
 
-#include <QTimer>
 #include "qgsvectorlayer.h"
+
+#include <QTimer>
 
 class RubberbandModel;
 
@@ -60,7 +61,7 @@ class Tracker : public QObject
     //! the created feature
     QgsFeature feature() const { return mFeature; }
     //! the created feature
-    void setFeature( const QgsFeature& feature ) { mFeature = feature; }
+    void setFeature( const QgsFeature &feature ) { mFeature = feature; }
     //! if the layer (and the rubberband ) is visible
     bool visible() const { return mVisible; }
     //! if the layer (and the rubberband ) is visible
@@ -94,8 +95,6 @@ class Tracker : public QObject
     QDateTime mStartPositionTimestamp;
 
     void trackPosition();
-
 };
 
 #endif // TRACKER_H
-

--- a/src/core/trackingmodel.cpp
+++ b/src/core/trackingmodel.cpp
@@ -77,7 +77,7 @@ QVariant TrackingModel::data( const QModelIndex &index, int role ) const
     case DisplayString:
       return QString( "Tracker on layer %1" ).arg( mTrackers.at( index.row() )->layer()->name() );
     case VectorLayer:
-      return QVariant::fromValue< QgsVectorLayer *>( mTrackers.at( index.row() )->layer() );
+      return QVariant::fromValue<QgsVectorLayer *>( mTrackers.at( index.row() )->layer() );
     case Visible:
       return mTrackers.at( index.row() )->visible();
     case StartPositionTimestamp:
@@ -89,7 +89,7 @@ QVariant TrackingModel::data( const QModelIndex &index, int role ) const
 
 bool TrackingModel::setData( const QModelIndex &index, const QVariant &value, int role )
 {
-  Tracker *currentTracker = mTrackers[ index.row() ];
+  Tracker *currentTracker = mTrackers[index.row()];
   switch ( role )
   {
     case TimeInterval:
@@ -102,10 +102,10 @@ bool TrackingModel::setData( const QModelIndex &index, const QVariant &value, in
       currentTracker->setConjunction( value.toBool() );
       break;
     case Feature:
-      currentTracker->setFeature( value.value< QgsFeature >() );
+      currentTracker->setFeature( value.value<QgsFeature>() );
       break;
     case RubberModel:
-      currentTracker->setModel( value.value< RubberbandModel * >() );
+      currentTracker->setModel( value.value<RubberbandModel *>() );
       break;
     case Visible:
       currentTracker->setVisible( value.toBool() );
@@ -122,7 +122,7 @@ bool TrackingModel::featureInTracking( QgsVectorLayer *layer, const QgsFeatureId
   if ( trackerIterator( layer ) != mTrackers.constEnd() )
   {
     int listIndex = trackerIterator( layer ) - mTrackers.constBegin();
-    if ( mTrackers[ listIndex ]->feature().id() == featureId )
+    if ( mTrackers[listIndex]->feature().id() == featureId )
       return true;
   }
   return false;
@@ -133,8 +133,8 @@ bool TrackingModel::featuresInTracking( QgsVectorLayer *layer, const QList<QgsFe
   if ( trackerIterator( layer ) != mTrackers.constEnd() )
   {
     int listIndex = trackerIterator( layer ) - mTrackers.constBegin();
-    QgsFeatureId fid = mTrackers[ listIndex ]->feature().id();
-    if ( std::any_of( features.begin(), features.end(), [fid]( const QgsFeature &f ) { return f.id() == fid; } ) )
+    QgsFeatureId fid = mTrackers[listIndex]->feature().id();
+    if ( std::any_of( features.begin(), features.end(), [fid]( const QgsFeature & f ) { return f.id() == fid; } ) )
     {
       return true;
     }
@@ -165,14 +165,14 @@ void TrackingModel::createTracker( QgsVectorLayer *layer, bool visible )
 void TrackingModel::startTracker( QgsVectorLayer *layer )
 {
   int listIndex = trackerIterator( layer ) - mTrackers.constBegin();
-  mTrackers[ listIndex ]->start();
+  mTrackers[listIndex]->start();
   emit layerInTrackingChanged( layer, true );
 }
 
 void TrackingModel::stopTracker( QgsVectorLayer *layer )
 {
   int listIndex = trackerIterator( layer ) - mTrackers.constBegin();
-  mTrackers[ listIndex ]->stop();
+  mTrackers[listIndex]->stop();
 
   beginRemoveRows( QModelIndex(), listIndex, listIndex );
   delete mTrackers.takeAt( listIndex );
@@ -189,4 +189,3 @@ void TrackingModel::setLayerVisible( QgsVectorLayer *layer, bool visible )
     setData( index( listIndex, 0, QModelIndex() ), visible, Visible );
   }
 }
-

--- a/src/core/trackingmodel.h
+++ b/src/core/trackingmodel.h
@@ -16,10 +16,10 @@
 #ifndef TRACKINGMODEL_H
 #define TRACKINGMODEL_H
 
-#include <QAbstractItemModel>
-
 #include "rubberbandmodel.h"
 #include "tracker.h"
+
+#include <QAbstractItemModel>
 
 class RubberbandModel;
 class Track;
@@ -35,14 +35,14 @@ class TrackingModel : public QAbstractItemModel
     enum TrackingRoles
     {
       DisplayString = Qt::UserRole,
-      VectorLayer,        //! the layer in the current tracking session
-      RubberModel,        //! the rubberbandmodel used in the current tracking session
-      TimeInterval,       //! the (minimum) time interval between setting trackpoints
-      MinimumDistance,    //! the minimum distance between setting trackpoints
-      Conjunction,        //! if both, the minimum distance and the time interval, needs to be fulfilled before setting trackpoints
-      Visible,            //! if the layer and so the tracking components like rubberband is visible
-      Feature,            //! the feature in the current tracking session
-      StartPositionTimestamp             //!
+      VectorLayer,           //! the layer in the current tracking session
+      RubberModel,           //! the rubberbandmodel used in the current tracking session
+      TimeInterval,          //! the (minimum) time interval between setting trackpoints
+      MinimumDistance,       //! the minimum distance between setting trackpoints
+      Conjunction,           //! if both, the minimum distance and the time interval, needs to be fulfilled before setting trackpoints
+      Visible,               //! if the layer and so the tracking components like rubberband is visible
+      Feature,               //! the feature in the current tracking session
+      StartPositionTimestamp //!
     };
 
     QHash<int, QByteArray> roleNames() const override;
@@ -77,10 +77,9 @@ class TrackingModel : public QAbstractItemModel
     QList<Tracker *> mTrackers;
     QList<Tracker *>::const_iterator trackerIterator( QgsVectorLayer *layer )
     {
-      return std::find_if( mTrackers.constBegin(), mTrackers.constEnd(), [layer]( const Tracker * tracker ) { return tracker->layer() == layer;} );
+      return std::find_if( mTrackers.constBegin(), mTrackers.constEnd(), [layer]( const Tracker * tracker ) { return tracker->layer() == layer; } );
     }
 };
-
 
 
 #endif // TRACKINGMODEL_H

--- a/src/core/utils/featureutils.cpp
+++ b/src/core/utils/featureutils.cpp
@@ -21,15 +21,15 @@
 #include <qgsvectorlayer.h>
 
 
-FeatureUtils::FeatureUtils(QObject *parent) : QObject(parent)
+FeatureUtils::FeatureUtils( QObject *parent )
+  : QObject( parent )
 {
-
 }
 
-QgsFeature FeatureUtils::initFeature(QgsVectorLayer *layer, QgsGeometry geometry)
+QgsFeature FeatureUtils::initFeature( QgsVectorLayer *layer, QgsGeometry geometry )
 {
-  QgsFeature f(layer->fields());
-  f.setGeometry(geometry);
+  QgsFeature f( layer->fields() );
+  f.setGeometry( geometry );
   return f;
 }
 

--- a/src/core/utils/featureutils.h
+++ b/src/core/utils/featureutils.h
@@ -16,29 +16,28 @@
 #ifndef FEATUREUTILS_H
 #define FEATUREUTILS_H
 
-#include <QObject>
-
-#include <qgsgeometry.h>
-#include <qgsfeature.h>
-
 #include "qfield_core_export.h"
+
+#include <QObject>
+#include <qgsfeature.h>
+#include <qgsgeometry.h>
 
 class QgsVectorLayer;
 
 class QFIELD_CORE_EXPORT FeatureUtils : public QObject
 {
-  Q_OBJECT
-public:
-  explicit FeatureUtils(QObject *parent = nullptr);
+    Q_OBJECT
+  public:
+    explicit FeatureUtils( QObject *parent = nullptr );
 
-  static Q_INVOKABLE QgsFeature initFeature(QgsVectorLayer *layer, QgsGeometry geometry = QgsGeometry());
+    static Q_INVOKABLE QgsFeature initFeature( QgsVectorLayer *layer, QgsGeometry geometry = QgsGeometry() );
 
-  /**
-   * Returns the display name of a given feature.
-   * \param layer the vector layer containing the feature
-   * \param feature the feature to be named
-   */
-  static Q_INVOKABLE QString displayName( QgsVectorLayer *layer, const QgsFeature &feature );
+    /**
+    * Returns the display name of a given feature.
+    * \param layer the vector layer containing the feature
+    * \param feature the feature to be named
+    */
+    static Q_INVOKABLE QString displayName( QgsVectorLayer *layer, const QgsFeature &feature );
 };
 
 #endif // FEATUREUTILS_H

--- a/src/core/utils/fileutils.cpp
+++ b/src/core/utils/fileutils.cpp
@@ -15,17 +15,17 @@
  ***************************************************************************/
 
 #include "fileutils.h"
-#include <qgis.h>
-#include <QMimeDatabase>
+
 #include <QDebug>
-#include <QFileInfo>
 #include <QDir>
 #include <QDirIterator>
+#include <QFileInfo>
+#include <QMimeDatabase>
+#include <qgis.h>
 
 FileUtils::FileUtils( QObject *parent )
   : QObject( parent )
 {
-
 }
 
 QString FileUtils::mimeTypeName( const QString &filePath )
@@ -62,7 +62,6 @@ bool FileUtils::copyRecursively( const QString &sourceFolder, const QString &des
   int current = 0;
   for ( QPair<QString, QString> srcDestFilePair : std::as_const( mapping ) )
   {
-
     QString srcName = srcDestFilePair.first;
     QString destName = srcDestFilePair.second;
 
@@ -125,7 +124,7 @@ QByteArray FileUtils::fileChecksum( const QString &fileName, const QCryptographi
 {
   QFile f( fileName );
 
-  if ( ! f.open( QFile::ReadOnly ) )
+  if ( !f.open( QFile::ReadOnly ) )
     return QByteArray();
 
   QCryptographicHash hash( hashAlgorithm );

--- a/src/core/utils/fileutils.h
+++ b/src/core/utils/fileutils.h
@@ -17,11 +17,11 @@
 #ifndef FILEUTILS_H
 #define FILEUTILS_H
 
-#include <QObject>
-#include <QCryptographicHash>
-#include <qgsfeedback.h>
-
 #include "qfield_core_export.h"
+
+#include <QCryptographicHash>
+#include <QObject>
+#include <qgsfeedback.h>
 
 class QFIELD_CORE_EXPORT FileUtils : public QObject
 {
@@ -51,7 +51,7 @@ class QFIELD_CORE_EXPORT FileUtils : public QObject
     Q_INVOKABLE static QByteArray fileChecksum( const QString &fileName, const QCryptographicHash::Algorithm hashAlgorithm = QCryptographicHash::Sha256 );
 
   private:
-    static int copyRecursivelyPrepare(const QString &sourceFolder, const QString &destFolder, QList<QPair<QString, QString> > &mapping );
+    static int copyRecursivelyPrepare( const QString &sourceFolder, const QString &destFolder, QList<QPair<QString, QString>> &mapping );
 };
 
 #endif // FILEUTILS_H

--- a/src/core/utils/geometryutils.cpp
+++ b/src/core/utils/geometryutils.cpp
@@ -15,17 +15,16 @@
  ***************************************************************************/
 
 #include "geometryutils.h"
+#include "rubberbandmodel.h"
 
 #include <qgslinestring.h>
 #include <qgspolygon.h>
-#include <qgsvectorlayer.h>
 #include <qgsproject.h>
+#include <qgsvectorlayer.h>
 
-#include "rubberbandmodel.h"
-
-GeometryUtils::GeometryUtils( QObject *parent ) : QObject( parent )
+GeometryUtils::GeometryUtils( QObject *parent )
+  : QObject( parent )
 {
-
 }
 
 
@@ -33,7 +32,7 @@ QgsGeometry GeometryUtils::polygonFromRubberband( RubberbandModel *rubberBandMod
 {
   QgsPointSequence ring = rubberBandModel->pointSequence( crs, QgsWkbTypes::Point, true );
   QgsLineString ext( ring );
-  std::unique_ptr< QgsPolygon > polygon = std::make_unique< QgsPolygon >( );
+  std::unique_ptr<QgsPolygon> polygon = std::make_unique<QgsPolygon>();
   polygon->setExteriorRing( ext.clone() );
   QgsGeometry g( std::move( polygon ) );
   return g;
@@ -43,8 +42,7 @@ QgsGeometry::OperationResult GeometryUtils::reshapeFromRubberband( QgsVectorLaye
 {
   QgsFeature feature = layer->getFeature( fid );
   QgsGeometry geom = feature.geometry();
-  if ( geom.isNull() ||
-       ( QgsWkbTypes::geometryType( geom.wkbType() ) != QgsWkbTypes::LineGeometry && QgsWkbTypes::geometryType( geom.wkbType() ) != QgsWkbTypes::PolygonGeometry ) )
+  if ( geom.isNull() || ( QgsWkbTypes::geometryType( geom.wkbType() ) != QgsWkbTypes::LineGeometry && QgsWkbTypes::geometryType( geom.wkbType() ) != QgsWkbTypes::PolygonGeometry ) )
     return QgsGeometry::InvalidBaseGeometry;
 
   QgsPointSequence points = rubberBandModel->pointSequence( layer->crs(), QgsWkbTypes::Point, false );
@@ -56,7 +54,7 @@ QgsGeometry::OperationResult GeometryUtils::reshapeFromRubberband( QgsVectorLaye
     //avoid intersections on polygon layers
     if ( layer->geometryType() == QgsWkbTypes::PolygonGeometry )
     {
-      QList<QgsVectorLayer *>  avoidIntersectionsLayers;
+      QList<QgsVectorLayer *> avoidIntersectionsLayers;
       switch ( QgsProject::instance()->avoidIntersectionsMode() )
       {
         case QgsProject::AvoidIntersectionsMode::AvoidIntersectionsCurrentLayer:
@@ -123,4 +121,3 @@ QgsGeometry::OperationResult GeometryUtils::splitFeatureFromRubberband( QgsVecto
   QgsPointSequence line = rubberBandModel->pointSequence( layer->crs(), QgsWkbTypes::Point, false );
   return layer->splitFeatures( line, true );
 }
-

--- a/src/core/utils/geometryutils.h
+++ b/src/core/utils/geometryutils.h
@@ -16,12 +16,11 @@
 #ifndef GEOMETRYUTILS_H
 #define GEOMETRYUTILS_H
 
-#include <QObject>
-
-#include <qgsgeometry.h>
-#include <qgsfeature.h>
-
 #include "qfield_core_export.h"
+
+#include <QObject>
+#include <qgsfeature.h>
+#include <qgsgeometry.h>
 
 class QgsVectorLayer;
 class RubberbandModel;
@@ -44,7 +43,6 @@ class QFIELD_CORE_EXPORT GeometryUtils : public QObject
 
     //! This will perform a split using the line in the rubberband model. It works with the layer selection if some features are selected.
     static Q_INVOKABLE QgsGeometry::OperationResult splitFeatureFromRubberband( QgsVectorLayer *layer, RubberbandModel *rubberBandModel );
-
 };
 
 #endif // GEOMETRYUTILS_H

--- a/src/core/utils/layerutils.cpp
+++ b/src/core/utils/layerutils.cpp
@@ -29,9 +29,9 @@
 #include <qgsvectorlayer.h>
 #include <qgswkbtypes.h>
 
-LayerUtils::LayerUtils( QObject *parent ) : QObject( parent )
+LayerUtils::LayerUtils( QObject *parent )
+  : QObject( parent )
 {
-
 }
 
 QgsSymbol *LayerUtils::defaultSymbol( QgsVectorLayer *layer )
@@ -59,7 +59,7 @@ QgsSymbol *LayerUtils::defaultSymbol( QgsVectorLayer *layer )
 
     case QgsWkbTypes::PolygonGeometry:
     {
-      QgsSimpleFillSymbolLayer *symbolLayer = new QgsSimpleFillSymbolLayer( QColor( 255, 0, 0, 100), DEFAULT_SIMPLEFILL_STYLE, QColor( 255, 0, 0), DEFAULT_SIMPLEFILL_BORDERSTYLE, 0.6 );
+      QgsSimpleFillSymbolLayer *symbolLayer = new QgsSimpleFillSymbolLayer( QColor( 255, 0, 0, 100 ), DEFAULT_SIMPLEFILL_STYLE, QColor( 255, 0, 0 ), DEFAULT_SIMPLEFILL_BORDERSTYLE, 0.6 );
       symbolLayers << symbolLayer;
       symbol = new QgsFillSymbol( symbolLayers );
       break;
@@ -78,7 +78,7 @@ bool LayerUtils::isAtlasCoverageLayer( QgsVectorLayer *layer )
     return false;
 
   const QList<QgsPrintLayout *> printLayouts = QgsProject::instance()->layoutManager()->printLayouts();
-  for( QgsPrintLayout *printLayout : printLayouts )
+  for ( QgsPrintLayout *printLayout : printLayouts )
   {
     if ( printLayout->atlas() )
     {

--- a/src/core/utils/layerutils.h
+++ b/src/core/utils/layerutils.h
@@ -13,7 +13,7 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
- 
+
 #ifndef LAYERUTILS_H
 #define LAYERUTILS_H
 
@@ -24,24 +24,23 @@ class QgsSymbol;
 
 class LayerUtils : public QObject
 {
-  Q_OBJECT
+    Q_OBJECT
 
-public:
+  public:
+    explicit LayerUtils( QObject *parent = nullptr );
 
-  explicit LayerUtils(QObject *parent = nullptr);
+    /**
+    * Returns the default symbol for a given layer.
+    * \param layer the vector layer used to create the default symbol
+    */
+    static QgsSymbol *defaultSymbol( QgsVectorLayer *layer );
 
-  /**
-   * Returns the default symbol for a given layer.
-   * \param layer the vector layer used to create the default symbol
-   */
-  static QgsSymbol *defaultSymbol( QgsVectorLayer *layer );
-
-  /**
-   * Returns TRUE if the vector layer is used as an atlas coverage layer in
-   * any of the print layouts of the currently opened project.
-   * \param layer the vector layer to check against print layouts
-   */
-  static Q_INVOKABLE bool isAtlasCoverageLayer( QgsVectorLayer *layer );
+    /**
+    * Returns TRUE if the vector layer is used as an atlas coverage layer in
+    * any of the print layouts of the currently opened project.
+    * \param layer the vector layer to check against print layouts
+    */
+    static Q_INVOKABLE bool isAtlasCoverageLayer( QgsVectorLayer *layer );
 };
 
 #endif // LAYERUTILS_H

--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -14,9 +14,10 @@
  ***************************************************************************/
 
 #include "qfieldcloudutils.h"
-#include <qgsapplication.h>
+
 #include <QDir>
 #include <QString>
+#include <qgsapplication.h>
 #include <qgsmessagelog.h>
 
 // NOTE directly setting does not work QgsApplication::qgisSettingsDirPath();
@@ -46,9 +47,7 @@ bool QFieldCloudUtils::isCloudAction( const QgsMapLayer *layer )
 
   const QString layerAction( layer->customProperty( QStringLiteral( "QFieldSync/action" ) ).toString().toUpper() );
 
-  if ( layerAction == QStringLiteral( "NO_ACTION" ) ||
-       layerAction == QStringLiteral( "REMOVE" )
-       )
+  if ( layerAction == QStringLiteral( "NO_ACTION" ) || layerAction == QStringLiteral( "REMOVE" ) )
     return false;
   return true;
 }

--- a/src/core/utils/qfieldcloudutils.h
+++ b/src/core/utils/qfieldcloudutils.h
@@ -16,9 +16,9 @@
 #ifndef QFIELDCLOUDUTILS_H
 #define QFIELDCLOUDUTILS_H
 
-#include <qgsproject.h>
-#include <qgsmaplayer.h>
 #include <qfieldcloudprojectsmodel.h>
+#include <qgsmaplayer.h>
+#include <qgsproject.h>
 
 class QString;
 class QFieldCloudProjectsModel;
@@ -30,7 +30,6 @@ class QFieldCloudUtils : public QObject
     Q_OBJECT
 
   public:
-
     static const QString localCloudDirectory();
     static const QString localProjectFilePath( const QString &username, const QString &projectId );
 
@@ -59,11 +58,10 @@ class QFieldCloudUtils : public QObject
     Q_INVOKABLE static const QString getProjectId( QgsProject *project );
 
   private:
-
     static QString sQgisSettingsDirPath;
 
-  friend TestDeltaFileWrapper;
-  friend TestLayerObserver;
+    friend TestDeltaFileWrapper;
+    friend TestLayerObserver;
 };
 
 #endif // QFIELDCLOUDUTILS_H

--- a/src/core/utils/stringutils.cpp
+++ b/src/core/utils/stringutils.cpp
@@ -15,17 +15,16 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsstringutils.h"
 #include "stringutils.h"
 
-#include "qgsstringutils.h"
-#include <QRegularExpression>
 #include <QDebug>
+#include <QRegularExpression>
 
 
 StringUtils::StringUtils( QObject *parent )
   : QObject( parent )
 {
-
 }
 
 
@@ -61,6 +60,6 @@ bool StringUtils::fuzzyMatch( const QString &source, const QString &term )
   }
 
   return lastMatchedTermPartIdx >= 0 && matchedTermItems == termPartsCount
-      ? true
-      : false;
+         ? true
+         : false;
 }

--- a/src/core/utils/stringutils.h
+++ b/src/core/utils/stringutils.h
@@ -18,17 +18,15 @@
 #ifndef STRINGUTILS_H
 #define STRINGUTILS_H
 
-#include <QObject>
-
 #include "qfield_core_export.h"
+
+#include <QObject>
 
 class QFIELD_CORE_EXPORT StringUtils : public QObject
 {
     Q_OBJECT
 
   public:
-
-
     explicit StringUtils( QObject *parent = nullptr );
 
 
@@ -42,4 +40,3 @@ class QFIELD_CORE_EXPORT StringUtils : public QObject
 };
 
 #endif // STRINGUTILS_H
-

--- a/src/core/utils/urlutils.cpp
+++ b/src/core/utils/urlutils.cpp
@@ -23,7 +23,6 @@
 UrlUtils::UrlUtils( QObject *parent )
   : QObject( parent )
 {
-
 }
 
 

--- a/src/core/utils/urlutils.h
+++ b/src/core/utils/urlutils.h
@@ -18,9 +18,9 @@
 #ifndef URLUTILS_H
 #define URLUTILS_H
 
-#include <QObject>
-
 #include "qfield_core_export.h"
+
+#include <QObject>
 
 
 class QFIELD_CORE_EXPORT UrlUtils : public QObject
@@ -28,8 +28,6 @@ class QFIELD_CORE_EXPORT UrlUtils : public QObject
     Q_OBJECT
 
   public:
-
-
     explicit UrlUtils( QObject *parent = nullptr );
 
 

--- a/src/core/valuemapmodel.cpp
+++ b/src/core/valuemapmodel.cpp
@@ -16,8 +16,9 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "valuemapmodel.h"
 #include "qgsvaluemapfieldformatter.h"
+#include "valuemapmodel.h"
+
 #include <QDebug>
 
 ValueMapModel::ValueMapModel( QObject *parent )

--- a/src/core/vertexmodel.cpp
+++ b/src/core/vertexmodel.cpp
@@ -14,16 +14,15 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <QDebug>
-
-#include <qgsgeometry.h>
-#include <qgswkbtypes.h>
-#include <qgslinestring.h>
-#include <qgspolygon.h>
-#include <qgsmessagelog.h>
-
-#include "vertexmodel.h"
 #include "qgsquickmapsettings.h"
+#include "vertexmodel.h"
+
+#include <QDebug>
+#include <qgsgeometry.h>
+#include <qgslinestring.h>
+#include <qgsmessagelog.h>
+#include <qgspolygon.h>
+#include <qgswkbtypes.h>
 
 
 VertexModel::VertexModel( QObject *parent )
@@ -175,7 +174,7 @@ void VertexModel::createCandidates()
     // adding new vertices
     if ( r < mVertices.count() - 1 && mVertices.at( r + 1 ).ring == vertex.ring && mGeometryType != QgsWkbTypes::PointGeometry )
     {
-      QVector<QgsPoint> points = {mVertices.at( r + 1 ).point, vertex.point};
+      QVector<QgsPoint> points = { mVertices.at( r + 1 ).point, vertex.point };
       QgsPoint centroid = QgsLineString( points ).centroid();
 
       Vertex newVertex;
@@ -219,7 +218,7 @@ void VertexModel::createCandidates()
         // TODO multipart
         lastVertex = mVertices.at( i );
       }
-      QVector<QgsPoint> points = {lastVertex.point, vertex.point};
+      QVector<QgsPoint> points = { lastVertex.point, vertex.point };
       QgsPoint centroid = QgsLineString( points ).centroid();
 
       Vertex newVertex;
@@ -729,14 +728,14 @@ void VertexModel::updateCanRemoveVertex()
         canRemoveVertex = false;
         break;
       case QgsWkbTypes::LineGeometry:
-        canRemoveVertex =  flatVertices().count() > 2;
+        canRemoveVertex = flatVertices().count() > 2;
         break;
       case QgsWkbTypes::PolygonGeometry:
-        canRemoveVertex =  flatVertices().count() > 4; // the polygon is returned closed
+        canRemoveVertex = flatVertices().count() > 4; // the polygon is returned closed
         break;
       case QgsWkbTypes::NullGeometry:
       case QgsWkbTypes::UnknownGeometry:
-        canRemoveVertex =  false;
+        canRemoveVertex = false;
         break;
     }
   }

--- a/src/core/vertexmodel.h
+++ b/src/core/vertexmodel.h
@@ -20,11 +20,10 @@
 
 class QgsQuickMapSettings;
 
-#include "qgspoint.h"
-#include "qgsgeometry.h"
-#include "qgscoordinatetransform.h"
-
 #include "qfield_core_export.h"
+#include "qgscoordinatetransform.h"
+#include "qgsgeometry.h"
+#include "qgspoint.h"
 
 /**
  * The VertexModel class is a model to highlight and edit vertices.

--- a/src/core/viewstatus.cpp
+++ b/src/core/viewstatus.cpp
@@ -19,5 +19,4 @@
 ViewStatus::ViewStatus( QObject *parent )
   : QObject( parent )
 {
-
 }

--- a/test/qfield_testbase.h
+++ b/test/qfield_testbase.h
@@ -1,21 +1,21 @@
-#include <qgsapplication.h>
 #include <qgis.h>
+#include <qgsapplication.h>
 
-#define QFIELDTEST_MAIN(TestObject) \
-  QT_BEGIN_NAMESPACE \
-  QTEST_ADD_GPU_BLACKLIST_SUPPORT_DEFS \
-  QT_END_NAMESPACE \
-  int main(int argc, char *argv[]) \
-  { \
-    QgsApplication app(argc, argv, false); \
-    app.init(); \
+#define QFIELDTEST_MAIN( TestObject )                \
+  QT_BEGIN_NAMESPACE                                 \
+  QTEST_ADD_GPU_BLACKLIST_SUPPORT_DEFS               \
+  QT_END_NAMESPACE                                   \
+  int main( int argc, char *argv[] )                 \
+  {                                                  \
+    QgsApplication app( argc, argv, false );         \
+    app.init();                                      \
     app.setPrefixPath( CMAKE_INSTALL_PREFIX, true ); \
-    app.initQgis(); \
-    app.setAttribute(Qt::AA_Use96Dpi, true); \
-    QTEST_DISABLE_KEYPAD_NAVIGATION \
-    QTEST_ADD_GPU_BLACKLIST_SUPPORT \
-    TestObject tc; \
-    QTEST_SET_MAIN_SOURCE_PATH \
-    return QTest::qExec(&tc, argc, argv); \
-    app.exitQgis(); \
+    app.initQgis();                                  \
+    app.setAttribute( Qt::AA_Use96Dpi, true );       \
+    QTEST_DISABLE_KEYPAD_NAVIGATION                  \
+    QTEST_ADD_GPU_BLACKLIST_SUPPORT                  \
+    TestObject tc;                                   \
+    QTEST_SET_MAIN_SOURCE_PATH                       \
+    return QTest::qExec( &tc, argc, argv );          \
+    app.exitQgis();                                  \
   }

--- a/test/qgistestapp.h
+++ b/test/qgistestapp.h
@@ -28,7 +28,7 @@ class QgisTestApp
       mApp = new QgsApplication( argc, argv, false );
 
       // load providers
-#if defined(Q_WS_WIN)
+#if defined( Q_WS_WIN )
       QString prefixPath = QApplication::applicationDirPath();
 #else
       QString prefixPath = QApplication::applicationDirPath() + "/..";
@@ -56,4 +56,3 @@ class QgisTestApp
 };
 
 #endif // QGISTESTAPP
-

--- a/test/qt_modeltest/dynamictreemodel.cpp
+++ b/test/qt_modeltest/dynamictreemodel.cpp
@@ -52,26 +52,25 @@
 
 
 DynamicTreeModel::DynamicTreeModel( QObject *parent )
-  : QAbstractItemModel( parent ),
-    nextId( 1 )
+  : QAbstractItemModel( parent ), nextId( 1 )
 {
 }
 
 QModelIndex DynamicTreeModel::index( int row, int column, const QModelIndex &parent ) const
 {
-//   if (column != 0)
-//     return QModelIndex();
+  //   if (column != 0)
+  //     return QModelIndex();
 
 
   if ( column < 0 || row < 0 )
     return QModelIndex();
 
-  QList<QList<qint64> > childIdColumns = m_childItems.value( parent.internalId() );
+  QList<QList<qint64>> childIdColumns = m_childItems.value( parent.internalId() );
 
   const qint64 grandParent = findParentId( parent.internalId() );
   if ( grandParent >= 0 )
   {
-    QList<QList<qint64> > parentTable = m_childItems.value( grandParent );
+    QList<QList<qint64>> parentTable = m_childItems.value( grandParent );
     Q_ASSERT( parent.column() < parentTable.size() );
     QList<qint64> parentSiblings = parentTable.at( parent.column() );
     Q_ASSERT( parent.row() < parentSiblings.size() );
@@ -91,7 +90,6 @@ QModelIndex DynamicTreeModel::index( int row, int column, const QModelIndex &par
   qint64 id = rowIds.at( row );
 
   return createIndex( row, column, reinterpret_cast<void *>( id ) );
-
 }
 
 qint64 DynamicTreeModel::findParentId( qint64 searchId ) const
@@ -99,11 +97,11 @@ qint64 DynamicTreeModel::findParentId( qint64 searchId ) const
   if ( searchId <= 0 )
     return -1;
 
-  QHashIterator<qint64, QList<QList<qint64> > > i( m_childItems );
+  QHashIterator<qint64, QList<QList<qint64>>> i( m_childItems );
   while ( i.hasNext() )
   {
     i.next();
-    QListIterator<QList<qint64> > j( i.value() );
+    QListIterator<QList<qint64>> j( i.value() );
     while ( j.hasNext() )
     {
       QList<qint64> l = j.next();
@@ -137,12 +135,11 @@ QModelIndex DynamicTreeModel::parent( const QModelIndex &index ) const
   int row = childList.indexOf( parentId );
 
   return createIndex( row, column, reinterpret_cast<void *>( parentId ) );
-
 }
 
 int DynamicTreeModel::rowCount( const QModelIndex &index ) const
 {
-  QList<QList<qint64> > cols = m_childItems.value( index.internalId() );
+  QList<QList<qint64>> cols = m_childItems.value( index.internalId() );
 
   if ( cols.size() == 0 )
     return 0;
@@ -155,7 +152,7 @@ int DynamicTreeModel::rowCount( const QModelIndex &index ) const
 
 int DynamicTreeModel::columnCount( const QModelIndex &index ) const
 {
-//   Q_UNUSED(index);
+  //   Q_UNUSED(index);
   return m_childItems.value( index.internalId() ).size();
 }
 
@@ -184,7 +181,6 @@ void DynamicTreeModel::clear()
 ModelChangeCommand::ModelChangeCommand( DynamicTreeModel *model, QObject *parent )
   : QObject( parent ), m_model( model ), m_numCols( 1 ), m_startRow( -1 ), m_endRow( -1 )
 {
-
 }
 
 QModelIndex ModelChangeCommand::findIndex( QList<int> rows )
@@ -203,7 +199,6 @@ QModelIndex ModelChangeCommand::findIndex( QList<int> rows )
 ModelInsertCommand::ModelInsertCommand( DynamicTreeModel *model, QObject *parent )
   : ModelChangeCommand( model, parent )
 {
-
 }
 
 void ModelInsertCommand::doCommand()
@@ -219,13 +214,12 @@ void ModelInsertCommand::doCommand()
       {
         m_model->m_childItems[parentId].append( QList<qint64>() );
       }
-//       QString name = QUuid::createUuid().toString();
+      //       QString name = QUuid::createUuid().toString();
       qint64 id = m_model->newId();
       QString name = QString::number( id );
 
       m_model->m_items.insert( id, name );
       m_model->m_childItems[parentId][col].insert( row, id );
-
     }
   }
   m_model->endInsertRows();
@@ -235,7 +229,6 @@ void ModelInsertCommand::doCommand()
 ModelMoveCommand::ModelMoveCommand( DynamicTreeModel *model, QObject *parent )
   : ModelChangeCommand( model, parent )
 {
-
 }
 bool ModelMoveCommand::emitPreSignal( const QModelIndex &srcParent, int srcStart, int srcEnd, const QModelIndex &destParent, int destRow )
 {
@@ -256,7 +249,7 @@ void ModelMoveCommand::doCommand()
   {
     QList<qint64> l = m_model->m_childItems.value( srcParent.internalId() )[column].mid( m_startRow, m_endRow - m_startRow + 1 );
 
-    for ( int i = m_startRow; i <= m_endRow ; i++ )
+    for ( int i = m_startRow; i <= m_endRow; i++ )
     {
       m_model->m_childItems[srcParent.internalId()][column].removeAt( m_startRow );
     }
@@ -288,12 +281,10 @@ void ModelMoveCommand::emitPostSignal()
 ModelResetCommand::ModelResetCommand( DynamicTreeModel *model, QObject *parent )
   : ModelMoveCommand( model, parent )
 {
-
 }
 
 ModelResetCommand::~ModelResetCommand()
 {
-
 }
 
 bool ModelResetCommand::emitPreSignal( const QModelIndex &srcParent, int srcStart, int srcEnd, const QModelIndex &destParent, int destRow )
@@ -315,12 +306,10 @@ void ModelResetCommand::emitPostSignal()
 ModelResetCommandFixed::ModelResetCommandFixed( DynamicTreeModel *model, QObject *parent )
   : ModelMoveCommand( model, parent )
 {
-
 }
 
 ModelResetCommandFixed::~ModelResetCommandFixed()
 {
-
 }
 
 bool ModelResetCommandFixed::emitPreSignal( const QModelIndex &srcParent, int srcStart, int srcEnd, const QModelIndex &destParent, int destRow )
@@ -339,4 +328,3 @@ void ModelResetCommandFixed::emitPostSignal()
 {
   m_model->endResetModel();
 }
-

--- a/test/qt_modeltest/dynamictreemodel.h
+++ b/test/qt_modeltest/dynamictreemodel.h
@@ -48,7 +48,6 @@
 #define DYNAMICTREEMODEL_H
 
 #include <QtCore/QAbstractItemModel>
-
 #include <QtCore/QHash>
 #include <QtCore/QList>
 
@@ -80,7 +79,7 @@ class DynamicTreeModel : public QAbstractItemModel
 
   private:
     QHash<qint64, QString> m_items;
-    QHash<qint64, QList<QList<qint64> > > m_childItems;
+    QHash<qint64, QList<QList<qint64>>> m_childItems;
     qint64 nextId;
     qint64 newId()
     {
@@ -97,7 +96,6 @@ class DynamicTreeModel : public QAbstractItemModel
     friend class ModelMoveCommand;
     friend class ModelResetCommand;
     friend class ModelResetCommandFixed;
-
 };
 
 
@@ -105,7 +103,6 @@ class ModelChangeCommand : public QObject
 {
     Q_OBJECT
   public:
-
     ModelChangeCommand( DynamicTreeModel *model, QObject *parent = 0 );
 
     virtual ~ModelChangeCommand() {}
@@ -140,7 +137,6 @@ class ModelChangeCommand : public QObject
     int m_numCols;
     int m_startRow;
     int m_endRow;
-
 };
 
 typedef QList<ModelChangeCommand *> ModelChangeCommandList;
@@ -150,7 +146,6 @@ class ModelInsertCommand : public ModelChangeCommand
     Q_OBJECT
 
   public:
-
     ModelInsertCommand( DynamicTreeModel *model, QObject *parent = 0 );
     virtual ~ModelInsertCommand() {}
 
@@ -200,7 +195,6 @@ class ModelResetCommand : public ModelMoveCommand
 
     virtual bool emitPreSignal( const QModelIndex &srcParent, int srcStart, int srcEnd, const QModelIndex &destParent, int destRow );
     virtual void emitPostSignal();
-
 };
 
 /**
@@ -216,7 +210,6 @@ class ModelResetCommandFixed : public ModelMoveCommand
 
     virtual bool emitPreSignal( const QModelIndex &srcParent, int srcStart, int srcEnd, const QModelIndex &destParent, int destRow );
     virtual void emitPostSignal();
-
 };
 
 

--- a/test/qt_modeltest/modeltest.cpp
+++ b/test/qt_modeltest/modeltest.cpp
@@ -45,20 +45,20 @@
 ****************************************************************************/
 
 
-#include <QtGui/QtGui>
-
 #include "modeltest.h"
 
+#include <QtGui/QtGui>
 #include <QtTest/QtTest>
 #undef Q_ASSERT
-#define Q_ASSERT  QVERIFY
+#define Q_ASSERT QVERIFY
 
 Q_DECLARE_METATYPE( QModelIndex )
 
 /*!
     Connect to all of the models signals.  Whenever anything happens recheck everything.
 */
-ModelTest::ModelTest( QAbstractItemModel *_model, QObject *parent ) : QObject( parent ), model( _model ), fetchingMore( false )
+ModelTest::ModelTest( QAbstractItemModel *_model, QObject *parent )
+  : QObject( parent ), model( _model ), fetchingMore( false )
 {
   Q_ASSERT( model );
 
@@ -159,7 +159,7 @@ void ModelTest::nonDestructiveBasicTest()
  */
 void ModelTest::rowCount()
 {
-//     qDebug() << "rc";
+  //     qDebug() << "rc";
   // check top row
   QModelIndex topIndex = model->index( 0, 0, QModelIndex() );
   int rows = model->rowCount( topIndex );
@@ -168,7 +168,7 @@ void ModelTest::rowCount()
     Q_ASSERT( model->hasChildren( topIndex ) );
 
   QModelIndex secondLevelIndex = model->index( 0, 0, topIndex );
-  if ( secondLevelIndex.isValid() )   // not the top level
+  if ( secondLevelIndex.isValid() ) // not the top level
   {
     // check a row count where parent is valid
     rows = model->rowCount( secondLevelIndex );
@@ -204,7 +204,7 @@ void ModelTest::columnCount()
  */
 void ModelTest::hasIndex()
 {
-//     qDebug() << "hi";
+  //     qDebug() << "hi";
   // Make sure that invalid values returns an invalid index
   Q_ASSERT( !model->hasIndex( -2, -2 ) );
   Q_ASSERT( !model->hasIndex( -2, 0 ) );
@@ -229,7 +229,7 @@ void ModelTest::hasIndex()
  */
 void ModelTest::index()
 {
-//     qDebug() << "i";
+  //     qDebug() << "i";
   // Make sure that invalid values returns an invalid index
   Q_ASSERT( model->index( -2, -2 ) == QModelIndex() );
   Q_ASSERT( model->index( -2, 0 ) == QModelIndex() );
@@ -259,7 +259,7 @@ void ModelTest::index()
  */
 void ModelTest::parent()
 {
-//     qDebug() << "p";
+  //     qDebug() << "p";
   // Make sure the model wont crash and will return an invalid QModelIndex
   // when asked for the parent of an invalid index.
   Q_ASSERT( model->parent( QModelIndex() ) == QModelIndex() );
@@ -377,7 +377,7 @@ void ModelTest::checkChildren( const QModelIndex &parent, int currentDepth )
       Q_ASSERT( index.column() == c );
       // While you can technically return a QVariant usually this is a sign
       // of an bug in data()  Disable if this really is ok in your model.
-//            Q_ASSERT ( model->data ( index, Qt::DisplayRole ).isValid() );
+      //            Q_ASSERT ( model->data ( index, Qt::DisplayRole ).isValid() );
 
       // If the next test fails here is some somewhat useful debug you play with.
 
@@ -386,14 +386,14 @@ void ModelTest::checkChildren( const QModelIndex &parent, int currentDepth )
         qDebug() << r << c << currentDepth << model->data( index ).toString()
                  << model->data( parent ).toString();
         qDebug() << index << parent << model->parent( index );
-//                 And a view that you can even use to show the model.
-//                 QTreeView view;
-//                 view.setModel(model);
-//                 view.show();
+        //                 And a view that you can even use to show the model.
+        //                 QTreeView view;
+        //                 view.setModel(model);
+        //                 view.show();
       }
 
       // Check that we can get back our real parent.
-//            qDebug() << model->parent ( index ) << parent;
+      //            qDebug() << model->parent ( index ) << parent;
       Q_ASSERT( model->parent( index ) == parent );
 
       // recursively go down the children
@@ -401,7 +401,7 @@ void ModelTest::checkChildren( const QModelIndex &parent, int currentDepth )
       {
         //qDebug() << r << c << "has children" << model->rowCount(index);
         checkChildren( index, ++currentDepth );
-      }/* else { if (currentDepth >= 10) qDebug() << "checked 10 deep"; };*/
+      } /* else { if (currentDepth >= 10) qDebug() << "checked 10 deep"; };*/
 
       // make sure that after testing the children that the index doesn't change.
       QModelIndex newerIndex = model->index( r, c, parent );
@@ -484,9 +484,7 @@ void ModelTest::data()
   if ( checkStateVariant.isValid() )
   {
     int state = checkStateVariant.toInt();
-    Q_ASSERT( state == Qt::Unchecked ||
-              state == Qt::PartiallyChecked ||
-              state == Qt::Checked );
+    Q_ASSERT( state == Qt::Unchecked || state == Qt::PartiallyChecked || state == Qt::Checked );
   }
 }
 
@@ -498,9 +496,9 @@ void ModelTest::data()
 void ModelTest::rowsAboutToBeInserted( const QModelIndex &parent, int start, int end )
 {
   Q_UNUSED( end );
-//    qDebug() << "rowsAboutToBeInserted" << "start=" << start << "end=" << end << "parent=" << model->data ( parent ).toString()
-//    << "current count of parent=" << model->rowCount ( parent ); // << "display of last=" << model->data( model->index(start-1, 0, parent) );
-//     qDebug() << model->index(start-1, 0, parent) << model->data( model->index(start-1, 0, parent) );
+  //    qDebug() << "rowsAboutToBeInserted" << "start=" << start << "end=" << end << "parent=" << model->data ( parent ).toString()
+  //    << "current count of parent=" << model->rowCount ( parent ); // << "display of last=" << model->data( model->index(start-1, 0, parent) );
+  //     qDebug() << model->index(start-1, 0, parent) << model->data( model->index(start-1, 0, parent) );
   Changing c;
   c.parent = parent;
   c.oldSize = model->rowCount( parent );
@@ -518,14 +516,14 @@ void ModelTest::rowsInserted( const QModelIndex &parent, int start, int end )
 {
   Changing c = insert.pop();
   Q_ASSERT( c.parent == parent );
-//    qDebug() << "rowsInserted"  << "start=" << start << "end=" << end << "oldsize=" << c.oldSize
-//    << "parent=" << model->data ( parent ).toString() << "current rowcount of parent=" << model->rowCount ( parent );
+  //    qDebug() << "rowsInserted"  << "start=" << start << "end=" << end << "oldsize=" << c.oldSize
+  //    << "parent=" << model->data ( parent ).toString() << "current rowcount of parent=" << model->rowCount ( parent );
 
-//    for (int ii=start; ii <= end; ii++)
-//    {
-//      qDebug() << "itemWasInserted:" << ii << model->data ( model->index ( ii, 0, parent ));
-//    }
-//    qDebug();
+  //    for (int ii=start; ii <= end; ii++)
+  //    {
+  //      qDebug() << "itemWasInserted:" << ii << model->data ( model->index ( ii, 0, parent ));
+  //    }
+  //    qDebug();
 
   Q_ASSERT( c.oldSize + ( end - start + 1 ) == model->rowCount( parent ) );
   Q_ASSERT( c.last == model->data( model->index( start - 1, 0, c.parent ) ) );
@@ -587,5 +585,3 @@ void ModelTest::rowsRemoved( const QModelIndex &parent, int start, int end )
   Q_ASSERT( c.last == model->data( model->index( start - 1, 0, c.parent ) ) );
   Q_ASSERT( c.next == model->data( model->index( start, 0, c.parent ) ) );
 }
-
-

--- a/test/qt_modeltest/modeltest.h
+++ b/test/qt_modeltest/modeltest.h
@@ -48,8 +48,8 @@
 #ifndef MODELTEST_H
 #define MODELTEST_H
 
-#include <QtCore/QObject>
 #include <QtCore/QAbstractItemModel>
+#include <QtCore/QObject>
 #include <QtCore/QStack>
 
 class ModelTest : public QObject

--- a/test/qt_modeltest/tst_modeltest.cpp
+++ b/test/qt_modeltest/tst_modeltest.cpp
@@ -45,11 +45,11 @@
 ****************************************************************************/
 
 
-#include <QtTest/QtTest>
-#include <QtGui/QtGui>
-
-#include "modeltest.h"
 #include "dynamictreemodel.h"
+#include "modeltest.h"
+
+#include <QtGui/QtGui>
+#include <QtTest/QtTest>
 
 
 class tst_ModelTest : public QObject
@@ -76,7 +76,6 @@ class tst_ModelTest : public QObject
 };
 
 
-
 void tst_ModelTest::initTestCase()
 {
 }
@@ -87,7 +86,6 @@ void tst_ModelTest::cleanupTestCase()
 
 void tst_ModelTest::init()
 {
-
 }
 
 void tst_ModelTest::cleanup()
@@ -107,8 +105,14 @@ void tst_ModelTest::stringListModel()
 
   proxy.setSourceModel( &model );
 
-  model.setStringList( QStringList() << "2" << "3" << "1" );
-  model.setStringList( QStringList() << "a" << "e" << "plop" << "b" << "c" );
+  model.setStringList( QStringList() << "2"
+                       << "3"
+                       << "1" );
+  model.setStringList( QStringList() << "a"
+                       << "e"
+                       << "plop"
+                       << "b"
+                       << "c" );
 
   proxy.setDynamicSortFilter( true );
   proxy.setFilterRegExp( QRegExp( "[^b]" ) );
@@ -194,7 +198,8 @@ class AccessibleProxyModel : public QSortFilterProxyModel
 {
     Q_OBJECT
   public:
-    AccessibleProxyModel( QObject *parent = 0 ) : QSortFilterProxyModel( parent ) {}
+    AccessibleProxyModel( QObject *parent = 0 )
+      : QSortFilterProxyModel( parent ) {}
 
     QModelIndexList persistent()
     {
@@ -206,9 +211,8 @@ class ObservingObject : public QObject
 {
     Q_OBJECT
   public:
-    ObservingObject( AccessibleProxyModel  *proxy, QObject *parent = 0 )
-      : QObject( parent ),
-        m_proxy( proxy )
+    ObservingObject( AccessibleProxyModel *proxy, QObject *parent = 0 )
+      : QObject( parent ), m_proxy( proxy )
     {
       connect( m_proxy, SIGNAL( layoutAboutToBeChanged() ), SLOT( storePersistent() ) );
       connect( m_proxy, SIGNAL( layoutChanged() ), SLOT( checkPersistent() ) );
@@ -259,7 +263,7 @@ class ObservingObject : public QObject
     }
 
   private:
-    AccessibleProxyModel  *m_proxy;
+    AccessibleProxyModel *m_proxy;
     QList<QPersistentModelIndex> m_persistentSourceIndexes;
     QList<QPersistentModelIndex> m_persistentProxyIndexes;
 };

--- a/test/test_deltafilewrapper.cpp
+++ b/test/test_deltafilewrapper.cpp
@@ -15,18 +15,17 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <QtTest>
-
-#include <qgsproject.h>
-
-#include "qfield_testbase.h"
-#include "qfield.h"
 #include "deltafilewrapper.h"
+#include "qfield.h"
+#include "qfield_testbase.h"
 #include "utils/fileutils.h"
 #include "utils/qfieldcloudutils.h"
 
+#include <QtTest>
+#include <qgsproject.h>
 
-class TestDeltaFileWrapper: public QObject
+
+class TestDeltaFileWrapper : public QObject
 {
     Q_OBJECT
   private slots:
@@ -37,7 +36,7 @@ class TestDeltaFileWrapper: public QObject
 
       QVERIFY2( settingsDir.isValid(), "Failed to create temp dir" );
       QVERIFY2( mTmpFile.open(), "Cannot open temporary delta file" );
-      QVERIFY2( QDir( settingsDir.path() ).mkpath( QStringLiteral("cloud_projects/TEST_PROJECT_ID") ), "Failed to create project dir" );
+      QVERIFY2( QDir( settingsDir.path() ).mkpath( QStringLiteral( "cloud_projects/TEST_PROJECT_ID" ) ), "Failed to create project dir" );
 
       QDir projectDir( QStringLiteral( "%1/cloud_projects/TEST_PROJECT_ID" ).arg( settingsDir.path() ) );
       QFieldCloudUtils::sQgisSettingsDirPath = settingsDir.path();
@@ -122,7 +121,7 @@ class TestDeltaFileWrapper: public QObject
       DeltaFileWrapper correctExistingDfw( mProject, mTmpFile.fileName() );
       QCOMPARE( correctExistingDfw.errorType(), DeltaFileWrapper::NoError );
       QJsonDocument correctExistingDoc = normalizeSchema( correctExistingDfw.toString() );
-      QVERIFY( ! correctExistingDoc.isNull() );
+      QVERIFY( !correctExistingDoc.isNull() );
       QCOMPARE( correctExistingDoc, QJsonDocument::fromJson( correctExistingContents.toUtf8() ) );
     }
 
@@ -137,7 +136,7 @@ class TestDeltaFileWrapper: public QObject
       QFile deltaFile( fileName );
       QVERIFY( deltaFile.open( QIODevice::ReadOnly ) );
       QJsonDocument fileContents = normalizeSchema( deltaFile.readAll() );
-      QVERIFY( ! fileContents.isNull() );
+      QVERIFY( !fileContents.isNull() );
       qDebug() << fileContents;
       QCOMPARE( fileContents, QJsonDocument::fromJson( R""""(
         {
@@ -251,7 +250,7 @@ class TestDeltaFileWrapper: public QObject
     {
       DeltaFileWrapper dfw( mProject, QString( std::tmpnam( nullptr ) ) );
 
-      QVERIFY( ! QUuid::fromString( dfw.id() ).isNull() );
+      QVERIFY( !QUuid::fromString( dfw.id() ).isNull() );
     }
 
 
@@ -304,7 +303,7 @@ class TestDeltaFileWrapper: public QObject
 
       QJsonDocument doc = normalizeSchema( dfw.toString() );
 
-      QVERIFY( ! doc.isNull() );
+      QVERIFY( !doc.isNull() );
       qDebug() << doc;
       QCOMPARE( doc, QJsonDocument::fromJson( R""""(
         {
@@ -363,7 +362,7 @@ class TestDeltaFileWrapper: public QObject
 
       QJsonDocument doc = normalizeSchema( QString( dfw.toJson() ) );
 
-      QVERIFY( ! doc.isNull() );
+      QVERIFY( !doc.isNull() );
       qDebug() << doc;
       QCOMPARE( doc, QJsonDocument::fromJson( R""""(
         {
@@ -526,7 +525,7 @@ class TestDeltaFileWrapper: public QObject
       DeltaFileWrapper dfw1( mProject, fileName );
       dfw1.addCreate( mLayer->id(), mLayer->id(), QStringLiteral( "fid" ), QStringLiteral( "fid" ), QgsFeature() );
 
-      QVERIFY( ! dfw1.hasError() );
+      QVERIFY( !dfw1.hasError() );
       QCOMPARE( getDeltasArray( dfw1.toString() ).size(), 1 );
       QVERIFY( dfw1.toFile() );
       QCOMPARE( getDeltasArray( dfw1.toString() ).size(), 1 );
@@ -554,7 +553,7 @@ class TestDeltaFileWrapper: public QObject
 
       QStringList attachmentFields = dfw.attachmentFieldNames( mProject, mLayer->id() );
 
-      QCOMPARE( attachmentFields, QStringList( {QStringLiteral( "attachment" )} ) );
+      QCOMPARE( attachmentFields, QStringList( { QStringLiteral( "attachment" ) } ) );
     }
 
 
@@ -638,19 +637,20 @@ class TestDeltaFileWrapper: public QObject
           "project": "projectId",
           "version": "1.0"
         }
-      )"""" ).arg( mLayer->id() ).toUtf8() ) );
+      )"""" )
+                                .arg( mLayer->id() )
+                                .toUtf8() ) );
       QVERIFY( deltaFile.flush() );
 
       DeltaFileWrapper dfw( mProject, deltaFile.fileName() );
 
-      QVERIFY( ! dfw.hasError() );
+      QVERIFY( !dfw.hasError() );
 
       QMap<QString, QString> attachmentFileNames = dfw.attachmentFileNames();
       QMap<QString, QString> expectedAttachmentFileNames(
       {
-        {"FILE1.jpg", ""},
-        {"FILE3.jpg", ""}
-      } );
+        { "FILE1.jpg", "" },
+        { "FILE3.jpg", "" } } );
 
       QCOMPARE( attachmentFileNames, expectedAttachmentFileNames );
     }
@@ -694,7 +694,9 @@ class TestDeltaFileWrapper: public QObject
             }
           }
         ]
-      )"""" ).arg( mAttachmentFileName, mAttachmentFileChecksum ).toUtf8() ) );
+      )"""" )
+                .arg( mAttachmentFileName, mAttachmentFileChecksum )
+                .toUtf8() ) );
 
 
       // Check if creates delta of a feature with a NULL geometry and non existant attachment.
@@ -728,7 +730,9 @@ class TestDeltaFileWrapper: public QObject
             }
           }
         ]
-      )"""" ).arg( f.attribute( QStringLiteral( "attachment" ) ).toString() ).toUtf8() ) );
+      )"""" )
+                .arg( f.attribute( QStringLiteral( "attachment" ) ).toString() )
+                .toUtf8() ) );
 
 
       // Check if creates delta of a feature without attributes
@@ -819,7 +823,9 @@ class TestDeltaFileWrapper: public QObject
             }
           }
         ]
-      )"""" ).arg( mAttachmentFileName, mAttachmentFileChecksum ).toUtf8() ) );
+      )"""" )
+                .arg( mAttachmentFileName, mAttachmentFileChecksum )
+                .toUtf8() ) );
 
 
       // Patch attributes only with non existing attachnment
@@ -860,7 +866,9 @@ class TestDeltaFileWrapper: public QObject
             }
           }
         ]
-      )"""" ).arg( newFeature.attribute( "attachment" ).toString() ).toUtf8() ) );
+      )"""" )
+                .arg( newFeature.attribute( "attachment" ).toString() )
+                .toUtf8() ) );
 
 
       // Patch feature without geometry on attributes only with non existant attachment
@@ -915,18 +923,18 @@ class TestDeltaFileWrapper: public QObject
 
     void testAddDeleteWithStringPk()
     {
-        DeltaFileWrapper dfw( mProject, QString( std::tmpnam( nullptr ) ) );
-        QgsFeature f( mLayer->fields(), 100 );
-        f.setAttribute( QStringLiteral( "fid" ), 100 );
-        f.setAttribute( QStringLiteral( "dbl" ), 3.14 );
-        f.setAttribute( QStringLiteral( "int" ), 42 );
-        f.setAttribute( QStringLiteral( "str" ), QStringLiteral( "stringy" ) );
-        f.setAttribute( QStringLiteral( "attachment" ), std::tmpnam( nullptr ) );
-        f.setGeometry( QgsGeometry() );
+      DeltaFileWrapper dfw( mProject, QString( std::tmpnam( nullptr ) ) );
+      QgsFeature f( mLayer->fields(), 100 );
+      f.setAttribute( QStringLiteral( "fid" ), 100 );
+      f.setAttribute( QStringLiteral( "dbl" ), 3.14 );
+      f.setAttribute( QStringLiteral( "int" ), 42 );
+      f.setAttribute( QStringLiteral( "str" ), QStringLiteral( "stringy" ) );
+      f.setAttribute( QStringLiteral( "attachment" ), std::tmpnam( nullptr ) );
+      f.setGeometry( QgsGeometry() );
 
-        dfw.addDelete( mLayer->id(), mLayer->id(), QStringLiteral( "fid" ), QStringLiteral( "str" ), f );
+      dfw.addDelete( mLayer->id(), mLayer->id(), QStringLiteral( "fid" ), QStringLiteral( "str" ), f );
 
-        QCOMPARE( QJsonDocument( getDeltasArray( dfw.toString() ) ), QJsonDocument::fromJson( QStringLiteral( R""""(
+      QCOMPARE( QJsonDocument( getDeltasArray( dfw.toString() ) ), QJsonDocument::fromJson( QStringLiteral( R""""(
           [
             {
               "uuid": "11111111-1111-1111-1111-111111111111",
@@ -950,7 +958,9 @@ class TestDeltaFileWrapper: public QObject
               }
             }
           ]
-        )"""" ).arg( f.attribute( QStringLiteral( "attachment" ) ).toString() ).toUtf8() ) );
+        )"""" )
+                .arg( f.attribute( QStringLiteral( "attachment" ) ).toString() )
+                .toUtf8() ) );
     }
 
     void testAddDelete()
@@ -993,7 +1003,9 @@ class TestDeltaFileWrapper: public QObject
             }
           }
         ]
-      )"""" ).arg( mAttachmentFileName, mAttachmentFileChecksum ).toUtf8() ) );
+      )"""" )
+                .arg( mAttachmentFileName, mAttachmentFileChecksum )
+                .toUtf8() ) );
 
       // Check if creates delta of a feature with a NULL geometry and non existant attachment.
       // NOTE this is the same as calling f clearGeometry()
@@ -1026,7 +1038,9 @@ class TestDeltaFileWrapper: public QObject
             }
           }
         ]
-      )"""" ).arg( f.attribute( QStringLiteral( "attachment" ) ).toString() ).toUtf8() ) );
+      )"""" )
+                .arg( f.attribute( QStringLiteral( "attachment" ) ).toString() )
+                .toUtf8() ) );
 
 
       // Check if creates delta of a feature without attributes
@@ -1090,7 +1104,7 @@ class TestDeltaFileWrapper: public QObject
 
       QJsonDocument doc = normalizeSchema( dfw.toString() );
 
-      QVERIFY( ! doc.isNull() );
+      QVERIFY( !doc.isNull() );
       QCOMPARE( doc, QJsonDocument::fromJson( R""""(
         {
           "deltas": [
@@ -1249,7 +1263,9 @@ class TestDeltaFileWrapper: public QObject
           "project": "projectId",
           "version": "1.0"
         }
-      )"""" ).arg( mLayer->id(), mAttachmentFileName ).toUtf8() ) );
+      )"""" )
+                                .arg( mLayer->id(), mAttachmentFileName )
+                                .toUtf8() ) );
       QVERIFY( deltaFile.flush() );
 
       DeltaFileWrapper dfw( mProject, deltaFile.fileName() );
@@ -1273,7 +1289,7 @@ class TestDeltaFileWrapper: public QObject
       QCOMPARE( f1.attribute( QStringLiteral( "dbl" ) ), 3.14 );
       QCOMPARE( f1.attribute( QStringLiteral( "str" ) ), QStringLiteral( "stringy" ) );
       QCOMPARE( f1.attribute( QStringLiteral( "attachment" ) ), QStringLiteral( "FILE1.jpg" ) );
-      QVERIFY( ! it1.nextFeature( f1 ) );
+      QVERIFY( !it1.nextFeature( f1 ) );
 
       QgsFeature f2;
       QgsFeatureIterator it2 = mLayer->getFeatures( QgsFeatureRequest( QgsExpression( " fid = 102 " ) ) );
@@ -1281,11 +1297,11 @@ class TestDeltaFileWrapper: public QObject
       QVERIFY( it2.nextFeature( f2 ) );
       QVERIFY( f2.isValid() );
       QCOMPARE( f2.attribute( QStringLiteral( "attachment" ) ).toString(), QStringLiteral( "FILE3.jpg" ) );
-      QVERIFY( ! it2.nextFeature( f2 ) );
+      QVERIFY( !it2.nextFeature( f2 ) );
 
       QgsFeature f3;
       QgsFeatureIterator it3 = mLayer->getFeatures( QgsFeatureRequest( QgsExpression( " fid = 1 " ) ) );
-      QVERIFY( ! it3.nextFeature( f3 ) );
+      QVERIFY( !it3.nextFeature( f3 ) );
     }
 
 
@@ -1391,7 +1407,9 @@ class TestDeltaFileWrapper: public QObject
           "project": "projectId",
           "version": "1.0"
         }
-      )"""" ).arg( mLayer->id(), mAttachmentFileName, mAttachmentFileChecksum ).toUtf8() ) );
+      )"""" )
+                                .arg( mLayer->id(), mAttachmentFileName, mAttachmentFileChecksum )
+                                .toUtf8() ) );
       QVERIFY( deltaFile.flush() );
 
       DeltaFileWrapper dfw( mProject, deltaFile.fileName() );
@@ -1415,7 +1433,7 @@ class TestDeltaFileWrapper: public QObject
       QCOMPARE( f1.attribute( QStringLiteral( "dbl" ) ), 3.14 );
       QCOMPARE( f1.attribute( QStringLiteral( "str" ) ), QStringLiteral( "stringy" ) );
       QCOMPARE( f1.attribute( QStringLiteral( "attachment" ) ), QStringLiteral( "FILE1.jpg" ) );
-      QVERIFY( ! it1.nextFeature( f1 ) );
+      QVERIFY( !it1.nextFeature( f1 ) );
 
       QgsFeature f2;
       QgsFeatureIterator it2 = mLayer->getFeatures( QgsFeatureRequest( QgsExpression( " fid = 102 " ) ) );
@@ -1423,11 +1441,11 @@ class TestDeltaFileWrapper: public QObject
       QVERIFY( it2.nextFeature( f2 ) );
       QVERIFY( f2.isValid() );
       QCOMPARE( f2.attribute( QStringLiteral( "attachment" ) ).toString(), QStringLiteral( "FILE3.jpg" ) );
-      QVERIFY( ! it2.nextFeature( f2 ) );
+      QVERIFY( !it2.nextFeature( f2 ) );
 
       QgsFeature f3;
       QgsFeatureIterator it3 = mLayer->getFeatures( QgsFeatureRequest( QgsExpression( " fid = 1 " ) ) );
-      QVERIFY( ! it3.nextFeature( f3 ) );
+      QVERIFY( !it3.nextFeature( f3 ) );
 
       // ^^^ the same as apply above
 
@@ -1435,7 +1453,7 @@ class TestDeltaFileWrapper: public QObject
 
       QgsFeature f4;
       QgsFeatureIterator it4 = mLayer->getFeatures( QgsFeatureRequest( QgsExpression( " fid = 100 OR fid = 102 " ) ) );
-      QVERIFY( ! it4.nextFeature( f4 ) );
+      QVERIFY( !it4.nextFeature( f4 ) );
 
       QgsFeature f5;
       QgsFeatureIterator it5 = mLayer->getFeatures( QgsFeatureRequest( QgsExpression( " fid = 1 " ) ) );
@@ -1446,7 +1464,7 @@ class TestDeltaFileWrapper: public QObject
       QCOMPARE( f5.attribute( QStringLiteral( "dbl" ) ), 3.14 );
       QCOMPARE( f5.attribute( QStringLiteral( "str" ) ), QStringLiteral( "stringy" ) );
       QCOMPARE( f5.attribute( QStringLiteral( "attachment" ) ), mAttachmentFileName );
-      QVERIFY( ! it5.nextFeature( f5 ) );
+      QVERIFY( !it5.nextFeature( f5 ) );
     }
 
 
@@ -1490,9 +1508,9 @@ class TestDeltaFileWrapper: public QObject
         return QJsonDocument();
       if ( QUuid::fromString( o.value( QStringLiteral( "id" ) ).toString() ).isNull() )
         return QJsonDocument();
-      if ( ! o.value( QStringLiteral( "deltas" ) ).isArray() )
+      if ( !o.value( QStringLiteral( "deltas" ) ).isArray() )
         return QJsonDocument();
-      if ( ! o.value( QStringLiteral( "files" ) ).isArray() )
+      if ( !o.value( QStringLiteral( "files" ) ).isArray() )
         return QJsonDocument();
 
       // normalize non-constant values
@@ -1518,10 +1536,10 @@ class TestDeltaFileWrapper: public QObject
         const QString localLayerId = deltaItem.value( QStringLiteral( "localLayerId" ) ).toString();
         const QString sourceLayerId = deltaItem.value( QStringLiteral( "sourceLayerId" ) ).toString();
 
-        if ( ! localLayerIds.contains( localLayerId ) )
+        if ( !localLayerIds.contains( localLayerId ) )
           localLayerIds.append( localLayerId );
 
-        if ( ! sourceLayerIds.contains( sourceLayerId ) )
+        if ( !sourceLayerIds.contains( sourceLayerId ) )
           sourceLayerIds.append( sourceLayerId );
 
         int localLayerIdx = localLayerIds.indexOf( localLayerId ) + 1;

--- a/test/test_featureutils.cpp
+++ b/test/test_featureutils.cpp
@@ -15,16 +15,14 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <QtTest>
-
 #include "qfield_testbase.h"
-
+#include "qgsvectorlayer.h"
 #include "utils/featureutils.h"
 
-#include "qgsvectorlayer.h"
+#include <QtTest>
 
 
-class TestFeatureUtils: public QObject
+class TestFeatureUtils : public QObject
 {
     Q_OBJECT
   private slots:
@@ -41,7 +39,6 @@ class TestFeatureUtils: public QObject
       QCOMPARE( f.fields(), vl->fields() );
       QVERIFY( f.geometry().equals( geometry ) );
     }
-
 };
 
 QFIELDTEST_MAIN( TestFeatureUtils )

--- a/test/test_fileutils.cpp
+++ b/test/test_fileutils.cpp
@@ -15,14 +15,13 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <QtTest>
-
 #include "qfield_testbase.h"
-
 #include "utils/fileutils.h"
 
+#include <QtTest>
 
-class TestFileUtils: public QObject
+
+class TestFileUtils : public QObject
 {
     Q_OBJECT
   private slots:
@@ -66,7 +65,7 @@ class TestFileUtils: public QObject
       QString fileName( f->fileName() );
       QVERIFY( FileUtils::fileExists( fileName ) );
       delete f;
-      QVERIFY( ! FileUtils::fileExists( fileName ) );
+      QVERIFY( !FileUtils::fileExists( fileName ) );
     }
 };
 

--- a/test/test_geometryutils.cpp
+++ b/test/test_geometryutils.cpp
@@ -15,17 +15,15 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qfield_testbase.h"
+#include "qgsvectorlayer.h"
+#include "rubberbandmodel.h"
+#include "utils/geometryutils.h"
+
 #include <QtTest>
 
-#include "qfield_testbase.h"
 
-#include "utils/geometryutils.h"
-#include "rubberbandmodel.h"
-
-#include "qgsvectorlayer.h"
-
-
-class TestGeometryUtils: public QObject
+class TestGeometryUtils : public QObject
 {
     Q_OBJECT
   private slots:

--- a/test/test_layerobserver.cpp
+++ b/test/test_layerobserver.cpp
@@ -15,14 +15,14 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <QtTest>
-
-#include "qfield_testbase.h"
 #include "layerobserver.h"
+#include "qfield_testbase.h"
 #include "utils/qfieldcloudutils.h"
 
+#include <QtTest>
 
-class TestLayerObserver: public QObject
+
+class TestLayerObserver : public QObject
 {
     Q_OBJECT
   private slots:
@@ -32,7 +32,7 @@ class TestLayerObserver: public QObject
       settingsDir.setAutoRemove( false );
 
       QVERIFY2( settingsDir.isValid(), "Failed to create temp dir" );
-      QVERIFY2( QDir( settingsDir.path() ).mkpath( QStringLiteral("cloud_projects/TEST_PROJECT_ID") ), "Failed to create project dir" );
+      QVERIFY2( QDir( settingsDir.path() ).mkpath( QStringLiteral( "cloud_projects/TEST_PROJECT_ID" ) ), "Failed to create project dir" );
 
       QDir projectDir( QStringLiteral( "%1/cloud_projects/TEST_PROJECT_ID" ).arg( settingsDir.path() ) );
       QFieldCloudUtils::sQgisSettingsDirPath = settingsDir.path();
@@ -71,7 +71,7 @@ class TestLayerObserver: public QObject
       mLayerObserver.reset( new LayerObserver( QgsProject::instance() ) );
 
       QVERIFY( QgsProject::instance()->addMapLayer( mLayer.get(), false, false ) );
-      QVERIFY( ! mLayerObserver->deltaFileWrapper()->hasError() );
+      QVERIFY( !mLayerObserver->deltaFileWrapper()->hasError() );
     }
 
 
@@ -139,7 +139,7 @@ class TestLayerObserver: public QObject
       QCOMPARE( getDeltaOperations( mLayerObserver->deltaFileWrapper()->fileName() ), QStringList() );
       // when we stop editing, all changes are written
       QVERIFY( mLayer->commitChanges() );
-      QCOMPARE( getDeltaOperations( mLayerObserver->deltaFileWrapper()->fileName() ), QStringList( {"create"} ) );
+      QCOMPARE( getDeltaOperations( mLayerObserver->deltaFileWrapper()->fileName() ), QStringList( { "create" } ) );
     }
 
 
@@ -153,7 +153,7 @@ class TestLayerObserver: public QObject
       QVERIFY( mLayer->startEditing() );
       QVERIFY( mLayer->addFeature( f1 ) );
       QVERIFY( mLayer->commitChanges() );
-      QCOMPARE( getDeltaOperations( mLayerObserver->deltaFileWrapper()->fileName() ), QStringList( {"create"} ) );
+      QCOMPARE( getDeltaOperations( mLayerObserver->deltaFileWrapper()->fileName() ), QStringList( { "create" } ) );
     }
 
 
@@ -162,7 +162,7 @@ class TestLayerObserver: public QObject
       QVERIFY( mLayer->startEditing() );
       QVERIFY( mLayer->deleteFeature( 1 ) );
       QVERIFY( mLayer->commitChanges() );
-      QCOMPARE( getDeltaOperations( mLayerObserver->deltaFileWrapper()->fileName() ), QStringList( {"delete"} ) );
+      QCOMPARE( getDeltaOperations( mLayerObserver->deltaFileWrapper()->fileName() ), QStringList( { "delete" } ) );
     }
 
 
@@ -178,7 +178,7 @@ class TestLayerObserver: public QObject
       QVERIFY( mLayer->updateFeature( f1 ) );
       QVERIFY( mLayer->updateFeature( f2 ) );
       QVERIFY( mLayer->commitChanges() );
-      QCOMPARE( getDeltaOperations( mLayerObserver->deltaFileWrapper()->fileName() ), QStringList( {"patch", "patch"} ) );
+      QCOMPARE( getDeltaOperations( mLayerObserver->deltaFileWrapper()->fileName() ), QStringList( { "patch", "patch" } ) );
     }
 
 
@@ -196,11 +196,10 @@ class TestLayerObserver: public QObject
       QVERIFY( mLayer->updateFeature( f2 ) );
 
       QVERIFY( mLayer->commitChanges() );
-      QCOMPARE( getDeltaOperations( mLayerObserver->deltaFileWrapper()->fileName() ), QStringList( {"patch", "patch"} ) );
+      QCOMPARE( getDeltaOperations( mLayerObserver->deltaFileWrapper()->fileName() ), QStringList( { "patch", "patch" } ) );
     }
 
   private:
-
     std::unique_ptr<QgsVectorLayer> mLayer;
     std::unique_ptr<LayerObserver> mLayerObserver;
 
@@ -210,7 +209,7 @@ class TestLayerObserver: public QObject
       QStringList operations;
       QFile deltaFile( fileName );
 
-      if ( ! deltaFile.open( QIODevice::ReadOnly ) )
+      if ( !deltaFile.open( QIODevice::ReadOnly ) )
         return operations;
 
       QJsonDocument doc = QJsonDocument::fromJson( deltaFile.readAll() );
@@ -231,7 +230,7 @@ class TestLayerObserver: public QObject
     {
       QFile deltaFile( fileName );
 
-      if ( ! deltaFile.open( QIODevice::ReadOnly ) )
+      if ( !deltaFile.open( QIODevice::ReadOnly ) )
         return QString();
 
       QJsonDocument doc = QJsonDocument::fromJson( deltaFile.readAll() );

--- a/test/test_referencingfeaturelistmodel.cpp
+++ b/test/test_referencingfeaturelistmodel.cpp
@@ -1,14 +1,14 @@
-#include <QtTest>
-#include <qgsapplication.h>
-#include <qgsvectorlayer.h>
-#include <qgsproject.h>
-#include <qgsrelationmanager.h>
-
+#include "qfield_testbase.h"
 #include "qgsquickmapsettings.h"
 #include "referencingfeaturelistmodel.h"
-#include "qfield_testbase.h"
 
-class TestReferencingFeatureListModel: public QObject
+#include <QtTest>
+#include <qgsapplication.h>
+#include <qgsproject.h>
+#include <qgsrelationmanager.h>
+#include <qgsvectorlayer.h>
+
+class TestReferencingFeatureListModel : public QObject
 {
     Q_OBJECT
   private slots:
@@ -261,7 +261,6 @@ class TestReferencingFeatureListModel: public QObject
       QVERIFY( QSignalSpy( mModel, &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
       //Frodo rules 2 lands (Gondor, Eriador) no Rohan anymore
       QCOMPARE( mModel->rowCount(), 2 );
-
     }
 
     /*
@@ -325,7 +324,6 @@ class TestReferencingFeatureListModel: public QObject
     QgsRelation mR_Sharehasoneking;
     QgsRelation mR_Shareofoneland;
     ReferencingFeatureListModel *mModel;
-
 };
 
 QFIELDTEST_MAIN( TestReferencingFeatureListModel )

--- a/test/test_stringutils.cpp
+++ b/test/test_stringutils.cpp
@@ -15,14 +15,13 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <QtTest>
-
 #include "qfield_testbase.h"
-
 #include "utils/stringutils.h"
 
+#include <QtTest>
 
-class TestStringUtils: public QObject
+
+class TestStringUtils : public QObject
 {
     Q_OBJECT
   private slots:
@@ -52,7 +51,6 @@ class TestStringUtils: public QObject
       QCOMPARE( StringUtils::fuzzyMatch( "Quercus rubra", "q   r" ), true );
       QCOMPARE( StringUtils::fuzzyMatch( "Quercus rubra", "q   ubra" ), false );
     }
-
 };
 
 QFIELDTEST_MAIN( TestStringUtils )

--- a/test/test_urlutils.cpp
+++ b/test/test_urlutils.cpp
@@ -15,16 +15,15 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <QtTest>
-#include <QFileInfo>
-#include <QDebug>
-
 #include "qfield_testbase.h"
-
 #include "utils/urlutils.h"
 
+#include <QDebug>
+#include <QFileInfo>
+#include <QtTest>
 
-class TestUrlUtils: public QObject
+
+class TestUrlUtils : public QObject
 {
     Q_OBJECT
   private slots:
@@ -37,12 +36,10 @@ class TestUrlUtils: public QObject
       QVERIFY( UrlUtils::isRelativeOrFileUrl( QStringLiteral( "file:///path/to/file" ) ) );
 
       // should NOT be considered relative
-      QVERIFY( ! UrlUtils::isRelativeOrFileUrl( QStringLiteral( "http://osm.org" ) ) );
-      QVERIFY( ! UrlUtils::isRelativeOrFileUrl( QStringLiteral( "http://osm.org/test?query=1" ) ) );
-      QVERIFY( ! UrlUtils::isRelativeOrFileUrl( QStringLiteral( "https://osm.org/test?query=1" ) ) );
+      QVERIFY( !UrlUtils::isRelativeOrFileUrl( QStringLiteral( "http://osm.org" ) ) );
+      QVERIFY( !UrlUtils::isRelativeOrFileUrl( QStringLiteral( "http://osm.org/test?query=1" ) ) );
+      QVERIFY( !UrlUtils::isRelativeOrFileUrl( QStringLiteral( "https://osm.org/test?query=1" ) ) );
     }
-
-
 };
 
 QFIELDTEST_MAIN( TestUrlUtils )

--- a/test/test_vertexmodel.cpp
+++ b/test/test_vertexmodel.cpp
@@ -1,33 +1,34 @@
 
-#include <QtTest>
-#include <qgsapplication.h>
-#include <qgslinestring.h>
-#include <qgsgeometry.h>
-#include <qgspoint.h>
-#include <qgspointxy.h>
-#include <qgsmessagelog.h>
-
+#include "qfield_testbase.h"
 #include "qgsquickmapsettings.h"
 #include "vertexmodel.h"
-#include "qfield_testbase.h"
+
+#include <QtTest>
+#include <qgsapplication.h>
+#include <qgsgeometry.h>
+#include <qgslinestring.h>
+#include <qgsmessagelog.h>
+#include <qgspoint.h>
+#include <qgspointxy.h>
 
 
-#define VERIFYNEAR(value,expected,epsilon) { \
-    QVERIFY2( qgsDoubleNear( value, expected, epsilon ), QStringLiteral("Expecting %1 got %2 (diff %3 > %4)").arg(expected).arg(value).arg(std::fabs( static_cast< double >( expected ) - value )).arg(epsilon).toUtf8().constData() ); \
-  }(void)(0)
+#define VERIFYNEAR( value, expected, epsilon )                                                                                                                                                                                                  \
+  {                                                                                                                                                                                                                                             \
+    QVERIFY2( qgsDoubleNear( value, expected, epsilon ), QStringLiteral( "Expecting %1 got %2 (diff %3 > %4)" ).arg( expected ).arg( value ).arg( std::fabs( static_cast<double>( expected ) - value ) ).arg( epsilon ).toUtf8().constData() ); \
+  }                                                                                                                                                                                                                                             \
+  ( void ) ( 0 )
 
 namespace QTest
 {
   template<>
   char *toString( const QgsPoint &point )
   {
-    QByteArray ba = "QgsPoint(" + QByteArray::number( point.x() ) +
-                    ", " + QByteArray::number( point.y() ) + ")";
+    QByteArray ba = "QgsPoint(" + QByteArray::number( point.x() ) + ", " + QByteArray::number( point.y() ) + ")";
     return qstrdup( ba.data() );
   }
-}
+} // namespace QTest
 
-class TestVertexModel: public QObject
+class TestVertexModel : public QObject
 {
     Q_OBJECT
   private slots:
@@ -48,7 +49,7 @@ class TestVertexModel: public QObject
                               << QgsPointXY( 2, 0 )
                               << QgsPointXY( 2, 2 )
                               << QgsPointXY( 0, 2 )
-                              << QgsPointXY( 0, 0 ) ) ) ;
+                              << QgsPointXY( 0, 0 ) ) );
 
       mRingPolygonGeometry = QgsGeometry::fromPolygonXY( QVector<QVector<QgsPointXY>>()
                              << ( QVector<QgsPointXY>()
@@ -62,12 +63,12 @@ class TestVertexModel: public QObject
                                   << QgsPointXY( 3, 1 )
                                   << QgsPointXY( 3, 3 )
                                   << QgsPointXY( 1, 3 )
-                                  << QgsPointXY( 1, 1 ) ) ) ;
+                                  << QgsPointXY( 1, 1 ) ) );
 
 
       mPoint2056Geometry = QgsGeometry::fromPointXY( QgsPointXY( 2500000, 1200000 ) );
 
-      mLine2056Geometry = QgsGeometry::fromPolylineXY( {QgsPointXY( 2500001, 1200001 ), QgsPointXY( 2500002, 1200002 ), QgsPointXY( 2500004, 1200004 )} );
+      mLine2056Geometry = QgsGeometry::fromPolylineXY( { QgsPointXY( 2500001, 1200001 ), QgsPointXY( 2500002, 1200002 ), QgsPointXY( 2500004, 1200004 ) } );
     }
 
     void testCandidates()


### PR DESCRIPTION
`clang-format-13` was also run once with `IndentAccessModifiers` before `astyle` was ran again and is now enforced.
clang-format helped to bring the current codebase into a more consistent shape but it's not yet widely available so we can't enforce it for now.