### PR TITLE
Fix relation combobox's bad black text color for null values in read mode

### DIFF
--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -310,7 +310,7 @@ Item {
                 height: fontMetrics.height + 20
                 text: comboBox.displayText
                 font: comboBox.font
-                color: value === undefined || enabled ? 'black' : 'gray'
+                color: value === undefined || !enabled ? 'gray' : 'black'
                 horizontalAlignment: Text.AlignLeft
                 verticalAlignment: Text.AlignVCenter
                 elide: Text.ElideRight


### PR DESCRIPTION
This fixes one of the increasingly small number of visual inconsistencies with the feature form. We're getting there.