### PR TITLE
Identify NMEA position information source

### DIFF
--- a/src/core/bluetoothreceiver.cpp
+++ b/src/core/bluetoothreceiver.cpp
@@ -84,7 +84,7 @@ void BluetoothReceiver::stateChanged( const QgsGpsInformation &info )
   // QgsGpsInformation's speed is served in km/h, translate to m/s
   mLastGnssPositionInformation = GnssPositionInformation( info.latitude, info.longitude, mEllipsoidalElevation ? info.elevation + info.elevation_diff : info.elevation, info.speed * 1000 / 60 / 60, info.direction, info.satellitesInView, info.pdop,
                                  info.hdop, info.vdop, info.hacc, info.vacc, info.utcDateTime, info.fixMode, info.fixType, info.quality,
-                                 info.satellitesUsed, info.status, info.satPrn, info.satInfoComplete );
+                                 info.satellitesUsed, info.status, info.satPrn, info.satInfoComplete, std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN(), QStringLiteral( "nmea" ) );
   emit lastGnssPositionInformationChanged( mLastGnssPositionInformation );
 }
 


### PR DESCRIPTION
@geckeau , this will fix the absence of @{gnss,position}_source_name content when using a GNSS device through bluetooth.

As for the other variables you mentioned:
- @position_vertical_speed is not something that's broadcasted/available via NMEA, there seems to be little we can do about this one
- @position_magnetic_variation is something NMEA covers but QGIS hasn't implemented yet.
- @position_used_satellites should work, but I don't have an NMEA device at hand to test ATM 