### PR TITLE
Handle importing of zipped projects

### DIFF
--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -146,6 +146,14 @@ public class QFieldActivity extends QtActivity {
                     String projectPath =
                         importProjectPath +
                         fileName.substring(0, fileName.lastIndexOf(".")) + "/";
+                    int i = 1;
+                    while(new File(projectPath).exists()) {
+                        projectPath =
+                            importProjectPath +
+                            fileName.substring(0, fileName.lastIndexOf(".")) +
+                            "_" + i + "/";
+                        i++;
+                    }
                     new File(projectPath).mkdir();
                     try {
                         InputStream input = resolver.openInputStream(uri);
@@ -166,6 +174,14 @@ public class QFieldActivity extends QtActivity {
                                     " : " + intent.getDataString() + " : " +
                                     type + " : " + fileNam
                 String importFilePath = importDatasetPath + fileName;
+                int i = 1;
+                while(new File(importFilePath).exists()) {
+                    importFilePath =
+                        importDatasetPath +
+                        fileName.substring(0, fileName.lastIndexOf(".")) +
+                        "_" + i + fileName.substring(fileName.lastIndexOf("."));
+                    i++;
+                }
                 Log.v("QField",
                       "Importing document to file path: " + importFilePath);
                 try {

--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -147,7 +147,7 @@ public class QFieldActivity extends QtActivity {
                         importProjectPath +
                         fileName.substring(0, fileName.lastIndexOf(".")) + "/";
                     int i = 1;
-                    while(new File(projectPath).exists()) {
+                    while (new File(projectPath).exists()) {
                         projectPath =
                             importProjectPath +
                             fileName.substring(0, fileName.lastIndexOf(".")) +
@@ -157,7 +157,7 @@ public class QFieldActivity extends QtActivity {
                     new File(projectPath).mkdir();
                     try {
                         InputStream input = resolver.openInputStream(uri);
-                        QFieldUtils.inputStreamToFolder(input, projectPath)
+                        QFieldUtils.inputStreamToFolder(input, projectPath);
                     } catch (Exception e) {
                         e.printStackTrace();
                     }
@@ -170,16 +170,16 @@ public class QFieldActivity extends QtActivity {
             Boolean canWrite =
                 filePath != "" ? new File(filePath).canWrite() : false;
             if (!canWrite) {
-                Log.v("QField", "Content intent detected: " + action +
-                                    " : " + intent.getDataString() + " : " +
-                                    type + " : " + fileNam
+                Log.v("QField", "Content intent detected: " + action + " : " +
+                                    intent.getDataString() + " : " + type +
+                                    " : " + fileName);
                 String importFilePath = importDatasetPath + fileName;
                 int i = 1;
-                while(new File(importFilePath).exists()) {
+                while (new File(importFilePath).exists()) {
                     importFilePath =
                         importDatasetPath +
-                        fileName.substring(0, fileName.lastIndexOf(".")) +
-                        "_" + i + fileName.substring(fileName.lastIndexOf("."));
+                        fileName.substring(0, fileName.lastIndexOf(".")) + "_" +
+                        i + fileName.substring(fileName.lastIndexOf("."));
                     i++;
                 }
                 Log.v("QField",

--- a/platform/android/src/ch/opengis/qfield/QFieldUtils.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldUtils.java
@@ -33,8 +33,55 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 public class QFieldUtils {
+
+    public static String getArchiveProjectName(InputStream in) {
+        String projectName = "";
+        try {
+            ZipInputStream zin = new ZipInputStream(in);
+            ZipEntry entry;
+            while ((entry = zin.getNextEntry()) != null) {
+               String entryName = entry.getName().toLowerCase();
+               if (entryName.endsWith(".qgs") ||
+                   entryName.endsWith(".qgz")) {
+                   projectName = entry.getName();
+                   break;
+               }
+            }
+            zin.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return projectName;
+    }
+
+    public static boolean inputStreamToFolder(InputStream in, String folder) {
+        try {
+            ZipInputStream zin = new ZipInputStream(in);
+            ZipEntry entry;
+            while ((entry = zin.getNextEntry()) != null) {
+                if (entry.isDirectory()) {
+                    new File(projectPath + entry.getName()).mkdirs();
+                    continue;
+                }
+                   OutputStream out = new FileOutputStream(new File(projectPath + entry.getName()));
+                int size = 0;
+                byte[] buffer = new byte[1024];
+                while ((size = zin.read(buffer, 0, buffer.length)) != -1) {
+                    out.write(buffer, 0, size);
+                }
+                   out.close();
+            }
+            zin.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+        return true;
+    }
 
     public static boolean inputStreamToFile(InputStream in, String file) {
         try {

--- a/platform/android/src/ch/opengis/qfield/QFieldUtils.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldUtils.java
@@ -44,12 +44,11 @@ public class QFieldUtils {
             ZipInputStream zin = new ZipInputStream(in);
             ZipEntry entry;
             while ((entry = zin.getNextEntry()) != null) {
-               String entryName = entry.getName().toLowerCase();
-               if (entryName.endsWith(".qgs") ||
-                   entryName.endsWith(".qgz")) {
-                   projectName = entry.getName();
-                   break;
-               }
+                String entryName = entry.getName().toLowerCase();
+                if (entryName.endsWith(".qgs") || entryName.endsWith(".qgz")) {
+                    projectName = entry.getName();
+                    break;
+                }
             }
             zin.close();
         } catch (Exception e) {
@@ -64,16 +63,17 @@ public class QFieldUtils {
             ZipEntry entry;
             while ((entry = zin.getNextEntry()) != null) {
                 if (entry.isDirectory()) {
-                    new File(projectPath + entry.getName()).mkdirs();
+                    new File(folder + entry.getName()).mkdirs();
                     continue;
                 }
-                   OutputStream out = new FileOutputStream(new File(projectPath + entry.getName()));
+                OutputStream out =
+                    new FileOutputStream(new File(folder + entry.getName()));
                 int size = 0;
                 byte[] buffer = new byte[1024];
                 while ((size = zin.read(buffer, 0, buffer.length)) != -1) {
                     out.write(buffer, 0, size);
                 }
-                   out.close();
+                out.close();
             }
             zin.close();
         } catch (Exception e) {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -41,8 +41,8 @@ ApplicationWindow {
       property alias height: mainWindow.height
 
       Component.onCompleted: {
-          width = Math.max(width, 500)
-          height = Math.max(height, 500)
+          width = Math.max(width, 50)
+          height = Math.max(height, 50)
           x = Math.min(x, mainWindow.screen.width - width)
           y = Math.min(y, mainWindow.screen.height - height)
       }


### PR DESCRIPTION
This builds on top of #2397 . It adds a mechanism to treat a .zip file as an archived project when the presence of a QGIS project file is detected. When that's the case, QField will decompress the project into the Imported protects directory.