### PR TITLE
Support UUID generator editor widget

### DIFF
--- a/src/core/utils/stringutils.cpp
+++ b/src/core/utils/stringutils.cpp
@@ -18,9 +18,8 @@
 #include "qgsstringutils.h"
 #include "stringutils.h"
 
-#include <QDebug>
 #include <QRegularExpression>
-
+#include <QUuid>
 
 StringUtils::StringUtils( QObject *parent )
   : QObject( parent )
@@ -33,6 +32,10 @@ QString StringUtils::insertLinks( const QString &string )
   return QgsStringUtils::insertLinks( string );
 }
 
+QString StringUtils::createUuid()
+{
+  return QUuid::createUuid().toString();
+}
 
 bool StringUtils::fuzzyMatch( const QString &source, const QString &term )
 {

--- a/src/core/utils/stringutils.h
+++ b/src/core/utils/stringutils.h
@@ -35,6 +35,11 @@ class QFIELD_CORE_EXPORT StringUtils : public QObject
      */
     static Q_INVOKABLE QString insertLinks( const QString &string );
 
+    /**
+     * Returns a new UUID string.
+     */
+    static Q_INVOKABLE QString createUuid();
+
     //! Checks whether the string \a term is part of \a source
     static bool fuzzyMatch( const QString &source, const QString &term );
 };

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -490,7 +490,7 @@ Page {
               Connections {
                 target: attributeEditorLoader.item
 
-                function onValueChanged(value, isNull) {
+                function onValueChangeRequested(value, isNull) {
                   //do not compare AttributeValue and value with strict comparison operators
                   if( ( AttributeValue != value || ( AttributeValue !== undefined && isNull ) ) && !( AttributeValue === undefined && isNull ) )
                   {

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -441,8 +441,23 @@ Page {
                   if ( widget === 'RelationEditor' ) {
                     return 'editorwidgets/relationeditors/' + ( RelationEditorWidget || 'relation_editor' ) + '.qml'
                   }
-
                   return 'editorwidgets/' + ( widget || 'TextEdit' ) + '.qml'
+                }
+
+                onLoaded: {
+                    item.processValue();
+                }
+
+                onIsEnabledChanged: {
+                    if (status == Loader.Ready) {
+                        item.processValue();
+                    }
+                }
+
+                onValueChanged: {
+                    if (status == Loader.Ready) {
+                        item.processValue();
+                    }
                 }
 
                 onStatusChanged: {

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -445,19 +445,7 @@ Page {
                 }
 
                 onLoaded: {
-                    item.processValue();
-                }
-
-                onIsEnabledChanged: {
-                    if (status == Loader.Ready) {
-                        item.processValue();
-                    }
-                }
-
-                onValueChanged: {
-                    if (status == Loader.Ready) {
-                        item.processValue();
-                    }
+                    item.isLoaded = true;
                 }
 
                 onStatusChanged: {

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -262,7 +262,7 @@ Item {
 
       onCurrentIndexChanged: {
         var newValue = featureListModel.dataFromRowIndex(currentIndex, FeatureListModel.KeyFieldRole)
-        valueChanged(newValue, false)
+        valueChangeRequested(newValue, false)
       }
 
       Connections {

--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -66,7 +66,7 @@ EditorWidgetBase {
     }
 
     onCheckedChanged: {
-        valueChanged( isBool ? checked : checked ? config['CheckedState'] : config['UncheckedState'], false )
+        valueChangeRequested( isBool ? checked : checked ? config['CheckedState'] : config['UncheckedState'], false )
         forceActiveFocus()
     }
   }

--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -147,11 +147,11 @@ EditorWidgetBase {
                 {
                     newDate = Qt.formatDateTime(newDate, config['field_format'])
                 }
-                valueChanged(newDate, newDate === undefined)
+                valueChangeRequested(newDate, newDate === undefined)
             }
             else
             {
-                valueChanged(undefined, true)
+                valueChangeRequested(undefined, true)
             }
         }
 
@@ -198,13 +198,13 @@ EditorWidgetBase {
                     if ( main.isDateTimeType )
                     {
                         var currentDateTime = new Date()
-                        valueChanged(currentDateTime, false)
+                        valueChangeRequested(currentDateTime, false)
                     }
                     else
                     {
                         var currentDate = new Date()
                         var textDate = Qt.formatDateTime(currentDate, config['field_format'])
-                        valueChanged(textDate, false)
+                        valueChangeRequested(textDate, false)
                     }
                     displayToast(qsTr( 'Date value set to today.'))
                 }
@@ -228,7 +228,7 @@ EditorWidgetBase {
             MouseArea {
                 anchors.fill: parent
                 onClicked: {
-                    valueChanged(undefined, true)
+                    valueChangeRequested(undefined, true)
                 }
             }
         }
@@ -468,12 +468,12 @@ EditorWidgetBase {
                         newDate.setSeconds(secondsSpinBox.value);
                         if ( main.isDateTimeType )
                         {
-                            valueChanged(newDate, newDate === undefined)
+                            valueChangeRequested(newDate, newDate === undefined)
                         }
                         else
                         {
                             var textDate = Qt.formatDateTime(newDate, config['field_format'])
-                            valueChanged(textDate, textDate === undefined)
+                            valueChangeRequested(textDate, textDate === undefined)
                         }
 
                         popup.close()

--- a/src/qml/editorwidgets/EditorWidgetBase.qml
+++ b/src/qml/editorwidgets/EditorWidgetBase.qml
@@ -1,6 +1,11 @@
 import QtQuick 2.12
 
 Item {
+    /* This function is triggered by the attribute form whenever a field value or
+     * editable state has changed.
+     */
+    function processValue() {}
+
     /* This signal is emmited when an editor widget has changed the value.
      */
     signal valueChangeRequested(var value, bool isNull)
@@ -11,9 +16,4 @@ Item {
      * handler is \c onRequestGeometry.
      */
     signal requestGeometry(var item, var layer)
-
-    /* This signal is emitted by the attribute form item when a value or the editable state
-     * has changed.
-     */
-    signal processValue();
 }

--- a/src/qml/editorwidgets/EditorWidgetBase.qml
+++ b/src/qml/editorwidgets/EditorWidgetBase.qml
@@ -9,4 +9,9 @@ Item {
      * handler is \c onRequestGeometry.
      */
     signal requestGeometry(var item, var layer)
+
+    /* This signal is emitted by the attribute form item when a value or the editable state
+     * has changed.
+     */
+    signal processValue();
 }

--- a/src/qml/editorwidgets/EditorWidgetBase.qml
+++ b/src/qml/editorwidgets/EditorWidgetBase.qml
@@ -1,10 +1,7 @@
 import QtQuick 2.12
 
 Item {
-    /* This function is triggered by the attribute form whenever a field value or
-     * editable state has changed.
-     */
-    function processValue() {}
+    property bool isLoaded: false
 
     /* This signal is emmited when an editor widget has changed the value.
      */

--- a/src/qml/editorwidgets/EditorWidgetBase.qml
+++ b/src/qml/editorwidgets/EditorWidgetBase.qml
@@ -1,7 +1,9 @@
 import QtQuick 2.12
 
 Item {
-    signal valueChanged( var value, bool isNull )
+    /* This signal is emmited when an editor widget has changed the value.
+     */
+    signal valueChangeRequested(var value, bool isNull)
 
     /* This signal is emitted when an editor widget is in need of a digitized geometry. The
      * geometry will be returned through calling a requestedGeometry(geometry) function

--- a/src/qml/editorwidgets/EditorWidgetBase.qml
+++ b/src/qml/editorwidgets/EditorWidgetBase.qml
@@ -1,6 +1,10 @@
 import QtQuick 2.12
 
 Item {
+    /* This property indicates whether the editor widget has been fully loaded by its Loader.
+     * Note: prior to this property being true, signals emitted by the editor widget will not be
+     * propagated.
+     */
     property bool isLoaded: false
 
     /* This signal is emmited when an editor widget has changed the value.

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -310,7 +310,7 @@ EditorWidgetBase {
         onFinished: {
             var filepath = getPictureFilePath()
             platformUtilities.renameFile( path, qgisProject.homePath +'/' + filepath)
-            valueChanged(filepath, false)
+            valueChangeRequested(filepath, false)
             campopup.close()
         }
         onCanceled: {
@@ -326,7 +326,7 @@ EditorWidgetBase {
     function onPictureReceived(path) {
       if( path )
       {
-          valueChanged(path, false)
+          valueChangeRequested(path, false)
       }
     }
   }

--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -57,7 +57,7 @@ EditorWidgetBase {
           }
 
           onTextChanged: {
-              valueChanged( text, text == '' )
+              valueChangeRequested( text, text == '' )
           }
       }
 

--- a/src/qml/editorwidgets/RelationReference.qml
+++ b/src/qml/editorwidgets/RelationReference.qml
@@ -45,7 +45,7 @@ EditorWidgetBase {
       }
     }
 
-    onValueChanged: parent.valueChanged(value, isNull)
+    onValueChanged: parent.valueChangeRequested(value, isNull)
   }
 
   Image {

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -82,7 +82,7 @@ EditorWidgetBase {
     }
 
     onTextChanged: {
-      valueChanged( text, text == '' )
+      valueChangeRequested( text, text == '' )
     }
   }
 
@@ -106,7 +106,7 @@ EditorWidgetBase {
     }
 
     onEditingFinished: {
-      valueChanged( text, text == '' )
+      valueChangeRequested( text, text == '' )
     }
   }
 

--- a/src/qml/editorwidgets/UuidGenerator.qml
+++ b/src/qml/editorwidgets/UuidGenerator.qml
@@ -1,0 +1,53 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+
+import Theme 1.0
+import org.qfield 1.0
+
+import "."
+
+EditorWidgetBase {
+  height: childrenRect.height
+
+  onProcessValue: {
+      if (isEnabled && (value === undefined || value == '')) {
+          console.log('changing');
+          valueChanged(StringUtils.createUuid() ,false);
+      }
+  }
+
+  anchors {
+    right: parent.right
+    left: parent.left
+  }
+
+  Label {
+      id: uuidLabel
+      height: fontMetrics.height + 20
+      anchors {
+          left: parent.left
+          right: parent.right
+      }
+
+      topPadding: 10
+      bottomPadding: 10
+      font: Theme.defaultFont
+      color: 'gray'
+      text: value !== undefined ? value : ''
+  }
+
+  Rectangle {
+      id: backgroundRect
+      anchors.left: parent.left
+      anchors.right: parent.right
+      y: uuidLabel.height - height - uuidLabel.bottomPadding / 2
+      implicitWidth: 120
+      height: 1
+      color: "#C8E6C9"
+  }
+
+  FontMetrics {
+    id: fontMetrics
+    font: uuidLabel.font
+  }
+}

--- a/src/qml/editorwidgets/UuidGenerator.qml
+++ b/src/qml/editorwidgets/UuidGenerator.qml
@@ -11,8 +11,7 @@ EditorWidgetBase {
 
   onProcessValue: {
       if (isEnabled && (value === undefined || value == '')) {
-          console.log('changing');
-          valueChanged(StringUtils.createUuid() ,false);
+          valueChangeRequested(StringUtils.createUuid() ,false);
       }
   }
 

--- a/src/qml/editorwidgets/UuidGenerator.qml
+++ b/src/qml/editorwidgets/UuidGenerator.qml
@@ -9,12 +9,6 @@ import "."
 EditorWidgetBase {
   height: childrenRect.height
 
-  function processValue() {
-      if (isEnabled && (value === undefined || value == '')) {
-          valueChangeRequested(StringUtils.createUuid() ,false);
-      }
-  }
-
   anchors {
     right: parent.right
     left: parent.left
@@ -32,7 +26,14 @@ EditorWidgetBase {
       bottomPadding: 10
       font: Theme.defaultFont
       color: 'gray'
-      text: value !== undefined ? value : ''
+      text: {
+        var displayValue = value !== undefined ? value : ''
+        if (isLoaded && isEnabled && (value === undefined || value == '')) {
+            displayValue = StringUtils.createUuid();
+            valueChangeRequested(displayValue ,false);
+        }
+        return displayValue;
+      }
   }
 
   Rectangle {

--- a/src/qml/editorwidgets/UuidGenerator.qml
+++ b/src/qml/editorwidgets/UuidGenerator.qml
@@ -9,7 +9,7 @@ import "."
 EditorWidgetBase {
   height: childrenRect.height
 
-  onProcessValue: {
+  function processValue() {
       if (isEnabled && (value === undefined || value == '')) {
           valueChangeRequested(StringUtils.createUuid() ,false);
       }

--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -50,7 +50,7 @@ EditorWidgetBase {
 
     onCurrentTextChanged: {
       var key = model.keyForValue(currentText)
-      valueChanged(key, false)
+      valueChangeRequested(key, false)
     }
 
     MouseArea {

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -25,6 +25,7 @@
         <file>editorwidgets/TextEdit.qml</file>
         <file>editorwidgets/Range.qml</file>
         <file>editorwidgets/ValueMap.qml</file>
+        <file>editorwidgets/UuidGenerator.qml</file>
         <file>editorwidgets/RelationReference.qml</file>
         <file>editorwidgets/relationeditors/relation_editor.qml</file>
         <file>editorwidgets/relationeditors/ordered_relation_editor.qml</file>


### PR DESCRIPTION
Because it's about time. Implements enhancement request #1661.

I took the time to rename the very confusing valueChanged( value, isnull ) editor widget signal to _changeValue( value, isnull )_.  IMHO, this is much better as a/ nobody can then confuse this with an onValueChanged signal emitted when the value property (which we pass around quite a lot) change, and also avoids duplicating an valueChanged signal in the attribute form item itself.
