### PR TITLE
Allow users (via the welcome screen) to specify the default project to use when opening individual datasets

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -909,7 +909,13 @@ void QgisMobileapp::readProjectFile()
   {
     if ( crs.isValid() )
     {
-      if ( QFile::exists( PlatformUtilities::instance()->qfieldDataDir() + QStringLiteral( "basemap.qgs" ) ) )
+      QSettings settings;
+      const QString fileAssociationProject = settings.value( QStringLiteral( "QField/fileAssociationProject" ), QString() ).toString();
+      if ( !fileAssociationProject.isEmpty() && QFile::exists( fileAssociationProject ) )
+      {
+        mProject->read( fileAssociationProject );
+      }
+      else if ( QFile::exists( PlatformUtilities::instance()->qfieldDataDir() + QStringLiteral( "basemap.qgs" ) ) )
       {
         mProject->read( PlatformUtilities::instance()->qfieldDataDir() + QStringLiteral( "basemap.qgs" ) );
       }

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -2,6 +2,7 @@ import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
 import QtQuick.Particles 2.0
+import Qt.labs.settings 1.0
 
 import org.qfield 1.0
 import Theme 1.0
@@ -14,6 +15,11 @@ Page {
   property alias model: table.model
   signal showOpenProjectDialog
   signal showQFieldCloudScreen
+
+  Settings {
+    id: registry
+    property string baseMapProject: ''
+  }
 
   Rectangle {
     id: welcomeBackground
@@ -366,13 +372,21 @@ Page {
                   id: projectNote
                   leftPadding: 3
                   text: {
-                    if (index == 0) {
+                    var notes = [];
+
+                    if ( index == 0 ) {
                         var firstRun = settings && !settings.value( "/QField/FirstRunFlag", false )
-                        return !firstRun && firstShown === false ? qsTr( "Last session" ) : ""
+                        if (!firstRun && firstShown === false) notes.push( qsTr( "Last session" ) );
                     }
-                    else
-                    {
-                        return ""
+
+                    if ( ProjectPath === registry.baseMapProject ) {
+                        notes.push( qsTr( "Base map project" ) );
+                    }
+
+                    if ( notes.length > 0 ) {
+                        return notes.join( '; ' );
+                    } else {
+                        return "";
                     }
                   }
                   visible: text != ""
@@ -445,21 +459,27 @@ Page {
             }
 
             MenuItem {
-              id: fileAssociationProject
+              id: baseMapProject
               visible: recentProjectActions.recentProjectType != 2;
 
               font: Theme.defaultFont
               width: parent.width
               height: visible ? 48: 0
-              leftPadding: 10
+              checkable: true
+              checked: recentProjectActions.recentProjectPath === registry.baseMapProject
 
-              text: recentProjectActions.recentProjectPath === settings.value( '/QField/fileAssociationProject', '' ) ? qsTr( "Unset as Default Project" ) : qsTr( "Set as Default Project" )
+              text: qsTr( "Base Map Project" )
               onTriggered: {
-                  settings.setValue( '/QField/fileAssociationProject', recentProjectActions.recentProjectPath === settings.value( '/QField/fileAssociationProject', '' ) ? '' : recentProjectActions.recentProjectPath );
-                  // reset the recentProjectPath to update menu item text
-                  recentProjectActions.recentProjectPath = '';
+                  registry.baseMapProject = recentProjectActions.recentProjectPath === registry.baseMapProject ? '' : recentProjectActions.recentProjectPath;
               }
             }
+
+            MenuSeparator {
+                visible: baseMapProject.visible
+                width: parent.width
+                height: visible ? undefined : 0
+            }
+
             MenuItem {
               id: removeProject
 

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -419,6 +419,7 @@ Page {
                 var item = table.itemAt(mouse.x, mouse.y)
                 if (item) {
                     recentProjectActions.recentProjectPath = item.path;
+                    recentProjectActions.recentProjectType = item.type;
                     recentProjectActions.popup(mouse.x, mouse.y)
                 }
             }
@@ -428,8 +429,10 @@ Page {
             id: recentProjectActions
 
             property string recentProjectPath: ''
+            property int recentProjectType: 0
 
             title: 'Recent Project Actions'
+
             width: {
                 var result = 0;
                 var padding = 0;
@@ -442,6 +445,22 @@ Page {
             }
 
             MenuItem {
+              id: fileAssociationProject
+              visible: recentProjectActions.recentProjectType != 2;
+
+              font: Theme.defaultFont
+              width: parent.width
+              height: visible ? 48: 0
+              leftPadding: 10
+
+              text: recentProjectActions.recentProjectPath === settings.value( '/QField/fileAssociationProject', '' ) ? qsTr( "Unset as Default Project" ) : qsTr( "Set as Default Project" )
+              onTriggered: {
+                  settings.setValue( '/QField/fileAssociationProject', recentProjectActions.recentProjectPath === settings.value( '/QField/fileAssociationProject', '' ) ? '' : recentProjectActions.recentProjectPath );
+                  // reset the recentProjectPath to update menu item text
+                  recentProjectActions.recentProjectPath = '';
+              }
+            }
+            MenuItem {
               id: removeProject
 
               font: Theme.defaultFont
@@ -449,7 +468,7 @@ Page {
               height: visible ? 48: 0
               leftPadding: 10
 
-              text: qsTr( "Remove Recent Project" )
+              text: qsTr( "Remove from Recent Projects" )
               onTriggered: {
                   iface.removeRecentProject( recentProjectActions.recentProjectPath );
                   model.reloadModel();


### PR DESCRIPTION
This comes in quite handy when people want to temporarily or permanently set a specific project as the one used as 'basemap' when opening individual datasets. 

It's *especially* useful for QField users who would want to make use of a QFieldCloud project, entirely removing the need to go through a USB cable file transfer.

The action is found in the menu that pops up when long-pressing a project in the recent projects list:
![image](https://user-images.githubusercontent.com/1728657/120879430-7a9d9200-c5ed-11eb-822c-0bc75b60fa37.png)

Note: I first add the menu item text be "set as file associated project", and wasn't satisfied with it. I've settled for "set as default project", which isn't ideal but is less obscure.

@xBcai , the feature request you filed doesn't quite match this PR but hopefully it'll meet you half way there :wink:

Edit: as of this PR, the 'basemap' logic when opening an individual dataset is as follow:
- first, check whether a default project has been set, if so, use that
- second, check for a basemap.{qgs,qgz} project file in the device's /QField/ directory, if present, use that
- last, if neither of the above is found, the code throws in an OSM XYZ layer as basemap