### PR TITLE
Use QGIS native pretty scale calculation for projected CRS

### DIFF
--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -496,7 +496,7 @@ Rectangle {
     CoordinateTransformer {
         id: moveFeaturesTransformer
         sourceCrs: mapCanvas.mapSettings.destinationCrs
-        destinationCrs: featureForm.selection.model.selectedLayer.crs
+        destinationCrs: featureForm.selection.model.selectedLayer ? featureForm.selection.model.selectedLayer.crs : mapCanvas.mapSettings.destinationCrs
     }
 
     Connections {


### PR DESCRIPTION
- if the scaledDistance.value is nan, better show "Unknown" than "nan km"
- if the scaledDistance.value is 0 (submeter values), better show all the decimals
- fix a warning on startup

Fix #2408 #1046

![Peek 2022-01-16 14-50](https://user-images.githubusercontent.com/2820439/149660732-b2e3222d-3d42-4979-b3e8-8f8f7c91345e.gif)
