### PR TITLE
Print pdfs to the project folder

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -1086,7 +1086,7 @@ bool QgisMobileapp::print( const QString &layoutName )
     layoutToPrint->referenceMap()->zoomToExtent( mMapCanvas->mapSettings()->visibleExtent() );
   layoutToPrint->refresh();
 
-  const QString destination = QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + '/' + layoutToPrint->name() + QStringLiteral( ".pdf" );
+  const QString destination = mProject->homePath() + '/' + layoutToPrint->name() + '-' + QDateTime::currentDateTime().toString( QStringLiteral( "yyyyMMdd_hhmmss" ) ) + QStringLiteral( ".pdf" );
 
   QgsLayoutExporter::PdfExportSettings pdfSettings;
   pdfSettings.rasterizeWholeImage = layoutToPrint->customProperty( QStringLiteral( "rasterize" ), false ).toBool();

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -1086,11 +1086,7 @@ bool QgisMobileapp::print( const QString &layoutName )
     layoutToPrint->referenceMap()->zoomToExtent( mMapCanvas->mapSettings()->visibleExtent() );
   layoutToPrint->refresh();
 
-  QString documentsLocation = QStringLiteral( "%1/QField" ).arg( QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) );
-  QDir documentsDir( documentsLocation );
-  if ( !documentsDir.exists() )
-    documentsDir.mkpath( "." );
-  const QString destination = documentsLocation + '/' + layoutToPrint->name() + QStringLiteral( ".pdf" );
+  const QString destination = mProject->homePath() + '/' + layoutToPrint->name() + QStringLiteral( ".pdf" );
 
   QgsLayoutExporter::PdfExportSettings pdfSettings;
   pdfSettings.rasterizeWholeImage = layoutToPrint->customProperty( QStringLiteral( "rasterize" ), false ).toBool();
@@ -1139,11 +1135,7 @@ bool QgisMobileapp::printAtlasFeatures( const QString &layoutName, const QList<l
   layoutToPrint->atlas()->setFilterExpression( QStringLiteral( "$id IN (%1)" ).arg( ids.join( ',' ) ), error );
   layoutToPrint->atlas()->setFilterFeatures( true );
 
-  const QString documentsLocation = QStringLiteral( "%1/QField" ).arg( QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) );
-  QDir documentsDir( documentsLocation );
-  if ( !documentsDir.exists() )
-    documentsDir.mkpath( "." );
-  const QString destination = documentsLocation + '/' + layoutToPrint->name() + QStringLiteral( ".pdf" );
+  const QString destination = mProject->homePath() + '/' + layoutToPrint->name() + QStringLiteral( ".pdf" );
 
   QgsLayoutExporter::PdfExportSettings pdfSettings;
   pdfSettings.rasterizeWholeImage = layoutToPrint->customProperty( QStringLiteral( "rasterize" ), false ).toBool();
@@ -1184,7 +1176,7 @@ bool QgisMobileapp::printAtlasFeatures( const QString &layoutName, const QList<l
       result = exporter.exportToPdfs( layoutToPrint->atlas(), destination, pdfSettings, error );
 #ifndef Q_OS_ANDROID
       if ( result == QgsLayoutExporter::Success )
-        PlatformUtilities::instance()->open( documentsLocation );
+        PlatformUtilities::instance()->open( mProject->homePath() );
 #endif
     }
     return result == QgsLayoutExporter::Success ? true : false;

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -1086,7 +1086,7 @@ bool QgisMobileapp::print( const QString &layoutName )
     layoutToPrint->referenceMap()->zoomToExtent( mMapCanvas->mapSettings()->visibleExtent() );
   layoutToPrint->refresh();
 
-  const QString destination = mProject->homePath() + '/' + layoutToPrint->name() + QStringLiteral( ".pdf" );
+  const QString destination = QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + '/' + layoutToPrint->name() + QStringLiteral( ".pdf" );
 
   QgsLayoutExporter::PdfExportSettings pdfSettings;
   pdfSettings.rasterizeWholeImage = layoutToPrint->customProperty( QStringLiteral( "rasterize" ), false ).toBool();


### PR DESCRIPTION
Since we cannot connect the Androids "Documents" path anymore, I think a good way to go is to write directly into the project's folder. This is the proposed folder in QGIS as well and I think it's clear for the user to find it again. Since it's opening right after writing, the user is free to put it somewhere else.

@nirvn Can you please check if it is really that simple as I thought :-)