### PR TITLE
Further improve the metrics popup, re-asks to get a clear(er) answer

### DIFF
--- a/src/qml/About.qml
+++ b/src/qml/About.qml
@@ -6,16 +6,12 @@ import Theme 1.0
 import org.qfield 1.0
 
 Item {
+    id: aboutPanel
+
     Rectangle {
         color: "black"
         opacity: 0.8
         anchors.fill: parent
-        MouseArea {
-            anchors.fill: parent
-            onClicked: {
-                parent.parent.visible = false
-            }
-        }
     }
 
     ColumnLayout {
@@ -33,10 +29,18 @@ Item {
             contentHeight: information.height
             clip: true
 
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    aboutPanel.visible = false
+                }
+            }
+
             ColumnLayout {
                 id: information
                 width: aboutContainer.width
-                height: Math.max(mainWindow.height - changelogButton.height * 2 - 60, childrenRect.height)
+                height: Math.max(mainWindow.height - changelogButton.height * 2 - 60,
+                                 opengisLogo.height + qfieldLogo.height + 100)
 
                 ColumnLayout {
                     Layout.fillHeight: true

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -327,7 +327,7 @@ Page {
           Text {
             Layout.margins: 6
             Layout.maximumWidth: collectionView.width - 12
-            text: qsTr("To improve stability for everyone, QField collects and sends anonymized metrics. To disable, click on the button below.")
+            text: qsTr("To improve stability for everyone, QField collects and sends anonymized metrics.")
             font: Theme.defaultFont
             horizontalAlignment: Text.AlignHCenter
             wrapMode: Text.WordWrap
@@ -335,16 +335,28 @@ Page {
 
           RowLayout {
             spacing: 6
-            Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
+            Layout.alignment: Qt.AlignVCenter
             Layout.bottomMargin: 10
             QfToolButton {
-              iconSource: Theme.getThemeIcon('ic_close_white_24dp')
+              text: qsTr('Thank you!')
               bgcolor: Theme.mainColor
-              round: true
 
               onClicked: {
                 qfieldSettings.enableInfoCollection = false
                 collectionView.currentIndex = 0
+                collectionView.visible = false
+              }
+            }
+
+            QfToolButton {
+              text: qsTr('I prefer not')
+              bgcolor: 'white'
+              color: Theme.mainColor
+
+              onClicked: {
+                qfieldSettings.enableInfoCollection = true
+                collectionView.currentIndex = 0
+                collectionView.visible = false
               }
             }
           }

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -339,7 +339,7 @@ Page {
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             Layout.bottomMargin: 10
             QfButton {
-              text: qsTr('Thank you!')
+              text: qsTr('OK')
 
               onClicked: {
                 qfieldSettings.enableInfoCollection = true

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -39,6 +39,7 @@ Page {
 
   ScrollView {
     padding: 0
+    topPadding: Math.max(0, Math.min(80, (mainWindow.height - welcomeGrid.height) / 2 - 45))
     ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
     ScrollBar.vertical.policy: ScrollBar.AsNeeded
     contentItem: welcomeGrid
@@ -383,7 +384,7 @@ Page {
       Layout.bottomMargin: 2
       Layout.fillWidth: true
       Layout.maximumWidth: 410
-      Layout.minimumHeight: welcomeActions.height
+      Layout.preferredHeight: welcomeActions.height
       Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
       color: "transparent"
 

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -253,11 +253,11 @@ Page {
       id: collectionView
       visible: false
 
-      Layout.margins: 6
+      Layout.margins: 0
       Layout.topMargin: 10
       Layout.bottomMargin: 10
       Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
-      Layout.preferredWidth: Math.min( 410, mainWindow.width - 30 )
+      Layout.preferredWidth: Math.min( 410, mainWindow.width - 20 )
       Layout.preferredHeight: Math.max(collectionOhno.childrenRect.height, collectionIntro.childrenRect.height)
       clip: true
 
@@ -335,27 +335,24 @@ Page {
 
           RowLayout {
             spacing: 6
-            Layout.alignment: Qt.AlignVCenter
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             Layout.bottomMargin: 10
-            QfToolButton {
+            QfButton {
               text: qsTr('Thank you!')
-              bgcolor: Theme.mainColor
 
               onClicked: {
-                qfieldSettings.enableInfoCollection = false
-                collectionView.currentIndex = 0
+                qfieldSettings.enableInfoCollection = true
                 collectionView.visible = false
               }
             }
 
-            QfToolButton {
+            QfButton {
               text: qsTr('I prefer not')
-              bgcolor: 'white'
+              bgcolor: "transparent"
               color: Theme.mainColor
 
               onClicked: {
-                qfieldSettings.enableInfoCollection = true
-                collectionView.currentIndex = 0
+                qfieldSettings.enableInfoCollection = false
                 collectionView.visible = false
               }
             }
@@ -776,10 +773,10 @@ Page {
     }
 
     if (platformUtilities.capabilities & PlatformUtilities.SentryFramework) {
-      var collectionFormShown = settings.value("/QField/CollectionFormShown",false)
+      var collectionFormShown = settings.value("/QField/CollectionFormShownV2",false)
       if (!collectionFormShown) {
         collectionView.visible = true
-        settings.setValue("/QField/CollectionFormShown",true)
+        settings.setValue("/QField/CollectionFormShownV2",true)
       }
     }
 

--- a/src/qml/imports/Theme/QfButton.qml
+++ b/src/qml/imports/Theme/QfButton.qml
@@ -8,15 +8,24 @@ import QtQuick.Controls.Material.impl 2.12
 Button {
   id: button
   property color bgcolor: Theme.mainColor
+  property alias color: label.color
+
   padding: 8
+  leftPadding: 8
+  rightPadding: 8
+  leftInset: 4
+  rightInset: 4
   topInset: 2
   bottomInset: 2
-  icon.color: 'white'
+
+  icon.color: button.color
 
   background: Rectangle {
       anchors.fill: parent
-      color: !parent.enabled ? Theme.lightGray : Theme.mainColor
+      color: !parent.enabled ? Theme.lightGray : button.bgcolor
       radius: 12
+      border.width: 1
+      border.color: button.bgcolor != "#00000000" ? button.bgcolor : button.color
 
       Ripple {
           clip: true
@@ -28,13 +37,15 @@ Button {
           color: Material.rippleColor
       }
   }
+
   contentItem: IconLabel {
+    id: label
     spacing: parent.spacing
     mirrored: parent.mirrored
     display: parent.display
 
     icon: parent.icon
-    color: 'white'
+    color: "white"
     font: Theme.tipFont
     alignment: Qt.AlignCenter | Qt.AlignVCenter
     text: parent.text

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -621,7 +621,7 @@ ApplicationWindow {
 
       property VectorLayer currentLayer: dashBoard.currentLayer
 
-      rubberbandModel: currentRubberband.model
+      rubberbandModel: currentRubberband ? currentRubberband.model : null
       project: qgisProject
       crs: qgisProject.crs
     }
@@ -2485,17 +2485,6 @@ ApplicationWindow {
 
     width: parent.width
     height: parent.height
-
-    Keys.onReleased: {
-      if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
-        event.accepted = true
-        close()
-      }
-    }
-
-    Component.onCompleted: {
-      focusstack.addFocusTaker( this )
-    }
   }
 
   QFieldCloudPackageLayersFeedback {


### PR DESCRIPTION
@m-kuhn , here's how it looks now:
![image](https://user-images.githubusercontent.com/1728657/162556970-32dcc49d-33a9-4060-ba4a-172ad059360e.png)

I've taken the liberty to change the "we've asked already" settings key so users are re-asked with this much clearer UI.