### PR TITLE
Fix QField unable to import project from a number of ZIP files, rename functions

### DIFF
--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -174,7 +174,7 @@ public class QFieldActivity extends QtActivity {
                     new File(projectPath).mkdir();
                     try {
                         InputStream input = resolver.openInputStream(uri);
-                        QFieldUtils.inputStreamToFolder(input, projectPath);
+                        QFieldUtils.zipToFolder(input, projectPath);
                     } catch (Exception e) {
                         e.printStackTrace();
                     }

--- a/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -238,7 +238,8 @@ public class QFieldProjectActivity
             case R.id.send_compressed_to: {
                 File temporaryFile =
                     new File(getCacheDir(), file.getName() + ".zip");
-                QFieldUtils.zipFolder(file.getPath(), temporaryFile.getPath());
+                QFieldUtils.folderToZip(file.getPath(),
+                                        temporaryFile.getPath());
 
                 DocumentFile documentFile =
                     DocumentFile.fromFile(temporaryFile);
@@ -902,8 +903,7 @@ public class QFieldProjectActivity
                     try {
                         InputStream input =
                             resolver.openInputStream(archiveUri);
-                        imported =
-                            QFieldUtils.inputStreamToFolder(input, importPath);
+                        imported = QFieldUtils.zipToFolder(input, importPath);
                     } catch (Exception e) {
                         e.printStackTrace();
                         AlertDialog alertDialog =

--- a/platform/android/src/ch/opengis/qfield/QFieldUtils.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldUtils.java
@@ -136,7 +136,7 @@ public class QFieldUtils {
         return true;
     }
 
-    public static boolean inputStreamToFolder(InputStream in, String folder) {
+    public static boolean zipToFolder(InputStream in, String folder) {
         try {
             ZipInputStream zin = new ZipInputStream(in);
             ZipEntry entry;
@@ -144,6 +144,12 @@ public class QFieldUtils {
                 if (entry.isDirectory()) {
                     new File(folder + entry.getName()).mkdirs();
                     continue;
+                } else {
+                    // some ZIP files don't include directory items, we
+                    // therefore have to make sure parent directories are always
+                    // created
+                    new File(new File(folder + entry.getName()).getParent())
+                        .mkdirs();
                 }
                 OutputStream out =
                     new FileOutputStream(new File(folder + entry.getName()));
@@ -162,7 +168,7 @@ public class QFieldUtils {
         return true;
     }
 
-    public static boolean zipFolder(String folder, String archivePath) {
+    public static boolean folderToZip(String folder, String archivePath) {
         try {
             FileOutputStream out = new FileOutputStream(archivePath);
             ZipOutputStream zip = new ZipOutputStream(out);


### PR DESCRIPTION
TIL: some ZIP programs don't include directory items, only the files (attached to which they prepend folder names to the file name string).

So for e.g., some ZIP programs do:
- my_dir/
- my_dir/my_file.txt

While other ZIP programs would only do:
- my_dir/my_file.txt

This PR insures QField behaves on both types.