### PR TITLE
Implement an image/resource editing mode to the image/external resource widget

### DIFF
--- a/platform/android/src/ch/opengis/qfield/QFieldOpenExternallyActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldOpenExternallyActivity.java
@@ -11,6 +11,7 @@ import android.content.Intent;
 import android.util.Log;
 import android.support.v4.content.FileProvider;
 import android.widget.Toast;
+import android.provider.MediaStore;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -53,8 +54,14 @@ public class QFieldOpenExternallyActivity extends Activity{
         Log.d(TAG, "content URI: " + contentUri);
         Log.d(TAG, isEditing ? "call ACTION_EDIT intent" : "call ACTION_VIEW intent");
         Intent intent = new Intent(isEditing ? Intent.ACTION_EDIT : Intent.ACTION_VIEW);
-        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        intent.setDataAndType(contentUri, isEditing ? "image/*" : mimeType);
+        if (isEditing) {
+            intent.setDataAndType(contentUri, "image/*");
+            intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+            intent.putExtra(MediaStore.EXTRA_OUTPUT, contentUri);
+        } else {
+            intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            intent.setDataAndType(contentUri, mimeType);
+        }
         try {
             startActivityForResult(intent, 102);
         } catch (Exception e) {

--- a/platform/android/src/ch/opengis/qfield/QFieldOpenExternallyActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldOpenExternallyActivity.java
@@ -81,7 +81,6 @@ public class QFieldOpenExternallyActivity extends Activity{
     protected void onActivityResult(int requestCode, int resultCode, Intent data)
     {
       //on ACTION_VIEW back key pressed it returns RESULT_CANCEL - on error as well
-      Log.d(TAG, data.getDataString());
       if (resultCode == RESULT_OK) {
           try {
               if (isEditing) {

--- a/platform/android/src/ch/opengis/qfield/QFieldOpenExternallyActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldOpenExternallyActivity.java
@@ -78,6 +78,7 @@ public class QFieldOpenExternallyActivity extends Activity{
     protected void onActivityResult(int requestCode, int resultCode, Intent data)
     {
       //on ACTION_VIEW back key pressed it returns RESULT_CANCEL - on error as well
+      Log.d(TAG, data.getDataString());
       if (resultCode == RESULT_OK) {
           try {
               if (isEditing) {

--- a/platform/android/src/ch/opengis/qfield/QFieldOpenExternallyActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldOpenExternallyActivity.java
@@ -55,9 +55,9 @@ public class QFieldOpenExternallyActivity extends Activity{
         Log.d(TAG, isEditing ? "call ACTION_EDIT intent" : "call ACTION_VIEW intent");
         Intent intent = new Intent(isEditing ? Intent.ACTION_EDIT : Intent.ACTION_VIEW);
         if (isEditing) {
-            intent.setDataAndType(contentUri, "image/*");
             intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-            intent.putExtra(MediaStore.EXTRA_OUTPUT, contentUri);
+            intent.setDataAndType(contentUri, mimeType);
+            //intent.putExtra(MediaStore.EXTRA_OUTPUT, contentUri);
         } else {
             intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
             intent.setDataAndType(contentUri, mimeType);

--- a/platform/android/src/ch/opengis/qfield/QFieldOpenExternallyActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldOpenExternallyActivity.java
@@ -50,13 +50,12 @@ public class QFieldOpenExternallyActivity extends Activity{
 
         Log.d(TAG, "content URI: " + contentUri);
         Log.d(TAG, "call ACTION_VIEW intent");
-        Intent intent = new Intent();
-        intent.setAction(Intent.ACTION_VIEW);
+        Intent intent = new Intent(Intent.ACTION_EDIT);
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         intent.setDataAndType(contentUri, mimeType);
-        try{
+        try {
             startActivityForResult(intent, 102);
-        }catch (Exception e) {
+        } catch (Exception e) {
             Log.d(TAG, e.getMessage());
             errorMessage = e.getMessage();
         }
@@ -67,8 +66,15 @@ public class QFieldOpenExternallyActivity extends Activity{
     {
       //on ACTION_VIEW back key pressed it returns RESULT_CANCEL - on error as well
       if (resultCode == RESULT_OK) {
-          Intent intent = this.getIntent();
-          setResult(RESULT_OK, intent);
+          try {
+              copyFile( cacheFile, file );
+              Intent intent = this.getIntent();
+              setResult(RESULT_OK, intent);
+          } catch(IOException e) {
+              Intent intent = this.getIntent();
+              intent.putExtra("ERROR_MESSAGE", e.getMessage());
+              setResult(RESULT_CANCELED, intent);
+          }
       } else {
           Intent intent = this.getIntent();
           intent.putExtra("ERROR_MESSAGE", errorMessage);

--- a/platform/android/src/ch/opengis/qfield/QFieldOpenExternallyActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldOpenExternallyActivity.java
@@ -54,7 +54,7 @@ public class QFieldOpenExternallyActivity extends Activity{
         Log.d(TAG, isEditing ? "call ACTION_EDIT intent" : "call ACTION_VIEW intent");
         Intent intent = new Intent(isEditing ? Intent.ACTION_EDIT : Intent.ACTION_VIEW);
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        intent.setDataAndType(contentUri, mimeType);
+        intent.setDataAndType(contentUri, isEditing ? "image/*" : mimeType);
         try {
             startActivityForResult(intent, 102);
         } catch (Exception e) {

--- a/platform/android/src/ch/opengis/qfield/QFieldOpenExternallyActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldOpenExternallyActivity.java
@@ -82,8 +82,16 @@ public class QFieldOpenExternallyActivity extends Activity{
       if (resultCode == RESULT_OK) {
           try {
               if (isEditing) {
-                  copyFile( cacheFile, file );
-                  Log.d(TAG, "copying file back");
+                  Log.d(TAG, "Copy file back from uri " + data.getDataString() + " to file: "+file.getAbsolutePath());
+                  InputStream in = getContentResolver().openInputStream(data.getData());
+                  OutputStream out = new FileOutputStream(file);
+                  // Transfer bytes from in to out
+                  byte[] buf = new byte[1024];
+                  int len;
+                  while ((len = in.read(buf)) > 0) {
+                      out.write(buf, 0, len);
+                  }
+                  out.close();
               }
               Intent intent = this.getIntent();
               setResult(RESULT_OK, intent);

--- a/platform/android/src/ch/opengis/qfield/QFieldOpenExternallyActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldOpenExternallyActivity.java
@@ -68,6 +68,9 @@ public class QFieldOpenExternallyActivity extends Activity{
         }
         try {
             startActivityForResult(intent, 102);
+        } catch(IllegalArgumentException e) {
+            Log.d(TAG, e.getMessage());
+            errorMessage = e.getMessage();
         } catch (Exception e) {
             Log.d(TAG, e.getMessage());
             errorMessage = e.getMessage();

--- a/platform/android/src/ch/opengis/qfield/QFieldOpenExternallyActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldOpenExternallyActivity.java
@@ -56,8 +56,12 @@ public class QFieldOpenExternallyActivity extends Activity{
         Intent intent = new Intent(isEditing ? Intent.ACTION_EDIT : Intent.ACTION_VIEW);
         if (isEditing) {
             intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-            intent.setDataAndType(contentUri, mimeType);
-            //intent.putExtra(MediaStore.EXTRA_OUTPUT, contentUri);
+            if (mimeType.contains("image/")) {
+              intent.setDataAndType(contentUri, "image/*");
+            } else {
+              intent.setDataAndType(contentUri, mimeType);
+            }
+            intent.putExtra(MediaStore.EXTRA_OUTPUT, contentUri);
         } else {
             intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
             intent.setDataAndType(contentUri, mimeType);

--- a/platform/android/src/ch/opengis/qfield/QFieldOpenExternallyActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldOpenExternallyActivity.java
@@ -95,6 +95,10 @@ public class QFieldOpenExternallyActivity extends Activity{
               }
               Intent intent = this.getIntent();
               setResult(RESULT_OK, intent);
+          } catch (SecurityException e) {
+              Intent intent = this.getIntent();
+              intent.putExtra("ERROR_MESSAGE", e.getMessage());
+              setResult(RESULT_CANCELED, intent);
           } catch(IOException e) {
               Intent intent = this.getIntent();
               intent.putExtra("ERROR_MESSAGE", e.getMessage());

--- a/platform/android/src/ch/opengis/qfield/QFieldOpenExternallyActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldOpenExternallyActivity.java
@@ -22,9 +22,8 @@ import java.text.SimpleDateFormat;
 
 public class QFieldOpenExternallyActivity extends Activity{
     private static final String TAG = "QField Open (file) Externally Activity";
-    private String filePath;
-    private String mimeType;
-    private String tempFileName;
+    private File file;
+    private File cacheFile;
     private String errorMessage;
 
     @Override
@@ -32,16 +31,16 @@ public class QFieldOpenExternallyActivity extends Activity{
         Log.d(TAG, "onCreate()");
         super.onCreate(savedInstanceState);
 
-        filePath = getIntent().getExtras().getString("filepath");
-        mimeType = getIntent().getExtras().getString("filetype");
+        String filePath = getIntent().getExtras().getString("filepath");
+        String mimeType = getIntent().getExtras().getString("filetype");
         Log.d(TAG, "Received filepath: " + filePath + " and mimeType: " + mimeType);
 
-        File file = new File(filePath);
-        File cacheFile = new File(getCacheDir(), file.getName());
+        file = new File(filePath);
+        cacheFile = new File(getCacheDir(), file.getName());
 
         //copy file to a temporary file
         try{
-            copyFile( file, cacheFile );
+            copyFile(file, cacheFile);
         }catch(IOException e){
             Log.d(TAG, e.getMessage());
             finish();

--- a/platform/android/src/ch/opengis/qfield/QFieldOpenExternallyActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldOpenExternallyActivity.java
@@ -24,6 +24,7 @@ public class QFieldOpenExternallyActivity extends Activity{
     private static final String TAG = "QField Open (file) Externally Activity";
     private File file;
     private File cacheFile;
+    private boolean isEditing;
     private String errorMessage;
 
     @Override
@@ -33,6 +34,7 @@ public class QFieldOpenExternallyActivity extends Activity{
 
         String filePath = getIntent().getExtras().getString("filepath");
         String mimeType = getIntent().getExtras().getString("filetype");
+        isEditing = getIntent().getExtras().getString("fileediting").compareTo("true") == 0;
         Log.d(TAG, "Received filepath: " + filePath + " and mimeType: " + mimeType);
 
         file = new File(filePath);
@@ -50,7 +52,7 @@ public class QFieldOpenExternallyActivity extends Activity{
 
         Log.d(TAG, "content URI: " + contentUri);
         Log.d(TAG, "call ACTION_VIEW intent");
-        Intent intent = new Intent(Intent.ACTION_EDIT);
+        Intent intent = new Intent(isEditing ? Intent.ACTION_EDIT : Intent.ACTION_VIEW);
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         intent.setDataAndType(contentUri, mimeType);
         try {
@@ -67,7 +69,9 @@ public class QFieldOpenExternallyActivity extends Activity{
       //on ACTION_VIEW back key pressed it returns RESULT_CANCEL - on error as well
       if (resultCode == RESULT_OK) {
           try {
-              copyFile( cacheFile, file );
+              if (isEditing) {
+                  copyFile( cacheFile, file );
+              }
               Intent intent = this.getIntent();
               setResult(RESULT_OK, intent);
           } catch(IOException e) {

--- a/platform/android/src/ch/opengis/qfield/QFieldOpenExternallyActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldOpenExternallyActivity.java
@@ -51,7 +51,7 @@ public class QFieldOpenExternallyActivity extends Activity{
         Uri contentUri =  Build.VERSION.SDK_INT < 24 ? Uri.fromFile(file) : FileProvider.getUriForFile( this, BuildConfig.APPLICATION_ID+".fileprovider", cacheFile );
 
         Log.d(TAG, "content URI: " + contentUri);
-        Log.d(TAG, "call ACTION_VIEW intent");
+        Log.d(TAG, isEditing ? "call ACTION_EDIT intent" : "call ACTION_VIEW intent");
         Intent intent = new Intent(isEditing ? Intent.ACTION_EDIT : Intent.ACTION_VIEW);
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         intent.setDataAndType(contentUri, mimeType);
@@ -71,6 +71,7 @@ public class QFieldOpenExternallyActivity extends Activity{
           try {
               if (isEditing) {
                   copyFile( cacheFile, file );
+                  Log.d(TAG, "copying file back");
               }
               Intent intent = this.getIntent();
               setResult(RESULT_OK, intent);

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -269,7 +269,7 @@ ViewStatus *AndroidPlatformUtilities::open( const QString &uri, bool editing )
   QAndroidJniObject filetype_label = QAndroidJniObject::fromString( "filetype" );
   QAndroidJniObject filetype = QAndroidJniObject::fromString( db.mimeTypeForFile( uri ).name() );
   QAndroidJniObject fileediting_label = QAndroidJniObject::fromString( "fileediting" );
-  QAndroidJniObject fileediting = QAndroidJniObject::fromString( editing ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
+  QAndroidJniObject fileediting = QAndroidJniObject::fromString( editing ? "true" : "false" );
 
   intent.callObjectMethod( "putExtra", "(Ljava/lang/String;Ljava/lang/String;)Landroid/content/Intent;", filepath_label.object<jstring>(), filepath.object<jstring>() );
   intent.callObjectMethod( "putExtra", "(Ljava/lang/String;Ljava/lang/String;)Landroid/content/Intent;", filetype_label.object<jstring>(), filetype.object<jstring>() );

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -253,7 +253,7 @@ PictureSource *AndroidPlatformUtilities::getGalleryPicture( QQuickItem *parent, 
   return pictureSource;
 }
 
-ViewStatus *AndroidPlatformUtilities::open( const QString &uri )
+ViewStatus *AndroidPlatformUtilities::open( const QString &uri, bool editing )
 {
   checkWriteExternalStoragePermissions();
 
@@ -268,9 +268,12 @@ ViewStatus *AndroidPlatformUtilities::open( const QString &uri )
   QAndroidJniObject filepath = QAndroidJniObject::fromString( uri );
   QAndroidJniObject filetype_label = QAndroidJniObject::fromString( "filetype" );
   QAndroidJniObject filetype = QAndroidJniObject::fromString( db.mimeTypeForFile( uri ).name() );
+  QAndroidJniObject fileediting_label = QAndroidJniObject::fromString( "fileediting" );
+  QAndroidJniObject fileediting = QAndroidJniObject::fromString( editing ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
 
   intent.callObjectMethod( "putExtra", "(Ljava/lang/String;Ljava/lang/String;)Landroid/content/Intent;", filepath_label.object<jstring>(), filepath.object<jstring>() );
   intent.callObjectMethod( "putExtra", "(Ljava/lang/String;Ljava/lang/String;)Landroid/content/Intent;", filetype_label.object<jstring>(), filetype.object<jstring>() );
+  intent.callObjectMethod( "putExtra", "(Ljava/lang/String;Ljava/lang/String;)Landroid/content/Intent;", fileediting_label.object<jstring>(), fileediting.object<jstring>() );
 
   AndroidViewStatus *viewStatus = new AndroidViewStatus();
   QtAndroid::startActivity( intent.object<jobject>(), 102, viewStatus );

--- a/src/core/platforms/android/androidplatformutilities.h
+++ b/src/core/platforms/android/androidplatformutilities.h
@@ -36,7 +36,7 @@ class AndroidPlatformUtilities : public PlatformUtilities
     QString qfieldDataDir() const override;
     PictureSource *getCameraPicture( QQuickItem *parent, const QString &prefix, const QString &pictureFilePath, const QString &suffix ) override;
     PictureSource *getGalleryPicture( QQuickItem *parent, const QString &prefix, const QString &pictureFilePath ) override;
-    ViewStatus *open( const QString &uri ) override;
+    ViewStatus *open( const QString &uri, bool editing ) override;
     ProjectSource *openProject() override;
 
     bool checkPositioningPermissions() const override;

--- a/src/core/platforms/android/androidviewstatus.cpp
+++ b/src/core/platforms/android/androidviewstatus.cpp
@@ -40,5 +40,6 @@ void AndroidViewStatus::handleActivityResult( int receiverRequestCode, int resul
     {
       emit statusReceived( errorMessage.toString() );
     }
+    emit finished();
   }
 }

--- a/src/core/platforms/platformutilities.cpp
+++ b/src/core/platforms/platformutilities.cpp
@@ -131,7 +131,7 @@ PictureSource *PlatformUtilities::getGalleryPicture( QQuickItem *parent, const Q
   return new PictureSource( nullptr, prefix, QString() );
 }
 
-ViewStatus *PlatformUtilities::open( const QString &uri )
+ViewStatus *PlatformUtilities::open( const QString &uri, bool )
 {
   QDesktopServices::openUrl( QStringLiteral( "file://%1" ).arg( uri ) );
   return nullptr;

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -89,9 +89,10 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
     /**
      * Open the resource (file, image, ...) that is available under \a uri.
      * The mimetype is detected to indicate the system how the file should
-     * be opened.
+     * be opened. An optional \a editing parameter can be set to true to indicate
+     * to supported systems the resource is expected to be edited.
      */
-    Q_INVOKABLE virtual ViewStatus *open( const QString &uri );
+    Q_INVOKABLE virtual ViewStatus *open( const QString &uri, bool editing = false );
 
     /**
      * Indicates the system that we want to open a project.

--- a/src/core/viewstatus.h
+++ b/src/core/viewstatus.h
@@ -29,8 +29,11 @@ class ViewStatus : public QObject
     virtual ~ViewStatus() = default;
 
   signals:
-    //! This signal is emitted, when a status about the view action has been received
+    //! This signal is emitted when a status about the view action has been received
     void statusReceived( const QString &statusText );
+
+    //! This signal is emitted when a view action is finished
+    void finished();
 };
 
 #endif // VIEWSTATUS_H

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -94,7 +94,8 @@ EditorWidgetBase {
               imageFrame.height = 200
               image.opacity = 1
               image.anchors.topMargin = 0
-              image.source= 'file://' + prefixToRelativePath + value
+              var date = new Date()
+              image.source= 'file://' + prefixToRelativePath + value + '?' + date.getTime()
               geoTagBadge.hasGeoTag = ExifTools.hasGeoTag(prefixToRelativePath + value)
               geoTagBadge.visible = true
           }
@@ -216,8 +217,8 @@ EditorWidgetBase {
                   if ( FileUtils.fileExists( prefixToRelativePath + value ) ) {
                       platformUtilities.open( prefixToRelativePath + value, isEnabled );
                       var imageSource = image.source;
-                      image.source = '';
-                      image.source = imageSource;
+                      var date = new Date()
+                      image.source = imageSource + date.getTime();
                   }
               }
           }

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -366,6 +366,7 @@ EditorWidgetBase {
 
     onFinished: {
       if (isImage) {
+        // In order to make sure the image shown reflects edits, reset the source
         var imageSource = image.source;
         image.source = '';
         image.source = imageSource;

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -213,7 +213,7 @@ EditorWidgetBase {
 
               onClicked: {
                   if ( FileUtils.fileExists( prefixToRelativePath + value ) )
-                      platformUtilities.open( prefixToRelativePath + value );
+                      platformUtilities.open( prefixToRelativePath + value, isEnabled );
               }
           }
 

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -94,8 +94,7 @@ EditorWidgetBase {
               imageFrame.height = 200
               image.opacity = 1
               image.anchors.topMargin = 0
-              var date = new Date()
-              image.source= 'file://' + prefixToRelativePath + value + '?' + date.getTime()
+              image.source= 'file://' + prefixToRelativePath + value
               geoTagBadge.hasGeoTag = ExifTools.hasGeoTag(prefixToRelativePath + value)
               geoTagBadge.visible = true
           }
@@ -216,9 +215,6 @@ EditorWidgetBase {
               onClicked: {
                   if ( FileUtils.fileExists( prefixToRelativePath + value ) ) {
                       platformUtilities.open( prefixToRelativePath + value, isEnabled );
-                      var imageSource = image.source;
-                      var date = new Date()
-                      image.source = imageSource + date.getTime();
                   }
               }
           }
@@ -367,6 +363,15 @@ EditorWidgetBase {
 
   Connections {
     target: __viewStatus
+
+    onFinished: {
+      if (isImage) {
+        var imageSource = image.source;
+        image.source = '';
+        image.source = imageSource;
+      }
+    }
+
     onStatusReceived: {
       if( status )
       {

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -214,7 +214,7 @@ EditorWidgetBase {
 
               onClicked: {
                   if ( FileUtils.fileExists( prefixToRelativePath + value ) ) {
-                      platformUtilities.open( prefixToRelativePath + value, isEnabled );
+                      __viewStatus = platformUtilities.open( prefixToRelativePath + value, isEnabled );
                   }
               }
           }

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -170,7 +170,7 @@ EditorWidgetBase {
         if (!UrlUtils.isRelativeOrFileUrl(value)) { // matches `http://...` but not `file://...` paths
           Qt.openUrlExternally(value)
         } else if (FileUtils.fileExists(prefixToRelativePath + value)) {
-          __viewStatus = platformUtilities.open(prefixToRelativePath + value)
+          __viewStatus = platformUtilities.open(prefixToRelativePath + value, isEnabled)
         }
       }
     }

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -207,13 +207,18 @@ EditorWidgetBase {
           verticalAlignment: Image.AlignVCenter
 
           source: Theme.getThemeIcon("ic_photo_notavailable_black_24dp")
+          cache: false
 
           MouseArea {
               anchors.fill: parent
 
               onClicked: {
-                  if ( FileUtils.fileExists( prefixToRelativePath + value ) )
+                  if ( FileUtils.fileExists( prefixToRelativePath + value ) ) {
                       platformUtilities.open( prefixToRelativePath + value, isEnabled );
+                      var imageSource = image.source;
+                      image.source = '';
+                      image.source = imageSource;
+                  }
               }
           }
 


### PR DESCRIPTION
This PR implements an editing mode to images (and other resources) through the external resource editor widget.

The implementation basically takes on what @m-kuhn did in 2020, but instead of hard-coding ACTION_EDIT, I've made it so we use ACTION_VIEW when the feature form isn't in edit mode. I think it makes a lot of sense, allows users to set a default app for viewing vs default app for editing. That takes care of Samsung Gallery gone missing when we only use ACTION_EDIT.

Edit: the PR now also handles scenarios where the app returns a file that's not the one we attached to the intent, which unlocks a bunch of apps that don't overwrite file (success not guaranteed if saved image is in a location within which permission isn't granted).

Video of editing in action:

https://user-images.githubusercontent.com/1728657/143735355-712a8888-f789-4c3b-9807-1ab07f9a5027.mp4



