### PR TITLE
Harmonize default font size across all QML items

### DIFF
--- a/images/qtquickcontrols2.conf
+++ b/images/qtquickcontrols2.conf
@@ -1,6 +1,18 @@
+[Default]
+Font\PointSize=16
+
 [Controls]
 Style=Material
+
+
+[Universal]
+Theme=System
+Accent=#80cc28
+[Universal\Font]
+PointSize=16
 
 [Material]
 Accent=#80cc28
 Theme=Light
+[Material\Font]
+PointSize=16


### PR DESCRIPTION
This avoid tiny font size in QML Dialog items (as well as combobox's default styling, etc.)

Makes us look better :)