### PR TITLE
Remove last leftovers from the black buttons in the header bar in QField forms

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -647,7 +647,6 @@ Page {
         width: 48
         height: 48
         clip: true
-        bgcolor: Theme.darkGray
 
         iconSource: Theme.getThemeIcon( "ic_check_white_48dp" )
         opacity: typeof featureFormList !== "undefined" ? featureFormList.model.constraintsHardValid ? 1.0 : 0.3 : 1.0
@@ -698,7 +697,6 @@ Page {
         width: 49
         height: 48
         clip: true
-        bgcolor: form.state === 'Add' ? "#900000" : Theme.darkGray
         visible: !setupOnly
 
         iconSource: form.state === 'Add' ? Theme.getThemeIcon( 'ic_delete_forever_white_24dp' ) : Theme.getThemeIcon( 'ic_close_white_24dp' )


### PR DESCRIPTION
The final bit after https://github.com/opengisch/QField/pull/2033 .

Also, the 1px on the top was driving me crazy.

before/after
![image](https://user-images.githubusercontent.com/2820439/145921560-11de5c7c-e89f-4c5e-9e83-88357af39ded.png)

