### PR TITLE
Avoid crashing by checking whether there's a geometry to constGet

### DIFF
--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -564,7 +564,7 @@ void FeatureModel::applyGeometry()
     {
       sanitizedGeometry = geometry.buffer( 0, 5 );
     }
-    if ( sanitizedGeometry.constGet()->isValid( error ) )
+    if ( !sanitizedGeometry.isNull() && sanitizedGeometry.constGet()->isValid( error ) )
       geometry = sanitizedGeometry;
 
     if ( mProject )


### PR DESCRIPTION
Spotted on sentry, not 2.2.0 specific, has been there forever.