### PR TITLE
Always show the iOS and cancel/delete button in the add feature form

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -618,7 +618,7 @@ Page {
 
         Layout.alignment: Qt.AlignTop | Qt.AlignLeft
 
-        visible: ( form.state === 'Add' || form.state === 'Edit' ) && ( !qfieldSettings.autoSave || dontSave )
+        visible: ( form.state === 'Add' || form.state === 'Edit' ) && !dontSave
         width: 48
         height: 48
         clip: true

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -30,8 +30,8 @@ Page {
   //! if embedded form called by RelationEditor or RelationReferenceWidget
   property bool embedded: false
   property int embeddedLevel: 0
-  //dontSave means data would be neither saved nor cleared (so feature data is handled elsewhere like e.g. in the tracking)
-  property bool dontSave: false
+  //setupOnly means data would be neither saved nor cleared (feature creation is handled elsewhere like e.g. in the tracking)
+  property bool setupOnly: false
   property bool featureCreated: false
 
   function reset() {
@@ -468,7 +468,7 @@ Page {
                       AttributeAllowEdit = true;
                     }
 
-                    if ( qfieldSettings.autoSave && !dontSave ) {
+                    if ( qfieldSettings.autoSave && !setupOnly ) {
                       // indirect action, no need to check for success and display a toast, the log is enough
                       save()
                     }
@@ -537,7 +537,7 @@ Page {
 
     parent.focus = true
 
-    if( dontSave ) {
+    if( setupOnly ) {
       temporaryStored()
       return
     }
@@ -618,7 +618,7 @@ Page {
 
         Layout.alignment: Qt.AlignTop | Qt.AlignLeft
 
-        visible: ( form.state === 'Add' || form.state === 'Edit' ) && !dontSave
+        visible: ( form.state === 'Add' || form.state === 'Edit' )
         width: 48
         height: 48
         clip: true
@@ -671,7 +671,7 @@ Page {
         height: 48
         clip: true
         bgcolor: form.state === 'Add' ? "#900000" : Theme.darkGray
-        visible: !dontSave
+        visible: !setupOnly
 
         iconSource: form.state === 'Add' ? Theme.getThemeIcon( 'ic_delete_forever_white_24dp' ) : Theme.getThemeIcon( 'ic_close_white_24dp' )
 

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -542,13 +542,12 @@ Page {
       return
     }
 
-    if ( !save() ) {
+    state = 'Edit'
+
+    if ( !qfieldSettings.autoSave && !save() ) {
       displayToast( qsTr( 'Unable to save changes') )
-      state = 'Edit'
       return
     }
-
-    state = 'Edit'
 
     confirmed()
     featureCreated = false

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -671,7 +671,7 @@ Page {
         height: 48
         clip: true
         bgcolor: form.state === 'Add' ? "#900000" : Theme.darkGray
-        visible: !qfieldSettings.autoSave || dontSave
+        visible: !dontSave
 
         iconSource: form.state === 'Add' ? Theme.getThemeIcon( 'ic_delete_forever_white_24dp' ) : Theme.getThemeIcon( 'ic_close_white_24dp' )
 

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -222,7 +222,7 @@ Rectangle {
     width: ( parent.state == "Edit" ? 48: 0 )
     height: 48
     clip: true
-    visible: !qfieldSettings.autoSave
+    visible: true
 
     iconSource: featureFormList.model.constraintsHardValid ? Theme.getThemeIcon( "ic_check_white_48dp" ) : Theme.getThemeIcon( "ic_check_gray_48dp" )
     onClicked: {

--- a/src/qml/Tracking.qml
+++ b/src/qml/Tracking.qml
@@ -112,7 +112,7 @@ Item{
             model: embeddedAttributeFormModel
 
             focus: true
-            dontSave: true
+            setupOnly: true
             embedded: true
             toolbarVisible: true
 


### PR DESCRIPTION
As discussed, to help UI/UX on iOS where it lacks a hardware back button, this PR insures that the OK and cancel/delete button is always visible in the add feature form, irrespective of whether fast editing is on or off.