### PR TITLE
Calendar panel follow ups

### DIFF
--- a/src/qml/CalendarPanel.qml
+++ b/src/qml/CalendarPanel.qml
@@ -37,6 +37,32 @@ Popup {
         }
     }
 
+    Timer {
+        id: changeCalendarTimer
+        interval: 700
+        repeat: true
+
+        property string action: ''
+
+        onTriggered: {
+          switch(action) {
+              case 'decreaseYear':
+                  calendar.decreaseYear();
+                  break;
+              case 'decreaseMonth':
+                  calendar.decreaseMonth();
+                  break;
+              case 'increaseYear':
+                  calendar.increaseYear();
+                  break;
+              case 'increaseMonth':
+                  calendar.increaseMonth();
+                  break;
+          }
+          if ( interval > 100 ) interval = interval * 0.8;
+        }
+    }
+
     ColumnLayout {
         Rectangle {
             id: calendarOverlay
@@ -66,8 +92,17 @@ Popup {
                         bgcolor: "transparent"
                         roundborder: true
 
-                        onClicked: {
-                            calendar.year -= 1;
+                        onPressed: {
+                            calendar.decreaseYear();
+                            changeCalendarTimer.action = 'decreaseYear';
+                            changeCalendarTimer.interval = 700;
+                            changeCalendarTimer.restart();
+                        }
+                        onReleased: {
+                            changeCalendarTimer.stop()
+                        }
+                        onCanceled: {
+                            changeCalendarTimer.stop()
                         }
                     }
 
@@ -77,13 +112,17 @@ Popup {
                         bgcolor: "transparent"
                         roundborder: true
 
-                        onClicked: {
-                            if (calendar.month !== Calendar.January) {
-                                calendar.month -= 1;
-                            } else {
-                                calendar.year -= 1;
-                                calendar.month = Calendar.December;
-                            }
+                        onPressed: {
+                            calendar.decreaseMonth();
+                            changeCalendarTimer.action = 'decreaseMonth';
+                            changeCalendarTimer.interval = 700;
+                            changeCalendarTimer.restart();
+                        }
+                        onReleased: {
+                            changeCalendarTimer.stop()
+                        }
+                        onCanceled: {
+                            changeCalendarTimer.stop()
                         }
                     }
                 }
@@ -107,13 +146,17 @@ Popup {
                         bgcolor: "transparent"
                         roundborder: true
 
-                        onClicked: {
-                            if (calendar.month != Calendar.December) {
-                                calendar.month += 1;
-                            } else {
-                                calendar.month = Calendar.January
-                                calendar.year += 1;
-                            }
+                        onPressed: {
+                            calendar.increaseMonth();
+                            changeCalendarTimer.action = 'increaseMonth';
+                            changeCalendarTimer.interval = 700;
+                            changeCalendarTimer.restart();
+                        }
+                        onReleased: {
+                            changeCalendarTimer.stop()
+                        }
+                        onCanceled: {
+                            changeCalendarTimer.stop()
                         }
                     }
                     QfToolButton {
@@ -122,8 +165,17 @@ Popup {
                         bgcolor: "transparent"
                         roundborder: true
 
-                        onClicked: {
-                            calendar.year += 1;
+                        onPressed: {
+                            calendar.increaseYear();
+                            changeCalendarTimer.action = 'increaseYear';
+                            changeCalendarTimer.interval = 700;
+                            changeCalendarTimer.restart();
+                        }
+                        onReleased: {
+                            changeCalendarTimer.stop()
+                        }
+                        onCanceled: {
+                            changeCalendarTimer.stop()
                         }
                     }
                 }
@@ -139,6 +191,29 @@ Popup {
 
                 MonthGrid {
                     id: calendar
+
+                    function decreaseYear() {
+                        year -= 1;
+                    }
+                    function increaseYear() {
+                        year += 1;
+                    }
+                    function decreaseMonth() {
+                        if (month !== Calendar.January) {
+                            month -= 1;
+                        } else {
+                            year -= 1;
+                            month = Calendar.December;
+                        }
+                    }
+                    function increaseMonth() {
+                        if (month != Calendar.December) {
+                            month += 1;
+                        } else {
+                            month = Calendar.January
+                            year += 1;
+                        }
+                    }
 
                     month: Calendar.January
                     year: 2020

--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -8,6 +8,7 @@ import Theme 1.0
 import org.qfield 1.0
 
 import "."
+import ".."
 
 /*
   Config:
@@ -127,16 +128,8 @@ EditorWidgetBase {
                 if (value !== undefined && value != '') {
                     usedDate = value;
                 }
-
-                calendar.selectedDate = usedDate
-                calendar.year = usedDate.getFullYear()
-                calendar.month = usedDate.getMonth()
-
-                hoursSpinBox.value = usedDate.getHours()
-                minutesSpinBox.value = usedDate.getMinutes()
-                secondsSpinBox.value = usedDate.getSeconds()
-
-                popup.open()
+                calendarPanel.selectedDate = usedDate
+                calendarPanel.open();
             }
         }
 
@@ -240,255 +233,16 @@ EditorWidgetBase {
         font: label.font
     }
 
-    Popup {
-        id: popup
-        modal: true
-        focus: true
-        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
-        parent: ApplicationWindow.overlay
-        x: (parent.width - width) / 2
-        y: (parent.height - height) / 2
-        z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes
-
-        ColumnLayout {
-            Rectangle {
-                id: calendarOverlay
-                width: 350
-                height: 240
-                color: "transparent"
-
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: mouse.accepted = true
-                    onWheel: wheel.accepted = true
-                }
-
-                GridLayout {
-                    id: calendarGrid
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    columns: 3
-
-                    Row {
-                        Layout.column: 0
-                        Layout.row: 0
-
-                        QfToolButton {
-                            enabled: true
-                            iconSource: Theme.getThemeIcon( 'ic_doublearrow_left_black_24dp' )
-                            bgcolor: "transparent"
-                            roundborder: true
-
-                            onClicked: {
-                                calendar.year -= 1;
-                            }
-                        }
-
-                        QfToolButton {
-                            enabled: true
-                            iconSource: Theme.getThemeIcon( 'ic_arrow_left_black_24dp' )
-                            bgcolor: "transparent"
-                            roundborder: true
-
-                            onClicked: {
-                                if (calendar.month !== Calendar.January) {
-                                    calendar.month -= 1;
-                                } else {
-                                    calendar.year -= 1;
-                                    calendar.month = Calendar.December;
-                                }
-                            }
-                        }
-                    }
-
-                    Text {
-                        text: calendar.title
-                        horizontalAlignment: Text.AlignHCenter
-                        Layout.column: 1
-                        Layout.row: 0
-                        Layout.fillWidth: true
-                        font: Theme.tipFont
-                    }
-
-                    Row {
-                        Layout.column: 2
-                        Layout.row: 0
-
-                        QfToolButton {
-                            enabled: true
-                            iconSource: Theme.getThemeIcon( 'ic_arrow_right_black_24dp' )
-                            bgcolor: "transparent"
-                            roundborder: true
-
-                            onClicked: {
-                                if (calendar.month != Calendar.December) {
-                                    calendar.month += 1;
-                                } else {
-                                    calendar.month = Calendar.January
-                                    calendar.year += 1;
-                                }
-                            }
-                        }
-                        QfToolButton {
-                            enabled: true
-                            iconSource: Theme.getThemeIcon( 'ic_doublearrow_right_black_24dp' )
-                            bgcolor: "transparent"
-                            roundborder: true
-
-                            onClicked: {
-                                calendar.year += 1;
-                            }
-                        }
-                    }
-
-                    DayOfWeekRow {
-                        locale: calendar.locale
-
-                        Layout.column: 0
-                        Layout.columnSpan: 3
-                        Layout.row: 1
-                        Layout.fillWidth: true
-                    }
-
-                    MonthGrid {
-                        id: calendar
-                        month: Calendar.January
-                        year: 2020
-                        Layout.row: 2
-                        Layout.column: 0
-                        Layout.columnSpan: 3
-                        Layout.fillWidth: true
-                        Layout.fillHeight: true
-
-                        property date selectedDate: new Date()
-
-                        delegate: Rectangle {
-                            property bool isDate: calendar.selectedDate.getYear() === model.date.getYear() && calendar.selectedDate.getMonth() === model.date.getMonth() && calendar.selectedDate.getDate() === model.date.getDate()
-                            color:  isDate ? Theme.mainColor : "transparent"
-                            width: 18
-                            height: 18
-
-                            Text {
-                                anchors.centerIn: parent
-                                horizontalAlignment: Text.AlignHCenter
-                                verticalAlignment: Text.AlignVCenter
-                                opacity: model.month !== calendar.month ? 0.5 : 1
-                                text: model.day
-                                font: parent.isDate ? Theme.strongTipFont : Theme.tipFont
-                                color: parent.isDate ? "white" : "black"
-                            }
-                        }
-
-                        onClicked: {
-                            selectedDate = date;
-                        }
-
-                        function resetDate() {
-                            selectedDate = main.currentValue ? main.isDateTimeType ? main.currentValue : Date.fromLocaleString(Qt.locale(), main.currentValue, config['field_format']) : new Date()
-                        }
-                    }
-                }
-            }
-
-            RowLayout {
-                GridLayout {
-                    id: timeGrid
-                    visible: !main.fieldIsDate
-                    Layout.alignment: Qt.AlignHCenter
-                    Layout.leftMargin: 20
-                    rows: 3
-                    columns: 2
-
-                    Label {
-                        Layout.alignment: Qt.AlignRight
-                        Layout.row: 0
-                        Layout.column: 0
-                        text: qsTr( "Hours" )
-                        font: Theme.tipFont
-                    }
-                    SpinBox {
-                        id: hoursSpinBox
-                        Layout.row: 0
-                        Layout.column: 1
-                        editable: true
-                        from: 0
-                        to: 23
-                        value: 12
-                        inputMethodHints: Qt.ImhTime
-                        font: Theme.tipFont
-                    }
-                    Label {
-                        Layout.alignment: Qt.AlignRight
-                        Layout.row: 1
-                        Layout.column: 0
-                        text: qsTr( "Minutes" )
-                        font: Theme.tipFont
-                    }
-                    SpinBox {
-                        id: minutesSpinBox
-                        Layout.row: 1
-                        Layout.column: 1
-                        editable: true
-                        from: 0
-                        to: 59
-                        value: 30
-                        inputMethodHints: Qt.ImhTime
-                        font: Theme.tipFont
-                    }
-                    Label {
-                        Layout.alignment: Qt.AlignRight
-                        Layout.row: 2
-                        Layout.column: 0
-                        text: qsTr( "Seconds" )
-                        font: Theme.tipFont
-                    }
-                    SpinBox {
-                        id: secondsSpinBox
-                        Layout.row: 2
-                        Layout.column: 1
-                        editable: true
-                        from: 0
-                        to: 59
-                        value: 30
-                        inputMethodHints: Qt.ImhTime
-                        font: Theme.tipFont
-                    }
-                }
-            }
-
-            RowLayout {
-                QfButton {
-                    text: qsTr( "OK" )
-                    font: Theme.tipFont
-                    Layout.fillWidth: true
-
-                    onClicked: {
-                        var newDate = calendar.selectedDate
-                        newDate.setHours(hoursSpinBox.value);
-                        newDate.setMinutes(minutesSpinBox.value);
-                        newDate.setSeconds(secondsSpinBox.value);
-                        if ( main.isDateTimeType )
-                        {
-                            valueChangeRequested(newDate, newDate === undefined)
-                        }
-                        else
-                        {
-                            var textDate = Qt.formatDateTime(newDate, config['field_format'])
-                            valueChangeRequested(textDate, textDate === undefined)
-                        }
-
-                        popup.close()
-                    }
-                }
+    CalendarPanel {
+        id: calendarPanel
+        isDateTime: !main.fieldIsDate
+        onDateTimePicked: {
+            if ( main.isDateTimeType ) {
+                valueChangeRequested(date, date === undefined)
+            } else {
+                var textDate = Qt.formatDateTime(date, config['field_format'])
+                valueChangeRequested(date, date === undefined)
             }
         }
-    }
-
-    onIsDateTimeTypeChanged: {
-        calendar.resetDate()
-    }
-
-    onCurrentValueChanged: {
-        calendar.resetDate()
     }
 }

--- a/src/qml/imports/Theme/QfToolButton.qml
+++ b/src/qml/imports/Theme/QfToolButton.qml
@@ -66,7 +66,7 @@ Item {
                 pressed: button.down
                 anchor: parent
                 active: button.down
-                color: bgcolor == "#ffffff" ? "#10000000" : "#22ffffff"
+                color: bgcolor == "#ffffff" || bgcolor == "#00000000" ? "#10000000" : "#22ffffff"
 
                 layer.enabled: true
                 layer.effect: OpacityMask {


### PR DESCRIPTION
As mentioned during the implementation of temporal support for QField, this follow up PR deduplicates code by having the datetime editor widget rely on the calendar panel item.

In addition, I've implemented a press and hold behavior for the increase/decrease year/month buttons in the calendar panel so values continuously increase/decrease while holding those:

https://user-images.githubusercontent.com/1728657/158005686-cfb74135-3eb1-4b5f-ba53-dfb619ef8bf3.mp4

