### PR TITLE
Add exportId and clientId in the delta data

### DIFF
--- a/src/core/deltafilewrapper.cpp
+++ b/src/core/deltafilewrapper.cpp
@@ -484,8 +484,6 @@ void DeltaFileWrapper::addPatch( const QString &localLayerId, const QString &sou
     const QgsField newField = newFields.at( idx );
     const int oldFieldIdx = oldFields.indexFromName( newField.name() );
 
-    Q_ASSERT( oldFieldIdx != -1 );
-
     switch ( newFields.fieldOrigin( idx ) )
     {
       case QgsFields::OriginExpression:
@@ -498,6 +496,8 @@ void DeltaFileWrapper::addPatch( const QString &localLayerId, const QString &sou
       case QgsFields::OriginUnknown:
         break;
     }
+
+    Q_ASSERT( oldFieldIdx != -1 );
 
     // Check if the new field is present in the fields of the old feature.
     // This would happen when there are calculated or joined fields. However, they should be already filtered out.

--- a/src/core/deltafilewrapper.cpp
+++ b/src/core/deltafilewrapper.cpp
@@ -455,6 +455,8 @@ void DeltaFileWrapper::addPatch( const QString &localLayerId, const QString &sou
     { "sourcePk", oldFeature.attribute( sourcePkAttrName ).toString() },
     { "sourceLayerId", sourceLayerId },
     { "uuid", QUuid::createUuid().toString( QUuid::WithoutBraces ) },
+    { "exportId", QFieldCloudUtils::projectSetting( mCloudProjectId, QStringLiteral( "lastExportId" ) ).toString() },
+    { "clientId", QFieldCloudUtils::projectSetting( mCloudProjectId, QStringLiteral( "lastLocalExportId" ) ).toString() },
   } );
 
   const QStringList attachmentFieldsList = attachmentFieldNames( mProject, localLayerId );
@@ -646,6 +648,8 @@ void DeltaFileWrapper::addDelete( const QString &localLayerId, const QString &so
     { "sourcePk", oldFeature.attribute( sourcePkAttrName ).toString() },
     { "sourceLayerId", sourceLayerId },
     { "uuid", QUuid::createUuid().toString( QUuid::WithoutBraces ) },
+    { "exportId", QFieldCloudUtils::projectSetting( mCloudProjectId, QStringLiteral( "lastExportId" ) ).toString() },
+    { "clientId", QFieldCloudUtils::projectSetting( mCloudProjectId, QStringLiteral( "lastLocalExportId" ) ).toString() },
   } );
 
   QMap<QString, int> layerPkDeltaIdx = mLocalPkDeltaIdx.value( localLayerId );
@@ -715,6 +719,8 @@ void DeltaFileWrapper::addCreate( const QString &localLayerId, const QString &so
     { "sourcePk", newFeature.attribute( sourcePkAttrName ).toString() },
     { "sourceLayerId", sourceLayerId },
     { "uuid", QUuid::createUuid().toString( QUuid::WithoutBraces ) },
+    { "exportId", QFieldCloudUtils::projectSetting( mCloudProjectId, QStringLiteral( "lastExportId" ) ).toString() },
+    { "clientId", QFieldCloudUtils::projectSetting( mCloudProjectId, QStringLiteral( "lastLocalExportId" ) ).toString() },
   } );
   const QStringList attachmentFieldsList = attachmentFieldNames( mProject, localLayerId );
   const QgsAttributes newAttrs = newFeature.attributes();

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -789,7 +789,7 @@ void QFieldCloudProjectsModel::uploadProject( const QString &projectId, const bo
     // ? should we also check the checksums of the files being uploaded? they are available at deltaFile->attachmentFileNames()->values()
     mCloudProjects[index].uploadAttachments.insert( fileName, FileTransfer( fileName, fileSize ) );
   }
-  projectSetSetting( projectId, QStringLiteral( "uploadAttachments" ), QStringList( mCloudProjects[index].uploadAttachments.keys() ) );
+  QFieldCloudUtils::setProjectSetting( projectId, QStringLiteral( "uploadAttachments" ), QStringList( mCloudProjects[index].uploadAttachments.keys() ) );
 
   QString deltaFileToUpload = deltaFileWrapper->toFileForUpload();
 
@@ -928,7 +928,7 @@ void QFieldCloudProjectsModel::uploadProject( const QString &projectId, const bo
         mCloudProjects[index].modification |= RemoteModification;
 
         mCloudProjects[index].lastLocalPushDeltas = QDateTime::currentDateTimeUtc().toString( Qt::ISODate );
-        projectSetSetting( projectId, QStringLiteral( "lastLocalPushDeltas" ), mCloudProjects[index].lastLocalPushDeltas );
+        QFieldCloudUtils::setProjectSetting( projectId, QStringLiteral( "lastLocalPushDeltas" ), mCloudProjects[index].lastLocalPushDeltas );
 
         emit dataChanged( idx, idx, QVector<int>() << ModificationRole << LastLocalPushDeltasRole );
 
@@ -1153,7 +1153,7 @@ void QFieldCloudProjectsModel::projectUploadAttachments( const QString &projectI
       else
       {
         mCloudProjects[index].uploadAttachments.remove( fileName );
-        projectSetSetting( projectId, QStringLiteral( "uploadAttachments" ), QStringList( mCloudProjects[index].uploadAttachments.keys() ) );
+        QFieldCloudUtils::setProjectSetting( projectId, QStringLiteral( "uploadAttachments" ), QStringList( mCloudProjects[index].uploadAttachments.keys() ) );
       }
 
       if ( mCloudProjects[index].uploadAttachments.size() - mCloudProjects[index].uploadAttachmentsFailed == 0 )
@@ -1426,7 +1426,7 @@ void QFieldCloudProjectsModel::downloadFileConnections( const QString &projectId
         mCloudProjects[index].checkout = ProjectCheckout::LocalAndRemoteCheckout;
         mCloudProjects[index].localPath = QFieldCloudUtils::localProjectFilePath( mUsername, projectId );
         mCloudProjects[index].lastLocalExport = QDateTime::currentDateTimeUtc().toString( Qt::ISODate );
-        projectSetSetting( projectId, QStringLiteral( "lastLocalExport" ), mCloudProjects[index].lastLocalExport );
+        QFieldCloudUtils::setProjectSetting( projectId, QStringLiteral( "lastLocalExport" ), mCloudProjects[index].lastLocalExport );
 
         emit projectDownloaded( projectId, mCloudProjects[index].name, false );
       }
@@ -1498,10 +1498,10 @@ void QFieldCloudProjectsModel::reload( const QJsonArray &remoteProjects )
   auto restoreLocalSettings = [ = ]( CloudProject & cloudProject, const QDir & localPath )
   {
     cloudProject.deltasCount = DeltaFileWrapper( qgisProject, QStringLiteral( "%1/deltafile.json" ).arg( localPath.absolutePath() ) ).count();
-    cloudProject.lastLocalExport = projectSetting( cloudProject.id, QStringLiteral( "lastLocalExport" ) ).toString();
-    cloudProject.lastLocalPushDeltas = projectSetting( cloudProject.id, QStringLiteral( "lastLocalPushDeltas" ) ).toString();
+    cloudProject.lastLocalExport = QFieldCloudUtils::projectSetting( cloudProject.id, QStringLiteral( "lastLocalExport" ) ).toString();
+    cloudProject.lastLocalPushDeltas = QFieldCloudUtils::projectSetting( cloudProject.id, QStringLiteral( "lastLocalPushDeltas" ) ).toString();
 
-    const QStringList fileNames = projectSetting( cloudProject.id, QStringLiteral( "uploadAttachments" ) ).toStringList();
+    const QStringList fileNames = QFieldCloudUtils::projectSetting( cloudProject.id, QStringLiteral( "uploadAttachments" ) ).toStringList();
     for ( const QString &fileName : fileNames )
     {
       QFileInfo fileInfo( fileName );
@@ -1524,11 +1524,11 @@ void QFieldCloudProjectsModel::reload( const QJsonArray &remoteProjects )
                                ProjectStatus::Idle );
 
     const QString projectPrefix = QStringLiteral( "QFieldCloud/projects/%1" ).arg( cloudProject.id );
-    projectSetSetting( cloudProject.id, QStringLiteral( "owner" ), cloudProject.owner );
-    projectSetSetting( cloudProject.id, QStringLiteral( "name" ), cloudProject.name );
-    projectSetSetting( cloudProject.id, QStringLiteral( "description" ), cloudProject.description );
-    projectSetSetting( cloudProject.id, QStringLiteral( "updatedAt" ), cloudProject.updatedAt );
-    projectSetSetting( cloudProject.id, QStringLiteral( "userRole" ), cloudProject.userRole );
+    QFieldCloudUtils::setProjectSetting( cloudProject.id, QStringLiteral( "owner" ), cloudProject.owner );
+    QFieldCloudUtils::setProjectSetting( cloudProject.id, QStringLiteral( "name" ), cloudProject.name );
+    QFieldCloudUtils::setProjectSetting( cloudProject.id, QStringLiteral( "description" ), cloudProject.description );
+    QFieldCloudUtils::setProjectSetting( cloudProject.id, QStringLiteral( "updatedAt" ), cloudProject.updatedAt );
+    QFieldCloudUtils::setProjectSetting( cloudProject.id, QStringLiteral( "userRole" ), cloudProject.userRole );
 
     if ( !mUsername.isEmpty() )
     {
@@ -1568,11 +1568,11 @@ void QFieldCloudProjectsModel::reload( const QJsonArray &remoteProjects )
       if ( !QSettings().contains( QStringLiteral( "%1/name" ).arg( projectPrefix ) ) )
         continue;
 
-      const QString owner = projectSetting( projectId, QStringLiteral( "owner" ) ).toString();
-      const QString name = projectSetting( projectId, QStringLiteral( "name" ) ).toString();
-      const QString description = projectSetting( projectId, QStringLiteral( "description" ) ).toString();
-      const QString updatedAt = projectSetting( projectId, QStringLiteral( "updatedAt" ) ).toString();
-      const QString userRole = projectSetting( projectId, QStringLiteral( "userRole" ) ).toString();
+      const QString owner = QFieldCloudUtils::projectSetting( projectId, QStringLiteral( "owner" ) ).toString();
+      const QString name = QFieldCloudUtils::projectSetting( projectId, QStringLiteral( "name" ) ).toString();
+      const QString description = QFieldCloudUtils::projectSetting( projectId, QStringLiteral( "description" ) ).toString();
+      const QString updatedAt = QFieldCloudUtils::projectSetting( projectId, QStringLiteral( "updatedAt" ) ).toString();
+      const QString userRole = QFieldCloudUtils::projectSetting( projectId, QStringLiteral( "userRole" ) ).toString();
 
       CloudProject cloudProject( projectId, true, owner, name, description, userRole, QString(), LocalCheckout, ProjectStatus::Idle );
 
@@ -1780,18 +1780,6 @@ QStringList QFieldCloudProjectsModel::projectFileNames( const QString &projectPa
   }
 
   return prefixedFileNames;
-}
-
-void QFieldCloudProjectsModel::projectSetSetting( const QString &projectId, const QString &setting, const QVariant &value )
-{
-  const QString projectPrefix = QStringLiteral( "QFieldCloud/projects/%1" ).arg( projectId );
-  return QSettings().setValue( QStringLiteral( "%1/%2" ).arg( projectPrefix, setting ), value );
-}
-
-QVariant QFieldCloudProjectsModel::projectSetting( const QString &projectId, const QString &setting, const QVariant &defaultValue )
-{
-  const QString projectPrefix = QStringLiteral( "QFieldCloud/projects/%1" ).arg( projectId );
-  return QSettings().value( QStringLiteral( "%1/%2" ).arg( projectPrefix, setting ), defaultValue );
 }
 
 // --

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -62,7 +62,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
       LocalDeltasCountRole,
       LocalPathRole,
       CanSyncRole,
-      LastLocalExportRole,
+      LastLocalExportedAtRole,
       LastLocalPushDeltasRole,
       UserRoleRole,
       DeltaListRole,
@@ -351,7 +351,10 @@ class QFieldCloudProjectsModel : public QAbstractListModel
       int deltasCount = 0;
       DeltaListModel *deltaListModel = nullptr;
 
-      QString lastLocalExport;
+      QString lastExportedAt;
+      QString lastExportId;
+      QString lastLocalExportedAt;
+      QString lastLocalExportId;
       QString lastLocalPushDeltas;
     };
 

--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -60,3 +60,15 @@ const QString QFieldCloudUtils::getProjectId( const QString &fileName )
 
   return QString();
 }
+
+void QFieldCloudUtils::setProjectSetting( const QString &projectId, const QString &setting, const QVariant &value )
+{
+  const QString projectPrefix = QStringLiteral( "QFieldCloud/projects/%1" ).arg( projectId );
+  return QSettings().setValue( QStringLiteral( "%1/%2" ).arg( projectPrefix, setting ), value );
+}
+
+const QVariant QFieldCloudUtils::projectSetting( const QString &projectId, const QString &setting, const QVariant &defaultValue )
+{
+  const QString projectPrefix = QStringLiteral( "QFieldCloud/projects/%1" ).arg( projectId );
+  return QSettings().value( QStringLiteral( "%1/%2" ).arg( projectPrefix, setting ), defaultValue );
+}

--- a/src/core/utils/qfieldcloudutils.h
+++ b/src/core/utils/qfieldcloudutils.h
@@ -49,6 +49,12 @@ class QFieldCloudUtils : public QObject
      */
     Q_INVOKABLE static const QString getProjectId( const QString &fileName );
 
+    //! Sets a \a setting to a given \a value for project with given \a projectId to the permanent storage.
+    static void setProjectSetting( const QString &projectId, const QString &setting, const QVariant &value );
+
+    //! Gets a \a setting value for project with given \a projectId from the permanent storage. Return \a defaultValue if not present.
+    static const QVariant projectSetting( const QString &projectId, const QString &setting, const QVariant &defaultValue = QVariant() );
+
   private:
     static QString sQgisSettingsDirPath;
 

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -420,7 +420,7 @@ Popup {
             color: Theme.gray
             text: {
               var exportText = ''
-              var dt = cloudProjectsModel.currentProjectData.LastLocalExport
+              var dt = cloudProjectsModel.currentProjectData.LastLocalExportedAt
               var timeDeltaMinutes = null
 
               if (dt) {

--- a/test/test_deltafilewrapper.cpp
+++ b/test/test_deltafilewrapper.cpp
@@ -66,6 +66,9 @@ class TestDeltaFileWrapper : public QObject
       QVERIFY( mJoinedLayer->isValid() );
       QVERIFY( QgsProject::instance()->addMapLayer( mLayer.get(), false, false ) );
       QVERIFY( QgsProject::instance()->addMapLayer( mJoinedLayer.get(), false, false ) );
+
+      QFieldCloudUtils::setProjectSetting( QStringLiteral( "TEST_PROJECT_ID" ), QStringLiteral( "lastLocalExportId" ), QStringLiteral( "22222222-2222-2222-2222-222222222222" ) );
+      QFieldCloudUtils::setProjectSetting( QStringLiteral( "TEST_PROJECT_ID" ), QStringLiteral( "lastExportId" ), QStringLiteral( "33333333-3333-3333-3333-333333333333" ) );
     }
 
 
@@ -330,6 +333,8 @@ class TestDeltaFileWrapper : public QObject
           "deltas": [
             {
               "uuid": "11111111-1111-1111-1111-111111111111",
+              "clientId": "22222222-2222-2222-2222-222222222222",
+              "exportId": "33333333-3333-3333-3333-333333333333",
               "localLayerId": "dummyLayerIdL1",
               "localPk": "100",
               "sourceLayerId": "dummyLayerIdS1",
@@ -344,6 +349,8 @@ class TestDeltaFileWrapper : public QObject
             },
             {
               "uuid": "11111111-1111-1111-1111-111111111111",
+              "clientId": "22222222-2222-2222-2222-222222222222",
+              "exportId": "33333333-3333-3333-3333-333333333333",
               "localLayerId": "dummyLayerIdL1",
               "localPk": "101",
               "sourceLayerId": "dummyLayerIdS1",
@@ -389,6 +396,8 @@ class TestDeltaFileWrapper : public QObject
           "deltas": [
             {
               "uuid": "11111111-1111-1111-1111-111111111111",
+              "clientId": "22222222-2222-2222-2222-222222222222",
+              "exportId": "33333333-3333-3333-3333-333333333333",
               "localLayerId": "dummyLayerIdL1",
               "localPk": "100",
               "sourceLayerId": "dummyLayerIdS1",
@@ -403,6 +412,8 @@ class TestDeltaFileWrapper : public QObject
             },
             {
               "uuid": "11111111-1111-1111-1111-111111111111",
+              "clientId": "22222222-2222-2222-2222-222222222222",
+              "exportId": "33333333-3333-3333-3333-333333333333",
               "localLayerId": "dummyLayerIdL1",
               "localPk": "101",
               "sourceLayerId": "dummyLayerIdS1",
@@ -485,6 +496,8 @@ class TestDeltaFileWrapper : public QObject
         [
           {
             "uuid": "11111111-1111-1111-1111-111111111111",
+            "clientId": "22222222-2222-2222-2222-222222222222",
+            "exportId": "33333333-3333-3333-3333-333333333333",
             "localLayerId": "dummyLayerIdL1",
             "localPk": "100",
             "sourceLayerId": "dummyLayerIdS1",
@@ -508,6 +521,8 @@ class TestDeltaFileWrapper : public QObject
         [
           {
             "uuid": "11111111-1111-1111-1111-111111111111",
+            "clientId": "22222222-2222-2222-2222-222222222222",
+            "exportId": "33333333-3333-3333-3333-333333333333",
             "localLayerId": "dummyLayerIdL1",
             "localPk": "100",
             "sourceLayerId": "dummyLayerIdS1",
@@ -522,6 +537,8 @@ class TestDeltaFileWrapper : public QObject
           },
           {
             "uuid": "11111111-1111-1111-1111-111111111111",
+            "clientId": "22222222-2222-2222-2222-222222222222",
+            "exportId": "33333333-3333-3333-3333-333333333333",
             "localLayerId": "dummyLayerIdL1",
             "localPk": "101",
             "sourceLayerId": "dummyLayerIdS1",
@@ -587,6 +604,8 @@ class TestDeltaFileWrapper : public QObject
           "deltas": [
             {
               "uuid": "11111111-1111-1111-1111-111111111111",
+              "clientId": "22222222-2222-2222-2222-222222222222",
+              "exportId": "33333333-3333-3333-3333-333333333333",
               "localLayerId": "%1",
               "localPk": "100",
               "sourceLayerId": "%1",
@@ -607,6 +626,8 @@ class TestDeltaFileWrapper : public QObject
             },
             {
               "uuid": "11111111-1111-1111-1111-111111111111",
+              "clientId": "22222222-2222-2222-2222-222222222222",
+              "exportId": "33333333-3333-3333-3333-333333333333",
               "localLayerId": "%1",
               "localPk": "102",
               "sourceLayerId": "%1",
@@ -627,6 +648,8 @@ class TestDeltaFileWrapper : public QObject
             },
             {
               "uuid": "11111111-1111-1111-1111-111111111111",
+              "clientId": "22222222-2222-2222-2222-222222222222",
+              "exportId": "33333333-3333-3333-3333-333333333333",
               "localLayerId": "%1",
               "localPk": "102",
               "sourceLayerId": "%1",
@@ -694,6 +717,8 @@ class TestDeltaFileWrapper : public QObject
         [
           {
             "uuid": "11111111-1111-1111-1111-111111111111",
+            "clientId": "22222222-2222-2222-2222-222222222222",
+            "exportId": "33333333-3333-3333-3333-333333333333",
             "localLayerId": "dummyLayerIdL1",
             "localPk": "100",
             "sourceLayerId": "dummyLayerIdS1",
@@ -730,6 +755,8 @@ class TestDeltaFileWrapper : public QObject
         [
           {
             "uuid": "11111111-1111-1111-1111-111111111111",
+            "clientId": "22222222-2222-2222-2222-222222222222",
+            "exportId": "33333333-3333-3333-3333-333333333333",
             "localLayerId": "dummyLayerIdL1",
             "localPk": "100",
             "sourceLayerId": "dummyLayerIdS1",
@@ -771,6 +798,8 @@ class TestDeltaFileWrapper : public QObject
         [
           {
             "uuid": "11111111-1111-1111-1111-111111111111",
+            "clientId": "22222222-2222-2222-2222-222222222222",
+            "exportId": "33333333-3333-3333-3333-333333333333",
             "localLayerId": "dummyLayerIdL1",
             "localPk": "101",
             "sourceLayerId": "dummyLayerIdS1",
@@ -815,6 +844,8 @@ class TestDeltaFileWrapper : public QObject
         [
           {
             "uuid": "11111111-1111-1111-1111-111111111111",
+            "clientId": "22222222-2222-2222-2222-222222222222",
+            "exportId": "33333333-3333-3333-3333-333333333333",
             "localLayerId": "dummyLayerIdL1",
             "localPk": "100",
             "sourceLayerId": "dummyLayerIdS1",
@@ -860,6 +891,8 @@ class TestDeltaFileWrapper : public QObject
         [
           {
             "uuid": "11111111-1111-1111-1111-111111111111",
+            "clientId": "22222222-2222-2222-2222-222222222222",
+            "exportId": "33333333-3333-3333-3333-333333333333",
             "localLayerId": "dummyLayerIdL1",
             "localPk": "100",
             "sourceLayerId": "dummyLayerIdS1",
@@ -915,6 +948,8 @@ class TestDeltaFileWrapper : public QObject
         [
           {
             "uuid": "11111111-1111-1111-1111-111111111111",
+            "clientId": "22222222-2222-2222-2222-222222222222",
+            "exportId": "33333333-3333-3333-3333-333333333333",
             "localLayerId": "dummyLayerIdL1",
             "localPk": "100",
             "sourceLayerId": "dummyLayerIdS1",
@@ -958,6 +993,8 @@ class TestDeltaFileWrapper : public QObject
           [
             {
               "uuid": "11111111-1111-1111-1111-111111111111",
+              "clientId": "22222222-2222-2222-2222-222222222222",
+              "exportId": "33333333-3333-3333-3333-333333333333",
               "localLayerId": "dummyLayerIdL1",
               "localPk": "100",
               "sourceLayerId": "dummyLayerIdS1",
@@ -1003,6 +1040,8 @@ class TestDeltaFileWrapper : public QObject
         [
           {
             "uuid": "11111111-1111-1111-1111-111111111111",
+            "clientId": "22222222-2222-2222-2222-222222222222",
+            "exportId": "33333333-3333-3333-3333-333333333333",
             "localLayerId": "dummyLayerIdL1",
             "localPk": "100",
             "sourceLayerId": "dummyLayerIdS1",
@@ -1038,6 +1077,8 @@ class TestDeltaFileWrapper : public QObject
         [
           {
             "uuid": "11111111-1111-1111-1111-111111111111",
+            "clientId": "22222222-2222-2222-2222-222222222222",
+            "exportId": "33333333-3333-3333-3333-333333333333",
             "localLayerId": "dummyLayerIdL1",
             "localPk": "100",
             "sourceLayerId": "dummyLayerIdS1",
@@ -1079,6 +1120,8 @@ class TestDeltaFileWrapper : public QObject
         [
           {
             "uuid": "11111111-1111-1111-1111-111111111111",
+            "clientId": "22222222-2222-2222-2222-222222222222",
+            "exportId": "33333333-3333-3333-3333-333333333333",
             "localLayerId": "dummyLayerIdL1",
             "localPk": "101",
             "sourceLayerId": "dummyLayerIdS1",
@@ -1130,6 +1173,8 @@ class TestDeltaFileWrapper : public QObject
           "deltas": [
             {
               "uuid": "11111111-1111-1111-1111-111111111111",
+              "clientId": "22222222-2222-2222-2222-222222222222",
+              "exportId": "33333333-3333-3333-3333-333333333333",
               "localLayerId": "dummyLayerIdL1",
               "localPk": "100",
               "sourceLayerId": "dummyLayerIdS1",
@@ -1147,6 +1192,8 @@ class TestDeltaFileWrapper : public QObject
             },
             {
               "uuid": "11111111-1111-1111-1111-111111111111",
+              "clientId": "22222222-2222-2222-2222-222222222222",
+              "exportId": "33333333-3333-3333-3333-333333333333",
               "localLayerId": "dummyLayerIdL2",
               "localPk": "101",
               "sourceLayerId": "dummyLayerIdS2",
@@ -1161,6 +1208,8 @@ class TestDeltaFileWrapper : public QObject
             },
             {
               "uuid": "11111111-1111-1111-1111-111111111111",
+              "clientId": "22222222-2222-2222-2222-222222222222",
+              "exportId": "33333333-3333-3333-3333-333333333333",
               "localLayerId": "dummyLayerIdL1",
               "localPk": "102",
               "sourceLayerId": "dummyLayerIdS1",
@@ -1196,6 +1245,8 @@ class TestDeltaFileWrapper : public QObject
           "deltas": [
             {
               "uuid": "11111111-1111-1111-1111-111111111111",
+              "clientId": "22222222-2222-2222-2222-222222222222",
+              "exportId": "33333333-3333-3333-3333-333333333333",
               "localLayerId": "%1",
               "localPk": "100",
               "sourceLayerId": "%1",
@@ -1217,6 +1268,8 @@ class TestDeltaFileWrapper : public QObject
             },
             {
               "uuid": "11111111-1111-1111-1111-111111111111",
+              "clientId": "22222222-2222-2222-2222-222222222222",
+              "exportId": "33333333-3333-3333-3333-333333333333",
               "localLayerId": "%1",
               "localPk": "102",
               "sourceLayerId": "%1",
@@ -1238,6 +1291,8 @@ class TestDeltaFileWrapper : public QObject
             },
             {
               "uuid": "11111111-1111-1111-1111-111111111111",
+              "clientId": "22222222-2222-2222-2222-222222222222",
+              "exportId": "33333333-3333-3333-3333-333333333333",
               "localLayerId": "%1",
               "localPk": "102",
               "sourceLayerId": "%1",
@@ -1264,6 +1319,8 @@ class TestDeltaFileWrapper : public QObject
             },
             {
               "uuid": "11111111-1111-1111-1111-111111111111",
+              "clientId": "22222222-2222-2222-2222-222222222222",
+              "exportId": "33333333-3333-3333-3333-333333333333",
               "localLayerId": "%1",
               "localPk": "1",
               "sourceLayerId": "%1",
@@ -1335,6 +1392,8 @@ class TestDeltaFileWrapper : public QObject
           "deltas": [
             {
               "uuid": "11111111-1111-1111-1111-111111111111",
+              "clientId": "22222222-2222-2222-2222-222222222222",
+              "exportId": "33333333-3333-3333-3333-333333333333",
               "localLayerId": "%1",
               "localPk": "100",
               "sourceLayerId": "%1",
@@ -1356,6 +1415,8 @@ class TestDeltaFileWrapper : public QObject
             },
             {
               "uuid": "11111111-1111-1111-1111-111111111111",
+              "clientId": "22222222-2222-2222-2222-222222222222",
+              "exportId": "33333333-3333-3333-3333-333333333333",
               "localLayerId": "%1",
               "localPk": "102",
               "sourceLayerId": "%1",
@@ -1377,6 +1438,8 @@ class TestDeltaFileWrapper : public QObject
             },
             {
               "uuid": "11111111-1111-1111-1111-111111111111",
+              "clientId": "22222222-2222-2222-2222-222222222222",
+              "exportId": "33333333-3333-3333-3333-333333333333",
               "localLayerId": "%1",
               "localPk": "102",
               "sourceLayerId": "%1",
@@ -1403,6 +1466,8 @@ class TestDeltaFileWrapper : public QObject
             },
             {
               "uuid": "11111111-1111-1111-1111-111111111111",
+              "clientId": "22222222-2222-2222-2222-222222222222",
+              "exportId": "33333333-3333-3333-3333-333333333333",
               "localLayerId": "%1",
               "localPk": "1",
               "sourceLayerId": "%1",
@@ -1520,6 +1585,8 @@ class TestDeltaFileWrapper : public QObject
         [
           {
             "uuid": "11111111-1111-1111-1111-111111111111",
+            "clientId": "22222222-2222-2222-2222-222222222222",
+            "exportId": "33333333-3333-3333-3333-333333333333",
             "localLayerId": "dummyLayerIdL1",
             "localPk": "2",
             "sourceLayerId": "dummyLayerIdS1",
@@ -1573,6 +1640,8 @@ class TestDeltaFileWrapper : public QObject
         [
           {
             "uuid": "11111111-1111-1111-1111-111111111111",
+            "clientId": "22222222-2222-2222-2222-222222222222",
+            "exportId": "33333333-3333-3333-3333-333333333333",
             "localLayerId": "dummyLayerIdL1",
             "localPk": "2",
             "sourceLayerId": "dummyLayerIdS1",
@@ -1631,6 +1700,8 @@ class TestDeltaFileWrapper : public QObject
         [
           {
             "uuid": "11111111-1111-1111-1111-111111111111",
+            "clientId": "22222222-2222-2222-2222-222222222222",
+            "exportId": "33333333-3333-3333-3333-333333333333",
             "localLayerId": "dummyLayerIdL1",
             "localPk": "1",
             "sourceLayerId": "dummyLayerIdS1",
@@ -1685,6 +1756,8 @@ class TestDeltaFileWrapper : public QObject
         [
           {
             "uuid": "11111111-1111-1111-1111-111111111111",
+            "clientId": "22222222-2222-2222-2222-222222222222",
+            "exportId": "33333333-3333-3333-3333-333333333333",
             "localLayerId": "dummyLayerIdL1",
             "localPk": "1",
             "sourceLayerId": "dummyLayerIdS1",


### PR DESCRIPTION
This way we can identify deltas on the server side that are comming from the same device and/or the same export. For privacy reasons of our users, we recreate the `clientId` after each successful export.

The `exportId` will not be directly used for now, but it is a good statistic for future use.