### PR TITLE
Fix project activity crash seen on sentry

### DIFF
--- a/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -713,7 +713,9 @@ public class QFieldProjectActivity
                     alertDialog.setTitle(getString(R.string.import_error));
                     alertDialog.setMessage(
                         getString(R.string.import_dataset_error));
-                    alertDialog.show();
+                    if (!isFinishing()) {
+                        alertDialog.show();
+                    }
                 }
             }
 
@@ -758,7 +760,9 @@ public class QFieldProjectActivity
                 alertDialog.setTitle(getString(R.string.import_error));
                 alertDialog.setMessage(
                     getString(R.string.import_project_folder_error));
-                alertDialog.show();
+                if (!isFinishing()) {
+                    alertDialog.show();
+                }
             }
         } else if (requestCode == R.id.import_project_archive &&
                    resultCode == Activity.RESULT_OK) {
@@ -806,7 +810,9 @@ public class QFieldProjectActivity
                     alertDialog.setTitle(getString(R.string.import_error));
                     alertDialog.setMessage(
                         getString(R.string.import_project_archive_error));
-                    alertDialog.show();
+                    if (!isFinishing()) {
+                        alertDialog.show();
+                    }
                 }
 
                 if (imported) {


### PR DESCRIPTION
I'm not able to replicate the crash itself but sentry's stacktrace is useful enough to know we benefit from adding this safeguard.