### PR TITLE
Only display legend icons when the drawer is expended as a workaround catching the right icon size

### DIFF
--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -7,6 +7,7 @@ import org.qfield 1.0
 import Theme 1.0
 
 Drawer {
+  id: dashBoard
   objectName: "dashBoard"
 
   signal showMenu
@@ -292,6 +293,7 @@ Drawer {
 
     Legend {
       id: legend
+      isVisible: position > 0
       Layout.fillWidth: true
       Layout.fillHeight: true
     }

--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -11,9 +11,11 @@ import "."
 
 
 ListView {
+  id: legend
+
+  property bool isVisible: false
   property VectorLayer currentLayer
 
-  id: table
   model: flatLayerTree
   flickableDirection: Flickable.VerticalFlick
   boundsBehavior: Flickable.StopAtBounds
@@ -83,6 +85,10 @@ ListView {
               anchors.margins: 4
               cache: false
               source: {
+                console.log(legend.isVisible);
+                if ( !legend.isVisible )
+                  return '';
+
                 if ( LegendImage != '' ) {
                   return "image://legend/" + LegendImage
                 } else if ( LayerType == "vectorlayer" ) {
@@ -211,7 +217,7 @@ ListView {
       property Item pressedItem
       anchors.fill: parent
       onClicked: {
-          var item = table.itemAt(table.contentX + mouse.x, table.contentY + mouse.y)
+          var item = legend.itemAt(legend.contentX + mouse.x, legend.contentY + mouse.y)
           if (item) {
               if (item.vectorLayer && item.vectorLayer.isValid) {
                 currentLayer = item.vectorLayer
@@ -219,22 +225,22 @@ ListView {
           }
       }
       onPressed: {
-          var item = table.itemAt(table.contentX + mouse.x, table.contentY + mouse.y)
+          var item = legend.itemAt(legend.contentX + mouse.x, legend.contentY + mouse.y)
           if (item && item.itemType) {
               pressedItem = item;
               pressedItem.state = "pressed"
           }
       }
       onDoubleClicked: {
-          var item = table.itemAt(table.contentX + mouse.x, table.contentY + mouse.y)
+          var item = legend.itemAt(legend.contentX + mouse.x, legend.contentY + mouse.y)
           if (item) {
-            itemProperties.index = table.model.index(item.itemRow, 0)
+            itemProperties.index = legend.model.index(item.itemRow, 0)
             itemProperties.open()
           }
       }
       onPressAndHold: {
           if (pressedItem) {
-            itemProperties.index = table.model.index(pressedItem.itemRow, 0)
+            itemProperties.index = legend.model.index(pressedItem.itemRow, 0)
             itemProperties.open()
           }
       }
@@ -254,7 +260,7 @@ ListView {
 
   LayerTreeItemProperties {
       id: itemProperties
-      layerTree: table.model
+      layerTree: legend.model
 
       modal: true
       closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside

--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -84,6 +84,8 @@ ListView {
               anchors.fill: parent
               anchors.margins: 4
               cache: false
+              smooth: true
+              mipmap: true
               source: {
                 console.log(legend.isVisible);
                 if ( !legend.isVisible )

--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -87,7 +87,6 @@ ListView {
               smooth: true
               mipmap: true
               source: {
-                console.log(legend.isVisible);
                 if ( !legend.isVisible )
                   return '';
 


### PR DESCRIPTION
This PR fixes https://github.com/opengisch/QField/issues/2286 by deferring the rendering of legend icons only when a user has opened the dashboard. It's essentially a bit of a work around QGIS layer tree model which doesn't emit a signal when changing legend node icon sizes (which happens after project load when getting the overall project context et al).

By waiting until the user expands the dashboard, we insure that the icon size when legend icons are drawn have the proper context.

It's also a nice micro optimization.