### PR TITLE
QField ❤️ 🔋 and now dims screen brightness when idling

### DIFF
--- a/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -59,6 +59,8 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
+import android.view.WindowManager;
+import android.view.WindowManager.LayoutParams;
 
 import org.qtproject.qt5.android.bindings.QtActivity;
 
@@ -69,6 +71,7 @@ import ch.opengis.qfield.QFieldUtils;
 public class QFieldActivity extends QtActivity {
 
     public static native void openProject(String url);
+    private float originalBrightness;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -84,6 +87,19 @@ public class QFieldActivity extends QtActivity {
             Context context = getApplication().getApplicationContext();
             openProject(QFieldUtils.getPathFromUri(context, uri));
         }
+    }
+
+    private void dimBrightness() {
+        WindowManager.LayoutParams lp = getWindow().getAttributes();
+        originalBrightness = lp.screenBrightness;
+        lp.screenBrightness = 0.01f;
+        getWindow().setAttributes(lp);
+    }
+
+    private void restoreBrightness() {
+        WindowManager.LayoutParams lp = getWindow().getAttributes();
+        lp.screenBrightness = originalBrightness;
+        getWindow().setAttributes(lp);
     }
 
     private void prepareQtActivity() {

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -353,6 +353,36 @@ void AndroidPlatformUtilities::setScreenLockPermission( const bool allowLock )
   }
 }
 
+void AndroidPlatformUtilities::dimBrightness()
+{
+  if ( mActivity.isValid() )
+  {
+    QtAndroid::runOnAndroidThread( []
+    {
+      QAndroidJniObject activity = QtAndroid::androidActivity();
+      if ( activity.isValid() )
+      {
+        activity.callMethod<void>( "dimBrightness" );
+      }
+    } );
+  }
+}
+
+void AndroidPlatformUtilities::restoreBrightness()
+{
+  if ( mActivity.isValid() )
+  {
+    QtAndroid::runOnAndroidThread( []
+    {
+      QAndroidJniObject activity = QtAndroid::androidActivity();
+      if ( activity.isValid() )
+      {
+        activity.callMethod<void>( "restoreBrightness" );
+      }
+    } );
+  }
+}
+
 bool AndroidPlatformUtilities::supportsNativeCamera() const
 {
   return true;

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -383,11 +383,6 @@ void AndroidPlatformUtilities::restoreBrightness()
   }
 }
 
-bool AndroidPlatformUtilities::supportsNativeCamera() const
-{
-  return true;
-}
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/core/platforms/android/androidplatformutilities.h
+++ b/src/core/platforms/android/androidplatformutilities.h
@@ -28,6 +28,8 @@ class AndroidPlatformUtilities : public PlatformUtilities
   public:
     AndroidPlatformUtilities();
 
+    PlatformUtilities::Capabilities capabilities() const override { return PlatformUtilities::AdjustBrightness; };
+
     void initSystem() override;
     QString systemGenericDataLocation() const override;
     QString qgsProject() const override;
@@ -47,8 +49,6 @@ class AndroidPlatformUtilities : public PlatformUtilities
 
     void dimBrightness() override;
     void restoreBrightness() override;
-
-    bool supportsNativeCamera() const override;
 
   private:
     bool checkAndAcquirePermissions( const QString &permissionString ) const;

--- a/src/core/platforms/android/androidplatformutilities.h
+++ b/src/core/platforms/android/androidplatformutilities.h
@@ -28,7 +28,7 @@ class AndroidPlatformUtilities : public PlatformUtilities
   public:
     AndroidPlatformUtilities();
 
-    PlatformUtilities::Capabilities capabilities() const override { return PlatformUtilities::AdjustBrightness; };
+    PlatformUtilities::Capabilities capabilities() const override { return Capabilities() | NativeCamera | AdjustBrightness; }
 
     void initSystem() override;
     QString systemGenericDataLocation() const override;

--- a/src/core/platforms/android/androidplatformutilities.h
+++ b/src/core/platforms/android/androidplatformutilities.h
@@ -45,6 +45,9 @@ class AndroidPlatformUtilities : public PlatformUtilities
 
     void setScreenLockPermission( const bool allowLock ) override;
 
+    void dimBrightness() override;
+    void restoreBrightness() override;
+
     bool supportsNativeCamera() const override;
 
   private:

--- a/src/core/platforms/platformutilities.cpp
+++ b/src/core/platforms/platformutilities.cpp
@@ -175,7 +175,3 @@ PlatformUtilities *PlatformUtilities::instance()
   return sPlatformUtils;
 }
 
-bool PlatformUtilities::supportsNativeCamera() const
-{
-  return false;
-}

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -119,6 +119,9 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
      */
     Q_INVOKABLE virtual void setScreenLockPermission( const bool allowLock ) { Q_UNUSED( allowLock ); }
 
+    Q_INVOKABLE virtual void dimBrightness() { return; };
+    Q_INVOKABLE virtual void restoreBrightness() { return; };
+
     static PlatformUtilities *instance();
 
     /**

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -119,7 +119,14 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
      */
     Q_INVOKABLE virtual void setScreenLockPermission( const bool allowLock ) { Q_UNUSED( allowLock ); }
 
+    /**
+     * Dims the brightness of the screen on supported devices.
+     */
     Q_INVOKABLE virtual void dimBrightness() { return; };
+
+    /**
+     * Restores the brightness of the screen to its original value on supported devices.
+     */
     Q_INVOKABLE virtual void restoreBrightness() { return; };
 
     static PlatformUtilities *instance();

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -51,7 +51,7 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
     /**
      * Returns flags containing the supported capabilities of the platform.
      */
-    virtual PlatformUtilities::Capabilities capabilities() const { return PlatformUtilities::NoCapabilities; }
+    virtual PlatformUtilities::Capabilities capabilities() const { return Capabilities() | NoCapabilities; }
 
     virtual void initSystem();
 

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -32,10 +32,26 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
 {
     Q_OBJECT
 
-    Q_PROPERTY( bool supportsNativeCamera READ supportsNativeCamera NOTIFY supportsNativeCameraChanged )
+    Q_PROPERTY( PlatformUtilities::Capabilities capabilities READ capabilities CONSTANT )
 
   public:
+
+    enum Capability
+    {
+      NoCapabilities = 0,    //!< No capabilities
+      NativeCamera = 1,      //!< Native camera handling support (returns true on Android where this is implemented through intents)
+      AdjustBrightness = 2,  //!< Capable of adjusting screen brightness
+    };
+
+    Q_DECLARE_FLAGS( Capabilities, Capability )
+    Q_FLAGS( Capabilities )
+
     virtual ~PlatformUtilities();
+
+    /**
+     * Returns flags containing the supported capabilities of the platform.
+     */
+    virtual PlatformUtilities::Capabilities capabilities() const { return PlatformUtilities::NoCapabilities; }
 
     virtual void initSystem();
 
@@ -131,16 +147,5 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
 
     static PlatformUtilities *instance();
 
-    /**
-     * Returns true if the platform supports native camera.
-     * This returns true on Android where this is implemented through intents
-     */
-    virtual bool supportsNativeCamera() const;
-
-  signals:
-    /**
-     * Will never be emitted, just here to avoid a warning about a non-signalling-property
-     */
-    void supportsNativeCameraChanged();
 };
 #endif // PLATFORMUTILITIES_H

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -358,6 +358,7 @@ void QgisMobileapp::initDeclarative()
 #if _QGIS_VERSION_INT >= 31900
   qRegisterMetaType<QgsPolymorphicRelation>( "QgsPolymorphicRelation" );
 #endif
+  qRegisterMetaType<PlatformUtilities::Capabilities>( "PlatformUtilities::Capabilities" );
   qRegisterMetaType<QgsField>( "QgsField" );
   qRegisterMetaType<QVariant::Type>( "QVariant::Type" );
   qRegisterMetaType<QgsDefaultValue>( "QgsDefaultValue" );
@@ -447,7 +448,7 @@ void QgisMobileapp::initDeclarative()
 
   qmlRegisterUncreatableType<AppInterface>( "org.qgis", 1, 0, "QgisInterface", "QgisInterface is only provided by the environment and cannot be created ad-hoc" );
   qmlRegisterUncreatableType<Settings>( "org.qgis", 1, 0, "Settings", "" );
-  qmlRegisterUncreatableType<PlatformUtilities>( "org.qgis", 1, 0, "PlatformUtilities", "" );
+  qmlRegisterUncreatableType<PlatformUtilities>( "org.qfield", 1, 0, "PlatformUtilities", "" );
   qmlRegisterUncreatableType<FlatLayerTreeModel>( "org.qfield", 1, 0, "FlatLayerTreeModel", "The FlatLayerTreeModel is available as context property `flatLayerTree`." );
   qmlRegisterUncreatableType<TrackingModel>( "org.qfield", 1, 0, "TrackingModel", "The TrackingModel is available as context property `trackingModel`." );
   qmlRegisterUncreatableType<QgsGpkgFlusher>( "org.qfield", 1, 0, "QgsGpkgFlusher", "The gpkgFlusher is available as context property `gpkgFlusher`" );

--- a/src/qml/EmbeddedFeatureForm.qml
+++ b/src/qml/EmbeddedFeatureForm.qml
@@ -31,9 +31,11 @@ Popup {
     }
 
     onAboutToShow: {
+        dimmer.suspended = true;
+        dimmer.resetTimer();
         if( state === 'Add' ) {
-           form.featureCreated = false
-           formFeatureModel.resetAttributes()
+           form.featureCreated = false;
+           formFeatureModel.resetAttributes();
         }
     }
 
@@ -95,6 +97,7 @@ Popup {
     }
 
     onClosed: {
+        dimmer.suspended = false
         if (!form.isSaved) {
             form.confirm()
             digitizingToolbar.digitizingLogger.writeCoordinates();

--- a/src/qml/OverlayFeatureFormDrawer.qml
+++ b/src/qml/OverlayFeatureFormDrawer.qml
@@ -39,10 +39,13 @@ Drawer {
    */
 
   onOpened: {
+      dimmer.suspended = true;
+      dimmer.resetTimer();
       isAdding = true
   }
 
   onClosed: {
+      dimmer.suspended = false;
       if ( !digitizingToolbar.geometryRequested ) {
           if( !overlayFeatureForm.isSaved ) {
               overlayFeatureForm.confirm()

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -28,10 +28,10 @@ Page {
     property bool fullScreenIdentifyView: false
     property bool locatorKeepScale: false
     property bool numericalDigitizingInformation: false
-    property bool nativeCamera: platformUtilities.supportsNativeCamera
+    property bool nativeCamera: platformUtilities.capabilities & PlatformUtilities.NativeCamera
     property bool autoSave: false
     property bool mouseAsTouchScreen: false
-    property bool dimBrightness: true
+    property bool dimBrightness: platformUtilities.capabilities & PlatformUtilities.AdjustBrightness
   }
 
   ListModel {
@@ -78,7 +78,9 @@ Page {
       Component.onCompleted: {
           for (var i = 0; i < settingsModel.count; i++) {
               if (settingsModel.get(i).settingAlias === 'nativeCamera') {
-                  settingsModel.setProperty(i, 'isVisible', platformUtilities.supportsNativeCamera)
+                  settingsModel.setProperty(i, 'isVisible', platformUtilities.capabilities & PlatformUtilities.NativeCamera)
+              } else if (settingsModel.get(i).settingAlias === 'dimBrightness') {
+                  settingsModel.setProperty(i, 'isVisible', platformUtilities.capabilities & PlatformUtilities.AdjustBrightness)
               } else {
                   settingsModel.setProperty(i, 'isVisible', true)   
               }

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -20,6 +20,7 @@ Page {
   property alias nativeCamera: registry.nativeCamera
   property alias autoSave: registry.autoSave
   property alias mouseAsTouchScreen: registry.mouseAsTouchScreen
+  property alias dimBrightness: registry.dimBrightness
 
   Settings {
     id: registry
@@ -30,6 +31,7 @@ Page {
     property bool nativeCamera: platformUtilities.supportsNativeCamera
     property bool autoSave: false
     property bool mouseAsTouchScreen: false
+    property bool dimBrightness: true
   }
 
   ListModel {
@@ -62,6 +64,11 @@ Page {
           title: qsTr( "Fast editing mode" )
           description: qsTr( "If enabled, the feature is stored after having a valid geometry and the constraints are fulfilled and atributes are commited immediately." )
           settingAlias: "autoSave"
+      }
+      ListElement {
+          title: qsTr( "Dim screen when idling" )
+          description: qsTr( "If enabled, the screen brightness will be dimmed after 20 seconds of inactivity to preserve battery." )
+          settingAlias: "dimBrightness"
       }
       ListElement {
           title: qsTr( "Consider mouse as a touchscreen device" )

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2345,8 +2345,8 @@ ApplicationWindow {
       anchors.fill: parent
       propagateComposedEvents: true
       onPressed: {
+          mouse.accepted = dimmed
           resetTimer();
-          mouse.accepted = false
       }
 
       Timer {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -755,8 +755,15 @@ ApplicationWindow {
     interactive: !welcomeScreen.visible
 
     onOpenedChanged: {
-      if ( !opened && featureForm.visible )
-        featureForm.focus = true
+      if ( opened ) {
+          dimmer.suspended = true;
+          dimmer.resetTimer();
+      } else {
+        dimmer.suspended = false;
+        if ( featureForm.visible ) {
+          featureForm.focus = true;
+        }
+      }
     }
 
     function ensureEditableLayerSelected() {
@@ -2327,5 +2334,42 @@ ApplicationWindow {
       currentPoint: coordinateLocator.currentCoordinate
       mapSettings: mapCanvas.mapSettings
       isHovering: hoverHandler.hovered
+  }
+
+  MouseArea {
+      id: dimmer
+
+      property bool dimmed: false
+      property bool suspended: false
+
+      anchors.fill: parent
+      propagateComposedEvents: true
+      onPressed: {
+          resetTimer();
+          mouse.accepted = false
+      }
+
+      Timer {
+          id: dimmerTimer
+          interval: 20000
+          repeat: false
+
+          onTriggered: {
+              if (!dimmer.suspended) {
+                dimmer.dimmed = true
+                platformUtilities.dimBrightness();
+              }
+          }
+      }
+
+      function resetTimer() {
+          if (dimmed) {
+              platformUtilities.restoreBrightness();
+              dimmed = false;
+          }
+          if (qfieldSettings.dimBrightness && !suspended) {
+            dimmerTimer.restart();
+          }
+      }
   }
 }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2342,10 +2342,16 @@ ApplicationWindow {
       property bool dimmed: false
       property bool suspended: false
 
+      enabled: platformUtilities.capabilities & PlatformUtilities.AdjustBrightness
       anchors.fill: parent
       propagateComposedEvents: true
       onPressed: {
-          mouse.accepted = dimmed
+          mouse.accepted = dimmed;
+          if (!dimmed)
+              resetTimer();
+      }
+      onClicked: {
+          mouse.accepted = dimmed;
           resetTimer();
       }
 
@@ -2363,6 +2369,9 @@ ApplicationWindow {
       }
 
       function resetTimer() {
+          if (!platformUtilities.capabilities & PlatformUtilities.AdjustBrightness)
+              return;
+
           if (dimmed) {
               platformUtilities.restoreBrightness();
               dimmed = false;


### PR DESCRIPTION
QField now dims screen brightness when idling. It's a default behavior which can be turned off via a setting toggle:
![image](https://user-images.githubusercontent.com/1728657/122543600-23b8a380-d056-11eb-9e6d-38fa35cee035.png)

This should make field users _very_ happy as it can result in much, much longer battery life when keeping QField on to do tracing et cie.