### PR TITLE
Make number edit widget's spin buttons less prone to go wild

### DIFF
--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -73,6 +73,8 @@ EditorWidgetBase {
 
           onPressed: {
               decreaseValue();
+          }
+          onPressAndHold: {
               changeValueTimer.increase = false
               changeValueTimer.interval = 700
               changeValueTimer.restart()
@@ -99,6 +101,8 @@ EditorWidgetBase {
 
           onPressed: {
               increaseValue();
+          }
+          onPressAndHold: {
               changeValueTimer.increase = true
               changeValueTimer.interval = 700
               changeValueTimer.restart()


### PR DESCRIPTION
This PR aims at improving (and possibly fixing) #2584.

Long story short is that if a user clicks at the very edge of the +/- button in the feature form's number edit widget, the release/canceled signal gets lost when the feature form moves to a different tab.

I have fixed this so that the increase/decrease value timer only starts on a pressandhold signal, which should reduce accidental loss of control. 