### PR TITLE
Improve .pg_service.conf logic, prioritize the more secure location

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -289,14 +289,18 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
     delete[] newPaths;
 
 #ifdef Q_OS_ANDROID
-    QFileInfo appDir( PlatformUtilities::instance()->qfieldDataDir() );
-    if ( appDir.exists() && appDir.isReadable() )
+    QFileInfo pgServiceFile( QStringLiteral( "%1/.pg_service.conf" ).arg( PlatformUtilities::instance()->qfieldAppDataDir() ) );
+    if ( pgServiceFile.exists() && pgServiceFile.isReadable() )
     {
-      setenv( "PGSYSCONFDIR", PlatformUtilities::instance()->qfieldDataDir().toUtf8(), true );
+      setenv( "PGSYSCONFDIR", PlatformUtilities::instance()->qfieldAppDataDir().toUtf8(), true );
     }
     else
     {
-      setenv( "PGSYSCONFDIR", PlatformUtilities::instance()->qfieldAppDataDir().toUtf8(), true );
+      pgServiceFile.setFile( QStringLiteral( "%1/.pg_service.conf" ).arg( PlatformUtilities::instance()->qfieldDataDir() ) );
+      if ( pgServiceFile.exists() && pgServiceFile.isReadable() )
+      {
+        setenv( "PGSYSCONFDIR", PlatformUtilities::instance()->qfieldDataDir().toUtf8(), true );
+      }
     }
 #endif
 


### PR DESCRIPTION
The previous code was bad in two ways:
1/ it'd set the PGSYSCONFDIR to <system root>/QField/ even if a .pg_service.conf was not present
2/ it prioritized the less secure <system root>/QField/ location

This change is required to help crafting a proper documentation on this feature. In the documentation, we should only refer to <system root>/Android/data/ch.opengis.qfield/files/QField as the proper/safer location to store the .pg_service.conf.

We still need to keep the old location as a mean to insure compatibility with preexisting users on Android <= 9.