### PR TITLE
Android {alert,progress} dialog improvements

### DIFF
--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -39,7 +39,8 @@
       android:label="@APP_NAME@"
       android:icon="@AT@drawable/@APP_ICON@"
       android:launchMode="singleTask"
-      android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|locale|fontScale|keyboard|keyboardHidden|navigation">
+      android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|locale|fontScale|keyboard|keyboardHidden|navigation"
+      android:theme="@style/AppTheme">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.LAUNCHER"/>

--- a/platform/android/res/values/strings.xml
+++ b/platform/android/res/values/strings.xml
@@ -68,4 +68,6 @@
     <string name="storage_information_message">Whether you are a pre-existing QField 1.x user wondering why your projects and datasets have gone missing or new to QField, we suggest you take a minute to read the storage handling documentation. A shortcut to this documentation will remain accessible in the title bar\'s actions menu.</string>
     <string name="storage_information_view">Show me the documentation</string>
     <string name="storage_information_dismiss">I\'ll read later</string>
+    <string name="import_project_wait">Please wait while QField is importing the project</string>
+    <string name="import_dataset_wait">Please wait while QField is importing the dataset(s)</string>
 </resources>

--- a/platform/android/res/values/styles.xml
+++ b/platform/android/res/values/styles.xml
@@ -4,4 +4,9 @@
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
     </style>
+    <style name="DialogTheme" parent="Theme.AppCompat.Light.Dialog">
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorAccent</item>
+    </style>
 </resources>

--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -237,8 +237,11 @@ public class QFieldActivity extends QtActivity {
     }
 
     private void showBlockingProgressDialog(String message) {
-        progressDialog = ProgressDialog.show(this, "", message, true);
+        progressDialog = new ProgressDialog(this, R.style.DialogTheme);
+        progressDialog.setMessage(message);
+        progressDialog.setIndeterminate(true);
         progressDialog.setCancelable(false);
+        progressDialog.show();
     }
 
     private void dismissBlockingProgressDialog() {
@@ -496,7 +499,8 @@ public class QFieldActivity extends QtActivity {
 
     private void removeDataset(String path) {
         File file = new File(path);
-        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        AlertDialog.Builder builder =
+            new AlertDialog.Builder(this, R.style.DialogTheme);
         builder.setTitle(getString(R.string.delete_confirm_title));
         builder.setMessage(getString(R.string.delete_confirm_dataset));
         builder.setPositiveButton(
@@ -571,10 +575,13 @@ public class QFieldActivity extends QtActivity {
             return;
         }
 
-        ProgressDialog progressDialog = ProgressDialog.show(
-            this, "", "Please wait while QField is importing the project",
-            true);
+        ProgressDialog progressDialog =
+            new ProgressDialog(this, R.style.DialogTheme);
+        progressDialog.setMessage(
+            "Please wait while QField is importing the dataset(s)");
+        progressDialog.setIndeterminate(true);
         progressDialog.setCancelable(false);
+        progressDialog.show();
 
         String importDatasetPath =
             externalFilesDir.getAbsolutePath() + "/Imported Datasets/";
@@ -609,7 +616,9 @@ public class QFieldActivity extends QtActivity {
                 progressDialog.dismiss();
                 if (!imported) {
                     AlertDialog alertDialog =
-                        new AlertDialog.Builder(QFieldActivity.this).create();
+                        new AlertDialog
+                            .Builder(QFieldActivity.this, R.style.DialogTheme)
+                            .create();
                     alertDialog.setTitle(getString(R.string.import_error));
                     alertDialog.setMessage(
                         getString(R.string.import_dataset_error));
@@ -629,10 +638,13 @@ public class QFieldActivity extends QtActivity {
             return;
         }
 
-        ProgressDialog progressDialog = ProgressDialog.show(
-            this, "", "Please wait while QField is importing the project",
-            true);
+        ProgressDialog progressDialog =
+            new ProgressDialog(this, R.style.DialogTheme);
+        progressDialog.setMessage(
+            "Please wait while QField is importing the project");
+        progressDialog.setIndeterminate(true);
         progressDialog.setCancelable(false);
+        progressDialog.show();
 
         String importProjectPath =
             externalFilesDir.getAbsolutePath() + "/Imported Projects/";
@@ -657,7 +669,9 @@ public class QFieldActivity extends QtActivity {
                     openPath(importPath);
                 } else {
                     AlertDialog alertDialog =
-                        new AlertDialog.Builder(QFieldActivity.this).create();
+                        new AlertDialog
+                            .Builder(QFieldActivity.this, R.style.DialogTheme)
+                            .create();
                     alertDialog.setTitle(getString(R.string.import_error));
                     alertDialog.setMessage(
                         getString(R.string.import_project_folder_error));
@@ -675,10 +689,13 @@ public class QFieldActivity extends QtActivity {
             return;
         }
 
-        ProgressDialog progressDialog = ProgressDialog.show(
-            this, "", "Please wait while QField is importing the project",
-            true);
+        ProgressDialog progressDialog =
+            new ProgressDialog(this, R.style.DialogTheme);
+        progressDialog.setMessage(
+            "Please wait while QField is importing the project");
+        progressDialog.setIndeterminate(true);
         progressDialog.setCancelable(false);
+        progressDialog.show();
 
         String importProjectPath =
             externalFilesDir.getAbsolutePath() + "/Imported Projects/";
@@ -716,7 +733,9 @@ public class QFieldActivity extends QtActivity {
                     } catch (Exception e) {
                         e.printStackTrace();
                         AlertDialog alertDialog =
-                            new AlertDialog.Builder(QFieldActivity.this)
+                            new AlertDialog
+                                .Builder(QFieldActivity.this,
+                                         R.style.DialogTheme)
                                 .create();
                         alertDialog.setTitle(getString(R.string.import_error));
                         alertDialog.setMessage(
@@ -796,7 +815,8 @@ public class QFieldActivity extends QtActivity {
                 return;
             }
 
-            AlertDialog.Builder builder = new AlertDialog.Builder(this);
+            AlertDialog.Builder builder =
+                new AlertDialog.Builder(this, R.style.DialogTheme);
             builder.setTitle(getString(R.string.grant_permission));
             builder.setMessage(
                 Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
@@ -891,7 +911,8 @@ public class QFieldActivity extends QtActivity {
             }
 
             if (hasExists) {
-                AlertDialog.Builder builder = new AlertDialog.Builder(this);
+                AlertDialog.Builder builder =
+                    new AlertDialog.Builder(this, R.style.DialogTheme);
                 builder.setTitle(getString(R.string.import_overwrite_title));
                 builder.setMessage(
                     datasetUris.length > 1
@@ -933,7 +954,8 @@ public class QFieldActivity extends QtActivity {
                 new File(externalFilesDir.getAbsolutePath() +
                          "/Imported Projects/" + directory.getName() + "/");
             if (importPath.exists()) {
-                AlertDialog.Builder builder = new AlertDialog.Builder(this);
+                AlertDialog.Builder builder =
+                    new AlertDialog.Builder(this, R.style.DialogTheme);
                 builder.setTitle(getString(R.string.import_overwrite_title));
                 builder.setMessage(getString(R.string.import_overwrite_folder));
                 builder.setPositiveButton(
@@ -981,7 +1003,8 @@ public class QFieldActivity extends QtActivity {
                     0, documentFile.getName().lastIndexOf(".")) +
                 "/");
             if (importPath.exists()) {
-                AlertDialog.Builder builder = new AlertDialog.Builder(this);
+                AlertDialog.Builder builder =
+                    new AlertDialog.Builder(this, R.style.DialogTheme);
                 builder.setTitle(getString(R.string.import_overwrite_title));
                 builder.setMessage(getString(R.string.import_overwrite_folder));
                 builder.setPositiveButton(
@@ -1028,7 +1051,9 @@ public class QFieldActivity extends QtActivity {
 
                     if (!exported) {
                         AlertDialog alertDialog =
-                            new AlertDialog.Builder(QFieldActivity.this)
+                            new AlertDialog
+                                .Builder(QFieldActivity.this,
+                                         R.style.DialogTheme)
                                 .create();
                         alertDialog.setTitle(getString(R.string.export_error));
                         alertDialog.setMessage(

--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -577,8 +577,7 @@ public class QFieldActivity extends QtActivity {
 
         ProgressDialog progressDialog =
             new ProgressDialog(this, R.style.DialogTheme);
-        progressDialog.setMessage(
-            "Please wait while QField is importing the dataset(s)");
+        progressDialog.setMessage(getString(R.string.import_dataset_wait));
         progressDialog.setIndeterminate(true);
         progressDialog.setCancelable(false);
         progressDialog.show();
@@ -640,8 +639,7 @@ public class QFieldActivity extends QtActivity {
 
         ProgressDialog progressDialog =
             new ProgressDialog(this, R.style.DialogTheme);
-        progressDialog.setMessage(
-            "Please wait while QField is importing the project");
+        progressDialog.setMessage(getString(R.string.import_project_wait));
         progressDialog.setIndeterminate(true);
         progressDialog.setCancelable(false);
         progressDialog.show();
@@ -691,8 +689,7 @@ public class QFieldActivity extends QtActivity {
 
         ProgressDialog progressDialog =
             new ProgressDialog(this, R.style.DialogTheme);
-        progressDialog.setMessage(
-            "Please wait while QField is importing the project");
+        progressDialog.setMessage(getString(R.string.import_project_wait));
         progressDialog.setIndeterminate(true);
         progressDialog.setCancelable(false);
         progressDialog.show();


### PR DESCRIPTION
This PR does a couple of nice things to our android dialogs (emitted from the main QtActivity)
- instead of using a layout straight from the 90s, it uses a slightly more modern design
- instead of using an old Android default blue color, it uses our QField green :heart_eyes: 
- progress bar dialogs' spinner is now using our QField green too (instead of light gray)

Before (left) vs. PR (right):
![image](https://user-images.githubusercontent.com/1728657/173289079-2566217a-cb3c-460c-baaf-b31f84aff993.png)
