### PR TITLE
Fix issues with editor widgets' height

### DIFF
--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -31,7 +31,7 @@ EditorWidgetBase {
         left: parent.left
     }
 
-    height: childrenRect.height + 10
+    height: childrenRect.height
     enabled: isEnabled
 
     property bool isDateTimeType: field.isDateOrTime

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -191,6 +191,21 @@ EditorWidgetBase {
 
     source: Theme.getThemeIcon("ic_photo_notavailable_black_24dp")
 
+    onStatusChanged: {
+        if (status == Image.Ready) {
+            if (sourceSize.height > sourceSize.width && sourceSize.height > 220) {
+                width = sourceSize.width * 220 / sourceSize.height
+                height = 220
+            } else if (sourceSize.width > 220) {
+                width = 220
+                height = sourceSize.height * 220 / sourceSize.width
+            } else {
+                width = sourceSize.width
+                height = sourceSize.height
+            }
+        }
+    }
+
     MouseArea {
       anchors.fill: parent
 

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -14,7 +14,7 @@ EditorWidgetBase {
   anchors.left: parent.left
   anchors.right: parent.right
 
-  height: Math.max(isImage? image.height : linkField.height, button_camera.height, button_gallery.height)
+  height: childrenRect.height
 
   ExpressionEvaluator {
     id: rootPathEvaluator
@@ -183,8 +183,7 @@ EditorWidgetBase {
     enabled: isImage
     anchors.left: parent.left
     anchors.top: parent.top
-    anchors.topMargin: 11
-    width: 24
+    width: 48
     opacity: 0.25
     autoTransform: true
     fillMode: Image.PreserveAspectFit
@@ -200,34 +199,34 @@ EditorWidgetBase {
           platformUtilities.open( prefixToRelativePath + value );
       }
     }
-  }
 
-  Image {
-    property bool hasGeoTag: false
-    id: geoTagBadge
-    visible: false
-    anchors.bottom: image.bottom
-    anchors.right: image.right
-    anchors.rightMargin: 10
-    anchors.bottomMargin: 12
-    fillMode: Image.PreserveAspectFit
-    width: 24
-    height: 24
-    source: hasGeoTag ? Theme.getThemeIcon("ic_geotag_24dp") : Theme.getThemeIcon("ic_geotag_missing_24dp")
-    sourceSize.width: 24 * Screen.devicePixelRatio
-    sourceSize.height: 24 * Screen.devicePixelRatio
+    Image {
+      property bool hasGeoTag: false
+      id: geoTagBadge
+      visible: false
+      anchors.bottom: image.bottom
+      anchors.right: image.right
+      anchors.rightMargin: 10
+      anchors.bottomMargin: 12
+      fillMode: Image.PreserveAspectFit
+      width: 24
+      height: 24
+      source: hasGeoTag ? Theme.getThemeIcon("ic_geotag_24dp") : Theme.getThemeIcon("ic_geotag_missing_24dp")
+      sourceSize.width: 24 * Screen.devicePixelRatio
+      sourceSize.height: 24 * Screen.devicePixelRatio
 
-  }
+    }
 
-  DropShadow {
-    anchors.fill: geoTagBadge
-    visible: geoTagBadge.visible
-    horizontalOffset: 0
-    verticalOffset: 0
-    radius: 6.0
-    samples: 17
-    color: "#DD000000"
-    source: geoTagBadge
+    DropShadow {
+      anchors.fill: geoTagBadge
+      visible: geoTagBadge.visible
+      horizontalOffset: 0
+      verticalOffset: 0
+      radius: 6.0
+      samples: 17
+      color: "#DD000000"
+      source: geoTagBadge
+    }
   }
 
   QfToolButton {
@@ -236,9 +235,9 @@ EditorWidgetBase {
     height: 48
 
     anchors.right: button_gallery.left
-    anchors.bottom: parent.bottom
+    anchors.top: parent.top
 
-    bgcolor: "transparent"
+    bgcolor: "white"
     visible: isImage && isEnabled
 
     onClicked: {
@@ -260,9 +259,9 @@ EditorWidgetBase {
     height: 48
 
     anchors.right: parent.right
-    anchors.bottom: parent.bottom
+    anchors.top: parent.top
 
-    bgcolor: "transparent"
+    bgcolor: "white"
     visible: isImage && isEnabled
 
     onClicked: {

--- a/src/qml/editorwidgets/RelationReference.qml
+++ b/src/qml/editorwidgets/RelationReference.qml
@@ -11,6 +11,7 @@ import ".."
 import "."
 
 EditorWidgetBase {
+  height: childrenRect.height
   anchors { left: parent.left; right: parent.right; }
 
   property bool showOpenFormButton: config['ShowOpenFormButton'] === undefined || config['ShowOpenFormButton'] === true

--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -21,7 +21,7 @@ EditorWidgetBase {
     comboBox.currentIndex = comboBox.model.keyToIndex(currentKeyValue)
   }
 
-  height: childrenRect.height + 10
+  height: childrenRect.height
   enabled: isEnabled
 
 


### PR DESCRIPTION
This PR fixes this kind of UI glitch:
![image](https://user-images.githubusercontent.com/1728657/130059843-7b6747bf-1186-4f45-b9b6-885d6651f300.png)
_Note the badly located value applied (click to toggle) label for the fk attribute_