### PR TITLE
Fix navigation bar's back button gone missing

### DIFF
--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -193,13 +193,15 @@ Rectangle {
 
     anchors.left: parent.left
 
-    width: parent.state == "Navigation" ? 48: 0
+    width: parent.state != "Edit" && !toolBar.multiSelection ? 48: 0
     height: 48
     clip: true
 
-    iconSource: Theme.getThemeIcon( "ic_chevron_left_white_24dp" )
+    iconSource: parent.state == "Navigation"
+                ? Theme.getThemeIcon( "ic_chevron_left_white_24dp" )
+                : Theme.getThemeVectorIcon( "ic_arrow_left_white_24dp" )
 
-    enabled: ( parent.state == "Navigation" )
+    enabled: parent.state != "Edit" && !toolBar.multiSelection
 
     onClicked: {
         if ( toolBar.model && ( selection.focusedItem > 0 ) ) {


### PR DESCRIPTION
Fixes this:
![image](https://user-images.githubusercontent.com/1728657/125064494-ebe3cf80-e0da-11eb-8eb2-fc2227681c79.png)
