### PR TITLE
Add zoom to group in the legend properties

### DIFF
--- a/src/core/layertreemodel.h
+++ b/src/core/layertreemodel.h
@@ -23,6 +23,7 @@
 class QgsLayerTree;
 class QgsLayerTreeModel;
 class QgsProject;
+class QgsQuickMapSettings;
 
 class FlatLayerTreeModelBase : public QAbstractProxyModel
 {
@@ -76,6 +77,9 @@ class FlatLayerTreeModelBase : public QAbstractProxyModel
     //! Returns whether the current layer tree has temporal awareness
     bool isTemporal() const { return mIsTemporal; }
 
+    //! Calculate layer tree node extent and add optional buffer
+    Q_INVOKABLE QgsRectangle nodeExtent( const QModelIndex &index, QgsQuickMapSettings *mapSettings, const float buffer );
+
   signals:
     void mapThemeChanged();
     void isTemporalChanged();
@@ -111,6 +115,7 @@ class FlatLayerTreeModel : public QSortFilterProxyModel
     {
       VectorLayerPointer = Qt::UserRole + 1,
       MapLayerPointer,
+      HasSpatialExtent,
       LegendImage,
       Type,
       Name,
@@ -128,7 +133,7 @@ class FlatLayerTreeModel : public QSortFilterProxyModel
       HasChildren,
       CanReloadData,
       HasLabels,
-      LabelsVisible
+      LabelsVisible,
     };
     Q_ENUM( Roles )
 
@@ -159,6 +164,9 @@ class FlatLayerTreeModel : public QSortFilterProxyModel
     QgsLayerTreeModel *layerTreeModel() const;
 
     QgsLayerTree *layerTree() const;
+
+    //! Calculate layer tree node extent
+    Q_INVOKABLE QgsRectangle nodeExtent( const QModelIndex &index, QgsQuickMapSettings *mapSettings, const float buffer = 0.02 );
 
   signals:
     void mapThemeChanged();


### PR DESCRIPTION
Also add a little padding so the whole layer is visible. As requested in #2739 .

Also removed `LayerTreeItemProperties.isSpatialLayer` (qml) - it is better suited to be as Cpp model attribute


https://user-images.githubusercontent.com/2820439/168296652-52d182d6-5e6b-4159-bb8f-426101e15ced.mp4


A project based on advanced bee for testing:
[qf_2739_zoom_to_layer.zip](https://github.com/opengisch/QField/files/8688318/qf_2739_zoom_to_layer.zip)

