### PR TITLE
Implement the QField _app_ directory concept (vs. storage-wide QField directory)

### DIFF
--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -15,7 +15,7 @@
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
       android:maxSdkVersion="28"
       />
-  <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+  <!--<uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />-->
 
   <uses-feature android:required="false" android:name="android.hardware.camera" />
   <uses-feature android:required="false" android:name="android.hardware.camera.autofocus" />

--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -15,7 +15,7 @@
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
       android:maxSdkVersion="28"
       />
-  <!--<uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />-->
+  <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 
   <uses-feature android:required="false" android:name="android.hardware.camera" />
   <uses-feature android:required="false" android:name="android.hardware.camera.autofocus" />

--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -121,7 +121,6 @@ public class QFieldActivity extends QtActivity {
 
         String storagePath =
             Environment.getExternalStorageDirectory().getAbsolutePath();
-
         String qFieldDir = storagePath + "/QField/";
         new File(qFieldDir).mkdir();
 
@@ -130,6 +129,19 @@ public class QFieldActivity extends QtActivity {
         new File(qFieldDir + "fonts/").mkdir();
         new File(qFieldDir + "proj/").mkdir();
         new File(qFieldDir + "auth/").mkdir();
+
+        File[] externalFilesDirs = getExternalFilesDirs(null);
+        String qFieldAppDir = "";
+        if (externalFilesDirs.length > 0) {
+            qFieldAppDir = externalFilesDirs[0].getAbsolutePath() + "/QField/";
+            new File(qFieldAppDir).mkdir();
+
+            // create directories
+            new File(qFieldAppDir + "basemaps/").mkdir();
+            new File(qFieldAppDir + "fonts/").mkdir();
+            new File(qFieldAppDir + "proj/").mkdir();
+            new File(qFieldAppDir + "auth/").mkdir();
+       }
 
         Intent intent = new Intent();
         intent.setClass(QFieldActivity.this, QtActivity.class);
@@ -145,6 +157,7 @@ public class QFieldActivity extends QtActivity {
         }
 
         intent.putExtra("QFIELD_DATA_DIR", qFieldDir);
+        intent.putExtra("QFIELD_APP_DATA_DIR", qFieldAppDir);
 
         Intent sourceIntent = getIntent();
         if (sourceIntent.getAction() == Intent.ACTION_VIEW) {

--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -141,7 +141,7 @@ public class QFieldActivity extends QtActivity {
             new File(qFieldAppDir + "fonts/").mkdir();
             new File(qFieldAppDir + "proj/").mkdir();
             new File(qFieldAppDir + "auth/").mkdir();
-       }
+        }
 
         Intent intent = new Intent();
         intent.setClass(QFieldActivity.this, QtActivity.class);

--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -44,6 +44,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.ActivityInfo;
+import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.net.Uri;
@@ -68,6 +69,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.Thread;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -211,6 +213,23 @@ public class QFieldActivity extends QtActivity {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
             !Environment.isExternalStorageManager() &&
             !sharedPreferences.getBoolean("DontAskAllFilesPermission", false)) {
+            // if MANAGE_EXTERNAL_STORAGE permission isn't in the manifest, bail
+            // out
+            String[] requestedPermissions;
+            try {
+                PackageInfo pi = getPackageManager().getPackageInfo(
+                    this.getPackageName(), PackageManager.GET_PERMISSIONS);
+                requestedPermissions = pi.requestedPermissions;
+            } catch (NameNotFoundException e) {
+                e.printStackTrace();
+                finish();
+                return;
+            }
+            if (!Arrays.asList(requestedPermissions)
+                     .contains(Manifest.permission.MANAGE_EXTERNAL_STORAGE)) {
+                return;
+            }
+
             AlertDialog.Builder builder = new AlertDialog.Builder(this);
             builder.setTitle(getString(R.string.grant_permission));
             builder.setMessage(

--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -124,13 +124,17 @@ public class QFieldActivity extends QtActivity {
         String storagePath =
             Environment.getExternalStorageDirectory().getAbsolutePath();
         String qFieldDir = storagePath + "/QField/";
-        new File(qFieldDir).mkdir();
-
-        // create directories
-        new File(qFieldDir + "basemaps/").mkdir();
-        new File(qFieldDir + "fonts/").mkdir();
-        new File(qFieldDir + "proj/").mkdir();
-        new File(qFieldDir + "auth/").mkdir();
+        File storageFile = new File(qFieldDir);
+        storageFile.mkdir();
+        if (storageFile.canWrite()) {
+            // create directories
+            new File(qFieldDir + "basemaps/").mkdir();
+            new File(qFieldDir + "fonts/").mkdir();
+            new File(qFieldDir + "proj/").mkdir();
+            new File(qFieldDir + "auth/").mkdir();
+        } else {
+            qFieldDir = "";
+        }
 
         File[] externalFilesDirs = getExternalFilesDirs(null);
         String qFieldAppDir = "";

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -138,6 +138,11 @@ QString AndroidPlatformUtilities::qfieldDataDir() const
   return getIntentExtra( "QFIELD_DATA_DIR" );
 }
 
+QString AndroidPlatformUtilities::qfieldAppDataDir() const
+{
+  return getIntentExtra( "QFIELD_APP_DATA_DIR" );
+}
+
 QString AndroidPlatformUtilities::getIntentExtra( const QString &extra, QAndroidJniObject extras ) const
 {
   if ( extras == nullptr )

--- a/src/core/platforms/android/androidplatformutilities.h
+++ b/src/core/platforms/android/androidplatformutilities.h
@@ -34,6 +34,7 @@ class AndroidPlatformUtilities : public PlatformUtilities
     QString systemGenericDataLocation() const override;
     QString qgsProject() const override;
     QString qfieldDataDir() const override;
+    QString qfieldAppDataDir() const override;
     PictureSource *getCameraPicture( QQuickItem *parent, const QString &prefix, const QString &pictureFilePath, const QString &suffix ) override;
     PictureSource *getGalleryPicture( QQuickItem *parent, const QString &prefix, const QString &pictureFilePath ) override;
     ViewStatus *open( const QString &uri, bool editing ) override;

--- a/src/core/platforms/platformutilities.cpp
+++ b/src/core/platforms/platformutilities.cpp
@@ -62,6 +62,11 @@ QString PlatformUtilities::qfieldDataDir() const
   return QStandardPaths::standardLocations( QStandardPaths::DocumentsLocation ).first() + QStringLiteral( "/QField/" );
 }
 
+QString PlatformUtilities::qfieldAppDataDir() const
+{
+  return QStandardPaths::standardLocations( QStandardPaths::DocumentsLocation ).first() + QStringLiteral( "/QField/" );
+}
+
 QStringList PlatformUtilities::availableGrids() const
 {
   if ( !qfieldDataDir().isEmpty() )

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -64,6 +64,7 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
     virtual QString systemGenericDataLocation() const;
     virtual QString qgsProject() const;
     virtual QString qfieldDataDir() const;
+    virtual QString qfieldAppDataDir() const;
     Q_INVOKABLE QStringList availableGrids() const;
     Q_INVOKABLE bool createDir( const QString &path, const QString &dirname ) const;
     Q_INVOKABLE bool rmFile( const QString &filename ) const;

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -63,8 +63,8 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
      */
     virtual QString systemGenericDataLocation() const;
     virtual QString qgsProject() const;
-    virtual QString qfieldDataDir() const;
-    virtual QString qfieldAppDataDir() const;
+    Q_INVOKABLE virtual QString qfieldDataDir() const;
+    Q_INVOKABLE virtual QString qfieldAppDataDir() const;
     Q_INVOKABLE QStringList availableGrids() const;
     Q_INVOKABLE bool createDir( const QString &path, const QString &dirname ) const;
     Q_INVOKABLE bool rmFile( const QString &filename ) const;

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -180,7 +180,7 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   QgsNetworkAccessManager::instance()->setAuthHandler( std::move( handler ) );
 
   QStringList dataDirs;
-  if ( PlatformUtilities::instance()->qfieldDataDir().isEmpty() )
+  if ( !PlatformUtilities::instance()->qfieldDataDir().isEmpty() )
     dataDirs << PlatformUtilities::instance()->qfieldDataDir();
   if ( !PlatformUtilities::instance()->qfieldAppDataDir().isEmpty() )
     dataDirs << PlatformUtilities::instance()->qfieldAppDataDir();

--- a/src/qml/About.qml
+++ b/src/qml/About.qml
@@ -111,6 +111,25 @@ Item {
             }
         }
 
+        Label {
+            Layout.fillWidth: true
+            Layout.maximumWidth: parent.width
+            Layout.alignment: Qt.AlignCenter
+            horizontalAlignment: Text.AlignHCenter
+            font: Theme.tinyFont
+            color: Theme.light
+            opacity: 0.6
+
+            text: {
+                var dataFields = [];
+                if (platformUtilities.qfieldDataDir() !== '')
+                    dataFields.push('QField storage-wide directory:\n' + platformUtilities.qfieldDataDir());
+                if (platformUtilities.qfieldAppDataDir() !== ''
+                    && platformUtilities.qfieldAppDataDir() !== platformUtilities.qfieldDataDir())
+                    dataFields.push('QField app directory:\n' + platformUtilities.qfieldAppDataDir());
+                return dataFields.join('\n');
+            }
+        }
 
         QfButton {
             id: sponsorshipButton

--- a/src/qml/imports/Theme/Theme.qml
+++ b/src/qml/imports/Theme/Theme.qml
@@ -21,6 +21,10 @@ QtObject {
     defaultFont.pointSize: 16
     defaultFont.weight: Font.Normal
 
+    property font tinyFont
+    tinyFont.pointSize: 12
+    tinyFont.weight: Font.Normal
+
     property font tipFont
     tipFont.pointSize: 14
     tipFont.weight: Font.Normal


### PR DESCRIPTION
Winter might be coming... 

Edit: I've added an helper label in QField's about panel to provider users with strings of QField storage-wide and app directories:
![image](https://user-images.githubusercontent.com/1728657/147844371-be08ce6b-3664-4c6d-b0b2-f7f76cecbc3c.png)

If storage-wide and app are the same, the latter is skipped (i.e. windows, linux)