### PR TITLE
Allow sub-second, sub-meter tracking constraints

### DIFF
--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -36,46 +36,6 @@ void Tracker::setModel( RubberbandModel *model )
   mRubberbandModel = model;
 }
 
-int Tracker::timeInterval() const
-{
-  return mTimeInterval;
-}
-
-void Tracker::setTimeInterval( const int timeInterval )
-{
-  mTimeInterval = timeInterval;
-}
-
-int Tracker::minimumDistance() const
-{
-  return mMinimumDistance;
-}
-
-void Tracker::setConjunction( const bool conjunction )
-{
-  mConjunction = conjunction;
-}
-
-QDateTime Tracker::startPositionTimestamp() const
-{
-  return mStartPositionTimestamp;
-}
-
-void Tracker::setStartPositionTimestamp( const QDateTime &startPositionTimestamp )
-{
-  mStartPositionTimestamp = startPositionTimestamp;
-}
-
-bool Tracker::conjunction() const
-{
-  return mConjunction;
-}
-
-void Tracker::setMinimumDistance( const int minimumDistance )
-{
-  mMinimumDistance = minimumDistance;
-}
-
 void Tracker::trackPosition()
 {
   if ( std::isnan( model()->currentCoordinate().x() ) || std::isnan( model()->currentCoordinate().y() ) )

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -35,24 +35,24 @@ class Tracker : public QObject
     void setModel( RubberbandModel *model );
 
     //! the (minimum) time interval between setting trackpoints
-    int timeInterval() const;
+    double timeInterval() const { return mTimeInterval; }
     //! the (minimum) time interval between setting trackpoints
-    void setTimeInterval( const int timeInterval );
+    void setTimeInterval( const double timeInterval ) { mTimeInterval = timeInterval; }
 
     //! the minimum distance between setting trackpoints
-    int minimumDistance() const;
+    double minimumDistance() const { return mMinimumDistance; }
     //! the minimum distance between setting trackpoints
-    void setMinimumDistance( const int minimumDistance );
+    void setMinimumDistance( const double minimumDistance ) { mMinimumDistance = minimumDistance; };
 
     //! if both, the minimum distance and the time interval, needs to be fulfilled before setting trackpoints
-    bool conjunction() const;
+    bool conjunction() const { return mConjunction; }
     //! if both, the minimum distance and the time interval, needs to be fulfilled before setting trackpoints
-    void setConjunction( const bool conjunction );
+    void setConjunction( const bool conjunction ) { mConjunction = conjunction; }
 
     //! the timestamp of the first recorded position
-    QDateTime startPositionTimestamp() const;
+    QDateTime startPositionTimestamp() const { return mStartPositionTimestamp; }
     //! the timestamp of the first recorded position
-    void setStartPositionTimestamp( const QDateTime &startPositionTimestamp );
+    void setStartPositionTimestamp( const QDateTime &startPositionTimestamp ) { mStartPositionTimestamp = startPositionTimestamp; }
 
     //! the current layer
     QgsVectorLayer *layer() const { return mLayer; }
@@ -81,8 +81,8 @@ class Tracker : public QObject
     RubberbandModel *mRubberbandModel = nullptr;
 
     QTimer mTimer;
-    int mTimeInterval = 0;
-    int mMinimumDistance = 0;
+    double mTimeInterval = 0;
+    double mMinimumDistance = 0;
     bool mConjunction = true;
     bool mTimeIntervalFulfilled = false;
     bool mMinimumDistanceFulfilled = false;

--- a/src/core/trackingmodel.cpp
+++ b/src/core/trackingmodel.cpp
@@ -93,10 +93,10 @@ bool TrackingModel::setData( const QModelIndex &index, const QVariant &value, in
   switch ( role )
   {
     case TimeInterval:
-      currentTracker->setTimeInterval( value.toInt() );
+      currentTracker->setTimeInterval( value.toDouble() );
       break;
     case MinimumDistance:
-      currentTracker->setMinimumDistance( value.toInt() );
+      currentTracker->setMinimumDistance( value.toDouble() );
       break;
     case Conjunction:
       currentTracker->setConjunction( value.toBool() );


### PR DESCRIPTION
This PR modifies the tracker code to allow sub-meter (and sub-second) time and distance constraints :tada: 
![image](https://user-images.githubusercontent.com/1728657/129858721-0c2630ca-e13d-4d1a-ad9a-a6eb781b13dc.png)

@bladnor , good feedback.