### PR TITLE
Introduce mechanism to import associated files/datasets into QField

### DIFF
--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -15,7 +15,6 @@
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
       android:maxSdkVersion="28"
       />
-  <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 
   <uses-feature android:required="false" android:name="android.hardware.camera" />
   <uses-feature android:required="false" android:name="android.hardware.camera.autofocus" />

--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -61,7 +61,6 @@
         <data android:mimeType="application/vnd.sqlite3" />
         <data android:mimeType="application/x-sqlite3" />
         <data android:mimeType="application/geopackage+sqlite3" />
-        <data android:mimeType="application/geopackage+sqlite3" />
         <data android:mimeType="application/vnd.geo+json" />
         <data android:mimeType="application/geo+json" />
         <data android:mimeType="application/gpx+xml" />

--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -47,6 +47,13 @@
       <intent-filter>
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />
+        <data android:scheme="content" />
+        <data android:mimeType="application/octet-stream" />
+      </intent-filter>
+
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE"/>
         <data android:scheme="file" />
         <data android:scheme="content" />

--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -58,6 +58,19 @@
         <data android:scheme="file" />
         <data android:scheme="content" />
         <data android:host="*" />
+        <data android:mimeType="application/pdf" />
+        <data android:mimeType="application/vnd.sqlite3" />
+        <data android:mimeType="application/x-sqlite3" />
+        <data android:mimeType="application/geopackage+sqlite3" />
+      </intent-filter>
+
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE"/>
+        <data android:scheme="file" />
+        <data android:scheme="content" />
+        <data android:host="*" />
         <data android:mimeType="*/*" />
         <data android:pathPattern=".*\\.qgs" />
         <data android:pathPattern=".*\\..*\\.qgs" />

--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -37,7 +37,7 @@
       android:name="ch.opengis.@APP_PACKAGE_NAME@.QFieldActivity"
       android:label="@APP_NAME@"
       android:icon="@AT@drawable/@APP_ICON@"
-      android:launchMode="singleTop"
+      android:launchMode="singleTask"
       android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|locale|fontScale|keyboard|keyboardHidden|navigation">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>

--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -62,6 +62,15 @@
         <data android:mimeType="application/vnd.sqlite3" />
         <data android:mimeType="application/x-sqlite3" />
         <data android:mimeType="application/geopackage+sqlite3" />
+        <data android:mimeType="application/geopackage+sqlite3" />
+        <data android:mimeType="application/vnd.geo+json" />
+        <data android:mimeType="application/geo+json" />
+        <data android:mimeType="application/gpx+xml" />
+        <data android:mimeType="application/vnd.google-earth.kml+xml" />
+        <data android:mimeType="application/vnd.google-earth.kmz" />
+        <data android:mimeType="application/zip" />
+        <data android:mimeType="image/tiff" />
+        <data android:mimeType="image/x-jp2" />
       </intent-filter>
 
       <intent-filter>

--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -30,6 +30,7 @@ def outputPathName = "some.apk"
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.documentfile:documentfile:1.0.1'
 }
 
 android {

--- a/platform/android/res/values/strings.xml
+++ b/platform/android/res/values/strings.xml
@@ -23,6 +23,8 @@
     <string name="no_thanks">No, thanks!</string>
     <string name="favorite_directories">Favorite directories</string>
     <string name="favorites_sample_projects">Sample projects</string>
+    <string name="favorites_imported_projects">Imported projects</string>
+    <string name="favorites_imported_datasets">Imported datasets</string>
     <string name="added_to_favorites">Added to favorites</string>
     <string name="removed_from_favorites">Removed from favorites</string>
     <string name="external_files_title">Important Note</string>

--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -39,6 +39,7 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Application;
 import android.app.Dialog;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -94,6 +95,33 @@ public class QFieldActivity extends QtActivity {
         super.onNewIntent(intent);
         if (intent.getAction() == Intent.ACTION_VIEW) {
             Uri uri = intent.getData();
+            String scheme = intent.getScheme();
+            String action = intent.getAction();
+            ContentResolver resolver = getContentResolver();
+
+            if (scheme.compareTo(ContentResolver.SCHEME_CONTENT) == 0) {
+                String name = QFieldUtils.getContentName(resolver, uri);
+
+                Log.v("QField" , "Content intent detected: " + action + " : " + intent.getDataString() + " : " + intent.getType() + " : " + name);
+
+                File[] externalFilesDirs = getExternalFilesDirs(null);
+                String importDatasetDir = "";
+                if (externalFilesDirs.length > 0) {
+                    importDatasetDir = externalFilesDirs[0].getAbsolutePath() +
+                                       "/Imported Datasets/";
+                    try {
+                        InputStream input = resolver.openInputStream(uri);
+                        String importFilePath = importDatasetDir + name;
+                        if (QFieldUtils.inputStreamToFile(input, importFilePath)) {
+                            openProject(importFilePath);
+                        }
+                    } catch (FileNotFoundException e) {
+                        e.printStackTrace();
+                    }
+                    return;
+                }
+            }
+
             Context context = getApplication().getApplicationContext();
             openProject(QFieldUtils.getPathFromUri(context, uri));
         }

--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -135,7 +135,6 @@ public class QFieldActivity extends QtActivity {
                         QFieldUtils.inputStreamToFile(input, importFilePath);
                     } catch (Exception e) {
                         e.printStackTrace();
-                        return "";
                     }
                     return importFilePath;
                 } else {

--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -112,9 +112,8 @@ public class QFieldActivity extends QtActivity {
             DocumentFile documentFile =
                 DocumentFile.fromSingleUri(context, uri);
             String fileName = documentFile.getName();
-            Boolean canWrite = filePath != ""
-                               ? new File(filePath).canWrite()
-                               : false;
+            Boolean canWrite =
+                filePath != "" ? new File(filePath).canWrite() : false;
             if (!canWrite) {
                 Log.v("QField", "Content intent detected: " + action + " : " +
                                     intent.getDataString() + " : " +
@@ -128,7 +127,7 @@ public class QFieldActivity extends QtActivity {
                     File importDatasetDir = new File(importDatasetPath);
                     importDatasetDir.mkdir();
                     String importFilePath = importDatasetPath + fileName;
-                    Log.v("QField" ,
+                    Log.v("QField",
                           "Importing document to file path: " + importFilePath);
                     ContentResolver resolver = getContentResolver();
                     try {

--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -70,8 +70,10 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.Thread;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -103,6 +105,7 @@ public class QFieldActivity extends QtActivity {
         Uri uri = intent.getData();
         String scheme = intent.getScheme();
         String action = intent.getAction();
+        String type = intent.getType();
 
         Context context = getApplication().getApplicationContext();
         String filePath = QFieldUtils.getPathFromUri(context, uri);
@@ -115,9 +118,15 @@ public class QFieldActivity extends QtActivity {
             Boolean canWrite =
                 filePath != "" ? new File(filePath).canWrite() : false;
             if (!canWrite) {
+                if (fileName == null) {
+                    // File name not provided
+                    fileName = new SimpleDateFormat("yyyyMMdd_HHmm")
+                                   .format(new Date().getTime()) +
+                               "." + QFieldUtils.getExtensionFromMimeType(type);
+                }
                 Log.v("QField", "Content intent detected: " + action + " : " +
-                                    intent.getDataString() + " : " +
-                                    intent.getType() + " : " + fileName);
+                                    intent.getDataString() + " : " + type +
+                                    " : " + fileName);
 
                 File[] externalFilesDirs = getExternalFilesDirs(null);
                 String importDatasetPath = "";

--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -133,7 +133,7 @@ public class QFieldActivity extends QtActivity {
                     try {
                         InputStream input = resolver.openInputStream(uri);
                         QFieldUtils.inputStreamToFile(input, importFilePath);
-                    } catch (FileNotFoundException e) {
+                    } catch (Exception e) {
                         e.printStackTrace();
                         return "";
                     }

--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -94,40 +94,43 @@ public class QFieldActivity extends QtActivity {
     public void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
         if (intent.getAction() == Intent.ACTION_VIEW) {
-            Uri uri = intent.getData();
-            String scheme = intent.getScheme();
-            String action = intent.getAction();
-            ContentResolver resolver = getContentResolver();
-
-            if (scheme.compareTo(ContentResolver.SCHEME_CONTENT) == 0) {
-                String name = QFieldUtils.getContentName(resolver, uri);
-
-                Log.v("QField" , "Content intent detected: " + action + " : " + intent.getDataString() + " : " + intent.getType() + " : " + name);
-
-                File[] externalFilesDirs = getExternalFilesDirs(null);
-                String importDatasetPath = "";
-                if (externalFilesDirs.length > 0) {
-                    importDatasetPath = externalFilesDirs[0].getAbsolutePath() +
-                                        "/Imported Datasets/";
-                    File importDatasetDir = new File(importDatasetPath);
-                    importDatasetDir.mkdir();
-                    String importFilePath = importDatasetPath + name;
-                    Log.v("QField" , "Imported file path: " + importFilePath);
-                    try {
-                        InputStream input = resolver.openInputStream(uri);
-                        QFieldUtils.inputStreamToFile(input, importFilePath);
-                    } catch (FileNotFoundException e) {
-                        e.printStackTrace();
-                        return;
-                    }
-                    openProject(importFilePath);
-                    return;
-                }
-            }
-
-            Context context = getApplication().getApplicationContext();
-            openProject(QFieldUtils.getPathFromUri(context, uri));
+            openProject(getPathFromIntent(intent));
         }
+    }
+
+    private String getPathFromIntent(Intent intent) {
+        Uri uri = intent.getData();
+        String scheme = intent.getScheme();
+        String action = intent.getAction();
+
+        ContentResolver resolver = getContentResolver();
+        if (scheme.compareTo(ContentResolver.SCHEME_CONTENT) == 0) {
+            String name = QFieldUtils.getContentName(resolver, uri);
+
+            Log.v("QField" , "Content intent detected: " + action + " : " + intent.getDataString() + " : " + intent.getType() + " : " + name);
+
+            File[] externalFilesDirs = getExternalFilesDirs(null);
+            String importDatasetPath = "";
+            if (externalFilesDirs.length > 0) {
+                importDatasetPath = externalFilesDirs[0].getAbsolutePath() +
+                                    "/Imported Datasets/";
+                File importDatasetDir = new File(importDatasetPath);
+                importDatasetDir.mkdir();
+                String importFilePath = importDatasetPath + name;
+                Log.v("QField" , "Imported file path: " + importFilePath);
+                try {
+                    InputStream input = resolver.openInputStream(uri);
+                    QFieldUtils.inputStreamToFile(input, importFilePath);
+                } catch (FileNotFoundException e) {
+                    e.printStackTrace();
+                    return "";
+                }
+                return importFilePath;
+            }
+        }
+
+        Context context = getApplication().getApplicationContext();
+        return QFieldUtils.getPathFromUri(context, uri);
     }
 
     private void dimBrightness() {
@@ -198,10 +201,8 @@ public class QFieldActivity extends QtActivity {
 
         Intent sourceIntent = getIntent();
         if (sourceIntent.getAction() == Intent.ACTION_VIEW) {
-            Uri uri = sourceIntent.getData();
-            Context context = getApplication().getApplicationContext();
             intent.putExtra("QGS_PROJECT",
-                            QFieldUtils.getPathFromUri(context, uri));
+                            getPathFromIntent(sourceIntent));
         }
         setIntent(intent);
     }

--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -105,19 +105,22 @@ public class QFieldActivity extends QtActivity {
                 Log.v("QField" , "Content intent detected: " + action + " : " + intent.getDataString() + " : " + intent.getType() + " : " + name);
 
                 File[] externalFilesDirs = getExternalFilesDirs(null);
-                String importDatasetDir = "";
+                String importDatasetPath = "";
                 if (externalFilesDirs.length > 0) {
-                    importDatasetDir = externalFilesDirs[0].getAbsolutePath() +
-                                       "/Imported Datasets/";
+                    importDatasetPath = externalFilesDirs[0].getAbsolutePath() +
+                                        "/Imported Datasets/";
+                    File importDatasetDir = new File(importDatasetPath);
+                    importDatasetDir.mkdir();
+                    String importFilePath = importDatasetPath + name;
+                    Log.v("QField" , "Imported file path: " + importFilePath);
                     try {
                         InputStream input = resolver.openInputStream(uri);
-                        String importFilePath = importDatasetDir + name;
-                        if (QFieldUtils.inputStreamToFile(input, importFilePath)) {
-                            openProject(importFilePath);
-                        }
+                        QFieldUtils.inputStreamToFile(input, importFilePath);
                     } catch (FileNotFoundException e) {
                         e.printStackTrace();
+                        return;
                     }
+                    openProject(importFilePath);
                     return;
                 }
             }

--- a/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -109,30 +109,6 @@ public class QFieldProjectActivity extends Activity {
             setTitle(getString(R.string.select_project));
             Collections.sort(values);
 
-            String lastUsedProjects =
-                sharedPreferences.getString("LastUsedProjects", null);
-            if (lastUsedProjects != null) {
-                String[] lastUsedProjectsArray =
-                    lastUsedProjects.split("--;--");
-                values.add(new QFieldProjectListItem(
-                    null, getString(R.string.recent_projects), 0,
-                    QFieldProjectListItem.TYPE_SEPARATOR));
-
-                for (int i = lastUsedProjectsArray.length - 1; i >= 0; i--) {
-                    File file = new File(lastUsedProjectsArray[i]);
-                    if (file.exists()) {
-                        values.add(new QFieldProjectListItem(
-                            file, file.getName(),
-                            file.getName().toLowerCase().endsWith(".qgs") ||
-                                    file.getName().toLowerCase().endsWith(
-                                        ".qgz")
-                                ? R.drawable.project
-                                : R.drawable.dataset,
-                            QFieldProjectListItem.TYPE_ITEM));
-                    }
-                }
-            }
-
             String sampleProjects = new File(getFilesDir().toString() +
                                              "/share/qfield/sample_projects/")
                                         .getAbsolutePath();

--- a/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -134,16 +134,19 @@ public class QFieldProjectActivity extends Activity {
             }
 
             String sampleProjects = new File(getFilesDir().toString() +
-                                             "/share/qfield/sample_projects/").getAbsolutePath();
+                                             "/share/qfield/sample_projects/")
+                                        .getAbsolutePath();
             String importDatasetsDir = "";
             String importProjectsDir = "";
             if (externalFilesDirs.length > 0) {
                 importDatasetsDir =
-                    new File(externalFilesDirs[0].getAbsolutePath()
-                             + "/Imported Datasets/").getAbsolutePath();
+                    new File(externalFilesDirs[0].getAbsolutePath() +
+                             "/Imported Datasets/")
+                        .getAbsolutePath();
                 importProjectsDir =
-                    new File(externalFilesDirs[0].getAbsolutePath()
-                             + "/Imported Projects/").getAbsolutePath();
+                    new File(externalFilesDirs[0].getAbsolutePath() +
+                             "/Imported Projects/")
+                        .getAbsolutePath();
             }
 
             String favoriteDirs =
@@ -151,12 +154,15 @@ public class QFieldProjectActivity extends Activity {
 
             // The first time, add sample projects and import directories to the
             // favorites
-            boolean favoriteDirsAdded = sharedPreferences.getBoolean(
-                "FavoriteDirsAdded", false);
+            boolean favoriteDirsAdded =
+                sharedPreferences.getBoolean("FavoriteDirsAdded", false);
             if (!favoriteDirsAdded) {
-                favoriteDirs = sampleProjects +
-                               + (importProjectsDir != "" ? "--;--" + importProjectsDir : "")
-                               + (importDatasetsDir != "" ? "--;--" + importDatasetsDir : "");
+                favoriteDirs =
+                    sampleProjects +
+                    (importProjectsDir != "" ? "--;--" + importProjectsDir
+                                             : "") +
+                    (importDatasetsDir != "" ? "--;--" + importDatasetsDir
+                                             : "");
                 editor.putString("FavoriteDirs", favoriteDirs);
                 editor.putBoolean("FavoriteDirsAdded", true);
                 editor.commit();
@@ -176,14 +182,14 @@ public class QFieldProjectActivity extends Activity {
                             favoriteName =
                                 getString(R.string.favorites_sample_projects);
                         } else if (filePath.equals(importDatasetsDir)) {
-                                     favoriteName =
-                                         getString(R.string.favorites_imported_datasets);
+                            favoriteName =
+                                getString(R.string.favorites_imported_datasets);
                         } else if (filePath.equals(importProjectsDir)) {
-                                     favoriteName =
-                                         getString(R.string.favorites_imported_projects);
+                            favoriteName =
+                                getString(R.string.favorites_imported_projects);
                         }
                         values.add(new QFieldProjectListItem(
-                            f, name, R.drawable.directory,
+                            f, favoriteName, R.drawable.directory,
                             QFieldProjectListItem.TYPE_ITEM));
                     }
                 }

--- a/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -131,19 +131,32 @@ public class QFieldProjectActivity extends Activity {
                 }
             }
 
-            File sampleProjects = new File(getFilesDir().toString() +
-                                           "/share/qfield/sample_projects");
+            String sampleProjects = new File(getFilesDir().toString() +
+                                             "/share/qfield/sample_projects/").getAbsolutePath();
+            String importDatasetsDir = "";
+            String importProjectsDir = "";
+            if (externalFilesDirs.length > 0) {
+                importDatasetsDir =
+                    new File(externalFilesDirs[0].getAbsolutePath()
+                             + "/Imported Datasets/").getAbsolutePath();
+                importProjectsDir =
+                    new File(externalFilesDirs[0].getAbsolutePath()
+                             + "/Imported Projects/").getAbsolutePath();
+            }
+
             String favoriteDirs =
                 sharedPreferences.getString("FavoriteDirs", null);
 
-            // The first time, add the sample projects directory to the
+            // The first time, add sample projects and import directories to the
             // favorites
-            boolean addSampleProjectsFavoriteDir = sharedPreferences.getBoolean(
-                "AddSampleProjectsFavoriteDir", true);
-            if (addSampleProjectsFavoriteDir) {
-                favoriteDirs = sampleProjects.getAbsolutePath();
+            boolean favoriteDirsAdded = sharedPreferences.getBoolean(
+                "FavoriteDirsAdded", false);
+            if (!favoriteDirsAdded) {
+                favoriteDirs = sampleProjects +
+                               + (importProjectsDir != "" ? "--;--" + importProjectsDir : "")
+                               + (importDatasetsDir != "" ? "--;--" + importDatasetsDir : "");
                 editor.putString("FavoriteDirs", favoriteDirs);
-                editor.putBoolean("AddSampleProjectsFavoriteDir", false);
+                editor.putBoolean("FavoriteDirsAdded", true);
                 editor.commit();
             }
             if (favoriteDirs != null) {
@@ -155,13 +168,20 @@ public class QFieldProjectActivity extends Activity {
                 for (int i = favoriteDirsArray.length - 1; i >= 0; i--) {
                     File f = new File(favoriteDirsArray[i]);
                     if (f.exists()) {
+                        String filePath = f.getAbsolutePath();
+                        String favoriteName = f.getName();
+                        if (filePath.equals(sampleProjects)) {
+                            favoriteName =
+                                getString(R.string.favorites_sample_projects);
+                        } else if (filePath.equals(importDatasetsDir)) {
+                                     favoriteName =
+                                         getString(R.string.favorites_imported_datasets);
+                        } else if (filePath.equals(importProjectsDir)) {
+                                     favoriteName =
+                                         getString(R.string.favorites_imported_projects);
+                        }
                         values.add(new QFieldProjectListItem(
-                            f,
-                            f.getAbsolutePath().equals(
-                                sampleProjects.getAbsolutePath())
-                                ? getString(R.string.favorites_sample_projects)
-                                : f.getName(),
-                            R.drawable.directory,
+                            f, name, R.drawable.directory,
                             QFieldProjectListItem.TYPE_ITEM));
                     }
                 }

--- a/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -86,8 +86,10 @@ public class QFieldProjectActivity extends Activity {
             for (File file : externalFilesDirs) {
                 if (file != null) {
                     // Don't add a external storage path if already included in
-                    // the primary one
-                    if (externalStorageDirectory != null) {
+                    // the primary one and isn't the first external files
+                    // directory
+                    if (externalStorageDirectory != null &&
+                        file != externalFilesDirs[0]) {
                         if (!file.getAbsolutePath().contains(
                                 externalStorageDirectory.getAbsolutePath())) {
                             values.add(new QFieldProjectListItem(

--- a/platform/android/src/ch/opengis/qfield/QFieldUtils.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldUtils.java
@@ -36,18 +36,6 @@ import java.io.OutputStream;
 
 public class QFieldUtils {
 
-    public static String getContentName(ContentResolver resolver, Uri uri) {
-        Cursor cursor = resolver.query(uri, null, null, null, null);
-        cursor.moveToFirst();
-        int nameIndex =
-            cursor.getColumnIndex(MediaStore.MediaColumns.DISPLAY_NAME);
-        if (nameIndex >= 0) {
-            return cursor.getString(nameIndex);
-        } else {
-            return null;
-        }
-    }
-
     public static boolean inputStreamToFile(InputStream in, String file) {
         try {
             OutputStream out = new FileOutputStream(new File(file));
@@ -74,10 +62,10 @@ public class QFieldUtils {
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
         String path = null;
 
-        // DocumentProvider
         if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
-            // ExternalStorageProvider
+            // DocumentProvider
             if (isExternalStorageDocument(uri)) {
+                // ExternalStorageProvider
                 final String docId = DocumentsContract.getDocumentId(uri);
                 final String[] split = docId.split(":");
                 final String type = split[0];
@@ -87,18 +75,16 @@ public class QFieldUtils {
                         split[1];
                 }
                 // TODO handle non-primary volumes
-            }
-            // DownloadsProvider
-            else if (isDownloadsDocument(uri)) {
+            } else if (isDownloadsDocument(uri)) {
+                // DownloadsProvider
                 final String id = DocumentsContract.getDocumentId(uri);
                 final Uri contentUri = ContentUris.withAppendedId(
                     Uri.parse("content://downloads/public_downloads"),
                     Long.valueOf(id));
 
                 path = getDataColumn(context, contentUri, null, null);
-            }
-            // MediaProvider
-            else if (isMediaDocument(uri)) {
+            } else if (isMediaDocument(uri)) {
+                // MediaProvider
                 final String docId = DocumentsContract.getDocumentId(uri);
                 final String[] split = docId.split(":");
                 final String type = split[0];
@@ -119,20 +105,20 @@ public class QFieldUtils {
                                      selectionArgs);
             }
         }
-        // MediaStore (and general)
-        else if ("content".equalsIgnoreCase(uri.getScheme())) {
-            // Return the remote address
-            if (isGooglePhotosUri(uri))
-                return uri.getLastPathSegment();
 
-            path = getDataColumn(context, uri, null, null);
-        }
-
+        // Fallback
         if (path == null && ("content".equalsIgnoreCase(uri.getScheme()) ||
                              "file".equalsIgnoreCase(uri.getScheme()))) {
             path = uri.getPath();
-            if (path != null)
+            if (path != null) {
                 path = path.replaceFirst("^/storage_root", "");
+            }
+        }
+
+        if (path != null) {
+            if (new File(path).exists() == false) {
+                path = "";
+            }
         }
 
         return path;
@@ -175,11 +161,6 @@ public class QFieldUtils {
 
     public static boolean isMediaDocument(Uri uri) {
         return "com.android.providers.media.documents".equals(
-            uri.getAuthority());
-    }
-
-    public static boolean isGooglePhotosUri(Uri uri) {
-        return "com.google.android.apps.photos.content".equals(
             uri.getAuthority());
     }
 }

--- a/platform/android/src/ch/opengis/qfield/QFieldUtils.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldUtils.java
@@ -26,8 +26,47 @@ import android.os.Build;
 import android.os.Environment;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
+import android.util.Log;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 public class QFieldUtils {
+
+    public static String getContentName(ContentResolver resolver, Uri uri) {
+        Cursor cursor = resolver.query(uri, null, null, null, null);
+        cursor.moveToFirst();
+        int nameIndex =
+            cursor.getColumnIndex(MediaStore.MediaColumns.DISPLAY_NAME);
+        if (nameIndex >= 0) {
+            return cursor.getString(nameIndex);
+        } else {
+            return null;
+        }
+    }
+
+    public static boolean inputStreamToFile(InputStream in, String file) {
+        try {
+            OutputStream out = new FileOutputStream(new File(file));
+
+            int size = 0;
+            byte[] buffer = new byte[1024];
+
+            while ((size = in.read(buffer)) != -1) {
+                out.write(buffer, 0, size);
+            }
+
+            out.close();
+        } catch (Exception e) {
+            Log.e("QField", "InputStreamToFile exception: " + e.getMessage());
+            return false;
+        }
+        return true;
+    }
+
     // original script by SANJAY GUPTA
     // (https://stackoverflow.com/questions/17546101/get-real-path-for-uri-android)
     public static String getPathFromUri(final Context context, final Uri uri) {

--- a/platform/android/src/ch/opengis/qfield/QFieldUtils.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldUtils.java
@@ -55,6 +55,33 @@ public class QFieldUtils {
         return true;
     }
 
+    public static String getExtensionFromMimeType(String type) {
+        if (type.equals("application/pdf")) {
+            return "pdf";
+        } else if (type.equals("application/vnd.sqlite3") ||
+                   type.equals("application/x-sqlite3")) {
+            return "db";
+        } else if (type.equals("application/geopackage+sqlite3")) {
+            return "gpkg";
+        } else if (type.equals("application/vnd.geo+json") ||
+                   type.equals("application/geo+json")) {
+            return "geojson";
+        } else if (type.equals("application/gpx+xml")) {
+            return "gpx";
+        } else if (type.equals("application/vnd.google-earth.kml+xml")) {
+            return "kml";
+        } else if (type.equals("application/vnd.google-earth.kmz")) {
+            return "kmz";
+        } else if (type.equals("application/zip")) {
+            return "zip";
+        } else if (type.equals("image/tiff")) {
+            return "tif";
+        } else if (type.equals("image/x-jp2")) {
+            return "jp2";
+        }
+        return "";
+    }
+
     // original script by SANJAY GUPTA
     // (https://stackoverflow.com/questions/17546101/get-real-path-for-uri-android)
     public static String getPathFromUri(final Context context, final Uri uri) {

--- a/platform/android/src/ch/opengis/qfield/QFieldUtils.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldUtils.java
@@ -61,7 +61,7 @@ public class QFieldUtils {
 
             out.close();
         } catch (Exception e) {
-            Log.e("QField", "InputStreamToFile exception: " + e.getMessage());
+            Log.e("QField", "inputStreamToFile exception: " + e.getMessage());
             return false;
         }
         return true;


### PR DESCRIPTION
This PR introduces a mechanism to import datasets into QField when opening of associated file datasets (via the "Open with QField" action in other apps) that are either a/ not a file path based content, or b/ not in a permission state that allows us to do in-place editing.

This is pretty cool as it allows us to _directly open in QField_ Gmail email attachments, Google Drive files, {WhatsApp, Telegram, Signal, etc} documents, and more.

The imported datasets are stored in the QField app's external files storage location, under a new "Imported datasets" directory. The directory is created and managed by QField, and is added by default in the favorites for easy access.

The PR also cleans up and improves pre-existing file association related functionalities.

_Note: the imported projects isn't actually used here but is a window into things to come :wink:_