### PR TITLE
Improve path slashes of authentication imports

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -307,18 +307,18 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
     QgsApplication::instance()->authManager()->setPasswordHelperEnabled( false );
     QgsApplication::instance()->authManager()->setMasterPassword( QString( "qfield" ) );
     // import authentication method configurations
-    qDebug() << dataDirs;
+    QgsMessageLog::logMessage( dataDirs.join( ',' ), QStringLiteral( "QField" ) );
     for ( const QString &dataDir : dataDirs )
     {
       QDir configurationsDir( QStringLiteral( "%1/auth" ).arg( dataDir ) );
-      qDebug() << QStringLiteral( "%1/auth" ).arg( dataDir );
+      QgsMessageLog::logMessage( QStringLiteral( "%1/auth" ).arg( dataDir ), QStringLiteral( "QField" ) );
       if ( configurationsDir.exists() )
       {
-        qDebug() << "Checking...";
+        QgsMessageLog::logMessage( QStringLiteral( "Checking..." ), QStringLiteral( "QField" ) );
         const QStringList configurations = configurationsDir.entryList( QStringList() << QStringLiteral( "*.xml" ) << QStringLiteral( "*.XML" ), QDir::Files );
         for ( const QString &configuration : configurations )
         {
-          qDebug() << QStringLiteral( "Importing authentication configuration file %1" ).arg( configurationsDir.absoluteFilePath( configuration ) );
+          QgsMessageLog::logMessage( QStringLiteral( "Importing authentication configuration file %1" ).arg( configurationsDir.absoluteFilePath( configuration ) ), QStringLiteral( "QField" ) );
           QgsApplication::instance()->authManager()->importAuthenticationConfigsFromXml( configurationsDir.absoluteFilePath( configuration ), QString(), true );
         }
       }

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -315,6 +315,7 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
       if ( configurationsDir.exists() )
       {
         QgsMessageLog::logMessage( QStringLiteral( "Checking..." ), QStringLiteral( "QField" ) );
+        QgsMessageLog::logMessage( configurationsDir.entryList( QStringList() << QStringLiteral( "*" ), QDir::NoFilter ).join( '|' ) );
         const QStringList configurations = configurationsDir.entryList( QStringList() << QStringLiteral( "*.xml" ) << QStringLiteral( "*.XML" ), QDir::Files );
         for ( const QString &configuration : configurations )
         {

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -30,6 +30,7 @@
 #include "cpl_vsi.h"
 
 #include <QDateTime>
+#include <QFile>
 #include <QFontDatabase>
 #include <QStandardItemModel>
 #include <QStandardPaths>
@@ -315,6 +316,12 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
       if ( configurationsDir.exists() )
       {
         QgsMessageLog::logMessage( QStringLiteral( "Checking..." ), QStringLiteral( "QField" ) );
+        QFile file( QString( "%1/findme.txt" ).arg( configurationsDir.absolutePath() ) );
+        file.open( QIODevice::WriteOnly );
+        QTextStream stream( &file );
+        stream << "here I am!";
+        file.close();
+
         QgsMessageLog::logMessage( configurationsDir.entryList( QStringList() << QStringLiteral( "*" ), QDir::NoFilter ).join( '|' ) );
         const QStringList configurations = configurationsDir.entryList( QStringList() << QStringLiteral( "*.xml" ) << QStringLiteral( "*.XML" ), QDir::Files );
         for ( const QString &configuration : configurations )

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -139,6 +139,7 @@
 #include <qgslocalizeddatapathregistry.h>
 #include <qgslocator.h>
 #include <qgslocatormodel.h>
+#include <qgslogger.h>
 #include <qgsmaplayer.h>
 #include <qgsmapthemecollection.h>
 #include <qgsnetworkaccessmanager.h>
@@ -308,12 +309,13 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
     // import authentication method configurations
     for ( const QString &dataDir : dataDirs )
     {
-      QDir configurationsDir( QStringLiteral( "%1/auth/" ).arg( dataDir ) );
+      QDir configurationsDir( QStringLiteral( "%1/auth" ).arg( dataDir ) );
       if ( configurationsDir.exists() )
       {
         const QStringList configurations = configurationsDir.entryList( QStringList() << QStringLiteral( "*.xml" ) << QStringLiteral( "*.XML" ), QDir::Files );
         for ( const QString &configuration : configurations )
         {
+          qDebug() << QStringLiteral( "Importing authentication configuration file %1" ).arg( configurationsDir.absoluteFilePath( configuration ) );
           QgsApplication::instance()->authManager()->importAuthenticationConfigsFromXml( configurationsDir.absoluteFilePath( configuration ), QString(), true );
         }
       }

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -307,11 +307,14 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
     QgsApplication::instance()->authManager()->setPasswordHelperEnabled( false );
     QgsApplication::instance()->authManager()->setMasterPassword( QString( "qfield" ) );
     // import authentication method configurations
+    qDebug() << dataDirs;
     for ( const QString &dataDir : dataDirs )
     {
       QDir configurationsDir( QStringLiteral( "%1/auth" ).arg( dataDir ) );
+      qDebug() << QStringLiteral( "%1/auth" ).arg( dataDir );
       if ( configurationsDir.exists() )
       {
+        qDebug() << "Checking...";
         const QStringList configurations = configurationsDir.entryList( QStringList() << QStringLiteral( "*.xml" ) << QStringLiteral( "*.XML" ), QDir::Files );
         for ( const QString &configuration : configurations )
         {


### PR DESCRIPTION
Tiny cleanup of / slashes in the authentication imports code (I don't think it was consequential). I've also added a debug message to help debugging.