### PR TITLE
Fix QField Dev package naming

### DIFF
--- a/scripts/ci/generate-version-details.sh
+++ b/scripts/ci/generate-version-details.sh
@@ -37,11 +37,11 @@ elif [[ ${CI_PULL_REQUEST} = false ]]; then
   CUSTOM_APP_PACKAGE_NAME=$(echo ${NIGHTLY_PACKAGE_NAME} | awk '{print $NF}' FS=.)
 
   if [[ ${ALL_FILES_ACCESS} == "ON" ]]; then
-    export APP_NAME="${CUSTOM_APP_NAME:-QField Dev}"
-    export APP_PACKAGE_NAME="${CUSTOM_APP_PACKAGE_NAME:-qfield_dev}"
-  else
     export APP_NAME="${CUSTOM_APP_NAME:-QField+ Dev}"
     export APP_PACKAGE_NAME="${CUSTOM_APP_PACKAGE_NAME:-qfield_plus_dev}"
+  else
+    export APP_NAME="${CUSTOM_APP_NAME:-QField Dev}"
+    export APP_PACKAGE_NAME="${CUSTOM_APP_PACKAGE_NAME:-qfield_dev}"
   fi
   export APP_ICON="qfield_logo_beta"
   export APP_VERSION=""


### PR DESCRIPTION
Small follow up to the PR I (accidentally) merged an hour ago to invert QField Dev package naming.

Issue raised through failed automated deployment of QField Dev on the play store.