### PR TITLE
Set a nice QField-green default app-wide hyperlink color

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -166,6 +166,12 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   format.setSamples( 4 );
   QSurfaceFormat::setDefaultFormat( format );
 
+  // Set a nicer default hyperlink color to be used in QML Text items
+  QPalette palette = app->palette();
+  palette.setColor( QPalette::Link, QColor( 128, 204, 40 ) );
+  palette.setColor( QPalette::LinkVisited, QColor( 128, 204, 40 ) );
+  app->setPalette( palette );
+
   QSettings settings;
   if ( PlatformUtilities::instance()->capabilities() & PlatformUtilities::AdjustBrightness )
   {

--- a/src/qml/About.qml
+++ b/src/qml/About.qml
@@ -75,7 +75,7 @@ Item {
                             if (appVersion && appVersion !== '1.0.0')
                                 links += ' <a href="https://github.com/opengisch/QField/releases/tag/' + appVersion + '">' + appVersion + '</a>'
 
-                            return "<style>a, a:hover, a:visited { color:" + Theme.mainColor + "; }></style>QField<br>" + appVersionStr + " (" + links + ")"
+                            return "QField<br>" + appVersionStr + " (" + links + ")"
                         }
                         onLinkActivated: Qt.openUrlExternally(link)
                     }
@@ -108,7 +108,7 @@ Item {
                         font: Theme.strongFont
                         color: Theme.light
                         textFormat: Text.RichText
-                        text: '<style>a, a:hover, a:visited { color:' + Theme.mainColor + '; }></style>' +qsTr( "Developed by" ) + '<br><a href="https://opengis.ch">OPENGIS.ch</a>'
+                        text: qsTr( "Developed by" ) + '<br><a href="https://opengis.ch">OPENGIS.ch</a>'
                         onLinkActivated: Qt.openUrlExternally(link)
                     }
                 }

--- a/src/qml/QFieldCloudLogin.qml
+++ b/src/qml/QFieldCloudLogin.qml
@@ -209,8 +209,7 @@ Item {
         id: cloudRegisterLabel
         Layout.fillWidth: true
         Layout.topMargin:6
-        text: '<style>a, a:hover, a:visited { color:' + Theme.mainColor + '; }></style>' +
-              qsTr( 'New user?') + ' <a href="https://app.qfield.cloud/accounts/signup/">' + qsTr( 'Register an account' ) + '</a>.'
+        text: qsTr( 'New user?') + ' <a href="https://app.qfield.cloud/accounts/signup/">' + qsTr( 'Register an account' ) + '</a>.'
         horizontalAlignment: Text.AlignHCenter
         font: Theme.defaultFont
         textFormat: Text.RichText
@@ -222,8 +221,7 @@ Item {
       Text {
         id: cloudIntroLabel
         Layout.fillWidth: true
-        text: '<style>a, a:hover, a:visited { color:' + Theme.mainColor + '; }></style>' +
-              qsTr( 'The easiest way to transfer you project from QGIS to your devices!' ) +
+        text: qsTr( 'The easiest way to transfer you project from QGIS to your devices!' ) +
               ' <a href="https://qfield.cloud/">' + qsTr( 'Learn more about QFieldCloud' ) + '</a>.'
         horizontalAlignment: Text.AlignHCenter
         font: Theme.defaultFont

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -45,8 +45,7 @@ Popup {
       Text {
         Layout.fillWidth: true
         font: Theme.defaultFont
-        text: '<style>a, a:hover, a:visited { color:' + Theme.mainColor + '; }></style>' +
-              qsTr('The current project is not stored on QFieldCloud.<br><br>') +
+        text: qsTr('The current project is not stored on QFieldCloud.<br><br>') +
               qsTr('Storing projects on QFieldCloud offers seamless synchornization, offline editing, and team management.<br><br>') +
               ' <a href="https://qfield.cloud/">' + qsTr( 'Learn more about QFieldCloud' ) + '</a>.'
         textFormat: Text.RichText

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -331,8 +331,7 @@ Page {
                       }
 
                       Label {
-                          text: '<style>a, a:hover, a:visited { color:' + Theme.mainColor + '; }></style>' +
-                                qsTr( "Found a missing or incomplete language? %1Join the translator community.%2" )
+                          text: qsTr( "Found a missing or incomplete language? %1Join the translator community.%2" )
                                   .arg( '<a href="https://www.transifex.com/opengisch/qfield-for-qgis/">' )
                                   .arg( '</a>' );
                           font: Theme.tipFont


### PR DESCRIPTION
Doing this allows us to skip CSS style declarations in a bunch of placement, but more importantly, it gets rid of the 1990s default blue hyperlink color for our changelogs panel. Long story short there is that QML Text formatted using MarkdownText hard-code style hyperlinks using the app's palette. 

My teeth won't grind every time I see an hyperlink in our release notes, woupidou.