### PR TITLE
Remove QField imported datasets feature

### DIFF
--- a/platform/android/res/menu/project_item_menu.xml
+++ b/platform/android/res/menu/project_item_menu.xml
@@ -5,5 +5,9 @@
         android:id="@+id/send_to"
         android:title="@string/send_to"
         app:showAsAction="never" />
+    <item
+        android:id="@+id/remove_dataset"
+        android:title="@string/remove_dataset"
+        app:showAsAction="never" />
 
 </menu>

--- a/platform/android/res/values/strings.xml
+++ b/platform/android/res/values/strings.xml
@@ -47,4 +47,10 @@
     <string name="send_to">Send to...</string>
     <string name="add_to_favorite">Add to Favorites</string>
     <string name="remove_from_favorite">Remove from Favorites</string>
+    <string name="remove_dataset">Remove Dataset</string>
+    <string name="delete_confirm_title">Removal Confirmation</string>
+    <string name="delete_confirm_dataset">The dataset will be permamently deleted, proceed with removal?</string>
+    <string name="delete_confirm_folder">The project folder will be permamently deleted, proceed with removal?</string>
+    <string name="delete_confirm">Remove</string>
+    <string name="delete_cancel">Cancel</string>
 </resources>


### PR DESCRIPTION
Title says it all; when users navigate to the import datasets folder, a new "remove dataset" action is added in the item popup menu.