### PR TITLE
Fix green attachment upload message never going away, fix count

### DIFF
--- a/src/qml/QFieldCloudExportLayersFeedback.qml
+++ b/src/qml/QFieldCloudExportLayersFeedback.qml
@@ -5,7 +5,6 @@ import QtQuick.Layouts 1.12
 import org.qfield 1.0
 import Theme 1.0
 
-// QFieldCloudExportLayersFeedback
 Dialog {
   parent: mainWindow.contentItem
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2112,6 +2112,9 @@ ApplicationWindow {
     id: cloudExportLayersFeedback
     visible: false
     parent: ApplicationWindow.overlay
+
+    width: parent.width
+    height: parent.height
   }
 
   WelcomeScreen {


### PR DESCRIPTION
@suricactus , @lindacamathias , this PR fixes an issue raised in the chat room a while back, whereas the green attachment upload label would appear and stick forever.