### PR TITLE
Allow users to add and edit bookmarks

### DIFF
--- a/src/core/bookmarkmodel.cpp
+++ b/src/core/bookmarkmodel.cpp
@@ -118,7 +118,7 @@ void BookmarkModel::setExtentFromBookmark( const QModelIndex &index )
   mMapSettings->setExtent( transformedRect );
 }
 
-QString BookmarkModel::addBookmarkAtPoint( QgsPoint point, QString name, QString group )
+QString BookmarkModel::addBookmarkAtPoint( QgsPoint point, const QString &name, const QString &group )
 {
   if ( !mMapSettings )
     return QString();
@@ -141,7 +141,7 @@ QString BookmarkModel::addBookmarkAtPoint( QgsPoint point, QString name, QString
   return mManager->addBookmark( bookmark );
 }
 
-void BookmarkModel::updateBookmarkDetails( QString id, QString name, QString group )
+void BookmarkModel::updateBookmarkDetails( const QString &id, const QString &name, const QString &group )
 {
   QgsBookmark bookmark = mManager->bookmarkById( id );
   bookmark.setName( name );
@@ -149,7 +149,7 @@ void BookmarkModel::updateBookmarkDetails( QString id, QString name, QString gro
   mManager->updateBookmark( bookmark );
 }
 
-void BookmarkModel::removeBookmark( QString id )
+void BookmarkModel::removeBookmark( const QString &id )
 {
   mManager->removeBookmark( id );
 }

--- a/src/core/bookmarkmodel.cpp
+++ b/src/core/bookmarkmodel.cpp
@@ -43,6 +43,9 @@ QVariant BookmarkModel::data( const QModelIndex &index, int role ) const
     case BookmarkModel::BookmarkName:
       return mModel->data( sourceIndex, QgsBookmarkManagerModel::RoleName );
 
+    case BookmarkModel::BookmarkGroup:
+      return mModel->data( sourceIndex, QgsBookmarkManagerModel::RoleGroup );
+
     case BookmarkModel::BookmarkPoint:
     {
       QgsReferencedRectangle rect = mModel->data( sourceIndex, QgsBookmarkManagerModel::RoleExtent ).value<QgsReferencedRectangle>();
@@ -70,6 +73,7 @@ QHash<int, QByteArray> BookmarkModel::roleNames() const
   QHash<int, QByteArray> roleNames = QAbstractProxyModel::roleNames();
   roleNames[BookmarkModel::BookmarkId] = "BookmarkId";
   roleNames[BookmarkModel::BookmarkName] = "BookmarkName";
+  roleNames[BookmarkModel::BookmarkGroup] = "BookmarkGroup";
   roleNames[BookmarkModel::BookmarkPoint] = "BookmarkPoint";
   roleNames[BookmarkModel::BookmarkCrs] = "BookmarkCrs";
   roleNames[BookmarkModel::BookmarkUser] = "BookmarkUser";
@@ -114,7 +118,7 @@ void BookmarkModel::setExtentFromBookmark( const QModelIndex &index )
   mMapSettings->setExtent( transformedRect );
 }
 
-QString BookmarkModel::addBookmarkAtPoint( QgsPoint point, QString name )
+QString BookmarkModel::addBookmarkAtPoint( QgsPoint point, QString name, QString group )
 {
   if ( !mMapSettings )
     return QString();
@@ -133,13 +137,15 @@ QString BookmarkModel::addBookmarkAtPoint( QgsPoint point, QString name )
   QgsBookmark bookmark;
   bookmark.setExtent( QgsReferencedRectangle( extent, mMapSettings->destinationCrs() ) );
   bookmark.setName( name );
+  bookmark.setGroup( group );
   return mManager->addBookmark( bookmark );
 }
 
-void BookmarkModel::updateBookmarkDetails( QString id, QString name )
+void BookmarkModel::updateBookmarkDetails( QString id, QString name, QString group )
 {
   QgsBookmark bookmark = mManager->bookmarkById( id );
   bookmark.setName( name );
+  bookmark.setGroup( group );
   mManager->updateBookmark( bookmark );
 }
 

--- a/src/core/bookmarkmodel.cpp
+++ b/src/core/bookmarkmodel.cpp
@@ -23,7 +23,7 @@
 
 BookmarkModel::BookmarkModel( QgsBookmarkManager *manager, QgsBookmarkManager *projectManager, QObject *parent )
   : QSortFilterProxyModel( parent )
-  , mModel( std::make_unique<QgsBookmarkManagerModel>( manager, projectManager, this ) )
+  , mModel( new QgsBookmarkManagerModel( manager, projectManager, this ) )
   , mManager( manager )
 {
   setSourceModel( mModel.get() );

--- a/src/core/bookmarkmodel.cpp
+++ b/src/core/bookmarkmodel.cpp
@@ -55,6 +55,11 @@ QVariant BookmarkModel::data( const QModelIndex &index, int role ) const
       QgsReferencedRectangle rect = mModel->data( sourceIndex, QgsBookmarkManagerModel::RoleExtent ).value<QgsReferencedRectangle>();
       return rect.crs();
     }
+
+    case BookmarkModel::BookmarkUser:
+    {
+      return mModel->data( mModel->index( sourceIndex.row(), QgsBookmarkManagerModel::ColumnStore ), Qt::CheckStateRole ).value<Qt::CheckState>() != Qt::Checked;
+    }
   }
 
   return QVariant();
@@ -67,6 +72,7 @@ QHash<int, QByteArray> BookmarkModel::roleNames() const
   roleNames[BookmarkModel::BookmarkName] = "BookmarkName";
   roleNames[BookmarkModel::BookmarkPoint] = "BookmarkPoint";
   roleNames[BookmarkModel::BookmarkCrs] = "BookmarkCrs";
+  roleNames[BookmarkModel::BookmarkUser] = "BookmarkUser";
   return roleNames;
 }
 

--- a/src/core/bookmarkmodel.h
+++ b/src/core/bookmarkmodel.h
@@ -50,11 +50,11 @@ class BookmarkModel : public QSortFilterProxyModel
 
     Q_INVOKABLE void setExtentFromBookmark( const QModelIndex &index );
 
-    Q_INVOKABLE QString addBookmarkAtPoint( QgsPoint point, QString name = QString(), QString group = QString() );
+    Q_INVOKABLE QString addBookmarkAtPoint( QgsPoint point, const QString &name = QString(), const QString &group = QString() );
 
-    Q_INVOKABLE void updateBookmarkDetails( QString id, QString name, QString group );
+    Q_INVOKABLE void updateBookmarkDetails( const QString &id, const QString &name, const QString &group );
 
-    Q_INVOKABLE void removeBookmark( QString id );
+    Q_INVOKABLE void removeBookmark( const QString &id );
 
     void setMapSettings( QgsQuickMapSettings *mapSettings );
 

--- a/src/core/bookmarkmodel.h
+++ b/src/core/bookmarkmodel.h
@@ -22,6 +22,7 @@
 
 #include <qgsbookmarkmanager.h>
 #include <qgsbookmarkmodel.h>
+#include <qobjectuniqueptr.h>
 
 class BookmarkModel : public QSortFilterProxyModel
 {
@@ -63,7 +64,7 @@ class BookmarkModel : public QSortFilterProxyModel
     void mapSettingsChanged();
 
   private:
-    std::unique_ptr<QgsBookmarkManagerModel> mModel = nullptr;
+    QObjectUniquePtr<QgsBookmarkManagerModel> mModel;
     QgsBookmarkManager *mManager = nullptr;
     QgsQuickMapSettings *mMapSettings = nullptr;
 };

--- a/src/core/bookmarkmodel.h
+++ b/src/core/bookmarkmodel.h
@@ -36,6 +36,7 @@ class BookmarkModel : public QSortFilterProxyModel
       BookmarkName,
       BookmarkPoint,
       BookmarkCrs,
+      BookmarkUser,
     };
     Q_ENUM( Roles )
 

--- a/src/core/bookmarkmodel.h
+++ b/src/core/bookmarkmodel.h
@@ -47,6 +47,12 @@ class BookmarkModel : public QSortFilterProxyModel
 
     Q_INVOKABLE void setExtentFromBookmark( const QModelIndex &index );
 
+    Q_INVOKABLE QString addBookmarkAtPoint( QgsPoint point, QString name = QString() );
+
+    Q_INVOKABLE void updateBookmarkDetails( QString id, QString name );
+
+    Q_INVOKABLE void removeBookmark( QString id );
+
     void setMapSettings( QgsQuickMapSettings *mapSettings );
 
     QgsQuickMapSettings *mapSettings() const { return mMapSettings; }
@@ -56,6 +62,7 @@ class BookmarkModel : public QSortFilterProxyModel
 
   private:
     std::unique_ptr<QgsBookmarkManagerModel> mModel = nullptr;
+    QgsBookmarkManager *mManager = nullptr;
     QgsQuickMapSettings *mMapSettings = nullptr;
 };
 

--- a/src/core/bookmarkmodel.h
+++ b/src/core/bookmarkmodel.h
@@ -34,6 +34,7 @@ class BookmarkModel : public QSortFilterProxyModel
     {
       BookmarkId = Qt::UserRole + 1,
       BookmarkName,
+      BookmarkGroup,
       BookmarkPoint,
       BookmarkCrs,
       BookmarkUser,
@@ -48,9 +49,9 @@ class BookmarkModel : public QSortFilterProxyModel
 
     Q_INVOKABLE void setExtentFromBookmark( const QModelIndex &index );
 
-    Q_INVOKABLE QString addBookmarkAtPoint( QgsPoint point, QString name = QString() );
+    Q_INVOKABLE QString addBookmarkAtPoint( QgsPoint point, QString name = QString(), QString group = QString() );
 
-    Q_INVOKABLE void updateBookmarkDetails( QString id, QString name );
+    Q_INVOKABLE void updateBookmarkDetails( QString id, QString name, QString group );
 
     Q_INVOKABLE void removeBookmark( QString id );
 

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -231,9 +231,7 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   mLegendImageProvider = new LegendImageProvider( mFlatLayerTree->layerTreeModel() );
   mTrackingModel = new TrackingModel;
 
-  mBookmarkManager = std::make_unique<QgsBookmarkManager>( nullptr );
-  mBookmarkManager->initialize( QgsApplication::qgisSettingsDirPath() + "/bookmarks.xml" );
-  mBookmarkModel = std::make_unique<BookmarkModel>( mBookmarkManager.get(), mProject->bookmarkManager(), nullptr );
+  mBookmarkModel = std::make_unique<BookmarkModel>( QgsApplication::bookmarkManager(), mProject->bookmarkManager(), nullptr );
 
   // Transition from 1.8 to 1.8.1+
   const QString deviceAddress = settings.value( QStringLiteral( "positioningDevice" ), QString() ).toString();

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -23,7 +23,6 @@
 
 // QGIS includes
 #include <qgsapplication.h>
-#include <qgsbookmarkmanager.h>
 #include <qgsconfig.h>
 #include <qgsexiftools.h>
 #include <qgsmaplayerproxymodel.h>
@@ -185,7 +184,6 @@ class QFIELD_CORE_EXPORT QgisMobileapp : public QQmlApplicationEngine
     std::unique_ptr<LayerObserver> mLayerObserver;
     QFieldAppAuthRequestHandler *mAuthRequestHandler = nullptr;
 
-    std::unique_ptr<QgsBookmarkManager> mBookmarkManager;
     std::unique_ptr<BookmarkModel> mBookmarkModel;
 
     // Dummy objects. We are not able to call static functions from QML, so we need something here.

--- a/src/qml/BookmarkHighlight.qml
+++ b/src/qml/BookmarkHighlight.qml
@@ -17,7 +17,8 @@ Repeater {
     geometryWrapper.crs: model.BookmarkCrs
 
     bookmarkIndex: model.index
-    bookmarkName: model.BookmarkName
     bookmarkId: model.BookmarkId
+    bookmarkName: model.BookmarkName
+    bookmarkUser: model.BookmarkUser
   }
 }

--- a/src/qml/BookmarkHighlight.qml
+++ b/src/qml/BookmarkHighlight.qml
@@ -19,6 +19,7 @@ Repeater {
     bookmarkIndex: model.index
     bookmarkId: model.BookmarkId
     bookmarkName: model.BookmarkName
+    bookmarkGroup: model.BookmarkGroup
     bookmarkUser: model.BookmarkUser
   }
 }

--- a/src/qml/BookmarkProperties.qml
+++ b/src/qml/BookmarkProperties.qml
@@ -53,7 +53,7 @@ Popup {
                 id: nameField
                 Layout.fillWidth: true
                 font: Theme.defaultFont
-                horizontalAlignment: TextInput.AlignHCenter
+                horizontalAlignment: TextInput.AlignHLeft
                 text: ''
 
                 background: Rectangle {

--- a/src/qml/BookmarkProperties.qml
+++ b/src/qml/BookmarkProperties.qml
@@ -12,6 +12,8 @@ Popup {
 
     property string bookmarkId: ''
     property string bookmarkName: ''
+    property string bookmarkGroup: ''
+
 
     width: Math.min(350, mainWindow.width - 20 )
     x: (parent.width - width) / 2
@@ -20,6 +22,7 @@ Popup {
 
     onAboutToShow: {
         nameField.text = bookmarkName;
+        groupField.value = bookmarkGroup;
     }
 
     Page {
@@ -61,20 +64,99 @@ Popup {
                 }
             }
 
+            Label {
+                Layout.fillWidth: true
+                text: qsTr('Color')
+                font: Theme.defaultFont
+            }
+
+            RowLayout {
+                id: groupField
+                spacing: 8
+                Layout.fillWidth: true
+
+                property int iconSize: 24
+                property string value: ''
+
+                Rectangle {
+                    id: defaultColor
+                    Layout.alignment: Qt.AlignVCenter
+                    width: groupField.iconSize
+                    height: groupField.iconSize
+                    color: Theme.bookmarkDefault
+                    border.width: 4
+                    border.color: groupField.value != 'orange' &&
+                                  groupField.value != 'red' &&
+                                  groupField.value != 'blue' ? "black" : "transparent"
+                    radius: 2
+
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: groupField.value = '';
+                    }
+                }
+                Rectangle {
+                    id: orangeColor
+                    width: groupField.iconSize
+                    height: groupField.iconSize
+                    color: Theme.bookmarkOrange
+                    border.width: 4
+                    border.color: groupField.value === 'orange' ? "black" : "transparent"
+                    radius: 2
+
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: groupField.value = 'orange';
+                    }
+                }
+                Rectangle {
+                    id: redColor
+                    width: groupField.iconSize
+                    height: groupField.iconSize
+                    color: Theme.bookmarkRed
+                    border.width: 4
+                    border.color: groupField.value === 'red' ? "black" : "transparent"
+                    radius: 2
+
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: groupField.value = 'red';
+                    }
+                }
+                Rectangle {
+                    id: blueColor
+                    width: groupField.iconSize
+                    height: groupField.iconSize
+                    color: Theme.bookmarkBlue
+                    border.width: 4
+                    border.color: groupField.value === 'blue' ? "black" : "transparent"
+                    radius: 2
+
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: groupField.value = 'blue';
+                    }
+                }
+                Item {
+                    Layout.fillWidth: true
+                }
+            }
+
             QfButton {
                 id: updateBookmarkButton
-                Layout.fillWidth: true;
+                Layout.fillWidth: true
+                Layout.topMargin: 10
                 text: 'Update bookmark details'
 
                 onClicked: {
-                    bookmarkModel.updateBookmarkDetails(bookmarkProperties.bookmarkId, nameField.text)
+                    bookmarkModel.updateBookmarkDetails(bookmarkProperties.bookmarkId, nameField.text, groupField.value)
                     bookmarkProperties.close();
                 }
             }
 
             QfButton {
                 id: deleteBookmarkButton
-                Layout.fillWidth: true;
+                Layout.fillWidth: true
                 text: 'Remove bookmark'
 
                 onClicked: {

--- a/src/qml/BookmarkProperties.qml
+++ b/src/qml/BookmarkProperties.qml
@@ -1,0 +1,111 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.12
+
+import org.qgis 1.0
+import org.qfield 1.0
+
+import Theme 1.0
+
+Popup {
+    id: bookmarkProperties
+
+    property string bookmarkId: ''
+    property string bookmarkName: ''
+
+    width: Math.min(350, mainWindow.width - 20 )
+    x: (parent.width - width) / 2
+    y: (parent.height - height) / 2
+    padding: 0
+
+    onAboutToShow: {
+        nameField.text = bookmarkName;
+    }
+
+    Page {
+        width: parent.width
+        padding: 10
+        header: Label {
+            padding: 10
+            topPadding: 15
+            bottomPadding: 0
+            width: parent.width - 20
+            text: qsTr('Bookmark Properties')
+            font: Theme.strongFont
+            horizontalAlignment: Text.AlignHCenter
+            wrapMode: Text.WordWrap
+        }
+
+        ColumnLayout {
+            spacing: 4
+            width: parent.width
+
+            Label {
+                Layout.fillWidth: true
+                text: qsTr('Name')
+                font: Theme.defaultFont
+            }
+
+            TextField {
+                id: nameField
+                Layout.fillWidth: true
+                font: Theme.defaultFont
+                horizontalAlignment: TextInput.AlignHCenter
+                text: ''
+
+                background: Rectangle {
+                    y: nameField.height - height * 2 - nameField.bottomPadding / 2
+                    implicitWidth: 120
+                    height: nameField.activeFocus ? 2 : 1
+                    color: nameField.activeFocus ? "#4CAF50" : "#C8E6C9"
+                }
+            }
+
+            QfButton {
+                id: updateBookmarkButton
+                Layout.fillWidth: true;
+                text: 'Update bookmark details'
+
+                onClicked: {
+                    bookmarkModel.updateBookmarkDetails(bookmarkProperties.bookmarkId, nameField.text)
+                    bookmarkProperties.close();
+                }
+            }
+
+            QfButton {
+                id: deleteBookmarkButton
+                Layout.fillWidth: true;
+                text: 'Remove bookmark'
+
+                onClicked: {
+                    removeBookmarkDialog.open();
+                }
+            }
+        }
+    }
+
+    Dialog {
+        id: removeBookmarkDialog
+        parent: mainWindow.contentItem
+
+        visible: false
+        modal: true
+
+        z: 10000 // 1000s are embedded feature forms, user a higher value to insure the dialog will always show above embedded feature forms
+        x: ( mainWindow.width - width ) / 2
+        y: ( mainWindow.height - height ) / 2
+
+        title: qsTr( "Remove bookmark" )
+        Label {
+            width: parent.width
+            wrapMode: Text.WordWrap
+            text: qsTr( "You are about to remove a bookmark, proceed?" )
+        }
+
+        standardButtons: Dialog.Ok | Dialog.Cancel
+        onAccepted: {
+            bookmarkModel.removeBookmark(bookmarkProperties.bookmarkId);
+            bookmarkProperties.close();
+        }
+    }
+}

--- a/src/qml/BookmarkProperties.qml
+++ b/src/qml/BookmarkProperties.qml
@@ -49,19 +49,11 @@ Popup {
                 font: Theme.defaultFont
             }
 
-            TextField {
+            QfTextField {
                 id: nameField
                 Layout.fillWidth: true
                 font: Theme.defaultFont
-                horizontalAlignment: TextInput.AlignHLeft
                 text: ''
-
-                background: Rectangle {
-                    y: nameField.height - height * 2 - nameField.bottomPadding / 2
-                    implicitWidth: 120
-                    height: nameField.activeFocus ? 2 : 1
-                    color: nameField.activeFocus ? "#4CAF50" : "#C8E6C9"
-                }
             }
 
             Label {

--- a/src/qml/BookmarkRenderer.qml
+++ b/src/qml/BookmarkRenderer.qml
@@ -117,6 +117,11 @@ Item {
                     onDoubleClicked: {
                         bookmarkModel.setExtentFromBookmark(bookmarkModel.index(bookmarkRenderer.bookmarkIndex, 0));
                     }
+                    onPressAndHold: {
+                        bookmarkProperties.bookmarkId = bookmarkRenderer.bookmarkId;
+                        bookmarkProperties.bookmarkName = bookmarkRenderer.bookmarkName;
+                        bookmarkProperties.open();
+                    }
                 }
             }
         }

--- a/src/qml/BookmarkRenderer.qml
+++ b/src/qml/BookmarkRenderer.qml
@@ -13,6 +13,7 @@ Item {
     property var bookmarkIndex: undefined
     property string bookmarkId: ''
     property string bookmarkName: ''
+    property string bookmarkGroup: ''
     property bool bookmarkUser: false
 
     property MapSettings mapSettings
@@ -67,7 +68,19 @@ Item {
                         strokeWidth: 3
                         strokeColor: "white"
                         strokeStyle: ShapePath.SolidLine
-                        fillColor: Theme.mainColor
+                        fillColor: {
+                            switch (bookmarkRenderer.bookmarkGroup) {
+                                case 'red':
+                                    return Theme.bookmarkRed;
+                                case 'orange':
+                                    return Theme.bookmarkOrange;
+                                case 'blue':
+                                    return Theme.bookmarkBlue;
+                                default:
+                                    return Theme.bookmarkDefault;
+                            }
+                        }
+
                         startX: 6
                         startY: 16
                         PathArc {
@@ -122,6 +135,7 @@ Item {
                         if (bookmarkRenderer.bookmarkUser) {
                             bookmarkProperties.bookmarkId = bookmarkRenderer.bookmarkId;
                             bookmarkProperties.bookmarkName = bookmarkRenderer.bookmarkName;
+                            bookmarkProperties.bookmarkGroup = bookmarkRenderer.bookmarkGroup;
                             bookmarkProperties.open();
                         } else {
                             displayToast(qsTr('Project bookmarks cannot be edited'))

--- a/src/qml/BookmarkRenderer.qml
+++ b/src/qml/BookmarkRenderer.qml
@@ -11,8 +11,9 @@ Item {
     id: bookmarkRenderer
 
     property var bookmarkIndex: undefined
-    property string bookmarkName: ''
     property string bookmarkId: ''
+    property string bookmarkName: ''
+    property bool bookmarkUser: false
 
     property MapSettings mapSettings
     property alias geometryWrapper: geometryWrapper
@@ -118,9 +119,13 @@ Item {
                         bookmarkModel.setExtentFromBookmark(bookmarkModel.index(bookmarkRenderer.bookmarkIndex, 0));
                     }
                     onPressAndHold: {
-                        bookmarkProperties.bookmarkId = bookmarkRenderer.bookmarkId;
-                        bookmarkProperties.bookmarkName = bookmarkRenderer.bookmarkName;
-                        bookmarkProperties.open();
+                        if (bookmarkRenderer.bookmarkUser) {
+                            bookmarkProperties.bookmarkId = bookmarkRenderer.bookmarkId;
+                            bookmarkProperties.bookmarkName = bookmarkRenderer.bookmarkName;
+                            bookmarkProperties.open();
+                        } else {
+                            displayToast(qsTr('Project bookmarks cannot be edited'))
+                        }
                     }
                 }
             }

--- a/src/qml/BookmarkRenderer.qml
+++ b/src/qml/BookmarkRenderer.qml
@@ -58,16 +58,17 @@ Item {
                 Shape {
                     id: bookmark
 
-                    x: mapToScreenPosition.screenPoint.x - width/2
-                    y: mapToScreenPosition.screenPoint.y - height
+                    x: mapToScreenPosition.screenPoint.x - width / 2
+                    y: mapToScreenPosition.screenPoint.y - height + 4
 
                     width: 36
-                    height: 36
+                    height: 40
 
                     ShapePath {
                         strokeWidth: 3
                         strokeColor: "white"
                         strokeStyle: ShapePath.SolidLine
+                        joinStyle: ShapePath.MiterJoin
                         fillColor: {
                             switch (bookmarkRenderer.bookmarkGroup) {
                                 case 'red':
@@ -113,6 +114,7 @@ Item {
                     }
 
                     layer.enabled: true
+                    layer.samples: 4
                     layer.effect: DropShadow {
                         transparentBorder: true
                         radius: 8

--- a/src/qml/imports/Theme/Theme.qml
+++ b/src/qml/imports/Theme/Theme.qml
@@ -25,6 +25,11 @@ QtObject {
     property color navigationColorSemiOpaque: "#77984ea3"
     property color navigationBackgroundColor: "#e2d7e4"
 
+    property color bookmarkDefault: "#80cc28"
+    property color bookmarkOrange: "orange"
+    property color bookmarkRed: "#c0392b"
+    property color bookmarkBlue: "#64b5f6"
+
     property font defaultFont
     defaultFont.pointSize: 16
     defaultFont.weight: Font.Normal

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1410,6 +1410,9 @@ ApplicationWindow {
     }
   }
 
+  BookmarkProperties {
+    id: bookmarkProperties
+  }
 
   Menu {
     id: mainMenu
@@ -1704,6 +1707,23 @@ ApplicationWindow {
     MenuSeparator { width: parent.width }
 
     MenuItem {
+      id: addBookmarkItem
+      text: qsTr( "Add Bookmark at Coordinates" )
+      height: 48
+      font: Theme.defaultFont
+
+      onTriggered: {
+        var name = qsTr('Untitled bookmark');
+        var id = bookmarkModel.addBookmarkAtPoint(canvasMenu.point);
+        if (id !== '') {
+          bookmarkProperties.bookmarkId = id;
+          bookmarkProperties.bookmarkName = qsTr('Untitled bookmark');
+          bookmarkProperties.open();
+        }
+      }
+    }
+
+    MenuItem {
       id: setDestinationItem
       text: qsTr( "Set Coordinates as Destination" )
       height: 48
@@ -1837,6 +1857,27 @@ ApplicationWindow {
 
       onTriggered: {
         mapCanvas.mapSettings.setCenter(positionSource.projectedPosition)
+      }
+    }
+
+    MenuItem {
+      text: qsTr( "Add Bookmark at Current Location" )
+      height: 48
+      font: Theme.defaultFont
+
+      onTriggered: {
+        if (!positioningSettings.positioningActivated || positionSource.positionInfo === undefined || !positionSource.positionInfo.latitudeValid) {
+          displayToast(qsTr('Current location unknown'));
+          return;
+        }
+
+        var name = qsTr('My location') + ' (' + new Date().toLocaleString() + ')';
+        var id = bookmarkModel.addBookmarkAtPoint(positionSource.projectedPosition, name)
+        if (id !== '') {
+          bookmarkProperties.bookmarkId = id;
+          bookmarkProperties.bookmarkName = name;
+          bookmarkProperties.open();
+        }
       }
     }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1714,10 +1714,12 @@ ApplicationWindow {
 
       onTriggered: {
         var name = qsTr('Untitled bookmark');
-        var id = bookmarkModel.addBookmarkAtPoint(canvasMenu.point);
+        var group = ''
+        var id = bookmarkModel.addBookmarkAtPoint(canvasMenu.point, group);
         if (id !== '') {
           bookmarkProperties.bookmarkId = id;
           bookmarkProperties.bookmarkName = qsTr('Untitled bookmark');
+          bookmarkProperties.bookmarkGroup = group;
           bookmarkProperties.open();
         }
       }
@@ -1872,10 +1874,12 @@ ApplicationWindow {
         }
 
         var name = qsTr('My location') + ' (' + new Date().toLocaleString() + ')';
-        var id = bookmarkModel.addBookmarkAtPoint(positionSource.projectedPosition, name)
+        var group = 'blue';
+        var id = bookmarkModel.addBookmarkAtPoint(positionSource.projectedPosition, name, group)
         if (id !== '') {
           bookmarkProperties.bookmarkId = id;
           bookmarkProperties.bookmarkName = name;
+          bookmarkProperties.bookmarkGroup = group;
           bookmarkProperties.open();
         }
       }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1715,10 +1715,10 @@ ApplicationWindow {
       onTriggered: {
         var name = qsTr('Untitled bookmark');
         var group = ''
-        var id = bookmarkModel.addBookmarkAtPoint(canvasMenu.point, group);
+        var id = bookmarkModel.addBookmarkAtPoint(canvasMenu.point, name, group);
         if (id !== '') {
           bookmarkProperties.bookmarkId = id;
-          bookmarkProperties.bookmarkName = qsTr('Untitled bookmark');
+          bookmarkProperties.bookmarkName = name;
           bookmarkProperties.bookmarkGroup = group;
           bookmarkProperties.open();
         }

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -3,6 +3,7 @@
         <file>About.qml</file>
         <file>BadLayerItem.qml</file>
         <file>BookmarkHighlight.qml</file>
+        <file>BookmarkProperties.qml</file>
         <file>BookmarkRenderer.qml</file>
         <file>BrowserPanel.qml</file>
         <file>CalendarPanel.qml</file>


### PR DESCRIPTION
This PR completes the implementation of bookmarks support in QField by allowing users to add and edit bookmarks.

Adding bookmarks can be in two different ways:
1/ long pressing on the map canvas to add a bookmark at the pressed location
2/ long pressing on the location/GPS button (bottom right of the screen) to add a bookmark from the current location

In addition, bookmark details can be edited by long pressing on a bookmark marker. Currently users can edit the bookmark name or remove the bookmark.

Screencast of bookmark addition / editing:

https://user-images.githubusercontent.com/1728657/158046114-2e8d5a66-6cb3-4c97-afdc-0a4b6cbf822d.mp4

Edit: one important fix in there is the de-duplication of the system bookmark manager. Somehow I had missed the one attached to QgsApplication until now.

Edit 2: thanks to @m-kuhn doing some Sunday approvals, we now have the cherry on top of the sundae, bookmark group color implementation:

https://user-images.githubusercontent.com/1728657/158051553-521ee468-0004-4ee9-8d6a-e3b757930f0c.mp4

Users are given the possibility to regroup their bookmarks into different colors (default green, orange, red, blue). By default, when adding a bookmark while hold pressing onto the canvas will be green while adding a bookmark from the current location will pick blue as default.

Coloring relies on the bookmark group name, so people can add read-only project bookmarks and color them by placing those bookmarks in a 'red' group for e.g.