### PR TITLE
Implement magnetometer-based on-canvas compass

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -199,7 +199,6 @@
         <file>themes/qfield/xhdpi/ic_geotag_missing_24dp.png</file>
         <file>themes/qfield/xxhdpi/ic_geotag_missing_24dp.png</file>
         <file>themes/qfield/xxxhdpi/ic_geotag_missing_24dp.png</file>
-        <file>themes/qfield/nodpi/ic_movement_direction.svg</file>
         <file>themes/qfield/nodpi/ic_compass_direction.svg</file>
         <file>themes/qfield/hdpi/ic_gps_not_fixed_white_24dp.png</file>
         <file>themes/qfield/hdpi/ic_location_disabled_white_24dp.png</file>

--- a/images/images.qrc
+++ b/images/images.qrc
@@ -199,7 +199,8 @@
         <file>themes/qfield/xhdpi/ic_geotag_missing_24dp.png</file>
         <file>themes/qfield/xxhdpi/ic_geotag_missing_24dp.png</file>
         <file>themes/qfield/xxxhdpi/ic_geotag_missing_24dp.png</file>
-        <file>themes/qfield/nodpi/ic_gps_direction.svg</file>
+        <file>themes/qfield/nodpi/ic_movement_direction.svg</file>
+        <file>themes/qfield/nodpi/ic_compass_direction.svg</file>
         <file>themes/qfield/hdpi/ic_gps_not_fixed_white_24dp.png</file>
         <file>themes/qfield/hdpi/ic_location_disabled_white_24dp.png</file>
         <file>themes/qfield/mdpi/ic_gps_not_fixed_white_24dp.png</file>

--- a/images/themes/qfield/nodpi/ic_compass_direction.svg
+++ b/images/themes/qfield/nodpi/ic_compass_direction.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="124" height="124" version="1.1" viewBox="-47.226 -112.76 124 124" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs>
+  <linearGradient id="linearGradient2207" x1="12.774" x2="12.774" y1="-17.764" y2="-102.76" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#2374b5" stop-opacity=".75" offset="0"/>
+   <stop stop-color="#2374b5" stop-opacity="0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient2534" x1="12.774" x2="13.443" y1="-17.764" y2="-107.6" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#2374b5" offset="0"/>
+   <stop stop-color="#2374b5" stop-opacity="0" offset="1"/>
+  </linearGradient>
+ </defs>
+ <path d="m-47.226-112.76 62 123 62-123h-124z" fill="url(#linearGradient2207)"/>
+ <path d="m14.774 9.236-47-122h-15l62 123 62-123h-14z" fill="url(#linearGradient2534)"/>
+</svg>

--- a/images/themes/qfield/nodpi/ic_gps_direction.svg
+++ b/images/themes/qfield/nodpi/ic_gps_direction.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-47.226 -112.764 124.451 123.624" height="123.624" width="124.451"><path d="M15-37.406l11.54 23.052c-8.522-5.643-16.104-4.875-23.08.027z" fill="#2374b5" stroke="#fff" stroke-width="8.062" stroke-linecap="round" stroke-linejoin="round"/><path d="M15-37.406l11.54 23.052c-8.522-5.643-16.104-4.875-23.08.027z" fill="#2374b5"/></svg>

--- a/images/themes/qfield/nodpi/ic_movement_direction.svg
+++ b/images/themes/qfield/nodpi/ic_movement_direction.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="124" height="124" version="1.1" viewBox="-47.226 -112.76 124 124" xmlns="http://www.w3.org/2000/svg">
+ <path d="m15-37.406 11.54 23.052c-8.522-5.643-16.104-4.875-23.08 0.027z" fill="#2374b5" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="8.062"/>
+ <path d="m15-37.406 11.54 23.052c-8.522-5.643-16.104-4.875-23.08 0.027z" fill="#2374b5"/>
+</svg>

--- a/images/themes/qfield/nodpi/ic_movement_direction.svg
+++ b/images/themes/qfield/nodpi/ic_movement_direction.svg
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="124" height="124" version="1.1" viewBox="-47.226 -112.76 124 124" xmlns="http://www.w3.org/2000/svg">
- <path d="m15-37.406 11.54 23.052c-8.522-5.643-16.104-4.875-23.08 0.027z" fill="#2374b5" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="8.062"/>
- <path d="m15-37.406 11.54 23.052c-8.522-5.643-16.104-4.875-23.08 0.027z" fill="#2374b5"/>
-</svg>

--- a/src/qml/LocationMarker.qml
+++ b/src/qml/LocationMarker.qml
@@ -41,7 +41,7 @@ Item {
     x: location.x - width/2
     y: location.y - height
 
-    source: Theme.getThemeVectorIcon( "ic_gps_direction" )
+    source: Theme.getThemeVectorIcon( "ic_movement_direction" )
     fillMode: Image.PreserveAspectFit
     rotation: direction
     transformOrigin: Item.Bottom

--- a/src/qml/LocationMarker.qml
+++ b/src/qml/LocationMarker.qml
@@ -37,8 +37,8 @@ Item {
     width: accuracy * 2
     height: accuracy * 2
 
-    x: screenLocation.x - width/2
-    y: screenLocation.y - height/2
+    x: screenLocation.x - width / 2
+    y: screenLocation.y - height / 2
 
     radius: width/2
 
@@ -56,7 +56,7 @@ Item {
     height: 48
     opacity: 0.6
 
-    x: screenLocation.x - width/2
+    x: screenLocation.x - width / 2
     y: screenLocation.y - height
 
     source: Theme.getThemeVectorIcon( "ic_compass_direction" )
@@ -74,7 +74,7 @@ Item {
     width: 48
     height: 48
 
-    x: screenLocation.x - width/2
+    x: screenLocation.x - width / 2
     y: screenLocation.y - height
 
     source: Theme.getThemeVectorIcon( "ic_movement_direction" )

--- a/src/qml/LocationMarker.qml
+++ b/src/qml/LocationMarker.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.12
+import QtQuick.Shapes 1.12
 import QtGraphicalEffects 1.12
 import QtSensors 5.12
 
@@ -50,7 +51,6 @@ Item {
   Image {
     id: compassDirectionMarker
     property point screenLocation
-    property real direction
     visible: magnetometer.hasValue
     width: 48
     height: 48
@@ -66,22 +66,34 @@ Item {
     smooth: true
   }
 
-  Image {
-    id: movementDirectionMarker
+  Shape {
+    id: movementMarker
     property point screenLocation
-    property real direction
     visible: direction >= 0
-    width: 48
-    height: 48
+    width: 20
+    height: 20
 
     x: screenLocation.x - width / 2
-    y: screenLocation.y - height
+    y: screenLocation.y - height / 2
 
-    source: Theme.getThemeVectorIcon( "ic_movement_direction" )
-    fillMode: Image.PreserveAspectFit
-    rotation: direction
-    transformOrigin: Item.Bottom
-    smooth: true
+    ShapePath {
+      strokeWidth: 3
+      strokeColor: "white"
+      strokeStyle: ShapePath.SolidLine
+      fillColor: Theme.positionColor
+      startX: 10
+      startY: 0
+      PathLine { x: 18; y: 20 }
+      PathLine { x: 10; y: 14 }
+      PathLine { x: 2; y: 20 }
+      PathLine { x: 10; y: 0 }
+
+      SequentialAnimation on fillColor  {
+        loops: Animation.Infinite
+        ColorAnimation  { from: Theme.positionColor; to: Theme.darkPositionColor; duration: 2000; easing.type: Easing.InOutQuad }
+        ColorAnimation  { from: "#2374b5"; to: Theme.positionColor; duration: 1000; easing.type: Easing.InOutQuad }
+      }
+    }
 
     layer.enabled: true
     layer.effect: DropShadow {
@@ -101,6 +113,7 @@ Item {
                               && screenLocation.x < mapCanvas.width
                               && screenLocation.y > 0
                               && screenLocation.y < mapCanvas.height
+    visible: direction == -1
 
     width: isOnCanvas ? 12 : 10
     height: isOnCanvas ? 12 : 10
@@ -151,10 +164,9 @@ Item {
     var point = mapSettings.coordinateToScreen( location )
     positionMarker.screenLocation = point
     compassDirectionMarker.screenLocation = point
-    movementDirectionMarker.screenLocation = point
+    movementMarker.screenLocation = point
     accuracyMarker.screenLocation = point
 
-    movementDirectionMarker.direction = direction
     accuracyMarker.accuracy = accuracy / mapSettings.mapUnitsPerPoint
   }
 

--- a/src/qml/LocationMarker.qml
+++ b/src/qml/LocationMarker.qml
@@ -31,7 +31,7 @@ Item {
   }
 
   Image {
-    id: directionMarker
+    id: movementDirectionMarker
     property point location
     property real direction
     visible: direction >= 0
@@ -106,20 +106,16 @@ Item {
     function onOutputSizeChanged() {
       updateScreenLocation()
     }
-
-    function updateScreenLocation() {
-      marker.location = mapSettings.coordinateToScreen( location )
-      directionMarker.location = mapSettings.coordinateToScreen( location )
-      directionMarker.direction = direction
-      accuracyMarker.location = mapSettings.coordinateToScreen( location )
-      accuracyMarker.accuracy = accuracy / mapSettings.mapUnitsPerPoint
-    }
   }
 
   onLocationChanged: {
-    marker.location = mapSettings.coordinateToScreen( location );
-    directionMarker.location = mapSettings.coordinateToScreen( location )
-    directionMarker.direction = direction
+   updateScreenLocation()
+  }
+
+  function updateScreenLocation() {
+    marker.location = mapSettings.coordinateToScreen( location )
+    movementDirectionMarker.location = mapSettings.coordinateToScreen( location )
+    movementDirectionMarker.direction = direction
     accuracyMarker.location = mapSettings.coordinateToScreen( location )
     accuracyMarker.accuracy = accuracy / mapSettings.mapUnitsPerPoint
   }

--- a/src/qml/LocationMarker.qml
+++ b/src/qml/LocationMarker.qml
@@ -61,7 +61,7 @@ Item {
 
     source: Theme.getThemeVectorIcon( "ic_compass_direction" )
     fillMode: Image.PreserveAspectFit
-    rotation: (Math.atan2(magnetometer.x, magnetometer.y) / Math.PI) * 180
+    rotation: -(Math.atan2(magnetometer.x, magnetometer.y) / Math.PI) * 180
     transformOrigin: Item.Bottom
     smooth: true
   }

--- a/src/qml/LocationMarker.qml
+++ b/src/qml/LocationMarker.qml
@@ -91,7 +91,7 @@ Item {
       SequentialAnimation on fillColor  {
         loops: Animation.Infinite
         ColorAnimation  { from: Theme.positionColor; to: Theme.darkPositionColor; duration: 2000; easing.type: Easing.InOutQuad }
-        ColorAnimation  { from: "#2374b5"; to: Theme.positionColor; duration: 1000; easing.type: Easing.InOutQuad }
+        ColorAnimation  { from: Theme.darkPositionColor; to: Theme.positionColor; duration: 1000; easing.type: Easing.InOutQuad }
       }
     }
 
@@ -130,7 +130,7 @@ Item {
     SequentialAnimation on color  {
       loops: Animation.Infinite
       ColorAnimation  { from: Theme.positionColor; to: Theme.darkPositionColor; duration: 2000; easing.type: Easing.InOutQuad }
-      ColorAnimation  { from: "#2374b5"; to: Theme.positionColor; duration: 1000; easing.type: Easing.InOutQuad }
+      ColorAnimation  { from: Theme.darkPositionColor; to: Theme.positionColor; duration: 1000; easing.type: Easing.InOutQuad }
     }
 
     layer.enabled: true

--- a/src/qml/LocationMarker.qml
+++ b/src/qml/LocationMarker.qml
@@ -15,10 +15,10 @@ Item {
 
   Magnetometer {
     id: magnetometer
-    active: true
+    active: false
     returnGeoValues: false
 
-    property bool hasValue: true
+    property bool hasValue: false
     property real x: 0
     property real y: 0
 
@@ -158,7 +158,24 @@ Item {
     accuracyMarker.accuracy = accuracy / mapSettings.mapUnitsPerPoint
   }
 
+  Connections {
+    target: positionSource
+
+    function onActiveChanged() {
+      if (positionSource.active) {
+        magnetometer.active = true
+        magnetometer.start()
+      } else {
+        magnetometer.stop()
+        magnetometer.active = false
+        magnetometer.hasValue = false
+      }
+    }
+  }
+
   Component.onCompleted: {
-    magnetometer.start()
+    if (positionSource.active) {
+      magnetometer.start()
+    }
   }
 }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -488,7 +488,12 @@ ApplicationWindow {
       visible: positionSource.active && positionSource.positionInfo && positionSource.positionInfo.latitudeValid
       location: positionSource.projectedPosition
       accuracy: positionSource.projectedHorizontalAccuracy
-      direction: positionSource.positionInfo && positionSource.positionInfo.directionValid ? positionSource.positionInfo.direction : -1
+      direction: positionSource.positionInfo
+                 && positionSource.positionInfo.directionValid
+                 && positionSource.positionInfo.speedValid
+                 && positionSource.positionInfo.speed > 0.0
+                 ? positionSource.positionInfo.direction
+                 : -1
 
       onLocationChanged: {
         if ( gpsButton.followActive ) {


### PR DESCRIPTION
This PR implements a proper magnetometer-based on-canvas compass in QField. The feature requires devices to have a magnetometer sensor hardware (PSA: when you buy a mobile device, make sure you check if that hardware is present or not, many entry level devices leave that piece of hardware out to lower production cost).

The sensor is only turned on whenever the positioning is active to insure we're not draining battery needlessly.

The visual compass looks like this:
![image](https://user-images.githubusercontent.com/1728657/155875113-7db5b98c-0b4f-486a-b6c3-8141d3beb3f7.png)

(Temporarily include #2539 until that is merged)