### PR TITLE
Support "show delete child button" configuration for relations

### DIFF
--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -75,6 +75,7 @@ EditorWidgetBase {
       anchors.top: referencingFeatureListView.bottom
       height: itemHeight
       width: parent.width
+      visible: isButtonEnabled('AddChildFeature')
 
       focus: true
 

--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -187,7 +187,7 @@ EditorWidgetBase {
                 id: deleteButton
                 width: parent.height
                 height: parent.height
-                visible: isEnabled
+                visible: isEnabled && isButtonEnabled('DeleteChildFeature')
 
                 contentItem: Rectangle {
                     anchors.fill: parent
@@ -301,6 +301,22 @@ EditorWidgetBase {
             relationEditorModel.featureFocus = id
             relationEditorModel.reload()
         }
+    }
+
+    function isButtonEnabled(buttonType) {
+      const buttons = relationEditorWidgetConfig.buttons
+
+      if (!buttons)
+        return false
+
+      if (buttons === 'AllButtons')
+        return true
+
+      if (buttons.split('|').indexOf(buttonType) >= 0) {
+        return true
+      }
+
+      return false
     }
 
     function requestedGeometry(geometry) {


### PR DESCRIPTION
Fix #2343 
@jpdupuy here is an example of the two relation editors in the advanced editor widget, one with and one without the configuration set.

![Peek 2022-01-24 21-00](https://user-images.githubusercontent.com/2820439/150846818-dbf84fb7-2abd-441a-8bc1-1bc2bf76c5b4.gif)
