### PR TITLE
Fix data corruption when multi editing

### DIFF
--- a/src/core/identifytool.cpp
+++ b/src/core/identifytool.cpp
@@ -58,7 +58,7 @@ void IdentifyTool::identify( const QPointF &point ) const
 
   QgsPointXY mapPoint = mMapSettings->screenToCoordinate( point );
 
-  const QList<QgsMapLayer *> layers { mMapSettings->mapSettings().layers() };
+  const QList<QgsMapLayer *> layers = mModel->selectedLayer() ? QList<QgsMapLayer *>() << mModel->selectedLayer() : mMapSettings->mapSettings().layers();
   for ( QgsMapLayer *layer : layers )
   {
     if ( !layer->flags().testFlag( QgsMapLayer::Identifiable ) )


### PR DESCRIPTION
This PR fixes a serious data corruption when multi editing features. The problem was that identifying additional features in the canvas while in multi editing mode would identify features from _all_ layers, and silently check/select them as part of the group of features being edited. It slipped through our (well, my :wink:) watchful eyes as the initial implementation did not auto select identified features.

The solution is to refine the identification of features to _only append features from the layer within which features are selected_. 

@lp-dj , this fixes #2082 . Feel free to test and confirm things are working as expected for you with these APKs.