### PR TITLE
Regroup onLoadProjectEnded under one function, insure local data picker is closed when loading a project

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1756,28 +1756,6 @@ ApplicationWindow {
       onObjectRemoved: printMenu.removeItem(object)
     }
 
-    Connections {
-      target: iface
-
-      function onLoadProjectEnded() {
-        projectInfo.reprojectDisplayCoordinatesToWGS84 = !mapCanvas.mapSettings.destinationCrs.isGeographic
-                                                         && iface.readProjectEntry("PositionPrecision", "/DegreeFormat", "MU") !== "MU"
-
-        layoutListInstantiator.model.project = qgisProject
-        layoutListInstantiator.model.reloadModel()
-        printMenu.enablePrintItem(layoutListInstantiator.model.rowCount())
-
-        welcomeScreen.visible = false
-        welcomeScreen.focus = false
-        recentProjectListModel.reloadModel()
-
-        settings.setValue( "/QField/FirstRunFlag", false )
-        if (stateMachine.state === "digitize") {
-            dashBoard.ensureEditableLayerSelected();
-        }
-      }
-    }
-
     Timer {
       id: timer
 
@@ -2228,7 +2206,10 @@ ApplicationWindow {
       target: iface
 
       function onLoadProjectTriggered(path,name) {
+        qfieldLocalDataPickerScreen.visible = false
+        qfieldLocalDataPickerScreen.focus = false
         welcomeScreen.visible = false
+        welcomeScreen.focus = false
 
         dashBoard.layerTree.freeze()
         mapCanvasMap.freeze('projectload')
@@ -2247,6 +2228,8 @@ ApplicationWindow {
         projectInfo.filePath = path;
 
         mapCanvasBackground.color = mapCanvas.mapSettings.backgroundColor
+
+        recentProjectListModel.reloadModel()
 
         var cloudProjectId = QFieldCloudUtils.getProjectId(qgisProject.fileName)
         cloudProjectsModel.currentProjectId = cloudProjectId
@@ -2282,6 +2265,19 @@ ApplicationWindow {
           projectInfo.hasInsertRights = true
           projectInfo.hasEditRights = true
         }
+
+        if (stateMachine.state === "digitize") {
+            dashBoard.ensureEditableLayerSelected();
+        }
+
+        projectInfo.reprojectDisplayCoordinatesToWGS84 = !mapCanvas.mapSettings.destinationCrs.isGeographic
+                                                         && iface.readProjectEntry("PositionPrecision", "/DegreeFormat", "MU") !== "MU"
+
+        layoutListInstantiator.model.project = qgisProject
+        layoutListInstantiator.model.reloadModel()
+        printMenu.enablePrintItem(layoutListInstantiator.model.rowCount())
+
+        settings.setValue( "/QField/FirstRunFlag", false )
       }
 
       function onSetMapExtent(extent) {


### PR DESCRIPTION
We had two connection { itarget: iface; function onLoadProjectEnded() { ... } }, which isn't great :) this PR fixes that, and insures that both the welcome screen _as well as_ the local data picker is closed when we start loading a project. 

PR aimed at fixing a situation whereas if someone opens the local data picker, switch to a different app and open a given project via file association, the local data picker wouldn't go away.