### PR TITLE
Important fix to geometry editor handling of vertex digitizing

### DIFF
--- a/src/qml/geometry_editors/FillRingToolBar.qml
+++ b/src/qml/geometry_editors/FillRingToolBar.qml
@@ -59,7 +59,6 @@ VisibilityFadingRow {
 
     onConfirm: {
       rubberbandModel.frozen = true
-      rubberbandModel.removeVertex()
       if (!featureModel.currentLayer.editBuffer())
         featureModel.currentLayer.startEditing()
       var result = GeometryUtils.addRingFromRubberband(featureModel.currentLayer, featureModel.feature.id, rubberbandModel)

--- a/src/qml/geometry_editors/ReshapeToolBar.qml
+++ b/src/qml/geometry_editors/ReshapeToolBar.qml
@@ -52,7 +52,6 @@ VisibilityFadingRow {
 
         onConfirm: {
             rubberbandModel.frozen = true
-            rubberbandModel.removeVertex()
             if (!featureModel.currentLayer.editBuffer())
                 featureModel.currentLayer.startEditing()
             var result = GeometryUtils.reshapeFromRubberband(featureModel.currentLayer, featureModel.feature.id, rubberbandModel)

--- a/src/qml/geometry_editors/SplitFeatureToolbar.qml
+++ b/src/qml/geometry_editors/SplitFeatureToolbar.qml
@@ -40,7 +40,6 @@ VisibilityFadingRow {
 
     onConfirm: {
       rubberbandModel.frozen = true
-      rubberbandModel.removeVertex()
 
       // TODO: featureModel.currentLayer.selectByIds([featureModel.feature.id], VectorLayerStatic.SetSelection)
       LayerUtils.selectFeaturesInLayer(featureModel.currentLayer, [featureModel.feature.id], VectorLayerStatic.SetSelection)

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -203,12 +203,16 @@ ApplicationWindow {
         grabPermissions: PointerHandler.TakeOverForbidden
 
         onPointChanged: {
-            var digitizingToolbarCoordinates = digitizingToolbar.mapToItem(mainWindow.contentItem, 0, 0)
-            if ( !freehandHandler.active &&
-                 point.position.x >= digitizingToolbarCoordinates.x && point.position.x <= digitizingToolbarCoordinates.x + digitizingToolbar.width &&
-                 point.position.y >= digitizingToolbarCoordinates.y && point.position.y <= digitizingToolbarCoordinates.y + digitizingToolbar.height ) {
-                // when hovering digitizing toolbar, reset coordinate locator position for nicer UX
+            function pointInItem(point, item) {
+                var itemCoordinates = item.mapToItem(mainWindow.contentItem, 0, 0);
+                return point.position.x >= itemCoordinates.x && point.position.x <= itemCoordinates.x + item.width &&
+                       point.position.y >= itemCoordinates.y && point.position.y <= itemCoordinates.y + item.height;
+            }
+            // when hovering digitizing toolbars, reset coordinate locator position for nicer UX
+            if ( !freehandHandler.active && pointInItem( point, digitizingToolbar ) ) {
                 coordinateLocator.sourceLocation = mapCanvas.mapSettings.coordinateToScreen( digitizingToolbar.rubberbandModel.lastCoordinate );
+            } else if ( !freehandHandler.active && pointInItem( point, geometryEditorsToolbar ) ) {
+                coordinateLocator.sourceLocation = mapCanvas.mapSettings.coordinateToScreen( geometryEditorsToolbar.editorRubberbandModel.lastCoordinate );
             } else {
                 // after a click, it seems that the position is sent once at 0,0 => weird
                 if (point.position !== Qt.point(0, 0))


### PR DESCRIPTION
While developing the digitizing logger feature, I realized the geometry editor vertex digitizing didn't align with the main digitizing toolbar (i.e. feature attention). Long story short here is that it removed the last vertex (mimicking QGIS instead of QField). 

This PR fixes that, as well as apply an important related fix  on handling of hovering pen when entering geometry editors' digizing toolbar area.