### PR TITLE
[Backport release-2_0] Make number edit widget's spin buttons less prone to go wild

### DIFF
--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -73,6 +73,8 @@ EditorWidgetBase {
 
           onPressed: {
               decreaseValue();
+          }
+          onPressAndHold: {
               changeValueTimer.increase = false
               changeValueTimer.interval = 700
               changeValueTimer.restart()
@@ -99,6 +101,8 @@ EditorWidgetBase {
 
           onPressed: {
               increaseValue();
+          }
+          onPressAndHold: {
               changeValueTimer.increase = true
               changeValueTimer.interval = 700
               changeValueTimer.restart()


### PR DESCRIPTION
Backport #2659
 **Authored by:** @nirvn