### PR TITLE
Fixes for checkbox and range editor widgets

### DIFF
--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -8,8 +8,8 @@ import "."
 EditorWidgetBase {
   height: childrenRect.height
 
-  property string checkedLabel: config['TextDisplayMethod'] === 1 && config['CheckedState'] != '' ? config['CheckedState'] : qsTr('True')
-  property string uncheckedLabel: config['TextDisplayMethod'] === 1 && config['UncheckedState'] != '' ? config['UncheckedState'] : qsTr('False')
+  property string checkedLabel: config['TextDisplayMethod'] === 1 && config['CheckedState'] != null && config['CheckedState'] !== '' ? config['CheckedState'] : qsTr('True')
+  property string uncheckedLabel: config['TextDisplayMethod'] === 1 && config['UncheckedState'] != null && config['UncheckedState'] !== '' ? config['UncheckedState'] : qsTr('False')
 
   anchors {
     right: parent.right

--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -8,6 +8,9 @@ import "."
 EditorWidgetBase {
   height: childrenRect.height
 
+  property string checkedLabel: config['TextDisplayMethod'] === 1 && config['CheckedState'] != '' ? config['CheckedState'] : qsTr('True')
+  property string uncheckedLabel: config['TextDisplayMethod'] === 1 && config['UncheckedState'] != '' ? config['UncheckedState'] : qsTr('False')
+
   anchors {
     right: parent.right
     left: parent.left
@@ -26,9 +29,7 @@ EditorWidgetBase {
       font: Theme.defaultFont
       color: isEnabled ? 'black' : 'gray'
 
-      text: config['TextDisplayMethod'] === 1
-            ? checkBox.checked ? config['CheckedState'] : config['UncheckedState']
-            : checkBox.checked ? qsTr('True') : qsTr('False')
+      text: checkBox.checked ? checkedLabel : uncheckedLabel
 
       MouseArea {
           id: checkArea

--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -29,8 +29,8 @@ EditorWidgetBase {
           height: fontMetrics.height + 20
           topPadding: 10
           bottomPadding: 10
-          anchors.left: parent.left
-          anchors.right: decreaseButton.left
+          width: parent.width - decreaseButton.width - increaseButton.width
+
           font: Theme.defaultFont
           color: value === undefined || !enabled ? 'gray' : 'black'
 
@@ -66,7 +66,6 @@ EditorWidgetBase {
           width: enabled ? 48 : 0
           height: 48
 
-          anchors.right: increaseButton.left
           anchors.verticalCenter: textField.verticalCenter
 
           bgcolor: "white"
@@ -93,7 +92,6 @@ EditorWidgetBase {
           width: enabled ? 48 : 0
           height: 48
 
-          anchors.right: parent.right
           anchors.verticalCenter: textField.verticalCenter
 
           bgcolor: "white"


### PR DESCRIPTION
Two fixes:
- Never rely on empty label strings for the checkbox widget (fixes #2062)
- Fix QML errors with the range editor widget 