### PR TITLE
When connected to an external GNSS device, disable compass for now

### DIFF
--- a/src/qml/LocationMarker.qml
+++ b/src/qml/LocationMarker.qml
@@ -66,7 +66,7 @@ Item {
 
   Image {
     id: compassDirectionMarker
-    visible: (device != '' && direction >= 0) || magnetometer.hasValue
+    visible: device == '' && magnetometer.hasValue
     width: 48
     height: 48
     opacity: 0.6
@@ -76,14 +76,14 @@ Item {
 
     source: Theme.getThemeVectorIcon( "ic_compass_direction" )
     fillMode: Image.PreserveAspectFit
-    rotation: device != '' ? direction : -(Math.atan2(magnetometer.x, magnetometer.y) / Math.PI) * 180
+    rotation:  -(Math.atan2(magnetometer.x, magnetometer.y) / Math.PI) * 180
     transformOrigin: Item.Bottom
     smooth: true
   }
 
   Shape {
     id: movementMarker
-    visible: device == '' && speed > 0 && props.isOnMapCanvas
+    visible: speed > 0 && props.isOnMapCanvas
     width: 26
     height: 26
 

--- a/src/qml/LocationMarker.qml
+++ b/src/qml/LocationMarker.qml
@@ -66,7 +66,7 @@ Item {
 
   Image {
     id: compassDirectionMarker
-    visible: device == '' && magnetometer.hasValue
+    visible: device === '' && magnetometer.hasValue
     width: 48
     height: 48
     opacity: 0.6

--- a/src/qml/LocationMarker.qml
+++ b/src/qml/LocationMarker.qml
@@ -10,8 +10,10 @@ Item {
   id: item
 
   property variant location // QgsPoint
+  property string device // Empty string means internal device is used
   property real accuracy
-  property real direction // A -1 value indicates absence of direction information
+  property real direction // A -1 value indicates absence of direction information (note: when an external GNSS device is connected, direction is actually a compass)
+  property real speed // A -1 value indicates absence of speed information
   property MapSettings mapSettings
 
   QtObject {
@@ -64,7 +66,7 @@ Item {
 
   Image {
     id: compassDirectionMarker
-    visible: magnetometer.hasValue
+    visible: (device != '' && direction >= 0) || magnetometer.hasValue
     width: 48
     height: 48
     opacity: 0.6
@@ -74,14 +76,14 @@ Item {
 
     source: Theme.getThemeVectorIcon( "ic_compass_direction" )
     fillMode: Image.PreserveAspectFit
-    rotation: -(Math.atan2(magnetometer.x, magnetometer.y) / Math.PI) * 180
+    rotation: device != '' ? direction : -(Math.atan2(magnetometer.x, magnetometer.y) / Math.PI) * 180
     transformOrigin: Item.Bottom
     smooth: true
   }
 
   Shape {
     id: movementMarker
-    visible: direction >= 0 && props.isOnMapCanvas
+    visible: device == '' && speed > 0 && props.isOnMapCanvas
     width: 26
     height: 26
 
@@ -125,7 +127,7 @@ Item {
 
   Rectangle {
     id: positionMarker
-    visible: direction == -1 && props.isOnMapCanvas
+    visible: !movementMarker.visible && props.isOnMapCanvas
 
     width: 12
     height: 12

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -487,13 +487,16 @@ ApplicationWindow {
       anchors.fill: parent
       visible: positionSource.active && positionSource.positionInfo && positionSource.positionInfo.latitudeValid
       location: positionSource.projectedPosition
+      device: positionSource.device
       accuracy: positionSource.projectedHorizontalAccuracy
       direction: positionSource.positionInfo
                  && positionSource.positionInfo.directionValid
-                 && positionSource.positionInfo.speedValid
-                 && positionSource.positionInfo.speed > 0.0
                  ? positionSource.positionInfo.direction
                  : -1
+      speed: positionSource.positionInfo
+             && positionSource.positionInfo.speedValid
+             ? positionSource.positionInfo.speed
+             : -1
 
       onLocationChanged: {
         if ( gpsButton.followActive ) {


### PR DESCRIPTION
The documentation is really unclear here, but as far as my understanding goes as of March 23, 2022, the NMEA direction data we get from an external GNSS device is a compass value. 

This PR insures that we treat the value as such.