### PR TITLE
Tweak inputStreamToFile implementation to guard from signal messenger crasher

### DIFF
--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -134,6 +134,7 @@ public class QFieldActivity extends QtActivity {
             DocumentFile documentFile =
                 DocumentFile.fromSingleUri(context, uri);
             String fileName = documentFile.getName();
+            long fileBytes = documentFile.length();
             if (fileName == null && type != null) {
                 // File name not provided
                 fileName = new SimpleDateFormat("yyyyMMdd_HHmmss")
@@ -195,7 +196,8 @@ public class QFieldActivity extends QtActivity {
                       "Importing document to file path: " + importFilePath);
                 try {
                     InputStream input = resolver.openInputStream(uri);
-                    QFieldUtils.inputStreamToFile(input, importFilePath);
+                    QFieldUtils.inputStreamToFile(input, importFilePath,
+                                                  fileBytes);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }

--- a/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -690,7 +690,7 @@ public class QFieldProjectActivity
                     try {
                         InputStream input = resolver.openInputStream(uri);
                         imported = QFieldUtils.inputStreamToFile(
-                            input, importFilePath);
+                            input, importFilePath, documentFile.length());
                     } catch (Exception e) {
                         e.printStackTrace();
                         break;
@@ -704,8 +704,8 @@ public class QFieldProjectActivity
                     importDatasetPath + documentFile.getName();
                 try {
                     InputStream input = resolver.openInputStream(uri);
-                    imported =
-                        QFieldUtils.inputStreamToFile(input, importFilePath);
+                    imported = QFieldUtils.inputStreamToFile(
+                        input, importFilePath, documentFile.length());
                 } catch (Exception e) {
                     e.printStackTrace();
                     AlertDialog alertDialog =

--- a/platform/android/src/ch/opengis/qfield/QFieldUtils.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldUtils.java
@@ -75,7 +75,8 @@ public class QFieldUtils {
                 String filePath = folder + file.getName();
                 try {
                     InputStream input = resolver.openInputStream(file.getUri());
-                    QFieldUtils.inputStreamToFile(input, filePath);
+                    QFieldUtils.inputStreamToFile(input, filePath,
+                                                  file.length());
                 } catch (Exception e) {
                     e.printStackTrace();
                     return false;
@@ -111,15 +112,26 @@ public class QFieldUtils {
         return true;
     }
 
-    public static boolean inputStreamToFile(InputStream in, String file) {
+    public static boolean inputStreamToFile(InputStream in, String file,
+                                            long totalBytes) {
         try {
             OutputStream out = new FileOutputStream(new File(file));
 
             int size = 0;
-            byte[] buffer = new byte[1024];
+            int bufferSize = 1024;
+            long bufferRead = 0;
+            byte[] buffer = new byte[bufferSize];
 
-            while ((size = in.read(buffer)) != -1) {
+            if (totalBytes > 0 && bufferRead + bufferSize > totalBytes) {
+                bufferSize = (int)(totalBytes - bufferRead);
+            }
+            while (bufferSize > 0 &&
+                   (size = in.read(buffer, 0, bufferSize)) != -1) {
                 out.write(buffer, 0, size);
+                bufferRead += bufferSize;
+                if (totalBytes > 0 && bufferRead + bufferSize > totalBytes) {
+                    bufferSize = (int)(totalBytes - bufferRead);
+                }
             }
 
             out.close();


### PR DESCRIPTION
PR fixes a crash when opening datasets and archived project from a signal messenger conversation.