### PR TITLE
Respect CRS axes order in go to locator and when copying a point to clipboard

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(QFIELD_CORE_SRCS
     platforms/platformutilities.cpp
+    utils/coordinatereferencesystemutils.cpp
     utils/expressioncontextutils.cpp
     utils/featureutils.cpp
     utils/fileutils.cpp
@@ -95,6 +96,7 @@ set(QFIELD_CORE_SRCS
 
 set(QFIELD_CORE_HDRS
     platforms/platformutilities.h
+    utils/coordinatereferencesystemutils.h
     utils/expressioncontextutils.h
     utils/featureutils.h
     utils/fileutils.h

--- a/src/core/locator/gotolocatorfilter.cpp
+++ b/src/core/locator/gotolocatorfilter.cpp
@@ -20,7 +20,9 @@
 
 #include <QAction>
 #include <QRegularExpression>
+#if _QGIS_VERSION_INT >= 32500
 #include <qgscoordinatereferencesystemutils.h>
+#endif
 #include <qgscoordinateutils.h>
 #include <qgsexpressioncontextutils.h>
 #include <qgsfeedback.h>
@@ -72,6 +74,7 @@ void GotoLocatorFilter::fetchResults( const QString &string, const QgsLocatorCon
     }
   }
 
+#if _QGIS_VERSION_INT >= 32500
   if ( !match.hasMatch() )
   {
     // Check if the string is a pair of decimal degrees with [N,S,E,W] suffixes
@@ -89,6 +92,7 @@ void GotoLocatorFilter::fetchResults( const QString &string, const QgsLocatorCon
         std::swap( firstNumber, secondNumber );
     }
   }
+#endif
 
   if ( !match.hasMatch() )
   {
@@ -114,24 +118,30 @@ void GotoLocatorFilter::fetchResults( const QString &string, const QgsLocatorCon
   if ( firstOk && secondOk )
   {
     QVariantMap data;
+#if _QGIS_VERSION_INT >= 32500
     const bool currentCrsIsXY = QgsCoordinateReferenceSystemUtils::defaultCoordinateOrderForCrs( currentCrs ) == Qgis::CoordinateOrder::XY;
     const bool withinWgs84 = wgs84Crs.bounds().contains( secondNumber, firstNumber );
-
+#else
+    const bool currentCrsIsXY = true;
+    const bool withinWgs84 = wgs84Crs.bounds().contains( firstNumber, secondNumber );
+#endif
     if ( !posIsWgs84 && currentCrs != wgs84Crs )
     {
-      const QgsPointXY point( currentCrsIsXY ? firstNumber : secondNumber,
+      // cppcheck-suppress knownConditionTrueFalse
+      const QgsPointXY point( currentCrsIsXY ? firstNumber : secondNumber, // cppcheck-suppress knownConditionTrueFalse
                               currentCrsIsXY ? secondNumber : firstNumber );
       data.insert( QStringLiteral( "point" ), point );
 
-      const QList<Qgis::CrsAxisDirection> axisList = currentCrs.axisOrdering();
       QString firstSuffix;
       QString secondSuffix;
+#if _QGIS_VERSION_INT >= 32500
+      const QList<Qgis::CrsAxisDirection> axisList = currentCrs.axisOrdering();
       if ( axisList.size() >= 2 )
       {
         firstSuffix = QgsCoordinateReferenceSystemUtils::axisDirectionToAbbreviatedString( axisList.at( 0 ) );
         secondSuffix = QgsCoordinateReferenceSystemUtils::axisDirectionToAbbreviatedString( axisList.at( 1 ) );
       }
-
+#endif
       QgsLocatorResult result;
       result.filter = this;
       result.displayString = tr( "Go to %1%2 %3%4 (Map CRS, %5)" ).arg( locale.toString( firstNumber, 'g', 10 ), firstSuffix, locale.toString( secondNumber, 'g', 10 ), secondSuffix, currentCrs.userFriendlyIdentifier() );
@@ -142,7 +152,11 @@ void GotoLocatorFilter::fetchResults( const QString &string, const QgsLocatorCon
 
     if ( withinWgs84 )
     {
+#if _QGIS_VERSION_INT >= 32500
       const QgsPointXY point( secondNumber, firstNumber );
+#else
+      const QgsPointXY point( firstNumber, secondNumber );
+#endif
       if ( currentCrs != wgs84Crs )
       {
         const QgsCoordinateTransform transform( wgs84Crs, currentCrs, QgsProject::instance()->transformContext() );

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -52,6 +52,7 @@
 #include "bluetoothdevicemodel.h"
 #include "bluetoothreceiver.h"
 #include "changelogcontents.h"
+#include "coordinatereferencesystemutils.h"
 #include "deltafilewrapper.h"
 #include "deltalistmodel.h"
 #include "digitizinglogger.h"
@@ -491,6 +492,7 @@ void QgisMobileapp::initDeclarative()
   REGISTER_SINGLETON( "org.qfield", UrlUtils, "UrlUtils" );
   REGISTER_SINGLETON( "org.qfield", QFieldCloudUtils, "QFieldCloudUtils" );
   REGISTER_SINGLETON( "org.qfield", PositioningUtils, "PositioningUtils" );
+  REGISTER_SINGLETON( "org.qfield", CoordinateReferenceSystemUtils, "CoordinateReferenceSystemUtils" );
 
   qmlRegisterUncreatableType<AppInterface>( "org.qgis", 1, 0, "QgisInterface", "QgisInterface is only provided by the environment and cannot be created ad-hoc" );
   qmlRegisterUncreatableType<Settings>( "org.qgis", 1, 0, "Settings", "" );

--- a/src/core/utils/coordinatereferencesystemutils.cpp
+++ b/src/core/utils/coordinatereferencesystemutils.cpp
@@ -16,7 +16,20 @@
 
 #include "coordinatereferencesystemutils.h"
 
+#if _QGIS_VERSION_INT >= 32500
+#include <qgscoordinatereferencesystemutils.h>
+#endif
+
 CoordinateReferenceSystemUtils::CoordinateReferenceSystemUtils( QObject *parent )
   : QObject( parent )
 {
+}
+
+bool CoordinateReferenceSystemUtils::defaultCoordinateOrderForCrsIsXY( QgsCoordinateReferenceSystem crs )
+{
+#if _QGIS_VERSION_INT >= 32500
+  return QgsCoordinateReferenceSystemUtils::defaultCoordinateOrderForCrs( crs ) == Qgis::CoordinateOrder::XY;
+#else
+  return true;
+#endif
 }

--- a/src/core/utils/coordinatereferencesystemutils.cpp
+++ b/src/core/utils/coordinatereferencesystemutils.cpp
@@ -1,0 +1,22 @@
+/***************************************************************************
+  coordinatereferencesystemutils.cpp - CoordinateReferenceSystemUtils
+
+ ---------------------
+ begin                : 28.05.2022
+ copyright            : (C) 2022 by Mathieu Pellerin
+ email                : mathieu at opengis dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "coordinatereferencesystemutils.h"
+
+CoordinateReferenceSystemUtils::CoordinateReferenceSystemUtils( QObject *parent )
+  : QObject( parent )
+{
+}

--- a/src/core/utils/coordinatereferencesystemutils.cpp
+++ b/src/core/utils/coordinatereferencesystemutils.cpp
@@ -25,7 +25,7 @@ CoordinateReferenceSystemUtils::CoordinateReferenceSystemUtils( QObject *parent 
 {
 }
 
-bool CoordinateReferenceSystemUtils::defaultCoordinateOrderForCrsIsXY( QgsCoordinateReferenceSystem crs )
+bool CoordinateReferenceSystemUtils::defaultCoordinateOrderForCrsIsXY( const QgsCoordinateReferenceSystem &crs )
 {
 #if _QGIS_VERSION_INT >= 32500
   return QgsCoordinateReferenceSystemUtils::defaultCoordinateOrderForCrs( crs ) == Qgis::CoordinateOrder::XY;

--- a/src/core/utils/coordinatereferencesystemutils.h
+++ b/src/core/utils/coordinatereferencesystemutils.h
@@ -1,0 +1,39 @@
+/***************************************************************************
+  coordinatereferencesystemutils.h - CoordinateReferenceSystemUtils
+
+ ---------------------
+ begin                : 28.05.2022
+ copyright            : (C) 2022 by Mathieu Pellerin
+ email                : mathieu at opengis dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef COORDINATEREFERENCESYSTEMUTILS_H
+#define COORDINATEREFERENCESYSTEMUTILS_H
+
+#include "qfield_core_export.h"
+
+#include <QObject>
+#include <qgscoordinatereferencesystem.h>
+#include <qgscoordinatetransformcontext.h>
+
+class QFIELD_CORE_EXPORT CoordinateReferenceSystemUtils : public QObject
+{
+    Q_OBJECT
+
+  public:
+    explicit CoordinateReferenceSystemUtils( QObject *parent = nullptr );
+
+    //! Returns an invalid CRS
+    static Q_INVOKABLE QgsCoordinateReferenceSystem invalidCrs() { return QgsCoordinateReferenceSystem(); }
+
+    //! Returns an empty transform context
+    static Q_INVOKABLE QgsCoordinateTransformContext emptyTransformContext() { return QgsCoordinateTransformContext(); }
+};
+
+#endif // COORDINATEREFERENCESYSTEMUTILS_H

--- a/src/core/utils/coordinatereferencesystemutils.h
+++ b/src/core/utils/coordinatereferencesystemutils.h
@@ -34,6 +34,9 @@ class QFIELD_CORE_EXPORT CoordinateReferenceSystemUtils : public QObject
 
     //! Returns an empty transform context
     static Q_INVOKABLE QgsCoordinateTransformContext emptyTransformContext() { return QgsCoordinateTransformContext(); }
+
+    //! Returns whether the default coordinate order of a given \a crs is XY
+    static Q_INVOKABLE bool defaultCoordinateOrderForCrsIsXY( QgsCoordinateReferenceSystem crs );
 };
 
 #endif // COORDINATEREFERENCESYSTEMUTILS_H

--- a/src/core/utils/coordinatereferencesystemutils.h
+++ b/src/core/utils/coordinatereferencesystemutils.h
@@ -36,7 +36,7 @@ class QFIELD_CORE_EXPORT CoordinateReferenceSystemUtils : public QObject
     static Q_INVOKABLE QgsCoordinateTransformContext emptyTransformContext() { return QgsCoordinateTransformContext(); }
 
     //! Returns whether the default coordinate order of a given \a crs is XY
-    static Q_INVOKABLE bool defaultCoordinateOrderForCrsIsXY( QgsCoordinateReferenceSystem crs );
+    static Q_INVOKABLE bool defaultCoordinateOrderForCrsIsXY( const QgsCoordinateReferenceSystem &crs );
 };
 
 #endif // COORDINATEREFERENCESYSTEMUTILS_H

--- a/src/core/utils/snappingutils.h
+++ b/src/core/utils/snappingutils.h
@@ -48,6 +48,8 @@ class SnappingUtils : public QgsSnappingUtils
 
     static QgsPoint newPoint( const QgsPoint &snappedPoint, const QgsWkbTypes::Type wkbType );
 
+    static Q_INVOKABLE QgsSnappingConfig emptySnappingConfig() { return QgsSnappingConfig(); }
+
   signals:
     void mapSettingsChanged();
     void currentLayerChanged();

--- a/src/core/utils/stringutils.cpp
+++ b/src/core/utils/stringutils.cpp
@@ -70,7 +70,7 @@ bool StringUtils::fuzzyMatch( const QString &source, const QString &term )
            : false;
 }
 
-QString StringUtils::pointInformation( QgsPoint point, QgsCoordinateReferenceSystem crs )
+QString StringUtils::pointInformation( const QgsPoint &point, const QgsCoordinateReferenceSystem &crs )
 {
   QString firstSuffix;
   QString secondSuffix;

--- a/src/core/utils/stringutils.h
+++ b/src/core/utils/stringutils.h
@@ -45,7 +45,7 @@ class QFIELD_CORE_EXPORT StringUtils : public QObject
     //! Checks whether the string \a term is part of \a source
     static bool fuzzyMatch( const QString &source, const QString &term );
 
-    static Q_INVOKABLE QString pointInformation( QgsPoint point, QgsCoordinateReferenceSystem crs );
+    static Q_INVOKABLE QString pointInformation( const QgsPoint &point, const QgsCoordinateReferenceSystem &crs );
 };
 
 #endif // STRINGUTILS_H

--- a/src/core/utils/stringutils.h
+++ b/src/core/utils/stringutils.h
@@ -21,6 +21,8 @@
 #include "qfield_core_export.h"
 
 #include <QObject>
+#include <qgscoordinatereferencesystem.h>
+#include <qgspoint.h>
 
 class QFIELD_CORE_EXPORT StringUtils : public QObject
 {
@@ -42,6 +44,8 @@ class QFIELD_CORE_EXPORT StringUtils : public QObject
 
     //! Checks whether the string \a term is part of \a source
     static bool fuzzyMatch( const QString &source, const QString &term );
+
+    static Q_INVOKABLE QString pointInformation( QgsPoint point, QgsCoordinateReferenceSystem crs );
 };
 
 #endif // STRINGUTILS_H

--- a/src/qml/About.qml
+++ b/src/qml/About.qml
@@ -126,7 +126,6 @@ Item {
 
             text: {
                 var dataDirs = platformUtilities.qfieldAppDataDirs();
-                console.log(dataDirs)
                 if (dataDirs.length > 0) {
                   return (dataDirs.length > 1
                           ? 'QField app directories'

--- a/src/qml/BookmarkProperties.qml
+++ b/src/qml/BookmarkProperties.qml
@@ -180,13 +180,7 @@ Popup {
                 onClicked: {
                     var point = bookmarkModel.getBookmarkPoint(bookmarkProperties.bookmarkId)
                     var crs = bookmarkModel.getBookmarkCrs(bookmarkProperties.bookmarkId)
-                    var coordinates = ''
-                    if (crs.isGeographic) {
-                      coordinates = qsTr( 'Lon' ) + ' ' +  point.x.toFixed(5) + ', ' + qsTr( 'Lat' ) + ' ' + point.y.toFixed(5)
-                    } else {
-                      coordinates = qsTr( 'X' ) + ' ' +  point.x.toFixed(2) + ', ' + qsTr( 'Y' ) + ' ' + point.y.toFixed(2)
-                    }
-                    coordinates += ' (' + crs.authid + ' ' + crs.description + ')'
+                    var coordinates = StringUtils.pointInformation(point, crs)
 
                     platformUtilities.copyTextToClipboard(nameField.text + '\n' + coordinates)
                     displayToast(qsTr('Bookmark details copied to clipboard'));

--- a/src/qml/BookmarkRenderer.qml
+++ b/src/qml/BookmarkRenderer.qml
@@ -46,7 +46,7 @@ Item {
                     sourceCrs: geometryWrapper.crs
                     sourcePosition: modelData
                     destinationCrs: mapCanvas.mapSettings.destinationCrs
-                    transformContext: qgisProject.transformContext
+                    transformContext: qgisProject ? qgisProject.transformContext : CoordinateReferenceSystemUtils.emptyTransformContext()
                 }
 
                 MapToScreen {

--- a/src/qml/CoordinateLocator.qml
+++ b/src/qml/CoordinateLocator.qml
@@ -54,7 +54,7 @@ Item {
 
     mapSettings: locator.mapSettings
     inputCoordinate: sourceLocation === undefined ? Qt.point( locator.width / 2, locator.height / 2 ) : sourceLocation // In screen coordinates
-    config: qgisProject.snappingConfig
+    config: qgisProject ? qgisProject.snappingConfig : snappingUtils.emptySnappingConfig()
 
     property variant snappedCoordinate
     property point snappedPoint

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -143,11 +143,11 @@ Popup {
         Layout.fillWidth: true
         Layout.topMargin: 5
         font: Theme.defaultFont
-        text: layerTree.data( index, FlatLayerTreeModel.Type ) === 'group'
-            ? qsTr('Zoom to group')
-            : layerTree.data( index, FlatLayerTreeModel.Type ) === 'legend'
-              ? qsTr('Zoom to parent layer')
-              : qsTr('Zoom to layer')
+        text: index ? layerTree.data( index, FlatLayerTreeModel.Type ) === 'group'
+                      ? qsTr('Zoom to group')
+                      : layerTree.data( index, FlatLayerTreeModel.Type ) === 'legend'
+                        ? qsTr('Zoom to parent layer')
+                        : qsTr('Zoom to layer') : ''
         visible: zoomToButtonVisible
         icon.source: Theme.getThemeVectorIcon( 'zoom_out_map_24dp' )
 

--- a/src/qml/NavigationHighlight.qml
+++ b/src/qml/NavigationHighlight.qml
@@ -14,7 +14,7 @@ Item {
     mapSettings: navigation.mapSettings
     geometry:   QgsGeometryWrapper {
       qgsGeometry: navigation.path
-      crs: navigation.mapSettings.crs
+      crs: navigation.mapSettings.crs ? navigation.mapSettings.crs : CoordinateReferenceSystemUtils.invalidCrs()
     }
     color: Theme.navigationColorSemiOpaque
     width: positionSource.active && positionSource.positionInformation && positionSource.positionInformation.latitudeValid ? 5 : 1

--- a/src/qml/PositionInformationView.qml
+++ b/src/qml/PositionInformationView.qml
@@ -38,9 +38,15 @@ Rectangle {
         anchors.left: parent.left
         font: Theme.tipFont
         color: textColor
-        text: positionSource.destinationCrs.isGeographic ?
-                  qsTr( "Lat." ) + ': ' + ( positionSource.positionInformation && positionSource.positionInformation.latitudeValid  ? Number( positionSource.projectedPosition.y ).toLocaleString( Qt.locale(), 'f', 7 ) : qsTr( "N/A" ) )
-                : qsTr( "X" )    + ': ' + ( positionSource.positionInformation && positionSource.positionInformation.longitudeValid ? Number( positionSource.projectedPosition.x ).toLocaleString( Qt.locale(), 'f', 3 ) : qsTr( "N/A" ) )
+        text: CoordinateReferenceSystemUtils.defaultCoordinateOrderForCrsIsXY(mapCanvas.mapSettings.destinationCrs)
+              ? (positionSource.destinationCrs.isGeographic ? qsTr( "Lon" ) : qsTr( "X" )) + ': '
+                + ( positionSource.positionInformation && positionSource.positionInformation.longitudeValid
+                   ? Number( positionSource.projectedPosition.x ).toLocaleString( Qt.locale(), 'f', positionSource.destinationCrs.isGeographic ? 7 : 3 )
+                   : qsTr( "N/A" ) )
+              : (positionSource.destinationCrs.isGeographic ? qsTr( "Lat" ) : qsTr( "Y" )) + ': '
+                + ( positionSource.positionInformation && positionSource.positionInformation.latitudeValid
+                   ? Number( positionSource.projectedPosition.y ).toLocaleString( Qt.locale(), 'f', positionSource.destinationCrs.isGeographic ? 7 : 3 )
+                   : qsTr( "N/A" ) )
       }
     }
 
@@ -55,9 +61,15 @@ Rectangle {
         anchors.left: parent.left
         font: Theme.tipFont
         color: textColor
-        text: positionSource.destinationCrs.isGeographic ?
-                  qsTr( "Lon." ) + ': ' + ( positionSource.positionInformation && positionSource.positionInformation.longitudeValid ? Number( positionSource.projectedPosition.x ).toLocaleString( Qt.locale(), 'f', 7 ) : qsTr( "N/A" ) )
-                : qsTr( "Y" )    + ': ' + ( positionSource.positionInformation && positionSource.positionInformation.latitudeValid  ? Number( positionSource.projectedPosition.y ).toLocaleString( Qt.locale(), 'f', 3 ) : qsTr( "N/A" ) )
+        text: CoordinateReferenceSystemUtils.defaultCoordinateOrderForCrsIsXY(mapCanvas.mapSettings.destinationCrs)
+              ? (positionSource.destinationCrs.isGeographic ? qsTr( "Lat" ) : qsTr( "Y" )) + ': '
+                + ( positionSource.positionInformation && positionSource.positionInformation.longitudeValid
+                   ? Number( positionSource.projectedPosition.y ).toLocaleString( Qt.locale(), 'f', positionSource.destinationCrs.isGeographic ? 7 : 3 )
+                   : qsTr( "N/A" ) )
+              : (positionSource.destinationCrs.isGeographic ? qsTr( "Lon" ) : qsTr( "X" )) + ': '
+                + ( positionSource.positionInformation && positionSource.positionInformation.latitudeValid
+                   ? Number( positionSource.projectedPosition.x ).toLocaleString( Qt.locale(), 'f', positionSource.destinationCrs.isGeographic ? 7 : 3 )
+                   : qsTr( "N/A" ) )
 
       }
     }

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -100,11 +100,11 @@ Page {
       Component.onCompleted: {
           for (var i = 0; i < settingsModel.count; i++) {
               if (settingsModel.get(i).settingAlias === 'nativeCamera') {
-                  settingsModel.setProperty(i, 'isVisible', platformUtilities.capabilities & PlatformUtilities.NativeCamera)
+                  settingsModel.setProperty(i, 'isVisible', platformUtilities.capabilities & PlatformUtilities.NativeCamera ? true : false)
               } else if (settingsModel.get(i).settingAlias === 'dimBrightness') {
-                  settingsModel.setProperty(i, 'isVisible', platformUtilities.capabilities & PlatformUtilities.AdjustBrightness)
+                  settingsModel.setProperty(i, 'isVisible', platformUtilities.capabilities & PlatformUtilities.AdjustBrightness ? true : false)
               } else if (settingsModel.get(i).settingAlias === 'enableInfoCollection') {
-                  settingsModel.setProperty(i, 'isVisible', platformUtilities.capabilities & PlatformUtilities.SentryFramework)
+                  settingsModel.setProperty(i, 'isVisible', platformUtilities.capabilities & PlatformUtilities.SentryFramework ? true : false)
               } else {
                   settingsModel.setProperty(i, 'isVisible', true)
               }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1862,15 +1862,7 @@ ApplicationWindow {
       font: Theme.defaultFont
 
       onTriggered: {
-        var coordinates = ''
-        if (mapCanvas.mapSettings.destinationCrs.isGeographic) {
-          coordinates = qsTr( 'Lon' ) + ' ' +  canvasMenu.point.x.toFixed(5) + ', ' + qsTr( 'Lat' ) + ' ' + canvasMenu.point.y.toFixed(5)
-        } else {
-          coordinates = qsTr( 'X' ) + ' ' +  canvasMenu.point.x.toFixed(2) + ', ' + qsTr( 'Y' ) + ' ' + canvasMenu.point.y.toFixed(2)
-        }
-        coordinates += ' (' + mapCanvas.mapSettings.destinationCrs.authid + ' ' + mapCanvas.mapSettings.destinationCrs.description + ')'
-
-        platformUtilities.copyTextToClipboard(coordinates)
+        platformUtilities.copyTextToClipboard(StringUtils.pointInformation(canvasMenu.point, mapCanvas.mapSettings.destinationCrs))
         displayToast(qsTr('Coordinates copied to clipboard'));
       }
     }
@@ -2023,18 +2015,11 @@ ApplicationWindow {
           return;
         }
 
-        var coordinates = ''
-        var point = positionSource.projectedPosition
-        if (mapCanvas.mapSettings.destinationCrs.isGeographic) {
-          coordinates = qsTr( 'Lon' ) + ' ' +  point.x.toFixed(7) + ', ' + qsTr( 'Lat' ) + ' ' + point.y.toFixed(7)
-        } else {
-          coordinates = qsTr( 'X' ) + ' ' +  point.x.toFixed(3) + ', ' + qsTr( 'Y' ) + ' ' + point.y.toFixed(3)
-        }
+        var coordinates = StringUtils.pointInformation(positionSource.projectedPosition, mapCanvas.mapSettings.destinationCrs)
         coordinates += ' ('+ qsTr('Accuracy') + ' ' +
                        ( positionSource.positionInformation && positionSource.positionInformation.haccValid
                          ? positionSource.positionInformation.hacc.toLocaleString(Qt.locale(), 'f', 3) + " m"
-                         : qsTr( "N/A" ) );
-        coordinates += '; ' + mapCanvas.mapSettings.destinationCrs.authid + ' ' + mapCanvas.mapSettings.destinationCrs.description + ')'
+                         : qsTr( "N/A" ) ) + ')';
 
         platformUtilities.copyTextToClipboard(coordinates)
         displayToast(qsTr('Current location copied to clipboard'));

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -175,7 +175,7 @@ ApplicationWindow {
 
     coordinateTransformer: CoordinateTransformer {
       destinationCrs: mapCanvas.mapSettings.destinationCrs
-      transformContext: qgisProject.transformContext
+      transformContext: qgisProject ? qgisProject.transformContext : CoordinateReferenceSystemUtils.emptyTransformContext()
       deltaZ: positioningSettings.antennaHeightActivated ? positioningSettings.antennaHeight * -1 : 0
       skipAltitudeTransformation: positioningSettings.skipAltitudeCorrection
     }
@@ -652,7 +652,7 @@ ApplicationWindow {
 
       rubberbandModel: currentRubberband ? currentRubberband.model : null
       project: qgisProject
-      crs: qgisProject.crs
+      crs: qgisProject ? qgisProject.crs : CoordinateReferenceSystemUtils.invalidCrs()
     }
 
     // The position is dynamically calculated to follow the coordinate locator
@@ -1241,7 +1241,7 @@ ApplicationWindow {
 
       property int followLocationMaxScale: 10
       property int followLocationMinMargin: 40
-      property int followLocationScreenFraction: settings.value( "/QField/Positioning/FollowScreenFraction", 5 )
+      property int followLocationScreenFraction: settings ? settings.value( "/QField/Positioning/FollowScreenFraction", 5 ) : 5
       function followLocation(forceRecenter) {
         var screenLocation = mapCanvas.mapSettings.coordinateToScreen(positionSource.projectedPosition);
         if (navigation.isActive && navigationButton.followIncludeDestination) {


### PR DESCRIPTION
Now that we're on QGIS 3.25, we can _finally_ respect axes ordering when handling coordinates. This PR updates the go to locator to make use of that (and match QGIS' updated logic on that front), as well as when copying coordinates to clipboard.

TLDR: people can enter WGS84 coordinates in its natural latitude, longitude ordering.

@m-kuhn , this also includes the decimal point locale fix.

Finally, the PR insures that _all_ positioning information displayed respects the axis ordering (e.g. before, we had the positioning information panel switch to lat lon but the coordinate cursor information overlay and the map canvas menu were stuck in lon lat). It's now consistently beautiful:
![Screenshot from 2022-05-28 12-51-42](https://user-images.githubusercontent.com/1728657/170812256-4d221d22-daed-475c-83bb-b3267c6b10fc.png)

_(I've also spent some time killing _all remaining QML errors/warnings_ on launch/shutdown. We finally have a clean console output.)_