### PR TITLE
Make sure the field visibility is enforced when opening the form of the feature created just before

### DIFF
--- a/src/core/attributeformmodel.cpp
+++ b/src/core/attributeformmodel.cpp
@@ -80,6 +80,11 @@ QVariant AttributeFormModel::attribute( const QString &name )
   return mSourceModel->attribute( name );
 }
 
+void AttributeFormModel::applyFeatureModel()
+{
+  return mSourceModel->applyFeatureModel();
+}
+
 bool AttributeFormModel::filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const
 {
   return mSourceModel->data( mSourceModel->index( source_row, 0, source_parent ), CurrentlyVisible ).toBool();

--- a/src/core/attributeformmodel.h
+++ b/src/core/attributeformmodel.h
@@ -94,6 +94,9 @@ class AttributeFormModel : public QSortFilterProxyModel
      */
     Q_INVOKABLE QVariant attribute( const QString &name );
 
+    //! Forces the form to update the fields visibility and constraints
+    Q_INVOKABLE void applyFeatureModel();
+
   signals:
     void featureModelChanged();
     void hasTabsChanged();

--- a/src/core/attributeformmodelbase.h
+++ b/src/core/attributeformmodelbase.h
@@ -58,6 +58,9 @@ class AttributeFormModelBase : public QStandardItemModel
 
     QVariant attribute( const QString &name );
 
+    //! Applies feature model data such as attribute values, constraints, visibility to the attribute form model
+    void applyFeatureModel();
+
   signals:
     void featureModelChanged();
     void hasTabsChanged();
@@ -95,9 +98,6 @@ class AttributeFormModelBase : public QStandardItemModel
 
     //! Resets the attribute form model
     void resetModel();
-
-    //! Applies feature model data such as attribute values, constraints, visibility to the attribute form model
-    void applyFeatureModel();
 
     //! Sets up a connection to listen to project map theme change
     void onMapThemeCollectionChanged();

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -270,6 +270,8 @@ Rectangle {
             featureForm.state = "FeatureForm"
             featureForm.multiSelection = false;
           }
+
+          featureFormList.model.applyFeatureModel()
         }
 
         onPressAndHold:
@@ -462,6 +464,7 @@ Rectangle {
         featureForm.selection.focusedItem = -1;
         if ( featureForm.multiSelection ) {
             featureFormList.model.featureModel.modelMode = FeatureModel.SingleFeatureModel
+            featureFormList.model.applyFeatureModel()
             featureForm.selection.model.clearSelection();
         } else {
             featureFormList.model.featureModel.modelMode = FeatureModel.MultiFeatureModel


### PR DESCRIPTION
Fixes #2406 

### Reproduction

1) create a feature with dependent fields. Make sure the newly created feature hides some of the fields.
2) open the newly created feature feature form.
3) the hidden fields are visible.

### Code comments

The problem was that `AttributeFormModelBase::applyFeatureModel` was not called once the form is opened.

Probably "the best solution" would be to use the `FeatureListModelSelection::focusedItemChanged()` event to call `AttributeFormModelBase::applyFeatureModel`. However, this would make more spaghetti, than explicitly calling the method.

