### PR TITLE
QField should respect projects' coordinate display unit type

### DIFF
--- a/resources/sample_projects/advanced_bee_farming.qgs
+++ b/resources/sample_projects/advanced_bee_farming.qgs
@@ -6521,7 +6521,7 @@ def my_form_open(dialog, layer, feature):
     <PositionPrecision>
       <Automatic type="bool">true</Automatic>
       <DecimalPlaces type="int">2</DecimalPlaces>
-      <DegreeFormat type="QString">MU</DegreeFormat>
+      <DegreeFormat type="QString">D</DegreeFormat>
     </PositionPrecision>
     <RequiredLayers>
       <Layers type="QStringList"></Layers>

--- a/resources/sample_projects/live_qfield_users_survey.qgs
+++ b/resources/sample_projects/live_qfield_users_survey.qgs
@@ -782,7 +782,7 @@ def my_form_open(dialog, layer, feature):
     <WMSAccessConstraints type="QString">None</WMSAccessConstraints>
     <PositionPrecision>
       <DecimalPlaces type="int">2</DecimalPlaces>
-      <DegreeFormat type="QString">MU</DegreeFormat>
+      <DegreeFormat type="QString">D</DegreeFormat>
       <Automatic type="bool">true</Automatic>
     </PositionPrecision>
     <Macros>

--- a/resources/sample_projects/simple_bee_farming.qgs
+++ b/resources/sample_projects/simple_bee_farming.qgs
@@ -3174,7 +3174,7 @@ def my_form_open(dialog, layer, feature):
     <PositionPrecision>
       <Automatic type="bool">true</Automatic>
       <DecimalPlaces type="int">2</DecimalPlaces>
-      <DegreeFormat type="QString">MU</DegreeFormat>
+      <DegreeFormat type="QString">D</DegreeFormat>
     </PositionPrecision>
     <RequiredLayers>
       <Layers type="QStringList"></Layers>

--- a/scripts/cppcheck.sh
+++ b/scripts/cppcheck.sh
@@ -29,6 +29,7 @@ cppcheck --library=qt.cfg --inline-suppr \
          -DSIP_INOUT= \
          -DSIP_OUT= \
          -DQ_FLAG= \
+         -D_QGIS_VERSION_INT=32600 \
          -j $(nproc) \
 	 -isrc/qml \
          ${SCRIPT_DIR}/../src \

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(QFIELD_CORE_SRCS
     platforms/platformutilities.cpp
+    utils/coordinatereferencesystemutils.cpp
     utils/expressioncontextutils.cpp
     utils/featureutils.cpp
     utils/fileutils.cpp
@@ -95,6 +96,7 @@ set(QFIELD_CORE_SRCS
 
 set(QFIELD_CORE_HDRS
     platforms/platformutilities.h
+    utils/coordinatereferencesystemutils.h
     utils/expressioncontextutils.h
     utils/featureutils.h
     utils/fileutils.h

--- a/src/core/locator/gotolocatorfilter.cpp
+++ b/src/core/locator/gotolocatorfilter.cpp
@@ -127,8 +127,7 @@ void GotoLocatorFilter::fetchResults( const QString &string, const QgsLocatorCon
 #endif
     if ( !posIsWgs84 && currentCrs != wgs84Crs )
     {
-      // cppcheck-suppress knownConditionTrueFalse
-      const QgsPointXY point( currentCrsIsXY ? firstNumber : secondNumber, // cppcheck-suppress knownConditionTrueFalse
+      const QgsPointXY point( currentCrsIsXY ? firstNumber : secondNumber,
                               currentCrsIsXY ? secondNumber : firstNumber );
       data.insert( QStringLiteral( "point" ), point );
 

--- a/src/core/locator/gotolocatorfilter.cpp
+++ b/src/core/locator/gotolocatorfilter.cpp
@@ -20,7 +20,9 @@
 
 #include <QAction>
 #include <QRegularExpression>
+#if _QGIS_VERSION_INT >= 32500
 #include <qgscoordinatereferencesystemutils.h>
+#endif
 #include <qgscoordinateutils.h>
 #include <qgsexpressioncontextutils.h>
 #include <qgsfeedback.h>
@@ -72,6 +74,7 @@ void GotoLocatorFilter::fetchResults( const QString &string, const QgsLocatorCon
     }
   }
 
+#if _QGIS_VERSION_INT >= 32500
   if ( !match.hasMatch() )
   {
     // Check if the string is a pair of decimal degrees with [N,S,E,W] suffixes
@@ -89,6 +92,7 @@ void GotoLocatorFilter::fetchResults( const QString &string, const QgsLocatorCon
         std::swap( firstNumber, secondNumber );
     }
   }
+#endif
 
   if ( !match.hasMatch() )
   {
@@ -114,24 +118,30 @@ void GotoLocatorFilter::fetchResults( const QString &string, const QgsLocatorCon
   if ( firstOk && secondOk )
   {
     QVariantMap data;
+#if _QGIS_VERSION_INT >= 32500
     const bool currentCrsIsXY = QgsCoordinateReferenceSystemUtils::defaultCoordinateOrderForCrs( currentCrs ) == Qgis::CoordinateOrder::XY;
     const bool withinWgs84 = wgs84Crs.bounds().contains( secondNumber, firstNumber );
-
+#else
+    const bool currentCrsIsXY = true;
+    const bool withinWgs84 = wgs84Crs.bounds().contains( firstNumber, secondNumber );
+#endif
     if ( !posIsWgs84 && currentCrs != wgs84Crs )
     {
-      const QgsPointXY point( currentCrsIsXY ? firstNumber : secondNumber,
+      // cppcheck-suppress knownConditionTrueFalse
+      const QgsPointXY point( currentCrsIsXY ? firstNumber : secondNumber, // cppcheck-suppress knownConditionTrueFalse
                               currentCrsIsXY ? secondNumber : firstNumber );
       data.insert( QStringLiteral( "point" ), point );
 
-      const QList<Qgis::CrsAxisDirection> axisList = currentCrs.axisOrdering();
       QString firstSuffix;
       QString secondSuffix;
+#if _QGIS_VERSION_INT >= 32500
+      const QList<Qgis::CrsAxisDirection> axisList = currentCrs.axisOrdering();
       if ( axisList.size() >= 2 )
       {
         firstSuffix = QgsCoordinateReferenceSystemUtils::axisDirectionToAbbreviatedString( axisList.at( 0 ) );
         secondSuffix = QgsCoordinateReferenceSystemUtils::axisDirectionToAbbreviatedString( axisList.at( 1 ) );
       }
-
+#endif
       QgsLocatorResult result;
       result.filter = this;
       result.displayString = tr( "Go to %1%2 %3%4 (Map CRS, %5)" ).arg( locale.toString( firstNumber, 'g', 10 ), firstSuffix, locale.toString( secondNumber, 'g', 10 ), secondSuffix, currentCrs.userFriendlyIdentifier() );
@@ -142,7 +152,11 @@ void GotoLocatorFilter::fetchResults( const QString &string, const QgsLocatorCon
 
     if ( withinWgs84 )
     {
+#if _QGIS_VERSION_INT >= 32500
       const QgsPointXY point( secondNumber, firstNumber );
+#else
+      const QgsPointXY point( firstNumber, secondNumber );
+#endif
       if ( currentCrs != wgs84Crs )
       {
         const QgsCoordinateTransform transform( wgs84Crs, currentCrs, QgsProject::instance()->transformContext() );

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -52,6 +52,7 @@
 #include "bluetoothdevicemodel.h"
 #include "bluetoothreceiver.h"
 #include "changelogcontents.h"
+#include "coordinatereferencesystemutils.h"
 #include "deltafilewrapper.h"
 #include "deltalistmodel.h"
 #include "digitizinglogger.h"
@@ -491,6 +492,7 @@ void QgisMobileapp::initDeclarative()
   REGISTER_SINGLETON( "org.qfield", UrlUtils, "UrlUtils" );
   REGISTER_SINGLETON( "org.qfield", QFieldCloudUtils, "QFieldCloudUtils" );
   REGISTER_SINGLETON( "org.qfield", PositioningUtils, "PositioningUtils" );
+  REGISTER_SINGLETON( "org.qfield", CoordinateReferenceSystemUtils, "CoordinateReferenceSystemUtils" );
 
   qmlRegisterUncreatableType<AppInterface>( "org.qgis", 1, 0, "QgisInterface", "QgisInterface is only provided by the environment and cannot be created ad-hoc" );
   qmlRegisterUncreatableType<Settings>( "org.qgis", 1, 0, "Settings", "" );

--- a/src/core/utils/coordinatereferencesystemutils.cpp
+++ b/src/core/utils/coordinatereferencesystemutils.cpp
@@ -16,7 +16,20 @@
 
 #include "coordinatereferencesystemutils.h"
 
+#if _QGIS_VERSION_INT >= 32500
+#include <qgscoordinatereferencesystemutils.h>
+#endif
+
 CoordinateReferenceSystemUtils::CoordinateReferenceSystemUtils( QObject *parent )
   : QObject( parent )
 {
+}
+
+bool CoordinateReferenceSystemUtils::defaultCoordinateOrderForCrsIsXY( QgsCoordinateReferenceSystem crs )
+{
+#if _QGIS_VERSION_INT >= 32500
+  return QgsCoordinateReferenceSystemUtils::defaultCoordinateOrderForCrs( crs ) == Qgis::CoordinateOrder::XY;
+#else
+  return true;
+#endif
 }

--- a/src/core/utils/coordinatereferencesystemutils.cpp
+++ b/src/core/utils/coordinatereferencesystemutils.cpp
@@ -1,0 +1,22 @@
+/***************************************************************************
+  coordinatereferencesystemutils.cpp - CoordinateReferenceSystemUtils
+
+ ---------------------
+ begin                : 28.05.2022
+ copyright            : (C) 2022 by Mathieu Pellerin
+ email                : mathieu at opengis dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "coordinatereferencesystemutils.h"
+
+CoordinateReferenceSystemUtils::CoordinateReferenceSystemUtils( QObject *parent )
+  : QObject( parent )
+{
+}

--- a/src/core/utils/coordinatereferencesystemutils.cpp
+++ b/src/core/utils/coordinatereferencesystemutils.cpp
@@ -25,7 +25,7 @@ CoordinateReferenceSystemUtils::CoordinateReferenceSystemUtils( QObject *parent 
 {
 }
 
-bool CoordinateReferenceSystemUtils::defaultCoordinateOrderForCrsIsXY( QgsCoordinateReferenceSystem crs )
+bool CoordinateReferenceSystemUtils::defaultCoordinateOrderForCrsIsXY( const QgsCoordinateReferenceSystem &crs )
 {
 #if _QGIS_VERSION_INT >= 32500
   return QgsCoordinateReferenceSystemUtils::defaultCoordinateOrderForCrs( crs ) == Qgis::CoordinateOrder::XY;

--- a/src/core/utils/coordinatereferencesystemutils.h
+++ b/src/core/utils/coordinatereferencesystemutils.h
@@ -32,10 +32,16 @@ class QFIELD_CORE_EXPORT CoordinateReferenceSystemUtils : public QObject
     //! Returns an EPGS:4326 WGS84 CRS
     static Q_INVOKABLE QgsCoordinateReferenceSystem wgs84Crs() { return QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ); }
 
-    //! Returns an invalid CRS
+    /**
+     * Returns an invalid CRS
+     * \note This can be used in QML to avoid errors when a parent object pointer goes undefined
+     */
     static Q_INVOKABLE QgsCoordinateReferenceSystem invalidCrs() { return QgsCoordinateReferenceSystem(); }
 
-    //! Returns an empty transform context
+    /**
+     * Returns an empty transform context
+     * \note This can be used in QML to avoid errors when a parent object pointer goes undefined
+     */
     static Q_INVOKABLE QgsCoordinateTransformContext emptyTransformContext() { return QgsCoordinateTransformContext(); }
 
     //! Returns whether the default coordinate order of a given \a crs is XY

--- a/src/core/utils/coordinatereferencesystemutils.h
+++ b/src/core/utils/coordinatereferencesystemutils.h
@@ -1,0 +1,39 @@
+/***************************************************************************
+  coordinatereferencesystemutils.h - CoordinateReferenceSystemUtils
+
+ ---------------------
+ begin                : 28.05.2022
+ copyright            : (C) 2022 by Mathieu Pellerin
+ email                : mathieu at opengis dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef COORDINATEREFERENCESYSTEMUTILS_H
+#define COORDINATEREFERENCESYSTEMUTILS_H
+
+#include "qfield_core_export.h"
+
+#include <QObject>
+#include <qgscoordinatereferencesystem.h>
+#include <qgscoordinatetransformcontext.h>
+
+class QFIELD_CORE_EXPORT CoordinateReferenceSystemUtils : public QObject
+{
+    Q_OBJECT
+
+  public:
+    explicit CoordinateReferenceSystemUtils( QObject *parent = nullptr );
+
+    //! Returns an invalid CRS
+    static Q_INVOKABLE QgsCoordinateReferenceSystem invalidCrs() { return QgsCoordinateReferenceSystem(); }
+
+    //! Returns an empty transform context
+    static Q_INVOKABLE QgsCoordinateTransformContext emptyTransformContext() { return QgsCoordinateTransformContext(); }
+};
+
+#endif // COORDINATEREFERENCESYSTEMUTILS_H

--- a/src/core/utils/coordinatereferencesystemutils.h
+++ b/src/core/utils/coordinatereferencesystemutils.h
@@ -29,6 +29,9 @@ class QFIELD_CORE_EXPORT CoordinateReferenceSystemUtils : public QObject
   public:
     explicit CoordinateReferenceSystemUtils( QObject *parent = nullptr );
 
+    //! Returns an EPGS:4326 WGS84 CRS
+    static Q_INVOKABLE QgsCoordinateReferenceSystem wgs84Crs() { return QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ); }
+
     //! Returns an invalid CRS
     static Q_INVOKABLE QgsCoordinateReferenceSystem invalidCrs() { return QgsCoordinateReferenceSystem(); }
 

--- a/src/core/utils/coordinatereferencesystemutils.h
+++ b/src/core/utils/coordinatereferencesystemutils.h
@@ -34,6 +34,9 @@ class QFIELD_CORE_EXPORT CoordinateReferenceSystemUtils : public QObject
 
     //! Returns an empty transform context
     static Q_INVOKABLE QgsCoordinateTransformContext emptyTransformContext() { return QgsCoordinateTransformContext(); }
+
+    //! Returns whether the default coordinate order of a given \a crs is XY
+    static Q_INVOKABLE bool defaultCoordinateOrderForCrsIsXY( QgsCoordinateReferenceSystem crs );
 };
 
 #endif // COORDINATEREFERENCESYSTEMUTILS_H

--- a/src/core/utils/coordinatereferencesystemutils.h
+++ b/src/core/utils/coordinatereferencesystemutils.h
@@ -36,7 +36,7 @@ class QFIELD_CORE_EXPORT CoordinateReferenceSystemUtils : public QObject
     static Q_INVOKABLE QgsCoordinateTransformContext emptyTransformContext() { return QgsCoordinateTransformContext(); }
 
     //! Returns whether the default coordinate order of a given \a crs is XY
-    static Q_INVOKABLE bool defaultCoordinateOrderForCrsIsXY( QgsCoordinateReferenceSystem crs );
+    static Q_INVOKABLE bool defaultCoordinateOrderForCrsIsXY( const QgsCoordinateReferenceSystem &crs );
 };
 
 #endif // COORDINATEREFERENCESYSTEMUTILS_H

--- a/src/core/utils/geometryutils.cpp
+++ b/src/core/utils/geometryutils.cpp
@@ -17,6 +17,7 @@
 #include "geometryutils.h"
 #include "rubberbandmodel.h"
 
+#include <qgscoordinatetransform.h>
 #include <qgslinestring.h>
 #include <qgspolygon.h>
 #include <qgsproject.h>
@@ -132,4 +133,21 @@ QgsPoint GeometryUtils::coordinateToPoint( const QGeoCoordinate &coor )
 double GeometryUtils::distanceBetweenPoints( const QgsPoint &start, const QgsPoint &end )
 {
   return start.distance( end );
+}
+
+QgsPoint GeometryUtils::reprojectPointToWgs84( const QgsPoint &point, const QgsCoordinateReferenceSystem &crs )
+{
+  QgsCoordinateReferenceSystem wgs84Crs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) );
+  const QgsCoordinateTransform ct( crs, wgs84Crs, QgsProject::instance() );
+  QgsPointXY reprojectedPoint;
+  try
+  {
+    ct.transform( point.x(), point.y() );
+    reprojectedPoint = ct.transform( point );
+  }
+  catch ( QgsCsException & )
+  {
+    return QgsPoint();
+  }
+  return QgsPoint( reprojectedPoint );
 }

--- a/src/core/utils/geometryutils.cpp
+++ b/src/core/utils/geometryutils.cpp
@@ -137,7 +137,7 @@ double GeometryUtils::distanceBetweenPoints( const QgsPoint &start, const QgsPoi
 
 QgsPoint GeometryUtils::reprojectPointToWgs84( const QgsPoint &point, const QgsCoordinateReferenceSystem &crs )
 {
-  QgsCoordinateReferenceSystem wgs84Crs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) );
+  const QgsCoordinateReferenceSystem wgs84Crs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) );
   const QgsCoordinateTransform ct( crs, wgs84Crs, QgsProject::instance() );
   QgsPointXY reprojectedPoint;
   try
@@ -149,5 +149,9 @@ QgsPoint GeometryUtils::reprojectPointToWgs84( const QgsPoint &point, const QgsC
   {
     return QgsPoint();
   }
-  return QgsPoint( reprojectedPoint );
+
+  return QgsPoint( reprojectedPoint.x(),
+                   reprojectedPoint.y(),
+                   point.is3D() ? point.z() : std::numeric_limits<double>::quiet_NaN(),
+                   point.isMeasure() ? point.m() : std::numeric_limits<double>::quiet_NaN() );
 }

--- a/src/core/utils/geometryutils.h
+++ b/src/core/utils/geometryutils.h
@@ -70,11 +70,14 @@ class QFIELD_CORE_EXPORT GeometryUtils : public QObject
     //! This will perform a split using the line in the rubberband model. It works with the layer selection if some features are selected.
     static Q_INVOKABLE GeometryOperationResult splitFeatureFromRubberband( QgsVectorLayer *layer, RubberbandModel *rubberBandModel );
 
-    //! Converts QGeoCoordinate to QgsPoint
+    //! Converts QGeoCoordinate to QgsPoint.
     static Q_INVOKABLE QgsPoint coordinateToPoint( const QGeoCoordinate &coor );
 
     //! Returns the distance between a pair of \a start and \a end points.
     static Q_INVOKABLE double distanceBetweenPoints( const QgsPoint &start, const QgsPoint &end );
+
+    //! Returns a reprojected \a point from the stated \a crs to WGS84.
+    static Q_INVOKABLE QgsPoint reprojectPointToWgs84( const QgsPoint &point, const QgsCoordinateReferenceSystem &crs );
 };
 
 #endif // GEOMETRYUTILS_H

--- a/src/core/utils/snappingutils.h
+++ b/src/core/utils/snappingutils.h
@@ -48,6 +48,8 @@ class SnappingUtils : public QgsSnappingUtils
 
     static QgsPoint newPoint( const QgsPoint &snappedPoint, const QgsWkbTypes::Type wkbType );
 
+    static Q_INVOKABLE QgsSnappingConfig emptySnappingConfig() { return QgsSnappingConfig(); }
+
   signals:
     void mapSettingsChanged();
     void currentLayerChanged();

--- a/src/core/utils/snappingutils.h
+++ b/src/core/utils/snappingutils.h
@@ -48,6 +48,10 @@ class SnappingUtils : public QgsSnappingUtils
 
     static QgsPoint newPoint( const QgsPoint &snappedPoint, const QgsWkbTypes::Type wkbType );
 
+    /**
+     * Returns an empty snapping configuration object
+     * \note This can be used in QML to avoid errors when a parent object pointer goes undefined
+     */
     static Q_INVOKABLE QgsSnappingConfig emptySnappingConfig() { return QgsSnappingConfig(); }
 
   signals:

--- a/src/core/utils/stringutils.cpp
+++ b/src/core/utils/stringutils.cpp
@@ -87,10 +87,8 @@ QString StringUtils::pointInformation( const QgsPoint &point, const QgsCoordinat
   firstSuffix = crs.isGeographic() ? QStringLiteral( "E" ) : QString();
   secondSuffix = crs.isGeographic() ? QStringLiteral( "N" ) : QString();
 #endif
-  // cppcheck-suppress knownConditionTrueFalse
   const QString firstNumber = QString::number( currentCrsIsXY ? point.x() : point.y(),
                                                'f', crs.isGeographic() ? 5 : 2 );
-  // cppcheck-suppress knownConditionTrueFalse
   const QString secondNumber = QString::number( currentCrsIsXY ? point.y() : point.x(),
                                                 'f', crs.isGeographic() ? 5 : 2 );
   return QStringLiteral( "%1%2, %3%4 — %5: %6" ).arg( firstNumber, firstSuffix, secondNumber, secondSuffix, crs.authid(), crs.description() );

--- a/src/core/utils/stringutils.cpp
+++ b/src/core/utils/stringutils.cpp
@@ -70,7 +70,7 @@ bool StringUtils::fuzzyMatch( const QString &source, const QString &term )
            : false;
 }
 
-QString StringUtils::pointInformation( QgsPoint point, QgsCoordinateReferenceSystem crs )
+QString StringUtils::pointInformation( const QgsPoint &point, const QgsCoordinateReferenceSystem &crs )
 {
   QString firstSuffix;
   QString secondSuffix;

--- a/src/core/utils/stringutils.h
+++ b/src/core/utils/stringutils.h
@@ -45,7 +45,7 @@ class QFIELD_CORE_EXPORT StringUtils : public QObject
     //! Checks whether the string \a term is part of \a source
     static bool fuzzyMatch( const QString &source, const QString &term );
 
-    static Q_INVOKABLE QString pointInformation( QgsPoint point, QgsCoordinateReferenceSystem crs );
+    static Q_INVOKABLE QString pointInformation( const QgsPoint &point, const QgsCoordinateReferenceSystem &crs );
 };
 
 #endif // STRINGUTILS_H

--- a/src/core/utils/stringutils.h
+++ b/src/core/utils/stringutils.h
@@ -21,6 +21,8 @@
 #include "qfield_core_export.h"
 
 #include <QObject>
+#include <qgscoordinatereferencesystem.h>
+#include <qgspoint.h>
 
 class QFIELD_CORE_EXPORT StringUtils : public QObject
 {
@@ -42,6 +44,8 @@ class QFIELD_CORE_EXPORT StringUtils : public QObject
 
     //! Checks whether the string \a term is part of \a source
     static bool fuzzyMatch( const QString &source, const QString &term );
+
+    static Q_INVOKABLE QString pointInformation( QgsPoint point, QgsCoordinateReferenceSystem crs );
 };
 
 #endif // STRINGUTILS_H

--- a/src/core/utils/stringutils.h
+++ b/src/core/utils/stringutils.h
@@ -32,19 +32,16 @@ class QFIELD_CORE_EXPORT StringUtils : public QObject
     explicit StringUtils( QObject *parent = nullptr );
 
 
-    /**
-     * Returns a string with any URL (e.g., http(s)/ftp) and mailto: text converted to valid HTML <a …> links.
-     */
+    //! Returns a string with any URL (e.g., http(s)/ftp) and mailto: text converted to valid HTML <a …> links
     static Q_INVOKABLE QString insertLinks( const QString &string );
 
-    /**
-     * Returns a new UUID string.
-     */
+    //! Returns a new UUID string
     static Q_INVOKABLE QString createUuid();
 
     //! Checks whether the string \a term is part of \a source
     static bool fuzzyMatch( const QString &source, const QString &term );
 
+    //! Returns a string containing the \a point location and details of the \a crs
     static Q_INVOKABLE QString pointInformation( const QgsPoint &point, const QgsCoordinateReferenceSystem &crs );
 };
 

--- a/src/qml/About.qml
+++ b/src/qml/About.qml
@@ -126,7 +126,6 @@ Item {
 
             text: {
                 var dataDirs = platformUtilities.qfieldAppDataDirs();
-                console.log(dataDirs)
                 if (dataDirs.length > 0) {
                   return (dataDirs.length > 1
                           ? 'QField app directories'

--- a/src/qml/BookmarkProperties.qml
+++ b/src/qml/BookmarkProperties.qml
@@ -182,13 +182,7 @@ Popup {
                 onClicked: {
                     var point = bookmarkModel.getBookmarkPoint(bookmarkProperties.bookmarkId)
                     var crs = bookmarkModel.getBookmarkCrs(bookmarkProperties.bookmarkId)
-                    var coordinates = ''
-                    if (crs.isGeographic) {
-                      coordinates = qsTr( 'Lon' ) + ' ' +  point.x.toFixed(5) + ', ' + qsTr( 'Lat' ) + ' ' + point.y.toFixed(5)
-                    } else {
-                      coordinates = qsTr( 'X' ) + ' ' +  point.x.toFixed(2) + ', ' + qsTr( 'Y' ) + ' ' + point.y.toFixed(2)
-                    }
-                    coordinates += ' (' + crs.authid + ' ' + crs.description + ')'
+                    var coordinates = StringUtils.pointInformation(point, crs)
 
                     platformUtilities.copyTextToClipboard(nameField.text + '\n' + coordinates)
                     displayToast(qsTr('Bookmark details copied to clipboard'));

--- a/src/qml/BookmarkRenderer.qml
+++ b/src/qml/BookmarkRenderer.qml
@@ -46,7 +46,7 @@ Item {
                     sourceCrs: geometryWrapper.crs
                     sourcePosition: modelData
                     destinationCrs: mapCanvas.mapSettings.destinationCrs
-                    transformContext: qgisProject.transformContext
+                    transformContext: qgisProject ? qgisProject.transformContext : CoordinateReferenceSystemUtils.emptyTransformContext()
                 }
 
                 MapToScreen {

--- a/src/qml/CoordinateLocator.qml
+++ b/src/qml/CoordinateLocator.qml
@@ -54,7 +54,7 @@ Item {
 
     mapSettings: locator.mapSettings
     inputCoordinate: sourceLocation === undefined ? Qt.point( locator.width / 2, locator.height / 2 ) : sourceLocation // In screen coordinates
-    config: qgisProject.snappingConfig
+    config: qgisProject ? qgisProject.snappingConfig : snappingUtils.emptySnappingConfig()
 
     property variant snappedCoordinate
     property point snappedPoint

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -143,11 +143,11 @@ Popup {
         Layout.fillWidth: true
         Layout.topMargin: 5
         font: Theme.defaultFont
-        text: layerTree.data( index, FlatLayerTreeModel.Type ) === 'group'
-            ? qsTr('Zoom to group')
-            : layerTree.data( index, FlatLayerTreeModel.Type ) === 'legend'
-              ? qsTr('Zoom to parent layer')
-              : qsTr('Zoom to layer')
+        text: index ? layerTree.data( index, FlatLayerTreeModel.Type ) === 'group'
+                      ? qsTr('Zoom to group')
+                      : layerTree.data( index, FlatLayerTreeModel.Type ) === 'legend'
+                        ? qsTr('Zoom to parent layer')
+                        : qsTr('Zoom to layer') : ''
         visible: zoomToButtonVisible
         icon.source: Theme.getThemeVectorIcon( 'zoom_out_map_24dp' )
 

--- a/src/qml/NavigationHighlight.qml
+++ b/src/qml/NavigationHighlight.qml
@@ -14,7 +14,7 @@ Item {
     mapSettings: navigation.mapSettings
     geometry:   QgsGeometryWrapper {
       qgsGeometry: navigation.path
-      crs: navigation.mapSettings.crs
+      crs: navigation.mapSettings.crs ? navigation.mapSettings.crs : CoordinateReferenceSystemUtils.invalidCrs()
     }
     color: Theme.navigationColorSemiOpaque
     width: positionSource.active && positionSource.positionInformation && positionSource.positionInformation.latitudeValid ? 5 : 1

--- a/src/qml/NavigationInformationView.qml
+++ b/src/qml/NavigationInformationView.qml
@@ -9,6 +9,14 @@ import Theme 1.0
 Rectangle {
   id: navigationInformationView
 
+  property var coordinates: projectInfo.reprojectDisplayCoordinatesToWGS84
+                                    ? GeometryUtils.reprojectPointToWgs84(navigation.destination, navigation.mapSettings.destinationCrs)
+                                    : navigation.destination
+  property bool coordinatesIsXY: !projectInfo.reprojectDisplayCoordinatesToWGS84
+                                && CoordinateReferenceSystemUtils.defaultCoordinateOrderForCrsIsXY(navigation.mapSettings.destinationCrs)
+  property bool coordinatesIsGeographic: projectInfo.reprojectDisplayCoordinatesToWGS84
+                                        || navigation.mapSettings.destinationCrs.isGeographic
+
   property Navigation navigation
   property int ceilsCount: 4
   property double rowHeight: 30
@@ -38,9 +46,11 @@ Rectangle {
         anchors.left: parent.left
         font: Theme.tipFont
         color: textColor
-        text: navigation.mapSettings.destinationCrs.isGeographic ?
-                qsTr( "Lat." ) + ': ' + ( Number( navigation.destination.x ).toLocaleString( Qt.locale(), 'f', 7 ) )
-              : qsTr( "X" )    + ': ' + ( Number( navigation.destination.x ).toLocaleString( Qt.locale(), 'f', 3 ) )
+        text: coordinatesIsXY
+              ? (coordinatesIsGeographic ? qsTr( "Lon" ) : qsTr( "X" )) + ': '
+                + Number( coordinates.x ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
+              : (coordinatesIsGeographic ? qsTr( "Lat" ) : qsTr( "Y" )) + ': '
+                + Number( coordinates.y ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
       }
     }
 
@@ -55,9 +65,11 @@ Rectangle {
         anchors.left: parent.left
         font: Theme.tipFont
         color: textColor
-        text: positionSource.destinationCrs.isGeographic ?
-                qsTr( "Lon." ) + ': ' + ( Number( navigation.destination.x ).toLocaleString( Qt.locale(), 'f', 7 ) )
-              : qsTr( "Y" )    + ': ' + ( Number( navigation.destination.y ).toLocaleString( Qt.locale(), 'f', 3 ) )
+        text: coordinatesIsXY
+              ? (coordinatesIsGeographic ? qsTr( "Lat" ) : qsTr( "Y" )) + ': '
+                + Number( coordinates.y ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
+              : (coordinatesIsGeographic ? qsTr( "Lon" ) : qsTr( "X" )) + ': '
+                + Number( coordinates.x ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
       }
     }
 

--- a/src/qml/NavigationRenderer.qml
+++ b/src/qml/NavigationRenderer.qml
@@ -43,7 +43,7 @@ Item {
                   sourceCrs: geometryWrapper.crs
                   sourcePosition: modelData
                   destinationCrs: mapCanvas.mapSettings.destinationCrs
-                  transformContext: qgisProject.transformContext
+                  transformContext: qgisProject ? qgisProject.transformContext : CoordinateReferenceSystemUtils.emptyTransformContext()
               }
 
               MapToScreen {

--- a/src/qml/PositionInformationView.qml
+++ b/src/qml/PositionInformationView.qml
@@ -8,7 +8,16 @@ import Theme 1.0
 
 Rectangle {
   id: positionInformationView
+
   property Positioning positionSource
+  property var coordinates: projectInfo.reprojectDisplayCoordinatesToWGS84
+                                    ? positionSource.sourcePosition
+                                    : positionSource.projectedPosition
+  property bool coordinatesIsXY: !projectInfo.reprojectDisplayCoordinatesToWGS84
+                                && CoordinateReferenceSystemUtils.defaultCoordinateOrderForCrsIsXY(mapCanvas.mapSettings.destinationCrs)
+  property bool coordinatesIsGeographic: projectInfo.reprojectDisplayCoordinatesToWGS84
+                                        || positionSource.destinationCrs.isGeographic
+
   property double antennaHeight: NaN
   property double rowHeight: 30
   property color backgroundColor: "white"
@@ -38,14 +47,14 @@ Rectangle {
         anchors.left: parent.left
         font: Theme.tipFont
         color: textColor
-        text: CoordinateReferenceSystemUtils.defaultCoordinateOrderForCrsIsXY(mapCanvas.mapSettings.destinationCrs)
-              ? (positionSource.destinationCrs.isGeographic ? qsTr( "Lon" ) : qsTr( "X" )) + ': '
+        text: coordinatesIsXY
+              ? (coordinatesIsGeographic ? qsTr( "Lon" ) : qsTr( "X" )) + ': '
                 + ( positionSource.positionInformation && positionSource.positionInformation.longitudeValid
-                   ? Number( positionSource.projectedPosition.x ).toLocaleString( Qt.locale(), 'f', positionSource.destinationCrs.isGeographic ? 7 : 3 )
+                   ? Number( coordinates.x ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
                    : qsTr( "N/A" ) )
-              : (positionSource.destinationCrs.isGeographic ? qsTr( "Lat" ) : qsTr( "Y" )) + ': '
+              : (coordinatesIsGeographic ? qsTr( "Lat" ) : qsTr( "Y" )) + ': '
                 + ( positionSource.positionInformation && positionSource.positionInformation.latitudeValid
-                   ? Number( positionSource.projectedPosition.y ).toLocaleString( Qt.locale(), 'f', positionSource.destinationCrs.isGeographic ? 7 : 3 )
+                   ? Number( coordinates.y ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
                    : qsTr( "N/A" ) )
       }
     }
@@ -61,14 +70,14 @@ Rectangle {
         anchors.left: parent.left
         font: Theme.tipFont
         color: textColor
-        text: CoordinateReferenceSystemUtils.defaultCoordinateOrderForCrsIsXY(mapCanvas.mapSettings.destinationCrs)
-              ? (positionSource.destinationCrs.isGeographic ? qsTr( "Lat" ) : qsTr( "Y" )) + ': '
+        text: coordinatesIsXY
+              ? (coordinatesIsGeographic ? qsTr( "Lat" ) : qsTr( "Y" )) + ': '
                 + ( positionSource.positionInformation && positionSource.positionInformation.longitudeValid
-                   ? Number( positionSource.projectedPosition.y ).toLocaleString( Qt.locale(), 'f', positionSource.destinationCrs.isGeographic ? 7 : 3 )
+                   ? Number( coordinates.y ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
                    : qsTr( "N/A" ) )
-              : (positionSource.destinationCrs.isGeographic ? qsTr( "Lon" ) : qsTr( "X" )) + ': '
+              : (coordinatesIsGeographic ? qsTr( "Lon" ) : qsTr( "X" )) + ': '
                 + ( positionSource.positionInformation && positionSource.positionInformation.latitudeValid
-                   ? Number( positionSource.projectedPosition.x ).toLocaleString( Qt.locale(), 'f', positionSource.destinationCrs.isGeographic ? 7 : 3 )
+                   ? Number( coordinates.x ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
                    : qsTr( "N/A" ) )
 
       }

--- a/src/qml/PositionInformationView.qml
+++ b/src/qml/PositionInformationView.qml
@@ -38,9 +38,15 @@ Rectangle {
         anchors.left: parent.left
         font: Theme.tipFont
         color: textColor
-        text: positionSource.destinationCrs.isGeographic ?
-                  qsTr( "Lat." ) + ': ' + ( positionSource.positionInformation && positionSource.positionInformation.latitudeValid  ? Number( positionSource.projectedPosition.y ).toLocaleString( Qt.locale(), 'f', 7 ) : qsTr( "N/A" ) )
-                : qsTr( "X" )    + ': ' + ( positionSource.positionInformation && positionSource.positionInformation.longitudeValid ? Number( positionSource.projectedPosition.x ).toLocaleString( Qt.locale(), 'f', 3 ) : qsTr( "N/A" ) )
+        text: CoordinateReferenceSystemUtils.defaultCoordinateOrderForCrsIsXY(mapCanvas.mapSettings.destinationCrs)
+              ? (positionSource.destinationCrs.isGeographic ? qsTr( "Lon" ) : qsTr( "X" )) + ': '
+                + ( positionSource.positionInformation && positionSource.positionInformation.longitudeValid
+                   ? Number( positionSource.projectedPosition.x ).toLocaleString( Qt.locale(), 'f', positionSource.destinationCrs.isGeographic ? 7 : 3 )
+                   : qsTr( "N/A" ) )
+              : (positionSource.destinationCrs.isGeographic ? qsTr( "Lat" ) : qsTr( "Y" )) + ': '
+                + ( positionSource.positionInformation && positionSource.positionInformation.latitudeValid
+                   ? Number( positionSource.projectedPosition.y ).toLocaleString( Qt.locale(), 'f', positionSource.destinationCrs.isGeographic ? 7 : 3 )
+                   : qsTr( "N/A" ) )
       }
     }
 
@@ -55,9 +61,15 @@ Rectangle {
         anchors.left: parent.left
         font: Theme.tipFont
         color: textColor
-        text: positionSource.destinationCrs.isGeographic ?
-                  qsTr( "Lon." ) + ': ' + ( positionSource.positionInformation && positionSource.positionInformation.longitudeValid ? Number( positionSource.projectedPosition.x ).toLocaleString( Qt.locale(), 'f', 7 ) : qsTr( "N/A" ) )
-                : qsTr( "Y" )    + ': ' + ( positionSource.positionInformation && positionSource.positionInformation.latitudeValid  ? Number( positionSource.projectedPosition.y ).toLocaleString( Qt.locale(), 'f', 3 ) : qsTr( "N/A" ) )
+        text: CoordinateReferenceSystemUtils.defaultCoordinateOrderForCrsIsXY(mapCanvas.mapSettings.destinationCrs)
+              ? (positionSource.destinationCrs.isGeographic ? qsTr( "Lat" ) : qsTr( "Y" )) + ': '
+                + ( positionSource.positionInformation && positionSource.positionInformation.longitudeValid
+                   ? Number( positionSource.projectedPosition.y ).toLocaleString( Qt.locale(), 'f', positionSource.destinationCrs.isGeographic ? 7 : 3 )
+                   : qsTr( "N/A" ) )
+              : (positionSource.destinationCrs.isGeographic ? qsTr( "Lon" ) : qsTr( "X" )) + ': '
+                + ( positionSource.positionInformation && positionSource.positionInformation.latitudeValid
+                   ? Number( positionSource.projectedPosition.x ).toLocaleString( Qt.locale(), 'f', positionSource.destinationCrs.isGeographic ? 7 : 3 )
+                   : qsTr( "N/A" ) )
 
       }
     }

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -100,11 +100,11 @@ Page {
       Component.onCompleted: {
           for (var i = 0; i < settingsModel.count; i++) {
               if (settingsModel.get(i).settingAlias === 'nativeCamera') {
-                  settingsModel.setProperty(i, 'isVisible', platformUtilities.capabilities & PlatformUtilities.NativeCamera)
+                  settingsModel.setProperty(i, 'isVisible', platformUtilities.capabilities & PlatformUtilities.NativeCamera ? true : false)
               } else if (settingsModel.get(i).settingAlias === 'dimBrightness') {
-                  settingsModel.setProperty(i, 'isVisible', platformUtilities.capabilities & PlatformUtilities.AdjustBrightness)
+                  settingsModel.setProperty(i, 'isVisible', platformUtilities.capabilities & PlatformUtilities.AdjustBrightness ? true : false)
               } else if (settingsModel.get(i).settingAlias === 'enableInfoCollection') {
-                  settingsModel.setProperty(i, 'isVisible', platformUtilities.capabilities & PlatformUtilities.SentryFramework)
+                  settingsModel.setProperty(i, 'isVisible', platformUtilities.capabilities & PlatformUtilities.SentryFramework ? true : false)
               } else {
                   settingsModel.setProperty(i, 'isVisible', true)
               }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -175,7 +175,7 @@ ApplicationWindow {
 
     coordinateTransformer: CoordinateTransformer {
       destinationCrs: mapCanvas.mapSettings.destinationCrs
-      transformContext: qgisProject.transformContext
+      transformContext: qgisProject ? qgisProject.transformContext : CoordinateReferenceSystemUtils.emptyTransformContext()
       deltaZ: positioningSettings.antennaHeightActivated ? positioningSettings.antennaHeight * -1 : 0
       skipAltitudeTransformation: positioningSettings.skipAltitudeCorrection
     }
@@ -652,7 +652,7 @@ ApplicationWindow {
 
       rubberbandModel: currentRubberband ? currentRubberband.model : null
       project: qgisProject
-      crs: qgisProject.crs
+      crs: qgisProject ? qgisProject.crs : CoordinateReferenceSystemUtils.invalidCrs()
     }
 
     // The position is dynamically calculated to follow the coordinate locator
@@ -1243,7 +1243,7 @@ ApplicationWindow {
 
       property int followLocationMaxScale: 10
       property int followLocationMinMargin: 40
-      property int followLocationScreenFraction: settings.value( "/QField/Positioning/FollowScreenFraction", 5 )
+      property int followLocationScreenFraction: settings ? settings.value( "/QField/Positioning/FollowScreenFraction", 5 ) : 5
       function followLocation(forceRecenter) {
         var screenLocation = mapCanvas.mapSettings.coordinateToScreen(positionSource.projectedPosition);
         if (navigation.isActive && navigationButton.followIncludeDestination) {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1864,15 +1864,7 @@ ApplicationWindow {
       font: Theme.defaultFont
 
       onTriggered: {
-        var coordinates = ''
-        if (mapCanvas.mapSettings.destinationCrs.isGeographic) {
-          coordinates = qsTr( 'Lon' ) + ' ' +  canvasMenu.point.x.toFixed(5) + ', ' + qsTr( 'Lat' ) + ' ' + canvasMenu.point.y.toFixed(5)
-        } else {
-          coordinates = qsTr( 'X' ) + ' ' +  canvasMenu.point.x.toFixed(2) + ', ' + qsTr( 'Y' ) + ' ' + canvasMenu.point.y.toFixed(2)
-        }
-        coordinates += ' (' + mapCanvas.mapSettings.destinationCrs.authid + ' ' + mapCanvas.mapSettings.destinationCrs.description + ')'
-
-        platformUtilities.copyTextToClipboard(coordinates)
+        platformUtilities.copyTextToClipboard(StringUtils.pointInformation(canvasMenu.point, mapCanvas.mapSettings.destinationCrs))
         displayToast(qsTr('Coordinates copied to clipboard'));
       }
     }
@@ -2025,18 +2017,11 @@ ApplicationWindow {
           return;
         }
 
-        var coordinates = ''
-        var point = positionSource.projectedPosition
-        if (mapCanvas.mapSettings.destinationCrs.isGeographic) {
-          coordinates = qsTr( 'Lon' ) + ' ' +  point.x.toFixed(7) + ', ' + qsTr( 'Lat' ) + ' ' + point.y.toFixed(7)
-        } else {
-          coordinates = qsTr( 'X' ) + ' ' +  point.x.toFixed(3) + ', ' + qsTr( 'Y' ) + ' ' + point.y.toFixed(3)
-        }
+        var coordinates = StringUtils.pointInformation(positionSource.projectedPosition, mapCanvas.mapSettings.destinationCrs)
         coordinates += ' ('+ qsTr('Accuracy') + ' ' +
                        ( positionSource.positionInformation && positionSource.positionInformation.haccValid
                          ? positionSource.positionInformation.hacc.toLocaleString(Qt.locale(), 'f', 3) + " m"
-                         : qsTr( "N/A" ) );
-        coordinates += '; ' + mapCanvas.mapSettings.destinationCrs.authid + ' ' + mapCanvas.mapSettings.destinationCrs.description + ')'
+                         : qsTr( "N/A" ) ) + ')';
 
         platformUtilities.copyTextToClipboard(coordinates)
         displayToast(qsTr('Current location copied to clipboard'));

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -669,23 +669,36 @@ ApplicationWindow {
         return newY;
     }
 
-    text: ( qfieldSettings.numericalDigitizingInformation && stateMachine.state === "digitize" ) || stateMachine.state === 'measure' ?
-              '%1%2%3%4%5'
-                .arg(stateMachine.state === 'digitize' || !digitizingToolbar.isDigitizing ? '<p>%1: %2<br>%3: %4</p>'
-                  .arg(coordinateLocator.mapSettings.destinationCrs.isGeographic ? qsTr( 'Lon' ) : 'X')
-                  .arg(coordinateLocator.currentCoordinate.x.toLocaleString( Qt.locale(), 'f', coordinateLocator.mapSettings.destinationCrs.isGeographic ? 5 : 2 ))
-                  .arg(coordinateLocator.mapSettings.destinationCrs.isGeographic ? qsTr( 'Lat' ) : 'Y')
-                  .arg(coordinateLocator.currentCoordinate.y.toLocaleString( Qt.locale(), 'f', coordinateLocator.mapSettings.destinationCrs.isGeographic ? 5 : 2 ))
-                  : '' )
+    text: {
+      if ((qfieldSettings.numericalDigitizingInformation && stateMachine.state === "digitize" ) || stateMachine.state === 'measure') {
+        var coordinates;
+        if (CoordinateReferenceSystemUtils.defaultCoordinateOrderForCrsIsXY(coordinateLocator.mapSettings.destinationCrs)) {
+          coordinates = '<p>%1: %2<br>%3: %4</p>'
+                        .arg(coordinateLocator.mapSettings.destinationCrs.isGeographic ? qsTr( 'Lon' ) : 'X')
+                        .arg(coordinateLocator.currentCoordinate.x.toLocaleString( Qt.locale(), 'f', coordinateLocator.mapSettings.destinationCrs.isGeographic ? 5 : 2 ))
+                        .arg(coordinateLocator.mapSettings.destinationCrs.isGeographic ? qsTr( 'Lat' ) : 'Y')
+                        .arg(coordinateLocator.currentCoordinate.y.toLocaleString( Qt.locale(), 'f', coordinateLocator.mapSettings.destinationCrs.isGeographic ? 5 : 2 ));
+        } else {
+          coordinates = '<p>%1: %2<br>%3: %4</p>'
+                        .arg(coordinateLocator.mapSettings.destinationCrs.isGeographic ? qsTr( 'Lat' ) : 'Y')
+                        .arg(coordinateLocator.currentCoordinate.x.toLocaleString( Qt.locale(), 'f', coordinateLocator.mapSettings.destinationCrs.isGeographic ? 5 : 2 ))
+                        .arg(coordinateLocator.mapSettings.destinationCrs.isGeographic ? qsTr( 'Lon' ) : 'X')
+                        .arg(coordinateLocator.currentCoordinate.y.toLocaleString( Qt.locale(), 'f', coordinateLocator.mapSettings.destinationCrs.isGeographic ? 5 : 2 ));
+        }
+
+        return '%1%2%3%4%5'
+                .arg(stateMachine.state === 'digitize' || !digitizingToolbar.isDigitizing
+                     ? coordinates
+                     : '')
 
                 .arg(digitizingGeometryMeasure.lengthValid && digitizingGeometryMeasure.segmentLength != 0.0
                      && digitizingGeometryMeasure.segmentLength != digitizingGeometryMeasure.length
                      ? '<p>%1: %2</p>'
                        .arg( qsTr( 'Segment') )
                        .arg(UnitTypes.formatDistance( digitizingGeometryMeasure.segmentLength, 3, digitizingGeometryMeasure.lengthUnits ) )
-                     : '' )
+                     : '')
 
-                .arg(currentRubberband.model.geometryType === QgsWkbTypes.PolygonGeometry
+                .arg(currentRubberband.model && currentRubberband.model.geometryType === QgsWkbTypes.PolygonGeometry
                      ? digitizingGeometryMeasure.perimeterValid
                        ? '<p>%1: %2</p>'
                          .arg( qsTr( 'Perimeter') )
@@ -695,20 +708,21 @@ ApplicationWindow {
                      ? '<p>%1: %2</p>'
                        .arg( qsTr( 'Length') )
                        .arg(UnitTypes.formatDistance( digitizingGeometryMeasure.length, 3, digitizingGeometryMeasure.lengthUnits ) )
-                     : '' )
+                     : '')
 
-                .arg(digitizingGeometryMeasure.areaValid ? '<p>%1: %2</p>'
-                  .arg( qsTr( 'Area') )
-                  .arg(UnitTypes.formatArea( digitizingGeometryMeasure.area, 3, digitizingGeometryMeasure.areaUnits ) )
-                  : '' )
+                .arg(digitizingGeometryMeasure.areaValid
+                     ? '<p>%1: %2</p>'
+                     .arg( qsTr( 'Area') )
+                     .arg(UnitTypes.formatArea( digitizingGeometryMeasure.area, 3, digitizingGeometryMeasure.areaUnits ) )
+                     : '')
 
-                .arg(stateMachine.state === 'measure' && digitizingToolbar.isDigitizing? '<p>%1: %2<br>%3: %4</p>'
-                  .arg(coordinateLocator.mapSettings.destinationCrs.isGeographic ? qsTr( 'Lon' ) : 'X')
-                  .arg(coordinateLocator.currentCoordinate.x.toFixed( coordinateLocator.mapSettings.destinationCrs.isGeographic ? 5 : 2 ))
-                  .arg(coordinateLocator.mapSettings.destinationCrs.isGeographic ? qsTr( 'Lat' ) : 'Y')
-                  .arg(coordinateLocator.currentCoordinate.y.toFixed( coordinateLocator.mapSettings.destinationCrs.isGeographic ? 5 : 2 ))
-                  : '' )
-              : ''
+                .arg(stateMachine.state === 'measure' && digitizingToolbar.isDigitizing
+                     ? coordinates
+                     : '')
+      } else {
+        return '';
+      }
+    }
 
     font: Theme.strongTipFont
     style: Text.Outline
@@ -1785,12 +1799,17 @@ ApplicationWindow {
 
     property var point
     onPointChanged: {
+      var isXY = CoordinateReferenceSystemUtils.defaultCoordinateOrderForCrsIsXY(mapCanvas.mapSettings.destinationCrs);
       var xLabel = mapCanvas.mapSettings.destinationCrs.isGeographic ? qsTr( 'Lon' ) : 'X';
       var xValue = Number( point.x ).toLocaleString( Qt.locale(), 'f', coordinateLocator.mapSettings.destinationCrs.isGeographic ? 7 : 3 )
       var yLabel = mapCanvas.mapSettings.destinationCrs.isGeographic ? qsTr( 'Lat' ) : 'Y'
       var yValue = Number( point.y ).toLocaleString( Qt.locale(), 'f', coordinateLocator.mapSettings.destinationCrs.isGeographic ? 7 : 3 )
-      xItem.text = xLabel + ': ' + xValue
-      yItem.text = yLabel + ': ' + yValue
+      xItem.text = isXY
+                   ? xLabel + ': ' + xValue
+                   : yLabel + ': ' + yValue
+      yItem.text = isXY
+                   ? yLabel + ': ' + yValue
+                   : xLabel + ': ' + xValue
     }
 
     width: {


### PR DESCRIPTION
_(This PR temporarily includes commits from #2942)_

This PR enhances QField so its respects projects' coordinate display unit (i.e. map unit vs geopgraphic). The displayed coordinates that will respect the flags are: the positioning information panel, the navigation information panel, the copy coordinates to clipboard actions, and the coordinate text overlay.

Case in point: sample projects' CRS shipped in QField is pseudo mercator (so the XYZ tiles can project neatly on the map canvas). Until now, it meant QField would display coordinates in what is for many users an obscure pair of pseudo mercator X,Y.

This is QField's simple bee project, displaying coordinates in pseudo mercator:
![image](https://user-images.githubusercontent.com/1728657/170851434-67af4900-4f83-4dc3-8366-dfa9f4025ce8.png)

Now, this is the same simple bee project with QField respecting the project's coordinate display unit type:
![image](https://user-images.githubusercontent.com/1728657/170851110-2c4692a1-4d8d-4db7-b02c-65294ccc0701.png)

:heart_eyes: 

Beyond making QField better match QGIS' handling of displayed coordinates, this undoubtedly provides a better first experience UX to new QField users who often rely on sample projects to form an opinion of the app.