### PR TITLE
Fix double feature creation when adding points in fast editing mode

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -32,6 +32,7 @@ Page {
   property int embeddedLevel: 0
   //setupOnly means data would be neither saved nor cleared (feature creation is handled elsewhere like e.g. in the tracking)
   property bool setupOnly: false
+  property bool ignoreChanges: false
   property bool featureCreated: false
 
   function reset() {
@@ -468,7 +469,7 @@ Page {
                       AttributeAllowEdit = true;
                     }
 
-                    if ( qfieldSettings.autoSave && !setupOnly ) {
+                    if ( qfieldSettings.autoSave && !setupOnly && !ignoreChanges ) {
                       // indirect action, no need to check for success and display a toast, the log is enough
                       save()
                     }
@@ -545,13 +546,14 @@ Page {
     if ( !save() ) {
       displayToast( qsTr( 'Unable to save changes') )
       state = 'Edit'
+      featureCreated = false
       return
     }
 
     state = 'Edit'
+    featureCreated = false
 
     confirmed()
-    featureCreated = false
   }
 
   function save() {
@@ -560,9 +562,11 @@ Page {
     }
 
     aboutToSave()
-    
-    var isSuccess = false;
 
+    // ignore changed value signals to avoid double feature creation / save when in fast editing mode
+    ignoreChanges = true;
+
+    var isSuccess = false;
     if( form.state === 'Add' && !featureCreated ) {
       isSuccess = model.create()
       featureCreated = isSuccess
@@ -570,6 +574,7 @@ Page {
       isSuccess = model.save()
     }
 
+    ignoreChanges = false;
     return isSuccess
   }
 

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -32,7 +32,6 @@ Page {
   property int embeddedLevel: 0
   //setupOnly means data would be neither saved nor cleared (feature creation is handled elsewhere like e.g. in the tracking)
   property bool setupOnly: false
-  property bool ignoreChanges: false
   property bool featureCreated: false
 
   function reset() {
@@ -62,6 +61,11 @@ Page {
      * be restored.
      */
     signal reset
+
+    /**
+     * When set to true, changed value signals are ignored to avoid double feature creation / save when in fast editing mode
+     */
+    property bool ignoreChanges: false
   }
 
   Item {
@@ -469,7 +473,7 @@ Page {
                       AttributeAllowEdit = true;
                     }
 
-                    if ( qfieldSettings.autoSave && !setupOnly && !ignoreChanges ) {
+                    if ( qfieldSettings.autoSave && !setupOnly && !master.ignoreChanges ) {
                       // indirect action, no need to check for success and display a toast, the log is enough
                       save()
                     }
@@ -563,8 +567,7 @@ Page {
 
     aboutToSave()
 
-    // ignore changed value signals to avoid double feature creation / save when in fast editing mode
-    ignoreChanges = true;
+    master.ignoreChanges = true;
 
     var isSuccess = false;
     if( form.state === 'Add' && !featureCreated ) {
@@ -574,7 +577,7 @@ Page {
       isSuccess = model.save()
     }
 
-    ignoreChanges = false;
+    master.ignoreChanges = false;
     return isSuccess
   }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1178,12 +1178,13 @@ ApplicationWindow {
                   digitizingFeature.geometry.applyRubberband()
                   digitizingFeature.applyGeometry()
                 }
+
                 if( !overlayFeatureFormDrawer.featureForm.featureCreated )
                 {
                     overlayFeatureFormDrawer.featureModel.geometry = digitizingFeature.geometry
                     overlayFeatureFormDrawer.featureModel.applyGeometry()
                     overlayFeatureFormDrawer.featureForm.resetAttributes()
-                    if( overlayFeatureFormDrawer.featureForm.model.constraintsHardValid ){
+                    if( overlayFeatureFormDrawer.featureForm.model.constraintsHardValid ) {
                       // when the constrainst are fulfilled
                       // indirect action, no need to check for success and display a toast, the log is enough
                       overlayFeatureFormDrawer.featureForm.featureCreated = overlayFeatureFormDrawer.featureForm.create()


### PR DESCRIPTION
While fixing the feature addition yesterday, I noticed a pretty bad bug with fast editing mode, whereas addition of points leading to double / triple feature creation follow by a bunch of message log errors thrown at the user and a broken UI.

The long story short here is that when we call feature form's create(), it leads to a values changed signal (e.g. fid value changes, etc.), which in turn triggers the fast editing's auto save on value changes. This would lead to worlds colliding, and end up with multiple points created and a broken UI (i.e. feature form drawer open without a navigation bar, etc.)