### PR TITLE
Remove project folder within QField imported projects feature

### DIFF
--- a/platform/android/res/menu/project_folder_menu.xml
+++ b/platform/android/res/menu/project_folder_menu.xml
@@ -8,5 +8,9 @@
     <item android:id="@+id/remove_from_favorite"
         android:title="@string/remove_from_favorite"
         app:showAsAction="never"/>
+    <item
+        android:id="@+id/remove_folder"
+        android:title="@string/remove_folder"
+        app:showAsAction="never" />
 
 </menu>

--- a/platform/android/res/values/strings.xml
+++ b/platform/android/res/values/strings.xml
@@ -48,6 +48,7 @@
     <string name="add_to_favorite">Add to Favorites</string>
     <string name="remove_from_favorite">Remove from Favorites</string>
     <string name="remove_dataset">Remove Dataset</string>
+    <string name="remove_folder">Remove Project Folder</string>
     <string name="delete_confirm_title">Removal Confirmation</string>
     <string name="delete_confirm_dataset">The dataset will be permamently deleted, proceed with removal?</string>
     <string name="delete_confirm_folder">The project folder will be permamently deleted, proceed with removal?</string>

--- a/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -181,6 +181,35 @@ public class QFieldProjectActivity
                 removeFileFromFavoriteDirs(file);
                 return true;
             }
+            case R.id.remove_folder: {
+                AlertDialog.Builder builder = new AlertDialog.Builder(this);
+                builder.setTitle(getString(R.string.delete_confirm_title));
+                builder.setMessage(getString(R.string.delete_confirm_folder));
+                builder.setPositiveButton(
+                    getString(R.string.delete_confirm),
+                    new DialogInterface.OnClickListener() {
+                        public void onClick(DialogInterface dialog, int id) {
+                            final QFieldProjectListItem listItem =
+                                (QFieldProjectListItem)list.getAdapter()
+                                    .getItem(currentPosition);
+                            QFieldUtils.deleteDirectory(listItem.getFile(),
+                                                        true);
+                            dialog.dismiss();
+                            drawView();
+                        }
+                    });
+                builder.setNegativeButton(
+                    getString(R.string.delete_cancel),
+                    new DialogInterface.OnClickListener() {
+                        public void onClick(DialogInterface dialog, int id) {
+                            dialog.dismiss();
+                        }
+                    });
+                AlertDialog dialog = builder.create();
+                dialog.setCancelable(false);
+                dialog.show();
+                return true;
+            }
             default:
                 return true;
         }
@@ -412,17 +441,20 @@ public class QFieldProjectActivity
         File file = item.getFile();
 
         boolean isImportedDataset = false;
-        boolean isImportedProject = false;
+        boolean isImportedProjectRoot = false;
         File primaryExternalFilesDir = getExternalFilesDir(null);
         if (primaryExternalFilesDir != null) {
             isImportedDataset = file.getAbsolutePath().startsWith(
                 new File(primaryExternalFilesDir.getAbsolutePath() +
                          "/Imported Datasets/")
                     .getAbsolutePath());
-            isImportedProject = file.getAbsolutePath().startsWith(
-                new File(primaryExternalFilesDir.getAbsolutePath() +
-                         "/Imported Projects/")
-                    .getAbsolutePath());
+            if (file.getParentFile() != null) {
+                isImportedProjectRoot =
+                    file.getParentFile().getAbsolutePath().equals(
+                        new File(primaryExternalFilesDir.getAbsolutePath() +
+                                 "/Imported Projects/")
+                            .getAbsolutePath());
+            }
         }
 
         PopupMenu popupMenu = new PopupMenu(QFieldProjectActivity.this, view);
@@ -459,6 +491,11 @@ public class QFieldProjectActivity
             } else {
                 popupMenu.getMenu()
                     .findItem(R.id.add_to_favorite)
+                    .setVisible(false);
+            }
+            if (!isImportedProjectRoot) {
+                popupMenu.getMenu()
+                    .findItem(R.id.remove_folder)
                     .setVisible(false);
             }
         }

--- a/platform/android/src/ch/opengis/qfield/QFieldUtils.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldUtils.java
@@ -148,7 +148,7 @@ public class QFieldUtils {
                 return false;
             }
         }
-        return true;
+        return file.delete();
     }
 
     public static String getExtensionFromMimeType(String type) {

--- a/platform/android/src/ch/opengis/qfield/QFieldUtils.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldUtils.java
@@ -130,6 +130,27 @@ public class QFieldUtils {
         return true;
     }
 
+    public static boolean deleteDirectory(File file, boolean recursive) {
+        if (!file.isDirectory()) {
+            return false;
+        }
+        File[] files = file.listFiles();
+        for (File f : files) {
+            boolean success = true;
+            if (f.isDirectory()) {
+                if (recursive) {
+                    success = deleteDirectory(f, true);
+                }
+            } else {
+                success = f.delete();
+            }
+            if (!success) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     public static String getExtensionFromMimeType(String type) {
         if (type.equals("application/pdf")) {
             return "pdf";


### PR DESCRIPTION
Alright, this is truly the last piece of the restricted storage implementation puzzle. 

When in the root directory of imported projects, a new menu item appears to allow for users to remove imported project folders.