### PR TITLE
Double escape backslash

### DIFF
--- a/cmake/Package.cmake
+++ b/cmake/Package.cmake
@@ -27,7 +27,7 @@ if(WIN32)
     # set(CPACK_WIX_TEMPLATE "${CMAKE_SOURCE_DIR}/cmake/windows/template.wxs.in")
     # set(CPACK_WIX_EXTRA_SOURCES "${CMAKE_SOURCE_DIR}/cmake/windows/shortcuts.wxs")
     # set(CPACK_GENERATOR "WIX")
-    set(CPACK_NSIS_EXECUTABLES_DIRECTORY "usr\\bin")
+    set(CPACK_NSIS_EXECUTABLES_DIRECTORY "usr\\\\bin")
 
     message(STATUS "   + NSIS                             YES ")
     list(APPEND CPACK_GENERATOR "NSIS")


### PR DESCRIPTION
Fix packaging error

```
  Running CPACK. Please wait...
  CMake Warning (dev) at C:/builddir/BundleConfig.cmake:25 (set):
    Syntax error in cmake code at
  
      C:/builddir/BundleConfig.cmake:25
  
    when parsing string
  
      usr\bin
  
    Invalid escape sequence \b
```