### PR TITLE
Just to rule out API use

### DIFF
--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -15,7 +15,7 @@
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
       android:maxSdkVersion="28"
       />
-  <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+  <!-- <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" /> -->
 
   <uses-feature android:required="false" android:name="android.hardware.camera" />
   <uses-feature android:required="false" android:name="android.hardware.camera.autofocus" />

--- a/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -37,6 +37,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import ch.opengis.qfield.QFieldUtils;
+
 public class QFieldProjectActivity extends Activity {
 
     private static final String TAG = "QField Project Activity";
@@ -413,6 +415,9 @@ public class QFieldProjectActivity extends Activity {
                 context.getContentResolver()
                        .takePersistableUriPermission(data.getData(),Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION );
                 String path = data.getDataString();
+                Log.d("QField Testing", path);
+                String absolutePath = QFieldUtils.getPathFromUri(context, data.getData());
+                Log.d("QField Testing", absolutePath);
             }
             return;
         }

--- a/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -1,5 +1,8 @@
 package ch.opengis.qfield;
 
+import static android.os.Build.VERSION.SDK_INT;
+import static android.os.Build.VERSION_CODES.Q;
+
 import android.Manifest;
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -52,6 +55,14 @@ public class QFieldProjectActivity extends Activity {
         getActionBar().setBackgroundDrawable(
             new ColorDrawable(Color.parseColor("#80CC28")));
         drawView();
+
+        if (!getIntent().hasExtra("path")) {
+            Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
+            intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+            intent.addFlags(Intent.FLAG_GRANT_PREFIX_URI_PERMISSION);
+            intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
+            startActivityForResult(intent, 777);
+        }
     }
 
     private void drawView() {
@@ -395,6 +406,16 @@ public class QFieldProjectActivity extends Activity {
                                     Intent data) {
         Log.d(TAG, "onActivityResult ");
         Log.d(TAG, "resultCode: " + resultCode);
+
+        if (requestCode == 777) {
+            if (SDK_INT >= Q) {
+                Context context = getApplication().getApplicationContext();
+                context.getContentResolver()
+                       .takePersistableUriPermission(data.getData(),Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION );
+                String path = data.getDataString();
+            }
+            return;
+        }
 
         // Close recursively the activity stack
         if (resultCode == Activity.RESULT_OK) {

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -179,6 +179,23 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   handler.reset( mAuthRequestHandler );
   QgsNetworkAccessManager::instance()->setAuthHandler( std::move( handler ) );
 
+  QDir d( PlatformUtilities::instance()->qfieldDataDir() );
+  const QStringList fs = d.entryList( QStringList() << "*.*", QDir::Files );
+  for ( auto f : fs )
+  {
+    qDebug() << f;
+  }
+  QFile file( PlatformUtilities::instance()->qfieldDataDir() + "test.qgs" );
+  qDebug() << ( file.exists() ? "project file registered as existing" : "project file not registered as existing" );
+  if ( file.open( QIODevice::ReadWrite ) )
+  {
+    qDebug() << file.readLine();
+  }
+  else
+  {
+    qDebug() << "can't open direct file paths";
+  }
+
   if ( !PlatformUtilities::instance()->qfieldDataDir().isEmpty() )
   {
     //set localized data paths


### PR DESCRIPTION
The only way what we're being told to use would _actually_ work is if somehow Android won't let native code _lists_ files within a directory granted permission but would somehow allow direct path name file opening... 

Merely doing this to get the data we need to show it's not sufficient.