### PR TITLE
Focus improvements all around

### DIFF
--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -352,6 +352,15 @@ Rectangle {
       }
     }
 
+    onBackClicked: {
+        featureForm.focus = true;
+        if ( featureForm.state != "FeatureList" ) {
+            featureForm.state = "FeatureList";
+        } else {
+            featureForm.state = "Hidden";
+        }
+    }
+
     onStatusIndicatorClicked: {
       featureForm.state = "FeatureList"
     }

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -425,6 +425,7 @@ Rectangle {
             featureFormList.model.featureModel.modelMode = FeatureModel.MultiFeatureModel
         }
         featureForm.multiSelection = !featureForm.multiSelection;
+        featureForm.focus = true;
     }
 
     onMultiEditClicked: {
@@ -459,26 +460,30 @@ Rectangle {
   }
 
   Keys.onReleased: {
-    if ( event.key === Qt.Key_Back ||
-        event.key === Qt.Key_Escape ) {
-      if( state != "FeatureList" ) {
-        if( featureListToolBar.state === "Edit"){
-          if( featureFormList.model.constraintsHardValid ) {
-            featureListToolBar.save()
-          } else {
-            displayToast( "Constraints not valid" )
-            if( qfieldSettings.autoSave ){
-               featureListToolBar.cancel()
-            }
+      if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
+          if (state != "FeatureList") {
+              if (featureListToolBar.state === "Edit") {
+                  if (featureFormList.model.constraintsHardValid) {
+                      featureListToolBar.save();
+                  } else {
+                      displayToast( "Constraints not valid" );
+                      if (qfieldSettings.autoSave) {
+                          featureListToolBar.cancel();
+                      }
+                  }
+              } else {
+                  state = "FeatureList";
+              }
+          } else  {
+              if (featureForm.multiSelection) {
+                  featureForm.selection.focusedItem = -1
+                  featureForm.multiSelection = false;
+              } else {
+                  state = "Hidden";
+              }
           }
-        }else{
-          state = "FeatureList"
-        }
-      }else{
-        state = "Hidden"
+          event.accepted = true;
       }
-      event.accepted = true
-    }
   }
 
   Behavior on width {
@@ -574,6 +579,7 @@ Rectangle {
   {
     props.isVisible = false;
     focus = false;
+
     fullScreenView = qfieldSettings.fullScreenIdentifyView;
 
     if ( !digitizingToolbar.geometryRequested )

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -32,6 +32,7 @@ Rectangle {
   property FeatureListModelSelection selection
   property FeaturelistExtentController extentController
 
+  signal backClicked
   signal statusIndicatorClicked
   signal statusIndicatorSwiped(var direction)
   signal editAttributesButtonClicked
@@ -176,7 +177,7 @@ Rectangle {
       if ( toolBar.model && ( selection.focusedItem + 1 ) < toolBar.model.count ) {
         selection.focusedItem = selection.focusedItem + 1;
       } else {
-        statusIndicatorClicked();
+        backClicked();
       }
     }
 
@@ -192,19 +193,19 @@ Rectangle {
 
     anchors.left: parent.left
 
-    width: ( parent.state == "Navigation" ? 48: 0 )
+    width: ( parent.state != "Edit" ? 48: 0 )
     height: 48
     clip: true
 
     iconSource: Theme.getThemeIcon( "ic_chevron_left_white_24dp" )
 
-    enabled: ( parent.state == "Navigation" )
+    enabled: ( parent.state != "Edit" )
 
     onClicked: {
         if ( toolBar.model && ( selection.focusedItem > 0 ) ) {
           selection.focusedItem = selection.focusedItem - 1;
         } else {
-          statusIndicatorClicked();
+          backClicked();
         }
     }
 

--- a/src/qml/imports/Theme/QfToolButton.qml
+++ b/src/qml/imports/Theme/QfToolButton.qml
@@ -31,6 +31,7 @@ Item {
 
     RoundButton {
         id: button
+        focusPolicy: Qt.NoFocus
         anchors.fill: parent
         topInset:0
         bottomInset:0

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -59,9 +59,10 @@ ApplicationWindow {
     focus: true
 
     Keys.onReleased: {
-      if ( event.key === Qt.Key_Back ||
-        event.key === Qt.Key_Escape ) {
-        if ( stateMachine.state === 'measure' ) {
+      if ( event.key === Qt.Key_Back || event.key === Qt.Key_Escape ) {
+        if ( featureForm.visible ) {
+            featureForm.hide();
+        } else if ( stateMachine.state === 'measure' ) {
           mainWindow.closeMeasureTool()
         } else {
           mainWindow.close();
@@ -673,6 +674,7 @@ ApplicationWindow {
       onClicked: {
           if ( gpsButton.followActive ) gpsButton.followActiveSkipExtentChanged = true;
           mapCanvasMap.zoomIn(Qt.point(mapCanvas.x + mapCanvas.width / 2,mapCanvas.y + mapCanvas.height / 2));
+          keyHandler.focus = true
       }
     }
     QfToolButton {
@@ -693,6 +695,7 @@ ApplicationWindow {
       onClicked: {
           if ( gpsButton.followActive ) gpsButton.followActiveSkipExtentChanged = true;
           mapCanvasMap.zoomOut(Qt.point(mapCanvas.x + mapCanvas.width / 2,mapCanvas.y + mapCanvas.height / 2));
+          keyHandler.focus = true
       }
     }
   }
@@ -1060,6 +1063,7 @@ ApplicationWindow {
             }
           }
         }
+        keyHandler.focus = true
       }
 
       onPressAndHold: {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -50,7 +50,6 @@ ApplicationWindow {
   }
 
   //this keyHandler is because otherwise the back-key is not handled in the mainWindow. Probably this could be solved cuter.
-
   Item {
     id: keyHandler
     objectName: "keyHandler"
@@ -674,7 +673,6 @@ ApplicationWindow {
       onClicked: {
           if ( gpsButton.followActive ) gpsButton.followActiveSkipExtentChanged = true;
           mapCanvasMap.zoomIn(Qt.point(mapCanvas.x + mapCanvas.width / 2,mapCanvas.y + mapCanvas.height / 2));
-          keyHandler.focus = true
       }
     }
     QfToolButton {
@@ -695,7 +693,6 @@ ApplicationWindow {
       onClicked: {
           if ( gpsButton.followActive ) gpsButton.followActiveSkipExtentChanged = true;
           mapCanvasMap.zoomOut(Qt.point(mapCanvas.x + mapCanvas.width / 2,mapCanvas.y + mapCanvas.height / 2));
-          keyHandler.focus = true
       }
     }
   }
@@ -1063,7 +1060,6 @@ ApplicationWindow {
             }
           }
         }
-        keyHandler.focus = true
       }
 
       onPressAndHold: {


### PR DESCRIPTION
This fixes #1883 as well as a bunch of other focus-related issues with tool buttons (e.g. zoom in / out) stealing focus and breaking our back / escape hardware key handling.

The PR also adds a permanent 'back' button to the feature list / form panel, which should please QField users on iOS.