### PR TITLE
Force using posix paths

### DIFF
--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -5,6 +5,7 @@ import QtGraphicalEffects 1.0
 import Qt.labs.calendar 1.0
 
 import Theme 1.0
+import org.qfield 1.0
 
 import "."
 

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -114,12 +114,12 @@ EditorWidgetBase {
 
   function getPictureFilePath() {
     var evaluatedFilepath = expressionEvaluator.evaluate()
+    var filepath = ( evaluatedFilepath && FileUtils.fileSuffix(evaluatedFilepath) !== '' )
+      ? evaluatedFilepath
+      : ('DCIM/JPEG_' + (new Date()).toISOString().replace(/[^0-9]/g, '') + '.jpg')
+    filepath = filepath.replace('\\', '/')
 
-    if ( evaluatedFilepath && FileUtils.fileSuffix(evaluatedFilepath) !== '' ) {
-      return evaluatedFilepath
-    } else {
-      return 'DCIM/JPEG_' + (new Date()).toISOString().replace(/[^0-9]/g, '') + '.jpg'
-    }
+    return filepath;
   }
 
   Label {


### PR DESCRIPTION
So even if the user have set `'DCIM\\IMG_' + $id + '.jpg'`, we store it correctly.