### PR TITLE
Cascading delete related features

### DIFF
--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -18,6 +18,7 @@
 #include "expressioncontextutils.h"
 #include "featuremodel.h"
 #include "vertexmodel.h"
+#include "layerutils.h"
 
 #include <QGeoPositionInfoSource>
 #include <QMutex>
@@ -674,69 +675,7 @@ bool FeatureModel::create()
 
 bool FeatureModel::deleteFeature()
 {
-  if ( !startEditing() )
-  {
-    QgsMessageLog::logMessage( tr( "Cannot start editing on layer \"%1\" to delete feature %2" ).arg( mLayer->name() ).arg( mFeature.id() ), QStringLiteral( "QField" ), Qgis::Critical );
-    return false;
-  }
-
-  bool isSuccess = true;
-
-  // delete parent and related features
-  QgsVectorLayer::DeleteContext deleteContext( true, mProject );
-  if ( mLayer->deleteFeature( mFeature.id(), &deleteContext ) )
-  {
-    // commit parent changes
-    if ( mLayer->commitChanges() )
-    {
-      // loop and commit referenced layers in reverse
-      QList<QgsVectorLayer *> constHandledLayers = deleteContext.handledLayers();
-
-      for ( QList<QgsVectorLayer *>::reverse_iterator it = constHandledLayers.rbegin(); it != constHandledLayers.rend(); ++it )
-      {
-        QgsVectorLayer *vl = *it;
-
-        if ( vl == mLayer )
-          continue;
-
-        if ( !vl->commitChanges() )
-        {
-          const QString msgs = vl->commitErrors().join( QStringLiteral( "\n" ) );
-          QgsMessageLog::logMessage( tr( "Cannot commit deletion in layer \"%1\". Reason:\n%3" ).arg( vl->name() ).arg( msgs ), QStringLiteral( "QField" ), Qgis::Warning );
-          isSuccess = false;
-          break;
-        }
-      }
-    }
-    else
-    {
-      const QString msgs = mLayer->commitErrors().join( QStringLiteral( "\n" ) );
-      QgsMessageLog::logMessage( tr( "Cannot commit deletion of feature %2 in layer \"%1\". Reason:\n%3" ).arg( mLayer->name() ).arg( mFeature.id() ).arg( msgs ), QStringLiteral( "QField" ), Qgis::Warning );
-      isSuccess = false;
-    }
-  }
-  else
-  {
-    QgsMessageLog::logMessage( tr( "Cannot delete feature %2 in layer %1" ).arg( mLayer->name() ).arg( mFeature.id() ), QStringLiteral( "QField" ), Qgis::Warning );
-
-    isSuccess = false;
-  }
-
-  if ( !isSuccess )
-  {
-    const QList<QgsVectorLayer *> constHandledLayers = deleteContext.handledLayers();
-    for ( QgsVectorLayer *vl : constHandledLayers )
-      if ( vl != mLayer )
-        if ( !vl->rollBack() )
-          QgsMessageLog::logMessage( tr( "Cannot rollback layer changes in layer %1" ).arg( vl->name() ), "QField", Qgis::Critical );
-
-    if ( mLayer->rollBack() )
-      QgsMessageLog::logMessage( tr( "Successfully rolled back changes in layer \"%1\" while attempting to delete feature %2" ).arg( mLayer->name() ).arg( mFeature.id() ), QStringLiteral( "QField" ), Qgis::Critical );
-    else
-      QgsMessageLog::logMessage( tr( "Cannot rollback layer changes in layer \"%1\" while attempting to delete feature %2" ).arg( mLayer->name() ).arg( mFeature.id() ), QStringLiteral( "QField" ), Qgis::Critical );
-  }
-
-  return isSuccess;
+  return LayerUtils::deleteFeature( mProject, mLayer, mFeature.id() );
 }
 
 bool FeatureModel::commit()
@@ -764,10 +703,8 @@ bool FeatureModel::startEditing()
     QgsMessageLog::logMessage( tr( "Cannot start editing" ), QStringLiteral( "QField" ), Qgis::Warning );
     return false;
   }
-  else
-  {
-    return true;
-  }
+
+  return true;
 }
 
 GnssPositionInformation FeatureModel::positionInformation() const

--- a/src/core/layerobserver.cpp
+++ b/src/core/layerobserver.cpp
@@ -255,7 +255,7 @@ void LayerObserver::addLayerListeners()
   {
     QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( layer );
 
-    if ( vl && vl->dataProvider() )
+    if ( vl && vl->isValid() )
     {
       if ( mObservedLayerIds.contains( vl->id() ) )
         continue;

--- a/src/core/utils/layerutils.cpp
+++ b/src/core/utils/layerutils.cpp
@@ -31,6 +31,7 @@
 #include <qgsfillsymbol.h>
 #include <qgsvectorlayer.h>
 #include <qgswkbtypes.h>
+#include <qgsmessagelog.h>
 
 LayerUtils::LayerUtils( QObject *parent )
   : QObject( parent )
@@ -110,4 +111,95 @@ void LayerUtils::selectFeaturesInLayer( QgsVectorLayer *layer, const QList<int> 
 QString LayerUtils::fieldType( const QgsField &field ) const
 {
   return QVariant( field.type() ).typeName();
+}
+
+bool LayerUtils::deleteFeature( QgsProject *project, QgsVectorLayer *layer, const QgsFeatureId fid, bool shouldWriteChanges )
+{
+  if ( !project )
+    return false;
+
+  if ( !layer )
+  {
+    QgsMessageLog::logMessage( tr( "Cannot start editing, no layer" ), "QField", Qgis::Warning );
+    return false;
+  }
+
+  if ( !shouldWriteChanges )
+  {
+    if ( ! layer->editBuffer() || !layer->startEditing() )
+    {
+      QgsMessageLog::logMessage( tr( "Cannot start editing" ), "QField", Qgis::Warning );
+      return false;
+    }
+  }
+  else
+  {
+    if ( !layer->editBuffer() )
+    {
+      return false;
+    }
+  }
+
+  bool isSuccess = true;
+
+  // delete parent and related features
+  QgsVectorLayer::DeleteContext deleteContext( true, project );
+  if ( layer->deleteFeature( fid, &deleteContext ) )
+  {
+    if ( !shouldWriteChanges )
+    {
+      // commit changes
+      if ( !layer->commitChanges() )
+      {
+        const QString msgs = layer->commitErrors().join( QStringLiteral( "\n" ) );
+        QgsMessageLog::logMessage( tr( "Cannot commit deletion of feature %2 in layer \"%1\". Reason:\n%3" ).arg( layer->name() ).arg( fid ).arg( msgs ), QStringLiteral( "QField" ), Qgis::Warning );
+        isSuccess = false;
+      }
+    }
+
+    if ( isSuccess )
+    {
+      // loop and commit referenced layers in reverse
+      QList<QgsVectorLayer *> constHandledLayers = deleteContext.handledLayers();
+
+      for ( QList<QgsVectorLayer *>::reverse_iterator it = constHandledLayers.rbegin(); it != constHandledLayers.rend(); ++it )
+      {
+        QgsVectorLayer *vl = *it;
+
+        if ( vl == layer )
+          continue;
+
+        if ( !vl->commitChanges() )
+        {
+          const QString msgs = vl->commitErrors().join( QStringLiteral( "\n" ) );
+          QgsMessageLog::logMessage( tr( "Cannot commit deletion in layer \"%1\". Reason:\n%3" ).arg( vl->name() ).arg( msgs ), QStringLiteral( "QField" ), Qgis::Warning );
+          isSuccess = false;
+          break;
+        }
+      }
+    }
+  }
+  else
+  {
+    QgsMessageLog::logMessage( tr( "Cannot delete feature %1" ).arg( fid ), "QField", Qgis::Warning );
+
+    isSuccess = false;
+  }
+
+  if ( !shouldWriteChanges )
+  {
+    if ( !isSuccess )
+    {
+      const QList<QgsVectorLayer *> constHandledLayers = deleteContext.handledLayers();
+      for ( QgsVectorLayer *vl : constHandledLayers )
+        if ( vl != layer )
+          if ( !vl->rollBack() )
+            QgsMessageLog::logMessage( tr( "Cannot rollback layer changes in layer %1" ).arg( vl->name() ), "QField", Qgis::Critical );
+
+      if ( !layer->rollBack() )
+        QgsMessageLog::logMessage( tr( "Cannot rollback layer changes in layer %1" ).arg( layer->name() ), "QField", Qgis::Critical );
+    }
+  }
+
+  return isSuccess;
 }

--- a/src/core/utils/layerutils.h
+++ b/src/core/utils/layerutils.h
@@ -58,6 +58,8 @@ class LayerUtils : public QObject
     static Q_INVOKABLE void selectFeaturesInLayer( QgsVectorLayer *layer, const QList<int> &fids, QgsVectorLayer::SelectBehavior behavior = QgsVectorLayer::SetSelection );
 #endif
 
+    static bool deleteFeature( QgsProject *project, QgsVectorLayer *layer, const QgsFeatureId fid, bool shouldWriteChanges = true );
+
     /**
      * Returns the QVariant typeName of a \a field.
      * This is a stable identifier (compared to the provider field name).


### PR DESCRIPTION
Allows deleting more than 1 level of children in relations. 
Currently it will delete the child features in L2, but leave the features in L3. With this PR it will cascade delete all the related features using the native QGIS cascading delete feature.
```
L1|    a
R1|   /  \
L2|  b   c
R2| / \
L3| d e 
```