### PR TITLE
Add a complete-as-you-type mode to the relation combobox

### DIFF
--- a/src/core/featurelistmodel.cpp
+++ b/src/core/featurelistmodel.cpp
@@ -168,6 +168,23 @@ int FeatureListModel::findKey( const QVariant &key ) const
   return -1;
 }
 
+QList<int> FeatureListModel::findDisplayValueMatches( const QString &filter ) const
+{
+  QMap<QString,int> matches;
+  const QString preparedFilter = filter.trimmed().toLower();
+  if ( !filter.trimmed().isEmpty() )
+  {
+    int idx = 0;
+    for ( const Entry &entry : mEntries )
+    {
+      if ( entry.displayString.trimmed().toLower().startsWith( preparedFilter ) )
+        matches.insert( entry.displayString.trimmed().toLower(), idx );
+      ++idx;
+    }
+  }
+  return matches.values();
+}
+
 void FeatureListModel::onFeatureAdded()
 {
   reloadLayer();

--- a/src/core/featurelistmodel.cpp
+++ b/src/core/featurelistmodel.cpp
@@ -267,20 +267,12 @@ void FeatureListModel::gatherFeatureList()
   if ( !mSearchTerm.isEmpty() )
   {
     QString escapedSearchTerm = QgsExpression::quotedValue( mSearchTerm ).replace( QRegularExpression( QStringLiteral( "^'|'$" ) ), QString( "" ) );
-    QString searchTermExpression = QStringLiteral( " %1 ILIKE '%%2%' " )
-                                   .arg( fieldDisplayString, escapedSearchTerm );
+    QString searchTermExpression = QStringLiteral( " %1 ILIKE '%%2%' " ).arg( fieldDisplayString, escapedSearchTerm );
 
-    QStringList searchTermParts = escapedSearchTerm.split( QRegularExpression( QStringLiteral( "\\s+" ) ) );
-
-    if ( searchTermParts.length() > 1 )
+    const QStringList searchTermParts = escapedSearchTerm.split( QRegularExpression( QStringLiteral( "\\s+" ) ), Qt::SkipEmptyParts );
+    for ( const QString &searchTermPart : searchTermParts )
     {
-      for ( const QString &searchTermPart : searchTermParts )
-      {
-        if ( searchTermPart.isEmpty() )
-          continue;
-
-        searchTermExpression += QStringLiteral( " OR %1 ILIKE '%%2%' " ).arg( fieldDisplayString, searchTermPart );
-      }
+      searchTermExpression += QStringLiteral( " OR %1 ILIKE '%%2%' " ).arg( fieldDisplayString, searchTermPart );
     }
 
     if ( mFilterExpression.isEmpty() )

--- a/src/core/featurelistmodel.h
+++ b/src/core/featurelistmodel.h
@@ -112,13 +112,18 @@ class FeatureListModel : public QAbstractItemModel
     void setDisplayValueField( const QString &displayValueField );
 
     /**
-       * Get the row for a given key value.
-       */
+     * Get the row for a given key value.
+     */
     Q_INVOKABLE int findKey( const QVariant &key ) const;
 
     /**
-       * Orders all the values alphabethically by their displayString.
-       */
+     * Get rows for a given filter string used to match display values.
+     */
+    Q_INVOKABLE QList<int> findDisplayValueMatches( const QString &filter ) const;
+
+    /**
+     * Orders all the values alphabethically by their displayString.
+     */
     bool orderByValue() const;
 
     /**

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -341,7 +341,7 @@ Item {
     Rectangle {
         id: searchable
         visible: !comboBox.visible
-        height: fontMetrics.height + 10
+        height: fontMetrics.height + 12
         Layout.fillWidth: true
         Layout.topMargin: 5
         Layout.bottomMargin: 5

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -8,566 +8,566 @@ import org.qgis 1.0
 import Theme 1.0
 
 Item {
-  id: relationCombobox
+    id: relationCombobox
 
-  property bool useCompleter: false
-  property bool useSearch: false
+    property bool useCompleter: false
+    property bool useSearch: false
 
-  Component.onCompleted: {
-    comboBox.currentIndex = featureListModel.findKey(value)
-    addButton.visible = _relation !== undefined ? _relation.isValid : false
-    invalidWarning.visible = _relation !== undefined ? !(_relation.isValid) : false
-  }
-
-  anchors {
-    left: parent.left
-    right: parent.right
-  }
-  height: childrenRect.height
-
-  property var currentKeyValue: value
-  property EmbeddedFeatureForm embeddedFeatureForm: embeddedPopup
-
-  onCurrentKeyValueChanged: {
-    comboBox._cachedCurrentValue = currentKeyValue
-    comboBox.currentIndex = featureListModel.findKey(currentKeyValue)
-  }
-
-  EmbeddedFeatureForm {
-      id: addFeaturePopup
-
-      embeddedLevel: form.embeddedLevel + 1
-      digitizingToolbar: form.digitizingToolbar
-
-      onFeatureSaved: {
-          var referencedValue = addFeaturePopup.attributeFormModel.attribute(relationCombobox._relation.resolveReferencedField(field.name))
-          var index = featureListModel.findKey(referencedValue)
-          if ( index < 0 ) {
-            // model not yet reloaded - keep the value and set it onModelReset
-            comboBox._cachedCurrentValue = referencedValue
-          } else {
-            comboBox.currentIndex = index
-          }
-      }
-  }
-
-  Popup {
-    id: searchFeaturePopup
-
-    parent: ApplicationWindow.overlay
-    x: 24
-    y: 24
-    z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes
-    width: parent.width - 48
-    height: parent.height - 48
-    padding: 0
-    modal: true
-    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
-    focus: visible
-
-    onOpened: {
-      if (searchableText.typedFilter != '') {
-          searchField.text = searchableText.typedFilter
-      }
-
-      if (resultsList.contentHeight > resultsList.height) {
-        searchField.forceActiveFocus()
-      }
+    Component.onCompleted: {
+        comboBox.currentIndex = featureListModel.findKey(value)
+        addButton.visible = _relation !== undefined ? _relation.isValid : false
+        invalidWarning.visible = _relation !== undefined ? !(_relation.isValid) : false
     }
 
-    onClosed: {
-      searchField.text = ''
+    anchors {
+        left: parent.left
+        right: parent.right
+    }
+    height: childrenRect.height
+
+    property var currentKeyValue: value
+    property EmbeddedFeatureForm embeddedFeatureForm: embeddedPopup
+
+    onCurrentKeyValueChanged: {
+        comboBox._cachedCurrentValue = currentKeyValue
+        comboBox.currentIndex = featureListModel.findKey(currentKeyValue)
     }
 
-    Page {
-      anchors.fill: parent
+    EmbeddedFeatureForm {
+        id: addFeaturePopup
 
-      header: PageHeader {
-        title: fieldLabel
-        showApplyButton: false
-        showCancelButton: true
-        onCancel: searchFeaturePopup.close()
-      }
+        embeddedLevel: form.embeddedLevel + 1
+        digitizingToolbar: form.digitizingToolbar
 
-      TextField {
-        z: 1
-        id: searchField
-        anchors.left: parent.left
-        anchors.right: parent.right
-
-        placeholderText: qsTr("Search…")
-        placeholderTextColor: Theme.mainColor
-
-        height: fontMetrics.height * 2.5
-        padding: 24
-        bottomPadding: 9
-        font: Theme.defaultFont
-        selectByMouse: true
-        verticalAlignment: TextInput.AlignVCenter
-
-        inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhSensitiveData
-
-        onDisplayTextChanged: {
-          featureListModel.searchTerm = searchField.displayText
-        }
-
-        Keys.onPressed: {
-            if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
-                if (featureListModel.rowCount() === 1) {
-                    resultsList.itemAtIndex(0).performClick()
-                    searchFeaturePopup.close()
-                }
+        onFeatureSaved: {
+            var referencedValue = addFeaturePopup.attributeFormModel.attribute(relationCombobox._relation.resolveReferencedField(field.name))
+            var index = featureListModel.findKey(referencedValue)
+            if ( index < 0 ) {
+                // model not yet reloaded - keep the value and set it onModelReset
+                comboBox._cachedCurrentValue = referencedValue
+            } else {
+                comboBox.currentIndex = index
             }
         }
-      }
+    }
 
-      Rectangle {
-          id: clearButtonRect
-          z: 1
-          width: fontMetrics.height
-          height: fontMetrics.height
-          anchors { top: searchField.top; right: searchField.right; topMargin: height - 7; rightMargin: height - 7 }
-          color: "transparent"
+    Popup {
+        id: searchFeaturePopup
 
-          Image {
-              id: clearButton
-              z: 1
-              width: 20
-              height: 20
-              source: Theme.getThemeIcon("ic_clear_black_18dp")
-              sourceSize.width: 20 * screen.devicePixelRatio
-              sourceSize.height: 20 * screen.devicePixelRatio
-              fillMode: Image.PreserveAspectFit
-              anchors.centerIn: clearButtonRect
-              opacity: searchField.displayText.length > 0 ? 1 : 0.25
-          }
-
-          MouseArea {
-              anchors.fill: parent
-              onClicked: {
-                  searchField.text = '';
-              }
-          }
-      }
-
-      ScrollView {
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.top: searchField.bottom
-
+        parent: ApplicationWindow.overlay
+        x: 24
+        y: 24
+        z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes
+        width: parent.width - 48
+        height: parent.height - 48
         padding: 0
-        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
-        ScrollBar.vertical.policy: ScrollBar.AsNeeded
-        contentItem: resultsList
-        contentWidth: resultsList.width
-        contentHeight: resultsList.height
-        clip: true
+        modal: true
+        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+        focus: visible
 
-        ListView {
-          id: resultsList
-          anchors.top: parent.top
-          model: featureListModel
-          width: parent.width
-          height: searchFeaturePopup.height - searchField.height - 50
-          clip: true
+        onOpened: {
+            if (searchableText.typedFilter != '') {
+                searchField.text = searchableText.typedFilter
+            }
 
-          delegate: Rectangle {
-            id: delegateRect
+            if (resultsList.contentHeight > resultsList.height) {
+                searchField.forceActiveFocus()
+            }
+        }
 
-            property int idx: index
+        onClosed: {
+            searchField.text = ''
+        }
 
-            anchors.margins: 10
-            height: radioButton.visible ? radioButton.height : checkBoxButton.height
-            width: parent ? parent.width : undefined
-            color: model.checked ? Theme.mainColor : 'transparent'
+        Page {
+            anchors.fill: parent
 
-            Row {
-                RadioButton {
-                    id: radioButton
+            header: PageHeader {
+                title: fieldLabel
+                showApplyButton: false
+                showCancelButton: true
+                onCancel: searchFeaturePopup.close()
+            }
 
-                    visible: !featureListModel.allowMulti
-                    checked: model.checked
-                    anchors.verticalCenter: parent.verticalCenter
-                    text: displayString
-                    width: resultsList.width - padding * 2
-                    padding: 12
-                    ButtonGroup.group: buttonGroup
-                    font.weight: model.checked ? Font.DemiBold : Font.Normal
+            TextField {
+                z: 1
+                id: searchField
+                anchors.left: parent.left
+                anchors.right: parent.right
 
-                    indicator: Rectangle {}
-                    contentItem: Text {
-                        text: parent.text
-                        font: parent.font
-                        width: parent.width
-                        verticalAlignment: Text.AlignVCenter
-                        leftPadding: parent.indicator.width + parent.spacing
-                        elide: Text.ElideRight
-                        color: model.checked ? Theme.light : Theme.darkGray
-                    }
+                placeholderText: qsTr("Search…")
+                placeholderTextColor: Theme.mainColor
+
+                height: fontMetrics.height * 2.5
+                padding: 24
+                bottomPadding: 9
+                font: Theme.defaultFont
+                selectByMouse: true
+                verticalAlignment: TextInput.AlignVCenter
+
+                inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhSensitiveData
+
+                onDisplayTextChanged: {
+                    featureListModel.searchTerm = searchField.displayText
                 }
 
-                CheckBox {
-                    id: checkBoxButton
-
-                    visible: !!featureListModel.allowMulti
-                    anchors.verticalCenter: parent.verticalCenter
-                    text: displayString
-                    padding: 12
+                Keys.onPressed: {
+                    if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                        if (featureListModel.rowCount() === 1) {
+                            resultsList.itemAtIndex(0).performClick()
+                            searchFeaturePopup.close()
+                        }
+                    }
                 }
             }
 
-
-            /* bottom border */
             Rectangle {
-                anchors.bottom: parent.bottom
-                height: 1
-                color: "lightGray"
-                width: resultsList.width
-            }
-
-            function performClick() {
-                model.checked = true;
-            }
-          }
-
-          MouseArea {
-            anchors.fill: parent
-            propagateComposedEvents: true
-
-            onClicked: {
-              var item = resultsList.itemAt(resultsList.contentX + mouse.x, resultsList.contentY + mouse.y)
-              if (!item)
-                return;
-
-              item.performClick()
-              model.checked = !model.checked
-
-              if (!resultsList.model.allowMulti) {
-                searchFeaturePopup.close()
-              }
-            }
-          }
-
-          onMovementStarted: {
-            Qt.inputMethod.hide()
-          }
-        }
-      }
-    }
-  }
-
-  ButtonGroup { id: buttonGroup }
-
-  RowLayout {
-    anchors { left: parent.left; right: parent.right }
-
-    ComboBox {
-      id: comboBox
-      visible: !enabled || (!useSearch && !useCompleter && (_relation !== undefined ? _relation.isValid : true))
-      Layout.fillWidth: true
-
-      property var _cachedCurrentValue
-
-      model: featureListModel
-
-      onCurrentIndexChanged: {
-        var newValue = featureListModel.dataFromRowIndex(currentIndex, FeatureListModel.KeyFieldRole)
-        valueChangeRequested(newValue, false)
-      }
-
-      Connections {
-        target: featureListModel
-
-        function onModelReset() {
-          comboBox.currentIndex = featureListModel.findKey(comboBox._cachedCurrentValue)
-        }
-      }
-
-      MouseArea {
-        anchors.fill: parent
-        propagateComposedEvents: true
-
-        onClicked: { mouse.accepted = false; }
-        onPressed: {
-          forceActiveFocus();
-          mouse.accepted = false;
-        }
-        onReleased: mouse.accepted = false;
-        onDoubleClicked: mouse.accepted = false;
-        onPositionChanged: mouse.accepted = false;
-        onPressAndHold: mouse.accepted = false;
-      }
-
-      Component.onCompleted: {
-          comboBox.popup.z = 10000 // 1000s are embedded feature forms, use a higher value to insure popups always show above embedded feature formes
-      }
-
-      textRole: 'display'
-      font: Theme.defaultFont
-      contentItem: Text {
-        leftPadding: enabled ? 5 : 0
-        height: fontMetrics.height + 20
-        text: comboBox.displayText
-        font: comboBox.font
-        color: value === undefined || enabled ? 'black' : 'gray'
-        horizontalAlignment: Text.AlignLeft
-        verticalAlignment: Text.AlignVCenter
-        elide: Text.ElideRight
-      }
-
-      background: Item {
-        implicitWidth: 120
-        implicitHeight: 36
-
-        Rectangle {
-          visible: !enabled
-          y: comboBox.height - 12
-          width: comboBox.width
-          height: comboBox.activeFocus ? 2 : 1
-          color: comboBox.activeFocus ? "#4CAF50" : "#C8E6C9"
-        }
-
-        Rectangle {
-          visible: enabled
-          anchors.fill: parent
-          border.color: comboBox.pressed ? "#4CAF50" : "#C8E6C9"
-          border.width: comboBox.visualFocus ? 2 : 1
-          color: Theme.lightGray
-          radius: 2
-        }
-      }
-    }
-
-    FontMetrics {
-      id: fontMetrics
-      font: comboBox.font
-    }
-
-    Rectangle {
-        id: searchable
-        visible: !comboBox.visible
-        height: fontMetrics.height + 12
-        Layout.fillWidth: true
-        Layout.topMargin: 5
-        Layout.bottomMargin: 5
-
-        Text {
-            id: searchableLabel
-
-            property bool useCompleter: false
-            property string completer: ''
-
-            leftPadding: 5
-            rightPadding: 5
-            width: parent.width - dropDownArrowCanvas.width - dropDownArrowCanvas.anchors.rightMargin * 2
-            height: fontMetrics.height + 12
-            text: useCompleter ? completer : comboBox.displayText
-            font: comboBox.font
-            horizontalAlignment: Text.AlignLeft
-            verticalAlignment: Text.AlignVCenter
-            textFormat: Text.RichText
-            clip: true
-            elide: Text.ElideRight
-
-            color: value === undefined || !enabled ? 'gray' : searchableText.text === '' ? 'black' : 'gray'
-        }
-
-        TextField  {
-            id: searchableText
-
-            property string typedFilter: ''
-
-            anchors.verticalCenter: parent.verticalCenter
-            padding: 5
-            topPadding: fontMetrics.ascent - 1
-            topInset: 0
-            bottomInset: 0
-            width: parent.width - dropDownArrowCanvas.width - dropDownArrowCanvas.anchors.rightMargin * 2
-            text: ''
-            font: comboBox.font
-            horizontalAlignment: TextInput.AlignLeft
-            verticalAlignment: TextInput.AlignVCenter
-
-            color: 'black'
-            background: Rectangle {
+                id: clearButtonRect
+                z: 1
+                width: fontMetrics.height
+                height: fontMetrics.height
+                anchors { top: searchField.top; right: searchField.right; topMargin: height - 7; rightMargin: height - 7 }
                 color: "transparent"
-                border.color: "transparent"
-                border.width: 0
-            }
 
-            inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhSensitiveData
+                Image {
+                    id: clearButton
+                    z: 1
+                    width: 20
+                    height: 20
+                    source: Theme.getThemeIcon("ic_clear_black_18dp")
+                    sourceSize.width: 20 * screen.devicePixelRatio
+                    sourceSize.height: 20 * screen.devicePixelRatio
+                    fillMode: Image.PreserveAspectFit
+                    anchors.centerIn: clearButtonRect
+                    opacity: searchField.displayText.length > 0 ? 1 : 0.25
+                }
 
-            onDisplayTextChanged: {
-                if (activeFocus) {
-                    if (text != comboBox.displayText) {
-                        var trimmedText = text.trim();
-                        var matches = featureListModel.findDisplayValueMatches(trimmedText)
-                        if (matches.length > 0) {
-                            var remainder = featureListModel.dataFromRowIndex(matches[0], featureListModel.DisplayStringRole).substring(trimmedText.length)
-                            searchableLabel.completer = '<span style="color:rgba(0,0,0,0);">' + trimmedText + '</span><span style="font-weight:'
-                                                        + (matches.length === 1 ? 'bold' : 'normal' ) + ';">'  + remainder + '</span>'
-                        } else {
-                            searchableLabel.completer = ''
-                        }
-                    } else {
-                        searchableLabel.completer = ''
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked: {
+                        searchField.text = '';
                     }
                 }
             }
 
-            onActiveFocusChanged: {
-                searchableLabel.useCompleter = activeFocus
-                if (activeFocus) {
-                    if (text === '') {
-                        if (!featureListModel.addNull || comboBox.currentIndex != 0) {
-                            text = comboBox.displayText
-                            searchableLabel.completer = ''
+            ScrollView {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.top: searchField.bottom
+
+                padding: 0
+                ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+                ScrollBar.vertical.policy: ScrollBar.AsNeeded
+                contentItem: resultsList
+                contentWidth: resultsList.width
+                contentHeight: resultsList.height
+                clip: true
+
+                ListView {
+                    id: resultsList
+                    anchors.top: parent.top
+                    model: featureListModel
+                    width: parent.width
+                    height: searchFeaturePopup.height - searchField.height - 50
+                    clip: true
+
+                    delegate: Rectangle {
+                        id: delegateRect
+
+                        property int idx: index
+
+                        anchors.margins: 10
+                        height: radioButton.visible ? radioButton.height : checkBoxButton.height
+                        width: parent ? parent.width : undefined
+                        color: model.checked ? Theme.mainColor : 'transparent'
+
+                        Row {
+                            RadioButton {
+                                id: radioButton
+
+                                visible: !featureListModel.allowMulti
+                                checked: model.checked
+                                anchors.verticalCenter: parent.verticalCenter
+                                text: displayString
+                                width: resultsList.width - padding * 2
+                                padding: 12
+                                ButtonGroup.group: buttonGroup
+                                font.weight: model.checked ? Font.DemiBold : Font.Normal
+
+                                indicator: Rectangle {}
+                                contentItem: Text {
+                                    text: parent.text
+                                    font: parent.font
+                                    width: parent.width
+                                    verticalAlignment: Text.AlignVCenter
+                                    leftPadding: parent.indicator.width + parent.spacing
+                                    elide: Text.ElideRight
+                                    color: model.checked ? Theme.light : Theme.darkGray
+                                }
+                            }
+
+                            CheckBox {
+                                id: checkBoxButton
+
+                                visible: !!featureListModel.allowMulti
+                                anchors.verticalCenter: parent.verticalCenter
+                                text: displayString
+                                padding: 12
+                            }
+                        }
+
+
+                        /* bottom border */
+                        Rectangle {
+                            anchors.bottom: parent.bottom
+                            height: 1
+                            color: "lightGray"
+                            width: resultsList.width
+                        }
+
+                        function performClick() {
+                            model.checked = true;
+                        }
+                    }
+
+                    MouseArea {
+                        anchors.fill: parent
+                        propagateComposedEvents: true
+
+                        onClicked: {
+                            var item = resultsList.itemAt(resultsList.contentX + mouse.x, resultsList.contentY + mouse.y)
+                            if (!item)
+                                return;
+
+                            item.performClick()
+                            model.checked = !model.checked
+
+                            if (!resultsList.model.allowMulti) {
+                                searchFeaturePopup.close()
+                            }
+                        }
+                    }
+
+                    onMovementStarted: {
+                        Qt.inputMethod.hide()
+                    }
+                }
+            }
+        }
+    }
+
+    ButtonGroup { id: buttonGroup }
+
+    RowLayout {
+        anchors { left: parent.left; right: parent.right }
+
+        ComboBox {
+            id: comboBox
+            visible: !enabled || (!useSearch && !useCompleter && (_relation !== undefined ? _relation.isValid : true))
+            Layout.fillWidth: true
+
+            property var _cachedCurrentValue
+
+            model: featureListModel
+
+            onCurrentIndexChanged: {
+                var newValue = featureListModel.dataFromRowIndex(currentIndex, FeatureListModel.KeyFieldRole)
+                valueChangeRequested(newValue, false)
+            }
+
+            Connections {
+                target: featureListModel
+
+                function onModelReset() {
+                    comboBox.currentIndex = featureListModel.findKey(comboBox._cachedCurrentValue)
+                }
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                propagateComposedEvents: true
+
+                onClicked: { mouse.accepted = false; }
+                onPressed: {
+                    forceActiveFocus();
+                    mouse.accepted = false;
+                }
+                onReleased: mouse.accepted = false;
+                onDoubleClicked: mouse.accepted = false;
+                onPositionChanged: mouse.accepted = false;
+                onPressAndHold: mouse.accepted = false;
+            }
+
+            Component.onCompleted: {
+                comboBox.popup.z = 10000 // 1000s are embedded feature forms, use a higher value to insure popups always show above embedded feature formes
+            }
+
+            textRole: 'display'
+            font: Theme.defaultFont
+            contentItem: Text {
+                leftPadding: enabled ? 5 : 0
+                height: fontMetrics.height + 20
+                text: comboBox.displayText
+                font: comboBox.font
+                color: value === undefined || enabled ? 'black' : 'gray'
+                horizontalAlignment: Text.AlignLeft
+                verticalAlignment: Text.AlignVCenter
+                elide: Text.ElideRight
+            }
+
+            background: Item {
+                implicitWidth: 120
+                implicitHeight: 36
+
+                Rectangle {
+                    visible: !enabled
+                    y: comboBox.height - 12
+                    width: comboBox.width
+                    height: comboBox.activeFocus ? 2 : 1
+                    color: comboBox.activeFocus ? "#4CAF50" : "#C8E6C9"
+                }
+
+                Rectangle {
+                    visible: enabled
+                    anchors.fill: parent
+                    border.color: comboBox.pressed ? "#4CAF50" : "#C8E6C9"
+                    border.width: comboBox.visualFocus ? 2 : 1
+                    color: Theme.lightGray
+                    radius: 2
+                }
+            }
+        }
+
+        FontMetrics {
+            id: fontMetrics
+            font: comboBox.font
+        }
+
+        Rectangle {
+            id: searchable
+            visible: !comboBox.visible
+            height: fontMetrics.height + 12
+            Layout.fillWidth: true
+            Layout.topMargin: 5
+            Layout.bottomMargin: 5
+
+            Text {
+                id: searchableLabel
+
+                property bool useCompleter: false
+                property string completer: ''
+
+                leftPadding: 5
+                rightPadding: 5
+                width: parent.width - dropDownArrowCanvas.width - dropDownArrowCanvas.anchors.rightMargin * 2
+                height: fontMetrics.height + 12
+                text: useCompleter ? completer : comboBox.displayText
+                font: comboBox.font
+                horizontalAlignment: Text.AlignLeft
+                verticalAlignment: Text.AlignVCenter
+                textFormat: Text.RichText
+                clip: true
+                elide: Text.ElideRight
+
+                color: value === undefined || !enabled ? 'gray' : searchableText.text === '' ? 'black' : 'gray'
+            }
+
+            TextField  {
+                id: searchableText
+
+                property string typedFilter: ''
+
+                anchors.verticalCenter: parent.verticalCenter
+                padding: 5
+                topPadding: fontMetrics.ascent - 1
+                topInset: 0
+                bottomInset: 0
+                width: parent.width - dropDownArrowCanvas.width - dropDownArrowCanvas.anchors.rightMargin * 2
+                text: ''
+                font: comboBox.font
+                horizontalAlignment: TextInput.AlignLeft
+                verticalAlignment: TextInput.AlignVCenter
+
+                color: 'black'
+                background: Rectangle {
+                    color: "transparent"
+                    border.color: "transparent"
+                    border.width: 0
+                }
+
+                inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhSensitiveData
+
+                onDisplayTextChanged: {
+                    if (activeFocus) {
+                        if (text != comboBox.displayText) {
+                            var trimmedText = text.trim();
+                            var matches = featureListModel.findDisplayValueMatches(trimmedText)
+                            if (matches.length > 0) {
+                                var remainder = featureListModel.dataFromRowIndex(matches[0], featureListModel.DisplayStringRole).substring(trimmedText.length)
+                                searchableLabel.completer = '<span style="color:rgba(0,0,0,0);">' + trimmedText + '</span><span style="font-weight:'
+                                        + (matches.length === 1 ? 'bold' : 'normal' ) + ';">'  + remainder + '</span>'
+                            } else {
+                                searchableLabel.completer = ''
+                            }
                         } else {
                             searchableLabel.completer = ''
                         }
                     }
-                } else {
-                    if (text === '' && featureListModel.addNull) {
-                        comboBox.currentIndex = 0;
+                }
+
+                onActiveFocusChanged: {
+                    searchableLabel.useCompleter = activeFocus
+                    if (activeFocus) {
+                        if (text === '') {
+                            if (!featureListModel.addNull || comboBox.currentIndex != 0) {
+                                text = comboBox.displayText
+                                searchableLabel.completer = ''
+                            } else {
+                                searchableLabel.completer = ''
+                            }
+                        }
+                    } else {
+                        if (text === '' && featureListModel.addNull) {
+                            comboBox.currentIndex = 0;
+                            searchableLabel.completer = comboBox.displayText
+                        } else {
+                            applyAutoCompletion(true)
+                        }
+                    }
+                }
+
+                Keys.onPressed: {
+                    if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                        applyAutoCompletion()
+                    }
+                }
+
+                function applyAutoCompletion(resetIfNone = false) {
+                    var trimmedText = text.trim();
+                    var matches = featureListModel.findDisplayValueMatches(trimmedText)
+                    if (matches.length > 0) {
+                        text = ''
+                        comboBox.currentIndex = matches[0]
                         searchableLabel.completer = comboBox.displayText
-                    } else {
-                        applyAutoCompletion(true)
+
+                        if (matches.length > 1) {
+                            // remember the typed filter in case users want to see the multiple hits by clicking on the search button
+                            typedFilter = trimmedText
+                            searchableTimer.restart()
+                        }
+                    } else if (resetIfNone) {
+                        text = ''
+                        searchableLabel.completer = comboBox.displayText
+                    }
+                }
+
+                Timer {
+                    id: searchableTimer
+                    interval: 500
+                    onTriggered: {
+                        searchableText.typedFilter = ''
                     }
                 }
             }
 
-            Keys.onPressed: {
-                if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
-                    applyAutoCompletion()
-                }
-            }
+            Canvas {
+                id: dropDownArrowCanvas
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                width: 30
+                height: 15
+                contextType: "2d"
+                visible: !useCompleter
 
-            function applyAutoCompletion(resetIfNone = false) {
-                var trimmedText = text.trim();
-                var matches = featureListModel.findDisplayValueMatches(trimmedText)
-                if (matches.length > 0) {
-                    text = ''
-                    comboBox.currentIndex = matches[0]
-                    searchableLabel.completer = comboBox.displayText
-
-                    if (matches.length > 1) {
-                        // remember the typed filter in case users want to see the multiple hits by clicking on the search button
-                        typedFilter = trimmedText
-                        searchableTimer.restart()
+                onPaint: {
+                    if (!context) {
+                        return
                     }
-                } else if (resetIfNone) {
-                    text = ''
-                    searchableLabel.completer = comboBox.displayText
+                    context.reset();
+                    context.moveTo(10, 5);
+                    context.lineTo(20, 5);
+                    context.lineTo(15, 10);
+                    context.closePath();
+                    context.fillStyle = !enabled ? 'gray' : 'black'
+                    context.fill();
                 }
+
+                onEnabledChanged: requestPaint()
             }
 
-            Timer {
-                id: searchableTimer
-                interval: 500
-                onTriggered: {
-                    searchableText.typedFilter = ''
+            border.color: comboBox.pressed ? "#4CAF50" : "#C8E6C9"
+            border.width: comboBox.visualFocus ? 2 : 1
+            color: Theme.lightGray
+            radius: 2
+
+            MouseArea {
+                enabled: !useCompleter
+                anchors.fill: parent
+                onClicked: {
+                    mouse.accepted = true
+                    searchFeaturePopup.open()
                 }
             }
         }
 
-        Canvas {
-            id: dropDownArrowCanvas
-            anchors.right: parent.right
-            anchors.verticalCenter: parent.verticalCenter
-            width: 30
-            height: 15
-            contextType: "2d"
-            visible: !useCompleter
+        QfToolButton {
+            id: searchButton
 
-            onPaint: {
-                if (!context) {
-                    return
-                }
-                context.reset();
-                context.moveTo(10, 5);
-                context.lineTo(20, 5);
-                context.lineTo(15, 10);
-                context.closePath();
-                context.fillStyle = !enabled ? 'gray' : 'black'
-                context.fill();
-            }
+            Layout.preferredWidth: enabled ? 48 : 0
+            Layout.preferredHeight: 48
 
-            onEnabledChanged: requestPaint()
-        }
+            bgcolor: "white"
+            iconSource: Theme.getThemeIcon("ic_baseline_search_black")
 
-        border.color: comboBox.pressed ? "#4CAF50" : "#C8E6C9"
-        border.width: comboBox.visualFocus ? 2 : 1
-        color: Theme.lightGray
-        radius: 2
+            visible: enabled
 
-        MouseArea {
-            enabled: !useCompleter
-            anchors.fill: parent
             onClicked: {
-                mouse.accepted = true
                 searchFeaturePopup.open()
             }
         }
-    }
 
-    QfToolButton {
-        id: searchButton
+        QfToolButton {
+            id: addButton
 
-        Layout.preferredWidth: enabled ? 48 : 0
-        Layout.preferredHeight: 48
+            Layout.preferredWidth: comboBox.enabled ? 48 : 0
+            Layout.preferredHeight: 48
 
-        bgcolor: "white"
-        iconSource: Theme.getThemeIcon("ic_baseline_search_black")
+            bgcolor: "white"
+            opacity: enabled ? 1 : 0.3
+            iconSource: Theme.getThemeIcon("ic_add_black_48dp")
 
-        visible: enabled
+            visible: enabled
 
-        onClicked: {
-          searchFeaturePopup.open()
+            onClicked: {
+                embeddedPopup.state = 'Add'
+                embeddedPopup.currentLayer = relationCombobox._relation ? relationCombobox._relation.referencedLayer : null
+                embeddedPopup.open()
+            }
+        }
+
+        Text {
+            id: invalidWarning
+            visible: false
+            text: qsTr( "Invalid relation")
+            color: Theme.errorColor
         }
     }
 
-    QfToolButton {
-        id: addButton
+    EmbeddedFeatureForm {
+        id: embeddedPopup
 
-        Layout.preferredWidth: comboBox.enabled ? 48 : 0
-        Layout.preferredHeight: 48
+        embeddedLevel: form.embeddedLevel + 1
+        digitizingToolbar: form.digitizingToolbar
 
-        bgcolor: "white"
-        opacity: enabled ? 1 : 0.3
-        iconSource: Theme.getThemeIcon("ic_add_black_48dp")
-
-        visible: enabled
-
-        onClicked: {
-            embeddedPopup.state = 'Add'
-            embeddedPopup.currentLayer = relationCombobox._relation ? relationCombobox._relation.referencedLayer : null
-            embeddedPopup.open()
+        onFeatureSaved: {
+            var referencedValue = embeddedPopup.attributeFormModel.attribute(relationCombobox._relation.resolveReferencedField(field.name))
+            var index = featureListModel.findKey(referencedValue)
+            if ( ( featureListModel.addNull == true && index < 1 ) || index < 0 ) {
+                // model not yet reloaded - keep the value and set it onModelReset
+                comboBox._cachedCurrentValue = referencedValue
+            } else {
+                comboBox.currentIndex = index
+            }
         }
     }
-
-    Text {
-      id: invalidWarning
-      visible: false
-      text: qsTr( "Invalid relation")
-      color: Theme.errorColor
-    }
-  }
-
-  EmbeddedFeatureForm {
-    id: embeddedPopup
-
-    embeddedLevel: form.embeddedLevel + 1
-    digitizingToolbar: form.digitizingToolbar
-
-    onFeatureSaved: {
-      var referencedValue = embeddedPopup.attributeFormModel.attribute(relationCombobox._relation.resolveReferencedField(field.name))
-      var index = featureListModel.findKey(referencedValue)
-      if ( ( featureListModel.addNull == true && index < 1 ) || index < 0 ) {
-        // model not yet reloaded - keep the value and set it onModelReset
-        comboBox._cachedCurrentValue = referencedValue
-      } else {
-        comboBox.currentIndex = index
-      }
-    }
-  }
 }

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -404,11 +404,20 @@ Item {
             onActiveFocusChanged: {
                 if (activeFocus) {
                     if (text === '') {
-                        text = comboBox.displayText
-                        searchableLabel.text = ''
+                        if (!featureListModel.addNull || comboBox.currentIndex != 0) {
+                            text = comboBox.displayText
+                            searchableLabel.text = ''
+                        } else {
+                            searchableLabel.text = ''
+                        }
                     }
-                } else  {
-                    applyAutoCompletion(true)
+                } else {
+                    if (text === '' && featureListModel.addNull) {
+                        comboBox.currentIndex = 0;
+                        searchableLabel.text = comboBox.displayText
+                    } else {
+                        applyAutoCompletion(true)
+                    }
                 }
             }
 

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -22,9 +22,8 @@ Item {
   anchors {
     left: parent.left
     right: parent.right
-    rightMargin: 10
   }
-  height: childrenRect.height + 10
+  height: childrenRect.height
 
   property var currentKeyValue: value
   property EmbeddedFeatureForm embeddedFeatureForm: embeddedPopup
@@ -51,7 +50,6 @@ Item {
           }
       }
   }
-
 
   Popup {
     id: searchFeaturePopup
@@ -511,44 +509,39 @@ Item {
         }
     }
 
-    Image {
-      id: searchButton
-      visible: enabled
+    QfToolButton {
+        id: searchButton
 
-      Layout.margins: 4
-      Layout.preferredWidth: width
-      Layout.preferredHeight: 18
-      source: Theme.getThemeIcon("ic_baseline_search_black")
-      width: visible ? 18 : 0
-      height: 18
-      opacity: enabled ? 1 : 0.3
+        Layout.preferredWidth: enabled ? 48 : 0
+        Layout.preferredHeight: 48
 
-      MouseArea {
-        anchors.fill: parent
+        bgcolor: "white"
+        iconSource: Theme.getThemeIcon("ic_baseline_search_black")
+
+        visible: enabled
+
         onClicked: {
           searchFeaturePopup.open()
         }
-      }
     }
 
-    Image {
-      Layout.margins: 4
-      Layout.preferredWidth: width
-      Layout.preferredHeight: 18
-      id: addButton
-      source: Theme.getThemeIcon("ic_add_black_48dp")
-      width: comboBox.enabled ? 18 : 0
-      height: 18
-      opacity: enabled ? 1 : 0.3
+    QfToolButton {
+        id: addButton
 
-      MouseArea {
-        anchors.fill: parent
+        Layout.preferredWidth: comboBox.enabled ? 48 : 0
+        Layout.preferredHeight: 48
+
+        bgcolor: "white"
+        opacity: enabled ? 1 : 0.3
+        iconSource: Theme.getThemeIcon("ic_add_black_48dp")
+
+        visible: enabled
+
         onClicked: {
             embeddedPopup.state = 'Add'
             embeddedPopup.currentLayer = relationCombobox._relation ? relationCombobox._relation.referencedLayer : null
             embeddedPopup.open()
         }
-      }
     }
 
     Text {

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -107,10 +107,19 @@ Item {
         selectByMouse: true
         verticalAlignment: TextInput.AlignVCenter
 
-        inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
+        inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhSensitiveData
 
         onDisplayTextChanged: {
           featureListModel.searchTerm = searchField.displayText
+        }
+
+        Keys.onPressed: {
+            if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                if (featureListModel.rowCount() === 1) {
+                    resultsList.itemAtIndex(0).performClick()
+                    searchFeaturePopup.close()
+                }
+            }
         }
       }
 
@@ -175,15 +184,12 @@ Item {
             color: model.checked ? Theme.mainColor : 'transparent'
 
             Row {
-                height: parent.height
-
                 RadioButton {
                     id: radioButton
 
                     visible: !featureListModel.allowMulti
                     checked: model.checked
                     anchors.verticalCenter: parent.verticalCenter
-                    anchors.left: parent.left
                     text: displayString
                     width: resultsList.width - padding * 2
                     padding: 12
@@ -207,19 +213,20 @@ Item {
 
                     visible: !!featureListModel.allowMulti
                     anchors.verticalCenter: parent.verticalCenter
-                    anchors.left: parent.left
                     text: displayString
                     padding: 12
                 }
-
-                /* bottom border */
-                Rectangle {
-                    anchors.bottom: parent.bottom
-                    height: 1
-                    color: "lightGray"
-                    width: parent.width
-                }
             }
+
+
+            /* bottom border */
+            Rectangle {
+                anchors.bottom: parent.bottom
+                height: 1
+                color: "lightGray"
+                width: resultsList.width
+            }
+
             function performClick() {
                 model.checked = true;
             }

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -185,7 +185,7 @@ Item {
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.left: parent.left
                     text: displayString
-                    width: parent.width
+                    width: resultsList.width - padding * 2
                     padding: 12
                     ButtonGroup.group: buttonGroup
                     font.weight: model.checked ? Font.DemiBold : Font.Normal

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -367,19 +367,22 @@ Item {
         TextField  {
             id: searchableText
 
-            leftPadding: 5
-            rightPadding: 5
+            anchors.verticalCenter: parent.verticalCenter
+            padding: 5
+            topPadding: fontMetrics.ascent - 1
+            topInset: 0
+            bottomInset: 0
             width: parent.width - dropDownArrowCanvas.width - dropDownArrowCanvas.anchors.rightMargin * 2
-            height: comboBox.height
             text: ''
             font: comboBox.font
-            horizontalAlignment: Text.AlignLeft
-            verticalAlignment: Text.AlignVCenter
+            horizontalAlignment: TextInput.AlignLeft
+            verticalAlignment: TextInput.AlignVCenter
 
             color: 'black'
             background: Rectangle {
-                implicitHeight: searchableText.height
                 color: "transparent"
+                border.color: "transparent"
+                border.width: 0
             }
 
             inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhSensitiveData
@@ -394,12 +397,17 @@ Item {
                         searchableLabel.text = ''
                     }
                 } else {
-                    searchableLabel.text = comboBox.displayText
+                    searchableLabel.text = ''
                 }
             }
 
             onActiveFocusChanged: {
-                if (!activeFocus) {
+                if (activeFocus) {
+                    if (text === '') {
+                        text = comboBox.displayText
+                        searchableLabel.text = ''
+                    }
+                } else  {
                     applyAutoCompletion(true)
                 }
             }

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -68,8 +68,8 @@ Item {
     focus: visible
 
     onOpened: {
-      if (searchableText.text != '') {
-          searchField.text = searchableText.text.trim();
+      if (searchableText.typedFilter != '') {
+          searchField.text = searchableText.typedFilter
       }
 
       if (resultsList.contentHeight > resultsList.height) {
@@ -367,6 +367,8 @@ Item {
         TextField  {
             id: searchableText
 
+            property string typedFilter: ''
+
             anchors.verticalCenter: parent.verticalCenter
             padding: 5
             topPadding: fontMetrics.ascent - 1
@@ -434,9 +436,23 @@ Item {
                     text = ''
                     searchableLabel.text = featureListModel.dataFromRowIndex(matches[0], featureListModel.DisplayStringRole)
                     comboBox.currentIndex = matches[0];
+
+                    if (matches.length > 1) {
+                        // remember the typed filter in case users want to see the multiple hits by clicking on the search button
+                        typedFilter = trimmedText
+                        searchableTimer.restart()
+                    }
                 } else if (resetIfNone) {
                     text = ''
                     searchableLabel.text = comboBox.displayText
+                }
+            }
+
+            Timer {
+                id: searchableTimer
+                interval: 500
+                onTriggered: {
+                    searchableText.typedFilter = ''
                 }
             }
         }

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -403,7 +403,9 @@ Item {
                         var trimmedText = text.trim();
                         var matches = featureListModel.findDisplayValueMatches(trimmedText)
                         if (matches.length > 0) {
-                            searchableLabel.completer = '<span style="color:rgba(0,0,0,0);">' + text + '</span><span style="font-weight:' + (matches.length === 1 ? 'bold' : 'normal' ) + ';">'  + featureListModel.dataFromRowIndex(matches[0], featureListModel.DisplayStringRole).substring(trimmedText.length) + '</span>'
+                            var remainder = featureListModel.dataFromRowIndex(matches[0], featureListModel.DisplayStringRole).substring(trimmedText.length)
+                            searchableLabel.completer = '<span style="color:rgba(0,0,0,0);">' + trimmedText + '</span><span style="font-weight:'
+                                                        + (matches.length === 1 ? 'bold' : 'normal' ) + ';">'  + remainder + '</span>'
                         } else {
                             searchableLabel.completer = ''
                         }
@@ -475,6 +477,7 @@ Item {
             width: 30
             height: 15
             contextType: "2d"
+            visible: !useCompleter
 
             onPaint: {
                 if (!context) {
@@ -490,14 +493,6 @@ Item {
             }
 
             onEnabledChanged: requestPaint()
-
-            MouseArea {
-                anchors.fill: parent
-                onClicked: {
-                    mouse.accepted = true
-                    searchFeaturePopup.open()
-                }
-            }
         }
 
         border.color: comboBox.pressed ? "#4CAF50" : "#C8E6C9"

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -354,11 +354,14 @@ Item {
         Text {
             id: searchableLabel
 
+            property bool useCompleter: false
+            property string completer: ''
+
             leftPadding: 5
             rightPadding: 5
             width: parent.width - dropDownArrowCanvas.width - dropDownArrowCanvas.anchors.rightMargin * 2
             height: fontMetrics.height + 12
-            text: comboBox.displayText
+            text: useCompleter ? completer : comboBox.displayText
             font: comboBox.font
             horizontalAlignment: Text.AlignLeft
             verticalAlignment: Text.AlignVCenter
@@ -395,33 +398,36 @@ Item {
             inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhSensitiveData
 
             onDisplayTextChanged: {
-                if (text != comboBox.displayText) {
-                    var trimmedText = text.trim();
-                    var matches = featureListModel.findDisplayValueMatches(trimmedText)
-                    if (matches.length > 0) {
-                        searchableLabel.text = '<span style="color:rgba(0,0,0,0);">' + text + '</span><span style="font-weight:' + (matches.length === 1 ? 'bold' : 'normal' ) + ';">'  + featureListModel.dataFromRowIndex(matches[0], featureListModel.DisplayStringRole).substring(trimmedText.length) + '</span>'
+                if (activeFocus) {
+                    if (text != comboBox.displayText) {
+                        var trimmedText = text.trim();
+                        var matches = featureListModel.findDisplayValueMatches(trimmedText)
+                        if (matches.length > 0) {
+                            searchableLabel.completer = '<span style="color:rgba(0,0,0,0);">' + text + '</span><span style="font-weight:' + (matches.length === 1 ? 'bold' : 'normal' ) + ';">'  + featureListModel.dataFromRowIndex(matches[0], featureListModel.DisplayStringRole).substring(trimmedText.length) + '</span>'
+                        } else {
+                            searchableLabel.completer = ''
+                        }
                     } else {
-                        searchableLabel.text = ''
+                        searchableLabel.completer = ''
                     }
-                } else {
-                    searchableLabel.text = ''
                 }
             }
 
             onActiveFocusChanged: {
+                searchableLabel.useCompleter = activeFocus
                 if (activeFocus) {
                     if (text === '') {
                         if (!featureListModel.addNull || comboBox.currentIndex != 0) {
                             text = comboBox.displayText
-                            searchableLabel.text = ''
+                            searchableLabel.completer = ''
                         } else {
-                            searchableLabel.text = ''
+                            searchableLabel.completer = ''
                         }
                     }
                 } else {
                     if (text === '' && featureListModel.addNull) {
                         comboBox.currentIndex = 0;
-                        searchableLabel.text = comboBox.displayText
+                        searchableLabel.completer = comboBox.displayText
                     } else {
                         applyAutoCompletion(true)
                     }
@@ -439,8 +445,8 @@ Item {
                 var matches = featureListModel.findDisplayValueMatches(trimmedText)
                 if (matches.length > 0) {
                     text = ''
-                    searchableLabel.text = featureListModel.dataFromRowIndex(matches[0], featureListModel.DisplayStringRole)
-                    comboBox.currentIndex = matches[0];
+                    comboBox.currentIndex = matches[0]
+                    searchableLabel.completer = comboBox.displayText
 
                     if (matches.length > 1) {
                         // remember the typed filter in case users want to see the multiple hits by clicking on the search button
@@ -449,7 +455,7 @@ Item {
                     }
                 } else if (resetIfNone) {
                     text = ''
-                    searchableLabel.text = comboBox.displayText
+                    searchableLabel.completer = comboBox.displayText
                 }
             }
 

--- a/src/qml/editorwidgets/RelationReference.qml
+++ b/src/qml/editorwidgets/RelationReference.qml
@@ -17,7 +17,7 @@ EditorWidgetBase {
 
   RelationCombobox {
     id: relationReference
-    anchors { left: parent.left; right: parent.right; rightMargin: showOpenFormButton ? 24 : 0 }
+    anchors { left: parent.left; right: parent.right; rightMargin: showOpenFormButton ? viewButton.width : 0 }
     enabled: isEnabled
     useSearch: true
 
@@ -44,24 +44,25 @@ EditorWidgetBase {
     }
   }
 
-  Image {
+  QfToolButton  {
     id: viewButton
-    anchors { right: parent.right; top: relationReference.top; topMargin: relationReference.childrenRect.height / 2 - 9 }
-    source: Theme.getThemeIcon("ic_view_green_48dp")
-    enabled: showOpenFormButton && relationReference.currentKeyValue !== undefined && relationReference.currentKeyValue !== ''
-    width: enabled ? 18 : 0
-    height: 18
 
-    MouseArea {
-      anchors.fill: parent
-      onClicked: {
+    enabled: showOpenFormButton && relationReference.currentKeyValue !== undefined && relationReference.currentKeyValue !== ''
+    anchors { right: parent.right; top: parent.top; }
+
+    width: enabled ? 48 : 0
+    height: 48
+
+    bgcolor: "white"
+    iconSource: Theme.getThemeIcon("ic_view_green_48dp")
+
+    onClicked: {
         if ( relationReference.currentKeyValue !== undefined && relationReference.currentKeyValue !== '' ) {
           relationReference.embeddedFeatureForm.state = isEnabled ? 'Edit' : 'ReadOnly'
           relationReference.embeddedFeatureForm.currentLayer = featureListModel.currentLayer
           relationReference.embeddedFeatureForm.feature = featureListModel.getFeatureFromKeyValue( relationReference.currentKeyValue )
           relationReference.embeddedFeatureForm.open()
         }
-      }
     }
   }
 }

--- a/src/qml/editorwidgets/RelationReference.qml
+++ b/src/qml/editorwidgets/RelationReference.qml
@@ -19,7 +19,7 @@ EditorWidgetBase {
     id: relationReference
     anchors { left: parent.left; right: parent.right; rightMargin: showOpenFormButton ? 24 : 0 }
     enabled: isEnabled
-    useCompleter: true
+    useSearch: true
 
     property var _relation: qgisProject.relationManager.relation(config['Relation'])
 


### PR DESCRIPTION
This PR adds a brand new autocomplete as you type mode to the relation combobox, used with the value relation editor widget when the user has the widget's [x] use completer settings turned on.

When switched on, the editor widget allows users to type in characters in an edit field, with instant matching against display name values:

https://user-images.githubusercontent.com/1728657/129692609-db73c810-2a3c-4d3b-8f81-c0cf8cb32d84.mp4

When the user hits enter (or 'done' on virtual keyboard), the currently displayed auto-completed value will be selected as attribute value. 

Similarly, if a user moves away from the edit field, the attribute value will be automatically set to the auto-completed value. If the entered characters don't match, the widget will revert to the last valid value.

The implementation also takes the [x] allow NULL settings seamlessly, which is quite nice. 

When the entered characters return more than one match, the auto-completion will pick the first returned match (sorted in alphabetical order); users can click on the search button to open the popup already filtered against the entered characters. If only one match is returned, the user will receive a hint by having the auto-completed value drawn in bold.

While implementing this feature, a bunch of fixes and improvements were also applied to the related editor widgets. Most noticeably:
- actions which were previously triggered via a small hit area are now served through proper tool buttons, which is much more finger friendly
- the popup dialog has better spacing, doesn't throw countless QML errors, and properly elides text

