### PR TITLE
Add a couple of long press action for map buttons (main and search)

### DIFF
--- a/src/qml/LocatorItem.qml
+++ b/src/qml/LocatorItem.qml
@@ -168,6 +168,11 @@ Item {
     onClicked: {
       locatorItem.state = locatorItem.state =="off" ? "on" : "off"
     }
+
+    onPressAndHold: {
+      locatorSettings.open();
+      locatorSettings.focus = true;
+    }
   }
 
   Rectangle {

--- a/src/qml/LocatorSettings.qml
+++ b/src/qml/LocatorSettings.qml
@@ -50,7 +50,7 @@ Popup {
               right: parent.right
             }
             iconSource: Theme.getThemeIcon( 'ic_close_black_24dp' )
-            bgcolor: "white"
+            bgcolor: "transparent"
 
             onClicked: {
               popup.close();

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -867,8 +867,13 @@ ApplicationWindow {
       id: menuButton
       round: true
       iconSource: Theme.getThemeIcon( "ic_menu_white_24dp" )
-      onClicked: dashBoard.opened ? dashBoard.close() : dashBoard.open()
       bgcolor: dashBoard.opened ? Theme.mainColor : Theme.darkGray
+
+      onClicked: dashBoard.opened ? dashBoard.close() : dashBoard.open()
+
+      onPressAndHold: {
+        mainMenu.popup(menuButton.x, menuButton.y)
+      }
     }
 
     CloseTool {


### PR DESCRIPTION
If people want to quickly access the main menu, they don't need to go through opening the dashboard and clicking on the gear icon, they can now hold press the top-left dashboard button:

![Peek 2022-04-02 19-22](https://user-images.githubusercontent.com/1728657/161383070-5820d9f0-12ba-4192-804e-75b9cae5f733.gif)

The idea behind this (beyond a speedy shortcut) is that the more long press actions we have, the higher the chance people try and discover those across the app (e.g. location button, navigation button, etc.)