### PR TITLE
Do *not* use qgis data directory as profile directory

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -172,7 +172,11 @@ int main( int argc, char **argv )
 #if defined( Q_OS_ANDROID )
   QString projPath = PlatformUtilities::instance()->systemGenericDataLocation() + QStringLiteral( "/proj" );
   qputenv( "PROJ_LIB", projPath.toUtf8() );
-  QgsApplication app( argc, argv, true, PlatformUtilities::instance()->systemGenericDataLocation() + QStringLiteral( "/qgis/resources" ), QStringLiteral( "mobile" ) );
+
+  const QDir rootPath = QStandardPaths::writableLocation( QStandardPaths::AppDataLocation );
+  rootPath.mkdir( QStringLiteral( "qgis_profile" ) );
+  const QString profilePath = QStandardPaths::writableLocation( QStandardPaths::AppDataLocation ) + QStringLiteral( "/qgis_profile" );
+  QgsApplication app( argc, argv, true, profilePath, QStringLiteral( "mobile" ) );
 
   QSettings settings;
 
@@ -180,11 +184,18 @@ int main( int argc, char **argv )
   app.setPrefixPath( "" QGIS_INSTALL_DIR, true );
   app.setPluginPath( PlatformUtilities::instance()->systemGenericDataLocation() + QStringLiteral( "/plugins" ) );
   app.setPkgDataPath( PlatformUtilities::instance()->systemGenericDataLocation() + QStringLiteral( "/qgis" ) );
+
+  app.createDatabase();
 #elif defined( Q_OS_IOS )
   QString projPath = PlatformUtilities::instance()->systemGenericDataLocation() + QStringLiteral( "/proj" );
   qputenv( "PROJ_LIB", projPath.toUtf8() );
-  QgsApplication app( argc, argv, true, PlatformUtilities::instance()->systemGenericDataLocation() + QStringLiteral( "/qgis/resources" ), QStringLiteral( "mobile" ) );
+
+  const QDir rootPath = QStandardPaths::writableLocation( QStandardPaths::AppDataLocation );
+  rootPath.mkdir( QStringLiteral( "qgis_profile" ) );
+  const QString profilePath = QStandardPaths::writableLocation( QStandardPaths::AppDataLocation ) + QStringLiteral( "/qgis_profile" );
+  QgsApplication app( argc, argv, true, profilePath, QStringLiteral( "mobile" ) );
   app.setPkgDataPath( PlatformUtilities::instance()->systemGenericDataLocation() + QStringLiteral( "/qgis" ) );
+  app.createDatabase();
 #else
   QgsApplication app( argc, argv, true );
   QSettings settings;


### PR DESCRIPTION
This PR fixes a pretty serious issue on Android (and iOS):
- on Android, we were setting the QGIS user profile directory to match that of QGIS' data resources (i.e. what is supposed to be a read-only directory that provides templates). It did work in part because qgis.db was in that directory to begin with, _however_ it meant that at every QField update, we'd _overwrite_ the user qgis.db with the template one. Practically speaking, this meant that every time someone updates QField, he/she would lose _all saved bookmarks_ :fearful: 
- On iOS, we were setting the QGIS user profile to the same problematic location, on top of which it was a read-only directory, meaning bookmarks wouldn't even save across sessions.

This is one of these "how was it ever working to begin with" moments :wink: 