### PR TITLE
Add cloud error class that wraps the error response within an object

### DIFF
--- a/src/core/qfieldcloudconnection.h
+++ b/src/core/qfieldcloudconnection.h
@@ -19,6 +19,7 @@
 #include "networkmanager.h"
 #include "networkreply.h"
 
+#include <QJsonDocument>
 #include <QObject>
 #include <QVariantMap>
 
@@ -60,6 +61,24 @@ class QFieldCloudConnection : public QObject
       Busy
     };
     Q_ENUM( ConnectionState )
+
+    class CloudError
+    {
+      public:
+        explicit CloudError( QNetworkReply *reply );
+
+        QString message() const { return mMessage; }
+        QString qfcCode() const { return mQfcCode; }
+
+      private:
+        int mHttpCode = 0;
+        QString mMessage;
+        QString mPayload;
+        QString mQfcCode;
+        QJsonDocument mJson;
+        QJsonParseError mJsonError;
+        QNetworkReply::NetworkError mError;
+    };
 
     QFieldCloudConnection();
 

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -348,8 +348,6 @@ class QFieldCloudProjectsModel : public QAbstractListModel
         QString id;
         QString projectId;
         JobType type;
-        QNetworkReply::NetworkError replyError;
-        QString errorString;
         JobStatus status = JobPendingStatus;
     };
 


### PR DESCRIPTION
Initially developed for particular use, but I found it would be much easier and nicer to solve the issue on the cloud. However, this code can help in the future to improve error handling on QField side, so I am commiting it anyway. 