### PR TITLE
Handle _all_ external dirs as potential QField data dirs

### DIFF
--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -126,14 +126,10 @@ QString AndroidPlatformUtilities::qgsProject() const
   return getIntentExtra( "QGS_PROJECT" );
 }
 
-QString AndroidPlatformUtilities::qfieldDataDir() const
+QStringList AndroidPlatformUtilities::qfieldAppDataDirs() const
 {
-  return getIntentExtra( "QFIELD_DATA_DIR" );
-}
-
-QString AndroidPlatformUtilities::qfieldAppDataDir() const
-{
-  return getIntentExtra( "QFIELD_APP_DATA_DIR" );
+  const QString dataDirs = getIntentExtra( "QFIELD_DATA_DIRS" );
+  return ( !dataDirs.isEmpty() ? dataDirs.split( "--;--" ) : QStringList() );
 }
 
 QString AndroidPlatformUtilities::getIntentExtra( const QString &extra, QAndroidJniObject extras ) const

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -128,7 +128,7 @@ QString AndroidPlatformUtilities::qgsProject() const
 
 QStringList AndroidPlatformUtilities::qfieldAppDataDirs() const
 {
-  const QString dataDirs = getIntentExtra( "QFIELD_DATA_DIRS" );
+  const QString dataDirs = getIntentExtra( "QFIELD_APP_DATA_DIRS" );
   return ( !dataDirs.isEmpty() ? dataDirs.split( "--;--" ) : QStringList() );
 }
 

--- a/src/core/platforms/android/androidplatformutilities.h
+++ b/src/core/platforms/android/androidplatformutilities.h
@@ -32,8 +32,7 @@ class AndroidPlatformUtilities : public PlatformUtilities
     void initSystem() override;
     QString systemGenericDataLocation() const override;
     QString qgsProject() const override;
-    QString qfieldDataDir() const override;
-    QString qfieldAppDataDir() const override;
+    QStringList qfieldAppDataDirs() const override;
     PictureSource *getCameraPicture( QQuickItem *parent, const QString &prefix, const QString &pictureFilePath, const QString &suffix ) override;
     PictureSource *getGalleryPicture( QQuickItem *parent, const QString &prefix, const QString &pictureFilePath ) override;
     ViewStatus *open( const QString &uri, bool editing ) override;

--- a/src/core/platforms/platformutilities.cpp
+++ b/src/core/platforms/platformutilities.cpp
@@ -72,24 +72,14 @@ QString PlatformUtilities::qgsProject() const
   return QString();
 }
 
-QString PlatformUtilities::qfieldDataDir() const
+QStringList PlatformUtilities::qfieldAppDataDirs() const
 {
-  return QStandardPaths::standardLocations( QStandardPaths::DocumentsLocation ).first() + QStringLiteral( "/QField/" );
-}
-
-QString PlatformUtilities::qfieldAppDataDir() const
-{
-  return QStandardPaths::standardLocations( QStandardPaths::DocumentsLocation ).first() + QStringLiteral( "/QField/" );
+  return QStringList() << QStandardPaths::standardLocations( QStandardPaths::DocumentsLocation ).first() + QStringLiteral( "/QField/" );
 }
 
 QStringList PlatformUtilities::availableGrids() const
 {
-  QStringList dataDirs;
-  if ( !qfieldDataDir().isEmpty() )
-    dataDirs << qfieldDataDir();
-  if ( !qfieldAppDataDir().isEmpty() )
-    dataDirs << qfieldAppDataDir();
-
+  QStringList dataDirs = qfieldAppDataDirs();
   QStringList grids;
   for ( const QString &dataDir : dataDirs )
   {

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -64,8 +64,7 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
      */
     virtual QString systemGenericDataLocation() const;
     virtual QString qgsProject() const;
-    Q_INVOKABLE virtual QString qfieldDataDir() const;
-    Q_INVOKABLE virtual QString qfieldAppDataDir() const;
+    Q_INVOKABLE virtual QStringList qfieldAppDataDirs() const;
     Q_INVOKABLE QStringList availableGrids() const;
     Q_INVOKABLE bool createDir( const QString &path, const QString &dirname ) const;
     Q_INVOKABLE bool rmFile( const QString &filename ) const;

--- a/src/core/qgsquick/qgsquickcoordinatetransformer.cpp
+++ b/src/core/qgsquick/qgsquickcoordinatetransformer.cpp
@@ -150,12 +150,7 @@ void QgsQuickCoordinateTransformer::updatePosition()
     {
       mVerticalGridName = verticalGridName;
 
-      QStringList dataDirs;
-      if ( !PlatformUtilities::instance()->qfieldDataDir().isEmpty() )
-        dataDirs << PlatformUtilities::instance()->qfieldDataDir();
-      if ( !PlatformUtilities::instance()->qfieldAppDataDir().isEmpty() )
-        dataDirs << PlatformUtilities::instance()->qfieldAppDataDir();
-
+      QStringList dataDirs = PlatformUtilities::instance()->qfieldAppDataDirs();
       if ( !dataDirs.isEmpty() )
       {
         for ( const QString &dataDir : dataDirs )

--- a/src/qml/About.qml
+++ b/src/qml/About.qml
@@ -125,13 +125,15 @@ Item {
             opacity: 0.6
 
             text: {
-                var dataFields = [];
-                if (platformUtilities.qfieldDataDir() !== '')
-                    dataFields.push('QField storage-wide directory:\n' + platformUtilities.qfieldDataDir());
-                if (platformUtilities.qfieldAppDataDir() !== ''
-                    && platformUtilities.qfieldAppDataDir() !== platformUtilities.qfieldDataDir())
-                    dataFields.push('QField app directory:\n' + platformUtilities.qfieldAppDataDir());
-                return dataFields.join('\n');
+                var dataDirs = platformUtilities.qfieldAppDataDirs();
+                console.log(dataDirs)
+                if (dataDirs.length > 0) {
+                  return (dataDirs.length > 1
+                          ? 'QField app directories'
+                          : 'QField app directory')
+                         + '\n' + dataDirs.join('\n');
+                }
+                return '';
             }
         }
 


### PR DESCRIPTION
This PR reworks the way we handle the QField data dir (within which users can set fonts, basemap/localized path datasets, etc.) so we take into account _all_ available external files directory to catch secondary /Android/data/ch.opengis.qfield/files living in external SD card.

See https://github.com/opengisch/QField/discussions/2878 for more background.

@Crapaud04 , please give these APKs a try.