### PR TITLE
Implement send compressed folder and export project folder [to folder] functionality

### DIFF
--- a/platform/android/res/menu/project_folder_menu.xml
+++ b/platform/android/res/menu/project_folder_menu.xml
@@ -9,6 +9,10 @@
         android:title="@string/remove_from_favorite"
         app:showAsAction="never"/>
     <item
+        android:id="@+id/send_compressed_to"
+        android:title="@string/send_compressed_to"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/export_to_folder"
         android:title="@string/export_to_folder"
         app:showAsAction="never" />

--- a/platform/android/res/menu/project_folder_menu.xml
+++ b/platform/android/res/menu/project_folder_menu.xml
@@ -9,6 +9,10 @@
         android:title="@string/remove_from_favorite"
         app:showAsAction="never"/>
     <item
+        android:id="@+id/export_to_folder"
+        android:title="@string/export_to_folder"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/remove_folder"
         android:title="@string/remove_folder"
         app:showAsAction="never" />

--- a/platform/android/res/menu/project_item_menu.xml
+++ b/platform/android/res/menu/project_item_menu.xml
@@ -6,6 +6,10 @@
         android:title="@string/send_to"
         app:showAsAction="never" />
     <item
+        android:id="@+id/export_to_folder"
+        android:title="@string/export_to_folder"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/remove_dataset"
         android:title="@string/remove_dataset"
         app:showAsAction="never" />

--- a/platform/android/res/values/strings.xml
+++ b/platform/android/res/values/strings.xml
@@ -47,8 +47,8 @@
     <string name="export_error">Export Error</string>
     <string name="export_to_folder_error">The selected project folder not be exported properly.</string>
     <string name="send_to">Send to...</string>
-    <string name="send_compressed_to">Send compressed folder to...</string>
-    <string name="export_to_folder">Export to folder...</string>
+    <string name="send_compressed_to">Send Compressed Folder to...</string>
+    <string name="export_to_folder">Export to Folder...</string>
     <string name="add_to_favorite">Add to Favorites</string>
     <string name="remove_from_favorite">Remove from Favorites</string>
     <string name="remove_dataset">Remove Dataset</string>

--- a/platform/android/res/values/strings.xml
+++ b/platform/android/res/values/strings.xml
@@ -46,6 +46,8 @@
     <string name="import_project_folder_error">The selected project folder was not imported properly.</string>
     <string name="import_overwrite_title">Import Warning</string>
     <string name="import_overwrite_folder">This project folder already exists. This operation will overwrite its data, proceed with import?</string>
+    <string name="import_overwrite_dataset_single">This dataset already exists. This operation will overwrite it, proceed with import?</string>
+    <string name="import_overwrite_dataset_multiple">One or more datasets already exists. This operation will overwrite these, proceed with import?</string>
     <string name="import_overwrite_confirm">Import and Overwrite</string>
     <string name="import_overwrite_cancel">Cancel</string>
     <string name="export_error">Export Error</string>

--- a/platform/android/res/values/strings.xml
+++ b/platform/android/res/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="export_error">Export Error</string>
     <string name="export_to_folder_error">The selected project folder not be exported properly.</string>
     <string name="send_to">Send to...</string>
+    <string name="send_compressed_to">Send compressed folder to...</string>
     <string name="export_to_folder">Export to folder...</string>
     <string name="add_to_favorite">Add to Favorites</string>
     <string name="remove_from_favorite">Remove from Favorites</string>

--- a/platform/android/res/values/strings.xml
+++ b/platform/android/res/values/strings.xml
@@ -42,10 +42,10 @@
     <string name="usb_cable_help">USB Cable Transfer Help</string>
     <string name="import_error">Import Error</string>
     <string name="import_dataset_error">The selected dataset(s) could not be imported properly.</string>
-    <string name="import_project_archive_error">The selected project archive not be imported properly.</string>
-    <string name="import_project_folder_error">The selected project folder not be imported properly.</string>
+    <string name="import_project_archive_error">The selected project archive was not imported properly.</string>
+    <string name="import_project_folder_error">The selected project folder was not imported properly.</string>
     <string name="export_error">Export Error</string>
-    <string name="export_to_folder_error">The selected project folder not be exported properly.</string>
+    <string name="export_to_folder_error">The selected project folder was not exported properly.</string>
     <string name="send_to">Send to...</string>
     <string name="send_compressed_to">Send Compressed Folder to...</string>
     <string name="export_to_folder">Export to Folder...</string>

--- a/platform/android/res/values/strings.xml
+++ b/platform/android/res/values/strings.xml
@@ -44,7 +44,10 @@
     <string name="import_dataset_error">The selected dataset(s) could not be imported properly.</string>
     <string name="import_project_archive_error">The selected project archive not be imported properly.</string>
     <string name="import_project_folder_error">The selected project folder not be imported properly.</string>
+    <string name="export_error">Export Error</string>
+    <string name="export_to_folder_error">The selected project folder not be exported properly.</string>
     <string name="send_to">Send to...</string>
+    <string name="export_to_folder">Export to folder...</string>
     <string name="add_to_favorite">Add to Favorites</string>
     <string name="remove_from_favorite">Remove from Favorites</string>
     <string name="remove_dataset">Remove Dataset</string>

--- a/platform/android/res/values/strings.xml
+++ b/platform/android/res/values/strings.xml
@@ -44,6 +44,10 @@
     <string name="import_dataset_error">The selected dataset(s) could not be imported properly.</string>
     <string name="import_project_archive_error">The selected project archive was not imported properly.</string>
     <string name="import_project_folder_error">The selected project folder was not imported properly.</string>
+    <string name="import_overwrite_title">Import Warning</string>
+    <string name="import_overwrite_folder">This project folder already exists. This operation will overwrite its data, proceed with import?</string>
+    <string name="import_overwrite_confirm">Import and Overwrite</string>
+    <string name="import_overwrite_cancel">Cancel</string>
     <string name="export_error">Export Error</string>
     <string name="export_to_folder_error">The selected project folder was not exported properly.</string>
     <string name="send_to">Send to...</string>

--- a/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -205,9 +205,9 @@ public class QFieldProjectActivity
             }
             case R.id.export_to_folder: {
                 Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
-                intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION |
-                                Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-                intent.addFlags(Intent.FLAG_GRANT_PREFIX_URI_PERMISSION);
+                intent.addCategory(Intent.CATEGORY_DEFAULT);
+                intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
                 intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
                 startActivityForResult(intent, R.id.export_to_folder);
                 return true;
@@ -869,6 +869,9 @@ public class QFieldProjectActivity
             Uri uri = data.getData();
             Context context = getApplication().getApplicationContext();
             ContentResolver resolver = getContentResolver();
+            resolver.takePersistableUriPermission(
+                uri, Intent.FLAG_GRANT_READ_URI_PERMISSION |
+                         Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
             DocumentFile directory = DocumentFile.fromTreeUri(context, uri);
 
             boolean exported = QFieldUtils.folderToDocumentFile(

--- a/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -48,6 +48,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 public class QFieldProjectActivity
     extends Activity implements OnMenuItemClickListener {
@@ -182,6 +183,24 @@ public class QFieldProjectActivity
             }
             case R.id.remove_from_favorite: {
                 removeFileFromFavoriteDirs(file);
+                return true;
+            }
+            case R.id.send_compressed_to: {
+                File temporaryFile =
+                    new File(getCacheDir(), file.getName() + ".zip");
+                QFieldUtils.zipFolder(file.getPath(), temporaryFile.getPath());
+
+                DocumentFile documentFile =
+                    DocumentFile.fromFile(temporaryFile);
+                Context context = getApplication().getApplicationContext();
+                Intent intent = new Intent(Intent.ACTION_SEND);
+                intent.putExtra(Intent.EXTRA_STREAM,
+                                FileProvider.getUriForFile(
+                                    context,
+                                    context.getPackageName() + ".fileprovider",
+                                    temporaryFile));
+                intent.setType(documentFile.getType());
+                startActivity(Intent.createChooser(intent, null));
                 return true;
             }
             case R.id.export_to_folder: {

--- a/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -1054,7 +1054,6 @@ public class QFieldProjectActivity
                 (QFieldProjectListItem)list.getAdapter().getItem(
                     currentPosition);
             File file = listItem.getFile();
-            String exportPath = file.getPath();
             Uri uri = data.getData();
             Context context = getApplication().getApplicationContext();
             ContentResolver resolver = getContentResolver();
@@ -1068,8 +1067,9 @@ public class QFieldProjectActivity
                     DocumentFile directory =
                         DocumentFile.fromTreeUri(context, uri);
 
-                    boolean exported = QFieldUtils.folderToDocumentFile(
-                        exportPath, directory, resolver);
+                    boolean exported = exported =
+                        QFieldUtils.fileToDocumentFile(file, directory,
+                                                       resolver);
 
                     if (!exported) {
                         AlertDialog alertDialog =

--- a/platform/android/src/ch/opengis/qfield/QFieldProjectListAdapter.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectListAdapter.java
@@ -72,6 +72,7 @@ public class QFieldProjectListAdapter
                 menuButtonListener != null) {
                 h.button.setTag(position);
                 h.button.setVisibility(View.VISIBLE);
+                h.button.setImageAlpha(172);
                 h.button.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View view) {

--- a/platform/android/src/ch/opengis/qfield/QFieldUtils.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldUtils.java
@@ -98,7 +98,11 @@ public class QFieldUtils {
             String filePath = file.getPath();
             String fileName = file.getName();
             if (file.isDirectory()) {
-                DocumentFile newDirectory = directory.createDirectory(fileName);
+                // Use pre-existing directory if present
+                DocumentFile newDirectory = directory.findFile(fileName);
+                if (newDirectory == null) {
+                    newDirectory = directory.createDirectory(fileName);
+                }
                 boolean success = folderToDocumentFile(file.getPath(),
                                                        newDirectory, resolver);
                 if (!success) {
@@ -114,8 +118,11 @@ public class QFieldUtils {
                         MimeTypeMap.getSingleton().getMimeTypeFromExtension(
                             extension);
                 }
-                DocumentFile documentFile =
-                    directory.createFile(mimeType, fileName);
+                // Use pre-existing file if present
+                DocumentFile documentFile = directory.findFile(fileName);
+                if (documentFile == null) {
+                    documentFile = directory.createFile(mimeType, fileName);
+                }
                 try {
                     InputStream input = new FileInputStream(file);
                     OutputStream output =

--- a/platform/android/src/ch/opengis/qfield/QFieldUtils.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldUtils.java
@@ -187,6 +187,9 @@ public class QFieldUtils {
         File dir = new File(folder);
         File[] files = dir.listFiles();
         String pathPrefix = folder.substring(rootFolder.length());
+        if (!pathPrefix.isEmpty()) {
+            pathPrefix = pathPrefix + "/";
+        }
         for (File file : files) {
             String filePath = file.getPath();
             String fileName = file.getName();
@@ -199,8 +202,7 @@ public class QFieldUtils {
                 }
             } else {
                 try {
-                    ZipEntry zipFile =
-                        new ZipEntry(pathPrefix + "/" + fileName);
+                    ZipEntry zipFile = new ZipEntry(pathPrefix + fileName);
                     zip.putNextEntry(zipFile);
 
                     InputStream input = new FileInputStream(file);

--- a/platform/android/src/ch/opengis/qfield/QFieldUtils.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldUtils.java
@@ -186,9 +186,12 @@ public class QFieldUtils {
                                           String rootFolder) {
         File dir = new File(folder);
         File[] files = dir.listFiles();
-        String pathPrefix = folder.substring(rootFolder.length());
-        if (!pathPrefix.isEmpty()) {
-            pathPrefix = pathPrefix + "/";
+        String pathPrefix = "";
+        if (folder.length() > rootFolder.length()) {
+            pathPrefix = folder.substring(rootFolder.length() + 1);
+            if (!pathPrefix.substring(pathPrefix.length() - 1).equals("/")) {
+                pathPrefix = pathPrefix + "/";
+            }
         }
         for (File file : files) {
             String filePath = file.getPath();

--- a/platform/android/src/ch/opengis/qfield/QFieldUtils.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldUtils.java
@@ -88,23 +88,20 @@ public class QFieldUtils {
         return true;
     }
 
-    public static boolean folderToDocumentFile(String folder,
-                                               DocumentFile directory,
-                                               ContentResolver resolver) {
-        File dir = new File(folder);
-
-        File[] files = dir.listFiles();
-        for (File file : files) {
-            String filePath = file.getPath();
-            String fileName = file.getName();
-            if (file.isDirectory()) {
+    public static boolean fileToDocumentFile(File file, DocumentFile directory,
+                                             ContentResolver resolver) {
+        File[] files =
+            file.isDirectory() ? file.listFiles() : new File[] {file};
+        for (File f : files) {
+            String filePath = f.getPath();
+            String fileName = f.getName();
+            if (f.isDirectory()) {
                 // Use pre-existing directory if present
                 DocumentFile newDirectory = directory.findFile(fileName);
                 if (newDirectory == null) {
                     newDirectory = directory.createDirectory(fileName);
                 }
-                boolean success = folderToDocumentFile(file.getPath(),
-                                                       newDirectory, resolver);
+                boolean success = fileToDocumentFile(f, newDirectory, resolver);
                 if (!success) {
                     return false;
                 }
@@ -124,11 +121,11 @@ public class QFieldUtils {
                     documentFile = directory.createFile(mimeType, fileName);
                 }
                 try {
-                    InputStream input = new FileInputStream(file);
+                    InputStream input = new FileInputStream(f);
                     OutputStream output =
                         resolver.openOutputStream(documentFile.getUri());
                     QFieldUtils.inputStreamToOutputStream(input, output,
-                                                          file.length());
+                                                          f.length());
                     output.close();
                 } catch (Exception e) {
                     e.printStackTrace();


### PR DESCRIPTION
This PR implements two ways to export project folder content out of QField's app files directory:
![image](https://user-images.githubusercontent.com/1728657/162918024-0eab8b7f-109d-4a6a-99b0-e0791c2ad2c6.png)

**'Send Compressed Folder to...'**
When selected, QField compresses the content of the select folder (as well as its sub folders) into a ZIP archive, and then asks the user through which app on his/her device the compressed project folder should be send through. The implementation allows for sending a root project folder (in the QField's imported projects directory), as well as being able to send selective folders _within_ that root project folder. This means that for e.g., users could decide to compress and send only a /data sub-folder, or a /dcim sub folder.

**'Export to Folder...'**
When selected, QField will ask users to pick a folder (using the Android system's folder picker activity) within which the content of a given project folder will be _copied_ to. For e.g., a user could export his/her complete project folder into a NextCloud folder for it to synchronize back. As with the send compressed folder action, users can select individual sub-folders within the root project folder to export. Note that exporting onto a folder will overwrite preexisting content.

E.g. of an export of folder through nextcloud app's directory provider:
https://user-images.githubusercontent.com/1728657/162948982-b7a127fc-684b-4daf-b212-9fedc18b4705.mp4


