### PR TITLE
[Backport release-1_9] Fix legend showing wrong symbol for layer sub items with same name

### DIFF
--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -468,7 +468,7 @@ QVariant FlatLayerTreeModelBase::data( const QModelIndex &index, int role ) cons
         QStringList legendParts;
         while ( sym )
         {
-          legendParts << sym->data( Qt::DisplayRole ).toString();
+          legendParts << QString::number( sourceIndex.internalId() );
           sourceIndex = sourceIndex.parent();
           sym = mLayerTreeModel->index2legendNode( sourceIndex );
         }

--- a/src/core/legendimageprovider.cpp
+++ b/src/core/legendimageprovider.cpp
@@ -47,7 +47,7 @@ QPixmap LegendImageProvider::requestPixmap( const QString &id, QSize *size, cons
     QStringList legendParts;
     while( index.isValid() )
     {
-      legendParts << mLayerTreeModel->data( index ).toString();
+      legendParts << QString::number( index.internalId() );
       if ( idParts.value( 2 ) == legendParts.join( QStringLiteral( "~__~" ) ) )
       {
         QPixmap pixmap = mLayerTreeModel->data( index, Qt::DecorationRole ).value<QPixmap>();


### PR DESCRIPTION
Backport #1945
 **Authored by:** @nirvn