### PR TITLE
[qgsquick] Properly handle deferred layer repaint requests

### DIFF
--- a/src/core/qgsquick/qgsquickmapcanvasmap.cpp
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.cpp
@@ -40,7 +40,7 @@ QgsQuickMapCanvasMap::QgsQuickMapCanvasMap( QQuickItem *parent )
   , mCache( std::make_unique<QgsMapRendererCache>() )
 {
   connect( this, &QQuickItem::windowChanged, this, &QgsQuickMapCanvasMap::onWindowChanged );
-  connect( &mRefreshTimer, &QTimer::timeout, this, &QgsQuickMapCanvasMap::refreshMap );
+  connect( &mRefreshTimer, &QTimer::timeout, this, [=] { refreshMap(); } );
   connect( &mMapUpdateTimer, &QTimer::timeout, this, &QgsQuickMapCanvasMap::renderJobUpdated );
 
   connect( mMapSettings.get(), &QgsQuickMapSettings::extentChanged, this, &QgsQuickMapCanvasMap::onExtentChanged );
@@ -97,7 +97,7 @@ void QgsQuickMapCanvasMap::pan( QPointF oldPos, QPointF newPos )
   mMapSettings->setExtent( extent );
 }
 
-void QgsQuickMapCanvasMap::refreshMap()
+void QgsQuickMapCanvasMap::refreshMap( bool silent )
 {
   stopRendering(); // if any...
 
@@ -151,7 +151,10 @@ void QgsQuickMapCanvasMap::refreshMap()
 
   mJob->start();
 
-  emit renderStarting();
+  if ( !silent )
+  {
+    emit renderStarting();
+  }
 }
 
 void QgsQuickMapCanvasMap::renderJobUpdated()
@@ -206,6 +209,30 @@ void QgsQuickMapCanvasMap::renderJobFinished()
 
   update();
   emit mapCanvasRefreshed();
+
+  if ( mDeferredRefreshPending )
+  {
+    mDeferredRefreshPending = false;
+    refreshMap( true );
+  }
+}
+
+void QgsQuickMapCanvasMap::layerRepaintRequested( bool deferred )
+{
+  if ( mMapSettings->outputSize().isNull() )
+    return; // the map image size has not been set yet
+
+  if ( !mFreeze )
+  {
+    if ( !deferred || !mJob )
+    {
+      refreshMap( deferred );
+    }
+    else
+    {
+      mDeferredRefreshPending = true;
+    }
+  }
 }
 
 void QgsQuickMapCanvasMap::onWindowChanged( QQuickWindow *window )
@@ -382,7 +409,7 @@ void QgsQuickMapCanvasMap::onLayersChanged()
   const QList<QgsMapLayer *> layers = mMapSettings->layers();
   for ( QgsMapLayer *layer : layers )
   {
-    mLayerConnections << connect( layer, &QgsMapLayer::repaintRequested, this, &QgsQuickMapCanvasMap::refresh );
+    mLayerConnections << connect( layer, &QgsMapLayer::repaintRequested, this, &QgsQuickMapCanvasMap::layerRepaintRequested );
   }
 
   refresh();

--- a/src/core/qgsquick/qgsquickmapcanvasmap.h
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.h
@@ -163,9 +163,10 @@ class QgsQuickMapCanvasMap : public QQuickItem
     void refresh();
 
   private slots:
-    void refreshMap();
+    void refreshMap( bool silent = false );
     void renderJobUpdated();
     void renderJobFinished();
+    void layerRepaintRequested( bool deferred );
     void onWindowChanged( QQuickWindow *window );
     void onScreenChanged( QScreen *screen );
     void onExtentChanged();
@@ -196,6 +197,7 @@ class QgsQuickMapCanvasMap : public QQuickItem
     QList<QMetaObject::Connection> mLayerConnections;
     QTimer mMapUpdateTimer;
     bool mIncrementalRendering = false;
+    bool mDeferredRefreshPending = false;
 
     QQuickWindow *mWindow = nullptr;
 


### PR DESCRIPTION
Without this, layers that signals repaint requests a lot (e.g., animation markers in upcoming 3.26 but _also_ layers set to auto refresh every X secs) would freeze map canvas.