### PR TITLE
Fix crash when activating multiselect with a focused item leading to mixed layer scenario

### DIFF
--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -435,10 +435,10 @@ Rectangle {
     }
 
     onToggleMultiSelection: {
+        featureForm.selection.focusedItem = -1;
         if ( featureForm.multiSelection ) {
             featureFormList.model.featureModel.modelMode = FeatureModel.SingleFeatureModel
             featureForm.selection.model.clearSelection();
-            featureForm.selection.focusedItem = -1;
         } else {
             featureFormList.model.featureModel.modelMode = FeatureModel.MultiFeatureModel
         }


### PR DESCRIPTION
This fixes the bang! reported by @suricactus in #2178. Good catch.