### PR TITLE
Fix geometry operation result enum compatibility workaround

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -370,11 +370,7 @@ void QgisMobileapp::initDeclarative()
   qRegisterMetaType<QVariant::Type>( "QVariant::Type" );
   qRegisterMetaType<QgsDefaultValue>( "QgsDefaultValue" );
   qRegisterMetaType<QgsFieldConstraints>( "QgsFieldConstraints" );
-#if _QGIS_VERSION_INT >= 32100
-  qRegisterMetaType<Qgis::GeometryOperationResult>( "QgsGeometry::OperationResult" );
-#else
-  qRegisterMetaType<QgsGeometry::OperationResult>( "QgsGeometry::OperationResult" );
-#endif
+  qRegisterMetaType<GeometryUtils::GeometryOperationResult>( "GeometryOperationResult" );
   qRegisterMetaType<QFieldCloudConnection::ConnectionStatus>( "QFieldCloudConnection::ConnectionStatus" );
   qRegisterMetaType<CloudUserInformation>( "CloudUserInformation" );
   qRegisterMetaType<QFieldCloudProjectsModel::ProjectStatus>( "QFieldCloudProjectsModel::ProjectStatus" );
@@ -388,7 +384,6 @@ void QgisMobileapp::initDeclarative()
   qmlRegisterUncreatableType<QgsWkbTypes>( "org.qgis", 1, 0, "QgsWkbTypes", "" );
   qmlRegisterUncreatableType<QgsMapLayer>( "org.qgis", 1, 0, "MapLayer", "" );
   qmlRegisterUncreatableType<QgsVectorLayer>( "org.qgis", 1, 0, "VectorLayerStatic", "" );
-  qmlRegisterUncreatableType<QgsGeometry>( "org.qgis", 1, 0, "QgsGeometryStatic", "" );
 
   // Register QgsQuick QML types
   qmlRegisterType<QgsQuickMapCanvasMap>( "org.qgis", 1, 0, "MapCanvasMap" );

--- a/src/core/utils/geometryutils.cpp
+++ b/src/core/utils/geometryutils.cpp
@@ -38,26 +38,18 @@ QgsGeometry GeometryUtils::polygonFromRubberband( RubberbandModel *rubberBandMod
   return g;
 }
 
-GeometryOperationResult GeometryUtils::reshapeFromRubberband( QgsVectorLayer *layer, QgsFeatureId fid, RubberbandModel *rubberBandModel )
+GeometryUtils::GeometryOperationResult GeometryUtils::reshapeFromRubberband( QgsVectorLayer *layer, QgsFeatureId fid, RubberbandModel *rubberBandModel )
 {
   QgsFeature feature = layer->getFeature( fid );
   QgsGeometry geom = feature.geometry();
   if ( geom.isNull() || ( QgsWkbTypes::geometryType( geom.wkbType() ) != QgsWkbTypes::LineGeometry && QgsWkbTypes::geometryType( geom.wkbType() ) != QgsWkbTypes::PolygonGeometry ) )
-#if _QGIS_VERSION_INT >= 32100
-    return Qgis::GeometryOperationResult::InvalidBaseGeometry;
-#else
-    return QgsGeometry::InvalidBaseGeometry;
-#endif
+    return GeometryUtils::GeometryOperationResult::InvalidBaseGeometry;
 
   QgsPointSequence points = rubberBandModel->pointSequence( layer->crs(), QgsWkbTypes::Point, false );
   QgsLineString reshapeLineString( points );
 
-  GeometryOperationResult reshapeReturn = geom.reshapeGeometry( reshapeLineString );
-#if _QGIS_VERSION_INT >= 32100
-  if ( reshapeReturn == Qgis::GeometryOperationResult::Success )
-#else
-  if ( reshapeReturn == QgsGeometry::Success )
-#endif
+  GeometryUtils::GeometryOperationResult reshapeReturn = static_cast<GeometryUtils::GeometryOperationResult>( geom.reshapeGeometry( reshapeLineString ) );
+  if ( reshapeReturn == GeometryUtils::GeometryOperationResult::Success )
   {
     //avoid intersections on polygon layers
     if ( layer->geometryType() == QgsWkbTypes::PolygonGeometry )
@@ -83,11 +75,7 @@ GeometryOperationResult GeometryUtils::reshapeFromRubberband( QgsVectorLayer *la
 
       if ( geom.isEmpty() ) //intersection removal might have removed the whole geometry
       {
-#if _QGIS_VERSION_INT >= 32100
-        return Qgis::GeometryOperationResult::NothingHappened;
-#else
-        return QgsGeometry::NothingHappened;
-#endif
+        return GeometryUtils::GeometryOperationResult::NothingHappened;
       }
     }
     layer->changeGeometry( fid, geom );
@@ -102,7 +90,7 @@ GeometryOperationResult GeometryUtils::reshapeFromRubberband( QgsVectorLayer *la
   return reshapeReturn;
 }
 
-GeometryOperationResult GeometryUtils::addRingFromRubberband( QgsVectorLayer *layer, QgsFeatureId fid, RubberbandModel *rubberBandModel )
+GeometryUtils::GeometryOperationResult GeometryUtils::addRingFromRubberband( QgsVectorLayer *layer, QgsFeatureId fid, RubberbandModel *rubberBandModel )
 {
   QgsPointSequence ring = rubberBandModel->pointSequence( layer->crs(), layer->wkbType(), true );
 
@@ -115,13 +103,13 @@ GeometryOperationResult GeometryUtils::addRingFromRubberband( QgsVectorLayer *la
     if ( !geometry.isNull() )
       static_cast<QgsLineString *>( geometry.get() )->points( ring );
   }
-  return layer->addRing( ring, &fid );
+  return static_cast<GeometryUtils::GeometryOperationResult>( layer->addRing( ring, &fid ) );
 }
 
-GeometryOperationResult GeometryUtils::splitFeatureFromRubberband( QgsVectorLayer *layer, RubberbandModel *rubberBandModel )
+GeometryUtils::GeometryOperationResult GeometryUtils::splitFeatureFromRubberband( QgsVectorLayer *layer, RubberbandModel *rubberBandModel )
 {
   QgsPointSequence line = rubberBandModel->pointSequence( layer->crs(), QgsWkbTypes::Point, false );
-  return layer->splitFeatures( line, true );
+  return static_cast<GeometryUtils::GeometryOperationResult>( layer->splitFeatures( line, true ) );
 }
 
 QgsPoint GeometryUtils::coordinateToPoint( const QGeoCoordinate &coor )

--- a/src/core/utils/geometryutils.h
+++ b/src/core/utils/geometryutils.h
@@ -28,16 +28,35 @@
 class QgsVectorLayer;
 class RubberbandModel;
 
-#if _QGIS_VERSION_INT >= 32100
-typedef Qgis::GeometryOperationResult GeometryOperationResult;
-#else
-typedef QgsGeometry::OperationResult GeometryOperationResult;
-#endif
-
 class QFIELD_CORE_EXPORT GeometryUtils : public QObject
 {
     Q_OBJECT
   public:
+
+    // Copy of the QGIS GeometryOperationResult enum, needed to keep compatibility with QGIS < 3.22
+    enum class GeometryOperationResult : int
+    {
+      Success = 0, //!< Operation succeeded
+      NothingHappened = 1000, //!< Nothing happened, without any error
+      InvalidBaseGeometry, //!< The base geometry on which the operation is done is invalid or empty
+      InvalidInputGeometryType, //!< The input geometry (ring, part, split line, etc.) has not the correct geometry type
+      SelectionIsEmpty, //!< No features were selected
+      SelectionIsGreaterThanOne, //!< More than one features were selected
+      GeometryEngineError, //!< Geometry engine misses a method implemented or an error occurred in the geometry engine
+      LayerNotEditable, //!< Cannot edit layer
+      /* Add part issues */
+      AddPartSelectedGeometryNotFound, //!< The selected geometry cannot be found
+      AddPartNotMultiGeometry, //!< The source geometry is not multi
+      /* Add ring issues*/
+      AddRingNotClosed, //!< The input ring is not closed
+      AddRingNotValid, //!< The input ring is not valid
+      AddRingCrossesExistingRings, //!< The input ring crosses existing rings (it is not disjoint)
+      AddRingNotInExistingFeature, //!< The input ring doesn't have any existing ring to fit into
+      /* Split features */
+      SplitCannotSplitPoint, //!< Cannot split points
+    };
+    Q_ENUM( GeometryOperationResult )
+
     explicit GeometryUtils( QObject *parent = nullptr );
 
     //! Returns a QgsGeometry with a polygon by using the point sequence in the rubberband model.

--- a/src/qml/geometry_editors/FillRingToolBar.qml
+++ b/src/qml/geometry_editors/FillRingToolBar.qml
@@ -64,15 +64,15 @@ VisibilityFadingRow {
       if (!featureModel.currentLayer.editBuffer())
         featureModel.currentLayer.startEditing()
       var result = GeometryUtils.addRingFromRubberband(featureModel.currentLayer, featureModel.feature.id, rubberbandModel)
-      if ( result !== QgsGeometryStatic.Success )
+      if ( result !== GeometryUtils.Success )
       {
-        if ( result === QgsGeometryStatic.AddRingNotClosed )
+        if ( result === GeometryUtils.AddRingNotClosed )
           displayToast( qsTr( 'The ring is not closed' ), 'error' );
-        else if ( result === QgsGeometryStatic.AddRingNotValid )
+        else if ( result === GeometryUtils.AddRingNotValid )
           displayToast( qsTr( 'The ring is not valid' ), 'error' );
-        else if ( result === QgsGeometryStatic.AddRingCrossesExistingRings )
+        else if ( result === GeometryUtils.AddRingCrossesExistingRings )
           displayToast( qsTr( 'The ring crosses existing rings (it is not disjoint)' ), 'error' );
-        else if ( result === QgsGeometryStatic.AddRingNotInExistingFeature )
+        else if ( result === GeometryUtils.AddRingNotInExistingFeature )
           displayToast( qsTr( 'The ring doesn\'t have any existing ring to fit into' ), 'error' );
         else
           displayToast( qsTr( 'Unknown error when creating the ring' ), 'error' );

--- a/src/qml/geometry_editors/ReshapeToolBar.qml
+++ b/src/qml/geometry_editors/ReshapeToolBar.qml
@@ -57,7 +57,7 @@ VisibilityFadingRow {
             if (!featureModel.currentLayer.editBuffer())
                 featureModel.currentLayer.startEditing()
             var result = GeometryUtils.reshapeFromRubberband(featureModel.currentLayer, featureModel.feature.id, rubberbandModel)
-            if ( result !== QgsGeometryStatic.Success )
+            if ( result !== GeometryUtils.Success )
             {
                 displayToast( qsTr( 'The geometry could not be reshaped' ), 'error' );
                 featureModel.currentLayer.rollBack()

--- a/src/qml/geometry_editors/SplitFeatureToolbar.qml
+++ b/src/qml/geometry_editors/SplitFeatureToolbar.qml
@@ -48,7 +48,7 @@ VisibilityFadingRow {
         featureModel.currentLayer.startEditing()
 
       var result = GeometryUtils.splitFeatureFromRubberband(featureModel.currentLayer, drawLineToolbar.rubberbandModel)
-      if ( result !== QgsGeometryStatic.Success )
+      if ( result !== GeometryUtils.Success )
       {
         displayToast( qsTr( 'Feature could not be split' ), 'error' );
         featureModel.currentLayer.rollBack()

--- a/test/test_geometryutils.cpp
+++ b/test/test_geometryutils.cpp
@@ -56,22 +56,14 @@ TEST_CASE( "GeometryUtils" )
   SECTION( "   AddRingFromRubberband" )
   {
     REQUIRE( mLayer->startEditing() );
-#if _QGIS_VERSION_INT >= 32100
-    REQUIRE( GeometryUtils::addRingFromRubberband( mLayer.get(), 100, model.get() ) == Qgis::GeometryOperationResult::AddRingNotInExistingFeature );
-#else
-    REQUIRE( GeometryUtils::addRingFromRubberband( mLayer.get(), 100, model.get() ) == QgsGeometry::AddRingNotInExistingFeature );
-#endif
+    REQUIRE( GeometryUtils::addRingFromRubberband( mLayer.get(), 100, model.get() ) == GeometryUtils::GeometryOperationResult::AddRingNotInExistingFeature );
 
     model->addVertexFromPoint( QgsPoint( 8.1, 8.1 ) );
     model->addVertexFromPoint( QgsPoint( 8.9, 8.1 ) );
     model->addVertexFromPoint( QgsPoint( 8.1, 8.9 ) );
     mLayer->select( 1 );
 
-#if _QGIS_VERSION_INT >= 32100
-    REQUIRE( GeometryUtils::addRingFromRubberband( mLayer.get(), 1, model.get() ) == Qgis::GeometryOperationResult::Success );
-#else
-    REQUIRE( GeometryUtils::addRingFromRubberband( mLayer.get(), 1, model.get() ) == QgsGeometry::Success );
-#endif
+    REQUIRE( GeometryUtils::addRingFromRubberband( mLayer.get(), 1, model.get() ) == GeometryUtils::GeometryOperationResult::Success );
     REQUIRE( mLayer->rollBack() );
   }
 
@@ -79,21 +71,13 @@ TEST_CASE( "GeometryUtils" )
   SECTION( "SplitFeatureFromRubberband" )
   {
     REQUIRE( mLayer->startEditing() );
-#if _QGIS_VERSION_INT >= 32100
-    REQUIRE( GeometryUtils::splitFeatureFromRubberband( mLayer.get(), model.get() ) == Qgis::GeometryOperationResult::NothingHappened );
-#else
-    REQUIRE( GeometryUtils::splitFeatureFromRubberband( mLayer.get(), model.get() ) == QgsGeometry::NothingHappened );
-#endif
+    REQUIRE( GeometryUtils::splitFeatureFromRubberband( mLayer.get(), model.get() ) == GeometryUtils::GeometryOperationResult::NothingHappened );
 
     model->addVertexFromPoint( QgsPoint( 7.5, 8.5 ) );
     model->addVertexFromPoint( QgsPoint( 9.5, 8.5 ) );
     mLayer->select( 1 );
 
-#if _QGIS_VERSION_INT >= 32100
-    REQUIRE( GeometryUtils::splitFeatureFromRubberband( mLayer.get(), model.get() ) == Qgis::GeometryOperationResult::Success );
-#else
-    REQUIRE( GeometryUtils::splitFeatureFromRubberband( mLayer.get(), model.get() ) == QgsGeometry::Success );
-#endif
+    REQUIRE( GeometryUtils::splitFeatureFromRubberband( mLayer.get(), model.get() ) == GeometryUtils::GeometryOperationResult::Success );
     REQUIRE( mLayer->rollBack() );
   }
 


### PR DESCRIPTION
This fixes #2131 -- a while back, I added a GeometryOperationResult enum compatibility workaround to support QField compilation against QGIS 3.22 and pre 3.22. That enum used to live in QgsGeometry pre 3.22, and is now in Qgis. My compatibility workaround was :hankey: , this fixes things.

