### PR TITLE
Fix longstanding regression whereas length/area information is missing when digitizing features

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -626,7 +626,7 @@ ApplicationWindow {
 
       property VectorLayer currentLayer: dashBoard.currentLayer
 
-      rubberbandModel: measuringRubberband.model
+      rubberbandModel: currentRubberband.model
       project: qgisProject
       crs: qgisProject.crs
     }


### PR DESCRIPTION
Title says it all. Regression occurred way back in 1.6, in this commit (https://github.com/opengisch/QField/commit/ee78e9b780f3740ffad6908cd68f39e9158bd7a9).

@signedav , I assume that line change back then was accidental?