### PR TITLE
One more legend corner scenario: insertion of rows with pre-existing children

### DIFF
--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -136,6 +136,24 @@ void FlatLayerTreeModelBase::insertInMap( const QModelIndex &parent, int first, 
   if ( mFrozen )
     return;
 
+  bool resetNeeded = false;
+  for ( int i = 0; first + i <= last; i++ )
+  {
+    QModelIndex index = mLayerTreeModel->index( first + i, 0, parent );
+    if ( mLayerTreeModel->hasChildren( index ) )
+    {
+      resetNeeded = true;
+      break;
+    }
+  }
+
+  if ( resetNeeded )
+  {
+    // Added rows with pre-existing children can't be handled, model reset needed
+    buildMap( mLayerTreeModel );
+    return;
+  }
+
   int insertedAt = -1;
   if ( first == 0 )
   {


### PR DESCRIPTION
So, turns out an abstract item model can insert row items with pre-existing children. In our legend context, it can happen when a layer has a multi-level rule-based renderer with feature count on. The source layer tree model deletes and re-inserts the root items of the rule-based renderer, with children attached to those parent items.

Practical example: the advanced bees demo's apiary layer.

I didn't know this was possible, I had (wrongly) assumed that inserted items would always be called individually. By not having handled the above scenario, we'd end up losing legend items (e.g., with the advanced bees demo, if you add a point, the individual disease marker legend items disappear).

The solution is to trigger the more costly model re-building when we detect this scenario (we do something similar for row deletion).

For the record, we do _not_ trigger a model re-building on every row being inserted whenever we can avoid it to avoid UI freeze on super large source layer tree models.

