### PR TITLE
Improve login screen on small vertical screen space

### DIFF
--- a/src/qml/QFieldCloudLogin.qml
+++ b/src/qml/QFieldCloudLogin.qml
@@ -55,7 +55,9 @@ Item {
 
     ColumnLayout {
       Layout.fillWidth: true
+      Layout.fillHeight: true
       Layout.maximumWidth: 410
+      Layout.minimumHeight: 800
       Layout.alignment: Qt.AlignHCenter
       spacing: 10
 
@@ -71,20 +73,6 @@ Item {
           anchors.fill: parent
           onDoubleClicked: toggleServerUrlEditing()
         }
-      }
-
-      Text {
-        id: cloudIntroLabel
-        Layout.fillWidth: true
-        text: '<style>a, a:hover, a:visited { color:' + Theme.mainColor + '; }></style>' +
-              qsTr( 'The easiest way to transfer you project from QGIS to your devices!' ) +
-              ' <a href="https://qfield.cloud/">' + qsTr( 'Learn more about QFieldCloud' ) + '</a>.'
-        horizontalAlignment: Text.AlignHCenter
-        font: Theme.defaultFont
-        textFormat: Text.RichText
-        wrapMode: Text.WordWrap
-
-        onLinkActivated: Qt.openUrlExternally(link)
       }
 
       Text {
@@ -242,6 +230,26 @@ Item {
         enabled: cloudConnection.status != QFieldCloudConnection.Connecting
 
         onClicked: loginFormSumbitHandler()
+      }
+
+      Text {
+        id: cloudIntroLabel
+        Layout.fillWidth: true
+        text: '<style>a, a:hover, a:visited { color:' + Theme.mainColor + '; }></style>' +
+              qsTr( 'The easiest way to transfer you project from QGIS to your devices!' ) +
+              ' <a href="https://qfield.cloud/">' + qsTr( 'Learn more about QFieldCloud' ) + '</a>.'
+        horizontalAlignment: Text.AlignHCenter
+        font: Theme.defaultFont
+        textFormat: Text.RichText
+        wrapMode: Text.WordWrap
+
+        onLinkActivated: Qt.openUrlExternally(link)
+      }
+
+      Item {
+          // spacer item
+          Layout.fillWidth: true
+          Layout.fillHeight: true
       }
     }
   }

--- a/src/qml/QFieldCloudLogin.qml
+++ b/src/qml/QFieldCloudLogin.qml
@@ -57,11 +57,12 @@ Item {
       Layout.fillWidth: true
       Layout.fillHeight: true
       Layout.maximumWidth: 410
-      Layout.minimumHeight: 800
+      Layout.minimumHeight: (logo.height + fontMetrics.height * 9) * 2
       Layout.alignment: Qt.AlignHCenter
       spacing: 10
 
       Image {
+        id: logo
         Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
         fillMode: Image.PreserveAspectFit
         smooth: true

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -32,35 +32,6 @@ Popup {
     }
 
     ColumnLayout {
-      visible: cloudProjectsModel.currentProjectId && cloudConnection.status !== QFieldCloudConnection.LoggedIn
-      id: connectionSettings
-      anchors.fill: parent
-      spacing: 2
-
-      ScrollView {
-        Layout.fillWidth: true
-        Layout.fillHeight: true
-        Layout.margins: 10
-        height: parent.height
-        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
-        ScrollBar.vertical.policy: ScrollBar.AsNeeded
-        contentWidth: qfieldCloudLogin.width
-        contentHeight: qfieldCloudLogin.childrenRect.height
-        clip: true
-
-        QFieldCloudLogin {
-          id: qfieldCloudLogin
-          width: parent.parent.width
-        }
-      }
-
-      Item {
-          Layout.fillHeight: true
-          height: 15
-      }
-    }
-
-    ColumnLayout {
       visible: !cloudProjectsModel.currentProjectId
       anchors.fill: parent
       anchors.margins: 20
@@ -88,7 +59,6 @@ Popup {
     }
 
     ScrollView {
-      visible: cloudProjectsModel.currentProjectId && cloudConnection.status === QFieldCloudConnection.LoggedIn
       padding: 0
       ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
       ScrollBar.vertical.policy: ScrollBar.AsNeeded
@@ -105,6 +75,8 @@ Popup {
         rowSpacing: 2
 
         RowLayout {
+          visible: cloudConnection.status === QFieldCloudConnection.LoggedIn
+
           Text {
               Layout.fillWidth: true
               Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
@@ -154,6 +126,24 @@ Popup {
               layer.enabled: true
               layer.effect: OpacityMask {
                   maskSource: cloudAvatarMask
+              }
+
+              MouseArea {
+                anchors.fill: parent
+
+                onClicked: {
+                  if (cloudConnection.status !== QFieldCloudConnection.LoggedIn ||
+                      cloudProjectsModel.currentProjectData.Status !== QFieldCloudProjectsModel.Idle)
+                      return;
+
+                  if (!connectionSettings.visible) {
+                    connectionSettings.visible = true;
+                    projects.visible = false;
+                  } else {
+                    connectionSettings.visible = false;
+                    projects.visible = true;
+                  }
+                }
               }
             }
           }
@@ -288,12 +278,12 @@ Popup {
         }
 
         GridLayout {
+          id: mainInnerGrid
           Layout.margins: 10
           Layout.maximumWidth: 525
           Layout.alignment: Qt.AlignHCenter
-          id: mainInnerGrid
           width: parent.width
-          visible: cloudConnection.status === QFieldCloudConnection.LoggedIn &&
+          visible: !connectionSettings.visible &&
                    cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Idle
           columns: 1
           columnSpacing: parent.columnSpacing
@@ -481,6 +471,38 @@ Popup {
             wrapMode: Text.WordWrap
             horizontalAlignment: Text.AlignHCenter
             Layout.fillWidth: true
+          }
+        }
+
+        ColumnLayout {
+          id: connectionSettings
+          Layout.fillWidth: true
+          Layout.fillHeight: true
+          spacing: 2
+
+          property bool visibility: false
+          visible: visibility || (cloudProjectsModel.currentProjectId && cloudConnection.status !== QFieldCloudConnection.LoggedIn)
+
+          ScrollView {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            Layout.margins: 10
+            height: parent.height
+            ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+            ScrollBar.vertical.policy: ScrollBar.AsNeeded
+            contentWidth: qfieldCloudLogin.width
+            contentHeight: qfieldCloudLogin.childrenRect.height
+            clip: true
+
+            QFieldCloudLogin {
+              id: qfieldCloudLogin
+              width: parent.parent.width
+            }
+          }
+
+          Item {
+              Layout.fillHeight: true
+              height: 15
           }
         }
       }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -111,7 +111,6 @@ Page {
       Layout.fillWidth: true
       Layout.fillHeight: true
       Layout.margins: 10
-      Layout.topMargin: !connectionInformation.visible ? connectionInformation.height + parent.spacing : 0
       spacing: 2
       visible: !connectionInformation.visible
 

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -45,7 +45,7 @@ Page {
             text: switch(cloudConnection.status) {
                     case 0: qsTr( 'Disconnected from the cloud.' ); break;
                     case 1: qsTr( 'Connecting to the cloud.' ); break;
-                    case 2: qsTr( 'Greetings %1.' ).arg( cloudConnection.username ); break;
+                    case 2: qsTr( 'Greetings <strong>%1</strong>.' ).arg( cloudConnection.username ); break;
                   }
             wrapMode: Text.WordWrap
             font: Theme.tipFont


### PR DESCRIPTION
Doing a couple of things here: a/ trying to increase vertical height to allow scrolling the panel when the virtual keyboard is open, and b/ moving the about label to sit _below_ the user/password/log in button widgets.

![image](https://user-images.githubusercontent.com/1728657/135554860-40b0b961-8d1b-47f3-a866-10a687c2117e.png)
