### PR TITLE
Allow copying bookmark details to clipboard, plus usuability improvements

### DIFF
--- a/src/core/bookmarkmodel.cpp
+++ b/src/core/bookmarkmodel.cpp
@@ -153,3 +153,15 @@ void BookmarkModel::removeBookmark( const QString &id )
 {
   mManager->removeBookmark( id );
 }
+
+QgsPointXY BookmarkModel::getBookmarkPoint( const QString &id )
+{
+  const QgsBookmark bookmark = mManager->bookmarkById( id );
+  return bookmark.extent().center();
+}
+
+QgsCoordinateReferenceSystem BookmarkModel::getBookmarkCrs( const QString &id )
+{
+  const QgsBookmark bookmark = mManager->bookmarkById( id );
+  return bookmark.extent().crs();
+}

--- a/src/core/bookmarkmodel.h
+++ b/src/core/bookmarkmodel.h
@@ -56,6 +56,10 @@ class BookmarkModel : public QSortFilterProxyModel
 
     Q_INVOKABLE void removeBookmark( const QString &id );
 
+    Q_INVOKABLE QgsPointXY getBookmarkPoint( const QString &id );
+
+    Q_INVOKABLE QgsCoordinateReferenceSystem getBookmarkCrs( const QString &id );
+
     void setMapSettings( QgsQuickMapSettings *mapSettings );
 
     QgsQuickMapSettings *mapSettings() const { return mMapSettings; }

--- a/src/qml/BookmarkProperties.qml
+++ b/src/qml/BookmarkProperties.qml
@@ -189,6 +189,7 @@ Popup {
                     coordinates += ' (' + crs.authid + ' ' + crs.description + ')'
 
                     platformUtilities.copyTextToClipboard(nameField.text + '\n' + coordinates)
+                    displayToast(qsTr('Bookmark details copied to clipboard'));
                 }
             }
 

--- a/src/qml/BookmarkProperties.qml
+++ b/src/qml/BookmarkProperties.qml
@@ -30,39 +30,39 @@ Popup {
 
     Page {
         width: parent.width
-        height: propertiesLayout.childrenRect.height + 68
         padding: 10
         header: ToolBar {
             id: toolBar
-            height: 48
 
             background: Rectangle {
                 color: "transparent"
+                height: 48
             }
 
-            Label {
-              anchors.centerIn: parent
-              leftPadding: 48
-              rightPadding: 48
-              width: parent.width - 20
-              text: qsTr('Bookmark Properties')
-              font: Theme.strongFont
-              color: Theme.mainColor
-              horizontalAlignment: Text.AlignHCenter
-              wrapMode: Text.WordWrap
-            }
+            RowLayout {
+                width: parent.width
+                height: 48
 
-            QfToolButton {
-                id: closeButton
-                anchors {
-                    top: parent.top
-                    right: parent.right
+                Label {
+                    Layout.leftMargin: 48
+                    Layout.fillWidth: true
+                    Layout.alignment: Qt.AlignVCenter
+                    text: qsTr('Bookmark Properties')
+                    font: Theme.strongFont
+                    color: Theme.mainColor
+                    horizontalAlignment: Text.AlignHCenter
+                    wrapMode: Text.WordWrap
                 }
-                iconSource: Theme.getThemeIcon( 'ic_close_black_24dp' )
-                bgcolor: "transparent"
 
-                onClicked: {
-                    bookmarkProperties.close();
+                QfToolButton {
+                    id: closeButton
+                    Layout.alignment: Qt.AlignVCenter
+                    iconSource: Theme.getThemeIcon( 'ic_close_black_24dp' )
+                    bgcolor: "transparent"
+
+                    onClicked: {
+                        bookmarkProperties.close();
+                    }
                 }
             }
         }

--- a/src/qml/BookmarkProperties.qml
+++ b/src/qml/BookmarkProperties.qml
@@ -14,7 +14,6 @@ Popup {
     property string bookmarkName: ''
     property string bookmarkGroup: ''
 
-
     width: Math.min(350, mainWindow.width - 20 )
     x: (parent.width - width) / 2
     y: (parent.height - height) / 2
@@ -23,6 +22,10 @@ Popup {
     onAboutToShow: {
         nameField.text = bookmarkName;
         groupField.value = bookmarkGroup;
+    }
+
+    function saveBookmark() {
+        bookmarkModel.updateBookmarkDetails(bookmarkProperties.bookmarkId, nameField.text, groupField.value)
     }
 
     Page {
@@ -80,6 +83,10 @@ Popup {
                 Layout.fillWidth: true
                 font: Theme.defaultFont
                 text: ''
+
+                onTextChanged: {
+                    saveBookmark();
+                }
             }
 
             Label {
@@ -93,8 +100,12 @@ Popup {
                 spacing: 8
                 Layout.fillWidth: true
 
-                property int iconSize: 24
+                property int iconSize: 32
                 property string value: ''
+
+                onValueChanged: {
+                    saveBookmark();
+                }
 
                 Rectangle {
                     id: defaultColor
@@ -164,17 +175,28 @@ Popup {
                 id: updateBookmarkButton
                 Layout.fillWidth: true
                 Layout.topMargin: 10
-                text: 'Update bookmark details'
+                text: 'Copy bookmark details'
 
                 onClicked: {
-                    bookmarkModel.updateBookmarkDetails(bookmarkProperties.bookmarkId, nameField.text, groupField.value)
-                    bookmarkProperties.close();
+                    var point = bookmarkModel.getBookmarkPoint(bookmarkProperties.bookmarkId)
+                    var crs = bookmarkModel.getBookmarkCrs(bookmarkProperties.bookmarkId)
+                    var coordinates = ''
+                    if (crs.isGeographic) {
+                      coordinates = qsTr( 'Lon' ) + ' ' +  point.x.toFixed(5) + ', ' + qsTr( 'Lat' ) + ' ' + point.y.toFixed(5)
+                    } else {
+                      coordinates = qsTr( 'X' ) + ' ' +  point.x.toFixed(2) + ', ' + qsTr( 'Y' ) + ' ' + point.y.toFixed(2)
+                    }
+                    coordinates += ' (' + crs.authid + ' ' + crs.description + ')'
+
+                    platformUtilities.copyTextToClipboard(nameField.text + '\n' + coordinates)
                 }
             }
 
             QfButton {
                 id: deleteBookmarkButton
                 Layout.fillWidth: true
+                bgcolor: 'transparent'
+                color: Theme.darkRed
                 text: 'Remove bookmark'
 
                 onClicked: {

--- a/src/qml/BookmarkProperties.qml
+++ b/src/qml/BookmarkProperties.qml
@@ -175,7 +175,7 @@ Popup {
                 id: updateBookmarkButton
                 Layout.fillWidth: true
                 Layout.topMargin: 10
-                text: 'Copy bookmark details'
+                text: qsTr('Copy bookmark details')
 
                 onClicked: {
                     var point = bookmarkModel.getBookmarkPoint(bookmarkProperties.bookmarkId)
@@ -197,7 +197,7 @@ Popup {
                 Layout.fillWidth: true
                 bgcolor: 'transparent'
                 color: Theme.darkRed
-                text: 'Remove bookmark'
+                text: qsTr('Remove bookmark')
 
                 onClicked: {
                     removeBookmarkDialog.open();

--- a/src/qml/imports/Theme/Theme.qml
+++ b/src/qml/imports/Theme/Theme.qml
@@ -3,7 +3,7 @@ pragma Singleton
 import QtQuick 2.12
 
 QtObject {
-    readonly property color darkRed: "#900000"
+    readonly property color darkRed: "#c0392b"
     readonly property color darkGray: "#212121"
     readonly property color darkGraySemiOpaque: "#88212121"
     readonly property color gray: "#888888"


### PR DESCRIPTION
This PR applies a couple of tweaks to bookmarks handling to make them even more useful (based on field use):
- Get rid of the "update bookmark details" button in favor of saving as edits are done, much smoother experience
- Make the color buttons slightly bigger to increase tap area
- Use a red color for the remove bookmark icon

![image](https://user-images.githubusercontent.com/1728657/167989204-ce0e1610-324e-483f-a113-c28be4b4d5f2.png)

In addition, a "copy bookmark details" button has been added, which copies a string into the clipboard that looks like:
```
near pp, anomaly
X 490289.77, Y 1283316.02 (EPSG:3148 Indian 1960 / UTM zone 48N)
```

This insures that spatial details of bookmarks can be retrieved and shared more easily.