### PR TITLE
Fix virtual keyboard not opening when first launching QField on Android platform

### DIFF
--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -39,6 +39,7 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Application;
 import android.app.Dialog;
+import android.app.ProgressDialog;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -82,6 +83,7 @@ public class QFieldActivity extends QtActivity {
 
     private SharedPreferences sharedPreferences;
     private SharedPreferences.Editor sharedPreferenceEditor;
+    private ProgressDialog progressDialog;
 
     public static native void openProject(String url);
     private float originalBrightness;
@@ -225,6 +227,18 @@ public class QFieldActivity extends QtActivity {
         WindowManager.LayoutParams lp = getWindow().getAttributes();
         lp.screenBrightness = originalBrightness;
         getWindow().setAttributes(lp);
+    }
+
+    private void showBlockingProgressDialog(String message) {
+        progressDialog = ProgressDialog.show(this, "", message, true);
+        progressDialog.setCancelable(false);
+    }
+
+    private void dismissBlockingProgressDialog() {
+        if (progressDialog != null) {
+            progressDialog.dismiss();
+            progressDialog = null;
+        }
     }
 
     private void initiateSentry() {

--- a/src/core/utils/fileutils.cpp
+++ b/src/core/utils/fileutils.cpp
@@ -100,7 +100,8 @@ bool FileUtils::copyRecursively( const QString &sourceFolder, const QString &des
 
     QFile( destName ).setPermissions( QFileDevice::ReadOwner | QFileDevice::WriteOwner );
 
-    feedback->setProgress( 100 * current / fileCount );
+    if ( feedback )
+      feedback->setProgress( 100 * current / fileCount );
 
     ++current;
   }

--- a/src/core/utils/fileutils.h
+++ b/src/core/utils/fileutils.h
@@ -40,7 +40,7 @@ class QFIELD_CORE_EXPORT FileUtils : public QObject
     Q_INVOKABLE static bool fileExists( const QString &filePath );
     //! returns the suffix (extension)
     Q_INVOKABLE static QString fileSuffix( const QString &filePath );
-    static bool copyRecursively( const QString &sourceFolder, const QString &destFolder, QgsFeedback *feedback, bool wipeDestFolder = true );
+    static bool copyRecursively( const QString &sourceFolder, const QString &destFolder, QgsFeedback *feedback = nullptr, bool wipeDestFolder = true );
     /**
      * Creates checksum of a file. Returns null QByteArray if cannot be calculated.
      *


### PR DESCRIPTION
Big, bad bug ATM: when installing _or upgrading_ QField on Android, the subsequent first launch "breaks" the virtual keyboard. Simple steps to witness the issue:
- Uninstall QField
- Re-install QField
- Launch QField, click on the "QFieldCloud projects" button
- Tap on the username text field
- **Notice the virtual keyboard _fails to show up_ :fearful: **
- Go back to the welcome screen
- Click on the simple bees farming demo
- Click on the map search bar
- **Notice the virtual keyboard _fails to show up_ :fearful: **

It only happens once. And the only thing that happens once when installing or upgrading is the asset copying process, which creates a pair of QApplication + QQmlApplicationEngine to provide some feedback, then quit() the app, followed by the creation of another QGuiApplication + QQmlApplicationEngine (the main QField QML scene/app). Doing that results in the second pair of application + QML application engine scene not being able to open the virtual keyboard.

I couldn't find an easy fix to this dual consecutive launch of a qml application on Android. 

The solution to fix this problem is to let go of the ephemeral QQmlApplicationEngine in favor of a simpler progress dialog popup on the java side of things (different thread, responsive UI). The bonus is that is _greatly_ simplifies the copying process as we can avoid the additional QThread (since the platform utils code is already running in a separate thread from the java UI).

IMHO this is an important issue we need to address, it makes for a really bad _first use experience_, which is crucial.