### PR TITLE
Calendar panel usuability improvements

### DIFF
--- a/src/qml/CalendarPanel.qml
+++ b/src/qml/CalendarPanel.qml
@@ -67,7 +67,7 @@ Popup {
         Rectangle {
             id: calendarOverlay
             width: 350
-            height: 240
+            height: childrenRect.height
             color: "transparent"
 
             MouseArea {
@@ -192,6 +192,8 @@ Popup {
                 MonthGrid {
                     id: calendar
 
+                    property date today: new Date()
+
                     function decreaseYear() {
                         year -= 1;
                     }
@@ -221,13 +223,15 @@ Popup {
                     Layout.column: 0
                     Layout.columnSpan: 3
                     Layout.fillWidth: true
-                    Layout.fillHeight: true
+                    Layout.preferredHeight: 40 * 6
 
                     delegate: Rectangle {
-                        property bool isDate: calendarPopup.selectedDate.getFullYear() === model.date.getFullYear() && calendarPopup.selectedDate.getMonth() === model.date.getMonth() && calendarPopup.selectedDate.getDate() === model.date.getDate()
-                        color:  isDate ? Theme.mainColor : "transparent"
+                        property bool isSelectedDate: calendarPopup.selectedDate.getFullYear() === model.date.getFullYear() && calendarPopup.selectedDate.getMonth() === model.date.getMonth() && calendarPopup.selectedDate.getDate() === model.date.getDate()
+                        property bool isNow: calendar.today.getFullYear() === model.date.getFullYear() && calendar.today.getMonth() === model.date.getMonth() && calendar.today.getDate() === model.date.getDate()
+                        color:  isSelectedDate ? Theme.mainColor : "transparent"
                         width: 18
                         height: 18
+                        radius: 10
 
                         Text {
                             anchors.centerIn: parent
@@ -235,8 +239,10 @@ Popup {
                             verticalAlignment: Text.AlignVCenter
                             opacity: model.month !== calendar.month ? 0.5 : 1
                             text: model.day
-                            font: parent.isDate ? Theme.strongTipFont : Theme.tipFont
-                            color: parent.isDate ? "white" : "black"
+                            font.pointSize: Theme.tipFont.pointSize
+                            font.bold: parent.isSelectedDate ? true : false
+                            font.underline: parent.isNow ? true : false
+                            color: parent.isSelectedDate ? "white" : "black"
                         }
                     }
 

--- a/src/qml/CalendarPanel.qml
+++ b/src/qml/CalendarPanel.qml
@@ -247,7 +247,13 @@ Popup {
                     }
 
                     onClicked: {
-                        calendarPopup.selectedDate = date;
+                        if (calendarPopup.selectedDate.getFullYear() !== date.getFullYear() ||
+                            calendarPopup.selectedDate.getMonth() !== date.getMonth() ||
+                            calendarPopup.selectedDate.getDate() !== date.getDate()) {
+                          calendarPopup.selectedDate = date;
+                        } else {
+                          calendarPopup.selectDate();
+                        }
                     }
 
                     function resetDate() {
@@ -325,22 +331,25 @@ Popup {
 
         RowLayout {
             QfButton {
+                id: okButton
                 text: qsTr( "OK" )
                 font: Theme.tipFont
                 Layout.fillWidth: true
 
-                onClicked: {
-                    var newDate = calendarPopup.selectedDate
-                    if (calendarPanel.isDateTime) {
-                        newDate.setHours(hoursSpinBox.value);
-                        newDate.setMinutes(minutesSpinBox.value);
-                        newDate.setSeconds(secondsSpinBox.value);
-                    }
-                    dateTimePicked(newDate);
-                    calendarPanel.close()
-                }
+                onClicked: selectDate();
             }
         }
+    }
+
+    function selectDate() {
+        var newDate = calendarPopup.selectedDate
+        if (calendarPanel.isDateTime) {
+            newDate.setHours(hoursSpinBox.value);
+            newDate.setMinutes(minutesSpinBox.value);
+            newDate.setSeconds(secondsSpinBox.value);
+        }
+        dateTimePicked(newDate);
+        calendarPanel.close()
     }
 }
 


### PR DESCRIPTION
The two improvements included here:
- the "hit" area for selecting the date has grown as it was rather small (more specifically, not tall enough), making it hard to use with fingers.
- the calendar now highlights "today" by underlining the day number that matches the current date.
- double clicking on a day will select the date.
 
![image](https://user-images.githubusercontent.com/1728657/159153772-4160dc0e-eafc-49e9-ae2e-dd21e7721e1b.png)

This improves the attribute form, as well as temporal filter since all is shared now :partying_face: 