### PR TITLE
Only add recent projects that are readable to the model

### DIFF
--- a/src/core/recentprojectlistmodel.cpp
+++ b/src/core/recentprojectlistmodel.cpp
@@ -59,7 +59,7 @@ void RecentProjectListModel::reloadModel()
 
     QString path = settings.value( QStringLiteral( "path" ) ).toString();
     QFileInfo fi( path );
-    if ( fi.exists() )
+    if ( fi.exists() && fi.isReadable() )
     {
       ProjectType projectType = path.startsWith( QFieldCloudUtils::localCloudDirectory() )
                                   ? CloudProject


### PR DESCRIPTION
For people upgrading QField from a pre-November 2021 Google-imposed reduced storage access, users could see recent projects from storage locations that they do not have access to anymore. This PR hides those projects / datasets from the recent projects model to avoid people staring at a blank canvas.

@m-kuhn , as discussed.