### PR TITLE
Fix confusing error widget when going into cloud log in panel

### DIFF
--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -31,7 +31,7 @@ Popup {
           connectionSettings.visible = false;
           projects.visible = true;
         } else {
-            popup.close()
+          popup.close()
         }
       }
     }

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -27,7 +27,12 @@ Popup {
             : 'off'
 
       onFinished: {
-        popup.close()
+        if (connectionSettings.visible) {
+          connectionSettings.visible = false;
+          projects.visible = true;
+        } else {
+            popup.close()
+        }
       }
     }
 
@@ -241,7 +246,7 @@ Popup {
 
             property bool hasError: false
 
-            visible: hasError && cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Idle
+            visible: hasError && cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Idle && !connectionSettings.visible
 
             Layout.fillWidth: true
             Layout.leftMargin: 10


### PR DESCRIPTION
ATM, if a user is going into the cloud log in panel through the cloud project panel after hitting a network error, he/she/they will see this:
![image](https://user-images.githubusercontent.com/1728657/150740777-3a3e16a1-d313-4995-842b-593e37c1e205.png)

Not a great look, leads to confusion as to whether there's an error even though the person successfully logged in.

This PR fixes that by hiding the project sync/push error widget when the log in panel is open.
