### PR TITLE
When manually hiding/showing layers, set map theme to none

### DIFF
--- a/src/core/layertreemapcanvasbridge.cpp
+++ b/src/core/layertreemapcanvasbridge.cpp
@@ -157,8 +157,8 @@ void LayerTreeMapCanvasBridge::nodeVisibilityChanged()
 
 void LayerTreeMapCanvasBridge::mapThemeChanged()
 {
-  QgsProject::instance()->mapThemeCollection()->applyTheme( mModel->mapTheme(), mRoot, mModel->layerTreeModel() );
-  // rebuilt the flat layer tree model
+  if ( !mModel->mapTheme().isEmpty() )
+    QgsProject::instance()->mapThemeCollection()->applyTheme( mModel->mapTheme(), mRoot, mModel->layerTreeModel() );
 }
 
 void LayerTreeMapCanvasBridge::layerInTrackingChanged( QgsVectorLayer *layer, bool tracking )

--- a/src/core/projectinfo.cpp
+++ b/src/core/projectinfo.cpp
@@ -104,7 +104,7 @@ void ProjectInfo::extentChanged()
 
 void ProjectInfo::mapThemeChanged()
 {
-  if ( mFilePath.isEmpty() )
+  if ( mFilePath.isEmpty() || mLayerTree->mapTheme().isEmpty() )
     return;
 
   QFileInfo fi( mFilePath );

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -223,8 +223,11 @@ Drawer {
         Connections {
           target: iface
 
+          function onLoadProjectTriggered() {
+              mapThemeContainer.isLoading = true
+          }
+
           function onLoadProjectEnded() {
-            mapThemeContainer.isLoading = true
             var themes = qgisProject.mapThemeCollection.mapThemes
             mapThemeComboBox.model = themes
             mapThemeContainer.visible = themes.length > 1
@@ -232,6 +235,18 @@ Drawer {
             mapThemeComboBox.currentIndex = flatLayerTree.mapTheme != '' ? mapThemeComboBox.find( flatLayerTree.mapTheme ) : -1
             mapThemeContainer.isLoading = false
           }
+        }
+
+        Connections {
+            target: flatLayerTree
+
+            function onMapThemeChanged() {
+                if (!mapThemeContainer.isLoading && mapThemeComboBox.currentText != flatLayerTree.mapTheme) {
+                  mapThemeContainer.isLoading = true
+                  mapThemeComboBox.currentIndex = flatLayerTree.mapTheme != '' ? mapThemeComboBox.find( flatLayerTree.mapTheme ) : -1
+                  mapThemeContainer.isLoading = false
+                }
+            }
         }
 
         onCurrentTextChanged: {

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -99,7 +99,8 @@ Popup {
 
         onClicked: {
           layerTree.setData(index, checkState === Qt.Checked, FlatLayerTreeModel.Visible);
-          close()
+          flatLayerTree.mapTheme = '';
+          close();
         }
       }
 
@@ -118,7 +119,7 @@ Popup {
 
         onClicked: {
           layerTree.setData(index, checkState === Qt.Checked, FlatLayerTreeModel.LabelsVisible);
-          close()
+          close();
         }
       }
 


### PR DESCRIPTION
This (mostly) fixes https://github.com/opengisch/QField/issues/2277 by setting the map theme to none when manually toggling individual layer visibility. When I say _mostly_, I'm referring to the absence of auto map theme matching when users would toggle individual layer visibility to match a given map theme setting. No plan to implement that behavior, I think we can save the CPU cycles on QField and avoid this.

Doing so allows for users to quickly reset the map theme via combobox.

There's also a small fix to avoid remembering an empty map theme string across project load sessions.