### PR TITLE
Always show the changelog once per version update

### DIFF
--- a/src/qml/Changelog.qml
+++ b/src/qml/Changelog.qml
@@ -122,10 +122,7 @@ Popup {
     }
 
     onClosed: {
-        if ( changelogContents.status === ChangelogContents.SuccessStatus ) {
-            settings.setValue( "/QField/ChangelogVersion", appVersion )
-        }
-
+        settings.setValue( "/QField/ChangelogVersion", appVersion )
         changelogFlickable.contentY = 0
     }
 


### PR DESCRIPTION
This fixes https://github.com/opengisch/QField/issues/2818 -- 

Long story short, we were waiting for a successful network fetching of the changelog to update the appVersion setting, which meant that if a device isn't meant to or is unable to connect to a network, the changelog overlay would pop up on every single launch.

I think we're better to play conservative here and only try to show the content once per app version update. 