### PR TITLE
Slightly improve handling of removal (sd card) storage in the project dataset picker

### DIFF
--- a/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldProjectActivity.java
@@ -303,6 +303,8 @@ public class QFieldProjectActivity
 
         final boolean isRootView = !getIntent().hasExtra("path");
         if (isRootView) {
+            setTitle(getString(R.string.select_project));
+
             File externalStorageDirectory = null;
             if (ContextCompat.checkSelfPermission(
                     QFieldProjectActivity.this,
@@ -344,26 +346,27 @@ public class QFieldProjectActivity
                             primaryExternalFilesDir.getAbsolutePath())) {
                         continue;
                     }
+                    Boolean isRemovable =
+                        Environment.isExternalStorageRemovable(file);
                     if (externalStorageDirectory != null) {
                         if (!file.getAbsolutePath().contains(
                                 externalStorageDirectory.getAbsolutePath())) {
                             values.add(new QFieldProjectListItem(
                                 file,
                                 getString(R.string.secondary_storage_extra),
-                                R.drawable.directory,
+                                isRemovable ? R.drawable.card
+                                            : R.drawable.directory,
                                 QFieldProjectListItem.TYPE_EXTERNAL_FILES));
                         }
                     } else {
                         values.add(new QFieldProjectListItem(
                             file, getString(R.string.secondary_storage_extra),
-                            R.drawable.directory,
+                            isRemovable ? R.drawable.card
+                                        : R.drawable.directory,
                             QFieldProjectListItem.TYPE_EXTERNAL_FILES));
                     }
                 }
             }
-
-            setTitle(getString(R.string.select_project));
-            Collections.sort(values);
 
             String sampleProjects = new File(getFilesDir().toString() +
                                              "/share/qfield/sample_projects/")


### PR DESCRIPTION
Tiny tweaks/improvements:
- The 'additional files directory' now always sits below the main QField directory
- An SD card image is now used to better communicate with the users were the files reside

Screenshot:
![Screenshot_20220510-195341](https://user-images.githubusercontent.com/1728657/167633305-b22ced61-ba68-4188-81e9-d3959f7f4612.jpg)

