### PR TITLE
Fix missing welcome screen / about logo on non-Android platforms

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -59,9 +59,13 @@ if(ANDROID)
 else()
   add_executable(
     qfield
-    main.cpp ${RESOURCES} ${CMAKE_SOURCE_DIR}/images/images.qrc
+    main.cpp
+    ${RESOURCES}
+    ${CMAKE_SOURCE_DIR}/images/images.qrc
     ${CMAKE_BINARY_DIR}/images/logo.qrc
-    ${CMAKE_SOURCE_DIR}/resources/resources.qrc ${ICON_SRC} ${TRANSLATIONS_QRC})
+    ${CMAKE_SOURCE_DIR}/resources/resources.qrc
+    ${ICON_SRC}
+    ${TRANSLATIONS_QRC})
 endif()
 
 target_compile_definitions(

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -60,6 +60,7 @@ else()
   add_executable(
     qfield
     main.cpp ${RESOURCES} ${CMAKE_SOURCE_DIR}/images/images.qrc
+    ${CMAKE_BINARY_DIR}/images/logo.qrc
     ${CMAKE_SOURCE_DIR}/resources/resources.qrc ${ICON_SRC} ${TRANSLATIONS_QRC})
 endif()
 


### PR DESCRIPTION
Before vs. PR:
![image](https://user-images.githubusercontent.com/1728657/142750236-6c390425-d2bf-4328-863d-37dc04ef6b02.png)

@m-kuhn , this fixes a regression introduced by the new packaging platform.