### PR TITLE
Update sample projects' coordinate display format to geographic

### DIFF
--- a/resources/sample_projects/advanced_bee_farming.qgs
+++ b/resources/sample_projects/advanced_bee_farming.qgs
@@ -6521,7 +6521,7 @@ def my_form_open(dialog, layer, feature):
     <PositionPrecision>
       <Automatic type="bool">true</Automatic>
       <DecimalPlaces type="int">2</DecimalPlaces>
-      <DegreeFormat type="QString">MU</DegreeFormat>
+      <DegreeFormat type="QString">D</DegreeFormat>
     </PositionPrecision>
     <RequiredLayers>
       <Layers type="QStringList"></Layers>

--- a/resources/sample_projects/live_qfield_users_survey.qgs
+++ b/resources/sample_projects/live_qfield_users_survey.qgs
@@ -782,7 +782,7 @@ def my_form_open(dialog, layer, feature):
     <WMSAccessConstraints type="QString">None</WMSAccessConstraints>
     <PositionPrecision>
       <DecimalPlaces type="int">2</DecimalPlaces>
-      <DegreeFormat type="QString">MU</DegreeFormat>
+      <DegreeFormat type="QString">D</DegreeFormat>
       <Automatic type="bool">true</Automatic>
     </PositionPrecision>
     <Macros>

--- a/resources/sample_projects/simple_bee_farming.qgs
+++ b/resources/sample_projects/simple_bee_farming.qgs
@@ -3174,7 +3174,7 @@ def my_form_open(dialog, layer, feature):
     <PositionPrecision>
       <Automatic type="bool">true</Automatic>
       <DecimalPlaces type="int">2</DecimalPlaces>
-      <DegreeFormat type="QString">MU</DegreeFormat>
+      <DegreeFormat type="QString">D</DegreeFormat>
     </PositionPrecision>
     <RequiredLayers>
       <Layers type="QStringList"></Layers>


### PR DESCRIPTION
A nice enhancement in an upcoming PR has QField respecting projects' coordinate display unit (i.e. map unit vs. geographic). 

This PR updates the shipped sample projects to switch coordinate display from map unit (pseudo-mercator) to geographic (i.e. WGS84). This is a _much better_ coordinates display for an average user than obscurer pseudo-mercator pairs of X Y :)