### PR TITLE
Insure sane scale when setting extent from points

### DIFF
--- a/src/core/qgsquick/qgsquickmapsettings.cpp
+++ b/src/core/qgsquick/qgsquickmapsettings.cpp
@@ -122,7 +122,7 @@ void QgsQuickMapSettings::setCenterToLayer( QgsMapLayer *layer, bool shouldZoom 
   }
 }
 
-void QgsQuickMapSettings::setExtentFromPoints( const QVariantList &points )
+void QgsQuickMapSettings::setExtentFromPoints( const QVariantList &points, const double &minimumScale )
 {
   if ( points.isEmpty() )
   {
@@ -159,6 +159,18 @@ void QgsQuickMapSettings::setExtentFromPoints( const QVariantList &points )
     unitPerPoint = extent.height() / size.height();
   }
   buffer = 80 * unitPerPoint;
+
+  if ( minimumScale > 0.0 )
+  {
+    QgsScaleCalculator calc;
+    calc.setMapUnits( mMapSettings.destinationCrs().mapUnits() );
+    calc.setDpi( outputDpi() );
+    double scale = calc.calculate( extent, outputSize().width() );
+    if ( scale < minimumScale )
+    {
+      extent.scale( minimumScale / scale );
+    }
+  }
 
   setExtent( extent.buffered( buffer ) );
 }

--- a/src/core/qgsquick/qgsquickmapsettings.h
+++ b/src/core/qgsquick/qgsquickmapsettings.h
@@ -163,7 +163,7 @@ class QFIELD_CORE_EXPORT QgsQuickMapSettings : public QObject
     Q_INVOKABLE void setCenterToLayer( QgsMapLayer *layer, bool shouldZoom = true );
 
     //! Move current map extent to center around the list of \a points provided
-    Q_INVOKABLE void setExtentFromPoints( const QVariantList &points );
+    Q_INVOKABLE void setExtentFromPoints( const QVariantList &points, const double &minimumScale = 0 );
 
     //! \copydoc QgsQuickMapSettings::mapUnitsPerPoint
     double mapUnitsPerPoint() const;

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1298,13 +1298,13 @@ ApplicationWindow {
         gnssMenu.popup(locationToolbar.x + locationToolbar.width - gnssMenu.width, locationToolbar.y + locationToolbar.height - gnssMenu.height)
       }
 
-      property int followLocationMaxScale: 10
+      property int followLocationMinScale: 125
       property int followLocationMinMargin: 40
       property int followLocationScreenFraction: settings ? settings.value( "/QField/Positioning/FollowScreenFraction", 5 ) : 5
       function followLocation(forceRecenter) {
         var screenLocation = mapCanvas.mapSettings.coordinateToScreen(positionSource.projectedPosition);
         if (navigation.isActive && navigationButton.followIncludeDestination) {
-          if (mapCanvas.mapSettings.scale > followLocationMaxScale) {
+          if (mapCanvas.mapSettings.scale > followLocationMinScale) {
             var screenDestination = mapCanvas.mapSettings.coordinateToScreen(navigation.destination);
             if (forceRecenter
                 || screenDestination.x < followLocationMinMargin
@@ -1319,7 +1319,7 @@ ApplicationWindow {
                     && Math.abs(screenDestination.y - screenLocation.y) < mainWindow.height / 3)) {
               gnssButton.followActiveSkipExtentChanged = true;
               var points = [positionSource.projectedPosition, navigation.destination];
-              mapCanvas.mapSettings.setExtentFromPoints(points)
+              mapCanvas.mapSettings.setExtentFromPoints(points, followLocationMinScale)
             }
           }
         } else {


### PR DESCRIPTION
While doing stress testing of the new navigation functionalities, I realized a shortcoming with the way we are attempting to insure QField's map won't end up with an insanely small scale value when following both destination and location.

Long story short here is that upon toggling the follow destination+location mode, we were scaling in to fit both points and ignoring our min scale value (which we otherwise enforce _after_ the initial toggle).

This PR insures that calling QgsQuickMapSettings::setExentFromPoints() will cap to a minimum scale if provided.