### PR TITLE
Fix java crasher seen on sentry

### DIFF
--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -137,7 +137,10 @@ public class QFieldActivity extends QtActivity {
                 DocumentFile.fromSingleUri(context, uri);
             String fileName = documentFile.getName();
             long fileBytes = documentFile.length();
-            if (fileName == null && type != null) {
+            if (fileName == null) {
+                if (type == null) {
+                    return filePath;
+                }
                 // File name not provided
                 fileName = new SimpleDateFormat("yyyyMMdd_HHmmss")
                                .format(new Date().getTime()) +

--- a/platform/android/src/ch/opengis/qfield/QFieldUtils.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldUtils.java
@@ -164,7 +164,9 @@ public class QFieldUtils {
     }
 
     public static String getExtensionFromMimeType(String type) {
-        if (type.equals("application/pdf")) {
+        if (type == null) {
+            return "";
+        } else if (type.equals("application/pdf")) {
             return "pdf";
         } else if (type.equals("application/vnd.sqlite3") ||
                    type.equals("application/x-sqlite3")) {


### PR DESCRIPTION
Fixes this sentry item:

```
[RuntimeException android.app.ActivityThread in performLaunchActivity](https://sentry.io/organizations/opengisch/issues/3117434221/?project=6119013&query=is%3Aunresolved&sort=freq&statsPeriod=14d)
Unable to start activity ComponentInfo{ch.opengis.qfield_dev/ch.opengis.qfield_dev.QFieldActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.String.lastIndexOf(java.lang.String)' on a null object reference
```

