### PR TITLE
Improve bookmark marker by using a Shape item instead of an SVG

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -268,7 +268,6 @@
         <file>themes/qfield/xxhdpi/ic_photo_notavailable_black_24dp.png</file>
         <file>themes/qfield/xxxhdpi/ic_photo_notavailable_black_24dp.png</file>
         <file>themes/qfield/nodpi/ic_photo_notavailable_black_24dp.svg</file>
-        <file>themes/qfield/nodpi/ic_place_white_24dp.svg</file>
         <file>themes/qfield/hdpi/ic_print_white_24dp.png</file>
         <file>themes/qfield/mdpi/ic_print_white_24dp.png</file>
         <file>themes/qfield/xhdpi/ic_print_white_24dp.png</file>

--- a/images/themes/qfield/nodpi/ic_place_white_24dp.svg
+++ b/images/themes/qfield/nodpi/ic_place_white_24dp.svg
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="24px" height="24px" fill="#FFFFFF" version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
- <path d="M0 0h24v24H0z" fill="none"/>
- <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/>
-</svg>

--- a/src/qml/BookmarkRenderer.qml
+++ b/src/qml/BookmarkRenderer.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.12
+import QtQuick.Shapes 1.12
 import QtGraphicalEffects 1.0
 
 import org.qgis 1.0
@@ -38,55 +39,84 @@ Item {
             model: geometryWrapper.pointList()
 
             Item {
-                Image {
+                property CoordinateTransformer ct: CoordinateTransformer {
+                    id: _ct
+                    sourceCrs: geometryWrapper.crs
+                    sourcePosition: modelData
+                    destinationCrs: mapCanvas.mapSettings.destinationCrs
+                    transformContext: qgisProject.transformContext
+                }
+
+                MapToScreen {
+                    id: mapToScreenPosition
+                    mapSettings: mapCanvas.mapSettings
+                    mapPoint: _ct.projectedPosition
+                }
+
+                Shape {
                     id: bookmark
-
-                    property CoordinateTransformer ct: CoordinateTransformer {
-                        id: _ct
-                        sourceCrs: geometryWrapper.crs
-                        sourcePosition: modelData
-                        destinationCrs: mapCanvas.mapSettings.destinationCrs
-                        transformContext: qgisProject.transformContext
-                    }
-
-                    MapToScreen {
-                        id: mapToScreenPosition
-                        mapSettings: mapCanvas.mapSettings
-                        mapPoint: _ct.projectedPosition
-                    }
 
                     x: mapToScreenPosition.screenPoint.x - width/2
                     y: mapToScreenPosition.screenPoint.y - height
 
                     width: 36
                     height: 36
-                    source: Theme.getThemeVectorIcon("ic_place_white_24dp")
-                    sourceSize.width: 36 * screen.devicePixelRatio
-                    sourceSize.height: 36 * screen.devicePixelRatio
 
-                    ColorOverlay {
-                        anchors.fill: bookmark
-                        source: bookmark
-                        color: Theme.mainColor
+                    ShapePath {
+                        strokeWidth: 3
+                        strokeColor: "white"
+                        strokeStyle: ShapePath.SolidLine
+                        fillColor: Theme.mainColor
+                        startX: 6
+                        startY: 16
+                        PathArc {
+                            x: 30
+                            y: 16
+                            radiusX: 12
+                            radiusY: 14
+                        }
+                        PathArc {
+                            x: 18
+                            y: 36
+                            radiusX: 36
+                            radiusY: 36
+                        }
+                        PathArc{
+                            x: 6
+                            y: 16
+                            radiusX: 36
+                            radiusY: 36
+                        }
                     }
 
-                    MouseArea {
-                        anchors.fill: bookmark
-                        onClicked: {
-                            displayToast(qsTr('Bookmark: %1').arg(bookmarkRenderer.bookmarkName));
-                        }
-                        onDoubleClicked: {
-                            bookmarkModel.setExtentFromBookmark(bookmarkModel.index(bookmarkRenderer.bookmarkIndex, 0));
-                        }
+                    Rectangle {
+                        x: 13
+                        y: 9
+                        width: 10
+                        height: 10
+                        color: "white"
+                        radius: 4
+                    }
+
+                    layer.enabled: true
+                    layer.effect: DropShadow {
+                        transparentBorder: true
+                        radius: 8
+                        samples: 25
+                        color: "#99000000"
+                        horizontalOffset: 0
+                        verticalOffset: 0
                     }
                 }
 
-                Glow {
+                MouseArea {
                     anchors.fill: bookmark
-                    source: bookmark
-                    radius: 7
-                    samples: 17
-                    color: "#44000000"
+                    onClicked: {
+                        displayToast(qsTr('Bookmark: %1').arg(bookmarkRenderer.bookmarkName));
+                    }
+                    onDoubleClicked: {
+                        bookmarkModel.setExtentFromBookmark(bookmarkModel.index(bookmarkRenderer.bookmarkIndex, 0));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Beyond looking better (i.e. a white dot instead of a hole on the top part of the marker), a bunch of advantages here:
- we can perfectly match looks of border width with other marker overlays (all using QML items)
- far less complex code (the color overlay filter is gone in favor of good old color fill property)

Here's how it looks standing next to other overlay markers:
![image](https://user-images.githubusercontent.com/1728657/158015759-83ab22eb-e18a-43c7-aab0-bb2843b10c2c.png)

In 2.1, I'm planning to add a "add bookmark" feature, where users can specify the bookmark marker color among other things.