### PR TITLE
Guard QField from crashing when handling an intent with missing mime type

### DIFF
--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -104,6 +104,10 @@ public class QFieldActivity extends QtActivity {
         String action = intent.getAction();
         String type = intent.getType();
 
+        if (type == null) {
+            return "";
+        }
+
         Uri uri = null;
         if (action.compareTo(Intent.ACTION_SEND) == 0) {
             uri = (Uri)intent.getParcelableExtra(Intent.EXTRA_STREAM);

--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -104,10 +104,6 @@ public class QFieldActivity extends QtActivity {
         String action = intent.getAction();
         String type = intent.getType();
 
-        if (type == null) {
-            return "";
-        }
-
         Uri uri = null;
         if (action.compareTo(Intent.ACTION_SEND) == 0) {
             uri = (Uri)intent.getParcelableExtra(Intent.EXTRA_STREAM);
@@ -138,7 +134,7 @@ public class QFieldActivity extends QtActivity {
             DocumentFile documentFile =
                 DocumentFile.fromSingleUri(context, uri);
             String fileName = documentFile.getName();
-            if (fileName == null) {
+            if (fileName == null && type != null) {
                 // File name not provided
                 fileName = new SimpleDateFormat("yyyyMMdd_HHmmss")
                                .format(new Date().getTime()) +
@@ -146,7 +142,7 @@ public class QFieldActivity extends QtActivity {
             }
 
             ContentResolver resolver = getContentResolver();
-            if (type.equals("application/zip")) {
+            if (type != null && type.equals("application/zip")) {
                 String projectName = "";
                 try {
                     InputStream input = resolver.openInputStream(uri);


### PR DESCRIPTION
As seen on sentry.