### PR TITLE
Fix handling of bluetooth gnss receiver's socket state following revamp of positioning

### DIFF
--- a/src/core/positioning/abstractgnssreceiver.h
+++ b/src/core/positioning/abstractgnssreceiver.h
@@ -37,10 +37,11 @@ class AbstractGnssReceiver : public QObject
     bool valid() const { return mValid; }
     void setValid( bool valid ) { mValid = valid; }
 
-    void connectDevice() { handleConnectDevice(); }
-    void disconnectDevice() { handleDisconnectDevice(); }
+    Q_INVOKABLE void connectDevice() { handleConnectDevice(); }
+    Q_INVOKABLE void disconnectDevice() { handleDisconnectDevice(); }
 
     GnssPositionInformation lastGnssPositionInformation() const { return mLastGnssPositionInformation; }
+
     QAbstractSocket::SocketState socketState() const { return mSocketState; }
     QString socketStateString() const { return mSocketStateString; }
 
@@ -59,7 +60,7 @@ class AbstractGnssReceiver : public QObject
 
     bool mValid = false;
     GnssPositionInformation mLastGnssPositionInformation;
-    QAbstractSocket::SocketState mSocketState;
+    QAbstractSocket::SocketState mSocketState = QAbstractSocket::UnconnectedState;
     QString mSocketStateString;
 };
 

--- a/src/core/positioning/bluetoothreceiver.cpp
+++ b/src/core/positioning/bluetoothreceiver.cpp
@@ -96,7 +96,9 @@ void BluetoothReceiver::stateChanged( const QgsGpsInformation &info )
 void BluetoothReceiver::setSocketState( const QBluetoothSocket::SocketState socketState )
 {
   if ( mSocketState == static_cast<QAbstractSocket::SocketState>( socketState ) )
+  {
     return;
+  }
 
   switch ( socketState )
   {

--- a/src/core/positioning/internalgnssreceiver.cpp
+++ b/src/core/positioning/internalgnssreceiver.cpp
@@ -30,6 +30,8 @@ InternalGnssReceiver::InternalGnssReceiver( QObject *parent )
     connect( mGeoPositionSource.get(), &QGeoPositionInfoSource::positionUpdated, this, &InternalGnssReceiver::handlePositionUpdated );
     connect( mGeoPositionSource.get(), qOverload<QGeoPositionInfoSource::Error>( &QGeoPositionInfoSource::error ), this, &InternalGnssReceiver::handleError );
 
+    mSocketState = QAbstractSocket::ConnectedState;
+
     setValid( true );
   }
 }

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -52,15 +52,15 @@ void Positioning::setActive( bool active )
   emit activeChanged();
 }
 
-void Positioning::setDevice( const QString &device )
+void Positioning::setDeviceId( const QString &id )
 {
-  if ( mDevice == device )
+  if ( mDeviceId == id )
     return;
 
-  mDevice = device;
+  mDeviceId = id;
   setupDevice();
 
-  emit deviceChanged();
+  emit deviceIdChanged();
 }
 
 void Positioning::setValid( bool valid )
@@ -116,17 +116,18 @@ void Positioning::setupDevice()
     disconnect( mReceiver.get(), &AbstractGnssReceiver::lastGnssPositionInformationChanged, this, &Positioning::lastGnssPositionInformationChanged );
   }
 
-  if ( mDevice.isEmpty() )
+  if ( mDeviceId.isEmpty() )
   {
     mReceiver = std::make_unique<InternalGnssReceiver>( this );
   }
   else
   {
-    mReceiver = std::make_unique<BluetoothReceiver>( mDevice, this );
+    mReceiver = std::make_unique<BluetoothReceiver>( mDeviceId, this );
   }
   connect( mReceiver.get(), &AbstractGnssReceiver::lastGnssPositionInformationChanged, this, &Positioning::lastGnssPositionInformationChanged );
-
   setValid( mReceiver->valid() );
+
+  emit deviceChanged();
 
   if ( mActive )
   {

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -35,7 +35,8 @@ class Positioning : public QObject
     Q_OBJECT
 
     Q_PROPERTY( bool active READ active WRITE setActive NOTIFY activeChanged )
-    Q_PROPERTY( QString device READ device WRITE setDevice NOTIFY deviceChanged )
+    Q_PROPERTY( QString deviceId READ deviceId WRITE setDeviceId NOTIFY deviceIdChanged )
+    Q_PROPERTY( AbstractGnssReceiver *device READ device NOTIFY deviceChanged )
 
     Q_PROPERTY( QgsQuickCoordinateTransformer *coordinateTransformer READ coordinateTransformer WRITE setCoordinateTransformer NOTIFY coordinateTransformerChanged )
 
@@ -67,17 +68,19 @@ class Positioning : public QObject
     void setActive( bool active );
 
     /**
-     * Returns the current positioning device name used to fetch position information.
+     * Returns the current positioning device \a id used to fetch position information.
      * \see setDevice
      */
-    QString device() const { return mDevice; }
+    QString deviceId() const { return mDeviceId; }
 
     /**
-     * Sets the positioning device name used to fetch position information.
+     * Sets the positioning device \a id used to fetch position information.
      * \note A blank string will connect the internal positioning device;
      * bluetooth addresses will trigger an NMEA connection to external devices.
      */
-    void setDevice( const QString &device );
+    void setDeviceId( const QString &id );
+
+    AbstractGnssReceiver *device() const { return mReceiver.get(); }
 
     /**
      * Returns the coordinate transformer object used to reproject the position location.
@@ -139,6 +142,7 @@ class Positioning : public QObject
   signals:
 
     void activeChanged();
+    void deviceIdChanged();
     void deviceChanged();
     void validChanged();
     void coordinateTransformerChanged();
@@ -157,7 +161,7 @@ class Positioning : public QObject
 
     bool mActive = false;
 
-    QString mDevice;
+    QString mDeviceId;
     bool mValid = false;
 
     QgsCoordinateReferenceSystem mSourceCrs;

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -481,6 +481,7 @@ void QgisMobileapp::initDeclarative()
   qmlRegisterType<Navigation>( "org.qfield", 1, 0, "Navigation" );
   qmlRegisterType<NavigationModel>( "org.qfield", 1, 0, "NavigationModel" );
   qmlRegisterType<Positioning>( "org.qfield", 1, 0, "Positioning" );
+  qmlRegisterUncreatableType<AbstractGnssReceiver>( "org.qfield", 1, 0, "AbstractGnssReceiver", "" );
 
   qRegisterMetaType<GnssPositionInformation>( "GnssPositionInformation" );
 

--- a/src/qml/LocationMarker.qml
+++ b/src/qml/LocationMarker.qml
@@ -11,7 +11,7 @@ Item {
   id: item
 
   property variant location // QgsPoint
-  property string device // Empty string means internal device is used
+  property string deviceId // Empty string means internal device is used
   property real accuracy
   property real direction // A -1 value indicates absence of direction information (note: when an external GNSS device is connected, direction is actually a compass)
   property real speed // A -1 value indicates absence of speed information
@@ -83,7 +83,7 @@ Item {
 
   Image {
     id: compassDirectionMarker
-    visible: device === '' && magnetometer.hasValue
+    visible: deviceId === '' && magnetometer.hasValue
     width: 48
     height: 48
     opacity: 0.6

--- a/src/qml/PositionInformationView.qml
+++ b/src/qml/PositionInformationView.qml
@@ -31,9 +31,9 @@ Rectangle {
   Grid {
     id: grid
     flow: GridLayout.TopToBottom
-    rows: ( positionSource.device === '' ? 1 : 2 ) * ( parent.width > 1000? 1 : parent.width > 620? 2 : 3 )
+    rows: ( positionSource.deviceId === '' ? 1 : 2 ) * ( parent.width > 1000? 1 : parent.width > 620? 2 : 3 )
     width: parent.width
-    property double cellWidth: grid.width / ( ( positionSource.device === '' ? 1 : 2 ) * 6 / grid.rows )
+    property double cellWidth: grid.width / ( ( positionSource.deviceId === '' ? 1 : 2 ) * 6 / grid.rows )
 
     Rectangle {
       id: x
@@ -159,7 +159,7 @@ Rectangle {
       height: rowHeight
       width: grid.cellWidth
       color: grid.rows % 2 === 0 ? backgroundColor : alternateBackgroundColor
-      visible: positionSource.device !== ''
+      visible: positionSource.deviceId !== ''
 
       Text {
         anchors.margins:  10
@@ -175,7 +175,7 @@ Rectangle {
       height: rowHeight
       width: grid.cellWidth
       color: grid.rows % 2 === 0 ? alternateBackgroundColor : backgroundColor
-      visible: positionSource.device !== ''
+      visible: positionSource.deviceId !== ''
 
       Text {
         anchors.margins:  10
@@ -191,7 +191,7 @@ Rectangle {
       height: rowHeight
       width: grid.cellWidth
       color: grid.rows === 6 ? backgroundColor : alternateBackgroundColor
-      visible: positionSource.device !== ''
+      visible: positionSource.deviceId !== ''
 
       Text {
         anchors.margins:  10
@@ -207,7 +207,7 @@ Rectangle {
       height: rowHeight
       width: grid.cellWidth
       color: grid.rows === 6 ? alternateBackgroundColor : backgroundColor
-      visible: positionSource.device !== ''
+      visible: positionSource.deviceId !== ''
 
       Text {
         anchors.margins:  10
@@ -223,7 +223,7 @@ Rectangle {
       height: rowHeight
       width: grid.cellWidth
       color: grid.rows === 2 || grid.rows === 6 ? backgroundColor : alternateBackgroundColor
-      visible: positionSource.device !== ''
+      visible: positionSource.deviceId !== ''
 
       Text {
         anchors.margins:  10
@@ -239,7 +239,7 @@ Rectangle {
       height: rowHeight
       width: grid.cellWidth
       color: grid.rows === 2 || grid.rows === 6 ? alternateBackgroundColor : backgroundColor
-      visible: positionSource.device !== ''
+      visible: positionSource.deviceId !== ''
 
       Text {
         anchors.margins:  10

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -515,25 +515,24 @@ Page {
                       Layout.topMargin: 5
                       font: Theme.defaultFont
                       text: {
-                          switch (positionSource.bluetoothSocketState)
-                          {
-                          case BluetoothSocket.Connected:
-                              return qsTr('Connected to %1').arg(positioningSettings.positioningDeviceName)
-                          case BluetoothSocket.Unconnected:
-                              return qsTr('Connect  to %1').arg(positioningSettings.positioningDeviceName)
-                          default:
-                              return qsTr('Connecting to %1').arg(positioningSettings.positioningDeviceName)
+                          switch (positionSource.device.socketState) {
+                              case BluetoothSocket.Connected:
+                                  return qsTr('Connected to %1').arg(positioningSettings.positioningDeviceName)
+                              case BluetoothSocket.Unconnected:
+                                  return qsTr('Connect  to %1').arg(positioningSettings.positioningDeviceName)
+                              default:
+                                  return qsTr('Connecting to %1').arg(positioningSettings.positioningDeviceName)
                           }
                       }
-                      enabled: positionSource.bluetoothSocketState === BluetoothSocket.Unconnected
-                      visible: positioningSettings.positioningDevice !== ''
+                      enabled: positionSource.device.socketState === BluetoothSocket.Unconnected
+                      visible: positionSource.deviceId !== ''
 
                       onClicked: {
                           // make sure positioning is active when connecting to the bluetooth device
                           if (!positioningSettings.positioningActivated) {
                               positioningSettings.positioningActivated = true
                           } else {
-                              positionSource.connectBluetoothSource()
+                              positionSource.device.connectDevice()
                           }
                       }
                   }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -168,7 +168,7 @@ ApplicationWindow {
    */
   Positioning {
     id: positionSource
-    device: positioningSettings.positioningDevice
+    deviceId: positioningSettings.positioningDevice
 
     property bool currentness: false;
     property alias destinationCrs: positionSource.coordinateTransformer.destinationCrs
@@ -521,7 +521,7 @@ ApplicationWindow {
       anchors.fill: parent
       visible: positionSource.active && positionSource.positionInformation && positionSource.positionInformation.latitudeValid
       location: positionSource.projectedPosition
-      device: positionSource.device
+      deviceId: positionSource.deviceId
       accuracy: positionSource.projectedHorizontalAccuracy
       direction: positionSource.positionInformation
                  && positionSource.positionInformation.directionValid


### PR DESCRIPTION
This PR fixes a couple of bluetooth GNSS device issues following the revamp of our positioning framework. Nothing major, but good to have been able to test a GNSS device that supports NMEA through bluetooth prior to 2.2. 

