### PR TITLE
Local data picker follow ups

### DIFF
--- a/src/core/localfilesmodel.cpp
+++ b/src/core/localfilesmodel.cpp
@@ -16,6 +16,7 @@
 
 #include "localfilesmodel.h"
 #include "platformutilities.h"
+#include "qfieldcloudutils.h"
 #include "qgismobileapp.h"
 
 #include <QDir>
@@ -107,6 +108,14 @@ const QString LocalFilesModel::getCurrentTitleFromPath( const QString &path ) co
   else if ( path == PlatformUtilities::instance()->systemGenericDataLocation() + QStringLiteral( "/qfield/sample_projects" ) )
   {
     return tr( "Sample projects" );
+  }
+  else
+  {
+    const QString cloudProjectId = QFieldCloudUtils::getProjectId( path );
+    if ( !cloudProjectId.isEmpty() )
+    {
+      return QFieldCloudUtils::projectSetting( cloudProjectId, QStringLiteral( "name" ), QString() ).toString();
+    }
   }
 
   return QFileInfo( path ).fileName();

--- a/src/core/utils/fileutils.cpp
+++ b/src/core/utils/fileutils.cpp
@@ -22,6 +22,7 @@
 #include <QFileInfo>
 #include <QMimeDatabase>
 #include <qgis.h>
+#include <qgsfileutils.h>
 
 FileUtils::FileUtils( QObject *parent )
   : QObject( parent )
@@ -51,6 +52,11 @@ bool FileUtils::fileExists( const QString &filePath )
 {
   QFileInfo fileInfo( filePath );
   return ( fileInfo.exists() && fileInfo.isFile() );
+}
+
+QString FileUtils::representFileSize( qint64 bytes )
+{
+  return QgsFileUtils::representFileSize( bytes );
 }
 
 bool FileUtils::copyRecursively( const QString &sourceFolder, const QString &destFolder, QgsFeedback *feedback, bool wipeDestFolder )

--- a/src/core/utils/fileutils.h
+++ b/src/core/utils/fileutils.h
@@ -29,17 +29,19 @@ class QFIELD_CORE_EXPORT FileUtils : public QObject
 
   public:
     explicit FileUtils( QObject *parent = nullptr );
-    //! Destructor
     ~FileUtils() = default;
 
-    //! returns the mimetype of a filepath as string
+    //! Returns the mimetype of a filepath as string
     Q_INVOKABLE static QString mimeTypeName( const QString &filePath );
-    //! returns the filename of a filepath - if no file name exists it's empty
+    //! Returns the filename of a filepath - if no file name exists it's empty
     Q_INVOKABLE static QString fileName( const QString &filePath );
-    //! returns true if the file exists (false if it's a directory)
+    //! Returns true if the file exists (false if it's a directory)
     Q_INVOKABLE static bool fileExists( const QString &filePath );
-    //! returns the suffix (extension)
+    //! Returns the suffix (extension)
     Q_INVOKABLE static QString fileSuffix( const QString &filePath );
+    //! Returns a human-friendly size from bytes
+    Q_INVOKABLE static QString representFileSize( qint64 bytes );
+
     static bool copyRecursively( const QString &sourceFolder, const QString &destFolder, QgsFeedback *feedback = nullptr, bool wipeDestFolder = true );
     /**
      * Creates checksum of a file. Returns null QByteArray if cannot be calculated.

--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -61,7 +61,8 @@ bool QFieldCloudUtils::isCloudAction( const QgsMapLayer *layer )
 
 const QString QFieldCloudUtils::getProjectId( const QString &fileName )
 {
-  QDir baseDir = QFileInfo( fileName ).dir();
+  QFileInfo fi( fileName );
+  QDir baseDir = fi.isDir() ? fi.canonicalFilePath() : fi.canonicalPath();
   QString basePath = QFileInfo( baseDir.path() ).canonicalFilePath();
   QString cloudPath = QFileInfo( localCloudDirectory() ).canonicalFilePath();
 

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -124,6 +124,8 @@ Page {
           property int itemType: ItemType
           property string itemTitle: ItemTitle
           property string itemPath: ItemPath
+          property bool itemMenuLoadable: !projectFolderView &&
+                                          (ItemMetaType === LocalFilesModel.Project || ItemMetaType === LocalFilesModel.Dataset)
           property bool itemMenuVisible: (platformUtilities.capabilities & PlatformUtilities.CustomExport ||
                                           platformUtilities.capabilities & PlatformUtilities.CustomSend) &&
                                          (ItemMetaType === LocalFilesModel.Dataset
@@ -183,8 +185,8 @@ Page {
                 Layout.preferredHeight: contentHeight
                 text: ItemTitle
                 font.pointSize: Theme.defaultFont.pointSize
-                font.underline: true
-                color: Theme.mainColor
+                font.underline: itemMenuLoadable
+                color: itemMenuLoadable ? Theme.mainColor : "black"
                 wrapMode: Text.WordWrap
               }
               Text {
@@ -269,7 +271,7 @@ Page {
                   table.contentX + mouse.x,
                   table.contentY + mouse.y
                   )
-            if (item) {
+            if (item && item.itemMenuLoadable) {
               pressedItem = item.children[0].children[1].children[0]
               pressedItem.color = "#5a8725"
             }

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -200,10 +200,10 @@ Page {
                     info = qsTr('Project file');
                     break;
                   case LocalFilesModel.VectorDataset:
-                    info = qsTr('Vector dataset') + ' (' + ItemFormat + ')';
+                    info = qsTr('Vector dataset') + ' (' + FileUtils.representFileSize(ItemSize) + ', ' + ItemFormat + ')';
                     break;
                   case LocalFilesModel.RasterDataset:
-                    info = qsTr('Raster dataset') + ' (' + ItemFormat + ')';
+                    info = qsTr('Raster dataset') + ' (' + FileUtils.representFileSize(ItemSize) + ', ' + ItemFormat + ')';
                     break;
                   }
                   return info;

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -66,6 +66,7 @@ Page {
           font: Theme.tipFont
           wrapMode: Text.NoWrap
           elide: Text.ElideMiddle
+          opacity: 0.35
         }
       }
     }
@@ -183,7 +184,7 @@ Page {
                 id: itemTitle
                 Layout.fillWidth: true
                 Layout.preferredHeight: contentHeight
-                text: ItemTitle
+                text: ItemTitle + (ItemType !== LocalFilesModel.ProjectFile && ItemFormat !== '' ? '.' + ItemFormat : '')
                 font.pointSize: Theme.defaultFont.pointSize
                 font.underline: itemMenuLoadable
                 color: itemMenuLoadable ? Theme.mainColor : "black"
@@ -200,10 +201,10 @@ Page {
                     info = qsTr('Project file');
                     break;
                   case LocalFilesModel.VectorDataset:
-                    info = qsTr('Vector dataset') + ' (' + FileUtils.representFileSize(ItemSize) + ', ' + ItemFormat + ')';
+                    info = qsTr('Vector dataset') + ' (' + FileUtils.representFileSize(ItemSize) + ')';
                     break;
                   case LocalFilesModel.RasterDataset:
-                    info = qsTr('Raster dataset') + ' (' + FileUtils.representFileSize(ItemSize) + ', ' + ItemFormat + ')';
+                    info = qsTr('Raster dataset') + ' (' + FileUtils.representFileSize(ItemSize) + ')';
                     break;
                   }
                   return info;
@@ -213,6 +214,7 @@ Page {
                 font.pointSize: Theme.tipFont.pointSize - 2
                 font.italic: true
                 wrapMode: Text.WordWrap
+                opacity: 0.35
               }
             }
             QfToolButton {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -827,6 +827,9 @@ ApplicationWindow {
     allowLayerChange: !digitizingToolbar.isDigitizing
     mapSettings: mapCanvas.mapSettings
     interactive: !welcomeScreen.visible
+                 && !qfieldSettings.visible
+                 && !qfieldCloudScreen.visible
+                 && !qfieldLocalDataPickerScreen.visible
 
     onOpenedChanged: {
       if ( !opened ) {


### PR DESCRIPTION
Commits' description self explanatory :)

Showing the cloud project name instead of the folder name (i.e. the cloud project UUID) is a nice improvement:
![image](https://user-images.githubusercontent.com/1728657/169439282-ca57138e-4714-404b-acc1-e312363b7279.png)

File size information added to dataset items:
![image](https://user-images.githubusercontent.com/1728657/169442614-a996c49b-9f56-405a-828a-e56f70c15820.png)
