### PR TITLE
[qgsquick] Fix silent refresh not sticking until the end of a refresh cycle

### DIFF
--- a/src/core/qgsquick/qgsquickmapcanvasmap.cpp
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.cpp
@@ -155,10 +155,6 @@ void QgsQuickMapCanvasMap::refreshMap()
   {
     emit renderStarting();
   }
-  else
-  {
-    mSilentRefresh = false;
-  }
 }
 
 void QgsQuickMapCanvasMap::renderJobUpdated()
@@ -176,7 +172,6 @@ void QgsQuickMapCanvasMap::renderJobUpdated()
   mFreeze = freeze;
 
   update();
-  emit mapCanvasRefreshed();
 }
 
 void QgsQuickMapCanvasMap::renderJobFinished()
@@ -212,7 +207,14 @@ void QgsQuickMapCanvasMap::renderJobFinished()
   mFreeze = freeze;
 
   update();
-  emit mapCanvasRefreshed();
+  if ( !mSilentRefresh )
+  {
+    emit mapCanvasRefreshed();
+  }
+  else
+  {
+    mSilentRefresh = false;
+  }
 
   if ( mDeferredRefreshPending )
   {


### PR DESCRIPTION
Helps with animation as the QML spinner element isn't needlessly showing and hiding.