### PR TITLE
Rework screen dimmer, react to all keys, touches, and mouses

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -18,8 +18,9 @@
 
 #include "fileutils.h"
 #include "qgismobileapp.h"
-#include "qgsapplication.h"
-#include "qgslogger.h"
+
+#include <qgsapplication.h>
+#include <qgslogger.h>
 
 #ifdef WITH_SPIX
 #include <Spix/AnyRpcServer.h>

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -76,6 +76,7 @@ set(QFIELD_CORE_SRCS
   referencingfeaturelistmodel.cpp
   rubberband.cpp
   rubberbandmodel.cpp
+  screendimmer.cpp
   settings.cpp
   sgrubberband.cpp
   snappingresult.cpp
@@ -167,6 +168,7 @@ set(QFIELD_CORE_HDRS
   referencingfeaturelistmodel.h
   rubberband.h
   rubberbandmodel.h
+  screendimmer.h
   settings.h
   sgrubberband.h
   snappingresult.h

--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -65,3 +65,8 @@ void AppInterface::openFeatureForm()
 {
   emit openFeatureFormRequested();
 }
+
+void AppInterface::setScreenDimmerActive( bool active )
+{
+  mApp->setScreenDimmerActive( active );
+}

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -47,6 +47,8 @@ class AppInterface : public QObject
     Q_INVOKABLE bool print( const QString &layoutName );
     Q_INVOKABLE bool printAtlasFeatures( const QString &layoutName, const QList<long long> &featureIds );
 
+    Q_INVOKABLE void setScreenDimmerActive( bool active );
+
     static void setInstance( AppInterface *instance ) { sAppInterface = instance; }
     static AppInterface *instance() { return sAppInterface; }
 

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -163,6 +163,13 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   create();
 #endif
 
+  QSettings settings;
+  if ( PlatformUtilities::instance()->capabilities() & PlatformUtilities::AdjustBrightness )
+  {
+    mScreenDimmer.reset( new ScreenDimmer( app ) );
+    mScreenDimmer->setActive( settings.value( QStringLiteral( "dimBrightness" ), true ).toBool() );
+  }
+
   AppInterface::setInstance( mIface );
 
   //set the authHandler to qfield-handler
@@ -212,7 +219,6 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   mTrackingModel = new TrackingModel;
 
   // Transition from 1.8 to 1.8.1+
-  QSettings settings;
   const QString deviceAddress = settings.value( QStringLiteral( "positioningDevice" ), QString() ).toString();
   if ( deviceAddress == QStringLiteral( "internal" ) )
   {
@@ -1140,6 +1146,14 @@ bool QgisMobileapp::printAtlasFeatures( const QString &layoutName, const QList<l
 #warning "No PrintSupport for iOs. QgisMobileapp::print won't do anything."
   return false;
 #endif
+}
+
+void QgisMobileapp::setScreenDimmerActive( bool active )
+{
+  if ( mScreenDimmer )
+  {
+    mScreenDimmer->setActive( active );
+  }
 }
 
 bool QgisMobileapp::event( QEvent *event )

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -166,7 +166,7 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   QSettings settings;
   if ( PlatformUtilities::instance()->capabilities() & PlatformUtilities::AdjustBrightness )
   {
-    mScreenDimmer.reset( new ScreenDimmer( app ) );
+    mScreenDimmer = std::make_unique<ScreenDimmer>( app );
     mScreenDimmer->setActive( settings.value( QStringLiteral( "dimBrightness" ), true ).toBool() );
   }
 

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -36,6 +36,7 @@
 #include "qfield_core_export.h"
 #include "qfieldappauthrequesthandler.h"
 #include "qgsgpkgflusher.h"
+#include "screendimmer.h"
 #include "settings.h"
 
 class AppInterface;
@@ -50,7 +51,6 @@ class TrackingModel;
 class LocatorFiltersModel;
 class QgsProject;
 class LayerObserver;
-
 
 #define REGISTER_SINGLETON( uri, _class, name ) qmlRegisterSingletonType<_class>( uri, 1, 0, name, []( QQmlEngine *engine, QJSEngine *scriptEngine ) -> QObject * { Q_UNUSED(engine); Q_UNUSED(scriptEngine); return new _class(); } )
 
@@ -122,6 +122,12 @@ class QFIELD_CORE_EXPORT QgisMobileapp : public QQmlApplicationEngine
      */
     bool printAtlasFeatures( const QString &layoutName, const QList<long long> &featureIds );
 
+    /**
+     * Sets whether the screen dimmer will be active or not
+     * \param active set to TRUE to activate screen dimmer
+     */
+    void setScreenDimmerActive( bool active );
+
     bool event( QEvent *event ) override;
 
   signals:
@@ -185,6 +191,8 @@ class QFIELD_CORE_EXPORT QgisMobileapp : public QQmlApplicationEngine
     TrackingModel *mTrackingModel = nullptr;
 
     AppMissingGridHandler *mAppMissingGridHandler = nullptr;
+
+    std::unique_ptr<ScreenDimmer> mScreenDimmer;
 };
 
 Q_DECLARE_METATYPE( QgsWkbTypes::GeometryType )
@@ -193,6 +201,5 @@ Q_DECLARE_METATYPE( QgsFeatureIds )
 Q_DECLARE_METATYPE( QgsAttributes )
 Q_DECLARE_METATYPE( QVariant::Type )
 Q_DECLARE_METATYPE( QgsFieldConstraints )
-
 
 #endif // QGISMOBILEAPP_H

--- a/src/core/screendimmer.cpp
+++ b/src/core/screendimmer.cpp
@@ -17,7 +17,6 @@
 #include "platformutilities.h"
 
 #include <QEvent>
-#include <QDebug>
 
 ScreenDimmer::ScreenDimmer( QgsApplication *app ) : QObject( app )
 {

--- a/src/core/screendimmer.cpp
+++ b/src/core/screendimmer.cpp
@@ -1,0 +1,92 @@
+/***************************************************************************
+              screendimmer.h
+               ----------------------------------------------------
+              date                 : 26.06.2021
+              copyright            : (C) 2021 by Mathieu Pellerin
+              email                : mathieu (at) opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "screendimmer.h"
+#include "platformutilities.h"
+
+#include <QEvent>
+#include <QDebug>
+
+ScreenDimmer::ScreenDimmer( QgsApplication *app ) : QObject( app )
+{
+  app->installEventFilter( this );
+  connect( app, &QGuiApplication::applicationStateChanged, this, [ = ]() { setSuspend( app->applicationState() != Qt::ApplicationActive ); } );
+
+  mTimer.setSingleShot( true );
+  mTimer.setInterval( 20000 );
+  connect( &mTimer, &QTimer::timeout, this, &ScreenDimmer::timeout );
+}
+
+void ScreenDimmer::setActive( bool active )
+{
+  mActive = active;
+  if ( !mActive )
+  {
+    mTimer.stop();
+    if ( mDimmed )
+    {
+      PlatformUtilities::instance()->restoreBrightness();
+      mDimmed = false;
+    }
+  }
+}
+
+void ScreenDimmer::setSuspend( bool suspend )
+{
+  mSuspend = suspend;
+  if ( mActive )
+  {
+    if ( mSuspend )
+    {
+      mTimer.stop();
+      if ( mDimmed )
+      {
+        PlatformUtilities::instance()->restoreBrightness();
+        mDimmed = false;
+      }
+    }
+    else
+    {
+      mTimer.start();
+    }
+  }
+}
+
+bool ScreenDimmer::eventFilter( QObject *obj, QEvent *event )
+{
+  if ( event->type() == QEvent::KeyPress ||
+       event->type() == QEvent::MouseButtonPress ||
+       event->type() == QEvent::TouchBegin ||
+       event->type() == QEvent::InputMethod )
+  {
+    if ( mActive && !mSuspend )
+      mTimer.start();
+
+    if ( mDimmed )
+    {
+      PlatformUtilities::instance()->restoreBrightness();
+      mDimmed = false;
+      return true;
+    }
+  }
+
+  return QObject::eventFilter( obj, event );
+}
+
+void ScreenDimmer::timeout()
+{
+  PlatformUtilities::instance()->dimBrightness();
+  mDimmed = true;
+}

--- a/src/core/screendimmer.h
+++ b/src/core/screendimmer.h
@@ -1,0 +1,54 @@
+/***************************************************************************
+              screendimmer.h
+               ----------------------------------------------------
+              date                 : 26.06.2021
+              copyright            : (C) 2021 by Mathieu Pellerin
+              email                : mathieu (at) opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef SCREENDIMMER_H
+#define SCREENDIMMER_H
+
+#include <qgsapplication.h>
+
+#include <QTimer>
+
+/**
+ * @brief The ScreenDimmer class handles dimming of screen brightness.
+ */
+class ScreenDimmer : public QObject
+{
+    Q_OBJECT
+
+  public:
+
+    explicit ScreenDimmer( QgsApplication *app );
+
+    void setActive( bool active );
+
+    void setSuspend( bool suspend );
+
+  protected:
+
+    bool eventFilter( QObject *obj, QEvent *event ) override;
+
+  private:
+
+    void timeout();
+
+    QTimer mTimer;
+
+    bool mActive = false;
+    bool mSuspend = false;
+    bool mDimmed = false;
+
+};
+
+#endif // SCREENDIMMER_H

--- a/src/core/screendimmer.h
+++ b/src/core/screendimmer.h
@@ -31,8 +31,14 @@ class ScreenDimmer : public QObject
 
     explicit ScreenDimmer( QgsApplication *app );
 
+    /**
+     * Sets whether the screen dimmer is \a active or not.
+     */
     void setActive( bool active );
 
+    /**
+     * Temporarily suspends the screen dimmer when \a is set to TRUE.
+     */
     void setSuspend( bool suspend );
 
   protected:

--- a/src/qml/EmbeddedFeatureForm.qml
+++ b/src/qml/EmbeddedFeatureForm.qml
@@ -32,8 +32,6 @@ Popup {
     }
 
     onAboutToShow: {
-        dimmer.suspended = true;
-        dimmer.resetTimer();
         if( state === 'Add' ) {
            form.featureCreated = false;
            formFeatureModel.resetAttributes();
@@ -98,7 +96,6 @@ Popup {
     }
 
     onClosed: {
-        dimmer.suspended = false
         if (!form.isSaved) {
             form.confirm()
             digitizingToolbar.digitizingLogger.writeCoordinates();

--- a/src/qml/OverlayFeatureFormDrawer.qml
+++ b/src/qml/OverlayFeatureFormDrawer.qml
@@ -39,13 +39,10 @@ Drawer {
    */
 
   onOpened: {
-      dimmer.suspended = true;
-      dimmer.resetTimer();
       isAdding = true
   }
 
   onClosed: {
-      dimmer.suspended = false;
       if ( !digitizingToolbar.geometryRequested ) {
           if( !overlayFeatureForm.isSaved ) {
               overlayFeatureForm.confirm()

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -757,11 +757,7 @@ ApplicationWindow {
     interactive: !welcomeScreen.visible
 
     onOpenedChanged: {
-      if ( opened ) {
-          dimmer.suspended = true;
-          dimmer.resetTimer();
-      } else {
-        dimmer.suspended = false;
+      if ( !opened ) {
         if ( featureForm.visible ) {
           featureForm.focus = true;
         }
@@ -2047,6 +2043,7 @@ ApplicationWindow {
       }
     }
 
+    onDimBrightnessChanged: iface.setScreenDimmerActive( qfieldSettings.dimBrightness )
     Component.onCompleted: focusstack.addFocusTaker( this )
   }
 
@@ -2336,51 +2333,5 @@ ApplicationWindow {
       currentPoint: coordinateLocator.currentCoordinate
       mapSettings: mapCanvas.mapSettings
       isHovering: hoverHandler.hovered
-  }
-
-  MouseArea {
-      id: dimmer
-
-      property bool dimmed: false
-      property bool suspended: false
-
-      enabled: platformUtilities.capabilities & PlatformUtilities.AdjustBrightness
-      anchors.fill: parent
-      propagateComposedEvents: true
-      onPressed: {
-          mouse.accepted = dimmed;
-          if (!dimmed)
-              resetTimer();
-      }
-      onClicked: {
-          mouse.accepted = dimmed;
-          resetTimer();
-      }
-
-      Timer {
-          id: dimmerTimer
-          interval: 60000
-          repeat: false
-
-          onTriggered: {
-              if (!dimmer.suspended) {
-                dimmer.dimmed = true
-                platformUtilities.dimBrightness();
-              }
-          }
-      }
-
-      function resetTimer() {
-          if (!platformUtilities.capabilities & PlatformUtilities.AdjustBrightness)
-              return;
-
-          if (dimmed) {
-              platformUtilities.restoreBrightness();
-              dimmed = false;
-          }
-          if (qfieldSettings.dimBrightness && !suspended) {
-            dimmerTimer.restart();
-          }
-      }
   }
 }


### PR DESCRIPTION
Screen brightness dimmer, take 2.

I've gotten rid of QML to detect mouse events in favor of good old C++ by plugging in an event filter with the application itself. The benefits are:
- it detects key strokes (both from hardware keyboards as well as virtual ones), which takes care of the issue @suricactus raised that had us temporarily bump timeout to 60sec
- we now listen to the application being suspended / resumed, and restore brightness when resuming the app (it'd otherwise timeout in the background, not great)
- gets rid of hacky QML setup which wasn't working with dashboard overlays et cie (and had us disable the dimmer as a workaround the QML limitation)

