### PR TITLE
 Friendlier cloud project synchronization error

### DIFF
--- a/src/core/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloudconnection.cpp
@@ -104,7 +104,7 @@ QString QFieldCloudConnection::errorString( QNetworkReply *reply )
       break;
   }
 
-  int httpCode = reply->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
+  const int httpCode = reply->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
   QString httpErrorMessage = QStringLiteral( "[HTTP/%1] %2 " ).arg( httpCode ).arg( reply->url().toString() );
   httpErrorMessage += ( httpCode >= 400 )
                       ? tr( "Server Error." )

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -251,7 +251,7 @@ Popup {
             titleText: detailsText.startsWith('[QF/')
                        ? qsTr('A server error has occured, please try again.')
                        : qsTr('A network error has occured, please try again.');
-            detailsText: '[HTTP/0] https://dev.qfield.cloud/api/v1/deltas/a5-66c6-4d76-eds4-dsddsa5d45/2dsadsad45-dsa545ddsa-dsa/ Network error'
+            detailsText: ''
 
             Connections {
               target: cloudProjectsModel

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -238,9 +238,24 @@ Popup {
 
         Text {
           id: transferErrorText
+
+          property string errorString: '[QF/invalid] This is an invalid error'
+          property bool showAllErrorString: false
+
           visible: false
-          font: Theme.defaultFont
-          text: ''
+          font: Theme.tipFont
+          text: {
+              if (errorString != '') {
+                  var errorLabel = errorString.startsWith('[QF/')
+                                   ? qsTr('A server error has occured, please try again.')
+                                   : qsTr('A network error has occured, please try again.');
+                  if (showAllErrorString) {
+                      errorLabel += '\n' + errorString;
+                  }
+                  return errorLabel;
+              }
+              return '';
+          }
           color: Theme.darkRed
           wrapMode: Text.WordWrap
           horizontalAlignment: Text.AlignHCenter
@@ -248,7 +263,7 @@ Popup {
 
           MouseArea {
               anchors.fill: parent
-              onClicked: transferErrorDialog.open()
+              onClicked: transferErrorText.showAllErrorString = !transferErrorText.showAllErrorString
           }
 
           Connections {
@@ -258,10 +273,7 @@ Popup {
               transferErrorText.visible = hasError && cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Idle;
 
               if (transferErrorText.visible) {
-                transferErrorText = errorString.startsWith('[QF/')
-                                    ? qsTr('A server error has occured, please try again.')
-                                    : qsTr('A network error has occured, please try again.')
-                transferErrorDialog.errorString = errorString
+                transferErrorText.errorString = errorString
               }
             }
 
@@ -271,10 +283,7 @@ Popup {
               transferErrorText.visible = hasError && projectData.Status === QFieldCloudProjectsModel.Idle;
 
               if (transferErrorText.visible) {
-                  transferErrorText = errorString.startsWith('[QF/')
-                                      ? qsTr('A server error has occured, please try again.')
-                                      : qsTr('A network error has occured, please try again.')
-                  transferErrorDialog.errorString = errorString
+                transferErrorText.errorString = errorString
               }
 
               if (projectData.ExportedLayerErrors.length !== 0)
@@ -519,31 +528,6 @@ Popup {
           }
         }
       }
-    }
-  }
-
-  Dialog {
-    id: transferErrorDialog
-    parent: mainWindow.contentItem
-
-    property string errorString: '[QF/fiction] This is a fictive server error'
-    visible: false
-    modal: true
-
-    x: ( mainWindow.width - width ) / 2
-    y: ( mainWindow.height - height ) / 2
-
-    title: qsTr( "Transfer Error" )
-    Label {
-      width: parent.width
-      wrapMode: Text.WordWrap
-      text: qsTr( "The following error occured while attempting to communicate with the QFieldCloud server:\n\n%1" ).arg( transferErrorDialog.errorString )
-    }
-
-    standardButtons: Dialog.Ok
-
-    onAccepted: {
-      revertLocalChangesFromCurrentProject();
     }
   }
 

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -236,67 +236,50 @@ Popup {
           }
         }
 
-        Text {
-          id: transferErrorText
+        QfCollapsibleMessage {
+            id: transferError
 
-          property string errorString: '[QF/invalid] This is an invalid error'
-          property bool showAllErrorString: false
+            visible: false
 
-          visible: false
-          font: Theme.tipFont
-          text: {
-              if (errorString != '') {
-                  var errorLabel = errorString.startsWith('[QF/')
-                                   ? qsTr('A server error has occured, please try again.')
-                                   : qsTr('A network error has occured, please try again.');
-                  if (showAllErrorString) {
-                      errorLabel += '\n' + errorString;
-                  }
-                  return errorLabel;
-              }
-              return '';
-          }
-          color: Theme.darkRed
-          wrapMode: Text.WordWrap
-          horizontalAlignment: Text.AlignHCenter
-          Layout.fillWidth: true
+            Layout.fillWidth: true
+            Layout.leftMargin: 10
+            Layout.rightMargin: 10
 
-          MouseArea {
-              anchors.fill: parent
-              onClicked: transferErrorText.showAllErrorString = !transferErrorText.showAllErrorString
-          }
+            color: Theme.darkRed
+            font: Theme.tipFont
 
-          Connections {
-            target: cloudProjectsModel
+            titleText: detailsText.startsWith('[QF/')
+                       ? qsTr('A server error has occured, please try again.')
+                       : qsTr('A network error has occured, please try again.');
+            detailsText: '[HTTP/0] https://dev.qfield.cloud/api/v1/deltas/a5-66c6-4d76-eds4-dsddsa5d45/2dsadsad45-dsa545ddsa-dsa/ Network error'
 
-            function onPushFinished(projectId, hasError, errorString) {
-              transferErrorText.visible = hasError && cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Idle;
+            Connections {
+              target: cloudProjectsModel
 
-              if (transferErrorText.visible) {
-                transferErrorText.errorString = errorString
-              }
-            }
+              function onPushFinished(projectId, hasError, errorString) {
+                transferError.visible = hasError && cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Idle;
 
-            function onProjectDownloaded(projectId, projectName, hasError, errorString) {
-              const projectData = cloudProjectsModel.getProjectData(projectId)
-
-              transferErrorText.visible = hasError && projectData.Status === QFieldCloudProjectsModel.Idle;
-
-              if (transferErrorText.visible) {
-                transferErrorText.errorString = errorString
+                if (transferError.visible) {
+                  transferError.detailsText = errorString
+                }
               }
 
-              if (projectData.ExportedLayerErrors.length !== 0)
-              {
-                cloudExportLayersFeedback.exportedLayersListViewModel = projectData.ExportedLayerErrors;
-                cloudExportLayersFeedback.visible = true;
+              function onProjectDownloaded(projectId, projectName, hasError, errorString) {
+                const projectData = cloudProjectsModel.getProjectData(projectId)
+
+                transferError.visible = hasError && projectData.Status === QFieldCloudProjectsModel.Idle;
+
+                if (transferError.visible) {
+                  transferError.detailsText = errorString
+                }
+
+                if (projectData.ExportedLayerErrors.length !== 0)
+                {
+                  cloudExportLayersFeedback.exportedLayersListViewModel = projectData.ExportedLayerErrors;
+                  cloudExportLayersFeedback.visible = true;
+                }
               }
             }
-
-            function onDataChanged() {
-              transferErrorText.visible = cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Idle;
-            }
-          }
         }
 
         GridLayout {

--- a/src/qml/imports/Theme/QfCollapsibleMessage.qml
+++ b/src/qml/imports/Theme/QfCollapsibleMessage.qml
@@ -1,0 +1,89 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+
+import QtQuick.Controls.Material 2.12
+import QtQuick.Controls.Material.impl 2.12
+import QtGraphicalEffects 1.12
+
+import Theme 1.0
+
+Item {
+    property bool collapsed: true
+    property alias color: titleText.color
+    property alias font: titleText.font
+    property alias titleText: titleText.text
+    property alias detailsText: detailsText.text
+
+    clip: true
+    height: collapsed ? titleText.height + 1 : titleText.height + detailsText.height + 1
+    implicitHeight: height
+
+    Behavior on height {
+        NumberAnimation { duration: 100; easing.type: Easing.InQuad; }
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        color: "transparent"
+        border.color: titleText.color
+        border.width: 1
+        radius: 12
+        clip: true
+    }
+
+    Text {
+        id: titleText
+
+        width: parent.width - 5
+        anchors.top: parent.top
+        anchors.left: parent.left
+        padding: 5
+        clip: true
+
+        font: Theme.defaultFont
+        color: "black"
+
+        horizontalAlignment: Text.AlignHCenter
+        wrapMode: Text.WordWrap
+    }
+
+    Rectangle {
+        id: separator
+
+        width: parent.width - 24
+        anchors.top: titleText.bottom
+        anchors.left: parent.left
+        anchors.leftMargin: 12
+
+        height: 1
+        color: titleText.color
+    }
+
+    Text {
+        id: detailsText
+
+        width: parent.width - 5
+        anchors.top: separator.bottom
+        anchors.left: parent.left
+        padding: 5
+        clip: true
+
+        font.pointSize: titleText.font.pointSize / 1.5
+        font.weight: titleText.font.weight
+        font.italic: titleText.font.italic
+        font.family: titleText.font.family
+
+        color: titleText.color
+
+        horizontalAlignment: Text.AlignHCenter
+        wrapMode: Text.WordWrap
+    }
+
+    MouseArea {
+        anchors.fill: parent
+
+        onClicked: {
+            parent.collapsed = !parent.collapsed
+        }
+    }
+}

--- a/src/qml/imports/Theme/QfCollapsibleMessage.qml
+++ b/src/qml/imports/Theme/QfCollapsibleMessage.qml
@@ -23,12 +23,14 @@ Item {
     }
 
     Rectangle {
+        id: background
         anchors.fill: parent
+
         color: "transparent"
         border.color: titleText.color
         border.width: 1
+        opacity: 0.25
         radius: 12
-        clip: true
     }
 
     Text {
@@ -57,6 +59,7 @@ Item {
 
         height: 1
         color: titleText.color
+        opacity: 0.25
     }
 
     Text {
@@ -74,6 +77,7 @@ Item {
         font.family: titleText.font.family
 
         color: titleText.color
+        opacity: 0.25
 
         horizontalAlignment: Text.AlignHCenter
         wrapMode: Text.WordWrap

--- a/src/qml/imports/Theme/qmldir
+++ b/src/qml/imports/Theme/qmldir
@@ -4,3 +4,4 @@ QfSwitch 1.0 QfSwitch.qml
 QfButton 1.0 QfButton.qml
 QfToolButton 1.0 QfToolButton.qml
 QfTextField 1.0 QfTextField.qml
+QfCollapsibleMessage 1.0 QfCollapsibleMessage.qml

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -57,6 +57,7 @@
         <file>imports/Theme/QfButton.qml</file>
         <file>imports/Theme/QfSwitch.qml</file>
         <file>imports/Theme/QfTextField.qml</file>
+        <file>imports/Theme/QfCollapsibleMessage.qml</file>
         <file>imports/Theme/qmldir</file>
         <file>PageHeader.qml</file>
         <file>Tracking.qml</file>


### PR DESCRIPTION
In action:

https://user-images.githubusercontent.com/1728657/135615807-726492d9-09d4-4d75-81af-3ee2967d2d49.mp4

This PR hides the advanced error strings behind a click on the error label. By default, a friendlier, more generic error is shown. Advanced errors are a/ scary, b/ not helpful for the avg. user, and c/ mostly there for debugging. By hiding those behind a click, we're still able to do remote debugging / help, while looking friendlier by default.