### PR TITLE
Reduce feature list model stress by increasing timer and avoiding needless gathers

### DIFF
--- a/src/core/featurelistmodel.cpp
+++ b/src/core/featurelistmodel.cpp
@@ -29,7 +29,7 @@ FeatureListModel::FeatureListModel( QObject *parent )
   : QAbstractItemModel( parent )
   , mCurrentLayer( nullptr )
 {
-  mReloadTimer.setInterval( 100 );
+  mReloadTimer.setInterval( 200 );
   mReloadTimer.setSingleShot( true );
   connect( &mReloadTimer, &QTimer::timeout, this, &FeatureListModel::gatherFeatureList );
 }
@@ -441,6 +441,9 @@ void FeatureListModel::setCurrentFormFeature( const QgsFeature &feature )
     return;
 
   mCurrentFormFeature = feature;
-  reloadLayer();
+
+  if ( !mFilterExpression.isEmpty() && QgsValueRelationFieldFormatter::expressionRequiresFormScope( mFilterExpression ) )
+    reloadLayer();
+
   emit currentFormFeatureChanged();
 }


### PR DESCRIPTION
This PR avoids needless (and possibly quite costly) feature fetching for value relation edit widgets by restricting the feature fetch triggering upon updating the current form feature _only_ when it actually matters (that is to say, only when a filter expression is used that relies on the feature form).

I've also slightly increased the reload timer to 200ms to decrease chance of double fetching whenever multiple properties are set at the same time.

Hoping this will help #2057. 