### PR TITLE
Fix what appears to be a serious warning from Qt

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -136,6 +136,11 @@ void qfMessageHandler( QtMsgType type, const QMessageLogContext &context, const 
 
 int main( int argc, char **argv )
 {
+  // Enables antialiasing in QML scenes
+  QSurfaceFormat format;
+  format.setSamples( 4 );
+  QSurfaceFormat::setDefaultFormat( format );
+
   // A dummy app for reading settings that need to be used before constructing the real app
   QCoreApplication *dummyApp = new QCoreApplication( argc, argv );
   QCoreApplication::setOrganizationName( "OPENGIS.ch" );

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -166,11 +166,6 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   , mIface( new AppInterface( this ) )
   , mFirstRenderingFlag( true )
 {
-  // Enables antialiasing in QML scenes
-  QSurfaceFormat format;
-  format.setSamples( 4 );
-  QSurfaceFormat::setDefaultFormat( format );
-
   // Set a nicer default hyperlink color to be used in QML Text items
   QPalette palette = app->palette();
   palette.setColor( QPalette::Link, QColor( 128, 204, 40 ) );


### PR DESCRIPTION
Setting the default surface when initializing the QtQmlApplicationEngine appears to be too late in the process, Qt tells us the following:

> Warning: Setting a new default format with a different version or profile after the global shared context is created may cause issues with context sharing.

I've moved it into main.cpp, and the warning is gone.

@mbernasocchi , although I couldn't reproduce your weird "canon" glitch, I think this could be a cause.