### PR TITLE
QField :heart: satellites

### DIFF
--- a/src/core/positioning/internalgnssreceiver.cpp
+++ b/src/core/positioning/internalgnssreceiver.cpp
@@ -37,6 +37,8 @@ InternalGnssReceiver::InternalGnssReceiver( QObject *parent )
     mGeoSatelliteSource = std::unique_ptr<QGeoSatelliteInfoSource>( QGeoSatelliteInfoSource::createDefaultSource( nullptr ) );
     if ( mGeoSatelliteSource.get() && mGeoSatelliteSource->error() == QGeoSatelliteInfoSource::NoError )
     {
+      mGeoSatelliteSource->setUpdateInterval( 1000 );
+
       connect( mGeoSatelliteSource.get(), &QGeoSatelliteInfoSource::satellitesInUseUpdated, this, &InternalGnssReceiver::handleSatellitesInUseUpdated );
       connect( mGeoSatelliteSource.get(), &QGeoSatelliteInfoSource::satellitesInViewUpdated, this, &InternalGnssReceiver::handleSatellitesInViewUpdated );
       connect( mGeoSatelliteSource.get(), qOverload<QGeoSatelliteInfoSource::Error>( &QGeoSatelliteInfoSource::error ), this, &InternalGnssReceiver::handleSatelliteError );

--- a/src/core/positioning/internalgnssreceiver.h
+++ b/src/core/positioning/internalgnssreceiver.h
@@ -50,7 +50,6 @@ class InternalGnssReceiver : public AbstractGnssReceiver
     GnssPositionInformation mLastGnssPositionInformation;
     bool mLastGnssPositionValid = false;
 
-    int mSatellitesUsed = 0;
     QList<int> mSatellitesID;
     QList<QgsSatelliteInfo> mSatellitesInfo;
     bool mSatelliteInformationValid = true;

--- a/src/core/positioning/internalgnssreceiver.h
+++ b/src/core/positioning/internalgnssreceiver.h
@@ -36,14 +36,22 @@ class InternalGnssReceiver : public AbstractGnssReceiver
     void handlePositionUpdated( const QGeoPositionInfo &positionInfo );
     void handleError( QGeoPositionInfoSource::Error positioningError );
 
+    void handleSatellitesInUseUpdated( const QList<QGeoSatelliteInfo> &satellites );
+    void handleSatelliteError( QGeoSatelliteInfoSource::Error satelliteError );
+
   private:
     void handleConnectDevice() override;
     void handleDisconnectDevice() override;
 
     std::unique_ptr<QGeoPositionInfoSource> mGeoPositionSource;
+    std::unique_ptr<QGeoSatelliteInfoSource> mGeoSatelliteSource;
 
     GnssPositionInformation mLastGnssPositionInformation;
     bool mLastGnssPositionValid = false;
+
+    int mSatellitesUsed = 0;
+    QList<int> mSatelliteIDs;
+    bool mSatelliteInformationValid = true;
 };
 
 #endif // INTERNALGNSSRECEIVER_H

--- a/src/core/positioning/internalgnssreceiver.h
+++ b/src/core/positioning/internalgnssreceiver.h
@@ -37,6 +37,7 @@ class InternalGnssReceiver : public AbstractGnssReceiver
     void handleError( QGeoPositionInfoSource::Error positioningError );
 
     void handleSatellitesInUseUpdated( const QList<QGeoSatelliteInfo> &satellites );
+    void handleSatellitesInViewUpdated( const QList<QGeoSatelliteInfo> &satellites );
     void handleSatelliteError( QGeoSatelliteInfoSource::Error satelliteError );
 
   private:
@@ -50,7 +51,8 @@ class InternalGnssReceiver : public AbstractGnssReceiver
     bool mLastGnssPositionValid = false;
 
     int mSatellitesUsed = 0;
-    QList<int> mSatelliteIDs;
+    QList<int> mSatellitesID;
+    QList<QgsSatelliteInfo> mSatellitesInfo;
     bool mSatelliteInformationValid = true;
 };
 


### PR DESCRIPTION
Moving our positioning code to C++ made it super easy to add satellite-related information to our handling of _internal_ GNSS positioning. 

