### PR TITLE
Do not double-compile value relation feature lists

### DIFF
--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -273,7 +273,9 @@ Item {
 
             onCurrentIndexChanged: {
                 var newValue = featureListModel.dataFromRowIndex(currentIndex, FeatureListModel.KeyFieldRole)
-                valueChangeRequested(newValue, false)
+                if (newValue !== currentKeyValue) {
+                    valueChangeRequested(newValue, false)
+                }
             }
 
             Connections {

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -10,6 +10,8 @@ import Theme 1.0
 Item {
     id: relationCombobox
 
+    property FeatureCheckListModel featureListModel
+
     property bool useCompleter: false
     property bool useSearch: false
     property bool allowAddFeature: false

--- a/src/qml/editorwidgets/RelationReference.qml
+++ b/src/qml/editorwidgets/RelationReference.qml
@@ -16,34 +16,35 @@ EditorWidgetBase {
 
   property bool showOpenFormButton: config['ShowOpenFormButton'] === undefined || config['ShowOpenFormButton'] === true
 
+  FeatureCheckListModel {
+    id: listModel
+
+    currentLayer: qgisProject.relationManager.relation(config['Relation']).referencedLayer
+    keyField: qgisProject.relationManager.relation(config['Relation']).resolveReferencedField(field.name)
+    // no, it is not a misspelled version of config['AllowNull']
+    addNull: config['AllowNULL']
+    orderByValue: config['OrderByValue']
+
+    attributeField: field
+    //passing "" instead of undefined, so the model is cleared on adding new features
+    attributeValue: value !== undefined ? value : ''
+    currentFormFeature: currentFeature
+    filterExpression: ""
+    allowMulti: false
+    onListUpdated: {
+      valueChangeRequested( attributeValue, false )
+    }
+  }
+
   RelationCombobox {
     id: relationReference
+    featureListModel: listModel
     anchors { left: parent.left; right: parent.right; rightMargin: showOpenFormButton ? viewButton.width : 0 }
     enabled: isEnabled
     useSearch: true
     allowAddFeature: config['AllowAddFeatures'] !== undefined && config['AllowAddFeatures'] === true
 
     property var _relation: qgisProject.relationManager.relation(config['Relation'])
-
-    FeatureCheckListModel {
-      id: featureListModel
-
-      currentLayer: qgisProject.relationManager.relation(config['Relation']).referencedLayer
-      keyField: qgisProject.relationManager.relation(config['Relation']).resolveReferencedField(field.name)
-      // no, it is not a misspelled version of config['AllowNull']
-      addNull: config['AllowNULL']
-      orderByValue: config['OrderByValue']
-
-      attributeField: field
-      //passing "" instead of undefined, so the model is cleared on adding new features
-      attributeValue: value !== undefined ? value : ''
-      currentFormFeature: currentFeature
-      filterExpression: ""
-      allowMulti: false
-      onListUpdated: {
-        valueChangeRequested( attributeValue, false )
-      }
-    }
   }
 
   QfToolButton  {

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -26,33 +26,34 @@ EditorWidgetBase {
       project: qgisProject
   }
 
+
+  FeatureCheckListModel {
+    id: listModel
+    attributeField: field
+    //passing "" instead of undefined, so the model is cleared on adding new features
+    attributeValue: value !== undefined ? value : ""
+    currentLayer: layerResolver.currentLayer
+    currentFormFeature: currentFeature
+    keyField: config['Key']
+    displayValueField: config['Value']
+    addNull: config['AllowNull']
+    orderByValue: config['OrderByValue']
+    filterExpression: config['FilterExpression']
+    allowMulti: Number(config['AllowMulti']) === 1
+    onListUpdated: {
+      valueChangeRequested( attributeValue, false )
+    }
+  }
+
   RelationCombobox {
     id: valueRelationCombobox
+    featureListModel: listModel
 
     property var _relation: undefined
 
     useCompleter: !!config['UseCompleter']
     enabled: isEnabled
     visible: Number(config['AllowMulti']) !== 1
-
-    FeatureCheckListModel {
-      id: featureListModel
-
-      attributeField: field
-      //passing "" instead of undefined, so the model is cleared on adding new features
-      attributeValue: value !== undefined ? value : ""
-      currentLayer: layerResolver.currentLayer
-      currentFormFeature: currentFeature
-      keyField: config['Key']
-      displayValueField: config['Value']
-      addNull: config['AllowNull']
-      orderByValue: config['OrderByValue']
-      filterExpression: config['FilterExpression']
-      allowMulti: Number(config['AllowMulti']) === 1
-      onListUpdated: {
-        valueChangeRequested( attributeValue, false )
-      }
-    }
   }
 
   Rectangle {
@@ -68,24 +69,6 @@ EditorWidgetBase {
 
     border.color: 'lightgray'
     border.width: 1
-
-    FeatureCheckListModel {
-        id: listModel
-        attributeField: field
-        //passing "" instead of undefined, so the model is cleared on adding new features
-        attributeValue: value !== undefined ? value : ""
-        currentLayer: layerResolver.currentLayer
-        currentFormFeature: currentFeature
-        keyField: config['Key']
-        displayValueField: config['Value']
-        addNull: config['AllowNull']
-        orderByValue: config['OrderByValue']
-        filterExpression: config['FilterExpression']
-        allowMulti: true
-        onListUpdated: {
-            valueChangeRequested( attributeValue, false )
-        }
-    }
 
     //the list
     ListView {
@@ -181,7 +164,7 @@ EditorWidgetBase {
   }
 
   function siblingValueChanged(field, feature) {
-    featureListModel.currentFormFeature = feature
+    listModel.currentFormFeature = feature
   }
 }
 


### PR DESCRIPTION
Our value relation editor widget had *two* feature list model running for each attribute (one for single-selection and one for multi-selection), ouch! This meant that for every editor refresh (say due to filter, current form feature change, etc.), we we triggering the dataset/provider twice.

Among other things, it lead to this obscure bug (https://github.com/opengisch/QField/issues/2594) which this PR fixes.

Safer QField, less CPU, less bandwidth.

I've also taken the time to dissect a infinite value loop detected by QML, that's never good.

