### PR TITLE
Support for 'live' default value updates when editing features 

### DIFF
--- a/src/core/attributeformmodel.h
+++ b/src/core/attributeformmodel.h
@@ -76,6 +76,7 @@ class AttributeFormModel : public QSortFilterProxyModel
      * Save the current (already existing) feature
      */
     Q_INVOKABLE bool save();
+
     /**
      * Create the current (not existing yet) feature
      */

--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -359,7 +359,8 @@ void AttributeFormModelBase::flatten( QgsAttributeEditorContainer *container, QS
 
         item->setData( currentTabIndex, AttributeFormModel::TabIndex );
         item->setData( mLayer->attributeDisplayName( fieldIndex ), AttributeFormModel::Name );
-        item->setData( !mLayer->editFormConfig().readOnly( fieldIndex ), AttributeFormModel::AttributeEditable );
+        item->setData( !mLayer->editFormConfig().readOnly( fieldIndex ) &&
+                       !( field.defaultValueDefinition().isValid() && field.defaultValueDefinition().applyOnUpdate() ), AttributeFormModel::AttributeEditable );
         const QgsEditorWidgetSetup setup = findBest( fieldIndex );
         item->setData( setup.type(), AttributeFormModel::EditorWidget );
         item->setData( setup.config(), AttributeFormModel::EditorWidgetConfig );

--- a/src/core/attributeformmodelbase.h
+++ b/src/core/attributeformmodelbase.h
@@ -78,7 +78,7 @@ class AttributeFormModelBase : public QStandardItemModel
 
     void flatten( QgsAttributeEditorContainer *container, QStandardItem *parent, const QString &parentVisibilityExpressions, QVector<QStandardItem *> &items, int currentTabIndex = 0, const QColor &color = QColor() );
 
-    void updateDefaultValues( int skipFieldIndex = -1 );
+    void updateDefaultValues( int fieldIndex = -1 );
 
     void updateVisibilityAndConstraints( int fieldIndex = -1 );
 

--- a/src/core/attributeformmodelbase.h
+++ b/src/core/attributeformmodelbase.h
@@ -78,6 +78,8 @@ class AttributeFormModelBase : public QStandardItemModel
 
     void flatten( QgsAttributeEditorContainer *container, QStandardItem *parent, const QString &parentVisibilityExpressions, QVector<QStandardItem *> &items, int currentTabIndex = 0, const QColor &color = QColor() );
 
+    void updateDefaultValues( int skipFieldIndex = -1 );
+
     void updateVisibilityAndConstraints( int fieldIndex = -1 );
 
     void setConstraintsHardValid( bool constraintsHardValid );

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -323,7 +323,11 @@ bool FeatureModel::setData( const QModelIndex &index, const QVariant &value, int
 
       bool success = mFeature.setAttribute( index.row(), val );
       if ( success )
+      {
         emit dataChanged( index, index, QVector<int>() << role );
+        // emit a feature changed signal so the attribute form's currentFeature has up-to-date values
+        emit featureChanged();
+      }
       return success;
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,6 +46,6 @@ ADD_QFIELD_TEST(geometryutilstest test_geometryutils.cpp)
 ADD_QFIELD_TEST(stringutilstest test_stringutils.cpp)
 ADD_QFIELD_TEST(urlutilstest test_urlutils.cpp)
 ADD_QFIELD_TEST(digitizingloggertest test_digitizinglogger.cpp)
+ADD_QFIELD_TEST(attributeformmodeltest test_attributeformmodel.cpp)
 
 ADD_QFIELD_QML_TEST(qmltest test_qml_editorwidgets.cpp)
-

--- a/test/test_attributeformmodel.cpp
+++ b/test/test_attributeformmodel.cpp
@@ -86,7 +86,7 @@ class TestAttributeFormModel : public QObject
       QVERIFY( mAttributeFormModel->save() );
 
       QgsFeature feature = mLayer->getFeature( fid );
-      QCOMPARE(feature.attributes().at( 2 ), QStringLiteral( "edit_feature__" ) );
+      QCOMPARE( feature.attributes().at( 2 ), QStringLiteral( "edit_feature__" ) );
     }
 
   private:

--- a/test/test_attributeformmodel.cpp
+++ b/test/test_attributeformmodel.cpp
@@ -1,0 +1,101 @@
+/***************************************************************************
+                        test_attributeformmodel.h
+                        --------------------
+  begin                : Jul 2021
+  copyright            : (C) 2021 by Mathieu Pellerin
+  email                : mathieu@opengis.ch
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "attributeformmodel.h"
+#include "featuremodel.h"
+
+#include "qfield_testbase.h"
+
+#include <QtTest>
+
+
+class TestAttributeFormModel : public QObject
+{
+    Q_OBJECT
+
+  private slots:
+
+    void initTestCase()
+    {
+      mLayer = std::make_unique< QgsVectorLayer >( QStringLiteral( "Point?crs=EPSG:3857&field=fid:integer&field=str:string&field=str2:string" ), QStringLiteral( "Input Layer" ), QStringLiteral( "memory" ) );
+      QVERIFY( mLayer->isValid() );
+
+      QgsFeature f1;
+      f1.setAttributes( QgsAttributes() << 1 << QStringLiteral( "string_a1" ) << QStringLiteral( "string_b1" ) );
+      qDebug() << f1.attributes();
+      QgsFeature f2;
+      f2.setAttributes( QgsAttributes() << 2 << QStringLiteral( "string_a2" ) << QStringLiteral( "string_b2" ) );
+      QgsFeature f3;
+      f3.setAttributes( QgsAttributes() << 1 << QStringLiteral( "string_a3" ) << QStringLiteral( "string_b3" ) );
+
+      mLayer->startEditing();
+      mLayer->addFeature( f1 );
+      mLayer->addFeature( f2 );
+      mLayer->addFeature( f3 );
+      mLayer->commitChanges();
+      QCOMPARE( mLayer->featureCount(), 3 );
+
+      mLayer->setDefaultValueDefinition( 2, QgsDefaultValue( QStringLiteral( " coalesce(\"str\",'') || '__'" ), true ) );
+
+      mAttributeFormModel = std::make_unique< AttributeFormModel >();
+      mFeatureModel = std::make_unique< FeatureModel >();
+      mAttributeFormModel->setFeatureModel( mFeatureModel.get() );
+      mFeatureModel->setCurrentLayer( mLayer.get() );
+    }
+
+    void testAttributes()
+    {
+      mFeatureModel->setFeature( mLayer->getFeature( 1 ) );
+      QCOMPARE( mAttributeFormModel->attribute( QStringLiteral( "str" ) ), QStringLiteral( "string_a1" ) );
+      QCOMPARE( mAttributeFormModel->data( mAttributeFormModel->index( 1, 0 ), AttributeFormModel::AttributeValue ), QStringLiteral( "string_a1" ) );
+    }
+
+    void testFeatureDefaultValue()
+    {
+      mFeatureModel->resetFeature();
+      mFeatureModel->resetAttributes();
+
+      mAttributeFormModel->setData( mAttributeFormModel->index( 1, 0 ), QString( "new_feature" ), AttributeFormModel::AttributeValue );
+      // test default value changed on update with new feature
+      QCOMPARE( mAttributeFormModel->attribute( QStringLiteral( "str2" ) ), QStringLiteral( "new_feature__" ) );
+
+      // create a feature through the attribute form model
+      QVERIFY( mAttributeFormModel->create() );
+
+      QgsFeatureId fid = mFeatureModel->feature().id();
+      QVERIFY( fid > 0 );
+
+      mAttributeFormModel->setData( mAttributeFormModel->index( 1, 0 ), QString( "edit_feature" ), AttributeFormModel::AttributeValue );
+      // test default value changed on update with existing feature being edited
+      QCOMPARE( mAttributeFormModel->attribute( QStringLiteral( "str2" ) ), QStringLiteral( "edit_feature__" ) );
+
+      QVERIFY( mAttributeFormModel->save() );
+
+      QgsFeature feature = mLayer->getFeature( fid );
+      QCOMPARE(feature.attributes().at( 2 ), QStringLiteral( "edit_feature__" ) );
+    }
+
+  private:
+
+    std::unique_ptr<QgsVectorLayer> mLayer;
+    std::unique_ptr<FeatureModel> mFeatureModel;
+    std::unique_ptr<AttributeFormModel> mAttributeFormModel;
+
+};
+
+QFIELDTEST_MAIN( TestAttributeFormModel )
+#include "test_attributeformmodel.moc"


### PR DESCRIPTION
This PR adds support for 'live' updating of default attribute values when editing features. While this was 'accidentally' working when fast-editing mode was turned on, the PR makes it working reliably all the time. 

In this screencast, you can see the "int" attribute value change makes the "blah2" attribute default value update:

https://user-images.githubusercontent.com/1728657/126150187-e1ea7d8a-1226-4db2-864b-18439e33332b.mp4

I've also taken the liberty to mark attribute fields with default values that are modified on feature update 'read-only'. It makes little sense to have those fields editable as whatever value is entered by the user will ultimately be overwritten. 


Linked issues:
Fixes #1741
Fixes #1193
Fixes #1127
Fixes #914 
and likely more.
