### PR TITLE
Avoid crashing when parsing a DownloadsProvider URI with a non-numerical ID

### DIFF
--- a/platform/android/src/ch/opengis/qfield/QFieldUtils.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldUtils.java
@@ -214,12 +214,17 @@ public class QFieldUtils {
                 // TODO handle non-primary volumes
             } else if (isDownloadsDocument(uri)) {
                 // DownloadsProvider
-                final String id = DocumentsContract.getDocumentId(uri);
-                final Uri contentUri = ContentUris.withAppendedId(
-                    Uri.parse("content://downloads/public_downloads"),
-                    Long.valueOf(id));
+                try {
+                    final String id = DocumentsContract.getDocumentId(uri);
+                    final Uri contentUri = ContentUris.withAppendedId(
+                        Uri.parse("content://downloads/public_downloads"),
+                        Long.valueOf(id));
 
-                path = getDataColumn(context, contentUri, null, null);
+                    path = getDataColumn(context, contentUri, null, null);
+                } catch (NumberFormatException e) {
+                    // Not numerical IDs, skipping
+                    path = null;
+                }
             } else if (isMediaDocument(uri)) {
                 // MediaProvider
                 final String docId = DocumentsContract.getDocumentId(uri);


### PR DESCRIPTION
Fixes this sentry issue: https://sentry.io/organizations/opengisch/issues/3155005227/?project=6119013&query=is%3Aunresolved