### PR TITLE
Until we support those, prevent text editing of JSON / list fields

### DIFF
--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -8,6 +8,8 @@ import "."
 EditorWidgetBase {
   id: topItem
 
+  property bool isEditable: isEnabled && typeof(value) != object
+
   height: childrenRect.height
 
   // Due to QTextEdit::onLinkActivated does not work on Android & iOS, we need a separate `Text` element to support links https://bugreports.qt.io/browse/QTBUG-38487
@@ -16,7 +18,7 @@ EditorWidgetBase {
     height: textArea.height == 0 ? textField.height : 0
     topPadding: 10
     bottomPadding: 10
-    visible: height !== 0 && !isEnabled
+    visible: height !== 0 && !isEditable
     anchors.left: parent.left
     anchors.right: parent.right
     font: Theme.defaultFont
@@ -32,7 +34,7 @@ EditorWidgetBase {
     id: textField
     topPadding: 10
     bottomPadding: 10
-    visible: height !== 0 && isEnabled
+    visible: height !== 0 && isEditable
     anchors.left: parent.left
     anchors.right: parent.right
     font: Theme.defaultFont
@@ -84,7 +86,7 @@ EditorWidgetBase {
     id: textArea
     height: config['IsMultiline'] === true ? undefined : 0
     visible: height !== 0
-    enabled: isEnabled
+    enabled: isEditable
     anchors.left: parent.left
     anchors.right: parent.right
     wrapMode: Text.Wrap

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -8,7 +8,7 @@ import "."
 EditorWidgetBase {
   id: topItem
 
-  property bool isEditable: isEnabled && typeof(value) != object
+  property bool isEditable: isEnabled && value && typeof(value) !== 'object'
 
   height: childrenRect.height
 


### PR DESCRIPTION
QField does not (yet?) support JSON and list field types. ATM, it defaults to using the text editor widget, which displays a string representation of those objects in read view just fine, _but_ throws an empty edit field when editing features, which is set to a blank value and can't really be edited.

Until further notice, just show the string representation whether we're in edit mode or not. Showing that instead of a blank important edit field makes us look a lot better ;-P