### PR TITLE
Use QSoundEffect instead of QSound for the proximity alarm

### DIFF
--- a/src/core/navigation.cpp
+++ b/src/core/navigation.cpp
@@ -36,12 +36,13 @@ Navigation::Navigation()
   connect( mModel.get(), &NavigationModel::modelReset, this, &Navigation::destinationChanged );
   connect( mModel.get(), &NavigationModel::modelReset, this, &Navigation::updateDetails );
 
+  mProximitySound.setSource( QUrl( QStringLiteral( "qrc:/sounds/proximity_alarm.wav" ) ) );
   mProximityAlarmTimer.setInterval( 250 );
   mProximityAlarmTimer.setSingleShot( false );
   connect( &mProximityAlarmTimer, &QTimer::timeout, this, [=] {
     if ( QDateTime::currentMSecsSinceEpoch() > mLastProximityAlarm + mProximityAlarmInterval )
     {
-      QSound::play( ":/sounds/proximity_alarm.wav" );
+      mProximitySound.play();
       mLastProximityAlarm = QDateTime::currentMSecsSinceEpoch();
     }
   } );
@@ -299,7 +300,7 @@ void Navigation::updateProximityAlarmState()
       mProximityAlarmInterval = 200 + ( 2000 * mDistance / mProximityAlarmThreshold );
       if ( !mProximityAlarmTimer.isActive() )
       {
-        QSound::play( ":/sounds/proximity_alarm.wav" );
+        mProximitySound.play();
         mLastProximityAlarm = QDateTime::currentMSecsSinceEpoch();
         mProximityAlarmTimer.start();
       }

--- a/src/core/navigation.h
+++ b/src/core/navigation.h
@@ -21,6 +21,7 @@
 #include "qgsquickmapsettings.h"
 
 #include <QObject>
+#include <QSoundEffect>
 #include <QTimer>
 #include <qgsdistancearea.h>
 
@@ -239,6 +240,7 @@ class Navigation : public QObject
     QTimer mProximityAlarmTimer;
     int mProximityAlarmInterval;
     qint64 mLastProximityAlarm;
+    QSoundEffect mProximitySound;
 };
 
 #endif // NAVIGATION_H


### PR DESCRIPTION
@m-kuhn , a subset of https://github.com/opengisch/QField/pull/3092 -- I've tested locally and it works (I think the error was the source string not liking ":..." instead of "qrc:...").

@lucienicolier , can you test this one out?