### PR TITLE
[Backport release-1_9] When exiting the multi selection mode via the back key, clear selection

### DIFF
--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -485,6 +485,7 @@ Rectangle {
               }
           } else  {
               if (featureForm.multiSelection) {
+                  featureForm.selection.model.clearSelection();
                   featureForm.selection.focusedItem = -1
                   featureForm.multiSelection = false;
               } else {


### PR DESCRIPTION
Backport #1909
 **Authored by:** @nirvn