### PR TITLE
Measuring tool improvements

### DIFF
--- a/src/core/distancearea.h
+++ b/src/core/distancearea.h
@@ -32,9 +32,11 @@ class DistanceArea : public QObject
     Q_PROPERTY( QgsProject *project READ project WRITE setProject NOTIFY projectChanged )
 
     Q_PROPERTY( qreal length READ length NOTIFY lengthChanged )
-    Q_PROPERTY( bool lengthValid READ lengthValid NOTIFY lengthValidChanged )
+    Q_PROPERTY( bool lengthValid READ lengthValid NOTIFY lengthChanged )
+    Q_PROPERTY( qreal perimeter READ perimeter NOTIFY perimeterChanged )
+    Q_PROPERTY( bool perimeterValid READ perimeterValid NOTIFY perimeterChanged )
     Q_PROPERTY( qreal area READ area NOTIFY areaChanged )
-    Q_PROPERTY( bool areaValid READ areaValid NOTIFY areaValidChanged )
+    Q_PROPERTY( bool areaValid READ areaValid NOTIFY areaChanged )
     Q_PROPERTY( QgsUnitTypes::DistanceUnit lengthUnits READ lengthUnits NOTIFY lengthUnitsChanged )
     Q_PROPERTY( QgsUnitTypes::AreaUnit areaUnits READ areaUnits NOTIFY areaUnitsChanged )
 
@@ -48,6 +50,8 @@ class DistanceArea : public QObject
 
     qreal length() const;
     bool lengthValid() const;
+    qreal perimeter() const;
+    bool perimeterValid() const;
     qreal area() const;
     bool areaValid() const;
     qreal segmentLength() const;
@@ -70,9 +74,8 @@ class DistanceArea : public QObject
     void projectChanged();
 
     void lengthChanged();
-    void lengthValidChanged();
+    void perimeterChanged();
     void areaChanged();
-    void areaValidChanged();
     void segmentLengthChanged();
     void lengthUnitsChanged();
     void areaUnitsChanged();

--- a/src/core/rubberbandmodel.cpp
+++ b/src/core/rubberbandmodel.cpp
@@ -200,6 +200,14 @@ QgsPoint RubberbandModel::currentCoordinate() const
   return mPointList.value( mCurrentCoordinateIndex );
 }
 
+QgsPoint RubberbandModel::firstCoordinate() const
+{
+  if ( mPointList.isEmpty() )
+    return QgsPoint();
+
+  return mPointList.at( 0 );
+}
+
 QgsPoint RubberbandModel::lastCoordinate() const
 {
   if ( mPointList.isEmpty() )

--- a/src/core/rubberbandmodel.h
+++ b/src/core/rubberbandmodel.h
@@ -40,12 +40,14 @@ class QFIELD_CORE_EXPORT RubberbandModel : public QObject
 {
     Q_OBJECT
 
+    Q_PROPERTY( QgsPoint firstCoordinate READ firstCoordinate NOTIFY currentCoordinateChanged )
     Q_PROPERTY( QgsPoint lastCoordinate READ lastCoordinate NOTIFY currentCoordinateChanged )
     Q_PROPERTY( QgsPoint currentCoordinate READ currentCoordinate WRITE setCurrentCoordinate NOTIFY currentCoordinateChanged )
     Q_PROPERTY( int currentCoordinateIndex READ currentCoordinateIndex WRITE setCurrentCoordinateIndex NOTIFY currentCoordinateIndexChanged )
     Q_PROPERTY( QgsWkbTypes::GeometryType geometryType READ geometryType WRITE setGeometryType NOTIFY geometryTypeChanged )
     Q_PROPERTY( QgsVectorLayer *vectorLayer READ vectorLayer WRITE setVectorLayer NOTIFY vectorLayerChanged )
     Q_PROPERTY( int vertexCount READ vertexCount NOTIFY vertexCountChanged )
+    Q_PROPERTY( QVector<QgsPoint> vertices READ vertices NOTIFY currentCoordinateChanged )
     Q_PROPERTY( QgsCoordinateReferenceSystem crs READ crs WRITE setCrs NOTIFY crsChanged )
     //! freeze the rubberband so it doesn't get modified while panning map
     Q_PROPERTY( bool frozen READ frozen WRITE setFrozen NOTIFY frozenChanged )
@@ -86,6 +88,7 @@ class QFIELD_CORE_EXPORT RubberbandModel : public QObject
 
     QgsPoint currentPoint( const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem(), QgsWkbTypes::Type wkbType = QgsWkbTypes::PointZ ) const;
 
+    QgsPoint firstCoordinate() const;
     QgsPoint lastCoordinate() const;
     QgsPoint currentCoordinate() const;
     void setCurrentCoordinate( const QgsPoint &currentCoordinate );

--- a/src/core/utils/geometryutils.cpp
+++ b/src/core/utils/geometryutils.cpp
@@ -128,3 +128,8 @@ QgsPoint GeometryUtils::coordinateToPoint( const QGeoCoordinate &coor )
 {
   return QgsPoint( coor.longitude(), coor.latitude(), coor.altitude() );
 }
+
+double GeometryUtils::distanceBetweenPoints( const QgsPoint &start, const QgsPoint &end )
+{
+  return start.distance( end );
+}

--- a/src/core/utils/geometryutils.h
+++ b/src/core/utils/geometryutils.h
@@ -72,6 +72,8 @@ class QFIELD_CORE_EXPORT GeometryUtils : public QObject
 
     //! Converts QGeoCoordinate to QgsPoint
     static Q_INVOKABLE QgsPoint coordinateToPoint( const QGeoCoordinate &coor );
+
+    static Q_INVOKABLE double distanceBetweenPoints( const QgsPoint &start, const QgsPoint &end );
 };
 
 #endif // GEOMETRYUTILS_H

--- a/src/core/utils/geometryutils.h
+++ b/src/core/utils/geometryutils.h
@@ -73,6 +73,7 @@ class QFIELD_CORE_EXPORT GeometryUtils : public QObject
     //! Converts QGeoCoordinate to QgsPoint
     static Q_INVOKABLE QgsPoint coordinateToPoint( const QGeoCoordinate &coor );
 
+    //! Returns the distance between a pair of \a start and \a end points.
     static Q_INVOKABLE double distanceBetweenPoints( const QgsPoint &start, const QgsPoint &end );
 };
 

--- a/src/qml/MeasuringTool.qml
+++ b/src/qml/MeasuringTool.qml
@@ -1,0 +1,78 @@
+import QtQuick 2.12
+
+import org.qgis 1.0
+import org.qfield 1.0
+
+import Theme 1.0
+
+Item {
+  id: measuringTool
+
+  property alias measuringRubberband: rubberband
+  property bool isClosingArea: rubberband.model.vertexCount > 2
+                               && vertexFirstLastDistance.screenDistance < 10
+  property bool isArea: false
+
+  MapToScreen {
+    id: vertexFirstLastDistance
+    mapSettings: rubberband.mapSettings
+    mapDistance: GeometryUtils.distanceBetweenPoints(rubberband.model.firstCoordinate,
+                                                     rubberband.model.currentCoordinate)
+  }
+
+  Repeater {
+    id: vertices
+    model: rubberband.model.vertices
+    delegate: Rectangle {
+      MapToScreen {
+        id: vertexToScreen
+        mapSettings: rubberband.mapSettings
+        mapPoint: modelData
+      }
+
+      visible: rubberband.model.vertexCount > 1
+
+      x: vertexToScreen.screenPoint.x - width/2
+      y: vertexToScreen.screenPoint.y - width/2
+
+      width: isClosingArea
+             && (index === 0 || index === rubberband.model.vertexCount - 1)
+             ? 20
+             : 10
+      height: width
+      radius: width / 2
+      color: "#20000000"
+      border.color: '#80000000'
+      border.width: 2
+    }
+  }
+
+  Rubberband {
+    id: rubberband
+    width: 2.5
+    color: '#80000000'
+
+    model: RubberbandModel {
+      frozen: false
+      geometryType: isClosingArea || isArea
+                    ? QgsWkbTypes.PolygonGeometry
+                    : QgsWkbTypes.LineGeometry
+      crs: rubberband.mapSettings.destinationCrs
+    }
+
+    anchors.fill: parent
+  }
+
+  Connections {
+    target: rubberband.model
+
+    function onVertexCountChanged() {
+      if (rubberband.model.vertexCount > 2
+          && vertexFirstLastDistance.screenDistance < 10) {
+        isArea = true;
+      } else if (rubberband.model.vertexCount <= 1) {
+        isArea = false;
+      }
+    }
+  }
+}

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -685,7 +685,13 @@ ApplicationWindow {
                        .arg(UnitTypes.formatDistance( digitizingGeometryMeasure.segmentLength, 3, digitizingGeometryMeasure.lengthUnits ) )
                      : '' )
 
-                .arg(digitizingGeometryMeasure.lengthValid
+                .arg(currentRubberband.model.geometryType === QgsWkbTypes.PolygonGeometry
+                     ? digitizingGeometryMeasure.perimeterValid
+                       ? '<p>%1: %2</p>'
+                         .arg( qsTr( 'Perimeter') )
+                         .arg(UnitTypes.formatDistance( digitizingGeometryMeasure.perimeter, 3, digitizingGeometryMeasure.lengthUnits ) )
+                       : ''
+                     : digitizingGeometryMeasure.lengthValid
                      ? '<p>%1: %2</p>'
                        .arg( qsTr( 'Length') )
                        .arg(UnitTypes.formatDistance( digitizingGeometryMeasure.length, 3, digitizingGeometryMeasure.lengthUnits ) )

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -123,7 +123,7 @@ ApplicationWindow {
       State {
         name: 'measure'
         PropertyChanges { target: identifyTool; deactivated: true }
-        PropertyChanges { target: mainWindow; currentRubberband: measuringRubberband }
+        PropertyChanges { target: mainWindow; currentRubberband: measuringTool.measuringRubberband }
         PropertyChanges { target: featureForm; state: "Hidden" }
       }
     ]
@@ -430,81 +430,13 @@ ApplicationWindow {
     }
 
     /** A rubberband for measuring **/
-    Item {
+    MeasuringTool {
       id: measuringTool
-
-      anchors.fill: parent
       visible: stateMachine.state === 'measure'
+      anchors.fill: parent
 
-      property bool isClosingArea: measuringRubberband.model.vertexCount > 2
-                                   && measuringVertexFirstLastDistance.screenDistance < 10
-      property bool isArea: false
-
-      MapToScreen {
-        id: measuringVertexFirstLastDistance
-        mapSettings: mapCanvas.mapSettings
-        mapDistance: GeometryUtils.distanceBetweenPoints(measuringRubberband.model.firstCoordinate,
-                                                         measuringRubberband.model.currentCoordinate)
-      }
-
-      Repeater {
-        id: measuringVertices
-        model: measuringRubberband.model.vertices
-        delegate: Rectangle {
-          MapToScreen {
-            id: measuringVertexToScreen
-            mapSettings: mapCanvas.mapSettings
-            mapPoint: modelData
-          }
-
-          visible: measuringRubberband.model.vertexCount > 1
-
-          x: measuringVertexToScreen.screenPoint.x - width/2
-          y: measuringVertexToScreen.screenPoint.y - width/2
-
-          width: measuringTool.isClosingArea
-                 && (index === 0 || index === measuringRubberband.model.vertexCount - 1)
-                 ? 20
-                 : 10
-          height: width
-          radius: width / 2
-          color: "#20000000"
-          border.color: '#80000000'
-          border.width: 2
-        }
-      }
-
-      Rubberband {
-        id: measuringRubberband
-        width: 2.5
-        color: '#80000000'
-
-        mapSettings: mapCanvas.mapSettings
-
-        model: RubberbandModel {
-          frozen: false
-          currentCoordinate: coordinateLocator.currentCoordinate
-          geometryType: measuringTool.isClosingArea || measuringTool.isArea
-                        ? QgsWkbTypes.PolygonGeometry
-                        : QgsWkbTypes.LineGeometry
-          crs: mapCanvas.mapSettings.destinationCrs
-        }
-
-        anchors.fill: parent
-      }
-
-      Connections {
-        target: measuringRubberband.model
-
-        function onVertexCountChanged() {
-          if (measuringRubberband.model.vertexCount > 2
-              && measuringVertexFirstLastDistance.screenDistance < 10) {
-            measuringTool.isArea = true;
-          } else if (measuringRubberband.model.vertexCount <= 1) {
-            measuringTool.isArea = false;
-          }
-        }
-      }
+      measuringRubberband.model.currentCoordinate: coordinateLocator.currentCoordinate
+      measuringRubberband.mapSettings: mapCanvas.mapSettings
     }
 
     /** Tracking sessions **/

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -738,7 +738,7 @@ ApplicationWindow {
     }
 
     text: ( qfieldSettings.numericalDigitizingInformation && stateMachine.state === "digitize" ) || stateMachine.state === 'measure' ?
-              '%1%2%3%4'
+              '%1%2%3%4%5'
                 .arg(stateMachine.state === 'digitize' || !digitizingToolbar.isDigitizing ? '<p>%1: %2<br>%3: %4</p>'
                   .arg(coordinateLocator.mapSettings.destinationCrs.isGeographic ? qsTr( 'Lon' ) : 'X')
                   .arg(coordinateLocator.currentCoordinate.x.toLocaleString( Qt.locale(), 'f', coordinateLocator.mapSettings.destinationCrs.isGeographic ? 5 : 2 ))
@@ -746,11 +746,18 @@ ApplicationWindow {
                   .arg(coordinateLocator.currentCoordinate.y.toLocaleString( Qt.locale(), 'f', coordinateLocator.mapSettings.destinationCrs.isGeographic ? 5 : 2 ))
                   : '' )
 
-                .arg(digitizingGeometryMeasure.lengthValid ? '<p>%1: %2%3</p>'
-                  .arg( digitizingGeometryMeasure.segmentLength != digitizingGeometryMeasure.length ? qsTr( 'Segment') : qsTr( 'Length') )
-                  .arg(UnitTypes.formatDistance( digitizingGeometryMeasure.segmentLength, 3, digitizingGeometryMeasure.lengthUnits ) )
-                  .arg(digitizingGeometryMeasure.length !== -1 && digitizingGeometryMeasure.segmentLength != digitizingGeometryMeasure.length ? '<br>%1: %2'.arg( qsTr( 'Length') ).arg(UnitTypes.formatDistance( digitizingGeometryMeasure.length, 3, digitizingGeometryMeasure.lengthUnits ) ) : '' )
-                  : '' )
+                .arg(digitizingGeometryMeasure.lengthValid && digitizingGeometryMeasure.segmentLength != 0.0
+                     && digitizingGeometryMeasure.segmentLength != digitizingGeometryMeasure.length
+                     ? '<p>%1: %2</p>'
+                       .arg( qsTr( 'Segment') )
+                       .arg(UnitTypes.formatDistance( digitizingGeometryMeasure.segmentLength, 3, digitizingGeometryMeasure.lengthUnits ) )
+                     : '' )
+
+                .arg(digitizingGeometryMeasure.lengthValid
+                     ? '<p>%1: %2</p>'
+                       .arg( qsTr( 'Length') )
+                       .arg(UnitTypes.formatDistance( digitizingGeometryMeasure.length, 3, digitizingGeometryMeasure.lengthUnits ) )
+                     : '' )
 
                 .arg(digitizingGeometryMeasure.areaValid ? '<p>%1: %2</p>'
                   .arg( qsTr( 'Area') )

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -430,23 +430,81 @@ ApplicationWindow {
     }
 
     /** A rubberband for measuring **/
-    Rubberband {
-      id: measuringRubberband
-      width: 2.5
-      color: '#80000000'
-
-      mapSettings: mapCanvas.mapSettings
-
-      model: RubberbandModel {
-        frozen: false
-        currentCoordinate: coordinateLocator.currentCoordinate
-        geometryType: QgsWkbTypes.PolygonGeometry
-        crs: mapCanvas.mapSettings.destinationCrs
-      }
+    Item {
+      id: measuringTool
 
       anchors.fill: parent
-
       visible: stateMachine.state === 'measure'
+
+      property bool isClosingArea: measuringRubberband.model.vertexCount > 2
+                                   && measuringVertexFirstLastDistance.screenDistance < 10
+      property bool isArea: false
+
+      MapToScreen {
+        id: measuringVertexFirstLastDistance
+        mapSettings: mapCanvas.mapSettings
+        mapDistance: GeometryUtils.distanceBetweenPoints(measuringRubberband.model.firstCoordinate,
+                                                         measuringRubberband.model.currentCoordinate)
+      }
+
+      Repeater {
+        id: measuringVertices
+        model: measuringRubberband.model.vertices
+        delegate: Rectangle {
+          MapToScreen {
+            id: measuringVertexToScreen
+            mapSettings: mapCanvas.mapSettings
+            mapPoint: modelData
+          }
+
+          visible: measuringRubberband.model.vertexCount > 1
+
+          x: measuringVertexToScreen.screenPoint.x - width/2
+          y: measuringVertexToScreen.screenPoint.y - width/2
+
+          width: measuringTool.isClosingArea
+                 && (index === 0 || index === measuringRubberband.model.vertexCount - 1)
+                 ? 20
+                 : 10
+          height: width
+          radius: width / 2
+          color: "#20000000"
+          border.color: '#80000000'
+          border.width: 2
+        }
+      }
+
+      Rubberband {
+        id: measuringRubberband
+        width: 2.5
+        color: '#80000000'
+
+        mapSettings: mapCanvas.mapSettings
+
+        model: RubberbandModel {
+          frozen: false
+          currentCoordinate: coordinateLocator.currentCoordinate
+          geometryType: measuringTool.isClosingArea || measuringTool.isArea
+                        ? QgsWkbTypes.PolygonGeometry
+                        : QgsWkbTypes.LineGeometry
+          crs: mapCanvas.mapSettings.destinationCrs
+        }
+
+        anchors.fill: parent
+      }
+
+      Connections {
+        target: measuringRubberband.model
+
+        function onVertexCountChanged() {
+          if (measuringRubberband.model.vertexCount > 2
+              && measuringVertexFirstLastDistance.screenDistance < 10) {
+            measuringTool.isArea = true;
+          } else if (measuringRubberband.model.vertexCount <= 1) {
+            measuringTool.isArea = false;
+          }
+        }
+      }
     }
 
     /** Tracking sessions **/
@@ -472,7 +530,6 @@ ApplicationWindow {
       }
 
       anchors.fill: parent
-
       visible: stateMachine.state === "digitize"
     }
 

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -16,6 +16,7 @@
         <file>LayerSelector.qml</file>
         <file>LocationMarker.qml</file>
         <file>MapCanvas.qml</file>
+        <file>MeasuringTool.qml</file>
         <file>MessageLog.qml</file>
         <file>NavigationBar.qml</file>
         <file>NavigationHighlight.qml</file>


### PR DESCRIPTION
Doing some field monitoring and need to quickly send screen grabs of QField representing line measurements. QField until now treats all measurements as filled. This makes for less than ideal screen grabs (confusing for viewers, etc.)

This PR fixes that by treating measurement geometry as a line until the user overs the current coordinate onto the first digitized coordinate. Hovering temporarily transform the geometry to an area, while clicking on add vertex while hovering over the first vertex transform the geometry to an area until the feature is cleared.

Screencast:

https://user-images.githubusercontent.com/1728657/170182115-c54fa882-b428-402f-a66f-4d4eaa57831c.mp4

I've also improved the digitizing text overlay by hiding Segment: XXXX when the segment length is 0.00000 :)