### PR TITLE
Fix non-native camera button MIA in 1.10 (fixes #2262)

### DIFF
--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -261,9 +261,7 @@ EditorWidgetBase {
     width: visible ? 48 : 0
     height: 48
 
-    property bool isCameraAvailable: ((platformUtilities.capabilities & PlatformUtilities.NativeCamera) && settings.valueBool("nativeCamera", true))
-                                     || ((!( platformUtilities.capabilities & PlatformUtilities.NativeCamera) || settings.valueBool("nativeCamera", false))
-                                         && QtMultimedia.availableCameras.length > 0)
+    property bool isCameraAvailable: platformUtilities.capabilities & PlatformUtilities.NativeCamera || QtMultimedia.availableCameras.length > 0
 
     anchors.right: galleryButton.left
     anchors.top: parent.top


### PR DESCRIPTION
Simplifying the conditions here to something more readable and less prone to failure. 

(Note: that probably warrant a 1.10.1 alone, but I'd like to see if we can dissect why people upgrading end up with 3.18 and 3.22 provider libraries)