### PR TITLE
User proper accentLightColor for the image frame

### DIFF
--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -639,7 +639,7 @@ Page {
                         y: parent.height - height - parent.bottomPadding / 2
                         implicitWidth: 120
                         height: parent.activeFocus ? 2: 1
-                        color: parent.activeFocus ? '#4CAF50' : '#C8E6C9'
+                        color: parent.activeFocus ? Theme.accentColor : Theme.accentLightColor
                       }
 
                       Component.onCompleted: {
@@ -680,7 +680,7 @@ Page {
                         y: parent.height - height - parent.bottomPadding / 2
                         implicitWidth: 120
                         height: parent.activeFocus ? 2: 1
-                        color: parent.activeFocus ? '#4CAF50' : '#C8E6C9'
+                        color: parent.activeFocus ? Theme.accentColor : Theme.accentLightColor
                       }
 
                       Component.onCompleted: {
@@ -788,7 +788,7 @@ Page {
                         y: parent.height - height - parent.bottomPadding / 2
                         implicitWidth: 120
                         height: parent.activeFocus ? 2: 1
-                        color: parent.activeFocus ? '#4CAF50' : '#C8E6C9'
+                        color: parent.activeFocus ? Theme.accentColor : Theme.accentLightColor
                       }
 
                       Component.onCompleted: {

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -329,13 +329,13 @@ Item {
                     y: comboBox.height - 12
                     width: comboBox.width
                     height: comboBox.activeFocus ? 2 : 1
-                    color: comboBox.activeFocus ? "#4CAF50" : "#C8E6C9"
+                    color: comboBox.activeFocus ? Theme.accentColor : Theme.accentLightColor
                 }
 
                 Rectangle {
                     visible: enabled
                     anchors.fill: parent
-                    border.color: comboBox.pressed ? "#4CAF50" : "#C8E6C9"
+                    border.color: comboBox.pressed ? Theme.accentColor : Theme.accentLightColor
                     border.width: comboBox.visualFocus ? 2 : 1
                     color: Theme.lightGray
                     radius: 2
@@ -500,7 +500,7 @@ Item {
                 onEnabledChanged: requestPaint()
             }
 
-            border.color: comboBox.pressed ? "#4CAF50" : "#C8E6C9"
+            border.color: comboBox.pressed ? Theme.accentColor : Theme.accentLightColor
             border.width: comboBox.visualFocus ? 2 : 1
             color: Theme.lightGray
             radius: 2

--- a/src/qml/Tracking.qml
+++ b/src/qml/Tracking.qml
@@ -253,7 +253,7 @@ Item{
                       y: parent.height - height - parent.bottomPadding / 2
                       implicitWidth: 120
                       height: parent.activeFocus ? 2: 1
-                      color: parent.activeFocus ? '#4CAF50' : '#C8E6C9'
+                      color: parent.activeFocus ? Theme.accentColor : Theme.accentLightColor
                     }
 
                     Component.onCompleted: {
@@ -325,7 +325,7 @@ Item{
                       y: parent.height - height - parent.bottomPadding / 2
                       implicitWidth: 120
                       height: parent.activeFocus ? 2: 1
-                      color: parent.activeFocus ? '#4CAF50' : '#C8E6C9'
+                      color: parent.activeFocus ? Theme.accentColor : Theme.accentLightColor
                     }
 
                     Component.onCompleted: {

--- a/src/qml/VariableEditor.qml
+++ b/src/qml/VariableEditor.qml
@@ -69,7 +69,7 @@ ColumnLayout {
                             y: variableNameText.height - height - variableNameText.bottomPadding / 2
                             implicitWidth: 120
                             height: variableNameText.activeFocus ? 2: variableNameText.enabled ? 1: 0
-                            color: variableNameText.activeFocus ? "#4CAF50" : "#C8E6C9"
+                            color: variableNameText.activeFocus ? Theme.accentColor : Theme.accentLightColor
                         }
 
                         onTextChanged: {
@@ -94,7 +94,7 @@ ColumnLayout {
                             y: variableValueText.height - height - variableValueText.bottomPadding / 2
                             implicitWidth: 120
                             height: variableValueText.activeFocus ? 2: variableNameText.enabled ? 1: 0
-                            color: variableValueText.activeFocus ? "#4CAF50" : "#C8E6C9"
+                            color: variableValueText.activeFocus ? Theme.accentColor : Theme.accentLightColor
                         }
 
                         onTextChanged: {

--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -79,7 +79,7 @@ EditorWidgetBase {
       y: checkValue.height - height - checkValue.bottomPadding / 2
       implicitWidth: 120
       height: checkBox.activeFocus || checkBox.pressed || checkArea.containsPress ? 2: 1
-      color: checkBox.activeFocus || checkBox.pressed || checkArea.containsPress ? "#4CAF50" : "#C8E6C9"
+      color: checkBox.activeFocus || checkBox.pressed || checkArea.containsPress ? Theme.accentColor : Theme.accentLightColor
   }
 
   FontMetrics {

--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -46,7 +46,7 @@ EditorWidgetBase {
         implicitWidth: 120
         width: label.width
         height: 1
-        color: "#C8E6C9"
+        color: Theme.accentLightColor
     }
 
     TextField {
@@ -112,7 +112,7 @@ EditorWidgetBase {
                 anchors.fill: parent
                 anchors.topMargin: label.topPadding / 2
                 anchors.bottomMargin: label.bottomPadding / 2
-                border.color: label.activeFocus ? "#4CAF50" : "#C8E6C9"
+                border.color: label.activeFocus ? Theme.accentColor : Theme.accentLightColor
                 border.width: label.activeFocus ? 2 : 1
                 color: enabled ? Theme.lightGray : "transparent"
                 radius: 2

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -157,7 +157,7 @@ EditorWidgetBase {
       y: linkField.height - height - linkField.bottomPadding / 2
       implicitWidth: 120
       height: 1
-      color: "#C8E6C9"
+      color: Theme.accentLightColor
     }
 
     MouseArea {

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -253,7 +253,7 @@ EditorWidgetBase {
           height: isEnabled ? parent.height : 1
           y: isEnabled ? 0 : parent.height - 1
           border.width: 1
-          border.color: Theme.mainColor
+          border.color: Theme.accentLightColor
           radius: 2
       }
   }

--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -53,7 +53,7 @@ EditorWidgetBase {
               y: textField.height - height - textField.bottomPadding / 2
               implicitWidth: 120
               height: textField.activeFocus ? 2: 1
-              color: textField.activeFocus ? "#4CAF50" : "#C8E6C9"
+              color: textField.activeFocus ? Theme.accentColor : Theme.accentLightColor
           }
 
           onTextChanged: {
@@ -225,7 +225,7 @@ EditorWidgetBase {
     width: sliderRow.width
     implicitWidth: 120
     height: slider.activeFocus ? 2: 1
-    color: slider.activeFocus ? "#4CAF50" : "#C8E6C9"
+    color: slider.activeFocus ? Theme.accentColor : Theme.accentLightColor
   }
 
   FontMetrics {

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -116,7 +116,7 @@ EditorWidgetBase {
       y: Math.max( textField.height, textArea.height ) - height - textField.bottomPadding / 2
       implicitWidth: 120
       height: textField.activeFocus || textArea.activeFocus ? 2: 1
-      color: textField.activeFocus || textArea.activeFocus ? "#4CAF50" : "#C8E6C9"
+      color: textField.activeFocus || textArea.activeFocus ? Theme.accentColor : Theme.accentLightColor
   }
 
   FontMetrics {

--- a/src/qml/editorwidgets/UuidGenerator.qml
+++ b/src/qml/editorwidgets/UuidGenerator.qml
@@ -43,7 +43,7 @@ EditorWidgetBase {
       y: uuidLabel.height - height - uuidLabel.bottomPadding / 2
       implicitWidth: 120
       height: 1
-      color: "#C8E6C9"
+      color: Theme.accentLightColor
   }
 
   FontMetrics {

--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -86,14 +86,14 @@ EditorWidgetBase {
         y: comboBox.height - 12
         width: comboBox.width
         height: comboBox.activeFocus ? 2: 1
-        color: comboBox.activeFocus ? "#4CAF50" : "#C8E6C9"
+        color: comboBox.activeFocus ? Theme.accentColor : Theme.accentLightColor
       }
 
       Rectangle {
         visible: enabled
         anchors.fill: parent
         id: backgroundRect
-        border.color: comboBox.pressed ? "#4CAF50" : "#C8E6C9"
+        border.color: comboBox.pressed ? Theme.accentColor : Theme.accentLightColor
         border.width: comboBox.visualFocus ? 2 : 1
         color: Theme.lightGray
         radius: 2

--- a/src/qml/imports/Theme/QfTextField.qml
+++ b/src/qml/imports/Theme/QfTextField.qml
@@ -32,7 +32,7 @@ Item {
       y: textField.height - height - textField.bottomPadding / 2
       implicitWidth: 120
       height: textField.activeFocus ? 2: 1
-      color: textField.activeFocus ? '#4CAF50' : '#C8E6C9'
+      color: textField.activeFocus ? Theme.accentColor : Theme.accentLightColor
     }
 
     onActiveFocusChanged: {

--- a/src/qml/imports/Theme/Theme.qml
+++ b/src/qml/imports/Theme/Theme.qml
@@ -30,6 +30,9 @@ QtObject {
     property color bookmarkRed: "#c0392b"
     property color bookmarkBlue: "#64b5f6"
 
+    property color accentColor: '#4CAF50'
+    property color accentLightColor: '#C8E6C9'
+
     property font defaultFont
     defaultFont.pointSize: 16
     defaultFont.weight: Font.Normal


### PR DESCRIPTION
This PR fixes the visual inconsistency spotted in this screenshot:

![image](https://user-images.githubusercontent.com/1728657/165729227-7ebde429-bcf2-4d0a-8c34-41dfea58f54c.png)

I took the opportunity to move those colors to our Theme object.