### PR TITLE
When moving a single feature, first center the map to that feature

### DIFF
--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -422,7 +422,7 @@ Rectangle {
     }
 
     onMoveClicked: {
-        if (featureForm.selection.focusedItem != -1) {
+        if (featureForm.selection.focusedItem !== -1) {
             featureForm.state = "FeatureList"
             featureForm.multiSelection = true
             featureForm.selection.model.toggleSelectedItem(featureForm.selection.focusedItem)

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1348,6 +1348,10 @@ ApplicationWindow {
         }
 
         function initializeMoveFeatures() {
+            if ( featureForm  && featureForm.selection.model.selectedCount === 1 ) {
+              featureForm.extentController.zoomToSelected()
+            }
+
             startPoint = mapCanvas.mapSettings.center
             moveFeaturesRequested = true
         }


### PR DESCRIPTION
Fix https://github.com/opengisch/QField/issues/2386

The feature is centered if:
1) you move feature from the feature form
2) there is only one feature selected in the multiselect

The features are not selected if there are more than one selected feature.

![Peek 2022-01-11 01-14](https://user-images.githubusercontent.com/2820439/148853607-bfbba045-5fe3-4bc7-becb-c8c73dab26af.gif)
