### PR TITLE
Enable antialiasing by default on QML scenes

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -33,6 +33,7 @@
 #include <QFontDatabase>
 #include <QStandardItemModel>
 #include <QStandardPaths>
+#include <QSurfaceFormat>
 #include <QtQml/QQmlApplicationEngine>
 #include <QtQml/QQmlContext>
 #include <QtQml/QQmlEngine>
@@ -160,12 +161,10 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   , mIface( new AppInterface( this ) )
   , mFirstRenderingFlag( true )
 {
-#if 0
+  // Enables antialiasing in QML scenes
   QSurfaceFormat format;
-  format.setSamples( 8 );
-  setFormat( format );
-  create();
-#endif
+  format.setSamples( 4 );
+  QSurfaceFormat::setDefaultFormat( format );
 
   QSettings settings;
   if ( PlatformUtilities::instance()->capabilities() & PlatformUtilities::AdjustBrightness )

--- a/src/core/qgssggeometry.cpp
+++ b/src/core/qgssggeometry.cpp
@@ -26,7 +26,7 @@ QgsSGGeometry::QgsSGGeometry()
 {
 }
 
-QgsSGGeometry::QgsSGGeometry( const QgsGeometry &geom, const QColor &color, int width, const QgsRectangle visibleExtent, double scaleFactor )
+QgsSGGeometry::QgsSGGeometry( const QgsGeometry &geom, const QColor &color, float width, const QgsRectangle visibleExtent, double scaleFactor )
 {
   //TODO: Fix const-correcteness upstream
   QgsGeometry &gg = const_cast<QgsGeometry &>( geom );
@@ -130,7 +130,7 @@ void QgsSGGeometry::applyStyle( QSGGeometryNode *geomNode )
   geomNode->setMaterial( &mMaterial );
 }
 
-QSGGeometry *QgsSGGeometry::qgsPolylineToQSGGeometry( const QgsPolylineXY &line, int width, const QgsRectangle visibleExtent, double scaleFactor )
+QSGGeometry *QgsSGGeometry::qgsPolylineToQSGGeometry( const QgsPolylineXY &line, float width, const QgsRectangle visibleExtent, double scaleFactor )
 {
   QSGGeometry *sgGeom = new QSGGeometry( QSGGeometry::defaultAttributes_Point2D(), line.count() );
   QSGGeometry::Point2D *vertices = sgGeom->vertexDataAsPoint2D();

--- a/src/core/qgssggeometry.h
+++ b/src/core/qgssggeometry.h
@@ -24,12 +24,12 @@ class QgsSGGeometry : public QSGNode
 {
   public:
     QgsSGGeometry();
-    QgsSGGeometry( const QgsGeometry &geom, const QColor &color, int width, const QgsRectangle visibleExtent, double scaleFactor );
+    QgsSGGeometry( const QgsGeometry &geom, const QColor &color, float width, const QgsRectangle visibleExtent, double scaleFactor );
 
   private:
     void applyStyle( QSGGeometryNode *geomNode );
 
-    static QSGGeometry *qgsPolylineToQSGGeometry( const QgsPolylineXY &line, int width, const QgsRectangle visibleExtent, double scaleFactor );
+    static QSGGeometry *qgsPolylineToQSGGeometry( const QgsPolylineXY &line, float width, const QgsRectangle visibleExtent, double scaleFactor );
     static QSGGeometry *qgsPolygonToQSGGeometry( const QgsPolygon *polygon, const QgsRectangle visibleExtent, double scaleFactor );
 
     QSGFlatColorMaterial mMaterial;

--- a/src/qml/FeatureListSelectionHighlight.qml
+++ b/src/qml/FeatureListSelectionHighlight.qml
@@ -11,7 +11,7 @@ Repeater {
   property double translateY: 0.0
   property color color: "yellow"
   property color focusedColor: "red"
-  property color selectedColor: "green"
+  property color selectedColor: Theme.mainColor
   property bool showSelectedOnly: false
 
   model: selectionModel.model

--- a/src/qml/GeometryRenderer.qml
+++ b/src/qml/GeometryRenderer.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.12
+import QtQuick.Window 2.2
 
 import org.qgis 1.0
 import org.qfield 1.0
@@ -8,7 +9,7 @@ Item {
   id: geometryRenderer
   property MapSettings mapSettings
   property alias geometryWrapper: geometryWrapper
-  property double lineWidth: 8
+  property double lineWidth: 3.5
   property color color: "yellow"
   property double pointSize: 20
   property color borderColor: "blue"
@@ -42,7 +43,7 @@ Item {
 
       geometry: geometryRenderer.geometryWrapper
       color: geometryRenderer.color
-      width: geometryRenderer.lineWidth
+      width: geometryRenderer.lineWidth * Screen.devicePixelRatio
     }
   }
 

--- a/src/qml/NavigationHighlight.qml
+++ b/src/qml/NavigationHighlight.qml
@@ -17,7 +17,7 @@ Item {
       crs: navigation.mapSettings.crs
     }
     color: Theme.navigationColorSemiOpaque
-    width: positionSource.active && positionSource.positionInfo && positionSource.positionInfo.latitudeValid ? 5 : 2
+    width: positionSource.active && positionSource.positionInfo && positionSource.positionInfo.latitudeValid ? 8 : 3
   }
 
   Repeater {

--- a/src/qml/NavigationHighlight.qml
+++ b/src/qml/NavigationHighlight.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.12
+import QtQuick.Window 2.2
 
 import org.qgis 1.0
 import org.qfield 1.0
@@ -17,7 +18,7 @@ Item {
       crs: navigation.mapSettings.crs
     }
     color: Theme.navigationColorSemiOpaque
-    width: positionSource.active && positionSource.positionInfo && positionSource.positionInfo.latitudeValid ? 8 : 3
+    width: positionSource.active && positionSource.positionInfo && positionSource.positionInfo.latitudeValid ? 5 * Screen.devicePixelRatio : 1 * Screen.devicePixelRatio
   }
 
   Repeater {


### PR DESCRIPTION
This makes our QSGeometry-based items look _a lot_ smoother. 

Before:
![Screenshot from 2022-03-26 19-15-01](https://user-images.githubusercontent.com/1728657/160239288-24e3dcab-110b-415d-ae0c-9d148a92e6d8.png)

PR:
![Screenshot from 2022-03-26 19-13-46](https://user-images.githubusercontent.com/1728657/160239292-40cfa18c-ad55-4401-a6d7-cafba9db21a0.png)

Take a close look at the edges of long segments, gone are non antialiased lines.