### PR TITLE
Fix 'logged out' showing when failing to log in

### DIFF
--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -487,23 +487,6 @@ Popup {
     }
   }
 
-  Connections {
-    target: cloudConnection
-
-    function onStatusChanged() {
-      if (cloudConnection.status === QFieldCloudConnection.Disconnected) {
-        displayToast(qsTr('Logged out'))
-      } else if (cloudConnection.status === QFieldCloudConnection.Connecting) {
-        displayToast(qsTr('Connecting...'))
-      } else if (cloudConnection.status === QFieldCloudConnection.LoggedIn) {
-        displayToast(qsTr('Logged in'))
-        if ( cloudProjectsModel.currentProjectId != '' )
-          cloudProjectsModel.refreshProjectDeltaList(cloudProjectsModel.currentProjectId)
-      }
-    }
-  }
-
-
   Dialog {
     id: revertDialog
     parent: mainWindow.contentItem

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2049,6 +2049,21 @@ ApplicationWindow {
 
   QFieldCloudConnection {
     id: cloudConnection
+
+    property int previousStatus: QFieldCloudConnection.Disconnected
+
+    onStatusChanged: {
+      if (cloudConnection.status === QFieldCloudConnection.Disconnected && previousStatus === QFieldCloudConnection.LoggedIn) {
+        displayToast(qsTr('Logged out'))
+      } else if (cloudConnection.status === QFieldCloudConnection.Connecting) {
+        displayToast(qsTr('Connecting...'))
+      } else if (cloudConnection.status === QFieldCloudConnection.LoggedIn) {
+        displayToast(qsTr('Logged in'))
+        if ( cloudProjectsModel.currentProjectId != '' )
+          cloudProjectsModel.refreshProjectDeltaList(cloudProjectsModel.currentProjectId)
+      }
+      previousStatus = cloudConnection.status
+    }
     onLoginFailed: function(reason) { displayToast( reason ) }
   }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2212,9 +2212,9 @@ ApplicationWindow {
         property var type: 'info'
 
         height: toastMessage.height
-        width: 8 + toastMessage.text.length * toastFontMetrics.averageCharacterWidth > mainWindow.width
+        width: 30 + toastMessage.text.length * toastFontMetrics.averageCharacterWidth > mainWindow.width
                ? mainWindow.width - 16
-               : 8 + toastMessage.text.length * toastFontMetrics.averageCharacterWidth
+               : 30 + toastMessage.text.length * toastFontMetrics.averageCharacterWidth
 
         anchors.centerIn: parent
 
@@ -2225,7 +2225,7 @@ ApplicationWindow {
         Rectangle {
           id: toastIndicator
           anchors.left: parent.left
-          anchors.leftMargin: 8
+          anchors.leftMargin: 6
           anchors.verticalCenter: parent.verticalCenter
           width:  10
           height: 10


### PR DESCRIPTION
Ouch, we were duplicating toast messages by having us react to a signal for every instance of QFieldCloudLogin object (not part of the fix in the title, just glad I caught that).

Also fixed an issue where narrow strings displayed in the toast message overlay would overflow to two lines instead of one (eg 'Logged out' would be 'Logged\nout').