### PR TITLE
Fix value relation editor widget's allow multi(ple selection) mode

### DIFF
--- a/src/qml/editorwidgets/RelationReference.qml
+++ b/src/qml/editorwidgets/RelationReference.qml
@@ -29,7 +29,7 @@ EditorWidgetBase {
     allowMulti: false
 
     // passing "" instead of undefined, so the model is cleared on adding new features
-    // attributeValue property has to be the last one set to make sure value handled properly (e.g. allow multiple)
+    // attributeValue has to be the last one set to make sure the property’s value is handled properly (e.g. allow multiple)
     attributeValue: value !== undefined ? value : ''
 
     onListUpdated: {

--- a/src/qml/editorwidgets/RelationReference.qml
+++ b/src/qml/editorwidgets/RelationReference.qml
@@ -21,16 +21,17 @@ EditorWidgetBase {
 
     currentLayer: qgisProject.relationManager.relation(config['Relation']).referencedLayer
     keyField: qgisProject.relationManager.relation(config['Relation']).resolveReferencedField(field.name)
-    // no, it is not a misspelled version of config['AllowNull']
-    addNull: config['AllowNULL']
+    addNull: config['AllowNULL'] // no, it is not a misspelled version of config['AllowNull']
     orderByValue: config['OrderByValue']
-
     attributeField: field
-    //passing "" instead of undefined, so the model is cleared on adding new features
-    attributeValue: value !== undefined ? value : ''
     currentFormFeature: currentFeature
     filterExpression: ""
     allowMulti: false
+
+    // passing "" instead of undefined, so the model is cleared on adding new features
+    // attributeValue property has to be the last one set to make sure value handled properly (e.g. allow multiple)
+    attributeValue: value !== undefined ? value : ''
+
     onListUpdated: {
       valueChangeRequested( attributeValue, false )
     }

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -40,7 +40,7 @@ EditorWidgetBase {
     filterExpression: config['FilterExpression']
 
     // passing "" instead of undefined, so the model is cleared on adding new features
-    // attributeValue property has to be the last one set to make sure value handled properly (e.g. allow multiple)
+    // attributeValue has to be the last property set to make sure its given value is handled properly (e.g. allow multiple)
     attributeValue: value !== undefined ? value : ""
 
     onListUpdated: {

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -29,9 +29,8 @@ EditorWidgetBase {
 
   FeatureCheckListModel {
     id: listModel
+    allowMulti: Number(config['AllowMulti']) === 1
     attributeField: field
-    //passing "" instead of undefined, so the model is cleared on adding new features
-    attributeValue: value !== undefined ? value : ""
     currentLayer: layerResolver.currentLayer
     currentFormFeature: currentFeature
     keyField: config['Key']
@@ -39,7 +38,11 @@ EditorWidgetBase {
     addNull: config['AllowNull']
     orderByValue: config['OrderByValue']
     filterExpression: config['FilterExpression']
-    allowMulti: Number(config['AllowMulti']) === 1
+
+    // passing "" instead of undefined, so the model is cleared on adding new features
+    // attributeValue property has to be the last one set to make sure value handled properly (e.g. allow multiple)
+    attributeValue: value !== undefined ? value : ""
+
     onListUpdated: {
       valueChangeRequested( attributeValue, false )
     }
@@ -137,7 +140,7 @@ EditorWidgetBase {
             bottomPadding: 4
             font: Theme.defaultFont
             color: !isEnabled ? 'grey' : 'black'
-            text: { text: model.displayString }
+            text: model.displayString
             wrapMode: Text.WordWrap
           }
         }


### PR DESCRIPTION
This PR fixes https://github.com/opengisch/QField/issues/2954 and https://github.com/opengisch/QField/issues/2865.

The problem had to do with us setting the allowMulti property _after_ the attributeValue property was set, which meant that the model would always parse the original attributeValue as _single value_. The world would subsequently collide, leaving users in tears.

Thanks goes to @bsaglio2001 who filed a detailed issue with a test project.