### PR TITLE
Storage help

### DIFF
--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -32,7 +32,8 @@
     android:label="@APP_NAME@"
     android:icon="@AT@drawable/@APP_ICON@"
     android:usesCleartextTraffic="true"
-    android:requestLegacyExternalStorage="true" >
+    android:requestLegacyExternalStorage="true"
+    android:theme="@style/AppTheme">
     <activity
       android:name="ch.opengis.@APP_PACKAGE_NAME@.QFieldActivity"
       android:label="@APP_NAME@"

--- a/platform/android/build.gradle.in
+++ b/platform/android/build.gradle.in
@@ -36,8 +36,9 @@ def outputPathName = "some.apk"
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.documentfile:documentfile:1.0.1'
+    implementation "androidx.fragment:fragment:1.3.4"
 }
 
 android {

--- a/platform/android/res/values/colors.xml
+++ b/platform/android/res/values/colors.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!--   color for the app bar and other primary UI elements -->
+    <color name="colorPrimary">#80cc28</color>
+
+    <!--   a darker variant of the primary color, used for
+           the status bar (on Android 5.0+) and contextual app bars -->
+    <color name="colorPrimaryDark">#5a8924</color>
+
+    <!--   a secondary color for controls like checkboxes and text fields -->
+    <color name="colorAccent">#80cc28</color>
+</resources>

--- a/platform/android/res/values/strings.xml
+++ b/platform/android/res/values/strings.xml
@@ -64,4 +64,8 @@
     <string name="delete_confirm_folder">The project folder will be permamently deleted, proceed with removal?</string>
     <string name="delete_confirm">Remove</string>
     <string name="delete_cancel">Cancel</string>
+    <string name="storage_information_title">Storage Information</string>
+    <string name="storage_information_message">Whether you are a pre-existing QField 1.x user wondering why your projects and datasets have gone missing or new to QField, we suggest you take a minute to read the storage handling documentation. A shortcut to this documentation will remain accessible in the title bar\'s actions menu.</string>
+    <string name="storage_information_view">Yes, show me the documentation</string>
+    <string name="storage_information_dismiss">No, I\'ll read later</string>
 </resources>

--- a/platform/android/res/values/strings.xml
+++ b/platform/android/res/values/strings.xml
@@ -66,6 +66,6 @@
     <string name="delete_cancel">Cancel</string>
     <string name="storage_information_title">Storage Information</string>
     <string name="storage_information_message">Whether you are a pre-existing QField 1.x user wondering why your projects and datasets have gone missing or new to QField, we suggest you take a minute to read the storage handling documentation. A shortcut to this documentation will remain accessible in the title bar\'s actions menu.</string>
-    <string name="storage_information_view">Yes, show me the documentation</string>
-    <string name="storage_information_dismiss">No, I\'ll read later</string>
+    <string name="storage_information_view">Show me the documentation</string>
+    <string name="storage_information_dismiss">I\'ll read later</string>
 </resources>

--- a/platform/android/res/values/styles.xml
+++ b/platform/android/res/values/styles.xml
@@ -1,0 +1,7 @@
+<resources>
+    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorAccent</item>
+    </style>
+</resources>

--- a/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -58,6 +58,9 @@ public class QFieldProjectActivity
     extends AppCompatActivity implements OnMenuItemClickListener {
 
     private static final String TAG = "QField Project Activity";
+    private static String STORAGE_HELP_URL =
+        "https://docs.qfield.org/get-started/storage";
+
     private String path;
     private SharedPreferences sharedPreferences;
     SharedPreferences.Editor editor;
@@ -70,12 +73,44 @@ public class QFieldProjectActivity
     public void onCreate(Bundle bundle) {
         super.onCreate(bundle);
 
-        sharedPreferences = getPreferences(Context.MODE_PRIVATE);
-        editor = sharedPreferences.edit();
         setContentView(R.layout.list_projects);
         getSupportActionBar().setBackgroundDrawable(
             new ColorDrawable(Color.parseColor("#80CC28")));
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
+        sharedPreferences = getPreferences(Context.MODE_PRIVATE);
+        editor = sharedPreferences.edit();
+
+        boolean storageDialogShown =
+            sharedPreferences.getBoolean("StorageDialogShown", false);
+        if (!storageDialogShown) {
+            AlertDialog.Builder builder = new AlertDialog.Builder(this);
+            builder.setTitle(getString(R.string.storage_information_title));
+            builder.setMessage(getString(R.string.storage_information_message));
+            builder.setPositiveButton(
+                getString(R.string.storage_information_view),
+                new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        dialog.dismiss();
+                        Intent i = new Intent(Intent.ACTION_VIEW);
+                        i.setData(Uri.parse(STORAGE_HELP_URL));
+                        startActivity(i);
+                    }
+                });
+            builder.setNegativeButton(
+                getString(R.string.storage_information_dismiss),
+                new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        dialog.dismiss();
+                    }
+                });
+            AlertDialog dialog = builder.create();
+            dialog.setCancelable(true);
+            dialog.show();
+
+            editor.putBoolean("StorageDialogShown", true);
+        }
+
         drawView();
     }
 
@@ -129,9 +164,8 @@ public class QFieldProjectActivity
                 return true;
             }
             case R.id.usb_cable_help: {
-                String url = "https://qfield.org/docs/";
                 Intent i = new Intent(Intent.ACTION_VIEW);
-                i.setData(Uri.parse(url));
+                i.setData(Uri.parse(STORAGE_HELP_URL));
                 startActivity(i);
                 return true;
             }

--- a/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -35,6 +35,7 @@ import android.widget.ListView;
 import android.widget.PopupMenu;
 import android.widget.PopupMenu.OnMenuItemClickListener;
 import android.widget.Toast;
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
 import androidx.core.view.MenuCompat;
@@ -54,7 +55,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 public class QFieldProjectActivity
-    extends Activity implements OnMenuItemClickListener {
+    extends AppCompatActivity implements OnMenuItemClickListener {
 
     private static final String TAG = "QField Project Activity";
     private String path;
@@ -72,9 +73,9 @@ public class QFieldProjectActivity
         sharedPreferences = getPreferences(Context.MODE_PRIVATE);
         editor = sharedPreferences.edit();
         setContentView(R.layout.list_projects);
-        getActionBar().setBackgroundDrawable(
+        getSupportActionBar().setBackgroundDrawable(
             new ColorDrawable(Color.parseColor("#80CC28")));
-        getActionBar().setDisplayHomeAsUpEnabled(true);
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         drawView();
     }
 
@@ -391,7 +392,7 @@ public class QFieldProjectActivity
             Log.d(TAG, "extra path: " + getIntent().getStringExtra("path"));
             File dir = new File(getIntent().getStringExtra("path"));
             setTitle(getIntent().getStringExtra("label"));
-            getActionBar().setSubtitle(dir.getPath());
+            getSupportActionBar().setSubtitle(dir.getPath());
 
             if (!dir.canRead()) {
                 setTitle(getTitle() + " (" + getString(R.string.inaccessible) +


### PR DESCRIPTION
This PR introduces a one-time pop up dialog when users first launch the project/dataset picker activity to provide them with a one-click access to storage handling documentation:
![image](https://user-images.githubusercontent.com/1728657/163548501-9c02536e-57e9-4841-8238-f59c2dd77423.png)

Hopefully this will help guide QField 1.x users migrating into the new Google-imposed storage paradigm. It also serves as a good intro to newcomers too.