### PR TITLE
Fix warning when attempting to delete a feature

### DIFF
--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -417,7 +417,14 @@ Rectangle {
     }
 
     onDeleteClicked: {
-        if( trackingModel.featureInTracking(featureForm.selection.focusedLayer, featureForm.selection.model.selectedFeatures) )
+        var selectedFeatures = featureForm.selection.model.selectedFeatures
+        var selectedFeature = selectedFeatures && selectedFeatures.length > 0 ? selectedFeatures[0] : null
+
+        if(
+            selectedFeature
+            && featureForm.selection.focusedLayer
+            && trackingModel.featureInTracking(featureForm.selection.focusedLayer, selectedFeature)
+        )
         {
           displayToast( qsTr( "A number of features are being tracked, stop tracking to delete those" ) )
         }


### PR DESCRIPTION
1) select a single feature
2) open the feature form
3) attempt to delete

```
Could not convert argument 1 at onDeleteClicked@qrc:/qml…/FeatureListForm.qml:424
```