### PR TITLE
revert to xargs to avoid failing without error

### DIFF
--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -199,7 +199,8 @@ jobs:
             pushd "${{ steps.vars.outputs.VCPKG_ROOT }}"
             ./vcpkg integrate install
             popd
-            ./scripts/ci/pull_translations.sh
+            #  lrelease is not installed yet
+            # ./scripts/ci/pull_translations.sh
           fi
 
       - name: 🌋 Build

--- a/scripts/ci/pull_translations.sh
+++ b/scripts/ci/pull_translations.sh
@@ -15,5 +15,5 @@ for x in android/res/values-*_*;do mv $x $(echo $x | sed -e 's/_/-r/') ;done
 echo "::endgroup::"
 
 echo "::group::lrelease"
-find ${DIR}/../../i18n -type f -name "*.ts" -exec lrelease "{}" \;
+find ${DIR}/../../i18n -type f -name "*.ts" | xargs lrelease
 echo "::endgroup::"


### PR DESCRIPTION
I switched to xargs to actually get an error if lrelease or the command fails.

If lrelease is not available on vcpkg CI for now, let's just not pull the translations instead of silently failing.