### PR TITLE
Improve navigation UX by auto-closing the feature form when using the set feature as destination action

### DIFF
--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -436,6 +436,7 @@ Rectangle {
 
     onDestinationClicked: {
       navigation.setDestinationFeature(featureForm.selection.focusedFeature,featureForm.selection.focusedLayer)
+      featureForm.state = "Hidden";
     }
 
     onMoveClicked: {


### PR DESCRIPTION
After much testing, I found out that 100% of the time, when using the feature form's set feature as destination menu action, you really want to jump onto the map canvas after that (especially now that we have feature vertex navigation). Let's improve UX and auto close the feature form.