### PR TITLE
Improvement on handling of feature editing / addition cancellation

### DIFF
--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -675,7 +675,7 @@ bool FeatureModel::create()
 
 bool FeatureModel::deleteFeature()
 {
-  return LayerUtils::deleteFeature( mProject, mLayer, mFeature.id() );
+  return LayerUtils::deleteFeature( mProject, mLayer, mFeature.id(), false );
 }
 
 bool FeatureModel::commit()

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -94,7 +94,16 @@ Drawer {
                       }
           bgcolor: "transparent"
 
-          onClicked: showCloudMenu()
+          onClicked: {
+            if (featureForm.state == "FeatureFormEdit") {
+              featureForm.requestCancel();
+              return;
+            }
+            if (featureForm.visible) {
+              featureForm.hide();
+            }
+            showCloudMenu()
+          }
           bottomRightIndicatorText: cloudProjectsModel.layerObserver.deltaFileWrapper.count > 0
                                       ? cloudProjectsModel.layerObserver.deltaFileWrapper.count
                                       : cloudProjectsModel.layerObserver.deltaFileWrapper.count >= 10

--- a/src/qml/EmbeddedFeatureForm.qml
+++ b/src/qml/EmbeddedFeatureForm.qml
@@ -42,6 +42,7 @@ Popup {
     signal featureCancelled
 
     parent: ApplicationWindow.overlay
+    closePolicy: Popup.NoAutoClose // prevent accidental feature addition and editing
 
     x: 24
     y: 24
@@ -50,7 +51,6 @@ Popup {
     width: parent.width - 48
     height: parent.height - 48
     modal: true
-    closePolicy: Popup.CloseOnEscape
 
     FeatureForm {
         id: form

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -39,7 +39,11 @@ Page {
   }
 
   function requestCancel() {
-    cancelDialog.open();
+    if (!qfieldSettings.autoSave) {
+      cancelDialog.open();
+    } else {
+      cancel()
+    }
   }
 
   states: [
@@ -707,7 +711,7 @@ Page {
 
         onClicked: {
           Qt.inputMethod.hide()
-          if (form.state === 'Add' || form.state === 'Edit') {
+          if ((form.state === 'Add' || form.state === 'Edit')) {
             form.requestCancel()
           } else {
             cancel();

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -38,6 +38,10 @@ Page {
     master.reset()
   }
 
+  function requestCancel() {
+    cancelDialog.open();
+  }
+
   states: [
     State {
       name: 'ReadOnly'
@@ -706,6 +710,29 @@ Page {
           cancel()
         }
       }
+    }
+  }
+
+  Dialog {
+    id: cancelDialog
+    parent: mainWindow.contentItem
+
+    visible: false
+    modal: true
+
+    x: ( mainWindow.width - width ) / 2
+    y: ( mainWindow.height - height ) / 2
+
+    title: qsTr( "Cancel editing" )
+    Label {
+      width: parent.width
+      wrapMode: Text.WordWrap
+      text: qsTr( "You are about to leave editing state, any changes will be lost. Proceed?" )
+    }
+
+    standardButtons: Dialog.Ok | Dialog.Cancel
+    onAccepted: {
+      form.cancelled()
     }
   }
 }

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -707,7 +707,7 @@ Page {
 
         onClicked: {
           Qt.inputMethod.hide()
-          cancel()
+          form.requestCancel()
         }
       }
     }
@@ -727,12 +727,14 @@ Page {
     Label {
       width: parent.width
       wrapMode: Text.WordWrap
-      text: qsTr( "You are about to leave editing state, any changes will be lost. Proceed?" )
+      text: form.state === 'Add'
+            ? qsTr( "You are about to dismiss the new feature, proceed?" )
+            : qsTr( "You are about to leave editing state, any changes will be lost. Proceed?" )
     }
 
     standardButtons: Dialog.Ok | Dialog.Cancel
     onAccepted: {
-      form.cancelled()
+      form.cancel()
     }
   }
 }

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -607,7 +607,7 @@ Page {
   }
 
   function cancel() {
-    if( form.state === 'Add' && featureCreated && !qfieldSettings.autoSave ) {
+    if( form.state === 'Add' && featureCreated && qfieldSettings.autoSave ) {
       // indirect action, no need to check for success and display a toast, the log is enough
       model.deleteFeature()
     }

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -707,7 +707,11 @@ Page {
 
         onClicked: {
           Qt.inputMethod.hide()
-          form.requestCancel()
+          if (form.state === 'Add' || form.state === 'Edit') {
+            form.requestCancel()
+          } else {
+            cancel();
+          }
         }
       }
     }
@@ -720,6 +724,7 @@ Page {
     visible: false
     modal: true
 
+    z: 10000 // 1000s are embedded feature forms, user a higher value to insure the dialog will always show above embedded feature forms
     x: ( mainWindow.width - width ) / 2
     y: ( mainWindow.height - height ) / 2
 

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -50,6 +50,10 @@ Rectangle {
   signal showMessage(string message)
   signal editGeometry
 
+  function requestCancel() {
+    featureFormList.requestCancel();
+  }
+
   width: {
       if ( props.isVisible || featureForm.canvasOperationRequested )
       {
@@ -343,6 +347,13 @@ Rectangle {
     focus: true
 
     visible: !globalFeaturesList.shown
+
+    onCancelled: {
+      featureForm.selection.focusedItemChanged()
+      featureFormList.model.featureModel.reset()
+      featureForm.state = featureForm.selection.model.selectedCount > 0 ? "FeatureList" : "FeatureForm"
+      displayToast( qsTr( "Last changes discarded" ) )
+    }
   }
 
   NavigationBar {
@@ -418,9 +429,7 @@ Rectangle {
     }
 
     onCancel: {
-        featureFormList.model.featureModel.reset()
-        featureForm.state = featureForm.selection.model.selectedCount > 0 ? "FeatureList" : "FeatureForm"
-        displayToast( qsTr( "Last changes discarded" ) )
+        featureForm.requestCancel();
     }
 
     onMoveClicked: {

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -555,14 +555,7 @@ Rectangle {
 
           if (state != "FeatureList") {
               if (featureListToolBar.state === "Edit") {
-                  if (featureFormList.model.constraintsHardValid) {
-                      featureListToolBar.save();
-                  } else {
-                      displayToast( "Constraints not valid", 'warning' );
-                      if (qfieldSettings.autoSave) {
-                          featureListToolBar.cancel();
-                      }
-                  }
+                  featureFormList.requestCancel();
               } else {
                   state = "FeatureList";
               }

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -352,7 +352,9 @@ Rectangle {
       featureForm.selection.focusedItemChanged()
       featureFormList.model.featureModel.reset()
       featureForm.state = featureForm.selection.model.selectedCount > 0 ? "FeatureList" : "FeatureForm"
-      displayToast( qsTr( "Last changes discarded" ) )
+      if (!qfieldSettings.autoSave) {
+          displayToast( qsTr( "Changes discarded" ), 'warning' )
+      }
     }
   }
 

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -259,7 +259,6 @@ Rectangle {
     iconSource: Theme.getThemeIcon( "ic_clear_white_24dp" )
 
     onClicked: {
-      selection.focusedItemChanged()
       toolBar.cancel()
     }
 

--- a/src/qml/OverlayFeatureFormDrawer.qml
+++ b/src/qml/OverlayFeatureFormDrawer.qml
@@ -14,6 +14,8 @@ Drawer {
   property bool isAdding: false
 
   edge: parent.width < parent.height ? Qt.BottomEdge : Qt.RightEdge
+  closePolicy: Popup.NoAutoClose // prevent accidental feature addition when clicking outside of the popup drawer
+
   width: {
       if (qfieldSettings.fullScreenIdentifyView || parent.width < parent.height || parent.width < 300) {
           parent.width

--- a/src/qml/OverlayFeatureFormDrawer.qml
+++ b/src/qml/OverlayFeatureFormDrawer.qml
@@ -104,7 +104,7 @@ Drawer {
     }
 
     onCancelled: {
-      displayToast( qsTr( "Last changes discarded" ) )
+      displayToast( qsTr( "Changes discarded" ) )
       //close drawer if still open
       if ( overlayFeatureFormDrawer.position > 0 ) {
         overlayFeatureForm.isSaved = true; //because never changed

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -299,7 +299,7 @@ ApplicationWindow {
 
       onClicked:  {
           if (featureForm.state == "FeatureFormEdit") {
-              // We are editing a feature form, don't accidentally close to prevent from accidental data loss
+              featureForm.requestCancel();
               return;
           }
 


### PR DESCRIPTION
This PR adds a confirmation dialog when users might accidentally be cancelling a feature addition / editing. There are also no more "silent" feature saving happening when users click outside popup / drawer areas.

Lastly, the PR insures that users are opening the cloud popup window to synchronize with a pending editing not committed (or cancelled).

