### PR TITLE
Allow for pictures taken (through camera or gallery) to be restricted to a maximum width/height

### DIFF
--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -54,6 +54,21 @@ void AppInterface::readProject()
   return mApp->readProjectFile();
 }
 
+QString AppInterface::readProjectEntry( const QString &scope, const QString &key, const QString &def ) const
+{
+  return mApp->readProjectEntry( scope, key, def );
+}
+
+int AppInterface::readProjectNumEntry( const QString &scope, const QString &key, int def ) const
+{
+  return mApp->readProjectNumEntry( scope, key, def );
+}
+
+double AppInterface::readProjectDoubleEntry( const QString &scope, const QString &key, double def ) const
+{
+  return mApp->readProjectDoubleEntry( scope, key, def );
+}
+
 bool AppInterface::print( const QString &layoutName )
 {
   return mApp->print( layoutName );

--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -134,3 +134,15 @@ void AppInterface::sendLog( const QString &message )
 {
   emit submitLog( message );
 }
+
+void AppInterface::restrictImageSize( const QString &imagePath, int maximumWidthHeight )
+{
+  QImage img( imagePath );
+  if ( !img.isNull() && ( img.width() > maximumWidthHeight || img.height() > maximumWidthHeight ) )
+  {
+    QImage scaledImage = img.width() > img.height()
+                           ? img.scaledToWidth( maximumWidthHeight, Qt::SmoothTransformation )
+                           : img.scaledToHeight( maximumWidthHeight, Qt::SmoothTransformation );
+    scaledImage.save( imagePath );
+  }
+}

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -44,6 +44,10 @@ class AppInterface : public QObject
     Q_INVOKABLE void readProject();
     Q_INVOKABLE void removeRecentProject( const QString &path );
 
+    Q_INVOKABLE QString readProjectEntry( const QString &scope, const QString &key, const QString &def = QString() ) const;
+    Q_INVOKABLE int readProjectNumEntry( const QString &scope, const QString &key, int def = 0 ) const;
+    Q_INVOKABLE double readProjectDoubleEntry( const QString &scope, const QString &key, double def = 0.0 ) const;
+
     Q_INVOKABLE bool print( const QString &layoutName );
     Q_INVOKABLE bool printAtlasFeatures( const QString &layoutName, const QList<long long> &featureIds );
 

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -59,6 +59,8 @@ class AppInterface : public QObject
 
     Q_INVOKABLE void sendLog( const QString &message );
 
+    Q_INVOKABLE void restrictImageSize( const QString &imagePath, int maximumWidthHeight );
+
     static void setInstance( AppInterface *instance ) { sAppInterface = instance; }
     static AppInterface *instance() { return sAppInterface; }
 

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -1069,6 +1069,30 @@ void QgisMobileapp::readProjectFile()
   emit loadProjectEnded( mProjectFilePath, mProjectFileName );
 }
 
+QString QgisMobileapp::readProjectEntry( const QString &scope, const QString &key, const QString &def ) const
+{
+  if ( !mProject )
+    return def;
+
+  return mProject->readEntry( scope, key, def );
+}
+
+int QgisMobileapp::readProjectNumEntry( const QString &scope, const QString &key, int def ) const
+{
+  if ( !mProject )
+    return def;
+
+  return mProject->readNumEntry( scope, key, def );
+}
+
+double QgisMobileapp::readProjectDoubleEntry( const QString &scope, const QString &key, double def ) const
+{
+  if ( !mProject )
+    return def;
+
+  return mProject->readDoubleEntry( scope, key, def );
+}
+
 bool QgisMobileapp::print( const QString &layoutName )
 {
 #ifndef QT_NO_PRINTER

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -109,14 +109,47 @@ class QFIELD_CORE_EXPORT QgisMobileapp : public QQmlApplicationEngine
     void readProjectFile();
 
     /**
-     * Prints a given layout to a PDF file
+     * Reads a string from the specified \a scope and \a key from the currently opened project
+     *
+     * \param scope entry scope (group) name
+     * \param key entry key name. Keys are '/'-delimited entries, implying a hierarchy of keys and corresponding values
+     * \param def default value to return if the specified \a key does not exist within the \a scope
+     *
+     * \returns entry value as string from \a scope given its \a key
+     */
+    QString readProjectEntry( const QString &scope, const QString &key, const QString &def = QString() ) const;
+
+    /**
+     * Reads an integer from the specified \a scope and \a key from the currently opened project
+     *
+     * \param scope entry scope (group) name
+     * \param key entry key name. Keys are '/'-delimited entries, implying a hierarchy of keys and corresponding values
+     * \param def default value to return if the specified \a key does not exist within the \a scope
+     *
+     * \returns entry value as integer from \a scope given its \a key
+     */
+    int readProjectNumEntry( const QString &scope, const QString &key, int def = 0 ) const;
+
+    /**
+     * Reads a double from the specified \a scope and \a key from the currently opened project
+     *
+     * \param scope entry scope (group) name
+     * \param key entry key name. Keys are '/'-delimited entries, implying a hierarchy of keys and corresponding values
+     * \param def default value to return if the specified \a key does not exist within the \a scope
+     *
+     * \returns entry value as double from \a scope given its \a key
+     */
+    double readProjectDoubleEntry( const QString &scope, const QString &key, double def = 0.0 ) const;
+
+    /**
+     * Prints a given layout from the currently opened project to a PDF file
      * \param layoutName the layout name that will be printed
      * \return TRUE if the layout was successfully printed
      */
     bool print( const QString &layoutName );
 
     /**
-     * Prints a given atlas-driven layout to one or more PDF files
+     * Prints a given atlas-driven layout from the currently opened project to one or more PDF files
      * \param layoutName the layout name that will be printed
      * \param featureIds the features from the atlas coverage vector layer that will be used to print the layout
      * \return TRUE if the layout was successfully printed

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -356,6 +356,10 @@ EditorWidgetBase {
     function onPictureReceived(path) {
       if( path )
       {
+          var maximumWidhtHeight = iface.readProjectNumEntry("qfieldsync", "maximumWidthHeight", 0)
+          if(maximumWidhtHeight > 0) {
+              iface.restrictImageSize(prefixToRelativePath + path, maximumWidhtHeight)
+          }
           valueChangeRequested(path, false)
       }
     }

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -341,7 +341,7 @@ EditorWidgetBase {
             var filepath = getPictureFilePath()
             platformUtilities.renameFile( path, prefixToRelativePath + filepath)
 
-            var maximumWidhtHeight = iface.readProjectNumEntry("qfieldsync", "maximumWidthHeight", 0)
+            var maximumWidhtHeight = iface.readProjectNumEntry("qfieldsync", "maximumImageWidthHeight", 0)
             if(maximumWidhtHeight > 0) {
                 iface.restrictImageSize(prefixToRelativePath + filepath, maximumWidhtHeight)
             }
@@ -362,7 +362,7 @@ EditorWidgetBase {
     function onPictureReceived(path) {
       if( path )
       {
-          var maximumWidhtHeight = iface.readProjectNumEntry("qfieldsync", "maximumWidthHeight", 0)
+          var maximumWidhtHeight = iface.readProjectNumEntry("qfieldsync", "maximumImageWidthHeight", 0)
           if(maximumWidhtHeight > 0) {
               iface.restrictImageSize(prefixToRelativePath + path, maximumWidhtHeight)
           }

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -339,7 +339,13 @@ EditorWidgetBase {
 
         onFinished: {
             var filepath = getPictureFilePath()
-            platformUtilities.renameFile( path, qgisProject.homePath +'/' + filepath)
+            platformUtilities.renameFile( path, prefixToRelativePath + filepath)
+
+            var maximumWidhtHeight = iface.readProjectNumEntry("qfieldsync", "maximumWidthHeight", 0)
+            if(maximumWidhtHeight > 0) {
+                iface.restrictImageSize(prefixToRelativePath + filepath, maximumWidhtHeight)
+            }
+
             valueChangeRequested(filepath, false)
             campopup.close()
         }
@@ -360,6 +366,7 @@ EditorWidgetBase {
           if(maximumWidhtHeight > 0) {
               iface.restrictImageSize(prefixToRelativePath + path, maximumWidhtHeight)
           }
+
           valueChangeRequested(path, false)
       }
     }


### PR DESCRIPTION
This PR adds the necessary bits on the QField side of things to implement a maximum picture width/height restriction to images/photos from the camera (native or Qt) and gallery. 

Note to self/others: we should eventually add Q_INVOKABLE functions to the QgsProject class in QGIS to avoid the iface.readProject{Num,Double}Entry() bridges in here. But that's for the future.