### PR TITLE
Do not add custom gdal and proj data paths when building against system libraries, bad stuff happens

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -207,15 +207,19 @@ int main( int argc, char **argv )
   QSettings settings;
   app.setThemeName( settings.value( "/Themes", "default" ).toString() );
 
+#ifdef RELATIVE_PREFIX_PATH
   qputenv( "GDAL_DATA", QDir::toNativeSeparators( app.applicationDirPath() + "/../share/gdal" ).toLocal8Bit() );
   qputenv( "PROJ_LIB", QDir::toNativeSeparators( app.applicationDirPath() + "/../share/proj" ).toLocal8Bit() );
-#ifdef RELATIVE_PREFIX_PATH
   app.setPrefixPath( app.applicationDirPath() + "/..", true );
 #else
   app.setPrefixPath( CMAKE_INSTALL_PREFIX, true );
 #endif
 #endif
-  qInfo() << "Proj path: " << qgetenv( "PROJ_LIB" );
+  const QString envProjPath( qgetenv( "PROJ_LIB" ) );
+  if ( !envProjPath.isEmpty() )
+  {
+    qInfo() << "Proj path: " << envProjPath;
+  }
 
   originalMessageHandler = qInstallMessageHandler( qfMessageHandler );
   app.initQgis();


### PR DESCRIPTION
@m-kuhn , a quick fix to follow up on your fantastic vcpkg work of the last few weeks. When doing home builds on my linux machine, the custom PROJ_LIB and GDAL_DATA paths are messing things up (as it should, since I'm not building with vcpkg).

The commit insures that those custom paths are only added when RELATIVE_PREFIX_PATH is set (which in turns is set when building WITH_VCPKG).

I'm also not force pushing the custom proj path into the console if it's empty, makes for a cleaner console when developing which increases the chances of catching regressions causing console outputs :)