### PR TITLE
Add a couple more gdal-supported vector/raster formats

### DIFF
--- a/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -185,6 +185,12 @@ public class QFieldProjectActivity extends Activity {
                                file.getName().toLowerCase().endsWith(
                                    ".geojson") ||
                                file.getName().toLowerCase().endsWith(".json") ||
+                               file.getName().toLowerCase().endsWith(".gml") ||
+                               file.getName().toLowerCase().endsWith(".mif") ||
+                               file.getName().toLowerCase().endsWith(".fgb") ||
+                               file.getName().toLowerCase().endsWith(".db") ||
+                               file.getName().toLowerCase().endsWith(
+                                   ".sqlite") ||
                                file.getName().toLowerCase().endsWith(".tif") ||
                                file.getName().toLowerCase().endsWith(".jpg") ||
                                file.getName().toLowerCase().endsWith(".png") ||
@@ -192,6 +198,7 @@ public class QFieldProjectActivity extends Activity {
                                file.getName().toLowerCase().endsWith(".gpx") ||
                                file.getName().toLowerCase().endsWith(".jp2") ||
                                file.getName().toLowerCase().endsWith(".webp") ||
+                               file.getName().toLowerCase().endsWith(".vrt") ||
                                file.getName().toLowerCase().endsWith(".zip")) {
                         values.add(new QFieldProjectListItem(
                             file, file.getName(),

--- a/scripts/ci/pull_translations.sh
+++ b/scripts/ci/pull_translations.sh
@@ -12,4 +12,9 @@ echo "::endgroup::"
 
 echo "::group::android specific translations"
 for x in platform/android/res/values-*_*;do mv $x $(echo $x | sed -e 's/_/-r/') ;done
+find platform/android/res/values-* -name strings.xml -type f -print0 | while read -d $'\0' file; do
+    # .bak is a workaround GNU & BSD/macOS compatibility
+    sed -i.bak 's/<!\[CDATA \[/<!\[CDATA\[/g' $file
+    rm $file.bak
+done
 echo "::endgroup::"

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -55,8 +55,8 @@ class LayerObserver;
 #define REGISTER_SINGLETON( uri, _class, name ) qmlRegisterSingletonType<_class>( uri, 1, 0, name, []( QQmlEngine *engine, QJSEngine *scriptEngine ) -> QObject * { Q_UNUSED(engine); Q_UNUSED(scriptEngine); return new _class(); } )
 
 #define SUPPORTED_PROJECT_EXTENSIONS QStringList( { QStringLiteral( "qgs" ), QStringLiteral( "qgz" ) } )
-#define SUPPORTED_VECTOR_EXTENSIONS QStringList( { QStringLiteral( "gpkg" ), QStringLiteral( "shp" ), QStringLiteral( "kml" ), QStringLiteral( "kmz" ), QStringLiteral( "geojson" ), QStringLiteral( "json" ), QStringLiteral( "pdf" ), QStringLiteral( "gpx" ), QStringLiteral( "zip" ) } )
-#define SUPPORTED_RASTER_EXTENSIONS QStringList( { QStringLiteral( "tif" ), QStringLiteral( "pdf" ), QStringLiteral( "jpg" ), QStringLiteral( "png" ), QStringLiteral( "gpkg" ), QStringLiteral( "jp2" ), QStringLiteral( "webp" ), QStringLiteral( "zip" ) } )
+#define SUPPORTED_VECTOR_EXTENSIONS QStringList( { QStringLiteral( "gpkg" ), QStringLiteral( "shp" ), QStringLiteral( "kml" ), QStringLiteral( "kmz" ), QStringLiteral( "geojson" ), QStringLiteral( "json" ), QStringLiteral( "pdf" ), QStringLiteral( "gpx" ), QStringLiteral( "gml" ), QStringLiteral( "mif" ), QStringLiteral( "fgb" ), QStringLiteral( "db" ), QStringLiteral( "sqlite" ), QStringLiteral( "vrt" ), QStringLiteral( "zip" ) } )
+#define SUPPORTED_RASTER_EXTENSIONS QStringList( { QStringLiteral( "tif" ), QStringLiteral( "pdf" ), QStringLiteral( "jpg" ), QStringLiteral( "png" ), QStringLiteral( "gpkg" ), QStringLiteral( "jp2" ), QStringLiteral( "webp" ), QStringLiteral( "vrt" ), QStringLiteral( "zip" ) } )
 
 class QFIELD_CORE_EXPORT QgisMobileapp : public QQmlApplicationEngine
 {


### PR DESCRIPTION
Formats are: GML, MapInfo MIF, FlatGeobuf (fixes #2341), spatialite [.db, .sqlite], and virtual vector/raster files (.vrt).