### PR TITLE
Always keep field label color to gray when not editable

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -369,7 +369,7 @@ Page {
               topPadding: 10
               bottomPadding: 5
               color: ConstraintHardValid
-                     ? form.state === 'ReadOnly' || embedded && EditorWidget === 'RelationEditor'
+                     ? ( form.state === 'ReadOnly' || !AttributeEditable ) || embedded && EditorWidget === 'RelationEditor'
                          ? 'grey'
                          : ConstraintSoftValid
                            ? 'black'


### PR DESCRIPTION
Another feature form papercut: when the feature form is in edit mode but a field is read-only, keep the field label grayed out. It improves UX _a lot_, you don't need to wonder whether your field is broken vs. read-only :)

Looks:
![image](https://user-images.githubusercontent.com/1728657/132081074-a8c2b7b0-bd29-477f-9828-985f0d561403.png)

Without graying out the field label, read-only fields such as _Karbonatgrenze_ have a misleading looks, leaving user unsure whether it's a text field that's somewhat broken.