### PR TITLE
Add a up/back button in the open local project/dataset activity navigation bar

### DIFF
--- a/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -74,7 +74,14 @@ public class QFieldProjectActivity
         setContentView(R.layout.list_projects);
         getActionBar().setBackgroundDrawable(
             new ColorDrawable(Color.parseColor("#80CC28")));
+        getActionBar().setDisplayHomeAsUpEnabled(true);
         drawView();
+    }
+
+    @Override
+    public boolean onNavigateUp() {
+        finish();
+        return true;
     }
 
     @Override


### PR DESCRIPTION
This PR adds a back button in the open local project/dataset activity's navigation bar:

![image](https://user-images.githubusercontent.com/1728657/163516811-5cf66fff-e261-4b0c-b6ad-e9247044d860.png)

That harmonizes this piece of Java UI with other QML counterparts.