### PR TITLE
Add a flag when the device crashes on request and disable QFC if needed

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -38,3 +38,13 @@ bool Settings::valueBool( const QString &key, bool defaultValue )
 {
   return QSettings::value( key, defaultValue ).toBool();
 }
+
+void Settings::remove( const QString &key )
+{
+  QSettings::remove( key );
+}
+
+void Settings::sync()
+{
+  QSettings::sync();
+}

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -38,6 +38,16 @@ class Settings : public QSettings
      */
     Q_INVOKABLE bool valueBool( const QString &key, bool defaultValue );
 
+    /**
+     * Removes the given \a key from settings.
+     */
+    Q_INVOKABLE void remove( const QString &key );
+
+    /**
+     * Writes any unsaved changes to permanent storage, and reloads the settings.
+     */
+    Q_INVOKABLE void sync();
+
   signals:
     void settingChanged( const QString &key );
 };

--- a/src/qml/Changelog.qml
+++ b/src/qml/Changelog.qml
@@ -112,6 +112,12 @@ Popup {
 
   ChangelogContents {
     id: changelogContents
+    onMarkdownChanged: {
+      if ( changelogContents.markdown ) {
+        settings.setValue( "/QField/isLoadingChangelog", false )
+        settings.remove( "/QField/isCrashingSslDevice" )
+      }
+    }
   }
 
   onClosed: {
@@ -123,8 +129,24 @@ Popup {
   }
 
   onOpened: {
+    if ( settings.valueBool( "/QField/isLoadingChangelog", false ) ) {
+      settings.setValue( "/QField/isCrashingSslDevice", true )
+    } else {
+      settings.remove( "/QField/isCrashingSslDevice" )
+    }
+
+    if ( settings.valueBool( "/QField/isCrashingSslDevice", false ) === true ) {
+      changelogBody.text = qsTr( "Change the latest QField changes on " )
+                            + ' <a href="https://github.com/opengisch/qfield/releases">' + qsTr( 'QField releases page' ) + '</a>.'
+      return
+    }
+
     if ( changelogContents.status === ChangelogContents.SuccessStatus || changelogContents.status === ChangelogContents.LoadingStatus )
       return
+
+    settings.remove( "/QField/isLoadingChangelog" )
+    settings.setValue( "/QField/isLoadingChangelog", true )
+    settings.sync()
 
     changelogContents.request()
   }

--- a/src/qml/QFieldCloudLogin.qml
+++ b/src/qml/QFieldCloudLogin.qml
@@ -8,7 +8,6 @@ import Theme 1.0
 Item {
   id: qfieldcloudLogin
   property bool isServerUrlEditingActive: false
-  property bool isSupportedDevice: settings && !settings.valueBool( "QField/isCrashingSslDevice", false )
 
   Image {
     id: sourceImg
@@ -75,18 +74,6 @@ Item {
       }
 
       Text {
-        text: qsTr( "This mobile device does not support QFieldCloud. Please upgrade your system to a newer Android version or use another device." )
-              + ' <a href="https://qfield.cloud/">' + qsTr( 'Learn more about QFieldCloud' ) + '</a>.'
-        horizontalAlignment: Text.AlignHCenter
-        font: Theme.defaultFont
-        textFormat: Text.RichText
-        wrapMode: Text.WordWrap
-        Layout.fillWidth: true
-        visible: !isSupportedDevice
-        onLinkActivated: Qt.openUrlExternally(link)
-      }
-
-      Text {
         id: cloudIntroLabel
         Layout.fillWidth: true
         text: '<style>a, a:hover, a:visited { color:' + Theme.mainColor + '; }></style>' +
@@ -96,7 +83,6 @@ Item {
         font: Theme.defaultFont
         textFormat: Text.RichText
         wrapMode: Text.WordWrap
-        visible: isSupportedDevice
 
         onLinkActivated: Qt.openUrlExternally(link)
       }
@@ -136,8 +122,7 @@ Item {
       Text {
         id: serverUrlLabel
         Layout.fillWidth: true
-        visible: isSupportedDevice
-                 && cloudConnection.status === QFieldCloudConnection.Disconnected
+        visible: cloudConnection.status === QFieldCloudConnection.Disconnected
                  && ( cloudConnection.url !== cloudConnection.defaultUrl || isServerUrlEditingActive )
         text: qsTr( "Server URL\n(Leave empty to use the default server)" )
         horizontalAlignment: Text.AlignHCenter
@@ -150,8 +135,7 @@ Item {
         id: serverUrlField
         Layout.preferredWidth: parent.width / 1.3
         Layout.alignment: Qt.AlignHCenter
-        visible: isSupportedDevice
-                 && cloudConnection.status === QFieldCloudConnection.Disconnected
+        visible: cloudConnection.status === QFieldCloudConnection.Disconnected
                  && ( prefixUrlWithProtocol(cloudConnection.url) !== cloudConnection.defaultUrl || isServerUrlEditingActive )
         enabled: visible
         height: Math.max(fontMetrics.height, fontMetrics.boundingRect(text).height) + 34
@@ -184,7 +168,7 @@ Item {
       Text {
         id: usernamelabel
         Layout.fillWidth: true
-        visible: isSupportedDevice && cloudConnection.status === QFieldCloudConnection.Disconnected
+        visible: cloudConnection.status === QFieldCloudConnection.Disconnected
         text: qsTr( "Username or email" )
         horizontalAlignment: Text.AlignHCenter
         font: Theme.defaultFont
@@ -195,7 +179,7 @@ Item {
         id: usernameField
         Layout.preferredWidth: parent.width / 1.3
         Layout.alignment: Qt.AlignHCenter
-        visible: isSupportedDevice && cloudConnection.status === QFieldCloudConnection.Disconnected
+        visible: cloudConnection.status === QFieldCloudConnection.Disconnected
         enabled: visible
         height: Math.max(fontMetrics.height, fontMetrics.boundingRect(text).height) + 34
         topPadding: 10
@@ -217,7 +201,7 @@ Item {
       Text {
         id: passwordlabel
         Layout.fillWidth: true
-        visible: isSupportedDevice && cloudConnection.status === QFieldCloudConnection.Disconnected
+        visible: cloudConnection.status === QFieldCloudConnection.Disconnected
         text: qsTr( "Password" )
         horizontalAlignment: Text.AlignHCenter
         font: Theme.defaultFont
@@ -229,7 +213,7 @@ Item {
         echoMode: TextInput.Password
         Layout.preferredWidth: parent.width / 1.3
         Layout.alignment: Qt.AlignHCenter
-        visible: isSupportedDevice && cloudConnection.status === QFieldCloudConnection.Disconnected
+        visible: cloudConnection.status === QFieldCloudConnection.Disconnected
         enabled: visible
         height: Math.max(fontMetrics.height, fontMetrics.boundingRect(text).height) + 34
         topPadding: 10
@@ -256,7 +240,7 @@ Item {
         Layout.fillWidth: true
         text: cloudConnection.status == QFieldCloudConnection.LoggedIn ? qsTr( "Logout" ) : cloudConnection.status == QFieldCloudConnection.Connecting ? qsTr( "Logging in, please wait" ) : qsTr( "Login" )
         enabled: cloudConnection.status != QFieldCloudConnection.Connecting
-        visible: isSupportedDevice
+
         onClicked: loginFormSumbitHandler()
       }
     }

--- a/src/qml/QFieldCloudLogin.qml
+++ b/src/qml/QFieldCloudLogin.qml
@@ -8,6 +8,7 @@ import Theme 1.0
 Item {
   id: qfieldcloudLogin
   property bool isServerUrlEditingActive: false
+  property bool isSupportedDevice: settings && !settings.valueBool( "QField/isCrashingSslDevice", false )
 
   Image {
     id: sourceImg
@@ -74,6 +75,18 @@ Item {
       }
 
       Text {
+        text: qsTr( "This mobile device does not support QFieldCloud. Please upgrade your system to a newer Android version or use another device." )
+              + ' <a href="https://qfield.cloud/">' + qsTr( 'Learn more about QFieldCloud' ) + '</a>.'
+        horizontalAlignment: Text.AlignHCenter
+        font: Theme.defaultFont
+        textFormat: Text.RichText
+        wrapMode: Text.WordWrap
+        Layout.fillWidth: true
+        visible: !isSupportedDevice
+        onLinkActivated: Qt.openUrlExternally(link)
+      }
+
+      Text {
         id: cloudIntroLabel
         Layout.fillWidth: true
         text: '<style>a, a:hover, a:visited { color:' + Theme.mainColor + '; }></style>' +
@@ -83,6 +96,7 @@ Item {
         font: Theme.defaultFont
         textFormat: Text.RichText
         wrapMode: Text.WordWrap
+        visible: isSupportedDevice
 
         onLinkActivated: Qt.openUrlExternally(link)
       }
@@ -122,7 +136,8 @@ Item {
       Text {
         id: serverUrlLabel
         Layout.fillWidth: true
-        visible: cloudConnection.status === QFieldCloudConnection.Disconnected
+        visible: isSupportedDevice
+                 && cloudConnection.status === QFieldCloudConnection.Disconnected
                  && ( cloudConnection.url !== cloudConnection.defaultUrl || isServerUrlEditingActive )
         text: qsTr( "Server URL\n(Leave empty to use the default server)" )
         horizontalAlignment: Text.AlignHCenter
@@ -135,7 +150,8 @@ Item {
         id: serverUrlField
         Layout.preferredWidth: parent.width / 1.3
         Layout.alignment: Qt.AlignHCenter
-        visible: cloudConnection.status === QFieldCloudConnection.Disconnected
+        visible: isSupportedDevice
+                 && cloudConnection.status === QFieldCloudConnection.Disconnected
                  && ( prefixUrlWithProtocol(cloudConnection.url) !== cloudConnection.defaultUrl || isServerUrlEditingActive )
         enabled: visible
         height: Math.max(fontMetrics.height, fontMetrics.boundingRect(text).height) + 34
@@ -168,7 +184,7 @@ Item {
       Text {
         id: usernamelabel
         Layout.fillWidth: true
-        visible: cloudConnection.status === QFieldCloudConnection.Disconnected
+        visible: isSupportedDevice && cloudConnection.status === QFieldCloudConnection.Disconnected
         text: qsTr( "Username or email" )
         horizontalAlignment: Text.AlignHCenter
         font: Theme.defaultFont
@@ -179,7 +195,7 @@ Item {
         id: usernameField
         Layout.preferredWidth: parent.width / 1.3
         Layout.alignment: Qt.AlignHCenter
-        visible: cloudConnection.status === QFieldCloudConnection.Disconnected
+        visible: isSupportedDevice && cloudConnection.status === QFieldCloudConnection.Disconnected
         enabled: visible
         height: Math.max(fontMetrics.height, fontMetrics.boundingRect(text).height) + 34
         topPadding: 10
@@ -201,7 +217,7 @@ Item {
       Text {
         id: passwordlabel
         Layout.fillWidth: true
-        visible: cloudConnection.status === QFieldCloudConnection.Disconnected
+        visible: isSupportedDevice && cloudConnection.status === QFieldCloudConnection.Disconnected
         text: qsTr( "Password" )
         horizontalAlignment: Text.AlignHCenter
         font: Theme.defaultFont
@@ -213,7 +229,7 @@ Item {
         echoMode: TextInput.Password
         Layout.preferredWidth: parent.width / 1.3
         Layout.alignment: Qt.AlignHCenter
-        visible: cloudConnection.status === QFieldCloudConnection.Disconnected
+        visible: isSupportedDevice && cloudConnection.status === QFieldCloudConnection.Disconnected
         enabled: visible
         height: Math.max(fontMetrics.height, fontMetrics.boundingRect(text).height) + 34
         topPadding: 10
@@ -240,7 +256,7 @@ Item {
         Layout.fillWidth: true
         text: cloudConnection.status == QFieldCloudConnection.LoggedIn ? qsTr( "Logout" ) : cloudConnection.status == QFieldCloudConnection.Connecting ? qsTr( "Logging in, please wait" ) : qsTr( "Login" )
         enabled: cloudConnection.status != QFieldCloudConnection.Connecting
-
+        visible: isSupportedDevice
         onClicked: loginFormSumbitHandler()
       }
     }


### PR DESCRIPTION
@m-kuhn @signedav as discussed

If loading the changelog from the internet is dangerous, let the user do it.

![Screenshot from 2021-06-14 09-13-36](https://user-images.githubusercontent.com/2820439/121849646-43696800-ccf4-11eb-9fc5-31d520586d5d.png)

Notify the user they need to change their device.

![Screenshot from 2021-06-14 08-57-52](https://user-images.githubusercontent.com/2820439/121849649-449a9500-ccf4-11eb-991d-a96260b53cba.png)
