### PR TITLE
Fix crash when auto-zoom on feature settings is on and focus is taken away from an open feature form

### DIFF
--- a/src/core/featurelistextentcontroller.cpp
+++ b/src/core/featurelistextentcontroller.cpp
@@ -47,27 +47,30 @@ void FeatureListExtentController::requestFeatureFormState()
 
 void FeatureListExtentController::zoomToSelected( bool skipIfIntersects ) const
 {
-  if ( mModel && mSelection && mMapSettings )
+  if ( mModel && mSelection && mSelection->focusedItem() > -1 && mMapSettings )
   {
     QgsFeature feat = mSelection->focusedFeature();
     QgsVectorLayer *layer = mSelection->focusedLayer();
 
-    QgsCoordinateTransform transf( layer->crs(), mMapSettings->destinationCrs(), mMapSettings->mapSettings().transformContext() );
-    QgsGeometry geom( feat.geometry() );
-    geom.transform( transf );
-
-    if ( geom.type() == QgsWkbTypes::PointGeometry )
+    if ( layer )
     {
-      if ( !skipIfIntersects || !mMapSettings->extent().intersects( geom.boundingBox() ) )
-        mMapSettings->setCenter( QgsPoint( geom.asPoint() ) );
-    }
-    else
-    {
-      QgsRectangle featureExtent = geom.boundingBox();
-      QgsRectangle bufferedExtent = featureExtent.buffered( std::max( featureExtent.width(), featureExtent.height() ) );
+      QgsCoordinateTransform transf( layer->crs(), mMapSettings->destinationCrs(), mMapSettings->mapSettings().transformContext() );
+      QgsGeometry geom( feat.geometry() );
+      geom.transform( transf );
 
-      if ( !skipIfIntersects || !mMapSettings->extent().intersects( bufferedExtent ) )
-        mMapSettings->setExtent( bufferedExtent );
+      if ( geom.type() == QgsWkbTypes::PointGeometry )
+      {
+        if ( !skipIfIntersects || !mMapSettings->extent().intersects( geom.boundingBox() ) )
+          mMapSettings->setCenter( QgsPoint( geom.asPoint() ) );
+      }
+      else
+      {
+        QgsRectangle featureExtent = geom.boundingBox();
+        QgsRectangle bufferedExtent = featureExtent.buffered( std::max( featureExtent.width(), featureExtent.height() ) );
+
+        if ( !skipIfIntersects || !mMapSettings->extent().intersects( bufferedExtent ) )
+          mMapSettings->setExtent( bufferedExtent );
+      }
     }
   }
 }


### PR DESCRIPTION
This PR safeguards from attempting to auto zoom into a non-feature scenario which results in accessing a null pointer.

@lp-dj , this PR fixes #2050 . Whenever you can, please test APKs and confirm the crash is gone on your device.