### PR TITLE
[Backport release-2_1] When triggering a search result action (i.e. right-end buttons), close the search result

### DIFF
--- a/src/qml/LocatorItem.qml
+++ b/src/qml/LocatorItem.qml
@@ -247,6 +247,7 @@ Item {
 
               onClicked: {
                 locator.triggerResultAtRow(delegateRect.resultIndex, model.id)
+                locatorItem.state = "off"
               }
             }
           }


### PR DESCRIPTION
Backport #2902
 **Authored by:** @nirvn