### PR TITLE
Navigation to feature vertices

### DIFF
--- a/src/core/locator/featureslocatorfilter.cpp
+++ b/src/core/locator/featureslocatorfilter.cpp
@@ -162,7 +162,7 @@ void FeaturesLocatorFilter::triggerResultFromAction( const QgsLocatorResult &res
     if ( !mLocatorBridge->navigation() )
       return;
 
-    QgsFeatureIterator it = layer->getFeatures( featureRequest.setNoAttributes() );
+    QgsFeatureIterator it = layer->getFeatures( featureRequest );
     it.nextFeature( feature );
     if ( feature.hasGeometry() )
     {

--- a/src/core/navigation.cpp
+++ b/src/core/navigation.cpp
@@ -95,17 +95,7 @@ QgsPoint Navigation::destination() const
 
 void Navigation::setDestination( const QgsPoint &point )
 {
-  if ( !mGeometry.isNull() )
-  {
-    mGeometry = QgsGeometry();
-    mDestinationName.clear();
-    emit destinationNameChanged();
-    mVertices = 0;
-    emit destinationFeatureVerticesChanged();
-    mCurrentVertex = -1;
-    emit destinationFeatureCurrentVertexChanged();
-  }
-
+  clearDestinationFeature();
   mModel->setDestination( point );
 }
 
@@ -147,6 +137,20 @@ void Navigation::setDestinationFeature( const QgsFeature &feature, QgsVectorLaye
     mCurrentVertex = -1;
     emit destinationFeatureCurrentVertexChanged();
     mModel->setDestination( QgsPoint() );
+  }
+}
+
+void Navigation::clearDestinationFeature()
+{
+  if ( !mGeometry.isNull() )
+  {
+    mGeometry = QgsGeometry();
+    mDestinationName.clear();
+    emit destinationNameChanged();
+    mVertices = 0;
+    emit destinationFeatureVerticesChanged();
+    mCurrentVertex = -1;
+    emit destinationFeatureCurrentVertexChanged();
   }
 }
 

--- a/src/core/navigation.cpp
+++ b/src/core/navigation.cpp
@@ -160,7 +160,7 @@ void Navigation::nextDestinationVertex()
   if ( mGeometry.isNull() )
     return;
 
-  if ( mCurrentVertex >= mVertices - 1 )
+  if ( mCurrentVertex >= mVertices )
   {
     mCurrentVertex = 0;
   }
@@ -170,7 +170,7 @@ void Navigation::nextDestinationVertex()
   }
   emit destinationFeatureCurrentVertexChanged();
 
-  mModel->setDestination( mGeometry.vertexAt( mCurrentVertex ) );
+  setDestinationFromCurrentVertex();
 }
 
 void Navigation::previousDestinationVertex()
@@ -180,7 +180,7 @@ void Navigation::previousDestinationVertex()
 
   if ( mCurrentVertex <= 0 )
   {
-    mCurrentVertex = mVertices - 1;
+    mCurrentVertex = mVertices;
   }
   else
   {
@@ -188,7 +188,28 @@ void Navigation::previousDestinationVertex()
   }
   emit destinationFeatureCurrentVertexChanged();
 
-  mModel->setDestination( mGeometry.vertexAt( mCurrentVertex ) );
+  setDestinationFromCurrentVertex();
+}
+
+void Navigation::setDestinationFromCurrentVertex()
+{
+  if ( mCurrentVertex == 0 )
+  {
+    const QgsGeometry pointOnSurface = mGeometry.pointOnSurface();
+    if ( !pointOnSurface.isNull() )
+    {
+      mModel->setDestination( pointOnSurface.vertexAt( 0 ) );
+    }
+    else
+    {
+      mCurrentVertex++;
+      mModel->setDestination( mGeometry.vertexAt( mCurrentVertex - 1 ) );
+    }
+  }
+  else
+  {
+    mModel->setDestination( mGeometry.vertexAt( mCurrentVertex - 1 ) );
+  }
 }
 
 int Navigation::destinationFeatureCurrentVertex() const

--- a/src/core/navigation.cpp
+++ b/src/core/navigation.cpp
@@ -124,8 +124,8 @@ void Navigation::setDestinationFeature( const QgsFeature &feature, QgsVectorLaye
   {
     mDestinationName = FeatureUtils::displayName( layer, feature );
     emit destinationNameChanged();
-    mVertices = mGeometry.get()->nCoordinates() - ( mGeometry.type() == QgsWkbTypes::PolygonGeometry ? 1 : 0 );
-    emit destinationFeatureVerticesChanged();
+    mVertexCount = mGeometry.get()->nCoordinates() - ( mGeometry.type() == QgsWkbTypes::PolygonGeometry ? 1 : 0 );
+    emit destinationFeatureVertexCountChanged();
     mCurrentVertex = -1;
     nextDestinationVertex();
   }
@@ -133,8 +133,8 @@ void Navigation::setDestinationFeature( const QgsFeature &feature, QgsVectorLaye
   {
     mDestinationName = FeatureUtils::displayName( layer, feature );
     emit destinationNameChanged();
-    mVertices = 0;
-    emit destinationFeatureVerticesChanged();
+    mVertexCount = 0;
+    emit destinationFeatureVertexCountChanged();
     mCurrentVertex = -1;
     emit destinationFeatureCurrentVertexChanged();
     mModel->setDestination( QgsPoint() );
@@ -148,8 +148,8 @@ void Navigation::clearDestinationFeature()
     mGeometry = QgsGeometry();
     mDestinationName.clear();
     emit destinationNameChanged();
-    mVertices = 0;
-    emit destinationFeatureVerticesChanged();
+    mVertexCount = 0;
+    emit destinationFeatureVertexCountChanged();
     mCurrentVertex = -1;
     emit destinationFeatureCurrentVertexChanged();
   }
@@ -160,7 +160,7 @@ void Navigation::nextDestinationVertex()
   if ( mGeometry.isNull() )
     return;
 
-  if ( mCurrentVertex >= mVertices )
+  if ( mCurrentVertex >= mVertexCount )
   {
     mCurrentVertex = 0;
   }
@@ -180,7 +180,7 @@ void Navigation::previousDestinationVertex()
 
   if ( mCurrentVertex <= 0 )
   {
-    mCurrentVertex = mVertices;
+    mCurrentVertex = mVertexCount;
   }
   else
   {
@@ -217,9 +217,9 @@ int Navigation::destinationFeatureCurrentVertex() const
   return mCurrentVertex;
 }
 
-int Navigation::destinationFeatureVertices() const
+int Navigation::destinationFeatureVertexCount() const
 {
-  return mVertices;
+  return mVertexCount;
 }
 
 void Navigation::updateDetails()

--- a/src/core/navigation.cpp
+++ b/src/core/navigation.cpp
@@ -126,6 +126,7 @@ void Navigation::setDestinationFeature( const QgsFeature &feature, QgsVectorLaye
     emit destinationNameChanged();
     mVertices = mGeometry.get()->nCoordinates() - ( mGeometry.type() == QgsWkbTypes::PolygonGeometry ? 1 : 0 );
     emit destinationFeatureVerticesChanged();
+    mCurrentVertex = -1;
     nextDestinationVertex();
   }
   else

--- a/src/core/navigation.h
+++ b/src/core/navigation.h
@@ -32,11 +32,15 @@ class Navigation : public QObject
 
     Q_PROPERTY( QgsPoint location READ location WRITE setLocation NOTIFY locationChanged )
     Q_PROPERTY( QgsPoint destination READ destination WRITE setDestination NOTIFY destinationChanged )
+    Q_PROPERTY( QString destinationName READ destinationName NOTIFY destinationNameChanged )
 
     Q_PROPERTY( QgsGeometry path READ path NOTIFY detailsChanged )
     Q_PROPERTY( double distance READ distance NOTIFY detailsChanged )
     Q_PROPERTY( QgsUnitTypes::DistanceUnit distanceUnits READ distanceUnits NOTIFY detailsChanged )
     Q_PROPERTY( double bearing READ bearing NOTIFY detailsChanged )
+
+    Q_PROPERTY( int destinationFeatureCurrentVertex READ destinationFeatureCurrentVertex NOTIFY destinationFeatureCurrentVertexChanged )
+    Q_PROPERTY( int destinationFeatureVertices READ destinationFeatureVertices NOTIFY destinationFeatureVerticesChanged )
 
     Q_PROPERTY( bool isActive READ isActive NOTIFY isActiveChanged )
 
@@ -57,7 +61,13 @@ class Navigation : public QObject
 
     QgsPoint destination() const;
     void setDestination( const QgsPoint &point );
+    QString destinationName() const;
+
     Q_INVOKABLE void setDestinationFeature( const QgsFeature &feature, QgsVectorLayer *layer );
+    Q_INVOKABLE void nextDestinationVertex();
+    Q_INVOKABLE void previousDestinationVertex();
+    int destinationFeatureCurrentVertex() const;
+    int destinationFeatureVertices() const;
 
     QgsGeometry path() const { return mPath; }
     double distance() const { return mDistance; }
@@ -74,6 +84,10 @@ class Navigation : public QObject
 
     void locationChanged();
     void destinationChanged();
+    void destinationNameChanged();
+
+    void destinationFeatureCurrentVertexChanged();
+    void destinationFeatureVerticesChanged();
 
     void detailsChanged();
 
@@ -90,6 +104,11 @@ class Navigation : public QObject
     QgsDistanceArea mDa;
     double mDistance = 0.0;
     double mBearing = 0.0;
+    QString mDestinationName;
+
+    QgsGeometry mGeometry;
+    int mCurrentVertex = -1;
+    int mVertices = 0;
 };
 
 #endif // NAVIGATION_H

--- a/src/core/navigation.h
+++ b/src/core/navigation.h
@@ -40,7 +40,7 @@ class Navigation : public QObject
     Q_PROPERTY( double bearing READ bearing NOTIFY detailsChanged )
 
     Q_PROPERTY( int destinationFeatureCurrentVertex READ destinationFeatureCurrentVertex NOTIFY destinationFeatureCurrentVertexChanged )
-    Q_PROPERTY( int destinationFeatureVertices READ destinationFeatureVertices NOTIFY destinationFeatureVerticesChanged )
+    Q_PROPERTY( int destinationFeatureVertexCount READ destinationFeatureVertexCount NOTIFY destinationFeatureVertexCountChanged )
 
     Q_PROPERTY( bool isActive READ isActive NOTIFY isActiveChanged )
 
@@ -63,13 +63,33 @@ class Navigation : public QObject
     void setDestination( const QgsPoint &point );
     QString destinationName() const;
 
+    /**
+     * Sets a provided feature as navigation destination, which allows for users to cycle through the
+     * feature centroid and its individual vertices as destination point.
+     * \param feature the feature used as destination
+     * \param layer the vector layer associated to the feature
+     */
     Q_INVOKABLE void setDestinationFeature( const QgsFeature &feature, QgsVectorLayer *layer );
+
+    /**
+     * Clears the current destination feature, as well as the current destination point.
+     */
     Q_INVOKABLE void clearDestinationFeature();
+
+    /**
+     * Sets the destination point to the next vertex or centroid of the current destination feature.
+     * \note if a destination feature has not been provided, calling this function does nothing
+     */
     Q_INVOKABLE void nextDestinationVertex();
+
+    /**
+     * Sets the destination point to the previous vertex or centroid of the current destination feature.
+     * \note if a destination feature has not been provided, calling this function does nothing
+     */
     Q_INVOKABLE void previousDestinationVertex();
 
     int destinationFeatureCurrentVertex() const;
-    int destinationFeatureVertices() const;
+    int destinationFeatureVertexCount() const;
 
     QgsGeometry path() const { return mPath; }
     double distance() const { return mDistance; }
@@ -89,7 +109,7 @@ class Navigation : public QObject
     void destinationNameChanged();
 
     void destinationFeatureCurrentVertexChanged();
-    void destinationFeatureVerticesChanged();
+    void destinationFeatureVertexCountChanged();
 
     void detailsChanged();
 
@@ -111,7 +131,7 @@ class Navigation : public QObject
 
     QgsGeometry mGeometry;
     int mCurrentVertex = -1;
-    int mVertices = 0;
+    int mVertexCount = 0;
 };
 
 #endif // NAVIGATION_H

--- a/src/core/navigation.h
+++ b/src/core/navigation.h
@@ -64,8 +64,10 @@ class Navigation : public QObject
     QString destinationName() const;
 
     Q_INVOKABLE void setDestinationFeature( const QgsFeature &feature, QgsVectorLayer *layer );
+    Q_INVOKABLE void clearDestinationFeature();
     Q_INVOKABLE void nextDestinationVertex();
     Q_INVOKABLE void previousDestinationVertex();
+
     int destinationFeatureCurrentVertex() const;
     int destinationFeatureVertices() const;
 

--- a/src/core/navigation.h
+++ b/src/core/navigation.h
@@ -98,6 +98,7 @@ class Navigation : public QObject
 
   private:
     void updateDetails();
+    void setDestinationFromCurrentVertex();
 
     std::unique_ptr<NavigationModel> mModel = nullptr;
     QgsQuickMapSettings *mMapSettings = nullptr;

--- a/src/qml/NavigationInformationView.qml
+++ b/src/qml/NavigationInformationView.qml
@@ -93,8 +93,8 @@ Rectangle {
           color: "#FFFFFF"
           text: navigation.destinationName +
                 (navigation.destinationFeatureVertices > 1
-                ? ' (' + (1 + navigation.destinationFeatureCurrentVertex) + '/'
-                      + navigation.destinationFeatureVertices + ')'
+                ? ': ' + (1 + navigation.destinationFeatureCurrentVertex) + '/'
+                      + navigation.destinationFeatureVertices
                 : '')
         }
 

--- a/src/qml/NavigationInformationView.qml
+++ b/src/qml/NavigationInformationView.qml
@@ -10,12 +10,12 @@ Rectangle {
   id: navigationInformationView
 
   property var coordinates: projectInfo.reprojectDisplayCoordinatesToWGS84
-                                    ? GeometryUtils.reprojectPointToWgs84(navigation.destination, navigation.mapSettings.destinationCrs)
-                                    : navigation.destination
+                            ? GeometryUtils.reprojectPointToWgs84(navigation.destination, navigation.mapSettings.destinationCrs)
+                            : navigation.destination
   property bool coordinatesIsXY: !projectInfo.reprojectDisplayCoordinatesToWGS84
-                                && CoordinateReferenceSystemUtils.defaultCoordinateOrderForCrsIsXY(navigation.mapSettings.destinationCrs)
+                                 && CoordinateReferenceSystemUtils.defaultCoordinateOrderForCrsIsXY(navigation.mapSettings.destinationCrs)
   property bool coordinatesIsGeographic: projectInfo.reprojectDisplayCoordinatesToWGS84
-                                        || navigation.mapSettings.destinationCrs.isGeographic
+                                         || navigation.mapSettings.destinationCrs.isGeographic
 
   property Navigation navigation
   property int ceilsCount: 4
@@ -24,88 +24,195 @@ Rectangle {
   property color alternateBackgroundColor: Theme.navigationBackgroundColor
   property color textColor: "black"
 
-  height: grid.rows * navigationInformationView.rowHeight
+  height: childrenRect.height//grid.rows * navigationInformationView.rowHeight
   width: parent.width
   anchors.margins: 20
 
-  Grid {
-    id: grid
-    flow: GridLayout.TopToBottom
-    rows: parent.width > 620? 1 : 2
+  Timer {
+    id: featureVertexTimer
+    interval: 700
+    repeat: true
+
+    property bool moveForward: true
+
+    onTriggered: {
+      if (moveForward) {
+        navigation.nextDestinationVertex();
+      } else {
+        navigation.previousDestinationVertex();
+      }
+
+      if (interval > 100) interval = interval * 0.8;
+    }
+  }
+
+  ColumnLayout {
     width: parent.width
-    property double cellWidth: grid.width / ( ceilsCount / grid.rows )
+    spacing: 0
 
     Rectangle {
-      height: rowHeight
-      width: grid.cellWidth
-      color: alternateBackgroundColor
+      Layout.fillWidth: true
+      Layout.preferredHeight: childrenRect.height
+      color: Theme.navigationColor
 
-      Text {
-        anchors.margins:  10
-        anchors.verticalCenter: parent.verticalCenter
-        anchors.left: parent.left
-        font: Theme.tipFont
-        color: textColor
-        text: coordinatesIsXY
-              ? (coordinatesIsGeographic ? qsTr( "Lon" ) : qsTr( "X" )) + ': '
-                + Number( coordinates.x ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
-              : (coordinatesIsGeographic ? qsTr( "Lat" ) : qsTr( "Y" )) + ': '
-                + Number( coordinates.y ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
+      RowLayout {
+        width: parent.width
+
+        QfToolButton {
+          id: previousFeatureVertex
+          visible: navigation.destinationFeatureVertices > 1
+          Layout.alignment: Qt.AlignTop
+          round: true
+          bgcolor: "transparent"
+          iconSource: Theme.getThemeIcon("ic_chevron_left_white_24dp")
+          transform: Scale {
+              origin.x: previousFeatureVertex.width * 0.5
+              origin.y: previousFeatureVertex.height * 0.5
+              xScale: 0.75
+              yScale: 0.75
+          }
+
+          onPressed: {
+            navigation.previousDestinationVertex()
+            featureVertexTimer.moveForward = false;
+            featureVertexTimer.interval = 700
+            featureVertexTimer.restart()
+          }
+          onReleased: {
+            featureVertexTimer.stop()
+          }
+          onCanceled: {
+            featureVertexTimer.stop()
+          }
+        }
+
+        Text {
+          Layout.fillWidth: true
+          Layout.margins: 5
+          visible: navigation.destinationName != ''
+          horizontalAlignment: Text.AlignHCenter
+          font: Theme.strongTipFont
+          elide: Text.ElideMiddle
+          wrapMode: Text.NoWrap
+          color: "#FFFFFF"
+          text: navigation.destinationName +
+                (navigation.destinationFeatureVertices > 1
+                ? ' (' + (1 + navigation.destinationFeatureCurrentVertex) + '/'
+                      + navigation.destinationFeatureVertices + ')'
+                : '')
+        }
+
+        QfToolButton {
+          id: nextFeatureVertex
+          visible: navigation.destinationFeatureVertices > 1
+          round: true
+          bgcolor: "transparent"
+          iconSource: Theme.getThemeIcon("ic_chevron_right_white_24dp")
+          transform: Scale {
+            origin.x: nextFeatureVertex.width * 0.5
+            origin.y: nextFeatureVertex.height * 0.5
+              xScale: 0.75
+              yScale: 0.75
+          }
+
+          onPressed: {
+            navigation.nextDestinationVertex()
+            featureVertexTimer.moveForward = true;
+            featureVertexTimer.interval = 700
+            featureVertexTimer.restart()
+          }
+          onReleased: {
+            featureVertexTimer.stop()
+          }
+          onCanceled: {
+            featureVertexTimer.stop()
+          }
+        }
       }
     }
 
-    Rectangle {
-      height: rowHeight
-      width: grid.cellWidth
-      color: backgroundColor
+    Grid {
+      id: grid
+      Layout.fillWidth: true
+      Layout.preferredHeight: childrenRect.height
+      width: parent.width
+      height: grid.rows * navigationInformationView.rowHeight
+      flow: GridLayout.TopToBottom
+      rows: parent.width > 620? 1 : 2
+      property double cellWidth: grid.width / ( ceilsCount / grid.rows )
 
-      Text {
-        anchors.margins:  10
-        anchors.verticalCenter: parent.verticalCenter
-        anchors.left: parent.left
-        font: Theme.tipFont
-        color: textColor
-        text: coordinatesIsXY
-              ? (coordinatesIsGeographic ? qsTr( "Lat" ) : qsTr( "Y" )) + ': '
-                + Number( coordinates.y ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
-              : (coordinatesIsGeographic ? qsTr( "Lon" ) : qsTr( "X" )) + ': '
-                + Number( coordinates.x ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
+      Rectangle {
+        height: rowHeight
+        width: grid.cellWidth
+        color: alternateBackgroundColor
+
+        Text {
+          anchors.margins:  10
+          anchors.verticalCenter: parent.verticalCenter
+          anchors.left: parent.left
+          font: Theme.tipFont
+          color: textColor
+          text: coordinatesIsXY
+                ? (coordinatesIsGeographic ? qsTr( "Lon" ) : qsTr( "X" )) + ': '
+                  + Number( coordinates.x ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
+                : (coordinatesIsGeographic ? qsTr( "Lat" ) : qsTr( "Y" )) + ': '
+                  + Number( coordinates.y ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
+        }
       }
-    }
 
-    Rectangle {
-      height: rowHeight
-      width: grid.cellWidth
-      color: grid.rows == 2 ? backgroundColor : alternateBackgroundColor
+      Rectangle {
+        height: rowHeight
+        width: grid.cellWidth
+        color: backgroundColor
 
-      Text {
-        anchors.margins:  10
-        anchors.verticalCenter: parent.verticalCenter
-        anchors.left: parent.left
-        font: Theme.tipFont
-        color: textColor
-        text: qsTr( "Dist." ) + ': ' +
-              ( positionSource.active && positionSource.positionInformation && positionSource.positionInformation.latitudeValid
-              ? ( UnitTypes.formatDistance( navigation.distance, 3, navigation.distanceUnits ) )
-              : qsTr( "N/A" ) )
+        Text {
+          anchors.margins:  10
+          anchors.verticalCenter: parent.verticalCenter
+          anchors.left: parent.left
+          font: Theme.tipFont
+          color: textColor
+          text: coordinatesIsXY
+                ? (coordinatesIsGeographic ? qsTr( "Lat" ) : qsTr( "Y" )) + ': '
+                  + Number( coordinates.y ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
+                : (coordinatesIsGeographic ? qsTr( "Lon" ) : qsTr( "X" )) + ': '
+                  + Number( coordinates.x ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
+        }
       }
-    }
 
-    Rectangle {
-      height: rowHeight
-      width: grid.cellWidth
-      color: grid.rows == 2 ? alternateBackgroundColor : backgroundColor
+      Rectangle {
+        height: rowHeight
+        width: grid.cellWidth
+        color: grid.rows == 2 ? backgroundColor : alternateBackgroundColor
 
-      Text {
-        anchors.margins:  10
-        anchors.verticalCenter: parent.verticalCenter
-        anchors.left: parent.left
-        font: Theme.tipFont
-        color: textColor
-        text: qsTr( "Bearing" ) + ': ' +
-              ( positionSource.active && positionSource.positionInformation && positionSource.positionInformation.latitudeValid
-              ? ( Number( navigation.bearing ).toLocaleString( Qt.locale(), 'f', 1 ) ) + '°'
-              : qsTr( "N/A" ) )
+        Text {
+          anchors.margins:  10
+          anchors.verticalCenter: parent.verticalCenter
+          anchors.left: parent.left
+          font: Theme.tipFont
+          color: textColor
+          text: qsTr( "Dist." ) + ': ' +
+                ( positionSource.active && positionSource.positionInformation && positionSource.positionInformation.latitudeValid
+                 ? ( UnitTypes.formatDistance( navigation.distance, 3, navigation.distanceUnits ) )
+                 : qsTr( "N/A" ) )
+        }
+      }
+
+      Rectangle {
+        height: rowHeight
+        width: grid.cellWidth
+        color: grid.rows == 2 ? alternateBackgroundColor : backgroundColor
+
+        Text {
+          anchors.margins:  10
+          anchors.verticalCenter: parent.verticalCenter
+          anchors.left: parent.left
+          font: Theme.tipFont
+          color: textColor
+          text: qsTr( "Bearing" ) + ': ' +
+                ( positionSource.active && positionSource.positionInformation && positionSource.positionInformation.latitudeValid
+                 ? ( Number( navigation.bearing ).toLocaleString( Qt.locale(), 'f', 1 ) ) + '°'
+                 : qsTr( "N/A" ) )
+        }
       }
     }
   }

--- a/src/qml/NavigationInformationView.qml
+++ b/src/qml/NavigationInformationView.qml
@@ -61,16 +61,12 @@ Rectangle {
         QfToolButton {
           id: previousFeatureVertex
           visible: navigation.destinationFeatureVertices > 1
-          Layout.alignment: Qt.AlignTop
+          Layout.alignment: Qt.AlignVCenter
+          width: 36
+          height: 36
           round: true
           bgcolor: "transparent"
           iconSource: Theme.getThemeIcon("ic_chevron_left_white_24dp")
-          transform: Scale {
-              origin.x: previousFeatureVertex.width * 0.5
-              origin.y: previousFeatureVertex.height * 0.5
-              xScale: 0.75
-              yScale: 0.75
-          }
 
           onPressed: {
             navigation.previousDestinationVertex()
@@ -105,15 +101,12 @@ Rectangle {
         QfToolButton {
           id: nextFeatureVertex
           visible: navigation.destinationFeatureVertices > 1
+          Layout.alignment: Qt.AlignVCenter
+          width: 36
+          height: 36
           round: true
           bgcolor: "transparent"
           iconSource: Theme.getThemeIcon("ic_chevron_right_white_24dp")
-          transform: Scale {
-            origin.x: nextFeatureVertex.width * 0.5
-            origin.y: nextFeatureVertex.height * 0.5
-              xScale: 0.75
-              yScale: 0.75
-          }
 
           onPressed: {
             navigation.nextDestinationVertex()

--- a/src/qml/NavigationInformationView.qml
+++ b/src/qml/NavigationInformationView.qml
@@ -60,7 +60,7 @@ Rectangle {
 
         QfToolButton {
           id: previousFeatureVertex
-          visible: navigation.destinationFeatureVertices > 1
+          visible: navigation.destinationFeatureVertexCount > 1
           Layout.alignment: Qt.AlignVCenter
           width: 36
           height: 36
@@ -92,18 +92,18 @@ Rectangle {
           wrapMode: Text.NoWrap
           color: "#FFFFFF"
           text: navigation.destinationName +
-                (navigation.destinationFeatureVertices > 1
+                (navigation.destinationFeatureVertexCount > 1
                 ? ': ' +
                   (navigation.destinationFeatureCurrentVertex > 0
                   ? (navigation.destinationFeatureCurrentVertex) + '/'
-                      + navigation.destinationFeatureVertices
+                      + navigation.destinationFeatureVertexCount
                   : qsTr('centroid'))
                 : '')
         }
 
         QfToolButton {
           id: nextFeatureVertex
-          visible: navigation.destinationFeatureVertices > 1
+          visible: navigation.destinationFeatureVertexCount > 1
           Layout.alignment: Qt.AlignVCenter
           width: 36
           height: 36

--- a/src/qml/NavigationInformationView.qml
+++ b/src/qml/NavigationInformationView.qml
@@ -93,8 +93,11 @@ Rectangle {
           color: "#FFFFFF"
           text: navigation.destinationName +
                 (navigation.destinationFeatureVertices > 1
-                ? ': ' + (1 + navigation.destinationFeatureCurrentVertex) + '/'
+                ? ': ' +
+                  (navigation.destinationFeatureCurrentVertex > 0
+                  ? (navigation.destinationFeatureCurrentVertex) + '/'
                       + navigation.destinationFeatureVertices
+                  : qsTr('centroid'))
                 : '')
         }
 

--- a/src/qml/imports/Theme/QfToolButton.qml
+++ b/src/qml/imports/Theme/QfToolButton.qml
@@ -21,8 +21,8 @@ RoundButton {
 
   width: 48
   height: 48
-  implicitWidth: 48
-  implicitHeight: 48
+  implicitWidth: width
+  implicitHeight: height
 
   focusPolicy: Qt.NoFocus
   topInset:0

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2219,6 +2219,8 @@ ApplicationWindow {
         busyMessageText.text = qsTr( "Loading %1" ).arg( name !== '' ? name : path )
         busyMessage.state = "visible"
 
+        navigation.clearDestinationFeature();
+
         projectInfo.filePath = '';
         readProjectTimer.start()
       }


### PR DESCRIPTION
This PR implements a navigation to feature vertices functionality within QField. First, a small screencast:
![Peek 2022-06-21 14-03](https://user-images.githubusercontent.com/1728657/174737345-c9ba6119-6bbf-4b4e-a602-0d90b1076d72.gif)

When setting a navigation destination using a feature, a new purple feature bar title appears as part of the navigation information panel. For single points, a destination name is displayed (matching a given vector layer's display name field / expression).

For multipoint or {multi,single}{line,polygon}, new navigation buttons are located at the left and right of the destination name. Those buttons allow users to cycle through vertices of the feature picked as navigation destination. Tap and holding onto these buttons will cycle through vertices (comes in handy when you have a feature with a large vertex count).

