### PR TITLE
Fix project activity crash when trying to use the 'send to' action with sample projects' datasets

### DIFF
--- a/platform/android/res/xml/file_paths.xml
+++ b/platform/android/res/xml/file_paths.xml
@@ -2,4 +2,5 @@
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <cache-path name="qfield_pictures" path="./" />
     <external-path name="external_files" path="."/>
+    <files-path name="internal_files" path="."/>
 </paths>


### PR DESCRIPTION
Fixes an IllegalArgumentException failure, spotted on sentry.