### PR TITLE
Improve help text by replacing "local cloud layers" with "local layers"

### DIFF
--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -421,7 +421,7 @@ Popup {
             font: Theme.tipFont
             color: Theme.gray
             text: !cloudProjectsModel.layerObserver.deltaFileWrapper.hasError()
-                  ? qsTr('Revert all modified features in the local cloud layers. You cannot restore those changes.')
+                  ? qsTr('Revert all modified features in the local layers. You cannot restore those changes.')
                   : qsTr('The local copy of this cloud project has been corrupted. Resetting the project will re-download the cloud version and will remove any local changes, make sure those were copied first if needed.\n\nWhile you can still view and use the project, it is strongly recommended to reset to avoid any accidental data loss as none of the changes made will be pushed back to the cloud.')
             wrapMode: Text.WordWrap
             horizontalAlignment: Text.AlignHCenter


### PR DESCRIPTION
Improved text as suggested by @BoswachterMarc in #2469 .

| before | after |
|----------|--------|
|  ![image](https://user-images.githubusercontent.com/2820439/157409820-97f9999e-6dad-4b3f-9077-0d4e6e2de62c.png) | ![image](https://user-images.githubusercontent.com/2820439/157409657-560a941e-ac0c-4d9b-a1a4-a8aea7454aab.png) |
