### PR TITLE
Try to fix virtual keyboard sometimes not popping up when focusing on text input

### DIFF
--- a/src/qml/QFieldCloudLogin.qml
+++ b/src/qml/QFieldCloudLogin.qml
@@ -120,7 +120,7 @@ Item {
         wrapMode: Text.WordWrap
       }
 
-      TextField {
+      QfTextField {
         id: serverUrlField
         Layout.preferredWidth: parent.width / 1.3
         Layout.alignment: Qt.AlignHCenter
@@ -128,23 +128,13 @@ Item {
                  && ( prefixUrlWithProtocol(cloudConnection.url) !== cloudConnection.defaultUrl || isServerUrlEditingActive )
         enabled: visible
         height: Math.max(fontMetrics.height, fontMetrics.boundingRect(text).height) + 34
-        topPadding: 10
-        bottomPadding: 10
         font: Theme.defaultFont
         horizontalAlignment: Text.AlignHCenter
         text: prefixUrlWithProtocol(cloudConnection.url )=== cloudConnection.defaultUrl ? '' : cloudConnection.url
-        background: Rectangle {
-          y: serverUrlField.height - height * 2 - serverUrlField.bottomPadding / 2
-          implicitWidth: 120
-          height: serverUrlField.activeFocus ? 2 : 1
-          color: serverUrlField.activeFocus ? "#4CAF50" : "#C8E6C9"
-        }
 
         onTextChanged: text = text.replace(/\s+/g, '')
-        Keys.onReturnPressed: loginFormSumbitHandler()
-        onEditingFinished: {
-          cloudConnection.url = text ? prefixUrlWithProtocol(text) : cloudConnection.defaultUrl
-        }
+        onEditingFinished: cloudConnection.url = text ? prefixUrlWithProtocol(text) : cloudConnection.defaultUrl
+        onReturnPressed: loginFormSumbitHandler()
 
         function prefixUrlWithProtocol(url) {
           if (!url || url.startsWith('http://')  || url.startsWith('https://') )
@@ -164,27 +154,18 @@ Item {
         color: 'gray'
       }
 
-      TextField {
+      QfTextField {
         id: usernameField
         Layout.preferredWidth: parent.width / 1.3
         Layout.alignment: Qt.AlignHCenter
         visible: cloudConnection.status === QFieldCloudConnection.Disconnected
         enabled: visible
         height: Math.max(fontMetrics.height, fontMetrics.boundingRect(text).height) + 34
-        topPadding: 10
-        bottomPadding: 10
         font: Theme.defaultFont
         horizontalAlignment: Text.AlignHCenter
 
-        background: Rectangle {
-          y: usernameField.height - height * 2 - usernameField.bottomPadding / 2
-          implicitWidth: 120
-          height: usernameField.activeFocus ? 2 : 1
-          color: usernameField.activeFocus ? "#4CAF50" : "#C8E6C9"
-        }
-
         onTextChanged: text = text.replace(/\s+/g, '')
-        Keys.onReturnPressed: loginFormSumbitHandler()
+        onReturnPressed: loginFormSumbitHandler();
       }
 
       Text {
@@ -197,7 +178,7 @@ Item {
         color: 'gray'
       }
 
-      TextField {
+      QfTextField {
         id: passwordField
         echoMode: TextInput.Password
         Layout.preferredWidth: parent.width / 1.3
@@ -205,19 +186,10 @@ Item {
         visible: cloudConnection.status === QFieldCloudConnection.Disconnected
         enabled: visible
         height: Math.max(fontMetrics.height, fontMetrics.boundingRect(text).height) + 34
-        topPadding: 10
-        bottomPadding: 10
         font: Theme.defaultFont
         horizontalAlignment: Text.AlignHCenter
 
-        background: Rectangle {
-          y: passwordField.height - height * 2 - passwordField.bottomPadding / 2
-          implicitWidth: 120
-          height: passwordField.activeFocus ? 2 : 1
-          color: passwordField.activeFocus ? "#4CAF50" : "#C8E6C9"
-        }
-
-        Keys.onReturnPressed: loginFormSumbitHandler()
+        onReturnPressed: loginFormSumbitHandler()
       }
 
       FontMetrics {

--- a/src/qml/imports/Theme/QfTextField.qml
+++ b/src/qml/imports/Theme/QfTextField.qml
@@ -13,6 +13,8 @@ Item {
   property var echoMode: TextInput.Normal
 
   signal textEdited
+  signal editingFinished
+  signal returnPressed
 
   width: textField.width
   height: textField.height
@@ -41,6 +43,20 @@ Item {
 
     onTextEdited: {
         textFieldWrapper.textEdited()
+    }
+
+    onEditingFinished: {
+        textFieldWrapper.editingFinished();
+    }
+
+    onFocusChanged: {
+        if (focus) {
+            Qt.inputMethod.show()
+        }
+    }
+
+    Keys.onReturnPressed: {
+        textFieldWrapper.returnPressed()
     }
   }
 


### PR DESCRIPTION
What this PR is trying to fix is a bug in Qt/QML that ends up with users unable to trigger the opening of their virtual keyboard on Android when focusing on a text input.

One reliable way to reproduce the issue: remove QField from your android device, re-install it, click on open QFieldCloud project, see how when you click on the user or password text input, the keyboard never shows up.

Bonus because we use QfEditInput, we get _for free_ a show password in the QFieldCloud login panel:
![image](https://user-images.githubusercontent.com/1728657/161384711-8536e347-8c4d-477e-91e4-cd64ee3ee303.png)

@suricactus , that should make you happy ;)