### PR TITLE
Avoid throwing harmless but disturbing warning messages when typing into range editor widget

### DIFF
--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -57,7 +57,9 @@ EditorWidgetBase {
           }
 
           onTextChanged: {
-              valueChangeRequested( text, text == '' )
+              if (text == '' || !isNaN(parseFloat(text))) {
+                  valueChangeRequested( text, text == '' )
+              }
           }
       }
 


### PR DESCRIPTION
Fixes #2695 