### PR TITLE
The features locator should not show "set feature as navigation destinaiton" action for geometryless layers

### DIFF
--- a/src/core/locator/featureslocatorfilter.cpp
+++ b/src/core/locator/featureslocatorfilter.cpp
@@ -117,7 +117,7 @@ void FeaturesLocatorFilter::fetchResults( const QString &string, const QgsLocato
       result.actions << QgsLocatorResult::ResultAction( OpenForm, tr( "Open form" ), QStringLiteral( "ic_baseline-list_alt-24px" ) );
       if ( preparedLayer->layerGeometryType != QgsWkbTypes::NullGeometry && preparedLayer->layerGeometryType != QgsWkbTypes::UnknownGeometry )
       {
-        result.actions << QgsLocatorResult::ResultAction( Navigation, tr( "Set feature as navigation" ), QStringLiteral( "ic_navigation_flag_purple_24dp" ) );
+        result.actions << QgsLocatorResult::ResultAction( Navigation, tr( "Set feature as destination" ), QStringLiteral( "ic_navigation_flag_purple_24dp" ) );
       }
 
       emit resultFetched( result );

--- a/src/core/locator/featureslocatorfilter.h
+++ b/src/core/locator/featureslocatorfilter.h
@@ -54,6 +54,7 @@ class FeaturesLocatorFilter : public QgsLocatorFilter
         QString layerName;
         QString layerId;
         QIcon layerIcon;
+        QgsWkbTypes::GeometryType layerGeometryType;
     };
 
     explicit FeaturesLocatorFilter( LocatorModelSuperBridge *locatorBridge, QObject *parent = nullptr );

--- a/src/qml/LocatorItem.qml
+++ b/src/qml/LocatorItem.qml
@@ -210,7 +210,7 @@ Item {
 
         anchors.margins: 10
         height: isFilterName || isGroup ? 30 : 40
-        width: parent.width
+        width: resultsList.width
         color: isFilterName ? Theme.mainColor : isGroup ? Theme.lightGray : "white"
         opacity: 0.95
 


### PR DESCRIPTION
Because we don't need to confuse users with an irrelevant action, let's hide the set feature as destination action in the search bar's features locator:

![image](https://user-images.githubusercontent.com/1728657/166133128-cfe0e5d9-3f26-4821-a7c3-cd250f36232f.png)

