### PR TITLE
Fix accuracy radius indicator gone missing

### DIFF
--- a/src/qml/TransformedPositionSource.qml
+++ b/src/qml/TransformedPositionSource.qml
@@ -14,10 +14,8 @@ Item{
     property alias destinationCrs: _ct.destinationCrs
     property alias projectedPosition: _ct.projectedPosition
     property real projectedHorizontalAccuracy: {
-      return positionInfo
-        && positionInfo.haccValid
-        && destinationCrs.mapUnits !== QgsUnitTypes.DistanceUnknownUnit
-          ? positionInfo.hacc * UnitTypes.formatDistance( QgsUnitTypes.DistanceMeters, destinationCrs.mapUnits, false )
+      return positionInfo && positionInfo.haccValid && destinationCrs.mapUnits !== QgsUnitTypes.DistanceUnknownUnit
+          ? 50 * UnitTypes.fromUnitToUnitFactor( QgsUnitTypes.DistanceMeters, destinationCrs.mapUnits )
           : 0.0
     }
     property alias deltaZ: _ct.deltaZ


### PR DESCRIPTION
This fixes a regression introduced this commit (https://github.com/opengisch/QField/commit/50587695f6790e24add031797a30f5579b116b15#diff-d0554b120b4c49e85d8747da005f129cd59618a977ac7b3032c48c9722c5194b).

@m-kuhn , this wasn't backported to 1.9 right?