### PR TITLE
Make the feature list form be a good citizen by not always taking over escapes and back button events

### DIFF
--- a/src/qml/EmbeddedFeatureForm.qml
+++ b/src/qml/EmbeddedFeatureForm.qml
@@ -32,7 +32,7 @@ Popup {
     }
 
     onAboutToShow: {
-        if( state === 'Add' ) {
+        if (state === 'Add') {
            form.featureCreated = false;
            formFeatureModel.resetAttributes();
         }
@@ -85,11 +85,11 @@ Popup {
             closePopup()
         }
 
-        function closePopup(){
-            if( formPopup.opened ){
+        function closePopup() {
+            if (formPopup.opened) {
                 isSaved = true
                 formPopup.close()
-            }else{
+            } else {
                 isSaved = false
             }
         }

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -479,6 +479,10 @@ Rectangle {
 
   Keys.onReleased: {
       if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
+          // if visible overlays (such as embedded feature forms) are present, don't take over
+          if (ApplicationWindow.overlay.visibleChildren.length > 0)
+              return;
+
           if (state != "FeatureList") {
               if (featureListToolBar.state === "Edit") {
                   if (featureFormList.model.constraintsHardValid) {


### PR DESCRIPTION
This PR fixes #2106 by ensuring that escape and back button events are passed on to visible application overlay widgets when their presence are detected.