### PR TITLE
Harmonize position

### DIFF
--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -572,13 +572,25 @@ void FeatureModel::applyGeometry()
       QList<QgsVectorLayer *> intersectionLayers;
       switch ( mProject->avoidIntersectionsMode() )
       {
+#if _QGIS_VERSION_INT >= 32500
+        case Qgis::AvoidIntersectionsMode::AvoidIntersectionsCurrentLayer:
+#else
         case QgsProject::AvoidIntersectionsMode::AvoidIntersectionsCurrentLayer:
+#endif
           intersectionLayers.append( mLayer );
           break;
+#if _QGIS_VERSION_INT >= 32500
+        case Qgis::AvoidIntersectionsMode::AvoidIntersectionsLayers:
+#else
         case QgsProject::AvoidIntersectionsMode::AvoidIntersectionsLayers:
+#endif
           intersectionLayers = QgsProject::instance()->avoidIntersectionsLayers();
           break;
+#if _QGIS_VERSION_INT >= 32500
+        case Qgis::AvoidIntersectionsMode::AllowIntersections:
+#else
         case QgsProject::AvoidIntersectionsMode::AllowIntersections:
+#endif
           break;
       }
       if ( !intersectionLayers.isEmpty() )

--- a/src/core/utils/geometryutils.cpp
+++ b/src/core/utils/geometryutils.cpp
@@ -57,13 +57,25 @@ GeometryUtils::GeometryOperationResult GeometryUtils::reshapeFromRubberband( Qgs
       QList<QgsVectorLayer *> avoidIntersectionsLayers;
       switch ( QgsProject::instance()->avoidIntersectionsMode() )
       {
+#if _QGIS_VERSION_INT >= 32500
+        case Qgis::AvoidIntersectionsMode::AvoidIntersectionsCurrentLayer:
+#else
         case QgsProject::AvoidIntersectionsMode::AvoidIntersectionsCurrentLayer:
+#endif
           avoidIntersectionsLayers.append( layer );
           break;
+#if _QGIS_VERSION_INT >= 32500
+        case Qgis::AvoidIntersectionsMode::AvoidIntersectionsLayers:
+#else
         case QgsProject::AvoidIntersectionsMode::AvoidIntersectionsLayers:
+#endif
           avoidIntersectionsLayers = QgsProject::instance()->avoidIntersectionsLayers();
           break;
+#if _QGIS_VERSION_INT >= 32500
+        case Qgis::AvoidIntersectionsMode::AllowIntersections:
+#else
         case QgsProject::AvoidIntersectionsMode::AllowIntersections:
+#endif
           break;
       }
       if ( !avoidIntersectionsLayers.isEmpty() )

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -659,9 +659,9 @@ ApplicationWindow {
               '%1%2%3%4'
                 .arg(stateMachine.state === 'digitize' || !digitizingToolbar.isDigitizing ? '<p>%1: %2<br>%3: %4</p>'
                   .arg(coordinateLocator.mapSettings.destinationCrs.isGeographic ? qsTr( 'Lon' ) : 'X')
-                  .arg(coordinateLocator.currentCoordinate.x.toFixed( coordinateLocator.mapSettings.destinationCrs.isGeographic ? 5 : 2 ))
+                  .arg(coordinateLocator.currentCoordinate.x.toLocaleString( Qt.locale(), 'f', coordinateLocator.mapSettings.destinationCrs.isGeographic ? 5 : 2 ))
                   .arg(coordinateLocator.mapSettings.destinationCrs.isGeographic ? qsTr( 'Lat' ) : 'Y')
-                  .arg(coordinateLocator.currentCoordinate.y.toFixed( coordinateLocator.mapSettings.destinationCrs.isGeographic ? 5 : 2 ))
+                  .arg(coordinateLocator.currentCoordinate.y.toLocaleString( Qt.locale(), 'f', coordinateLocator.mapSettings.destinationCrs.isGeographic ? 5 : 2 ))
                   : '' )
 
                 .arg(digitizingGeometryMeasure.lengthValid ? '<p>%1: %2%3</p>'


### PR DESCRIPTION
 This PR harmonizes the way we format coordinates in our coordinate cursor overlay vs. the positioning information panel.

Fixed:
![image](https://user-images.githubusercontent.com/1728657/169691149-3922e860-33e5-480c-b2f7-9f62438b7255.png)

(A commit in there fix compilation of QField against upcoming QGIS 3.26 too)