### PR TITLE
Fix/unlock self-built APKs using android_dev docker

### DIFF
--- a/.docker/android_dev/Dockerfile
+++ b/.docker/android_dev/Dockerfile
@@ -36,3 +36,6 @@ RUN pip3 install aqtinstall cmake && \
     /usr/local/bin/aqt install-qt linux android 5.14.2 -m qtcharts
 
 ENV PATH="/home/devel/.local/bin:${PATH}"
+
+# Needs to be in sync with cmake/Platform.cmake's ANDROID_TARGET_PLATFORM value
+RUN /home/devel/android/tools/bin/sdkmanager --verbose "platforms;android-30"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -157,7 +157,6 @@ jobs:
           STOREPASS: ${{ secrets.STOREPASS }}
         run: |
           cmake --build  "${{ env.CMAKE_BUILD_DIR }}" --target bundle --config Release
-          ${ANDROID_SDK_ROOT}/build-tools/29.0.2/apksigner sign --v2-signing-enabled true --ks ./keystore.p12 --ks-pass "pass:${{ secrets.STOREPASS }}" --ks-key-alias "qfield" --key-pass "pass:${{ secrets.KEYPASS }}" ${{ env.CMAKE_BUILD_DIR }}/android-build/build/outputs/apk/release/android-build-release-signed.apk
 
       - name: 📦 Upload artifacts
         uses: actions/upload-artifact@v2

--- a/cmake/Platform.cmake
+++ b/cmake/Platform.cmake
@@ -13,6 +13,7 @@ elseif(VCPKG_TARGET_TRIPLET STREQUAL "x86-android")
 endif()
 
 if(ANDROID_ABI)
+  set(ANDROID_BUILD_TOOLS_VERSION "29.0.2" CACHE STRING "Android build-tools version")
   set(ANDROID_TARGET_PLATFORM 30 CACHE INT "Target Android platform SDK version")
   set(ANDROID_PLATFORM 21 CACHE INT "Minimum Android platform SDK version")
 endif()

--- a/platform/android/CPackAndroidDeployQt.cmake.in
+++ b/platform/android/CPackAndroidDeployQt.cmake.in
@@ -18,7 +18,7 @@ file(COPY_FILE @CMAKE_BINARY_DIR@/android_deployment_settings.json @CMAKE_BINARY
 execute_process(
   COMMAND
   "bash"
-  -c "cat <<< \"$(jq '. += { \"sdkBuildToolsRevision\" : \"29.0.2\" }' < @CMAKE_BINARY_DIR@/android_deployment_settings.tmp)\" > @CMAKE_BINARY_DIR@/android_deployment_settings.json"
+  -c "cat <<< \"$(jq '. += { \"sdkBuildToolsRevision\" : \"@ANDROID_BUILD_TOOLS_VERSION@\" }' < @CMAKE_BINARY_DIR@/android_deployment_settings.tmp)\" > @CMAKE_BINARY_DIR@/android_deployment_settings.json"
 )
 if(DEFINED ENV{KEYNAME}
    AND DEFINED ENV{KEYPASS}
@@ -35,6 +35,15 @@ if(DEFINED ENV{KEYNAME}
       --android-platform android-@ANDROID_TARGET_PLATFORM@
       --gradle
       --aab
+    WORKING_DIRECTORY @CMAKE_BINARY_DIR@ COMMAND_ECHO STDERR)
+  execute_process(
+    COMMAND
+      "@ANDROID_SDK@/build-tools/@ANDROID_BUILD_TOOLS_VERSION@/apksigner" sign
+      --v2-signing-enabled true
+      --ks @CMAKE_SOURCE_DIR@/keystore.p12 --ks-key-alias "$ENV{KEYNAME}"
+      --ks-pass "pass:$ENV{STOREPASS}"
+      --key-pass "pass:$ENV{KEYPASS}"
+        @CMAKE_BINARY_DIR@/android-build/build/outputs/apk/release/android-build-release-signed.apk
     WORKING_DIRECTORY @CMAKE_BINARY_DIR@ COMMAND_ECHO STDERR)
 else()
   execute_process(

--- a/scripts/build-vcpkg.sh
+++ b/scripts/build-vcpkg.sh
@@ -11,6 +11,7 @@ export Qt5_Dir=/home/devel/5.14.2/android/
 export Qt5_DIR=${Qt5_Dir}
 export ANDROID_PLATFORM=21
 export ANDROID_TARGET_PLATFORM=30
+export ANDROID_BUILD_TOOLS_VERSION=29.0.2
 
 [[ -z ${APP_NAME} ]] && APP_NAME="QField"
 [[ -z ${APP_PACKAGE_NAME} ]] && APP_PACKAGE_NAME="qfield"
@@ -43,6 +44,3 @@ cmake --build "${CMAKE_BUILD_DIR}"
 
 # Package app
 cmake --build  "${CMAKE_BUILD_DIR}" --target bundle --config Release
-
-# Sign app (uncomment if you have signature details)
-#${ANDROID_SDK_ROOT}/build-tools/29.0.2/apksigner sign --v2-signing-enabled true --ks ./keystore.p12 --ks-pass pass:"${STOREPASS}" --ks-key-alias "qfield" --key-pass pass:"${KEYPASS}" ${CMAKE_BUILD_DIR}/android-build/build/outputs/apk/release/android-build-release-signed.apk

--- a/scripts/build-vcpkg.sh
+++ b/scripts/build-vcpkg.sh
@@ -7,7 +7,8 @@ cd /usr/src/qfield || exit
 CMAKE_BUILD_DIR=/usr/src/qfield/build-${triplet}
 
 export ANDROID_NDK_HOME=${ANDROID_NDK_ROOT}
-export Qt5_DIR=/home/devel/5.14.2/android/
+export Qt5_Dir=/home/devel/5.14.2/android/
+export Qt5_DIR=${Qt5_Dir}
 export ANDROID_PLATFORM=21
 export ANDROID_TARGET_PLATFORM=30
 
@@ -21,9 +22,12 @@ echo "Package name ${APP_PACKAGE_NAME}"
 cmake -S "${SOURCE_DIR}" \
       -B "${CMAKE_BUILD_DIR}" \
       -G Ninja \
+      -D CMAKE_PREFIX_PATH=${Qt5_Dir} \
       -D CMAKE_TOOLCHAIN_FILE=/usr/src/qfield/vcpkg/base/scripts/buildsystems/vcpkg.cmake \
       -D VCPKG_OVERLAY_PORTS=/usr/src/qfield/vcpkg/overlay_system_qt\;/usr/src/qfield/vcpkg/overlay \
       -D VCPKG_TARGET_TRIPLET="${triplet}" \
+      -D SYSTEM_QT=ON \
+      -D ANDROID_SDK=/home/devel/android/ \
       -D WITH_SPIX=OFF \
       -D APP_VERSION="v1.0.0" \
       -D APK_VERSION_CODE="${APK_VERSION_CODE}" \
@@ -39,4 +43,6 @@ cmake --build "${CMAKE_BUILD_DIR}"
 
 # Package app
 cmake --build  "${CMAKE_BUILD_DIR}" --target bundle --config Release
-${ANDROID_SDK_ROOT}/build-tools/29.0.2/apksigner sign --v2-signing-enabled true --ks ./keystore.p12 --ks-pass pass:"${STOREPASS}" --ks-key-alias "qfield" --key-pass pass:"${KEYPASS}" ${CMAKE_BUILD_DIR}/android-build/build/outputs/apk/release/android-build-release-signed.apk
+
+# Sign app (uncomment if you have signature details)
+#${ANDROID_SDK_ROOT}/build-tools/29.0.2/apksigner sign --v2-signing-enabled true --ks ./keystore.p12 --ks-pass pass:"${STOREPASS}" --ks-key-alias "qfield" --key-pass pass:"${KEYPASS}" ${CMAKE_BUILD_DIR}/android-build/build/outputs/apk/release/android-build-release-signed.apk


### PR DESCRIPTION
This PR fixes self-built vcpkg-based APKs using the android_dev docker's ./scripts/build.sh method. 