### PR TITLE
Consider all writable vector layers as part of topology when editing

### DIFF
--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -356,8 +356,7 @@ bool FeatureModel::save()
 
       if ( QgsProject::instance()->topologicalEditing() )
       {
-        applyVertexModelToLayerTopography();
-        mLayer->addTopologicalPoints( feat.geometry() );
+        applyVertexModelTopography();
       }
 
       rv &= commit();
@@ -850,31 +849,50 @@ class MatchCollectingFilter : public QgsPointLocator::MatchFilter
     }
 };
 
-void FeatureModel::applyVertexModelToLayerTopography()
+void FeatureModel::applyVertexModelTopography()
 {
   if ( !mVertexModel )
     return;
 
-  QgsPointLocator *loc = new QgsPointLocator( mLayer );
   const QVector<QPair<QgsPoint, QgsPoint>> pointsMoved = mVertexModel->verticesMoved();
-  for ( const auto &point : pointsMoved )
-  {
-    MatchCollectingFilter filter;
-    loc->nearestVertex( point.first, 0, &filter );
-    for ( int i = 0; i < filter.matches.size(); i++ )
-    {
-      mLayer->moveVertex( point.second, filter.matches.at( i ).featureId(), filter.matches.at( i ).vertexIndex() );
-    }
-  }
-
   const QVector<QgsPoint> pointsDeleted = mVertexModel->verticesDeleted();
-  for ( const auto &point : pointsDeleted )
+
+  const QVector<QgsVectorLayer*> vectorLayers = QgsProject::instance()->layers<QgsVectorLayer*>();
+  for ( auto vectorLayer : vectorLayers )
   {
-    MatchCollectingFilter filter;
-    loc->nearestVertex( point, 0, &filter );
-    for ( int i = 0; i < filter.matches.size(); i++ )
+    if ( vectorLayer->readOnly() )
+      continue;
+
+    if ( vectorLayer != mLayer )
     {
-      mLayer->deleteVertex( filter.matches.at( i ).featureId(), filter.matches.at( i ).vertexIndex() );
+      vectorLayer->startEditing();
+    }
+
+    QgsPointLocator loc( vectorLayer );
+    for ( const auto &point : pointsMoved )
+    {
+      MatchCollectingFilter filter;
+      loc.nearestVertex( point.first, 0, &filter );
+      for ( int i = 0; i < filter.matches.size(); i++ )
+      {
+        vectorLayer->moveVertex( point.second, filter.matches.at( i ).featureId(), filter.matches.at( i ).vertexIndex() );
+      }
+    }
+
+    for ( const auto &point : pointsDeleted )
+    {
+      MatchCollectingFilter filter;
+      loc.nearestVertex( point, 0, &filter );
+      for ( int i = 0; i < filter.matches.size(); i++ )
+      {
+        vectorLayer->deleteVertex( filter.matches.at( i ).featureId(), filter.matches.at( i ).vertexIndex() );
+      }
+    }
+
+    vectorLayer->addTopologicalPoints( mFeature.geometry() );
+    if ( vectorLayer != mLayer )
+    {
+      vectorLayer->commitChanges( true );
     }
   }
 }

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -857,7 +857,7 @@ void FeatureModel::applyVertexModelTopography()
   const QVector<QPair<QgsPoint, QgsPoint>> pointsMoved = mVertexModel->verticesMoved();
   const QVector<QgsPoint> pointsDeleted = mVertexModel->verticesDeleted();
 
-  const QVector<QgsVectorLayer*> vectorLayers = QgsProject::instance()->layers<QgsVectorLayer*>();
+  const QVector<QgsVectorLayer *> vectorLayers = QgsProject::instance()->layers<QgsVectorLayer *>();
   for ( auto vectorLayer : vectorLayers )
   {
     if ( vectorLayer->readOnly() )

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -200,8 +200,8 @@ class FeatureModel : public QAbstractListModel
     //! Apply the feature geometry to a vertex model if present.
     Q_INVOKABLE void applyGeometryToVertexModel();
 
-    //! Apply the vertex model changes to the layer topography.
-    Q_INVOKABLE void applyVertexModelToLayerTopography();
+    //! Apply the vertex model changes to editablelayers' topography.
+    Q_INVOKABLE void applyVertexModelTopography();
 
     //! Update the linked geometry rubber band to match the feature's geometry
     Q_INVOKABLE void updateRubberband() const;


### PR DESCRIPTION
This PR alters how QField behaves when topological editing is on to consider _all_ editable (i.e. non read-only) vector layers as part of the overall project topology. This means that if I move a vertex from a currently selected / active line layer, it will not only insure that overlapping vertices within the line layer are moved too, it'll also do so for all other editable layers.

Makes topological editing that much more useful in QField. We'll need to add a note in the documentation so people are aware of this behavior, since it diverges from what QGIS does. Our big brother applies topological changes only to layers with edit state toggled on, which isn't appropriate for the QField environment.