### PR TITLE
fix cloud projects location

### DIFF
--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -17,6 +17,7 @@
 
 #include <QDir>
 #include <QString>
+#include <QStandardPaths>
 #include <qgsapplication.h>
 #include <qgsmessagelog.h>
 
@@ -30,7 +31,7 @@ void QFieldCloudUtils::setLocalCloudDirectory( const QString &path )
 const QString QFieldCloudUtils::localCloudDirectory()
 {
   QString cloudDirectoryPath = sLocalCloudDirectory.isNull()
-                               ? QFileInfo( QgsApplication::qgisSettingsDirPath() ).canonicalFilePath() + QStringLiteral( "/cloud_projects" )
+                               ? QStandardPaths::writableLocation( QStandardPaths::AppDataLocation ) + QStringLiteral( "/cloud_projects" )
                                : sLocalCloudDirectory;
   return cloudDirectoryPath;
 }


### PR DESCRIPTION
on iOS the settings dir is not writable, use QStandardPaths::writableLocation( QStandardPaths::AppDataLocation ) instead