### PR TITLE
Adjust file picker behavior based on permissions

### DIFF
--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -6,6 +6,7 @@
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+  <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
   <uses-permission android:name="android.permission.CAMERA" />
   <uses-permission android:name="android.permission.WAKE_LOCK" />
   <uses-permission android:name="android.permission.BLUETOOTH" />

--- a/platform/android/res/values/strings.xml
+++ b/platform/android/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="remind_later">Remind me later</string>
     <string name="no_thanks">No, thanks!</string>
     <string name="favorite_directories">Favorite directories</string>
+    <string name="favorites_demo_projects">Demo projects</string>
     <string name="added_to_favorites">Added to favorites</string>
     <string name="removed_from_favorites">Removed from favorites</string>
     <string name="external_files_title">Important Note</string>

--- a/platform/android/res/values/strings.xml
+++ b/platform/android/res/values/strings.xml
@@ -10,7 +10,7 @@
     <string name="external_storage_unavailable">Unpacking post install data. This might take a some time.</string>
     <string name="noexternalstorage_dialog">Looks like your external storage (/sdcard) is not available. This happens when you connect your device to a PC via USB.\nQGIS can run from the internal storage but this is not recomended as it might be too small.\nIt is suggested to chose CANCEL, disconnect any USB cable and restart QGIS.</string>
     <string name="primary_storage">Internal storage</string>
-    <string name="secondary_storage">QField directory on external storage</string>
+    <string name="secondary_storage">QField files directory</string>
     <string name="secondary_storage_read_only">External storage (read only)</string>
     <string name="inaccessible">inaccessible</string>
     <string name="loading">Loading</string>
@@ -25,7 +25,7 @@
     <string name="added_to_favorites">Added to favorites</string>
     <string name="removed_from_favorites">Removed from favorites</string>
     <string name="alert_sd_card_title">Warning</string>
-    <string name="alert_sd_card_message">This directory, including all contained files, will be deleted by the system if you uninstall QField from your Android device!</string>
+    <string name="alert_sd_card_message">This directory, including all contained files, will be deleted by the system if you uninstall QField from your Android device.</string>
     <string name="alert_sd_card_ok">OK</string>
     <string name="grant_permission">All files access</string>
     <string name="grant_all_files_permission"><![CDATA[QField needs all files access permission to be able to open local projects and datasets as well as supporting custom projection grids, fonts, and base maps. While not required, <i>allowing access is highly recommended</i>.<br/><br/>On the next screen, please select <b>QField</b> and select the <b>Allow access to all files</b> option.]]></string>

--- a/platform/android/res/values/strings.xml
+++ b/platform/android/res/values/strings.xml
@@ -24,9 +24,9 @@
     <string name="favorite_directories">Favorite directories</string>
     <string name="added_to_favorites">Added to favorites</string>
     <string name="removed_from_favorites">Removed from favorites</string>
-    <string name="alert_sd_card_title">Warning</string>
-    <string name="alert_sd_card_message">This directory, including all contained files, will be deleted by the system if you uninstall QField from your Android device.</string>
-    <string name="alert_sd_card_ok">OK</string>
+    <string name="external_files_title">Important Note</string>
+    <string name="external_files_message"><![CDATA[The QField files directory can be used to copy files and projects onto your device via USB cable. You can see the directory\'s absolute path in the header bar.<br/><br/>Be aware that content of this directory <i>will be deleted</i> if you uninstall QField from your device.]]></string>
+    <string name="external_files_ok">OK</string>
     <string name="grant_permission">All files access</string>
     <string name="grant_all_files_permission"><![CDATA[QField needs all files access permission to be able to open local projects and datasets as well as supporting custom projection grids, fonts, and base maps. While not required, <i>allowing access is highly recommended</i>.<br/><br/>On the next screen, please select <b>QField</b> and select the <b>Allow access to all files</b> option.]]></string>
     <string name="grant">Allow</string>

--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -162,6 +162,9 @@ public class QFieldActivity extends QtActivity {
         if (ContextCompat.checkSelfPermission(QFieldActivity.this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_DENIED) {
             permissionsList.add(Manifest.permission.ACCESS_FINE_LOCATION);
         }
+        if (ContextCompat.checkSelfPermission(QFieldActivity.this, Manifest.permission.ACCESS_MEDIA_LOCATION) == PackageManager.PERMISSION_DENIED) {
+            permissionsList.add(Manifest.permission.ACCESS_MEDIA_LOCATION);
+        }
         if (ContextCompat.checkSelfPermission(QFieldActivity.this, Manifest.permission.BLUETOOTH) == PackageManager.PERMISSION_DENIED) {
             permissionsList.add(Manifest.permission.BLUETOOTH);
         }

--- a/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Arrays;
 
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.net.Uri;
@@ -16,6 +17,9 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.pm.PackageManager;
+import android.Manifest;
+import android.support.v4.app.ActivityCompat;
 import android.util.Log;
 import android.view.View;
 import android.view.Window;
@@ -56,13 +60,16 @@ public class QFieldProjectActivity extends Activity {
 
         // Roots
         if (!getIntent().hasExtra("path")) {
-
-            File externalStorageDirectory = Environment.getExternalStorageDirectory();
-            Log.d(TAG, "externalStorageDirectory: " + externalStorageDirectory);
-            if (externalStorageDirectory != null){
-                values.add(new QFieldProjectListItem(externalStorageDirectory, getString(R.string.primary_storage),
-                                                     R.drawable.tablet, QFieldProjectListItem.TYPE_ROOT));
-           }
+            File externalStorageDirectory = null;
+            if (ActivityCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED ||
+                (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && Environment.isExternalStorageManager())) {
+                externalStorageDirectory = Environment.getExternalStorageDirectory();
+                Log.d(TAG, "externalStorageDirectory: " + externalStorageDirectory);
+                if (externalStorageDirectory != null){
+                    values.add(new QFieldProjectListItem(externalStorageDirectory, getString(R.string.primary_storage),
+                                                         R.drawable.tablet, QFieldProjectListItem.TYPE_ROOT));
+                }
+            }
 
             File[] externalFilesDirs = getExternalFilesDirs(null);
             Log.d(TAG, "externalFilesDirs: " + Arrays.toString(externalFilesDirs));
@@ -70,9 +77,9 @@ public class QFieldProjectActivity extends Activity {
                 if (file != null){
                     // Don't add a external storage path if already included in the primary one
                     if(externalStorageDirectory != null){
-                        values.add(new QFieldProjectListItem(file, getString(R.string.secondary_storage), R.drawable.card, QFieldProjectListItem.TYPE_SECONDARY_ROOT));
-
                         if (!file.getAbsolutePath().contains(externalStorageDirectory.getAbsolutePath())){
+                            values.add(new QFieldProjectListItem(file, getString(R.string.secondary_storage), R.drawable.card, QFieldProjectListItem.TYPE_SECONDARY_ROOT));
+
                             // Add root as read-only
                             if(file.getPath().contains("/Android/data/ch.opengis.qfield/files")){
                                 values.add(new QFieldProjectListItem(file.getParentFile().getParentFile().getParentFile().getParentFile(), getString(R.string.secondary_storage_read_only), R.drawable.card, QFieldProjectListItem.TYPE_SECONDARY_ROOT_RO));

--- a/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -119,7 +119,7 @@ public class QFieldProjectActivity extends Activity {
                 for (int i=favoriteDirsArray.length-1; i>=0; i--) {
                     File f = new File(favoriteDirsArray[i]);
                     if (f.exists()){
-                        values.add(new QFieldProjectListItem(f, f.getName(), R.drawable.directory, QFieldProjectListItem.TYPE_ITEM));
+                        values.add(new QFieldProjectListItem(f, getString(R.string.favorites_demo_projects), R.drawable.directory, QFieldProjectListItem.TYPE_ITEM));
                     }
                 }
             }

--- a/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -70,9 +70,9 @@ public class QFieldProjectActivity extends Activity {
                 if (file != null){
                     // Don't add a external storage path if already included in the primary one
                     if(externalStorageDirectory != null){
-                        if (!file.getAbsolutePath().contains(externalStorageDirectory.getAbsolutePath())){
-                            values.add(new QFieldProjectListItem(file, getString(R.string.secondary_storage), R.drawable.card, QFieldProjectListItem.TYPE_SECONDARY_ROOT));
+                        values.add(new QFieldProjectListItem(file, getString(R.string.secondary_storage), R.drawable.card, QFieldProjectListItem.TYPE_SECONDARY_ROOT));
 
+                        if (!file.getAbsolutePath().contains(externalStorageDirectory.getAbsolutePath())){
                             // Add root as read-only
                             if(file.getPath().contains("/Android/data/ch.opengis.qfield/files")){
                                 values.add(new QFieldProjectListItem(file.getParentFile().getParentFile().getParentFile().getParentFile(), getString(R.string.secondary_storage_read_only), R.drawable.card, QFieldProjectListItem.TYPE_SECONDARY_ROOT_RO));

--- a/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -32,6 +32,7 @@ import android.widget.AdapterView.OnItemClickListener;
 import android.widget.AdapterView.OnItemLongClickListener;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
+import android.text.Html;
 import android.text.TextUtils;
 
 public class QFieldProjectActivity extends Activity {
@@ -44,7 +45,6 @@ public class QFieldProjectActivity extends Activity {
 
     @Override
     public void onCreate(Bundle bundle) {
-        Log.d(TAG, "onCreate() ");
         super.onCreate(bundle);
 
         sharedPreferences = getPreferences(Context.MODE_PRIVATE);
@@ -61,7 +61,6 @@ public class QFieldProjectActivity extends Activity {
         // Roots
         if (!getIntent().hasExtra("path")) {
             File externalStorageDirectory = null;
-            Log.d(TAG, ContextCompat.checkSelfPermission(QFieldProjectActivity.this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED ? "granted" : "not granted" );
             if (ContextCompat.checkSelfPermission(QFieldProjectActivity.this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED ||
                 (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && Environment.isExternalStorageManager())) {
                 externalStorageDirectory = Environment.getExternalStorageDirectory();
@@ -79,10 +78,10 @@ public class QFieldProjectActivity extends Activity {
                     // Don't add a external storage path if already included in the primary one
                     if(externalStorageDirectory != null){
                         if (!file.getAbsolutePath().contains(externalStorageDirectory.getAbsolutePath())){
-                            values.add(new QFieldProjectListItem(file, getString(R.string.secondary_storage), R.drawable.tablet, QFieldProjectListItem.TYPE_SECONDARY_ROOT));
+                            values.add(new QFieldProjectListItem(file, getString(R.string.secondary_storage), R.drawable.tablet, QFieldProjectListItem.TYPE_EXTERNAL_FILES));
                         }
                     }else{
-                        values.add(new QFieldProjectListItem(file, getString(R.string.secondary_storage), R.drawable.card, QFieldProjectListItem.TYPE_SECONDARY_ROOT));
+                        values.add(new QFieldProjectListItem(file, getString(R.string.secondary_storage), R.drawable.tablet, QFieldProjectListItem.TYPE_EXTERNAL_FILES));
                     }
                 }
             }
@@ -201,20 +200,20 @@ public class QFieldProjectActivity extends Activity {
         if (item.getType() == QFieldProjectListItem.TYPE_SEPARATOR){
             return;
         }
-        // Show a warning if it's the first time the sd-card is used
-        boolean showSdCardWarning = sharedPreferences.getBoolean("ShowSdCardWarning", true);
-        if (item.getType() == QFieldProjectListItem.TYPE_SECONDARY_ROOT && showSdCardWarning){
+        // Show an information notice if it's the first time the external files directory is used
+        boolean showExternalFilesNotice = sharedPreferences.getBoolean("ShowExternalFilesNotice", true);
+        if (item.getType() == QFieldProjectListItem.TYPE_EXTERNAL_FILES && showExternalFilesNotice){
             AlertDialog alertDialog = new AlertDialog.Builder(this).create();
-            alertDialog.setTitle(getString(R.string.alert_sd_card_title));
-            alertDialog.setMessage(getString(R.string.alert_sd_card_message));
-            alertDialog.setButton(AlertDialog.BUTTON_POSITIVE, getString(R.string.alert_sd_card_ok), new DialogInterface.OnClickListener() {
+            alertDialog.setTitle(getString(R.string.external_files_title));
+            alertDialog.setMessage(Html.fromHtml(getString(R.string.external_files_message), Html.FROM_HTML_MODE_LEGACY));
+            alertDialog.setButton(AlertDialog.BUTTON_POSITIVE, getString(R.string.external_files_ok), new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int which) {
                         dialog.dismiss();
                         startItemClickActivity(item);
                     }
                 });
             alertDialog.show();
-            editor.putBoolean("ShowSdCardWarning", false);
+            editor.putBoolean("ShowExternalFilesNotice", false);
             editor.commit();
         }else {
             startItemClickActivity(item);

--- a/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -19,7 +19,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.pm.PackageManager;
 import android.Manifest;
-import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 import android.util.Log;
 import android.view.View;
 import android.view.Window;
@@ -61,7 +61,8 @@ public class QFieldProjectActivity extends Activity {
         // Roots
         if (!getIntent().hasExtra("path")) {
             File externalStorageDirectory = null;
-            if (ActivityCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED ||
+            Log.d(TAG, ContextCompat.checkSelfPermission(QFieldProjectActivity.this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED ? "granted" : "not granted" );
+            if (ContextCompat.checkSelfPermission(QFieldProjectActivity.this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED ||
                 (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && Environment.isExternalStorageManager())) {
                 externalStorageDirectory = Environment.getExternalStorageDirectory();
                 Log.d(TAG, "externalStorageDirectory: " + externalStorageDirectory);
@@ -78,19 +79,10 @@ public class QFieldProjectActivity extends Activity {
                     // Don't add a external storage path if already included in the primary one
                     if(externalStorageDirectory != null){
                         if (!file.getAbsolutePath().contains(externalStorageDirectory.getAbsolutePath())){
-                            values.add(new QFieldProjectListItem(file, getString(R.string.secondary_storage), R.drawable.card, QFieldProjectListItem.TYPE_SECONDARY_ROOT));
-
-                            // Add root as read-only
-                            if(file.getPath().contains("/Android/data/ch.opengis.qfield/files")){
-                                values.add(new QFieldProjectListItem(file.getParentFile().getParentFile().getParentFile().getParentFile(), getString(R.string.secondary_storage_read_only), R.drawable.card, QFieldProjectListItem.TYPE_SECONDARY_ROOT_RO));
-                            }
+                            values.add(new QFieldProjectListItem(file, getString(R.string.secondary_storage), R.drawable.tablet, QFieldProjectListItem.TYPE_SECONDARY_ROOT));
                         }
                     }else{
                         values.add(new QFieldProjectListItem(file, getString(R.string.secondary_storage), R.drawable.card, QFieldProjectListItem.TYPE_SECONDARY_ROOT));
-                        // Add root as read-only
-                        if(file.getPath().contains("/Android/data/ch.opengis.qfield/files")){
-                            values.add(new QFieldProjectListItem(file.getParentFile().getParentFile().getParentFile().getParentFile(), getString(R.string.secondary_storage_read_only), R.drawable.card, QFieldProjectListItem.TYPE_SECONDARY_ROOT_RO));
-                        }
                     }
                 }
             }

--- a/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -107,7 +107,7 @@ public class QFieldProjectActivity extends Activity {
             // The first time, add the demo projects directory to the favorites
             boolean addDemoProjectsFavoriteDir = sharedPreferences.getBoolean("AddDemoProjectsFavoriteDir", true);
             if (addDemoProjectsFavoriteDir){
-                favoriteDirs = getFilesDir().toString() + "/resources/demo_projects";
+                favoriteDirs = getFilesDir().toString() + "/share/qfield/demo_projects";
                 editor.putString("FavoriteDirs", favoriteDirs);
                 editor.putBoolean("AddDemoProjectsFavoriteDir", false);
                 editor.commit();

--- a/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -105,11 +105,11 @@ public class QFieldProjectActivity extends Activity {
             String favoriteDirs = sharedPreferences.getString("FavoriteDirs", null);
 
             // The first time, add the demo projects directory to the favorites
-            boolean addDemoProjectsFavoriteDir = sharedPreferences.getBoolean("AddDemoProjectsFavoriteDir", true);
+            boolean addDemoProjectsFavoriteDir = sharedPreferences.getBoolean("AddDemoProjectsFavoriteDir2", true);
             if (addDemoProjectsFavoriteDir){
                 favoriteDirs = getFilesDir().toString() + "/share/qfield/demo_projects";
                 editor.putString("FavoriteDirs", favoriteDirs);
-                editor.putBoolean("AddDemoProjectsFavoriteDir", false);
+                editor.putBoolean("AddDemoProjectsFavoriteDir2", false);
                 editor.commit();
             }
             if (favoriteDirs != null){

--- a/platform/android/src/ch/opengis/qfield/QFieldProjectListItem.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectListItem.java
@@ -12,8 +12,7 @@ public class QFieldProjectListItem implements Comparable<QFieldProjectListItem>{
     public static final int TYPE_ITEM = 0;
     public static final int TYPE_SEPARATOR = 1;
     public static final int TYPE_ROOT = 2;
-    public static final int TYPE_SECONDARY_ROOT = 3;
-    public static final int TYPE_SECONDARY_ROOT_RO = 4;
+    public static final int TYPE_EXTERNAL_FILES = 3;
 
     public QFieldProjectListItem(File file, String text, int imageId, int type){
         this.file = file;


### PR DESCRIPTION
This PR further adjusts permission handling based on recent work we've done.

In addition, it slightly reworks the file picker activity to behave better and be more informative to users in environments where permissions are not fully granted.

The long story short is that we present the app's external files directory as a location than can be used to drop content via USB cable while still warning of data loss if the app is uninstalled. Wordings have been adjusted all around. The ~~warning~~ information note looks like this:
![image](https://user-images.githubusercontent.com/1728657/142601046-5af6afa4-2ada-4a86-b7d0-b5165ce0fd91.png)

As a nice little extra, this fixes the addition of the demo projects folder in the favorites when first launching QField (broken since forever ago).