### PR TITLE
Update OSGeo4A to fix a spatialite views regression

### DIFF
--- a/sdk.conf
+++ b/sdk.conf
@@ -1,1 +1,1 @@
-osgeo4a_version=gdal34
+osgeo4a_version=20211106

--- a/sdk.conf
+++ b/sdk.conf
@@ -1,1 +1,1 @@
-osgeo4a_version=20211023
+osgeo4a_version=nirvn-patch-1

--- a/sdk.conf
+++ b/sdk.conf
@@ -1,1 +1,1 @@
-osgeo4a_version=nirvn-patch-1
+osgeo4a_version=gdal34


### PR DESCRIPTION
This PR takes on an updated SDK that downgrades sqlite to 3.35.5 to provide time for GIS users out there to a/ be aware of a change in sqlite 3.36.0 that can lead to broken views (eg https://github.com/opengisch/QField/issues/2260), b/ adapt their syntax.

That's likely the right thing to do for QField 1
10.