### PR TITLE
import local folder on iOS

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -195,11 +195,12 @@ if(ANDROID)
       platforms/android/androidviewstatus.cpp
       platforms/android/androidprojectsource.cpp)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "iOS")
-  set(QFIELD_CORE_HDRS ${QFIELD_CORE_HDRS} platforms/ios/iosplatformutilities.h
-                       platforms/ios/iospicturesource.h)
+  set(QFIELD_CORE_HDRS
+      ${QFIELD_CORE_HDRS} platforms/ios/iosplatformutilities.h
+      platforms/ios/iospicturesource.h platforms/ios/iosprojectsource.h)
   set(QFIELD_CORE_SRCS
       ${QFIELD_CORE_SRCS} platforms/ios/iosplatformutilities.mm
-      platforms/ios/iospicturesource.mm)
+      platforms/ios/iospicturesource.mm platforms/ios/iosprojectsource.mm)
 endif()
 
 find_package(Sqlite3)

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -274,7 +274,7 @@ ViewStatus *AndroidPlatformUtilities::open( const QString &uri, bool editing )
   return viewStatus;
 }
 
-ProjectSource *AndroidPlatformUtilities::openProject( QQuickItem *parent )
+ProjectSource *AndroidPlatformUtilities::openProject( QObject *parent )
 {
   checkWriteExternalStoragePermissions();
 

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -274,7 +274,7 @@ ViewStatus *AndroidPlatformUtilities::open( const QString &uri, bool editing )
   return viewStatus;
 }
 
-ProjectSource *AndroidPlatformUtilities::openProject()
+ProjectSource *AndroidPlatformUtilities::openProject( QQuickItem *parent )
 {
   checkWriteExternalStoragePermissions();
 
@@ -290,7 +290,7 @@ ProjectSource *AndroidPlatformUtilities::openProject()
 
   if ( intent.isValid() )
   {
-    projectSource = new AndroidProjectSource();
+    projectSource = new AndroidProjectSource( parent );
     QtAndroid::startActivity( intent.object<jobject>(), 103, projectSource );
   }
   else

--- a/src/core/platforms/android/androidplatformutilities.h
+++ b/src/core/platforms/android/androidplatformutilities.h
@@ -36,7 +36,7 @@ class AndroidPlatformUtilities : public PlatformUtilities
     PictureSource *getCameraPicture( QQuickItem *parent, const QString &prefix, const QString &pictureFilePath, const QString &suffix ) override;
     PictureSource *getGalleryPicture( QQuickItem *parent, const QString &prefix, const QString &pictureFilePath ) override;
     ViewStatus *open( const QString &uri, bool editing ) override;
-    ProjectSource *openProject( QQuickItem *parent = nullptr ) override;
+    ProjectSource *openProject( QObject *parent = nullptr ) override;
 
     bool checkPositioningPermissions() const override;
 

--- a/src/core/platforms/android/androidplatformutilities.h
+++ b/src/core/platforms/android/androidplatformutilities.h
@@ -36,7 +36,7 @@ class AndroidPlatformUtilities : public PlatformUtilities
     PictureSource *getCameraPicture( QQuickItem *parent, const QString &prefix, const QString &pictureFilePath, const QString &suffix ) override;
     PictureSource *getGalleryPicture( QQuickItem *parent, const QString &prefix, const QString &pictureFilePath ) override;
     ViewStatus *open( const QString &uri, bool editing ) override;
-    ProjectSource *openProject() override;
+    ProjectSource *openProject( QQuickItem *parent = nullptr ) override;
 
     bool checkPositioningPermissions() const override;
 

--- a/src/core/platforms/android/androidprojectsource.cpp
+++ b/src/core/platforms/android/androidprojectsource.cpp
@@ -20,8 +20,8 @@
 #include <QFile>
 #include <QtAndroid>
 
-AndroidProjectSource::AndroidProjectSource()
-  : ProjectSource( nullptr )
+AndroidProjectSource::AndroidProjectSource( QQuickItem *parent )
+  : ProjectSource( parent )
   , QAndroidActivityResultReceiver()
 {
 }

--- a/src/core/platforms/android/androidprojectsource.cpp
+++ b/src/core/platforms/android/androidprojectsource.cpp
@@ -20,7 +20,7 @@
 #include <QFile>
 #include <QtAndroid>
 
-AndroidProjectSource::AndroidProjectSource( QQuickItem *parent )
+AndroidProjectSource::AndroidProjectSource( QObject *parent )
   : ProjectSource( parent )
   , QAndroidActivityResultReceiver()
 {

--- a/src/core/platforms/android/androidprojectsource.cpp
+++ b/src/core/platforms/android/androidprojectsource.cpp
@@ -20,7 +20,7 @@
 #include <QFile>
 #include <QtAndroid>
 
-AndroidProjectSource::AndroidProjectSource( QObject *parent )
+AndroidProjectSource::AndroidProjectSource( QQuickItem *parent )
   : ProjectSource( parent )
   , QAndroidActivityResultReceiver()
 {

--- a/src/core/platforms/android/androidprojectsource.h
+++ b/src/core/platforms/android/androidprojectsource.h
@@ -27,7 +27,7 @@ class AndroidProjectSource : public ProjectSource, public QAndroidActivityResult
     Q_OBJECT
 
   public:
-    explicit AndroidProjectSource( QObject *parent = nullptr );
+    explicit AndroidProjectSource( QQuickItem *parent = nullptr );
 
     void handleActivityResult( int receiverRequestCode, int resultCode, const QAndroidJniObject &data ) override;
 };

--- a/src/core/platforms/android/androidprojectsource.h
+++ b/src/core/platforms/android/androidprojectsource.h
@@ -27,7 +27,7 @@ class AndroidProjectSource : public ProjectSource, public QAndroidActivityResult
     Q_OBJECT
 
   public:
-    AndroidProjectSource( QObject *parent = nullptr );
+    explicit AndroidProjectSource( QObject *parent = nullptr );
 
     void handleActivityResult( int receiverRequestCode, int resultCode, const QAndroidJniObject &data ) override;
 };

--- a/src/core/platforms/android/androidprojectsource.h
+++ b/src/core/platforms/android/androidprojectsource.h
@@ -27,7 +27,7 @@ class AndroidProjectSource : public ProjectSource, public QAndroidActivityResult
     Q_OBJECT
 
   public:
-    explicit AndroidProjectSource( QQuickItem *parent = nullptr );
+    explicit AndroidProjectSource( QObject *parent = nullptr );
 
     void handleActivityResult( int receiverRequestCode, int resultCode, const QAndroidJniObject &data ) override;
 };

--- a/src/core/platforms/android/androidprojectsource.h
+++ b/src/core/platforms/android/androidprojectsource.h
@@ -27,7 +27,7 @@ class AndroidProjectSource : public ProjectSource, public QAndroidActivityResult
     Q_OBJECT
 
   public:
-    AndroidProjectSource();
+    AndroidProjectSource( QQuickItem *parent );
 
     void handleActivityResult( int receiverRequestCode, int resultCode, const QAndroidJniObject &data ) override;
 };

--- a/src/core/platforms/android/androidprojectsource.h
+++ b/src/core/platforms/android/androidprojectsource.h
@@ -27,7 +27,7 @@ class AndroidProjectSource : public ProjectSource, public QAndroidActivityResult
     Q_OBJECT
 
   public:
-    AndroidProjectSource( QQuickItem *parent = nullptr );
+    AndroidProjectSource( QObject *parent = nullptr );
 
     void handleActivityResult( int receiverRequestCode, int resultCode, const QAndroidJniObject &data ) override;
 };

--- a/src/core/platforms/android/androidprojectsource.h
+++ b/src/core/platforms/android/androidprojectsource.h
@@ -27,7 +27,7 @@ class AndroidProjectSource : public ProjectSource, public QAndroidActivityResult
     Q_OBJECT
 
   public:
-    AndroidProjectSource( QQuickItem *parent );
+    AndroidProjectSource( QQuickItem *parent = nullptr );
 
     void handleActivityResult( int receiverRequestCode, int resultCode, const QAndroidJniObject &data ) override;
 };

--- a/src/core/platforms/ios/iosplatformutilities.h
+++ b/src/core/platforms/ios/iosplatformutilities.h
@@ -33,6 +33,7 @@ class IosPlatformUtilities : public PlatformUtilities
     bool checkCameraPermissions() const override;
     virtual PictureSource *getCameraPicture( QQuickItem *parent, const QString &prefix, const QString &pictureFilePath, const QString &suffix ) override;
     virtual PictureSource *getGalleryPicture( QQuickItem *parent, const QString &prefix, const QString &pictureFilePath ) override;
+    virtual ProjectSource *openProject( QQuickItem *parent = nullptr ) override;
 };
 
 #endif

--- a/src/core/platforms/ios/iosplatformutilities.h
+++ b/src/core/platforms/ios/iosplatformutilities.h
@@ -33,7 +33,7 @@ class IosPlatformUtilities : public PlatformUtilities
     bool checkCameraPermissions() const override;
     virtual PictureSource *getCameraPicture( QQuickItem *parent, const QString &prefix, const QString &pictureFilePath, const QString &suffix ) override;
     virtual PictureSource *getGalleryPicture( QQuickItem *parent, const QString &prefix, const QString &pictureFilePath ) override;
-    virtual ProjectSource *openProject( QQuickItem *parent = nullptr ) override;
+    virtual ProjectSource *openProject( QObject *parent = nullptr ) override;
 };
 
 #endif

--- a/src/core/platforms/ios/iosplatformutilities.mm
+++ b/src/core/platforms/ios/iosplatformutilities.mm
@@ -18,6 +18,7 @@
 
 #include "iosplatformutilities.h"
 #include "iospicturesource.h"
+#include "iosprojectsource.h"
 
 #import <AVFoundation/AVFoundation.h>
 #import <CoreLocation/CoreLocation.h>
@@ -71,4 +72,11 @@ PictureSource *IosPlatformUtilities::getGalleryPicture(
       new IosPictureSource(parent, prefix, pictureFilePath);
   pictureSource->pickGalleryPicture();
   return pictureSource;
+}
+
+ProjectSource *IosPlatformUtilities::openProject(QQuickItem *parent) {
+  QSettings settings;
+  IosProjectSource *projectSource = new IosProjectSource(parent);
+  projectSource->pickProject();
+  return projectSource;
 }

--- a/src/core/platforms/ios/iosplatformutilities.mm
+++ b/src/core/platforms/ios/iosplatformutilities.mm
@@ -74,7 +74,7 @@ PictureSource *IosPlatformUtilities::getGalleryPicture(
   return pictureSource;
 }
 
-ProjectSource *IosPlatformUtilities::openProject(QQuickItem *parent) {
+ProjectSource *IosPlatformUtilities::openProject(QObject *parent) {
   QSettings settings;
   IosProjectSource *projectSource = new IosProjectSource(parent);
   projectSource->pickProject();

--- a/src/core/platforms/ios/iosprojectsource.h
+++ b/src/core/platforms/ios/iosprojectsource.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-  iospicturesource.h - IosPictureSource
+  iosprojectsource.h - IosProjectSource
 
   begin                : September 2021
   copyright            : (C) 2020 by Denis Rouzaud
@@ -12,36 +12,29 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
-#ifndef IOSPICTURESOURCE_H
-#define IOSPICTURESOURCE_H
+#ifndef IOSPROJECTSOURCE_H
+#define IOSPROJECTSOURCE_H
 
-#include "picturesource.h"
+#include "projectsource.h"
 
 
-class IosPictureSource : public PictureSource
+class IosProjectSource : public ProjectSource
 {
     Q_OBJECT
 
   public:
-    explicit IosPictureSource( QObject *parent = nullptr, const QString &prefix = QString(), const QString &pictureFilePath = QString() );
+    explicit IosProjectSource( QObject *parent = nullptr );
 
-    QString pictureFilePath() const { return mPictureFilePath; }
-    QString prefixPath() const { return mPrefixPath; }
-
-  signals:
-    void pictureReceived( const QString &path );
+    QString projectFromFolder( const QString &folder ) const;
 
   public slots:
-    void takePicture();
-    void pickGalleryPicture();
+    void pickProject();
 
   private:
     QQuickItem *mParent = nullptr;
-    QString mPrefixPath;
-    QString mPictureFilePath;
-    class CameraDelegateContainer;
-    CameraDelegateContainer *mDelegate = nullptr;
+    class ProjectDelegateContainer;
+    ProjectDelegateContainer *mDelegate = nullptr;
 };
 
 
-#endif // IOSPICTURESOURCE_H
+#endif // IOSPROJECTSOURCE_H

--- a/src/core/platforms/ios/iosprojectsource.mm
+++ b/src/core/platforms/ios/iosprojectsource.mm
@@ -69,10 +69,8 @@ static NSString *const FIELD_NAME = @"name";
   for (id url in urls) {
     NSError *error;
     NSMutableDictionary *result = [self getMetadataForUrl:url error:&error];
-    qDebug() << result;
     const QString projectPath = mIosProjectSource->projectFromFolder(
         QString::fromNSString(result[FIELD_FILE_COPY_URI]));
-    qDebug() << "yo" << projectPath;
     emit mIosProjectSource->projectOpened(projectPath);
     break;
   }
@@ -219,7 +217,6 @@ QString IosProjectSource::projectFromFolder(const QString &folder) const {
   folderPath.remove(QStringLiteral("file://"));
   QDir directory(folderPath);
   if (!directory.exists()) {
-    qDebug() << "directory not found " << folderPath;
     return;
   }
   const QStringList projects = directory.entryList(QStringList() << "*.qgs"
@@ -230,11 +227,8 @@ QString IosProjectSource::projectFromFolder(const QString &folder) const {
   if (projects.count() > 0) {
     const QString projectPath =
         QStringLiteral("%1/%2").arg(folderPath, projects.at(0));
-    qDebug() << "project found " << projectPath;
-    qDebug() << "file exists: " << QFileInfo(projectPath).exists();
     return projectPath;
   } else {
-    qDebug() << "no project found in folder " << folderPath;
   }
   return QString();
 }

--- a/src/core/platforms/ios/iosprojectsource.mm
+++ b/src/core/platforms/ios/iosprojectsource.mm
@@ -1,0 +1,240 @@
+/***************************************************************************
+  iosprojectsource.mm - IosProjectSource
+
+  begin                : September 2021
+  copyright            : (C) 2020 by Denis Rouzaud
+  email                : denis@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QDir>
+#include <QGuiApplication>
+#include <QQuickItem>
+#include <QQuickWindow>
+
+#include <MobileCoreServices/MobileCoreServices.h>
+#include <UIKit/UIKit.h>
+#include <qpa/qplatformnativeinterface.h>
+
+#include "iosprojectsource.h"
+
+static NSString *const FIELD_URI = @"uri";
+static NSString *const FIELD_FILE_COPY_URI = @"fileCopyUri";
+static NSString *const FIELD_COPY_ERR = @"copyError";
+static NSString *const FIELD_NAME = @"name";
+
+@interface ProjectDelegate
+    : NSObject <UIDocumentPickerDelegate, UINavigationControllerDelegate> {
+  IosProjectSource *mIosProjectSource;
+}
+@end
+
+@implementation ProjectDelegate {
+  NSMutableArray *urlsInOpenMode;
+}
+
+- (id)initWithIosProjectSource:(IosProjectSource *)iosProjectSource {
+  self = [super init];
+  if (self) {
+    mIosProjectSource = iosProjectSource;
+    urlsInOpenMode = [NSMutableArray new];
+  }
+  return self;
+}
+
+- (void)dealloc {
+  for (NSURL *url in urlsInOpenMode) {
+    [url stopAccessingSecurityScopedResource];
+  }
+}
+
++ (BOOL)requiresMainQueueSetup {
+  return NO;
+}
+
+- (dispatch_queue_t)methodQueue {
+  return dispatch_get_main_queue();
+}
+
+- (void)documentPicker:(UIDocumentPickerViewController *)picker
+    didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
+
+  NSMutableArray *results = [NSMutableArray array];
+  for (id url in urls) {
+    NSError *error;
+    NSMutableDictionary *result = [self getMetadataForUrl:url error:&error];
+    qDebug() << result;
+    const QString projectPath = mIosProjectSource->projectFromFolder(
+        QString::fromNSString(result[FIELD_FILE_COPY_URI]));
+    qDebug() << "yo" << projectPath;
+    emit mIosProjectSource->projectOpened(projectPath);
+    break;
+  }
+}
+
+- (NSMutableDictionary *)getMetadataForUrl:(NSURL *)url
+                                     error:(NSError **)error {
+  __block NSMutableDictionary *result = [NSMutableDictionary dictionary];
+
+  [urlsInOpenMode addObject:url];
+
+  // TODO handle error
+  [url startAccessingSecurityScopedResource];
+
+  NSFileCoordinator *coordinator = [NSFileCoordinator new];
+  NSError *fileError;
+
+  // TODO double check this implemenation, see eg.
+  // https://developer.apple.com/documentation/foundation/nsfilecoordinator/1412420-prepareforreadingitemsaturls
+  [coordinator
+      coordinateReadingItemAtURL:url
+                         options:NSFileCoordinatorReadingResolvesSymbolicLink
+                           error:&fileError
+                      byAccessor:^(NSURL *newURL) {
+                          // If the coordinated operation fails, then the
+                          // accessor block never runs
+                          result[FIELD_URI] = url.absoluteString;
+
+                          NSError *copyError;
+                          NSString *copyPath =
+                              [ProjectDelegate
+                                  copyToUniqueDestinationFrom:newURL
+                                                        error:copyError]
+                                  .absoluteString;
+
+                          if (!copyError) {
+                            result[FIELD_FILE_COPY_URI] = copyPath;
+                          } else {
+                            result[FIELD_COPY_ERR] =
+                                copyError.localizedDescription;
+                            result[FIELD_FILE_COPY_URI] = [NSNull null];
+                          }
+
+                          result[FIELD_NAME] = newURL.lastPathComponent;
+                      }];
+
+  if (fileError) {
+    *error = fileError;
+    return nil;
+  } else {
+    return result;
+  }
+}
+
+- (void)documentPickerWasCancelled:
+    (UIDocumentPickerViewController *)controller {
+  [self rejectAsUserCancellationError];
+}
+
+- (void)presentationControllerDidDismiss:
+    (UIPresentationController *)presentationController {
+  [self rejectAsUserCancellationError];
+}
+
+- (void)rejectAsUserCancellationError {
+  // TODO make error nullable?
+  NSError *error = [NSError errorWithDomain:NSCocoaErrorDomain
+                                       code:NSUserCancelledError
+                                   userInfo:nil];
+  //[promiseWrapper reject:@"user canceled the document picker"
+  // withCode:E_DOCUMENT_PICKER_CANCELED withError:error];
+}
+
++ (NSURL *)copyToUniqueDestinationFrom:(NSURL *)url error:(NSError *)error {
+  // destination can be NSDocumentDirectory or NSCachesDirectory
+  NSURL *destinationRootDir =
+      [NSFileManager.defaultManager URLsForDirectory:NSDocumentDirectory
+                                           inDomains:NSUserDomainMask]
+          .firstObject;
+  // we don't want to rename the file so we put it into a unique location
+  NSString *uniqueSubDirName = [[NSUUID UUID] UUIDString];
+  NSURL *destinationDir = [destinationRootDir
+      URLByAppendingPathComponent:[NSString stringWithFormat:@"%@/",
+                                                             uniqueSubDirName]];
+  NSURL *destinationUrl = [destinationDir
+      URLByAppendingPathComponent:[NSString
+                                      stringWithFormat:@"%@",
+                                                       url.lastPathComponent]];
+
+  [NSFileManager.defaultManager createDirectoryAtURL:destinationDir
+                         withIntermediateDirectories:YES
+                                          attributes:nil
+                                               error:&error];
+  if (error) {
+    return url;
+  }
+  [NSFileManager.defaultManager copyItemAtURL:url
+                                        toURL:destinationUrl
+                                        error:&error];
+  if (error) {
+    return url;
+  } else {
+    return destinationUrl;
+  }
+}
+
+@end
+
+class IosProjectSource::ProjectDelegateContainer {
+public:
+  ProjectDelegate *_projectDelegate = nullptr;
+};
+
+IosProjectSource::IosProjectSource(QObject *parent)
+    : ProjectSource(parent), mDelegate(new ProjectDelegateContainer()) {
+  mParent = qobject_cast<QQuickItem *>(parent);
+  Q_ASSERT(mParent);
+  mDelegate->_projectDelegate =
+      [[ProjectDelegate alloc] initWithIosProjectSource:this];
+}
+
+void IosProjectSource::pickProject() {
+  // Get the UIView that backs our QQuickWindow:
+  UIView *view = (__bridge UIView *)(QGuiApplication::platformNativeInterface()
+                                         ->nativeResourceForWindow(
+                                             "uiview", mParent->window()));
+  UIViewController *qtController = [[view window] rootViewController];
+
+  UIDocumentPickerViewController *controller =
+      [[UIDocumentPickerViewController alloc]
+          initWithDocumentTypes:@[ (__bridge NSString *)kUTTypeFolder ]
+                         inMode:UIDocumentPickerModeOpen
+          // inMode:UIDocumentPickerModeImport
+  ];
+
+  [controller setDelegate:id(mDelegate->_projectDelegate)];
+
+  // Tell the imagecontroller to animate on top:
+  [qtController presentViewController:controller animated:YES completion:nil];
+}
+
+QString IosProjectSource::projectFromFolder(const QString &folder) const {
+  QString folderPath = folder;
+  folderPath.remove(QStringLiteral("file://"));
+  QDir directory(folderPath);
+  if (!directory.exists()) {
+    qDebug() << "directory not found " << folderPath;
+    return;
+  }
+  const QStringList projects = directory.entryList(QStringList() << "*.qgs"
+                                                                 << "*.QGS"
+                                                                 << "*.qgz"
+                                                                 << "*.QGZ",
+                                                   QDir::Files);
+  if (projects.count() > 0) {
+    const QString projectPath =
+        QStringLiteral("%1/%2").arg(folderPath, projects.at(0));
+    qDebug() << "project found " << projectPath;
+    qDebug() << "file exists: " << QFileInfo(projectPath).exists();
+    return projectPath;
+  } else {
+    qDebug() << "no project found in folder " << folderPath;
+  }
+  return QString();
+}

--- a/src/core/platforms/platformutilities.cpp
+++ b/src/core/platforms/platformutilities.cpp
@@ -154,8 +154,9 @@ ViewStatus *PlatformUtilities::open( const QString &uri, bool )
   return nullptr;
 }
 
-ProjectSource *PlatformUtilities::openProject()
+ProjectSource *PlatformUtilities::openProject( QQuickItem *parent )
 {
+  Q_UNUSED( parent );
   QSettings settings;
   ProjectSource *source = new ProjectSource();
   QString fileName { QFileDialog::getOpenFileName( nullptr,

--- a/src/core/platforms/platformutilities.cpp
+++ b/src/core/platforms/platformutilities.cpp
@@ -154,7 +154,7 @@ ViewStatus *PlatformUtilities::open( const QString &uri, bool )
   return nullptr;
 }
 
-ProjectSource *PlatformUtilities::openProject( QParent *parent )
+ProjectSource *PlatformUtilities::openProject( QObject *parent )
 {
   Q_UNUSED( parent );
   QSettings settings;

--- a/src/core/platforms/platformutilities.cpp
+++ b/src/core/platforms/platformutilities.cpp
@@ -154,7 +154,7 @@ ViewStatus *PlatformUtilities::open( const QString &uri, bool )
   return nullptr;
 }
 
-ProjectSource *PlatformUtilities::openProject( QQuickItem *parent )
+ProjectSource *PlatformUtilities::openProject( QParent *parent )
 {
   Q_UNUSED( parent );
   QSettings settings;

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -101,7 +101,7 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
      * The call returns immediately and the returned ProjectSource will notify
      * when the project has actually been chosen.
      */
-    Q_INVOKABLE virtual ProjectSource *openProject( QParent *parent = nullptr );
+    Q_INVOKABLE virtual ProjectSource *openProject( QObject *parent = nullptr );
 
     /**
      * Checks for positioning (GPS etc) permissions on the device.

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -101,7 +101,7 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
      * The call returns immediately and the returned ProjectSource will notify
      * when the project has actually been chosen.
      */
-    Q_INVOKABLE virtual ProjectSource *openProject( QQuickItem *parent = nullptr );
+    Q_INVOKABLE virtual ProjectSource *openProject( QParent *parent = nullptr );
 
     /**
      * Checks for positioning (GPS etc) permissions on the device.

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -101,7 +101,7 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
      * The call returns immediately and the returned ProjectSource will notify
      * when the project has actually been chosen.
      */
-    Q_INVOKABLE virtual ProjectSource *openProject();
+    Q_INVOKABLE virtual ProjectSource *openProject( QQuickItem *parent = nullptr );
 
     /**
      * Checks for positioning (GPS etc) permissions on the device.

--- a/src/core/projectsource.cpp
+++ b/src/core/projectsource.cpp
@@ -18,7 +18,7 @@
 
 #include <QQuickItem>
 
-ProjectSource::ProjectSource( QQuickItem *parent )
+ProjectSource::ProjectSource( QObject *parent )
   : QObject( parent )
 {
 }

--- a/src/core/projectsource.cpp
+++ b/src/core/projectsource.cpp
@@ -16,9 +16,9 @@
 
 #include "projectsource.h"
 
-#include <QDebug>
+#include <QQuickItem>
 
-ProjectSource::ProjectSource( QObject *parent )
+ProjectSource::ProjectSource( QQuickItem *parent )
   : QObject( parent )
 {
 }

--- a/src/core/projectsource.h
+++ b/src/core/projectsource.h
@@ -36,7 +36,7 @@ class ProjectSource : public QObject
 {
     Q_OBJECT
   public:
-    explicit ProjectSource( QObject *parent = nullptr );
+    explicit ProjectSource( QQuickItem *parent = nullptr );
 
     virtual ~ProjectSource() = default;
 

--- a/src/core/projectsource.h
+++ b/src/core/projectsource.h
@@ -36,7 +36,7 @@ class ProjectSource : public QObject
 {
     Q_OBJECT
   public:
-    explicit ProjectSource( QQuickItem *parent = nullptr );
+    explicit ProjectSource( QObject *parent = nullptr );
 
     virtual ~ProjectSource() = default;
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2548,7 +2548,7 @@ ApplicationWindow {
     visible: true
 
     onShowOpenProjectDialog: {
-      __projectSource = platformUtilities.openProject()
+      __projectSource = platformUtilities.openProject(this)
     }
     onShowQFieldCloudScreen: {
       welcomeScreen.visible = false


### PR DESCRIPTION
this allows to import project from a local folder (copies directory to writable location + opens first project in this folder)
further improvements (choose the project + retrieve already imported folders/projects) will follow later