### PR TITLE
Tweak language of default QField language

### DIFF
--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -308,7 +308,7 @@ Page {
 
                       Label {
                           text: '<style>a, a:hover, a:visited { color:' + Theme.mainColor + '; }></style>' +
-                                qsTr( "QField's user interface is available in many languages through the efforts of its community members. If you find a language is missing or incomplete, visit its %1transifex page%2 and help out." )
+                                qsTr( "Found a missing or incomplete language? %1Join the translator community.%2" )
                                   .arg( '<a href="https://www.transifex.com/opengisch/qfield-for-qgis/">' )
                                   .arg( '</a>' );
                           font: Theme.tipFont


### PR DESCRIPTION
Moving away from system language to system default to avoid the following confusion: If I have my OS system language set to Arabic, setting QField to the default "System language" combobox item, QField will actually be in English since we don't have an Arabic translation (yet?).

So, to avoid confusion, set the label to "system default".