### PR TITLE
Return a default image instead of a blank one when we can't produce a preview thumbnail, and...

### DIFF
--- a/src/core/localfilesmodel.cpp
+++ b/src/core/localfilesmodel.cpp
@@ -286,9 +286,8 @@ QVariant LocalFilesModel::data( const QModelIndex &index, int role ) const
       return mItems[index.row()].size;
 
     case ItemHasThumbnailRole:
-      return mItems[index.row()].type == RasterDataset
-             && mItems[index.row()].size < 25000000
-             && SUPPORTED_RASTER_THUMBNAIL.contains( mItems[index.row()].format );
+      return mItems[index.row()].size < 25000000
+             && SUPPORTED_DATASET_THUMBNAIL.contains( mItems[index.row()].format );
   }
 
   return QVariant();

--- a/src/core/localfilesmodel.h
+++ b/src/core/localfilesmodel.h
@@ -18,7 +18,7 @@
 
 #include <QAbstractListModel>
 
-#define SUPPORTED_RASTER_THUMBNAIL QStringList( { QStringLiteral( "tif" ), QStringLiteral( "tiff" ), QStringLiteral( "pdf" ), QStringLiteral( "jpg" ), QStringLiteral( "jpeg" ), QStringLiteral( "png" ), QStringLiteral( "jp2" ), QStringLiteral( "webp" ) } )
+#define SUPPORTED_DATASET_THUMBNAIL QStringList( { QStringLiteral( "zip" ), QStringLiteral( "tif" ), QStringLiteral( "tiff" ), QStringLiteral( "pdf" ), QStringLiteral( "jpg" ), QStringLiteral( "jpeg" ), QStringLiteral( "png" ), QStringLiteral( "jp2" ), QStringLiteral( "webp" ) } )
 
 class LocalFilesModel : public QAbstractListModel
 {


### PR DESCRIPTION
… support single raster within zip thumbnails.

I'm quite happy about the zipped single raster thumbnails being so easily achievable. It's often the case one would zip up a tiff to reduce its size, we'll now get a preview of that. Woupidou.