### PR TITLE
Auto sync translations

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -102,25 +102,6 @@ jobs:
           modules: 'qtcharts'
           target: ${{ steps.vars.outputs.QT_TARGET }}
 
-      # transifex-client is not compatible with py >= 3.10
-      # temporary band aid
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
-
-
-      - name: 🌍 Pull Translations
-        shell: bash
-        env:
-          TX_TOKEN: ${{ secrets.TX_TOKEN }}
-        run: |
-          if [[ -z "${TX_TOKEN}" ]]; then
-            echo "TX_TOKEN not set, skip tx pull"
-          else
-            pip install transifex-client
-            ./scripts/ci/pull_translations.sh
-          fi
-
       # The sentry-android dependency is added via gradle
       # This downloads the pre-compiled sentry-android-ndk libraries
       # But we are compiling this before gradle is executed, so it is not downloaded

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -157,24 +157,6 @@ jobs:
             echo "EXTRA_CMAKE_ARGS=-DCMAKE_WIN32_EXECUTABLE=ON" >> $GITHUB_ENV
           fi
 
-      # transifex-client is not compatible with py >= 3.10
-      # temporary band aid
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
-
-      - name: 🌍 Pull Translations
-        shell: bash
-        env:
-          TX_TOKEN: ${{ secrets.TX_TOKEN }}
-        run: |
-          if [[ -z "${TX_TOKEN}" ]]; then
-            echo "TX_TOKEN not set, skip tx pull"
-          else
-            pip install transifex-client
-            ./scripts/ci/pull_translations.sh
-          fi
-
       - name: Prepare osx build env
         if: ${{ matrix.os == 'macos-10.15' }}
         run: |

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -30,23 +30,8 @@ jobs:
       with:
         submodules: 'recursive'
 
-    - uses: actions/setup-python@v2
-      with:
-        python-version: '3.8'
-
     - name: Install deps
       run: brew install gnu-sed
-
-    - name: "🌍 Pull Translations"
-      run: |
-        if [[ -z "${TX_TOKEN}" ]]; then
-          echo "TX_TOKEN not set, skip tx pull"
-        else
-          pip install transifex-client
-          ./scripts/ci/pull_translations.sh
-        fi
-      env:
-        TX_TOKEN: ${{ secrets.TX_TOKEN }}
 
     - name: Download artifact
       env:

--- a/.github/workflows/sync-translations.yml
+++ b/.github/workflows/sync-translations.yml
@@ -1,0 +1,30 @@
+name: 🌍 Sync Translations
+on:
+  schedule:
+    - cron: "5 1 * * *"
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      # transifex-client is not compatible with py >= 3.10
+      # temporary band aid
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: 🌍 Pull Translations
+        shell: bash
+        env:
+          TX_TOKEN: ${{ secrets.TX_TOKEN }}
+        run: |
+          pip install transifex-client
+          ./scripts/ci/pull_translations.sh
+
+      - uses: EndBug/add-and-commit@v8
+        with:
+          message: Synchronize translations
+          author_name: Translation update 💬
+          author_email: info@opengis.ch

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -1,4 +1,4 @@
-name: 🌎 Translations
+name: 🌎 Push Translations
 
 on:
   push:


### PR DESCRIPTION
This is a proposal PR

This aims to synchronize the complete translations into our sources.
It does synchronization once a day.

Advantages:

- Translated builds without transifex tokens (locals, other ci)
- Seeing translations as part of the code
- Reduced build time
- Reduced build failure risk triggered by unavailable external services
- Safety copy and historization of translations

Disadvantages:

- Duplicated information
- Release branches do not get translation updates
- Latest translation might be a couple of hours old at build time