### PR TITLE
Disable native camera on non android devices

### DIFF
--- a/src/core/androidplatformutilities.cpp
+++ b/src/core/androidplatformutilities.cpp
@@ -353,6 +353,11 @@ void AndroidPlatformUtilities::setScreenLockPermission( const bool allowLock )
   }
 }
 
+bool AndroidPlatformUtilities::supportsNativeCamera() const
+{
+  return true;
+}
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/core/androidplatformutilities.h
+++ b/src/core/androidplatformutilities.h
@@ -28,22 +28,24 @@ class AndroidPlatformUtilities : public PlatformUtilities
   public:
     AndroidPlatformUtilities();
 
-    virtual void initSystem() override;
-    virtual QString systemGenericDataLocation() const override;
-    virtual QString qgsProject() const override;
-    virtual QString qfieldDataDir() const override;
-    virtual PictureSource *getCameraPicture( const QString &prefix, const QString &pictureFilePath, const QString &suffix ) override;
-    virtual PictureSource *getGalleryPicture( const QString &prefix, const QString &pictureFilePath ) override;
-    virtual ViewStatus *open( const QString &uri ) override;
-    virtual ProjectSource *openProject() override;
+    void initSystem() override;
+    QString systemGenericDataLocation() const override;
+    QString qgsProject() const override;
+    QString qfieldDataDir() const override;
+    PictureSource *getCameraPicture( const QString &prefix, const QString &pictureFilePath, const QString &suffix ) override;
+    PictureSource *getGalleryPicture( const QString &prefix, const QString &pictureFilePath ) override;
+    ViewStatus *open( const QString &uri ) override;
+    ProjectSource *openProject() override;
 
-    virtual bool checkPositioningPermissions() const override;
+    bool checkPositioningPermissions() const override;
 
-    virtual bool checkCameraPermissions() const override;
+    bool checkCameraPermissions() const override;
 
     bool checkWriteExternalStoragePermissions() const override;
 
     void setScreenLockPermission( const bool allowLock ) override;
+
+    bool supportsNativeCamera() const override;
 
   private:
     bool checkAndAcquirePermissions( const QString &permissionString ) const;

--- a/src/core/platformutilities.cpp
+++ b/src/core/platformutilities.cpp
@@ -174,3 +174,8 @@ PlatformUtilities *PlatformUtilities::instance()
 {
   return sPlatformUtils;
 }
+
+bool PlatformUtilities::supportsNativeCamera() const
+{
+  return false;
+}

--- a/src/core/platformutilities.h
+++ b/src/core/platformutilities.h
@@ -32,6 +32,8 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
 {
     Q_OBJECT
 
+    Q_PROPERTY( bool supportsNativeCamera READ supportsNativeCamera NOTIFY supportsNativeCameraChanged )
+
   public:
     virtual ~PlatformUtilities();
 
@@ -118,5 +120,17 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
     Q_INVOKABLE virtual void setScreenLockPermission( const bool allowLock ) { Q_UNUSED( allowLock ); }
 
     static PlatformUtilities *instance();
+
+    /**
+     * Returns true if the platform supports native camera.
+     * This returns true on Android where this is implemented through intents
+     */
+    virtual bool supportsNativeCamera() const;
+
+  signals:
+    /**
+     * Will never be emitted, just here to avoid a warning about a non-signalling-property
+     */
+    void supportsNativeCameraChanged();
 };
 #endif // PLATFORMUTILITIES_H

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -27,7 +27,7 @@ Page {
     property bool fullScreenIdentifyView: false
     property bool locatorKeepScale: false
     property bool numericalDigitizingInformation: false
-    property bool nativeCamera: true
+    property bool nativeCamera: platformUtilities.supportsNativeCamera
     property bool autoSave: false
     property bool mouseAsTouchScreen: false
   }
@@ -56,6 +56,7 @@ Page {
           title: qsTr( "Use native camera" )
           description: qsTr( "If disabled, QField will use a minimalist internal camera instead of the camera app on the device.<br>Tip: Enable this option and install the open camera app to create geo tagged photos." )
           settingAlias: "nativeCamera"
+          isVisible: true
       }
       ListElement {
           title: qsTr( "Fast editing mode" )
@@ -66,6 +67,15 @@ Page {
           title: qsTr( "Consider mouse as a touchscreen device" )
           description: qsTr( "If disabled, the mouse will act as a stylus pen." )
           settingAlias: "mouseAsTouchScreen"
+      }
+      Component.onCompleted: {
+          var i;
+          for (i = 0; i < count; i++) {
+              if (get(i).settingAlias == 'nativeCamera')
+                  setProperty(i, 'isVisible', platformUtilities.supportsNativeCamera)
+              else
+                  setProperty(i, 'isVisible', true)
+          }
       }
   }
 
@@ -181,6 +191,8 @@ Page {
 
                       delegate: Row {
                           width: parent ? parent.width - 16 : undefined
+                          height: !!isVisible ? undefined : 0
+                          visible: !!isVisible
 
                           Column {
                               width: parent.width - toggle.width

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -69,12 +69,12 @@ Page {
           settingAlias: "mouseAsTouchScreen"
       }
       Component.onCompleted: {
-          var i;
-          for (i = 0; i < count; i++) {
-              if (get(i).settingAlias == 'nativeCamera')
-                  setProperty(i, 'isVisible', platformUtilities.supportsNativeCamera)
-              else
-                  setProperty(i, 'isVisible', true)
+          for (var i = 0; i < settingsModel.count; i++) {
+              if (settingsModel.get(i).settingAlias === 'nativeCamera') {
+                  settingsModel.setProperty(i, 'isVisible', platformUtilities.supportsNativeCamera)
+              } else {
+                  settingsModel.setProperty(i, 'isVisible', true)   
+              }
           }
       }
   }


### PR DESCRIPTION
It doesn't make sense to show a setting without effect