### PR TITLE
Remove crash prone feedback connection in the system loader scene

### DIFF
--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -107,8 +107,6 @@ void AndroidPlatformUtilities::initSystem()
     Feedback feedback;
     QApplication app( argc, nullptr );
     QQmlApplicationEngine engine;
-    qmlRegisterType<Feedback>( "org.qfield", 1, 0, "Feedback" );
-    engine.rootContext()->setContextProperty( "feedback", &feedback );
     engine.load( QUrl( QStringLiteral( "qrc:/qml/SystemLoader.qml" ) ) );
 
     QMetaObject::invokeMethod( &app, [this, &app, &feedback] {

--- a/src/qml/SystemLoader.qml
+++ b/src/qml/SystemLoader.qml
@@ -38,8 +38,8 @@ ApplicationWindow
             opacity: 0
             from: 0
             to: 100
-            indeterminate: feedback.progress == -1
-            value: feedback.progress
+            indeterminate: true
+            value: -1
             width: parent.width * 0.6
 
             Layout.alignment: Qt.AlignCenter


### PR DESCRIPTION
By current stats, the 6th most reported crash on sentry has to do with the feedback context passed onto the system loader scene. I vote to remove that crash prone code in favor of an indefinite loader bar instead.

The crash isn't that bad since just re-launching QField works, but it does happen immediately after installing QField, which isn't a great look.