### PR TITLE
Insure that our rubber bands take device pixel ratio into account to harmonize rendering on all screen densities

### DIFF
--- a/src/core/rubberband.cpp
+++ b/src/core/rubberband.cpp
@@ -172,7 +172,7 @@ QSGNode *Rubberband::updatePaintNode( QSGNode *n, QQuickItem::UpdatePaintNodeDat
     {
       transformPoints( allVertices );
 
-      SGRubberband *rb = new SGRubberband( allVertices, geomType, mColor, mWidth );
+      SGRubberband *rb = new SGRubberband( allVertices, geomType, mColor, mWidth * mMapSettings->devicePixelRatio() );
       rb->setFlag( QSGNode::OwnedByParent );
       n->appendChildNode( rb );
 
@@ -181,7 +181,7 @@ QSGNode *Rubberband::updatePaintNode( QSGNode *n, QQuickItem::UpdatePaintNodeDat
         QVector<QgsPoint> allButCurrentVertices = mRubberbandModel->flatVertices( true );
         transformPoints( allButCurrentVertices );
 
-        SGRubberband *rbCurrentPoint = new SGRubberband( allButCurrentVertices, geomType, mColorCurrentPoint, mWidthCurrentPoint );
+        SGRubberband *rbCurrentPoint = new SGRubberband( allButCurrentVertices, geomType, mColorCurrentPoint, mWidthCurrentPoint * mMapSettings->devicePixelRatio() );
         rbCurrentPoint->setFlag( QSGNode::OwnedByParent );
         n->appendChildNode( rbCurrentPoint );
       }
@@ -192,12 +192,12 @@ QSGNode *Rubberband::updatePaintNode( QSGNode *n, QQuickItem::UpdatePaintNodeDat
   return n;
 }
 
-qreal Rubberband::width() const
+float Rubberband::width() const
 {
   return mWidth;
 }
 
-void Rubberband::setWidth( qreal width )
+void Rubberband::setWidth( float width )
 {
   if ( mWidth == width )
     return;
@@ -222,12 +222,12 @@ void Rubberband::setColor( const QColor &color )
   emit colorChanged();
 }
 
-qreal Rubberband::widthCurrentPoint() const
+float Rubberband::widthCurrentPoint() const
 {
   return mWidthCurrentPoint;
 }
 
-void Rubberband::setWidthCurrentPoint( qreal width )
+void Rubberband::setWidthCurrentPoint( float width )
 {
   if ( mWidthCurrentPoint == width )
     return;

--- a/src/core/rubberband.h
+++ b/src/core/rubberband.h
@@ -61,9 +61,9 @@ class Rubberband : public QQuickItem
     void setColor( const QColor &color );
 
     //! \copydoc width
-    qreal width() const;
+    float width() const;
     //! \copydoc width
-    void setWidth( qreal width );
+    void setWidth( float width );
 
     //! \copydoc colorCurrentPoint
     QColor colorCurrentPoint() const;
@@ -71,9 +71,9 @@ class Rubberband : public QQuickItem
     void setColorCurrentPoint( const QColor &color );
 
     //! \copydoc widthCurrentPoint
-    qreal widthCurrentPoint() const;
+    float widthCurrentPoint() const;
     //! \copydoc widthCurrentPoint
-    void setWidthCurrentPoint( qreal width );
+    void setWidthCurrentPoint( float width );
 
   signals:
     void modelChanged();
@@ -103,9 +103,9 @@ class Rubberband : public QQuickItem
     QgsQuickMapSettings *mMapSettings = nullptr;
     bool mDirty = false;
     QColor mColor = QColor( 192, 57, 43, 80 );
-    qreal mWidth = 1.8;
+    float mWidth = 1.8;
     QColor mColorCurrentPoint = QColor( 192, 57, 43, 150 );
-    qreal mWidthCurrentPoint = 1.2;
+    float mWidthCurrentPoint = 1.2;
 };
 
 

--- a/src/core/sgrubberband.cpp
+++ b/src/core/sgrubberband.cpp
@@ -23,7 +23,7 @@
 #include <qgssurface.h>
 #include <qgstessellator.h>
 
-SGRubberband::SGRubberband( const QVector<QgsPoint> &points, QgsWkbTypes::GeometryType type, const QColor &color, qreal width )
+SGRubberband::SGRubberband( const QVector<QgsPoint> &points, QgsWkbTypes::GeometryType type, const QColor &color, float width )
   : QSGNode()
 {
   mMaterial.setColor( color );
@@ -85,7 +85,7 @@ SGRubberband::SGRubberband( const QVector<QgsPoint> &points, QgsWkbTypes::Geomet
   }
 }
 
-QSGGeometryNode *SGRubberband::createLineGeometry( const QVector<QgsPoint> &points, qreal width )
+QSGGeometryNode *SGRubberband::createLineGeometry( const QVector<QgsPoint> &points, float width )
 {
   QSGGeometryNode *node = new QSGGeometryNode;
   QSGGeometry *sgGeom = new QSGGeometry( QSGGeometry::defaultAttributes_Point2D(), points.count() );

--- a/src/core/sgrubberband.h
+++ b/src/core/sgrubberband.h
@@ -32,10 +32,10 @@ class RubberbandModel;
 class SGRubberband : public QSGNode
 {
   public:
-    SGRubberband( const QVector<QgsPoint> &points, QgsWkbTypes::GeometryType type, const QColor &color, qreal width );
+    SGRubberband( const QVector<QgsPoint> &points, QgsWkbTypes::GeometryType type, const QColor &color, float width );
 
   private:
-    QSGGeometryNode *createLineGeometry( const QVector<QgsPoint> &points, qreal width );
+    QSGGeometryNode *createLineGeometry( const QVector<QgsPoint> &points, float width );
     QSGGeometryNode *createPolygonGeometry( const QVector<QgsPoint> &points );
 
     QSGFlatColorMaterial mMaterial;

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -395,7 +395,7 @@ ApplicationWindow {
     /** A rubberband for measuring **/
     Rubberband {
       id: measuringRubberband
-      width: 2
+      width: 2.5
       color: '#80000000'
 
       mapSettings: mapCanvas.mapSettings
@@ -423,7 +423,7 @@ ApplicationWindow {
     /** A rubberband for ditizing **/
     Rubberband {
       id: digitizingRubberband
-      width: 2
+      width: 2.5
 
       mapSettings: mapCanvas.mapSettings
 
@@ -442,7 +442,7 @@ ApplicationWindow {
     /** A rubberband for the different geometry editors **/
     Rubberband {
       id: geometryEditorsRubberband
-      width: 2
+      width: 2.5
       color: '#80000000'
 
       mapSettings: mapCanvas.mapSettings


### PR DESCRIPTION
Until now, we were not taking into account the device pixel ratio when rendering the rubber band's QSGGeometry. This meant that lines would look fine on some screens (i.e. a developer's desktop screen) but would look quite small on devices with high density screens.

A similar fix was applied to the line polygon geometry objects a short while back.

This fixes #2362.