### PR TITLE
Fix feature selection after it was duplicated from the attribute form

### DIFF
--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -469,6 +469,8 @@ bool MultiFeatureListModelBase::duplicateFeature( QgsVectorLayer *layer, const Q
     mFeatures = duplicatedFeatures;
     mSelectedFeatures = duplicatedFeatures;
     endResetModel();
+
+    emit selectedCountChanged();
   }
 
   return feature.isValid();


### PR DESCRIPTION
Quite annoying problem mentioned by @ipickedausername in https://github.com/opengisch/QField/issues/2387#issuecomment-1008302114 and also confirmed by me.

Here is what was fixed:
![Peek 2022-01-10 23-40](https://user-images.githubusercontent.com/2820439/148844314-ffbf4425-9c83-4d82-aeff-00ec44077076.gif)
