### PR TITLE
Fix broken config-less field relation reference edit widget

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -696,7 +696,12 @@ QgsEditorWidgetSetup AttributeFormModelBase::findBest( const int fieldIndex )
       setup = QgsEditorWidgetSetup( QStringLiteral( "Range" ), QVariantMap() );
     //if it's a foreign key configured in a relation take "RelationReference"
     if ( !mLayer->referencingRelations( fieldIndex ).isEmpty() )
-      setup = QgsEditorWidgetSetup( QStringLiteral( "RelationReference" ), QVariantMap() );
+    {
+      QgsRelation relation = mLayer->referencingRelations( fieldIndex )[0];
+      QVariantMap config;
+      config.insert( QStringLiteral( "Relation" ), relation.id() );
+      setup = QgsEditorWidgetSetup( QStringLiteral( "RelationReference" ), config );
+    }
   }
 
   return setup;

--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -700,6 +700,8 @@ QgsEditorWidgetSetup AttributeFormModelBase::findBest( const int fieldIndex )
       QgsRelation relation = mLayer->referencingRelations( fieldIndex )[0];
       QVariantMap config;
       config.insert( QStringLiteral( "Relation" ), relation.id() );
+      config.insert( QStringLiteral( "AllowAddFeatures" ), false );
+      config.insert( QStringLiteral( "ShowOpenFormButton" ), true );
       setup = QgsEditorWidgetSetup( QStringLiteral( "RelationReference" ), config );
     }
   }

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -12,10 +12,10 @@ Item {
 
     property bool useCompleter: false
     property bool useSearch: false
+    property bool allowAddFeature: false
 
     Component.onCompleted: {
         comboBox.currentIndex = featureListModel.findKey(value)
-        addButton.visible = _relation !== undefined ? _relation.isValid : false
         invalidWarning.visible = _relation !== undefined ? !(_relation.isValid) : false
     }
 
@@ -528,7 +528,7 @@ Item {
         }
 
         QfToolButton {
-            id: addButton
+            id: addFeatureButton
 
             Layout.preferredWidth: comboBox.enabled ? 48 : 0
             Layout.preferredHeight: 48
@@ -537,7 +537,7 @@ Item {
             opacity: enabled ? 1 : 0.3
             iconSource: Theme.getThemeIcon("ic_add_black_48dp")
 
-            visible: enabled
+            visible: enabled && allowAddFeature && _relation !== undefined && _relation.isValid
 
             onClicked: {
                 embeddedPopup.state = 'Add'

--- a/src/qml/editorwidgets/RelationReference.qml
+++ b/src/qml/editorwidgets/RelationReference.qml
@@ -21,6 +21,7 @@ EditorWidgetBase {
     anchors { left: parent.left; right: parent.right; rightMargin: showOpenFormButton ? viewButton.width : 0 }
     enabled: isEnabled
     useSearch: true
+    allowAddFeature: config['AllowAddFeatures'] !== undefined && config['AllowAddFeatures'] === true
 
     property var _relation: qgisProject.relationManager.relation(config['Relation'])
 


### PR DESCRIPTION
I *finally* found the scenario under which a relation reference edit widget breaks down and shows a red "invalid relation" label.

Long story short, we were failing to properly setup config-less fields linked to a child relation pair.

@lindacamathias , the test project you shared with me had a couple of these broken relations.