### PR TITLE
When copying share assets on update, wipe pre-existing share folder

### DIFF
--- a/src/core/utils/fileutils.cpp
+++ b/src/core/utils/fileutils.cpp
@@ -53,10 +53,17 @@ bool FileUtils::fileExists( const QString &filePath )
   return ( fileInfo.exists() && fileInfo.isFile() );
 }
 
-bool FileUtils::copyRecursively( const QString &sourceFolder, const QString &destFolder, QgsFeedback *feedback )
+bool FileUtils::copyRecursively( const QString &sourceFolder, const QString &destFolder, QgsFeedback *feedback, bool wipeDestFolder )
 {
-  QList<QPair<QString, QString>> mapping;
+  // Remove the destination folder and its content if it already exists
+  if ( wipeDestFolder )
+  {
+    QDir destDir( destFolder );
+    if ( destDir.exists() )
+      destDir.removeRecursively();
+  }
 
+  QList<QPair<QString, QString>> mapping;
   int fileCount = copyRecursivelyPrepare( sourceFolder, destFolder, mapping );
 
   int current = 0;

--- a/src/core/utils/fileutils.h
+++ b/src/core/utils/fileutils.h
@@ -40,7 +40,7 @@ class QFIELD_CORE_EXPORT FileUtils : public QObject
     Q_INVOKABLE static bool fileExists( const QString &filePath );
     //! returns the suffix (extension)
     Q_INVOKABLE static QString fileSuffix( const QString &filePath );
-    static bool copyRecursively( const QString &sourceFolder, const QString &destFolder, QgsFeedback *feedback );
+    static bool copyRecursively( const QString &sourceFolder, const QString &destFolder, QgsFeedback *feedback, bool wipeDestFolder = true );
     /**
      * Creates checksum of a file. Returns null QByteArray if cannot be calculated.
      *


### PR DESCRIPTION
@m-kuhn , this is needed for people who would update from QField 1.9 to QField 2.0. Since QGIS 3.22 renamed its provider plugins, not wiping the share folder means we'd end up with users having a share/plugins directory containing provider plugins from both QGIS 3.20 and 3.22. I assume this can lead to crashes.

