### PR TITLE
Don't auto lock please

### DIFF
--- a/src/core/platforms/ios/iosplatformutilities.h
+++ b/src/core/platforms/ios/iosplatformutilities.h
@@ -31,6 +31,7 @@ class IosPlatformUtilities : public PlatformUtilities
     QString systemGenericDataLocation() const override;
     bool checkPositioningPermissions() const override;
     bool checkCameraPermissions() const override;
+    void setScreenLockPermission( const bool allowLock ) override;
     virtual PictureSource *getCameraPicture( QQuickItem *parent, const QString &prefix, const QString &pictureFilePath, const QString &suffix ) override;
     virtual PictureSource *getGalleryPicture( QQuickItem *parent, const QString &prefix, const QString &pictureFilePath ) override;
     virtual ProjectSource *openProject( QObject *parent = nullptr ) override;

--- a/src/core/platforms/ios/iosplatformutilities.mm
+++ b/src/core/platforms/ios/iosplatformutilities.mm
@@ -57,6 +57,14 @@ bool IosPlatformUtilities::checkCameraPermissions() const {
   return true;
 }
 
+void IosPlatformUtilities::setScreenLockPermission(const bool allowLock) {
+  if (allowLock) {
+    [UIApplication sharedApplication].idleTimerDisabled = NO;
+  } else {
+    [UIApplication sharedApplication].idleTimerDisabled = YES;
+  }
+}
+
 PictureSource *IosPlatformUtilities::getCameraPicture(
     QQuickItem *parent, const QString &prefix, const QString &pictureFilePath,
     const QString &suffix) {


### PR DESCRIPTION
Tried QFieldCloud on QField iOS earlier today. One fundamental flaw: I couldn't get to download a 80mb project because the screen kept auto-locking (followed by outstanding network requests shutting down).

Let's just do what we do with QField, which is disable auto lock.