### PR TITLE
When opening individual datasets with a {date,datetime} field, setup temporal properties

### DIFF
--- a/src/core/layertreemodel.h
+++ b/src/core/layertreemodel.h
@@ -87,6 +87,7 @@ class FlatLayerTreeModelBase : public QAbstractProxyModel
   private:
     void featureCountChanged();
     void updateTemporalState();
+    void adjustTemporalStateFromAddedLayers( const QList<QgsMapLayer *> &layers );
 
     QMap<QModelIndex, int> mRowMap;
     QMap<int, QModelIndex> mIndexMap;

--- a/src/core/projectinfo.cpp
+++ b/src/core/projectinfo.cpp
@@ -128,8 +128,8 @@ void ProjectInfo::saveTemporalState()
     settings.beginGroup( QStringLiteral( "/qgis/projectInfo/%1" ).arg( mFilePath ) );
     settings.setValue( QStringLiteral( "filesize" ), fi.size() );
     settings.setValue( QStringLiteral( "isTemporal" ), mMapSettings->isTemporal() );
-    settings.setValue( QStringLiteral( "StartDateTime" ), mMapSettings->temporalBegin().toTimeSpec( Qt::OffsetFromUTC ).toString( Qt::ISODateWithMs ) );
-    settings.setValue( QStringLiteral( "EndDateTime" ), mMapSettings->temporalEnd().toTimeSpec( Qt::OffsetFromUTC ).toString( Qt::ISODateWithMs ) );
+    settings.setValue( QStringLiteral( "StartDateTime" ), mMapSettings->temporalBegin().toTimeSpec( Qt::LocalTime ).toString( Qt::ISODateWithMs ) );
+    settings.setValue( QStringLiteral( "EndDateTime" ), mMapSettings->temporalEnd().toTimeSpec( Qt::LocalTime ).toString( Qt::ISODateWithMs ) );
     settings.endGroup();
   }
 }

--- a/src/core/qgsquick/qgsquickmapsettings.cpp
+++ b/src/core/qgsquick/qgsquickmapsettings.cpp
@@ -383,7 +383,7 @@ QDateTime QgsQuickMapSettings::temporalBegin() const
   return mMapSettings.temporalRange().begin();
 }
 
-void QgsQuickMapSettings::setTemporalBegin( QDateTime &begin )
+void QgsQuickMapSettings::setTemporalBegin( const QDateTime &begin )
 {
   const QgsDateTimeRange range = mMapSettings.temporalRange();
   mMapSettings.setTemporalRange( QgsDateTimeRange( begin, range.end() ) );
@@ -395,7 +395,7 @@ QDateTime QgsQuickMapSettings::temporalEnd() const
   return mMapSettings.temporalRange().end();
 }
 
-void QgsQuickMapSettings::setTemporalEnd( QDateTime &end )
+void QgsQuickMapSettings::setTemporalEnd( const QDateTime &end )
 {
   const QgsDateTimeRange range = mMapSettings.temporalRange();
   mMapSettings.setTemporalRange( QgsDateTimeRange( range.begin(), end ) );

--- a/src/core/qgsquick/qgsquickmapsettings.h
+++ b/src/core/qgsquick/qgsquickmapsettings.h
@@ -273,13 +273,13 @@ class QFIELD_CORE_EXPORT QgsQuickMapSettings : public QObject
     QDateTime temporalBegin() const;
 
     //! \copydoc QgsQuickMapSettings::temporalBegin
-    void setTemporalBegin( QDateTime &begin );
+    void setTemporalBegin( const QDateTime &begin );
 
     //! \copydoc QgsQuickMapSettings::temporalEnd
     QDateTime temporalEnd() const;
 
     //! \copydoc QgsQuickMapSettings::temporalEnd
-    void setTemporalEnd( QDateTime &end );
+    void setTemporalEnd( const QDateTime &end );
 
   signals:
     //! \copydoc QgsQuickMapSettings::project


### PR DESCRIPTION
This PR improves our handling of individual datasets containing temporal fields. When opening datasets, QField now checks for the presence of a {date,datetime} field. If such a field is present, QField will automatically setup temporal properties, allow for users to then filter those datasets using QField's temporal UI.

This means that people can now consume e.g. GPX files, and be able to narrow down the drawing of track points to a specific date and time:
![Peek 2022-06-19 10-58](https://user-images.githubusercontent.com/1728657/174465233-dd8144f2-cf95-4ff6-83b0-ac1fdace8ed1.gif)
