### PR TITLE
Relation editor's add button gone missing regression fix

### DIFF
--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -121,7 +121,7 @@ EditorWidgetBase {
         }
 
         MouseArea {
-            enabled: config['calendar_popup']
+            enabled: config['calendar_popup'] === undefined || config['calendar_popup']
             anchors.fill: parent
             onClicked: {
                 var usedDate = new Date();
@@ -217,7 +217,8 @@ EditorWidgetBase {
             anchors.rightMargin: 4
             anchors.verticalCenter: parent.verticalCenter
             anchors.verticalCenterOffset: -2
-            visible: ( value !== undefined ) && config['allow_null'] && enabled
+            visible: (value !== undefined) && enabled
+                     && (config['allow_null'] === undefined || config['allow_null'])
 
             MouseArea {
                 anchors.fill: parent

--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -306,16 +306,15 @@ EditorWidgetBase {
 
     function isButtonEnabled(buttonType) {
       const buttons = relationEditorWidgetConfig.buttons
+      if (buttons === undefined)
+        return true
 
-      if (!buttons)
-        return false
-
+      if (buttons === 'NoButton')
+        return false;
       if (buttons === 'AllButtons')
         return true
-
-      if (buttons.split('|').indexOf(buttonType) >= 0) {
+      if (buttons.split('|').indexOf(buttonType) >= 0)
         return true
-      }
 
       return false
     }


### PR DESCRIPTION
Follow up to https://github.com/opengisch/QField/commit/b38bf0aafdf6192359658374c883d78a1909bf7f which caused a regression whereas configuration-less relation editor widget (i.e., auto generated form) would have the add child feature button gone missing.

This fixes #2999 .

@suricactus , tweaked your logic a bit to fix the regression, all good?