### PR TITLE
Fix ListView going broken when resetting feature form

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -214,7 +214,7 @@ Page {
                 target: master
 
                 function onReset() {
-                  content.contentY = 0
+                    content.positionViewAtBeginning();
                 }
               }
 


### PR DESCRIPTION
This PR fixes #1884 . The long story short here is that when the feature form contained items with conditional visibility and items' visibility would change between the time you closed a feature form and re-opened it, the ListView would go broken. Reason for it going :boom: is our use _against documentation warning_ of ListView.contentY = 0. That led to worlds colliding, Thanos snapping our form out of existence, etc.etc.

