### PR TITLE
Bookmark basics

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -263,6 +263,7 @@
         <file>themes/qfield/xxhdpi/ic_photo_notavailable_black_24dp.png</file>
         <file>themes/qfield/xxxhdpi/ic_photo_notavailable_black_24dp.png</file>
         <file>themes/qfield/nodpi/ic_photo_notavailable_black_24dp.svg</file>
+        <file>themes/qfield/nodpi/ic_place_white_24dp.svg</file>
         <file>themes/qfield/hdpi/ic_print_white_24dp.png</file>
         <file>themes/qfield/mdpi/ic_print_white_24dp.png</file>
         <file>themes/qfield/xhdpi/ic_print_white_24dp.png</file>

--- a/images/themes/qfield/nodpi/ic_place_white_24dp.svg
+++ b/images/themes/qfield/nodpi/ic_place_white_24dp.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#FFFFFF"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>

--- a/images/themes/qfield/nodpi/ic_place_white_24dp.svg
+++ b/images/themes/qfield/nodpi/ic_place_white_24dp.svg
@@ -1,1 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#FFFFFF"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" fill="#FFFFFF" version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+ <path d="M0 0h24v24H0z" fill="none"/>
+ <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/>
+</svg>

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -24,6 +24,7 @@ set(QFIELD_CORE_SRCS
     badlayerhandler.cpp
     bluetoothdevicemodel.cpp
     bluetoothreceiver.cpp
+    bookmarkmodel.cpp
     changelogcontents.cpp
     deltafilewrapper.cpp
     deltalistmodel.cpp
@@ -110,6 +111,7 @@ set(QFIELD_CORE_HDRS
     badlayerhandler.h
     bluetoothdevicemodel.h
     bluetoothreceiver.h
+    bookmarkmodel.h
     changelogcontents.h
     deltafilewrapper.h
     deltalistmodel.h

--- a/src/core/bookmarkmodel.cpp
+++ b/src/core/bookmarkmodel.cpp
@@ -1,9 +1,9 @@
 /***************************************************************************
-                            featuremodel.cpp
+                            bookmarkmodel.cpp
                               -------------------
-              begin                : 10.12.2014
-              copyright            : (C) 2014 by Matthias Kuhn
-              email                : matthias (at) opengis.ch
+              begin                : 12.12.2021
+              copyright            : (C) 2021 by Mathieu Pellerin
+              email                : mathieu (at) opengis.ch
  ***************************************************************************/
 
 /***************************************************************************

--- a/src/core/bookmarkmodel.cpp
+++ b/src/core/bookmarkmodel.cpp
@@ -66,3 +66,23 @@ QHash<int, QByteArray> BookmarkModel::roleNames() const
   roleNames[BookmarkModel::BookmarkCrs] = "BookmarkCrs";
   return roleNames;
 }
+
+void BookmarkModel::setMapSettings( QgsQuickMapSettings *mapSettings )
+{
+  if ( mMapSettings == mapSettings )
+    return;
+
+  mMapSettings = mapSettings;
+
+  emit mapSettingsChanged();
+}
+
+void BookmarkModel::setExtentFromBookmark( const QModelIndex &index )
+{
+  QModelIndex sourceIndex = mapToSource( index );
+  if ( !sourceIndex.isValid() || !mMapSettings )
+    return;
+
+  QgsReferencedRectangle rect = mModel->data( sourceIndex, QgsBookmarkManagerModel::RoleExtent ).value< QgsReferencedRectangle >();
+  mMapSettings->setExtent( rect );
+}

--- a/src/core/bookmarkmodel.cpp
+++ b/src/core/bookmarkmodel.cpp
@@ -1,0 +1,68 @@
+/***************************************************************************
+                            featuremodel.cpp
+                              -------------------
+              begin                : 10.12.2014
+              copyright            : (C) 2014 by Matthias Kuhn
+              email                : matthias (at) opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "bookmarkmodel.h"
+
+#include <qgsgeometry.h>
+
+BookmarkModel::BookmarkModel( QgsBookmarkManager *manager, QgsBookmarkManager *projectManager, QObject *parent )
+  : QSortFilterProxyModel( parent )
+{
+  mModel = std::make_unique<QgsBookmarkManagerModel>( manager, projectManager, this );
+  setSourceModel( mModel.get() );
+}
+
+QVariant BookmarkModel::data( const QModelIndex &index, int role ) const
+{
+  QModelIndex sourceIndex = mapToSource( index );
+  if ( !sourceIndex.isValid() )
+    return QVariant();
+
+  switch ( role )
+  {
+    case BookmarkModel::BookmarkId:
+      return mModel->data( sourceIndex, QgsBookmarkManagerModel::RoleId );
+
+    case BookmarkModel::BookmarkName:
+      return mModel->data( sourceIndex, QgsBookmarkManagerModel::RoleName );
+
+    case BookmarkModel::BookmarkPoint:
+    {
+      QgsReferencedRectangle rect = mModel->data( sourceIndex, QgsBookmarkManagerModel::RoleExtent ).value< QgsReferencedRectangle >();
+      QgsGeometry geom( new QgsPoint( rect.center() ) );
+      return geom;
+    }
+
+    case BookmarkModel::BookmarkCrs:
+    {
+      QgsReferencedRectangle rect = mModel->data( sourceIndex, QgsBookmarkManagerModel::RoleExtent ).value< QgsReferencedRectangle >();
+      return rect.crs();
+    }
+  }
+
+  return QVariant();
+}
+
+QHash<int, QByteArray> BookmarkModel::roleNames() const
+{
+  QHash<int, QByteArray> roleNames = QAbstractProxyModel::roleNames();
+  roleNames[BookmarkModel::BookmarkId] = "BookmarkId";
+  roleNames[BookmarkModel::BookmarkName] = "BookmarkName";
+  roleNames[BookmarkModel::BookmarkPoint] = "BookmarkPoint";
+  roleNames[BookmarkModel::BookmarkCrs] = "BookmarkCrs";
+  return roleNames;
+}

--- a/src/core/bookmarkmodel.h
+++ b/src/core/bookmarkmodel.h
@@ -1,0 +1,50 @@
+/***************************************************************************
+                            bookmarkmodel.h
+                              -------------------
+              begin                : 12.12.2021
+              copyright            : (C) 2021 by Mathieu Pellerin
+              email                : mathieu (at) opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef BOOKMARKMODEL_H
+#define BOOKMARKMODEL_H
+
+#include <qgsbookmarkmanager.h>
+#include <qgsbookmarkmodel.h>
+
+class BookmarkModel : public QSortFilterProxyModel
+{
+
+  public:
+
+    enum Roles
+    {
+      BookmarkId = Qt::UserRole + 1,
+      BookmarkName,
+      BookmarkPoint,
+      BookmarkCrs,
+    };
+    Q_ENUM( Roles )
+
+    explicit BookmarkModel( QgsBookmarkManager *manager, QgsBookmarkManager *projectManager = nullptr, QObject *parent = nullptr );
+
+    QVariant data( const QModelIndex &index, int role ) const override;
+
+    QHash<int, QByteArray> roleNames() const override;
+
+  private:
+
+    std::unique_ptr<QgsBookmarkManagerModel> mModel = nullptr;
+
+};
+
+#endif // BOOKMARKMODEL_H

--- a/src/core/bookmarkmodel.h
+++ b/src/core/bookmarkmodel.h
@@ -30,7 +30,6 @@ class BookmarkModel : public QSortFilterProxyModel
     Q_PROPERTY( QgsQuickMapSettings *mapSettings READ setMapSettings READ mapSettings NOTIFY mapSettingsChanged )
 
   public:
-
     enum Roles
     {
       BookmarkId = Qt::UserRole + 1,
@@ -53,14 +52,11 @@ class BookmarkModel : public QSortFilterProxyModel
     QgsQuickMapSettings *mapSettings() const { return mMapSettings; }
 
   signals:
-
     void mapSettingsChanged();
 
   private:
-
     std::unique_ptr<QgsBookmarkManagerModel> mModel = nullptr;
     QgsQuickMapSettings *mMapSettings = nullptr;
-
 };
 
 #endif // BOOKMARKMODEL_H

--- a/src/core/bookmarkmodel.h
+++ b/src/core/bookmarkmodel.h
@@ -25,9 +25,9 @@
 
 class BookmarkModel : public QSortFilterProxyModel
 {
-  Q_OBJECT
+    Q_OBJECT
 
-  Q_PROPERTY( QgsQuickMapSettings *mapSettings READ setMapSettings READ mapSettings NOTIFY mapSettingsChanged )
+    Q_PROPERTY( QgsQuickMapSettings *mapSettings READ setMapSettings READ mapSettings NOTIFY mapSettingsChanged )
 
   public:
 

--- a/src/core/bookmarkmodel.h
+++ b/src/core/bookmarkmodel.h
@@ -18,11 +18,16 @@
 #ifndef BOOKMARKMODEL_H
 #define BOOKMARKMODEL_H
 
+#include "qgsquickmapsettings.h"
+
 #include <qgsbookmarkmanager.h>
 #include <qgsbookmarkmodel.h>
 
 class BookmarkModel : public QSortFilterProxyModel
 {
+  Q_OBJECT
+
+  Q_PROPERTY( QgsQuickMapSettings *mapSettings READ setMapSettings READ mapSettings NOTIFY mapSettingsChanged )
 
   public:
 
@@ -41,9 +46,20 @@ class BookmarkModel : public QSortFilterProxyModel
 
     QHash<int, QByteArray> roleNames() const override;
 
+    Q_INVOKABLE void setExtentFromBookmark( const QModelIndex &index );
+
+    void setMapSettings( QgsQuickMapSettings *mapSettings );
+
+    QgsQuickMapSettings *mapSettings() const { return mMapSettings; }
+
+  signals:
+
+    void mapSettingsChanged();
+
   private:
 
     std::unique_ptr<QgsBookmarkManagerModel> mModel = nullptr;
+    QgsQuickMapSettings *mMapSettings = nullptr;
 
 };
 

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -296,6 +296,7 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
 
   mMapCanvas = rootObjects().first()->findChild<QgsQuickMapCanvasMap *>();
   mMapCanvas->mapSettings()->setProject( mProject );
+  mBookmarkModel->setMapSettings( mMapCanvas->mapSettings() );
 
   QFieldCloudProjectsModel *qFieldCloudProjectsModel = rootObjects().first()->findChild<QFieldCloudProjectsModel *>();
 

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -219,6 +219,10 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   mLegendImageProvider = new LegendImageProvider( mFlatLayerTree->layerTreeModel() );
   mTrackingModel = new TrackingModel;
 
+  mBookmarkManager = std::make_unique<QgsBookmarkManager>( nullptr );
+  mBookmarkManager->initialize( QgsApplication::qgisSettingsDirPath() + "/bookmarks.xml" );
+  mBookmarkModel = std::make_unique<BookmarkModel>( mBookmarkManager.get(), mProject->bookmarkManager(), nullptr );
+
   // Transition from 1.8 to 1.8.1+
   const QString deviceAddress = settings.value( QStringLiteral( "positioningDevice" ), QString() ).toString();
   if ( deviceAddress == QStringLiteral( "internal" ) )
@@ -453,7 +457,6 @@ void QgisMobileapp::initDeclarative()
   REGISTER_SINGLETON( "org.qfield", UrlUtils, "UrlUtils" );
   REGISTER_SINGLETON( "org.qfield", QFieldCloudUtils, "QFieldCloudUtils" );
 
-
   qmlRegisterUncreatableType<AppInterface>( "org.qgis", 1, 0, "QgisInterface", "QgisInterface is only provided by the environment and cannot be created ad-hoc" );
   qmlRegisterUncreatableType<Settings>( "org.qgis", 1, 0, "Settings", "" );
   qmlRegisterUncreatableType<PlatformUtilities>( "org.qfield", 1, 0, "PlatformUtilities", "" );
@@ -462,6 +465,7 @@ void QgisMobileapp::initDeclarative()
   qmlRegisterUncreatableType<QgsGpkgFlusher>( "org.qfield", 1, 0, "QgsGpkgFlusher", "The gpkgFlusher is available as context property `gpkgFlusher`" );
   qmlRegisterUncreatableType<LayerObserver>( "org.qfield", 1, 0, "LayerObserver", "" );
   qmlRegisterUncreatableType<DeltaFileWrapper>( "org.qfield", 1, 0, "DeltaFileWrapper", "" );
+  qmlRegisterUncreatableType<BookmarkModel>( "org.qfield", 1, 0, "BookmarkModel", "The BookmarkModel is available as context property `bookmarkModel`" );
 
   qRegisterMetaType<SnappingResult>( "SnappingResult" );
 
@@ -473,6 +477,7 @@ void QgisMobileapp::initDeclarative()
   rootContext()->setContextProperty( "ppi", dpi );
   rootContext()->setContextProperty( "mouseDoubleClickInterval", QApplication::styleHints()->mouseDoubleClickInterval() );
   rootContext()->setContextProperty( "qgisProject", mProject );
+  rootContext()->setContextProperty( "bookmarkModel", mBookmarkModel.get() );
   rootContext()->setContextProperty( "iface", mIface );
   rootContext()->setContextProperty( "settings", &mSettings );
   rootContext()->setContextProperty( "appVersion", qfield::appVersion );

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -23,12 +23,14 @@
 
 // QGIS includes
 #include <qgsapplication.h>
+#include <qgsbookmarkmanager.h>
 #include <qgsconfig.h>
 #include <qgsexiftools.h>
 #include <qgsmaplayerproxymodel.h>
 
-// QGIS mobile includes
+// QField includes
 #include "appcoordinateoperationhandlers.h"
+#include "bookmarkmodel.h"
 #include "focusstack.h"
 #include "geometryeditorsmodel.h"
 #include "multifeaturelistmodel.h"
@@ -182,6 +184,9 @@ class QFIELD_CORE_EXPORT QgisMobileapp : public QQmlApplicationEngine
     std::unique_ptr<QgsGpkgFlusher> mGpkgFlusher;
     std::unique_ptr<LayerObserver> mLayerObserver;
     QFieldAppAuthRequestHandler *mAuthRequestHandler = nullptr;
+
+    std::unique_ptr<QgsBookmarkManager> mBookmarkManager;
+    std::unique_ptr<BookmarkModel> mBookmarkModel;
 
     // Dummy objects. We are not able to call static functions from QML, so we need something here.
     QgsCoordinateReferenceSystem mCrsFactory;

--- a/src/qml/BookmarkHighlight.qml
+++ b/src/qml/BookmarkHighlight.qml
@@ -1,0 +1,21 @@
+import QtQuick 2.12
+
+import org.qgis 1.0
+import org.qfield 1.0
+
+import Theme 1.0
+
+Repeater {
+  id: bookmarkHighlight
+  property MapSettings mapSettings
+
+  model: bookmarkModel
+
+  delegate: BookmarkRenderer {
+    mapSettings: bookmarkHighlight.mapSettings
+    geometryWrapper.qgsGeometry: model.BookmarkPoint
+    geometryWrapper.crs: model.BookmarkCrs
+    bookmarkName: model.BookmarkName
+    bookmarkId: model.BookmarkId
+  }
+}

--- a/src/qml/BookmarkHighlight.qml
+++ b/src/qml/BookmarkHighlight.qml
@@ -15,6 +15,8 @@ Repeater {
     mapSettings: bookmarkHighlight.mapSettings
     geometryWrapper.qgsGeometry: model.BookmarkPoint
     geometryWrapper.crs: model.BookmarkCrs
+
+    bookmarkIndex: model.index
     bookmarkName: model.BookmarkName
     bookmarkId: model.BookmarkId
   }

--- a/src/qml/BookmarkRenderer.qml
+++ b/src/qml/BookmarkRenderer.qml
@@ -9,6 +9,7 @@ import Theme 1.0
 Item {
     id: bookmarkRenderer
 
+    property var bookmarkIndex: undefined
     property string bookmarkName: ''
     property string bookmarkId: ''
 
@@ -73,6 +74,9 @@ Item {
                         anchors.fill: bookmark
                         onClicked: {
                             displayToast(qsTr('Bookmark: %1').arg(bookmarkRenderer.bookmarkName));
+                        }
+                        onDoubleClicked: {
+                            bookmarkModel.setExtentFromBookmark(bookmarkModel.index(bookmarkRenderer.bookmarkIndex, 0));
                         }
                     }
                 }

--- a/src/qml/BookmarkRenderer.qml
+++ b/src/qml/BookmarkRenderer.qml
@@ -1,0 +1,98 @@
+import QtQuick 2.12
+import QtGraphicalEffects 1.0
+
+import org.qgis 1.0
+import org.qfield 1.0
+
+import Theme 1.0
+
+Item {
+    id: bookmarkRenderer
+
+    property string bookmarkName: ''
+    property string bookmarkId: ''
+
+    property MapSettings mapSettings
+    property alias geometryWrapper: geometryWrapper
+
+    QgsGeometryWrapper {
+        id: geometryWrapper
+    }
+
+    Connections {
+        target: geometryWrapper
+
+        function onQgsGeometryChanged() {
+            geometryComponent.sourceComponent = undefined
+            if (geometryWrapper && geometryWrapper.qgsGeometry.type === QgsWkbTypes.PointGeometry) {
+                geometryComponent.sourceComponent = pointHighlight
+            }
+        }
+    }
+
+    Component {
+        id: pointHighlight
+
+        Repeater {
+            model: geometryWrapper.pointList()
+
+            Item {
+                Image {
+                    id: bookmark
+
+                    property CoordinateTransformer ct: CoordinateTransformer {
+                        id: _ct
+                        sourceCrs: geometryWrapper.crs
+                        sourcePosition: modelData
+                        destinationCrs: mapCanvas.mapSettings.destinationCrs
+                        transformContext: qgisProject.transformContext
+                    }
+
+                    MapToScreen {
+                        id: mapToScreenPosition
+                        mapSettings: mapCanvas.mapSettings
+                        mapPoint: _ct.projectedPosition
+                    }
+
+                    x: mapToScreenPosition.screenPoint.x - width/2
+                    y: mapToScreenPosition.screenPoint.y - height
+
+                    width: 36
+                    height: 36
+                    source: Theme.getThemeVectorIcon("ic_place_white_24dp")
+                    sourceSize.width: 36 * screen.devicePixelRatio
+                    sourceSize.height: 36 * screen.devicePixelRatio
+
+                    ColorOverlay {
+                        anchors.fill: bookmark
+                        source: bookmark
+                        color: Theme.mainColor
+                    }
+
+                    MouseArea {
+                        anchors.fill: bookmark
+                        onClicked: {
+                            displayToast(qsTr('Bookmark: %1').arg(bookmarkRenderer.bookmarkName));
+                        }
+                    }
+                }
+
+                Glow {
+                    anchors.fill: bookmark
+                    source: bookmark
+                    radius: 7
+                    samples: 17
+                    color: "#44000000"
+                }
+            }
+        }
+    }
+
+    Loader {
+        id: geometryComponent
+        // the sourceComponent is updated with the connection on wrapper qgsGeometryChanged signal
+        // but it needs to be ready on first used
+        sourceComponent: geometryWrapper && geometryWrapper.qgsGeometry.type === QgsWkbTypes.PointGeometry ? pointHighlight : undefined
+    }
+}
+

--- a/src/qml/GeometryRenderer.qml
+++ b/src/qml/GeometryRenderer.qml
@@ -87,5 +87,4 @@ Item {
     // but it needs to be ready on first used
     sourceComponent: geometryWrapper && geometryWrapper.qgsGeometry.type === QgsWkbTypes.PointGeometry ? pointHighlight : linePolygonHighlight
   }
-
 }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -504,6 +504,11 @@ ApplicationWindow {
       }
     }
 
+    BookmarkHighlight {
+        id: bookmarkHighlight
+        mapSettings: mapCanvas.mapSettings
+    }
+
     /* Locator Highlight */
     GeometryHighlighter {
       id: locatorHighlightItem

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -2,6 +2,8 @@
     <qresource prefix="/qml">
         <file>About.qml</file>
         <file>BadLayerItem.qml</file>
+        <file>BookmarkHighlight.qml</file>
+        <file>BookmarkRenderer.qml</file>
         <file>BrowserPanel.qml</file>
         <file>ConfirmationToolbar.qml</file>
         <file>CoordinateLocator.qml</file>


### PR DESCRIPTION
This PR implements basic bookmarks display framework for QField. In action:

https://user-images.githubusercontent.com/1728657/145700930-9ae95f3b-0409-4b51-a1c6-eaf044a69331.mp4

The framework displays both project bookmarks (see in the screencast) as well as app-wide bookmarks (UI to be implemented in a different PR).

This is cool for a couple of reasons:
a/ the bookmarks are rendered as QML items, so it is always shown and not bound to canvas rendering
b/ the app-wide bookmarks will be saved across projects

A single click/tap on the bookmark throws a toaster message with the bookmark name. A double click/tap sets the map canvas extent to the bookmark extent:

https://user-images.githubusercontent.com/1728657/145706411-f90aa4da-0bd9-4114-a1af-abc1d664eeea.mp4

