### PR TITLE
Fix the 'send to...' action in the project activity for non-app locations

### DIFF
--- a/platform/android/res/xml/file_paths.xml
+++ b/platform/android/res/xml/file_paths.xml
@@ -3,4 +3,9 @@
     <cache-path name="qfield_pictures" path="./" />
     <external-path name="external_files" path="."/>
     <files-path name="internal_files" path="."/>
+    <!--
+    root-path is suggested in https://stackoverflow.com/q/42516126
+    as a workaround to access files only accessible via root
+    -->
+    <root-path path="." name="storage_root" />
 </paths>


### PR DESCRIPTION
Fixes a crash seen on sentry when someone tries to use the "send to..." action in the project/dataset picker activity on external storage direct access (i.e. android < 11)