### PR TITLE
Enable (non-native) camera on linux's AppImage

### DIFF
--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -222,7 +222,7 @@ jobs:
 
           source ./scripts/version_number.sh
           source ./scripts/ci/generate-version-details.sh
-          source /opt/qt514/bin/qt514-env.sh
+          # source /opt/qt514/bin/qt514-env.sh
 
           overlay_ports=(${WORKSPACE}/${{ steps.vars.outputs.OVERLAY }} ${WORKSPACE}/vcpkg/overlay)
           echo "Building with $(IFS=\; ; echo "${overlay_ports[*]}")"

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -223,6 +223,8 @@ jobs:
           source ./scripts/version_number.sh
           source ./scripts/ci/generate-version-details.sh
           # source /opt/qt514/bin/qt514-env.sh
+          cat /opt/qt514/bin/qt514-env.sh
+          /opt/qt514/bin/qt514-env.sh
 
           overlay_ports=(${WORKSPACE}/${{ steps.vars.outputs.OVERLAY }} ${WORKSPACE}/vcpkg/overlay)
           echo "Building with $(IFS=\; ; echo "${overlay_ports[*]}")"

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -21,7 +21,7 @@ jobs:
             os: 'windows-2019'
 
           - triplet: 'x64-linux'
-            os: 'ubuntu-20.04'
+            os: 'ubuntu-18.04'
 
           - triplet: 'x64-osx'
             os: 'macos-10.15'
@@ -157,21 +157,23 @@ jobs:
           sudo apt clean
           df -h
 
-      - name: 💐 Install Qt
-        if: ${{ steps.vars.outputs.INSTALL_QT }}
-        uses: jurplel/install-qt-action@v2
-        with:
-          version: 5.15.2
-          modules: 'qtcharts'
-          target: ${{ steps.vars.outputs.QT_TARGET }}
-          arch: ${{ steps.vars.outputs.QT_ARCH }}
+          #      - name: 💐 Install Qt
+          #        if: ${{ steps.vars.outputs.INSTALL_QT }}
+          #        uses: jurplel/install-qt-action@v2
+          #        with:
+          #          version: 5.15.2
+          #          modules: 'qtcharts'
+          #          target: ${{ steps.vars.outputs.QT_TARGET }}
+          #          arch: ${{ steps.vars.outputs.QT_ARCH }}
 
       - name: 🐧 Prepare linux build env
         if: ${{ matrix.triplet == 'x64-linux' }}
         run: |
+          sudo add-apt-repository ppa:beineri/opt-qt-5.14.2-bionic
           sudo apt-get update
-          sudo apt-get install -y gperf autopoint '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-bad
+          sudo apt-get install -y gperf autopoint '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev qt514-meta-full
           sudo apt-get remove -y libopenexr-dev # Avoid gdal picking this system lib up
+
           # Required to run unit tests on linux
           echo "QT_QPA_PLATFORM=offscreen" >> $GITHUB_ENV
           echo "TESTWRAPPER=xvfb-run" >> $GITHUB_ENV
@@ -182,7 +184,7 @@ jobs:
         uses: miurahr/install-linuxdeploy-action@v1
         with:
           dir: ${{ steps.vars.outputs.BUILD_ROOT }}
-          plugins: qt appimage gstreamer
+          plugins: qt appimage
 
       - name: 🌍 Pull Translations
         shell: bash
@@ -219,6 +221,7 @@ jobs:
 
           source ./scripts/version_number.sh
           source ./scripts/ci/generate-version-details.sh
+          source /opt/qt514/bin/qt514-env.sh
 
           overlay_ports=(${WORKSPACE}/${{ steps.vars.outputs.OVERLAY }} ${WORKSPACE}/vcpkg/overlay)
           echo "Building with $(IFS=\; ; echo "${overlay_ports[*]}")"

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -170,7 +170,7 @@ jobs:
         if: ${{ matrix.triplet == 'x64-linux' }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y gperf autopoint '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev
+          sudo apt-get install -y gperf autopoint '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-bad
           sudo apt-get remove -y libopenexr-dev # Avoid gdal picking this system lib up
           # Required to run unit tests on linux
           echo "QT_QPA_PLATFORM=offscreen" >> $GITHUB_ENV
@@ -182,7 +182,7 @@ jobs:
         uses: miurahr/install-linuxdeploy-action@v1
         with:
           dir: ${{ steps.vars.outputs.BUILD_ROOT }}
-          plugins: qt appimage
+          plugins: qt appimage gstreamer
 
       - name: 🌍 Pull Translations
         shell: bash

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -192,6 +192,7 @@ jobs:
           if [[ -z "${TX_TOKEN}" ]]; then
             echo "TX_TOKEN not set, skip tx pull"
           else
+            sudo apt-get install python3-setuptools
             pip3 install transifex-client
             pushd "${{ steps.vars.outputs.VCPKG_ROOT }}"
             ./vcpkg integrate install

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -223,8 +223,8 @@ jobs:
           source ./scripts/version_number.sh
           source ./scripts/ci/generate-version-details.sh
           # source /opt/qt514/bin/qt514-env.sh
-          cat /opt/qt514/bin/qt514-env.sh
-          /opt/qt514/bin/qt514-env.sh
+          export Qt5_DIR=/opt/qt514/
+          
 
           overlay_ports=(${WORKSPACE}/${{ steps.vars.outputs.OVERLAY }} ${WORKSPACE}/vcpkg/overlay)
           echo "Building with $(IFS=\; ; echo "${overlay_ports[*]}")"

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -21,7 +21,7 @@ jobs:
             os: 'windows-2019'
 
           - triplet: 'x64-linux'
-            os: 'ubuntu-18.04'
+            os: 'ubuntu-20.04'
 
           - triplet: 'x64-osx'
             os: 'macos-10.15'
@@ -169,7 +169,7 @@ jobs:
       - name: 🐧 Prepare linux build env
         if: ${{ matrix.triplet == 'x64-linux' }}
         run: |
-          sudo add-apt-repository ppa:beineri/opt-qt-5.14.2-bionic
+          sudo add-apt-repository ppa:beineri/opt-qt-5.14.2-focal
           sudo apt-get update
           sudo apt-get install -y gperf autopoint '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev qt514-meta-full
           sudo apt-get remove -y libopenexr-dev # Avoid gdal picking this system lib up
@@ -192,7 +192,6 @@ jobs:
           if [[ -z "${TX_TOKEN}" ]]; then
             echo "TX_TOKEN not set, skip tx pull"
           else
-            sudo apt-get install python3-setuptools
             pip3 install transifex-client
             pushd "${{ steps.vars.outputs.VCPKG_ROOT }}"
             ./vcpkg integrate install

--- a/platform/linux/CPackLinuxDeployQt.cmake.in
+++ b/platform/linux/CPackLinuxDeployQt.cmake.in
@@ -5,6 +5,6 @@ message("Installing to ${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/Linux/External
 message("  - qmake path: ${qmake_executable}")
 execute_process(COMMAND ${CMAKE_MAKE_PROGRAM} install
                 WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-              execute_process(COMMAND env QMAKE=${qmake_executable} "${LINUXDEPLOY_EXECUTABLE}" --plugin=qt --output=appimage --appdir=${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/Linux/External/AppImage -e ./output/bin/qfield -d ${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/Linux/External/AppImage/usr/share/qfield/qfield.desktop
+              execute_process(COMMAND env QMAKE=${qmake_executable} "${LINUXDEPLOY_EXECUTABLE}" --plugin=gstreamer --plugin=qt --output=appimage --appdir=${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/Linux/External/AppImage -e ./output/bin/qfield -d ${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/Linux/External/AppImage/usr/share/qfield/qfield.desktop
                 WORKING_DIRECTORY ${CPACK_PACKAGE_DIRECTORY}
                 COMMAND_ECHO STDERR)

--- a/platform/linux/CPackLinuxDeployQt.cmake.in
+++ b/platform/linux/CPackLinuxDeployQt.cmake.in
@@ -1,4 +1,5 @@
 set(ENV{QML_SOURCES_PATHS} ${CMAKE_SOURCE_DIR}/src/qml)
+set(ENV{EXTRA_QT_PLUGINS} "multimedia")
 set(ENV{DESTDIR} ${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/Linux/External/AppImage)
 message("Installing to ${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/Linux/External/AppImage")
 message("  - qmake path: ${qmake_executable}")

--- a/platform/linux/CPackLinuxDeployQt.cmake.in
+++ b/platform/linux/CPackLinuxDeployQt.cmake.in
@@ -5,6 +5,6 @@ message("Installing to ${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/Linux/External
 message("  - qmake path: ${qmake_executable}")
 execute_process(COMMAND ${CMAKE_MAKE_PROGRAM} install
                 WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-              execute_process(COMMAND env QMAKE=${qmake_executable} "${LINUXDEPLOY_EXECUTABLE}" --plugin=gstreamer --plugin=qt --output=appimage --appdir=${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/Linux/External/AppImage -e ./output/bin/qfield -d ${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/Linux/External/AppImage/usr/share/qfield/qfield.desktop
+              execute_process(COMMAND env QMAKE=${qmake_executable} "${LINUXDEPLOY_EXECUTABLE}" --plugin=qt --output=appimage --appdir=${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/Linux/External/AppImage -e ./output/bin/qfield -d ${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/Linux/External/AppImage/usr/share/qfield/qfield.desktop
                 WORKING_DIRECTORY ${CPACK_PACKAGE_DIRECTORY}
                 COMMAND_ECHO STDERR)

--- a/vcpkg/overlay_system_qt/qt5-multimedia/CONTROL
+++ b/vcpkg/overlay_system_qt/qt5-multimedia/CONTROL
@@ -1,4 +1,3 @@
 Source: qt5-multimedia
 Version: 5.14.2
 Description: Qt5 Multimedia Module - Classes and widgets for audio, video, radio and camera functionality
-Build-Depends: gstreamer

--- a/vcpkg/overlay_system_qt/qt5-multimedia/CONTROL
+++ b/vcpkg/overlay_system_qt/qt5-multimedia/CONTROL
@@ -1,3 +1,4 @@
 Source: qt5-multimedia
 Version: 5.14.2
 Description: Qt5 Multimedia Module - Classes and widgets for audio, video, radio and camera functionality
+Build-Depends: gstreamer


### PR DESCRIPTION
Long story short: the AppImage is missing gstreamer libraries for Qt multimedia's mediaserver plugin to be bundled. 

This PR is bringing us on the verge of success, but not quite there yet. I've filled an issue in the linuxdeploy-plugin-qt respository (https://github.com/linuxdeploy/linuxdeploy-plugin-qt/issues/94).