### PR TITLE
Avoid zoom in/out button overlapping bottom-right buttons on narrow screen heights

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -781,6 +781,8 @@ ApplicationWindow {
     anchors.bottomMargin: ( mapCanvas.height - zoomToolbar.height / 2 ) / 2
     spacing: 4
 
+    visible: locationToolbar.height / mapCanvas.height < 0.41
+
     QfToolButton {
       id: zoomInButton
       round: true


### PR DESCRIPTION
This PR fixes the following situation whereas on narrow screen heights buttons overlap each other:
![image](https://user-images.githubusercontent.com/1728657/174574679-b72bd84b-0a70-477e-a5c9-9061fb14f216.png)

In this scenario, IMHO it's better to just remove the zoom in and out button instead of having worlds collide :)