### PR TITLE
Improvements to the checkbox editor widget

### DIFF
--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -1,42 +1,87 @@
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 
+import Theme 1.0
+
 import "."
 
 EditorWidgetBase {
   height: childrenRect.height
-  enabled: isEnabled
 
   anchors {
     right: parent.right
     left: parent.left
   }
 
-  CheckBox {
-    id: checkBox
+  Label {
+      id: checkValue
+      height: fontMetrics.height + 20
+      anchors {
+          left: parent.left
+          right: checkBox.left
+      }
 
-    property var currentValue: value
+      topPadding: 10
+      bottomPadding: 10
+      font: Theme.defaultFont
+      color: isEnabled ? 'black' : 'gray'
+
+      text: config['TextDisplayMethod'] === 1
+            ? checkBox.checked ? config['CheckedState'] : config['UncheckedState']
+            : checkBox.checked ? qsTr('True') : qsTr('False')
+
+      MouseArea {
+          id: checkArea
+          enabled: isEnabled
+          anchors.fill: parent
+
+          onClicked: {
+              checkBox.checked = !checkBox.checked
+              checkBox.forceActiveFocus();
+          }
+      }
+  }
+
+  QfSwitch {
+    id: checkBox
+    enabled: isEnabled
+    visible: isEnabled
+    width: implicitContentWidth
+    switchWidth: 36
+
+    anchors {
+      right: parent.right
+    }
+
     //if the field type is boolean, ignore the configured 'CheckedState' and 'UncheckedState' values and work with true/false always
     readonly property bool isBool: field.type == 1 //needs type coercion
 
-    checked: if( isBool ) {
-                 if( currentValue !== undefined ) {
-                     currentValue
-                 } else {
-                     false
-                 }
-             } else {
-                 String(currentValue) === config['CheckedState']
-             }
-
-    onCheckedChanged: {
-      valueChanged( isBool ? checked : checked ? config['CheckedState'] : config['UncheckedState'], false )
-      forceActiveFocus()
+    checked: {
+        if( isBool ) {
+            return value !== undefined ? value : false;
+        } else {
+            return String(value) === config['CheckedState']
+        }
     }
 
-    indicator.height: 16
-    indicator.width: 16
-    indicator.implicitHeight: 24
-    indicator.implicitWidth: 24
+    onCheckedChanged: {
+        valueChanged( isBool ? checked : checked ? config['CheckedState'] : config['UncheckedState'], false )
+        forceActiveFocus()
+    }
+  }
+
+  Rectangle {
+      id: backgroundRect
+      anchors.left: parent.left
+      anchors.right: parent.right
+      y: checkValue.height - height - checkValue.bottomPadding / 2
+      implicitWidth: 120
+      height: checkBox.activeFocus || checkBox.pressed || checkArea.containsPress ? 2: 1
+      color: checkBox.activeFocus || checkBox.pressed || checkArea.containsPress ? "#4CAF50" : "#C8E6C9"
+  }
+
+  FontMetrics {
+    id: fontMetrics
+    font: checkValue.font
   }
 }

--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -47,10 +47,11 @@ EditorWidgetBase {
     enabled: isEnabled
     visible: isEnabled
     width: implicitContentWidth
-    switchWidth: 36
+    small: true
 
     anchors {
       right: parent.right
+      verticalCenter: checkValue.verticalCenter
     }
 
     //if the field type is boolean, ignore the configured 'CheckedState' and 'UncheckedState' values and work with true/false always

--- a/src/qml/imports/Theme/QfSwitch.qml
+++ b/src/qml/imports/Theme/QfSwitch.qml
@@ -2,7 +2,9 @@ import QtQuick.Controls 2.12
 import QtQuick 2.12
 
 SwitchDelegate {
-    width: 48
+    property int switchWidth: 48
+
+    width: switchWidth
     padding: 10
     indicator: Rectangle {
         implicitWidth: 48
@@ -18,7 +20,7 @@ SwitchDelegate {
             width: 26
             height: 26
             radius: 13
-            color: parent.parent.down ? Theme.lightGray : Theme.light
+            color: parent.parent.down ? Theme.lightestGray : Theme.light
             border.color: parent.parent.checked ? Theme.mainColor : Theme.lightGray
             Behavior on x {
                 PropertyAnimation {
@@ -27,5 +29,12 @@ SwitchDelegate {
                 }
             }
         }
+    }
+
+    background: Rectangle {
+        implicitWidth: 100
+        implicitHeight: 40
+        visible: false
+        color: "transparent"
     }
 }

--- a/src/qml/imports/Theme/QfSwitch.qml
+++ b/src/qml/imports/Theme/QfSwitch.qml
@@ -2,24 +2,24 @@ import QtQuick.Controls 2.12
 import QtQuick 2.12
 
 SwitchDelegate {
-    property int switchWidth: 48
+    property bool small: false
 
-    width: switchWidth
+    width: small ? 34 : 48
     padding: 10
     indicator: Rectangle {
-        implicitWidth: 48
-        implicitHeight: 26
+        implicitWidth: small ? 34 : 48
+        implicitHeight: small ? 16 : 26
         x: parent.leftPadding
         y: ( parent.height + parent.topPadding - 6 ) / 2 - height / 2
-        radius: 13
+        radius: implicitHeight / 2
         color: parent.checked ? Theme.mainColor : Theme.lightGray
         border.color: parent.checked ? Theme.mainColor : Theme.lightGray
     
         Rectangle {
             x: parent.parent.checked ? parent.width - width : 0
-            width: 26
-            height: 26
-            radius: 13
+            width: parent.implicitHeight
+            height: parent.implicitHeight
+            radius: parent.implicitHeight / 2
             color: parent.parent.down ? Theme.lightestGray : Theme.light
             border.color: parent.parent.checked ? Theme.mainColor : Theme.lightGray
             Behavior on x {


### PR DESCRIPTION
This PR revamps the checkbox editor widget. Obligatory GIF:
![Peek 2021-05-08 13-01](https://user-images.githubusercontent.com/1728657/117528727-dcbea380-affd-11eb-8da6-ee18ed9e0d2f.gif)

Improvements include:
- Most importantly, we have a string representation of the state (true/false) in the form of a label, which is _very_ good as quite a few people out there don't know what a label-less empty square means :)
- Much nicer looks relying on our QfSwitch style
- Adjusted spacing/padding and added a bottom green line to harmonize with other editor widgets
- A nicer "hit area"

Because the widget now has a label, we can support QGIS' stored value display settings configuration. Second GIF:
![Peek 2021-05-08 13-02](https://user-images.githubusercontent.com/1728657/117528804-4c349300-affe-11eb-8cd7-2e896b8e9902.gif)

That option is in QGIS' checkbox widget configuration panel:
![image](https://user-images.githubusercontent.com/1728657/117528814-59ea1880-affe-11eb-908c-8e0e4e587b14.png)

It also fixes an issue whereas cancelling form change wouldn't have modified checkboxes sync back to the original value.