### PR TITLE
Respect a base map project's default styles (if any) when opening individual datasets

### DIFF
--- a/src/core/utils/layerutils.cpp
+++ b/src/core/utils/layerutils.cpp
@@ -34,7 +34,6 @@
 #include <qgssymbol.h>
 #include <qgssymbollayer.h>
 #include <qgstextbuffersettings.h>
-#include <qgstextformat.h>
 #include <qgsvectorlayer.h>
 #include <qgsvectorlayerlabeling.h>
 #include <qgsvectorlayerutils.h>
@@ -91,7 +90,7 @@ QgsSymbol *LayerUtils::defaultSymbol( QgsVectorLayer *layer )
   return symbol;
 }
 
-QgsAbstractVectorLayerLabeling *LayerUtils::defaultLabeling( QgsVectorLayer *layer )
+QgsAbstractVectorLayerLabeling *LayerUtils::defaultLabeling( QgsVectorLayer *layer, QgsTextFormat textFormat )
 {
   QgsAbstractVectorLayerLabeling *labeling = nullptr;
 
@@ -150,17 +149,19 @@ QgsAbstractVectorLayerLabeling *LayerUtils::defaultLabeling( QgsVectorLayer *lay
       break;
   }
 
-  QgsTextFormat textFormat;
-  textFormat.setSize( 9 );
-  textFormat.setSizeUnit( QgsUnitTypes::RenderPoints );
-  textFormat.setColor( QColor( 0, 0, 0 ) );
+  if ( !textFormat.isValid() )
+  {
+    textFormat.setSize( 9 );
+    textFormat.setSizeUnit( QgsUnitTypes::RenderPoints );
+    textFormat.setColor( QColor( 0, 0, 0 ) );
 
-  QgsTextBufferSettings bufferSettings;
-  bufferSettings.setEnabled( true );
-  bufferSettings.setColor( QColor( 255, 255, 255 ) );
-  bufferSettings.setSize( 1 );
-  bufferSettings.setSizeUnit( QgsUnitTypes::RenderMillimeters );
-  textFormat.setBuffer( bufferSettings );
+    QgsTextBufferSettings bufferSettings;
+    bufferSettings.setEnabled( true );
+    bufferSettings.setColor( QColor( 255, 255, 255 ) );
+    bufferSettings.setSize( 1 );
+    bufferSettings.setSizeUnit( QgsUnitTypes::RenderMillimeters );
+    textFormat.setBuffer( bufferSettings );
+  }
   settings.setFormat( textFormat );
 
   labeling = new QgsVectorLayerSimpleLabeling( settings );

--- a/src/core/utils/layerutils.h
+++ b/src/core/utils/layerutils.h
@@ -19,6 +19,7 @@
 
 #include <QObject>
 #include <qgis.h>
+#include <qgstextformat.h>
 #include <qgsvectorlayer.h>
 
 class QgsVectorLayer;
@@ -37,7 +38,7 @@ class LayerUtils : public QObject
     */
     static QgsSymbol *defaultSymbol( QgsVectorLayer *layer );
 
-    static QgsAbstractVectorLayerLabeling *defaultLabeling( QgsVectorLayer *layer );
+    static QgsAbstractVectorLayerLabeling *defaultLabeling( QgsVectorLayer *layer, QgsTextFormat textFormat = QgsTextFormat() );
 
     /**
     * Returns TRUE if the vector layer is used as an atlas coverage layer in


### PR DESCRIPTION
This PR makes use of a new feature in QGIS 3.26 to allow for users' base map projects to dictate the symbols and labeling styles of features when opening individual datasets.

E.g., this is my base map project's default styles settings:
![Screenshot from 2022-06-18 11-20-45](https://user-images.githubusercontent.com/1728657/174422584-33d832bf-6981-4b85-9df0-f0213666718a.png)

This translates into this beautiful rendering when opening individual (in this case point) dataset in QField:
![Screenshot from 2022-06-18 11-21-22](https://user-images.githubusercontent.com/1728657/174422591-480a5cc4-381e-4532-b00d-9a41391dfff2.png)

