### PR TITLE
Fix snapping to segment

### DIFF
--- a/src/core/snappingutils.cpp
+++ b/src/core/snappingutils.cpp
@@ -90,13 +90,16 @@ void SnappingUtils::snap()
     case QgsPointLocator::Type::Invalid:
     case QgsPointLocator::Type::MiddleOfSegment:
       vertexIndexValid = false;
+      break;
 
     case QgsPointLocator::Type::Vertex:
     case QgsPointLocator::Type::LineEndpoint:
       vertexIndexValid = true;
+      break;
 
     case QgsPointLocator::Type::All:
       Q_ASSERT( false );
+      break;
   }
 
   if ( vertexIndexValid

--- a/src/core/snappingutils.cpp
+++ b/src/core/snappingutils.cpp
@@ -78,9 +78,30 @@ void SnappingUtils::snap()
   QgsPointLocator::Match match = snapToMap( point );
   mSnappingResult = SnappingResult( match );
 
-  //set point containing ZM if existing
+  //set point containing ZM if we snapped to a point/vertex
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( currentLayer() );
-  if ( vlayer && match.layer()
+
+  bool vertexIndexValid;
+  switch ( match.type() )
+  {
+      case QgsPointLocator::Type::Area:
+      case QgsPointLocator::Type::Centroid:
+      case QgsPointLocator::Type::Edge:
+      case QgsPointLocator::Type::Invalid:
+      case QgsPointLocator::Type::MiddleOfSegment:
+      vertexIndexValid = false;
+
+    case QgsPointLocator::Type::Vertex:
+      case QgsPointLocator::Type::LineEndpoint:
+      vertexIndexValid = true;
+
+      case QgsPointLocator::Type::All:
+      Q_ASSERT( false );
+  }
+
+  if ( vertexIndexValid
+       && vlayer
+       && match.layer()
        && ( QgsWkbTypes::hasZ( vlayer->wkbType() ) || QgsWkbTypes::hasM( vlayer->wkbType() ) ) )
   {
     const QgsFeature ft = match.layer()->getFeature( match.featureId() );

--- a/src/core/snappingutils.cpp
+++ b/src/core/snappingutils.cpp
@@ -84,18 +84,18 @@ void SnappingUtils::snap()
   bool vertexIndexValid;
   switch ( match.type() )
   {
-      case QgsPointLocator::Type::Area:
-      case QgsPointLocator::Type::Centroid:
-      case QgsPointLocator::Type::Edge:
-      case QgsPointLocator::Type::Invalid:
-      case QgsPointLocator::Type::MiddleOfSegment:
+    case QgsPointLocator::Type::Area:
+    case QgsPointLocator::Type::Centroid:
+    case QgsPointLocator::Type::Edge:
+    case QgsPointLocator::Type::Invalid:
+    case QgsPointLocator::Type::MiddleOfSegment:
       vertexIndexValid = false;
 
     case QgsPointLocator::Type::Vertex:
-      case QgsPointLocator::Type::LineEndpoint:
+    case QgsPointLocator::Type::LineEndpoint:
       vertexIndexValid = true;
 
-      case QgsPointLocator::Type::All:
+    case QgsPointLocator::Type::All:
       Q_ASSERT( false );
   }
 


### PR DESCRIPTION
The code for adding Z/M from snapping results always took the closest vertex to force the snapping result.

This code is now disabled for segments and area, we only take the 2D results in these cases.

Note: we don't do any interpolation of Z/M, this differs from QGIS which assumes a linear interpolation of Z/M along line segments.

Fixes #1929