### PR TITLE
Remember tracking settings values, revamp UI

### DIFF
--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -43,7 +43,9 @@ Popup {
     showFeaturesListButtonVisible = isShowFeaturesListButtonVisible();
 
     trackingButtonVisible = isTrackingButtonVisible()
-    trackingButtonText = trackingModel.layerInTracking( layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer) ) ? qsTr('Stop tracking') : qsTr('Setup tracking')
+    trackingButtonText = trackingModel.layerInTracking( layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer) )
+        ? qsTr('Stop tracking')
+        : qsTr('Setup tracking')
   }
 
   Page {

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -43,7 +43,7 @@ Popup {
     showFeaturesListButtonVisible = isShowFeaturesListButtonVisible();
 
     trackingButtonVisible = isTrackingButtonVisible()
-    trackingButtonText = trackingModel.layerInTracking( layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer) ) ? qsTr('Stop tracking') : qsTr('Start tracking')
+    trackingButtonText = trackingModel.layerInTracking( layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer) ) ? qsTr('Stop tracking') : qsTr('Setup tracking')
   }
 
   Page {

--- a/src/qml/PageHeader.qml
+++ b/src/qml/PageHeader.qml
@@ -7,6 +7,7 @@ import Theme 1.0
 
 ToolBar {
   property alias title: titleLabel.text
+  property alias showBackButton: backButton.visible
   property alias showApplyButton: applyButton.visible
   property alias showCancelButton: cancelButton.visible
   property alias busyIndicatorState: busyIndicator.state
@@ -15,6 +16,7 @@ ToolBar {
 
   signal cancel
   signal apply
+  signal back
   signal finished
 
   anchors {
@@ -73,6 +75,24 @@ ToolBar {
     Layout.margins: 0
 
     QfToolButton {
+      id: backButton
+
+      Layout.alignment: Qt.AlignTop | Qt.AlignLeft
+
+      width: 48
+      height: 48
+      clip: true
+
+      iconSource: Theme.getThemeVectorIcon( 'ic_arrow_left_white_24dp' )
+
+      onClicked:
+      {
+        back()
+        finished()
+      }
+    }
+
+    QfToolButton {
       id: applyButton
 
       Layout.alignment: Qt.AlignTop | Qt.AlignLeft
@@ -93,7 +113,7 @@ ToolBar {
     Label {
       id: titleLabel
       leftPadding: !showApplyButton && showCancelButton ? 48: 0
-      rightPadding: showApplyButton && !showCancelButton ? 48: 0
+      rightPadding: (showApplyButton || showBackButton) && !showCancelButton ? 48: 0
       font: Theme.strongFont
       color: Theme.light
       elide: Label.ElideRight

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -20,4 +20,10 @@ LabSettings.Settings {
     property bool skipAltitudeCorrection: false
 
     property string verticalGrid: ""
+
+    property bool trackerTimeIntervalConstraint: false
+    property double trackerTimeInterval: 30
+    property bool trackerMinimumDistanceConstraint: false
+    property double trackerMinimumDistance: 30
+    property bool trackerMeetAllConstraints: false
 }

--- a/src/qml/Tracking.qml
+++ b/src/qml/Tracking.qml
@@ -205,7 +205,7 @@ Item{
 
 
                 Label {
-                    text: qsTr("Activate time interval constraint")
+                    text: qsTr("Activate time constraint")
                     font: Theme.defaultFont
                     wrapMode: Text.WordWrap
                     Layout.fillWidth: true
@@ -270,7 +270,7 @@ Item{
                 }
 
                 Label {
-                    text: qsTr("Activate distance interval constraint")
+                    text: qsTr("Activate distance constraint")
                     font: Theme.defaultFont
                     wrapMode: Text.WordWrap
                     Layout.fillWidth: true
@@ -342,7 +342,7 @@ Item{
                 }
 
                 Label {
-                    text: qsTr("Digitize when all constraints are met")
+                    text: qsTr("Record when all active constraints are met")
                     font: Theme.defaultFont
                     wrapMode: Text.WordWrap
                     Layout.fillWidth: true
@@ -365,7 +365,7 @@ Item{
 
 
                 Label {
-                    text: qsTr( "When enabled, vertices with only be digitized when all active constraints are met. If the setting is disabled, individual constraints met will trigger a vertex addition." )
+                    text: qsTr( "When enabled, vertices with only be recorded when all active constraints are met. If the setting is disabled, individual constraints met will trigger a vertex addition." )
                     font: Theme.tipFont
                     color: Theme.gray
                     textFormat: Qt.RichText

--- a/src/qml/Tracking.qml
+++ b/src/qml/Tracking.qml
@@ -175,28 +175,9 @@ Item{
             header: PageHeader {
                 title: qsTr("Tracker Settings")
 
-                showApplyButton: true
+                showApplyButton: false
                 showCancelButton: true
 
-                onApply: {
-                    if( Number(timeIntervalValue.text) + Number(minimumDistanceValue.text) === 0 ||
-                        ( timeInterval.checked && minimumDistance.checked && allConstraints.checked &&
-                          ( Number(timeIntervalValue.text) === 0 || Number(minimumDistanceValue.text) === 0 ) ) ||
-                        ( !timeInterval.checked && !minimumDistance.checked ) )
-                    {
-                        displayToast( qsTr( 'Cannot start track with empty values' ), 'warning' )
-                    }
-                    else
-                    {
-                        mainModel.timeInterval = timeIntervalValue.text.length == 0 || !timeInterval.checked ? 0 : timeIntervalValue.text
-                        mainModel.minimumDistance = minimumDistanceValue.text.length == 0 || !minimumDistance.checked ? 0 : minimumDistanceValue.text
-                        mainModel.conjunction = allConstraints.checked
-                        mainModel.rubberModel = rubberbandModel
-
-                        trackInformationDialog.active = false
-                        embeddedFeatureForm.active = true
-                    }
-                }
                 onCancel: {
                     trackInformationDialog.active = false
                     trackingModel.stopTracker( mainModel.vectorLayer )
@@ -387,6 +368,37 @@ Item{
 
                 Item {
                     Layout.preferredWidth: allConstraints.width
+                }
+
+                QfButton {
+                  id: trackingButton
+                  Layout.topMargin: 8
+                  Layout.fillWidth: true
+                  Layout.columnSpan: 2
+                  font: Theme.defaultFont
+                  text: qsTr( "Start tracking")
+                  visible: trackingButtonVisible
+                  icon.source: Theme.getThemeVectorIcon( 'directions_walk_24dp' )
+
+                  onClicked: {
+                      if( Number(timeIntervalValue.text) + Number(minimumDistanceValue.text) === 0 ||
+                              ( timeInterval.checked && minimumDistance.checked && allConstraints.checked &&
+                               ( Number(timeIntervalValue.text) === 0 || Number(minimumDistanceValue.text) === 0 ) ) ||
+                              ( !timeInterval.checked && !minimumDistance.checked ) )
+                      {
+                          displayToast( qsTr( 'Cannot start track with empty values' ), 'warning' )
+                      }
+                      else
+                      {
+                          mainModel.timeInterval = timeIntervalValue.text.length == 0 || !timeInterval.checked ? 0 : timeIntervalValue.text
+                          mainModel.minimumDistance = minimumDistanceValue.text.length == 0 || !minimumDistance.checked ? 0 : minimumDistanceValue.text
+                          mainModel.conjunction = allConstraints.checked
+                          mainModel.rubberModel = rubberbandModel
+
+                          trackInformationDialog.active = false
+                          embeddedFeatureForm.active = true
+                      }
+                  }
                 }
 
                 Item {

--- a/src/qml/Tracking.qml
+++ b/src/qml/Tracking.qml
@@ -257,7 +257,7 @@ Item{
                     }
 
                     Component.onCompleted: {
-                        text = isNaN( positioningSettings.trackerTimeInterval) ? '' : positioningSettings.trackerTimeInterval
+                        text = isNaN(positioningSettings.trackerTimeInterval) ? '' : positioningSettings.trackerTimeInterval
                     }
 
                     onTextChanged: {

--- a/src/qml/Tracking.qml
+++ b/src/qml/Tracking.qml
@@ -179,18 +179,18 @@ Item{
                 showCancelButton: true
 
                 onApply: {
-                    if( Number(timeIntervalText.text) + Number(distanceText.text) === 0 ||
-                        ( timeIntervalCheck.checked && distanceCheck.checked && conjunction.checked &&
-                          ( Number(timeIntervalText.text) === 0 || Number(distanceText.text) === 0 ) ) ||
-                        ( !timeIntervalCheck.checked && !distanceCheck.checked ) )
+                    if( Number(timeIntervalValue.text) + Number(minimumDistanceValue.text) === 0 ||
+                        ( timeInterval.checked && minimumDistance.checked && allConstraints.checked &&
+                          ( Number(timeIntervalValue.text) === 0 || Number(minimumDistanceValue.text) === 0 ) ) ||
+                        ( !timeInterval.checked && !minimumDistance.checked ) )
                     {
                         displayToast( qsTr( 'Cannot start track with empty values' ), 'warning' )
                     }
                     else
                     {
-                        mainModel.timeInterval = timeIntervalText.text.length == 0 || !timeIntervalCheck.checked ? 0 : timeIntervalText.text
-                        mainModel.minimumDistance = distanceText.text.length == 0 || !distanceCheck.checked ? 0 : distanceText.text
-                        mainModel.conjunction = conjunction.checked
+                        mainModel.timeInterval = timeIntervalValue.text.length == 0 || !timeInterval.checked ? 0 : timeIntervalValue.text
+                        mainModel.minimumDistance = minimumDistanceValue.text.length == 0 || !minimumDistance.checked ? 0 : minimumDistanceValue.text
+                        mainModel.conjunction = allConstraints.checked
                         mainModel.rubberModel = rubberbandModel
 
                         trackInformationDialog.active = false
@@ -203,124 +203,196 @@ Item{
                 }
             }
 
-            ColumnLayout{
+            GridLayout {
                 anchors.fill: parent
+                anchors {
+                    margins: 20
+                }
                 Layout.fillWidth: true
                 Layout.fillHeight: true
 
-                spacing: 2
-                anchors {
-                    margins: 4
-                    topMargin: 35// Leave space for the toolbar
-                }
+                columns: 2
+                columnSpacing: 0
+                rowSpacing: 5
 
-                CheckBox {
-                    id: timeIntervalCheck
-                    text: qsTr( 'Time interval (s)' )
+
+                Label {
+                    text: qsTr("Activate time interval constraint")
                     font: Theme.defaultFont
-
+                    wrapMode: Text.WordWrap
                     Layout.fillWidth: true
-                    indicator.height: 16
-                    indicator.width: 16
-                    indicator.implicitHeight: 24
-                    indicator.implicitWidth: 24
-                }
 
-                TextField {
-                    id: timeIntervalText
-                    enabled: timeIntervalCheck.checked
-                    height: fontMetrics.height + 20
-                    topPadding: 10
-                    bottomPadding: 10
-                    Layout.fillWidth: true
-                    font: Theme.defaultFont
-                    text: '30'
-
-                    inputMethodHints: Qt.ImhFormattedNumbersOnly
-
-                    validator: IntValidator {
-                    }
-
-                    background: Rectangle {
-                    y: timeIntervalText.height - height - timeIntervalText.bottomPadding / 2
-                    implicitWidth: 120
-                    height: timeIntervalText.activeFocus ? 2: 1
-                    color: timeIntervalText.activeFocus ? "#4CAF50" : "#C8E6C9"
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: timeInterval.toggle()
                     }
                 }
 
-                CheckBox {
-                    DistanceArea {
-                      id: infoDistanceArea
-                      property VectorLayer currentLayer: mainModel.vectorLayer
-                      project: qgisProject
-                      crs: qgisProject.crs
+                QfSwitch {
+                    id: timeInterval
+                    Layout.preferredWidth: implicitContentWidth
+                    Layout.alignment: Qt.AlignTop
+                    checked: positioningSettings.trackerTimeIntervalConstraint
+                    onCheckedChanged: {
+                        positioningSettings.trackerTimeIntervalConstraint = checked
                     }
+                }
 
-                    id: distanceCheck
-
-                    text: qsTr( 'Distance (%1)' ).arg( UnitTypes.toAbbreviatedString( infoDistanceArea.lengthUnits ) )
+                Label {
+                    text: qsTr("Minimum time [sec]")
                     font: Theme.defaultFont
-
+                    wrapMode: Text.WordWrap
+                    enabled: timeInterval.checked
+                    visible: timeInterval.checked
+                    Layout.leftMargin: 8
                     Layout.fillWidth: true
-                    indicator.height: 16
-                    indicator.width: 16
-                    indicator.implicitHeight: 24
-                    indicator.implicitWidth: 24
                 }
 
                 TextField {
-                    id: distanceText
-                    enabled: distanceCheck.checked
-                    height: fontMetrics.height + 20
-                    topPadding: 10
-                    bottomPadding: 10
-                    Layout.fillWidth: true
+                    id: timeIntervalValue
+                    width: timeInterval.width
                     font: Theme.defaultFont
-                    text: '50'
+                    enabled: timeInterval.checked
+                    visible: timeInterval.checked
+                    horizontalAlignment: TextInput.AlignHCenter
+                    Layout.preferredWidth: 60
+                    Layout.preferredHeight: font.height + 20
 
                     inputMethodHints: Qt.ImhFormattedNumbersOnly
-
-                    validator: IntValidator {
-                    }
+                    validator: DoubleValidator { locale: 'C' }
 
                     background: Rectangle {
-                    y: distanceText.height - height - distanceText.bottomPadding / 2
-                    implicitWidth: 120
-                    height: distanceText.activeFocus ? 2: 1
-                    color: distanceText.activeFocus ? "#4CAF50" : "#C8E6C9"
+                      y: parent.height - height - parent.bottomPadding / 2
+                      implicitWidth: 120
+                      height: parent.activeFocus ? 2: 1
+                      color: parent.activeFocus ? '#4CAF50' : '#C8E6C9'
                     }
+
+                    Component.onCompleted: {
+                        text = isNaN( positioningSettings.trackerTimeInterval) ? '' : positioningSettings.trackerTimeInterval
+                    }
+
+                    onTextChanged: {
+                        if( text.length === 0 || isNaN(text) ) {
+                            positioningSettings.trackerTimeInterval = NaN
+                        } else {
+                            positioningSettings.trackerTimeInterval = parseFloat( text )
+                        }
+                    }
+                }
+
+                Label {
+                    text: qsTr("Activate distance interval constraint")
+                    font: Theme.defaultFont
+                    wrapMode: Text.WordWrap
+                    Layout.fillWidth: true
+
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: minimumDistance.toggle()
+                    }
+                }
+
+                QfSwitch {
+                    id: minimumDistance
+                    Layout.preferredWidth: implicitContentWidth
+                    Layout.alignment: Qt.AlignTop
+                    checked: positioningSettings.trackerMinimumDistanceConstraint
+                    onCheckedChanged: {
+                        positioningSettings.trackerMinimumDistanceConstraint = checked
+                    }
+                }
+
+                DistanceArea {
+                  id: infoDistanceArea
+                  property VectorLayer currentLayer: mainModel.vectorLayer
+                  project: qgisProject
+                  crs: qgisProject.crs
+                }
+
+                Label {
+                    text: qsTr("Minimum distance [%1]").arg( UnitTypes.toAbbreviatedString( infoDistanceArea.lengthUnits ) )
+                    font: Theme.defaultFont
+                    wrapMode: Text.WordWrap
+                    enabled: minimumDistance.checked
+                    visible: minimumDistance.checked
+                    Layout.leftMargin: 8
+                    Layout.fillWidth: true
+                }
+
+                TextField {
+                    id: minimumDistanceValue
+                    width: minimumDistance.width
+                    font: Theme.defaultFont
+                    enabled: minimumDistance.checked
+                    visible: minimumDistance.checked
+                    horizontalAlignment: TextInput.AlignHCenter
+                    Layout.preferredWidth: 60
+                    Layout.preferredHeight: font.height + 20
+
+                    inputMethodHints: Qt.ImhFormattedNumbersOnly
+                    validator: DoubleValidator { locale: 'C' }
+
+                    background: Rectangle {
+                      y: parent.height - height - parent.bottomPadding / 2
+                      implicitWidth: 120
+                      height: parent.activeFocus ? 2: 1
+                      color: parent.activeFocus ? '#4CAF50' : '#C8E6C9'
+                    }
+
+                    Component.onCompleted: {
+                        text = isNaN( positioningSettings.trackerMinimumDistance) ? '' : positioningSettings.trackerMinimumDistance
+                    }
+
+                    onTextChanged: {
+                        if( text.length === 0 || isNaN(text) ) {
+                            positioningSettings.trackerMinimumDistance = NaN
+                        } else {
+                            positioningSettings.trackerMinimumDistance = parseFloat( text )
+                        }
+                    }
+                }
+
+                Label {
+                    text: qsTr("Digitize when all constraints are met")
+                    font: Theme.defaultFont
+                    wrapMode: Text.WordWrap
+                    Layout.fillWidth: true
+
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: allConstraints.toggle()
+                    }
+                }
+
+                QfSwitch {
+                    id: allConstraints
+                    Layout.preferredWidth: implicitContentWidth
+                    Layout.alignment: Qt.AlignTop
+                    checked: positioningSettings.trackerMeetAllConstraints
+                    onCheckedChanged: {
+                        positioningSettings.trackerMeetAllConstraints = checked
+                    }
+                }
+
+
+                Label {
+                    text: qsTr( "When enabled, vertices with only be digitized when all active constraints are met. If the setting is disabled, individual constraints met will trigger a vertex addition." )
+                    font: Theme.tipFont
+                    color: Theme.gray
+                    textFormat: Qt.RichText
+                    wrapMode: Text.WordWrap
+                    Layout.fillWidth: true
                 }
 
                 Item {
-                    // spacer item
-                    height: 12
-                }
-
-                CheckBox {
-                    id: conjunction
-                    text: qsTr('Digitize vertex only when both conditions are met')
-                    font: Theme.defaultFont
-                    checked: timeIntervalCheck.checked && distanceCheck.checked
-                    enabled: timeIntervalCheck.checked && distanceCheck.checked
-
-                    Layout.fillWidth: true
-                    indicator.height: 16
-                    indicator.width: 16
-                    indicator.implicitHeight: 24
-                    indicator.implicitWidth: 24
+                    Layout.preferredWidth: allConstraints.width
                 }
 
                 Item {
                     // spacer item
                     Layout.fillWidth: true
                     Layout.fillHeight: true
-                }
-            }
-
-            onVisibleChanged: {
-                if (visible) {
-                    timeIntervalText.forceActiveFocus();
                 }
             }
         }

--- a/src/qml/Tracking.qml
+++ b/src/qml/Tracking.qml
@@ -176,9 +176,10 @@ Item{
                 title: qsTr("Tracker Settings")
 
                 showApplyButton: false
-                showCancelButton: true
+                showCancelButton: false
+                showBackButton: true
 
-                onCancel: {
+                onBack: {
                     trackInformationDialog.active = false
                     trackingModel.stopTracker( mainModel.vectorLayer )
                 }
@@ -377,7 +378,6 @@ Item{
                   Layout.columnSpan: 2
                   font: Theme.defaultFont
                   text: qsTr( "Start tracking")
-                  visible: trackingButtonVisible
                   icon.source: Theme.getThemeVectorIcon( 'directions_walk_24dp' )
 
                   onClicked: {

--- a/src/qml/Tracking.qml
+++ b/src/qml/Tracking.qml
@@ -342,10 +342,12 @@ Item{
                 }
 
                 Label {
-                    text: qsTr("Record when all active constraints are met")
+                    text: qsTr("Record when both active constraints are met")
                     font: Theme.defaultFont
                     wrapMode: Text.WordWrap
                     Layout.fillWidth: true
+                    enabled: timeInterval.checked && minimumDistance.checked
+                    visible: timeInterval.checked && minimumDistance.checked
 
                     MouseArea {
                         anchors.fill: parent
@@ -357,6 +359,8 @@ Item{
                     id: allConstraints
                     Layout.preferredWidth: implicitContentWidth
                     Layout.alignment: Qt.AlignTop
+                    enabled: timeInterval.checked && minimumDistance.checked
+                    visible: timeInterval.checked && minimumDistance.checked
                     checked: positioningSettings.trackerMeetAllConstraints
                     onCheckedChanged: {
                         positioningSettings.trackerMeetAllConstraints = checked
@@ -365,12 +369,14 @@ Item{
 
 
                 Label {
-                    text: qsTr( "When enabled, vertices with only be recorded when all active constraints are met. If the setting is disabled, individual constraints met will trigger a vertex addition." )
+                    text: qsTr( "When enabled, vertices with only be recorded when both active constraints are met. If the setting is disabled, individual constraints met will trigger a vertex addition." )
                     font: Theme.tipFont
                     color: Theme.gray
                     textFormat: Qt.RichText
                     wrapMode: Text.WordWrap
                     Layout.fillWidth: true
+                    enabled: timeInterval.checked && minimumDistance.checked
+                    visible: timeInterval.checked && minimumDistance.checked
                 }
 
                 Item {
@@ -398,7 +404,7 @@ Item{
                       {
                           mainModel.timeInterval = timeIntervalValue.text.length == 0 || !timeInterval.checked ? 0 : timeIntervalValue.text
                           mainModel.minimumDistance = minimumDistanceValue.text.length == 0 || !minimumDistance.checked ? 0 : minimumDistanceValue.text
-                          mainModel.conjunction = allConstraints.checked
+                          mainModel.conjunction = timeInterval.checked && minimumDistance.checked && allConstraints.checked
                           mainModel.rubberModel = rubberbandModel
 
                           trackInformationDialog.active = false

--- a/src/qml/Tracking.qml
+++ b/src/qml/Tracking.qml
@@ -185,13 +185,19 @@ Item{
                 }
             }
 
-            GridLayout {
+            ScrollView {
+                padding: 20
+                ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+                ScrollBar.vertical.policy: ScrollBar.AsNeeded
+                contentWidth: trackerSettingsGrid.width
+                contentHeight: trackerSettingsGrid.height
                 anchors.fill: parent
-                anchors {
-                    margins: 20
-                }
+                clip: true
+
+            GridLayout {
+                id: trackerSettingsGrid
+                width: parent.parent.width
                 Layout.fillWidth: true
-                Layout.fillHeight: true
 
                 columns: 2
                 columnSpacing: 0
@@ -406,6 +412,8 @@ Item{
                     Layout.fillWidth: true
                     Layout.fillHeight: true
                 }
+            }
+
             }
         }
       }


### PR DESCRIPTION
First,a before vs. PR screenshot:
![image](https://user-images.githubusercontent.com/1728657/129722204-14302613-9331-4feb-bd00-ecb056d760fc.png)

The big enhancement here is that all of the tracking settings will be remembered across sessions. This should really help out users out there who might grow tired of re-entering the same values again and again.

While visiting this part of QField, I've taken the opportunity to revamp the UI a bit so it feels more integrated into the rest of the app. Improvements there include:
- the settings is now parented to a scrollable area so people can reach settings that are outside of the current view (it'd happen if you open the tracking popup while your phone is in landscape mode for e.g.)
- the slightly confusing reliance on the page header's :heavy_check_mark: accept button has been replaced with the use of a full-width button with text,which will do a better job at telling users how to proceed forward (in doing so, I've also replaced the header buttons with @m-kuhn 's favorite back button)
- an overall more verbose UI which should better guide users (noticeably, the respect all constraints label isn't chopped off at the edge of the screen :) )