### PR TITLE
Improve formatted code readability for multiline objects/function calls

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -46,7 +46,7 @@ CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 2
-ContinuationIndentWidth: 0
+ContinuationIndentWidth: 2
 Cpp11BracedListStyle: true
 DerivePointerAlignment: false
 DisableFormat:   false

--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -380,8 +380,8 @@ void AttributeFormModelBase::flatten( QgsAttributeEditorContainer *container, QS
         if ( field.constraints().constraints() & QgsFieldConstraints::ConstraintExpression )
         {
           descriptions << ( !field.constraints().constraintDescription().isEmpty()
-                            ? field.constraints().constraintDescription()
-                            : tr( "Expression constraint" ) );
+                              ? field.constraints().constraintDescription()
+                              : tr( "Expression constraint" ) );
         }
         if ( field.constraints().constraints() & QgsFieldConstraints::ConstraintNotNull )
         {

--- a/src/core/deltafilewrapper.cpp
+++ b/src/core/deltafilewrapper.cpp
@@ -227,17 +227,17 @@ DeltaFileWrapper::ErrorTypes DeltaFileWrapper::errorType() const
 QString DeltaFileWrapper::errorString() const
 {
   const QMap<DeltaFileWrapper::ErrorTypes, QString> errorMessages(
-  { { DeltaFileWrapper::ErrorTypes::NoError, QString() },
-    { DeltaFileWrapper::ErrorTypes::LockError, QStringLiteral( "Delta file is already opened" ) },
-    { DeltaFileWrapper::ErrorTypes::NotCloudProjectError, QStringLiteral( "The current project is not a cloud project" ) },
-    { DeltaFileWrapper::ErrorTypes::IOError, QStringLiteral( "Cannot open file for read and write" ) },
-    { DeltaFileWrapper::ErrorTypes::JsonParseError, QStringLiteral( "Unable to parse JSON" ) },
-    { DeltaFileWrapper::ErrorTypes::JsonFormatIdError, QStringLiteral( "Delta file is missing a valid id" ) },
-    { DeltaFileWrapper::ErrorTypes::JsonFormatProjectIdError, QStringLiteral( "Delta file is missing a valid project id" ) },
-    { DeltaFileWrapper::ErrorTypes::JsonFormatVersionError, QStringLiteral( "Delta file is missing a valid version" ) },
-    { DeltaFileWrapper::ErrorTypes::JsonFormatDeltasError, QStringLiteral( "Delta file is missing a valid deltas" ) },
-    { DeltaFileWrapper::ErrorTypes::JsonFormatDeltaItemError, QStringLiteral( "Delta file is missing a valid delta item" ) },
-    { DeltaFileWrapper::ErrorTypes::JsonIncompatibleVersionError, QStringLiteral( "Delta file has incompatible version" ) } } );
+    { { DeltaFileWrapper::ErrorTypes::NoError, QString() },
+      { DeltaFileWrapper::ErrorTypes::LockError, QStringLiteral( "Delta file is already opened" ) },
+      { DeltaFileWrapper::ErrorTypes::NotCloudProjectError, QStringLiteral( "The current project is not a cloud project" ) },
+      { DeltaFileWrapper::ErrorTypes::IOError, QStringLiteral( "Cannot open file for read and write" ) },
+      { DeltaFileWrapper::ErrorTypes::JsonParseError, QStringLiteral( "Unable to parse JSON" ) },
+      { DeltaFileWrapper::ErrorTypes::JsonFormatIdError, QStringLiteral( "Delta file is missing a valid id" ) },
+      { DeltaFileWrapper::ErrorTypes::JsonFormatProjectIdError, QStringLiteral( "Delta file is missing a valid project id" ) },
+      { DeltaFileWrapper::ErrorTypes::JsonFormatVersionError, QStringLiteral( "Delta file is missing a valid version" ) },
+      { DeltaFileWrapper::ErrorTypes::JsonFormatDeltasError, QStringLiteral( "Delta file is missing a valid deltas" ) },
+      { DeltaFileWrapper::ErrorTypes::JsonFormatDeltaItemError, QStringLiteral( "Delta file is missing a valid delta item" ) },
+      { DeltaFileWrapper::ErrorTypes::JsonIncompatibleVersionError, QStringLiteral( "Delta file has incompatible version" ) } } );
 
   Q_ASSERT( errorMessages.contains( mErrorType ) );
 
@@ -453,16 +453,16 @@ QMap<QString, QString> DeltaFileWrapper::attachmentFileNames() const
 void DeltaFileWrapper::addPatch( const QString &localLayerId, const QString &sourceLayerId, const QString &localPkAttrName, const QString &sourcePkAttrName, const QgsFeature &oldFeature, const QgsFeature &newFeature, bool storeSnapshot )
 {
   QJsonObject delta(
-  {
-  { "localPk", oldFeature.attribute( localPkAttrName ).toString() },
-  { "localLayerId", localLayerId },
-  { "method", "patch" },
-  { "sourcePk", oldFeature.attribute( sourcePkAttrName ).toString() },
-  { "sourceLayerId", sourceLayerId },
-  { "uuid", QUuid::createUuid().toString( QUuid::WithoutBraces ) },
-  { "exportId", QFieldCloudUtils::projectSetting( mCloudProjectId, QStringLiteral( "lastExportId" ) ).toString() },
-  { "clientId", QFieldCloudUtils::projectSetting( mCloudProjectId, QStringLiteral( "lastLocalExportId" ) ).toString() },
-  } );
+    {
+      { "localPk", oldFeature.attribute( localPkAttrName ).toString() },
+      { "localLayerId", localLayerId },
+      { "method", "patch" },
+      { "sourcePk", oldFeature.attribute( sourcePkAttrName ).toString() },
+      { "sourceLayerId", sourceLayerId },
+      { "uuid", QUuid::createUuid().toString( QUuid::WithoutBraces ) },
+      { "exportId", QFieldCloudUtils::projectSetting( mCloudProjectId, QStringLiteral( "lastExportId" ) ).toString() },
+      { "clientId", QFieldCloudUtils::projectSetting( mCloudProjectId, QStringLiteral( "lastLocalExportId" ) ).toString() },
+    } );
 
   const QStringList attachmentFieldsList = attachmentFieldNames( mProject, localLayerId );
   const QgsGeometry oldGeom = oldFeature.geometry();
@@ -656,16 +656,16 @@ void DeltaFileWrapper::addPatch( const QString &localLayerId, const QString &sou
 void DeltaFileWrapper::addDelete( const QString &localLayerId, const QString &sourceLayerId, const QString &localPkAttrName, const QString &sourcePkAttrName, const QgsFeature &oldFeature )
 {
   QJsonObject delta(
-  {
-  { "localPk", oldFeature.attribute( localPkAttrName ).toString() },
-  { "localLayerId", localLayerId },
-  { "method", "delete" },
-  { "sourcePk", oldFeature.attribute( sourcePkAttrName ).toString() },
-  { "sourceLayerId", sourceLayerId },
-  { "uuid", QUuid::createUuid().toString( QUuid::WithoutBraces ) },
-  { "exportId", QFieldCloudUtils::projectSetting( mCloudProjectId, QStringLiteral( "lastExportId" ) ).toString() },
-  { "clientId", QFieldCloudUtils::projectSetting( mCloudProjectId, QStringLiteral( "lastLocalExportId" ) ).toString() },
-  } );
+    {
+      { "localPk", oldFeature.attribute( localPkAttrName ).toString() },
+      { "localLayerId", localLayerId },
+      { "method", "delete" },
+      { "sourcePk", oldFeature.attribute( sourcePkAttrName ).toString() },
+      { "sourceLayerId", sourceLayerId },
+      { "uuid", QUuid::createUuid().toString( QUuid::WithoutBraces ) },
+      { "exportId", QFieldCloudUtils::projectSetting( mCloudProjectId, QStringLiteral( "lastExportId" ) ).toString() },
+      { "clientId", QFieldCloudUtils::projectSetting( mCloudProjectId, QStringLiteral( "lastLocalExportId" ) ).toString() },
+    } );
 
   QMap<QString, int> layerPkDeltaIdx = mLocalPkDeltaIdx.value( localLayerId );
   QString localPk = delta.value( QStringLiteral( "localPk" ) ).toString();
@@ -727,16 +727,16 @@ void DeltaFileWrapper::addDelete( const QString &localLayerId, const QString &so
 void DeltaFileWrapper::addCreate( const QString &localLayerId, const QString &sourceLayerId, const QString &localPkAttrName, const QString &sourcePkAttrName, const QgsFeature &newFeature )
 {
   QJsonObject delta(
-  {
-  { "localPk", newFeature.attribute( localPkAttrName ).toString() },
-  { "localLayerId", localLayerId },
-  { "method", "create" },
-  { "sourcePk", newFeature.attribute( sourcePkAttrName ).toString() },
-  { "sourceLayerId", sourceLayerId },
-  { "uuid", QUuid::createUuid().toString( QUuid::WithoutBraces ) },
-  { "exportId", QFieldCloudUtils::projectSetting( mCloudProjectId, QStringLiteral( "lastExportId" ) ).toString() },
-  { "clientId", QFieldCloudUtils::projectSetting( mCloudProjectId, QStringLiteral( "lastLocalExportId" ) ).toString() },
-  } );
+    {
+      { "localPk", newFeature.attribute( localPkAttrName ).toString() },
+      { "localLayerId", localLayerId },
+      { "method", "create" },
+      { "sourcePk", newFeature.attribute( sourcePkAttrName ).toString() },
+      { "sourceLayerId", sourceLayerId },
+      { "uuid", QUuid::createUuid().toString( QUuid::WithoutBraces ) },
+      { "exportId", QFieldCloudUtils::projectSetting( mCloudProjectId, QStringLiteral( "lastExportId" ) ).toString() },
+      { "clientId", QFieldCloudUtils::projectSetting( mCloudProjectId, QStringLiteral( "lastLocalExportId" ) ).toString() },
+    } );
   const QStringList attachmentFieldsList = attachmentFieldNames( mProject, localLayerId );
   const QgsAttributes newAttrs = newFeature.attributes();
   const QgsFields newFields = newFeature.fields();

--- a/src/core/featurelistmodel.cpp
+++ b/src/core/featurelistmodel.cpp
@@ -277,8 +277,8 @@ void FeatureListModel::gatherFeatureList()
   }
 
   QString fieldDisplayString = displayValueIndex >= 0
-                               ? QgsExpression::quotedColumnRef( mDisplayValueField )
-                               : QStringLiteral( " ( %1 ) " ).arg( mCurrentLayer->displayExpression() );
+                                 ? QgsExpression::quotedColumnRef( mDisplayValueField )
+                                 : QStringLiteral( " ( %1 ) " ).arg( mCurrentLayer->displayExpression() );
 
   if ( !mSearchTerm.isEmpty() )
   {
@@ -352,8 +352,8 @@ void FeatureListModel::processFeatureList()
   {
     std::sort( entries.begin(), entries.end(), []( const Entry &entry1, const Entry &entry2 ) {
       return entry1.fuzzyScore == entry2.fuzzyScore
-             ? entry1.displayString.toLower() < entry2.displayString.toLower()
-             : entry1.fuzzyScore > entry2.fuzzyScore;
+               ? entry1.displayString.toLower() < entry2.displayString.toLower()
+               : entry1.fuzzyScore > entry2.fuzzyScore;
     } );
   }
 

--- a/src/core/locator/featureslocatorfilter.cpp
+++ b/src/core/locator/featureslocatorfilter.cpp
@@ -69,8 +69,8 @@ QStringList FeaturesLocatorFilter::prepare( const QString &string, const QgsLoca
     QString enhancedSearch = string;
     enhancedSearch.replace( " ", "%" );
     req.setFilterExpression( QStringLiteral( "%1 ILIKE '%%2%'" )
-                             .arg( layer->displayExpression() )
-                             .arg( enhancedSearch ) );
+                               .arg( layer->displayExpression() )
+                               .arg( enhancedSearch ) );
     req.setLimit( 30 );
 
     std::shared_ptr<PreparedLayer> preparedLayer( new PreparedLayer() );

--- a/src/core/locator/locatormodelsuperbridge.cpp
+++ b/src/core/locator/locatormodelsuperbridge.cpp
@@ -192,9 +192,9 @@ QHash<int, QByteArray> LocatorFiltersModel::roleNames() const
 QVariant LocatorFiltersModel::data( const QModelIndex &index, int role ) const
 {
   const static QMap<QString, QString> sLocatorFilterDescriptions = {
-  { QStringLiteral( "allfeatures" ), tr( "Returns a list of features accross all searchable layers with matching attributes" ) },
-  { QStringLiteral( "goto" ), tr( "Returns a point from a pair of X and Y coordinates typed in the search bar" ) },
-  { QStringLiteral( "pelias-finland" ), tr( "Returns a list of locations and addresses within Finland with matching terms" ) } };
+    { QStringLiteral( "allfeatures" ), tr( "Returns a list of features accross all searchable layers with matching attributes" ) },
+    { QStringLiteral( "goto" ), tr( "Returns a point from a pair of X and Y coordinates typed in the search bar" ) },
+    { QStringLiteral( "pelias-finland" ), tr( "Returns a list of locations and addresses within Finland with matching terms" ) } };
 
   if ( !mLocatorModelSuperBridge->locator() || !index.isValid() || index.parent().isValid() || index.row() < 0 || index.row() >= rowCount( QModelIndex() ) )
     return QVariant();

--- a/src/core/orderedrelationmodel.cpp
+++ b/src/core/orderedrelationmodel.cpp
@@ -155,8 +155,8 @@ bool OrderedRelationModel::moveItems( const int fromIdx, const int toIdx )
   for ( int i = startIdx; i <= endIdx; i++ )
   {
     int newIdx = ( i == fromIdx )
-                 ? toIdx + 1
-                 : mEntries[i].referencingFeature.attribute( orderingFieldIdx ).toInt() + delta;
+                   ? toIdx + 1
+                   : mEntries[i].referencingFeature.attribute( orderingFieldIdx ).toInt() + delta;
     bool isSuccess = referencingLayer->changeAttributeValue( mEntries[i].referencingFeature.id(), orderingFieldIdx, newIdx );
 
     if ( !isSuccess )

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -93,8 +93,8 @@ void AndroidPlatformUtilities::initSystem()
 
   {
     qDebug() << QStringLiteral( "Different build git revision detected (previous: %1, current: %2)" )
-                .arg( localGitRev.size() > 0 ? localGitRev.mid( 0, 7 ) : QStringLiteral( "n/a" ) )
-                .arg( appGitRev.size() > 0 ? appGitRev.mid( 0, 7 ) : QStringLiteral( "n/a" ) );
+                  .arg( localGitRev.size() > 0 ? localGitRev.mid( 0, 7 ) : QStringLiteral( "n/a" ) )
+                  .arg( appGitRev.size() > 0 ? appGitRev.mid( 0, 7 ) : QStringLiteral( "n/a" ) );
     int argc = 0;
     QApplication app( argc, nullptr );
     QQmlApplicationEngine engine;

--- a/src/core/qfieldappauthrequesthandler.cpp
+++ b/src/core/qfieldappauthrequesthandler.cpp
@@ -129,9 +129,9 @@ void QFieldAppAuthRequestHandler::handleAuthRequest( QNetworkReply *reply, QAuth
   for ( ;; )
   {
     bool ok = QgsCredentials::instance()->get(
-    QStringLiteral( "%1 at %2" ).arg( auth->realm(), reply->url().host() ),
-    username, password,
-    QObject::tr( "Authentication required" ) );
+      QStringLiteral( "%1 at %2" ).arg( auth->realm(), reply->url().host() ),
+      username, password,
+      QObject::tr( "Authentication required" ) );
 
     if ( !ok )
     {
@@ -143,16 +143,16 @@ void QFieldAppAuthRequestHandler::handleAuthRequest( QNetworkReply *reply, QAuth
     {
       // save credentials
       QgsCredentials::instance()->put(
-      QStringLiteral( "%1 at %2" ).arg( auth->realm(), reply->url().host() ),
-      username, password );
+        QStringLiteral( "%1 at %2" ).arg( auth->realm(), reply->url().host() ),
+        username, password );
       break;
     }
     else
     {
       // credentials didn't change - stored ones probably wrong? clear password and retry
       QgsCredentials::instance()->put(
-      QStringLiteral( "%1 at %2" ).arg( auth->realm(), reply->url().host() ),
-      username, QString() );
+        QStringLiteral( "%1 at %2" ).arg( auth->realm(), reply->url().host() ),
+        username, QString() );
     }
   }
 

--- a/src/core/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloudconnection.cpp
@@ -46,20 +46,20 @@ QFieldCloudConnection::QFieldCloudConnection()
 }
 
 QMap<QString, QString> QFieldCloudConnection::sErrors = QMap<QString, QString>(
-{
-{ "unknown_error", QObject::tr( "QFieldCloud Unknown Error" ) },
-{ "status_not_ok", QObject::tr( "Status not ok" ) },
-{ "empty_content", QObject::tr( "Empty content" ) },
-{ "object_not_found", QObject::tr( "Object not found" ) },
-{ "api_error", QObject::tr( "API Error" ) },
-{ "validation_error", QObject::tr( "Validation Error" ) },
-{ "multiple_projects", QObject::tr( "Multiple Projects" ) },
-{ "invalid_deltafile", QObject::tr( "Invalid delta file" ) },
-{ "no_qgis_project", QObject::tr( "The project does not contain a valid QGIS project file" ) },
-{ "invalid_job", QObject::tr( "Invalid job" ) },
-{ "qgis_export_error", QObject::tr( "QGIS export failed" ) },
-{ "qgis_cannot_open_project", QObject::tr( "QGIS is unable to open the QGIS project" ) },
-} );
+  {
+    { "unknown_error", QObject::tr( "QFieldCloud Unknown Error" ) },
+    { "status_not_ok", QObject::tr( "Status not ok" ) },
+    { "empty_content", QObject::tr( "Empty content" ) },
+    { "object_not_found", QObject::tr( "Object not found" ) },
+    { "api_error", QObject::tr( "API Error" ) },
+    { "validation_error", QObject::tr( "Validation Error" ) },
+    { "multiple_projects", QObject::tr( "Multiple Projects" ) },
+    { "invalid_deltafile", QObject::tr( "Invalid delta file" ) },
+    { "no_qgis_project", QObject::tr( "The project does not contain a valid QGIS project file" ) },
+    { "invalid_job", QObject::tr( "Invalid job" ) },
+    { "qgis_export_error", QObject::tr( "QGIS export failed" ) },
+    { "qgis_cannot_open_project", QObject::tr( "QGIS is unable to open the QGIS project" ) },
+  } );
 
 QString QFieldCloudConnection::errorString( QNetworkReply *reply )
 {
@@ -107,8 +107,8 @@ QString QFieldCloudConnection::errorString( QNetworkReply *reply )
   const int httpCode = reply->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
   QString httpErrorMessage = QStringLiteral( "[HTTP/%1] %2 " ).arg( httpCode ).arg( reply->url().toString() );
   httpErrorMessage += ( httpCode >= 400 )
-                      ? tr( "Server Error." )
-                      : tr( "Network Error." );
+                        ? tr( "Server Error." )
+                        : tr( "Network Error." );
   httpErrorMessage += payload.left( 200 );
 
   if ( payload.size() > 200 )
@@ -192,12 +192,12 @@ CloudUserInformation QFieldCloudConnection::userInformation() const
 void QFieldCloudConnection::login()
 {
   NetworkReply *reply = ( !mToken.isEmpty() && ( mPassword.isEmpty() || mUsername.isEmpty() ) )
-                        ? get( QStringLiteral( "/api/v1/auth/user/" ) )
-                        : post( QStringLiteral( "/api/v1/auth/token/" ), QVariantMap(
-                                                                         {
-                                                                         { "username", mUsername },
-                                                                         { "password", mPassword },
-                                                                         } ) );
+                          ? get( QStringLiteral( "/api/v1/auth/user/" ) )
+                          : post( QStringLiteral( "/api/v1/auth/token/" ), QVariantMap(
+                                                                             {
+                                                                               { "username", mUsername },
+                                                                               { "password", mPassword },
+                                                                             } ) );
 
   setStatus( ConnectionStatus::Connecting );
 

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -474,8 +474,8 @@ void QFieldCloudProjectsModel::projectGetPackagingStatus( const QString &project
     mCloudProjects[index].packagingStatus = packagingStatus( payload.value( QStringLiteral( "status" ) ).toString() );
 
     QgsLogger::debug( QStringLiteral( "Packaging request for \"%1\" finished with no error and status \"%2\"" )
-                      .arg( projectId )
-                      .arg( QVariant::fromValue( mCloudProjects[index].packagingStatus ).toString() ) );
+                        .arg( projectId )
+                        .arg( QVariant::fromValue( mCloudProjects[index].packagingStatus ).toString() ) );
 
     switch ( mCloudProjects[index].packagingStatus )
     {
@@ -568,8 +568,8 @@ void QFieldCloudProjectsModel::projectGetPackagingStatus( const QString &project
               QString layerStatus = layer.value( QStringLiteral( "status" ) ).toString();
 
               mCloudProjects[index].packagedLayerErrors.append( tr( "Packaged layer '%1' is not valid: '%2'" )
-                                                                .arg( layerName )
-                                                                .arg( layerStatus ) );
+                                                                  .arg( layerName )
+                                                                  .arg( layerStatus ) );
               QgsMessageLog::logMessage( mCloudProjects[index].packagedLayerErrors.last() );
 
               hasLayerExportErrror = true;
@@ -583,8 +583,8 @@ void QFieldCloudProjectsModel::projectGetPackagingStatus( const QString &project
           }
 
           QgsLogger::debug( QStringLiteral( "Packaged files to download - %1 files, namely: %2" )
-                            .arg( mCloudProjects[index].downloadFileTransfers.count() )
-                            .arg( mCloudProjects[index].downloadFileTransfers.keys().join( ", " ) ) );
+                              .arg( mCloudProjects[index].downloadFileTransfers.count() )
+                              .arg( mCloudProjects[index].downloadFileTransfers.keys().join( ", " ) ) );
 
           updateActiveProjectFilesToDownload( projectId );
           projectDownloadFiles( projectId );
@@ -691,8 +691,8 @@ void QFieldCloudProjectsModel::projectDownloadFiles( const QString &projectId )
     {
       mCloudProjects[index].downloadFilesFailed++;
       projectDownloadFinishedWithError( projectId, tr( "Failed to open temporary file for \"%1\", reason:\n%2" )
-                                                   .arg( fileName )
-                                                   .arg( file->errorString() ) );
+                                                     .arg( fileName )
+                                                     .arg( file->errorString() ) );
       return;
     }
 
@@ -871,9 +871,9 @@ void QFieldCloudProjectsModel::uploadProject( const QString &projectId, const bo
   // 1) upload the deltas
   // //////////
   NetworkReply *deltasCloudReply = mCloudConnection->post(
-  QStringLiteral( "/api/v1/deltas/%1/" ).arg( projectId ),
-  QVariantMap(),
-  QStringList( { deltaFileToUpload } ) );
+    QStringLiteral( "/api/v1/deltas/%1/" ).arg( projectId ),
+    QVariantMap(),
+    QStringList() );
 
   Q_ASSERT( deltasCloudReply );
 
@@ -1207,8 +1207,8 @@ void QFieldCloudProjectsModel::projectUploadAttachments( const QString &projectI
       {
         mCloudProjects[index].uploadAttachmentsFailed++;
         QgsMessageLog::logMessage( tr( "Failed to upload attachment stored at \"%1\", reason:\n%2" )
-                                   .arg( fileName )
-                                   .arg( QFieldCloudConnection::errorString( attachmentReply ) ) );
+                                     .arg( fileName )
+                                     .arg( QFieldCloudConnection::errorString( attachmentReply ) ) );
       }
       else
       {
@@ -1445,8 +1445,8 @@ void QFieldCloudProjectsModel::downloadFileConnections( const QString &projectId
     if ( hasError )
     {
       QString trimmedErrorMessage = errorMessageDetail.size() > 100
-                                    ? ( errorMessageDetail.left( 100 ) + tr( " (see more in the QField error log)…" ) )
-                                    : errorMessageDetail;
+                                      ? ( errorMessageDetail.left( 100 ) + tr( " (see more in the QField error log)…" ) )
+                                      : errorMessageDetail;
       mCloudProjects[index].downloadFilesFailed++;
       mCloudProjects[index].errorStatus = DownloadErrorStatus;
       mCloudProjects[index].packagingStatusString = QStringLiteral( "%1: \n%2" ).arg( errorMessageTemplate, fileName ).arg( trimmedErrorMessage );
@@ -1719,7 +1719,7 @@ QVariant QFieldCloudProjectsModel::data( const QModelIndex &index, int role ) co
       return static_cast<int>( mCloudProjects.at( index.row() ).errorStatus );
     case ErrorStringRole:
       return mCloudProjects.at( index.row() ).errorStatus == DownloadErrorStatus
-             ? mCloudProjects.at( index.row() ).packagingStatusString
+               ? mCloudProjects.at( index.row() ).packagingStatusString
              : mCloudProjects.at( index.row() ).errorStatus == UploadErrorStatus
                ? mCloudProjects.at( index.row() ).deltaFileUploadStatusString
                : QString();

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -276,10 +276,10 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     struct FileTransfer
     {
         FileTransfer(
-        const QString &fileName,
-        const long long bytesTotal,
-        NetworkReply *networkReply = nullptr,
-        const QStringList &layerIds = QStringList() )
+          const QString &fileName,
+          const long long bytesTotal,
+          NetworkReply *networkReply = nullptr,
+          const QStringList &layerIds = QStringList() )
           : fileName( fileName ), bytesTotal( bytesTotal ), networkReply( networkReply ), layerIds( layerIds ) {};
 
         FileTransfer() = default;

--- a/src/core/recentprojectlistmodel.cpp
+++ b/src/core/recentprojectlistmodel.cpp
@@ -62,7 +62,7 @@ void RecentProjectListModel::reloadModel()
     if ( fi.exists() )
     {
       ProjectType projectType = path.startsWith( QFieldCloudUtils::localCloudDirectory() )
-                                ? CloudProject
+                                  ? CloudProject
                                 : SUPPORTED_PROJECT_EXTENSIONS.contains( fi.suffix() )
                                   ? LocalProject
                                   : LocalDataset;
@@ -78,9 +78,9 @@ void RecentProjectListModel::reloadModel()
 
   // update demo projects
   const QList<RecentProject> demoProjects {
-  RecentProject( LocalProject, QStringLiteral( "Simple Bee Farming Demo" ), QStringLiteral( "/qfield/demo_projects/simple_bee_farming.qgs" ), true ),
-  RecentProject( LocalProject, QStringLiteral( "Advanced Bee Farming Demo" ), QStringLiteral( "/qfield/demo_projects/advanced_bee_farming.qgs" ), true ),
-  RecentProject( LocalProject, QStringLiteral( "Live QField Users Survey Demo" ), QStringLiteral( "/qfield/demo_projects/live_qfield_users_survey.qgs" ), true ) };
+    RecentProject( LocalProject, QStringLiteral( "Simple Bee Farming Demo" ), QStringLiteral( "/qfield/demo_projects/simple_bee_farming.qgs" ), true ),
+    RecentProject( LocalProject, QStringLiteral( "Advanced Bee Farming Demo" ), QStringLiteral( "/qfield/demo_projects/advanced_bee_farming.qgs" ), true ),
+    RecentProject( LocalProject, QStringLiteral( "Live QField Users Survey Demo" ), QStringLiteral( "/qfield/demo_projects/live_qfield_users_survey.qgs" ), true ) };
   for ( const RecentProject &demoProject : demoProjects )
   {
     bool recentProjectsContainsDemoProject = false;

--- a/src/core/scalebarmeasurement.cpp
+++ b/src/core/scalebarmeasurement.cpp
@@ -107,8 +107,8 @@ void ScaleBarMeasurement::measure()
     const double exponent = std::floor( std::log( range ) / 2.302585092994046 );
     const double magnitude = std::pow( 10, exponent );
     const double adjustedMagnitude = ( mapUnits == QgsUnitTypes::DistanceDegrees
-                                       ? magnitude / ( 1 + ( magnitude / factor ) / mReferenceScreenLength )
-                                       : magnitude / ( 1 + std::round( ( magnitude / factor ) / mReferenceScreenLength ) ) );
+                                         ? magnitude / ( 1 + ( magnitude / factor ) / mReferenceScreenLength )
+                                         : magnitude / ( 1 + std::round( ( magnitude / factor ) / mReferenceScreenLength ) ) );
     const double decimalsAdjustment = mapUnits == QgsUnitTypes::DistanceDegrees ? adjustedMagnitude < 0.01 ? 4 : 3 : 0;
 
     mScreenLength = adjustedMagnitude / factor;

--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -31,8 +31,8 @@ void QFieldCloudUtils::setLocalCloudDirectory( const QString &path )
 const QString QFieldCloudUtils::localCloudDirectory()
 {
   QString cloudDirectoryPath = sLocalCloudDirectory.isNull()
-                               ? QStandardPaths::writableLocation( QStandardPaths::AppDataLocation ) + QStringLiteral( "/cloud_projects" )
-                               : sLocalCloudDirectory;
+                                 ? QStandardPaths::writableLocation( QStandardPaths::AppDataLocation ) + QStringLiteral( "/cloud_projects" )
+                                 : sLocalCloudDirectory;
   return cloudDirectoryPath;
 }
 

--- a/src/core/utils/stringutils.cpp
+++ b/src/core/utils/stringutils.cpp
@@ -63,6 +63,6 @@ bool StringUtils::fuzzyMatch( const QString &source, const QString &term )
   }
 
   return lastMatchedTermPartIdx >= 0 && matchedTermItems == termPartsCount
-         ? true
-         : false;
+           ? true
+           : false;
 }

--- a/test/test_deltafilewrapper.cpp
+++ b/test/test_deltafilewrapper.cpp
@@ -123,9 +123,9 @@ QJsonDocument normalizeSchema( const QString &json )
 QJsonArray getDeltasArray( const QString &json )
 {
   return normalizeSchema( json.toUtf8() )
-  .object()
-  .value( QStringLiteral( "deltas" ) )
-  .toArray();
+    .object()
+    .value( QStringLiteral( "deltas" ) )
+    .toArray();
 }
 
 
@@ -761,8 +761,8 @@ TEST_CASE( "Delta File Wrapper" )
           "version": "1.0"
         }
       )"""" )
-                              .arg( layer->id() )
-                              .toUtf8() ) );
+                                .arg( layer->id() )
+                                .toUtf8() ) );
     REQUIRE( deltaFile.flush() );
 
     DeltaFileWrapper dfw( project, deltaFile.fileName() );
@@ -771,8 +771,8 @@ TEST_CASE( "Delta File Wrapper" )
 
     QMap<QString, QString> attachmentFileNames = dfw.attachmentFileNames();
     QMap<QString, QString> expectedAttachmentFileNames(
-    { { "FILE1.jpg", "" },
-      { "FILE3.jpg", "" } } );
+      { { "FILE1.jpg", "" },
+        { "FILE3.jpg", "" } } );
 
     REQUIRE( attachmentFileNames == expectedAttachmentFileNames );
   }
@@ -819,8 +819,8 @@ TEST_CASE( "Delta File Wrapper" )
           }
         ]
       )"""" )
-                                                         .arg( attachmentFileName, attachmentFileChecksum )
-                                                         .toUtf8() );
+                                                           .arg( attachmentFileName, attachmentFileChecksum )
+                                                           .toUtf8() );
     REQUIRE( QJsonDocument( getDeltasArray( dfw.toString() ) ) == expectedDoc );
 
 
@@ -858,8 +858,8 @@ TEST_CASE( "Delta File Wrapper" )
           }
         ]
       )"""" )
-                                           .arg( f.attribute( QStringLiteral( "attachment" ) ).toString() )
-                                           .toUtf8() );
+                                             .arg( f.attribute( QStringLiteral( "attachment" ) ).toString() )
+                                             .toUtf8() );
     REQUIRE( QJsonDocument( getDeltasArray( dfw.toString() ) ) == expectedDoc );
 
 
@@ -959,8 +959,8 @@ TEST_CASE( "Delta File Wrapper" )
           }
         ]
       )"""" )
-                                                         .arg( attachmentFileName, attachmentFileChecksum )
-                                                         .toUtf8() );
+                                                           .arg( attachmentFileName, attachmentFileChecksum )
+                                                           .toUtf8() );
     REQUIRE( QJsonDocument( getDeltasArray( dfw.toString() ) ) == expectedDoc );
 
 
@@ -1007,8 +1007,8 @@ TEST_CASE( "Delta File Wrapper" )
           }
         ]
       )"""" )
-                                           .arg( newFeature.attribute( "attachment" ).toString() )
-                                           .toUtf8() );
+                                             .arg( newFeature.attribute( "attachment" ).toString() )
+                                             .toUtf8() );
     REQUIRE( QJsonDocument( getDeltasArray( dfw.toString() ) ) == expectedDoc );
 
 
@@ -1116,8 +1116,8 @@ TEST_CASE( "Delta File Wrapper" )
             }
           ]
         )"""" )
-                                                         .arg( f.attribute( QStringLiteral( "attachment" ) ).toString() )
-                                                         .toUtf8() );
+                                                           .arg( f.attribute( QStringLiteral( "attachment" ) ).toString() )
+                                                           .toUtf8() );
     REQUIRE( QJsonDocument( getDeltasArray( dfw.toString() ) ) == expectedDoc );
   }
 
@@ -1164,8 +1164,8 @@ TEST_CASE( "Delta File Wrapper" )
           }
         ]
       )"""" )
-                                                         .arg( attachmentFileName, attachmentFileChecksum )
-                                                         .toUtf8() );
+                                                           .arg( attachmentFileName, attachmentFileChecksum )
+                                                           .toUtf8() );
     REQUIRE( QJsonDocument( getDeltasArray( dfw.toString() ) ) == expectedDoc );
 
     // Check if creates delta of a feature with a NULL geometry and non existant attachment.
@@ -1202,8 +1202,8 @@ TEST_CASE( "Delta File Wrapper" )
           }
         ]
       )"""" )
-                                                                                           .arg( f.attribute( QStringLiteral( "attachment" ) ).toString() )
-                                                                                           .toUtf8() ) );
+                                                                                             .arg( f.attribute( QStringLiteral( "attachment" ) ).toString() )
+                                                                                             .toUtf8() ) );
 
 
     // Check if creates delta of a feature without attributes
@@ -1443,8 +1443,8 @@ TEST_CASE( "Delta File Wrapper" )
           "version": "1.0"
         }
       )"""" )
-                              .arg( layer->id(), attachmentFileName )
-                              .toUtf8() ) );
+                                .arg( layer->id(), attachmentFileName )
+                                .toUtf8() ) );
     REQUIRE( deltaFile.flush() );
 
     DeltaFileWrapper dfw( project, deltaFile.fileName() );
@@ -1596,8 +1596,8 @@ TEST_CASE( "Delta File Wrapper" )
           "version": "1.0"
         }
       )"""" )
-                              .arg( layer->id(), attachmentFileName, attachmentFileChecksum )
-                              .toUtf8() ) );
+                                .arg( layer->id(), attachmentFileName, attachmentFileChecksum )
+                                .toUtf8() ) );
     REQUIRE( deltaFile.flush() );
 
     DeltaFileWrapper dfw( project, deltaFile.fileName() );
@@ -1711,8 +1711,8 @@ TEST_CASE( "Delta File Wrapper" )
           }
         ]
       )"""" )
-                                                                                           .arg( attachmentFileName, attachmentFileChecksum )
-                                                                                           .toUtf8() ) );
+                                                                                             .arg( attachmentFileName, attachmentFileChecksum )
+                                                                                             .toUtf8() ) );
   }
 
 
@@ -1766,8 +1766,8 @@ TEST_CASE( "Delta File Wrapper" )
           }
         ]
       )"""" )
-                                                                                           .arg( attachmentFileName, attachmentFileChecksum )
-                                                                                           .toUtf8() ) );
+                                                                                             .arg( attachmentFileName, attachmentFileChecksum )
+                                                                                             .toUtf8() ) );
   }
 
 
@@ -1831,7 +1831,7 @@ TEST_CASE( "Delta File Wrapper" )
           }
         ]
       )"""" )
-                                                                                           .toUtf8() ) );
+                                                                                             .toUtf8() ) );
   }
 
 
@@ -1889,7 +1889,7 @@ TEST_CASE( "Delta File Wrapper" )
           }
         ]
       )"""" )
-                                                                                           .toUtf8() ) );
+                                                                                             .toUtf8() ) );
   }
 
   project->removeMapLayer( layer.get() );


### PR DESCRIPTION
Fixes weird situations like:
before:
```
  NetworkReply *deltasCloudReply = mCloudConnection->post(
  QStringLiteral( "/api/v1/deltas/%1/" ).arg( projectId ),
  QVariantMap(),
  QStringList() );
```
after

```
  NetworkReply *deltasCloudReply = mCloudConnection->post(
    QStringLiteral( "/api/v1/deltas/%1/" ).arg( projectId ),
    QVariantMap(),
    QStringList() );
```

==================

before
```
  QJsonObject delta(
  {
    { "localPk", oldFeature.attribute( localPkAttrName ).toString() },
  } );
```
after
```
  QJsonObject delta(
    {
      { "localPk", oldFeature.attribute( localPkAttrName ).toString() },
    } );
```