### PR TITLE
Add useful copy {coordinates,current location} to clipboard menu actions

### DIFF
--- a/src/core/platforms/platformutilities.cpp
+++ b/src/core/platforms/platformutilities.cpp
@@ -22,6 +22,7 @@
 #include "qgismobileapp.h"
 #include "qgsmessagelog.h"
 
+#include <QClipboard>
 #include <QDebug>
 #include <QDesktopServices>
 #include <QDir>
@@ -180,6 +181,12 @@ bool PlatformUtilities::checkCameraPermissions() const
 bool PlatformUtilities::checkWriteExternalStoragePermissions() const
 {
   return true;
+}
+
+void PlatformUtilities::copyTextToClipboard( const QString &string ) const
+{
+  QClipboard *clipboard = QGuiApplication::clipboard();
+  clipboard->setText( string );
 }
 
 PlatformUtilities *PlatformUtilities::instance()

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -143,6 +143,11 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
      */
     Q_INVOKABLE virtual void restoreBrightness() { return; };
 
+    /**
+     * Copies a text \a string to the system clipboard.
+     */
+    Q_INVOKABLE virtual void copyTextToClipboard( const QString &string ) const;
+
     static PlatformUtilities *instance();
 };
 #endif // PLATFORMUTILITIES_H

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1705,12 +1705,31 @@ ApplicationWindow {
 
     MenuItem {
       id: setDestinationItem
-      text: qsTr( "Set As Destination" )
+      text: qsTr( "Set Coordinates as Destination" )
       height: 48
       font: Theme.defaultFont
 
       onTriggered: {
         navigation.destination = canvasMenu.point
+      }
+    }
+
+    MenuItem {
+      id: copyCoordinatesItem
+      text: qsTr( "Copy Coordinates" )
+      height: 48
+      font: Theme.defaultFont
+
+      onTriggered: {
+        var coordinates = ''
+        if (mapCanvas.mapSettings.destinationCrs.isGeographic) {
+          coordinates = qsTr( 'Lon' ) + ' ' +  canvasMenu.point.x.toFixed(5) + ', ' + qsTr( 'Lat' ) + ' ' + canvasMenu.point.y.toFixed(5)
+        } else {
+          coordinates = qsTr( 'X' ) + ' ' +  canvasMenu.point.x.toFixed(2) + ', ' + qsTr( 'Y' ) + ' ' + canvasMenu.point.y.toFixed(2)
+        }
+
+        platformUtilities.copyTextToClipboard(coordinates)
+        displayToast(qsTr('Coordinates copied to clipboard'));
       }
     }
   }
@@ -1818,6 +1837,34 @@ ApplicationWindow {
 
       onTriggered: {
         mapCanvas.mapSettings.setCenter(positionSource.projectedPosition)
+      }
+    }
+
+    MenuItem {
+      text: qsTr( "Copy Current Location" )
+      height: 48
+      font: Theme.defaultFont
+
+      onTriggered: {
+        if (!positioningSettings.positioningActivated || positionSource.positionInfo === undefined || !positionSource.positionInfo.latitudeValid) {
+          displayToast(qsTr('Current location unknown'));
+          return;
+        }
+
+        var coordinates = ''
+        var point = positionSource.projectedPosition
+        if (mapCanvas.mapSettings.destinationCrs.isGeographic) {
+          coordinates = qsTr( 'Lon' ) + ' ' +  point.x.toFixed(7) + ', ' + qsTr( 'Lat' ) + ' ' + point.y.toFixed(7)
+        } else {
+          coordinates = qsTr( 'X' ) + ' ' +  point.x.toFixed(3) + ', ' + qsTr( 'Y' ) + ' ' + point.y.toFixed(3)
+        }
+        coordinates += ' ('+ qsTr('Accuracy') + ' ' +
+                       ( positionSource.positionInfo && positionSource.positionInfo.haccValid
+                         ? positionSource.positionInfo.hacc.toLocaleString(Qt.locale(), 'f', 3) + " m"
+                         : qsTr( "N/A" ) ) + ')'
+
+        platformUtilities.copyTextToClipboard(coordinates)
+        displayToast(qsTr('Current location copied to clipboard'));
       }
     }
   }


### PR DESCRIPTION
Two actions were added to the map canvas menu and location menu:
- copy [pressed map canvas] coordinates to clipboard
- copy current location to clipboard

Obligatory screenshots:
![image](https://user-images.githubusercontent.com/1728657/156916519-27b58758-5319-4d5d-a39c-13b74d00c5d7.png)

![image](https://user-images.githubusercontent.com/1728657/156916536-5eb919df-f83b-4ad3-9c98-b9eae599a6f0.png)

@suricactus , that one's for you :wink: good idea.