### PR TITLE
Fix group visibility change leading to out of sync feature form tabs

### DIFF
--- a/src/core/attributeformmodel.cpp
+++ b/src/core/attributeformmodel.cpp
@@ -28,16 +28,6 @@ AttributeFormModel::AttributeFormModel( QObject *parent )
   connect( mSourceModel, &AttributeFormModelBase::featureChanged, this, &AttributeFormModel::featureChanged );
   connect( mSourceModel, &AttributeFormModelBase::constraintsHardValidChanged, this, &AttributeFormModel::constraintsHardValidChanged );
   connect( mSourceModel, &AttributeFormModelBase::constraintsSoftValidChanged, this, &AttributeFormModel::constraintsSoftValidChanged );
-
-  connect( mSourceModel, &AttributeFormModelBase::dataChanged, this, [=]( const QModelIndex &from, const QModelIndex &, const QVector<int> &roles )
-  {
-    // listen for visibility change of root items and reset model when needed to work around feature form falling out of sync
-    if ( hasTabs() && roles.contains( AttributeFormModel::CurrentlyVisible ) && !from.parent().isValid() )
-    {
-      emit beginResetModel();
-      emit endResetModel();
-    }
-  } );
 }
 
 bool AttributeFormModel::hasTabs() const

--- a/src/core/attributeformmodel.cpp
+++ b/src/core/attributeformmodel.cpp
@@ -22,11 +22,22 @@ AttributeFormModel::AttributeFormModel( QObject *parent )
   , mSourceModel( new AttributeFormModelBase( this ) )
 {
   setSourceModel( mSourceModel );
+
   connect( mSourceModel, &AttributeFormModelBase::hasTabsChanged, this, &AttributeFormModel::hasTabsChanged );
   connect( mSourceModel, &AttributeFormModelBase::featureModelChanged, this, &AttributeFormModel::featureModelChanged );
   connect( mSourceModel, &AttributeFormModelBase::featureChanged, this, &AttributeFormModel::featureChanged );
   connect( mSourceModel, &AttributeFormModelBase::constraintsHardValidChanged, this, &AttributeFormModel::constraintsHardValidChanged );
   connect( mSourceModel, &AttributeFormModelBase::constraintsSoftValidChanged, this, &AttributeFormModel::constraintsSoftValidChanged );
+
+  connect( mSourceModel, &AttributeFormModelBase::dataChanged, this, [=]( const QModelIndex &from, const QModelIndex &, const QVector<int> &roles )
+  {
+    // listen for visibility change of root items and reset model when needed to work around feature form falling out of sync
+    if ( roles.contains( AttributeFormModel::CurrentlyVisible ) && !from.parent().isValid() )
+    {
+      emit beginResetModel();
+      emit endResetModel();
+    }
+  } );
 }
 
 bool AttributeFormModel::hasTabs() const

--- a/src/core/attributeformmodel.cpp
+++ b/src/core/attributeformmodel.cpp
@@ -32,7 +32,7 @@ AttributeFormModel::AttributeFormModel( QObject *parent )
   connect( mSourceModel, &AttributeFormModelBase::dataChanged, this, [=]( const QModelIndex &from, const QModelIndex &, const QVector<int> &roles )
   {
     // listen for visibility change of root items and reset model when needed to work around feature form falling out of sync
-    if ( roles.contains( AttributeFormModel::CurrentlyVisible ) && !from.parent().isValid() )
+    if ( hasTabs() && roles.contains( AttributeFormModel::CurrentlyVisible ) && !from.parent().isValid() )
     {
       emit beginResetModel();
       emit endResetModel();

--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -536,6 +536,7 @@ void AttributeFormModelBase::updateVisibilityAndConstraints( int fieldIndex )
         if ( item->data( AttributeFormModel::CurrentlyVisible ).toBool() != visible )
         {
           item->setData( visible, AttributeFormModel::CurrentlyVisible );
+          emit dataChanged( item->index(), item->index(), QVector<int>() << AttributeFormModel::CurrentlyVisible );
         }
       }
     }

--- a/src/core/submodel.cpp
+++ b/src/core/submodel.cpp
@@ -15,8 +15,6 @@
  ***************************************************************************/
 #include "submodel.h"
 
-#include <QDebug>
-
 SubModel::SubModel( QObject *parent )
   : QAbstractItemModel( parent )
 {
@@ -69,11 +67,9 @@ QModelIndex SubModel::rootIndex() const
 
 void SubModel::setRootIndex( const QModelIndex &rootIndex )
 {
-  if ( rootIndex == mRootIndex )
-    return;
-
   beginResetModel();
   mRootIndex = rootIndex;
+  mMappings.clear();
   endResetModel();
   emit rootIndexChanged();
 }
@@ -95,7 +91,7 @@ void SubModel::setModel( QAbstractItemModel *model )
   connect( model, &QAbstractItemModel::dataChanged, this, &SubModel::onDataChanged );
 
   mModel = model;
-  emit modelChanged();
+  mMappings.clear();
 }
 
 void SubModel::onRowsInserted( const QModelIndex &parent, int first, int last )

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -43,7 +43,7 @@ EditorWidgetBase {
     anchors.right: parent.right
     font: Theme.defaultFont
     color: 'black'
-    maximumLength: field.length > 0 ? field.length : -1
+    maximumLength: field != undefined && field.length > 0 ? field.length : -1
     wrapMode: TextInput.Wrap
 
     text: value == null ? '' : value


### PR DESCRIPTION
Update: happy to report the root cause of submodel falling into an out of sync situation has been identified and fixing. This means no costly model reset needed to fix feature form tab visibility :tada: 

---

OK, this is a pretty crucial fix, and one that was pretty hard to dissect. 

@3nids identified a serious issue whereas feature form tabs would get out of sync when tabs had expression-based visibility. It was difficult to diagnose what's wrong here but it boils down to the FeatureForm.qml's SubModel (line 226-230) getting out of sync when the parent Repeater item has filter changes in its model. 

The solution fixes this serious issue. However, the model reset signal has one downside: it forces all feature form tabs to re-build, which means that for e.g. value relation and relation reference widgets re-load, which does come at a little bit of a cost.

I've tried countless alternatives here, and I simply couldn't come up with a better solution.