### PR TITLE
Fix QField freeze when toggling to digitize mode…

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -767,7 +767,7 @@ ApplicationWindow {
     function ensureEditableLayerSelected() {
       var firstEditableLayer = null;
       var currentLayerLocked = false;
-      for (var i = 0; layerTree.rowCount(); i++)
+      for (var i = 0; i < layerTree.rowCount(); i++)
       {
         var index = layerTree.index(i,0)
         if (firstEditableLayer === null)


### PR DESCRIPTION
…with projects containing no editable layers.

That's a rather unfortunate typo, not sure why it took so long to get to our attention. Fixes #2135.