### PR TITLE
Fix navigation button not snapping to the right edge of the screen

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1005,6 +1005,7 @@ ApplicationWindow {
       id: navigationButton
       visible: navigation.isActive
       round: true
+      anchors.right: parent.right
 
       iconSource: Theme.getThemeIcon( "ic_navigation_flag_purple_24dp" )
       bgcolor: Theme.darkGray


### PR DESCRIPTION
PR fixes this navigation button issue:
![Screenshot from 2022-03-20 14-34-14](https://user-images.githubusercontent.com/1728657/159152817-e8ed2ae4-a45a-4c28-8f37-abc073456d80.png)
