### PR TITLE
CMake changes for Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ set(APP_VERSION "" CACHE STRING "Application Version (Example: 1.0.0)")
 set(APP_VERSION_STR "local - dev" CACHE STRING "Application Version Name (Example: 1.0.0 - Homerun)")
 set(APP_PACKAGE_NAME "qfield" CACHE STRING "Package name suffix. E.g. qfield --> ch.opengis.qfield")
 
+set(BUILD_WITH_QT6 OFF CACHE BOOLEAN "Build with Qt6")
+
 string(REGEX REPLACE "v" "" CLEAN_APP_VERSION "${APP_VERSION}")
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
@@ -87,6 +89,12 @@ if(WITH_SENTRY)
   find_package(sentry REQUIRED)
 endif()
 
+if(BUILD_WITH_QT6)
+  set(QT_PKG Qt6)
+else()
+  set(QT_PKG Qt5)
+endif()
+
 if (ANDROID)
   if(VCPKG_TARGET_TRIPLET STREQUAL "arm-android" OR VCPKG_TARGET_TRIPLET STREQUAL "arm-neon-android")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -fstack-protector-strong -lunwind -Wl,--exclude-libs=libunwind.a")
@@ -109,7 +117,9 @@ if (ANDROID)
 
   include(platform/android/openssl/CMakeLists.txt)
 
-  find_package(Qt5 COMPONENTS AndroidExtras REQUIRED)
+  if(NOT BUILD_WITH_QT6)
+    find_package(Qt5 COMPONENTS AndroidExtras REQUIRED)
+  endif()
 
   if(NOT EXISTS "${VCPKG_BASE_DIR}/share/proj/data/proj.db")
     message(FATAL_ERROR "proj.db not found, aborting")
@@ -130,11 +140,11 @@ if (ANDROID)
 endif()
 
 set(QT_MIN_VERSION 5.14.0)
-find_package(Qt5 COMPONENTS Concurrent Core Qml Gui Xml Positioning Widgets Network Quick Svg OpenGL Sql Sensors WebView MultimediaQuick REQUIRED)
+find_package(${QT_PKG} COMPONENTS Concurrent Core Qml Gui Xml Positioning Widgets Network Quick Svg OpenGL Sql Sensors WebView Multimedia REQUIRED)
 
 # PrintSupport isn't required, because it doesn't exist for ios
 # qgis will deal with it an define a public 'QT_NO_PRINTER'
-find_package(Qt5 COMPONENTS PrintSupport QUIET)
+find_package(${QT_PKG} COMPONENTS PrintSupport QUIET)
 
 find_package(QGIS REQUIRED)
 if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "iOS")
@@ -167,7 +177,6 @@ endif()
 set(ENABLE_TESTS CACHE BOOL "Build unit tests")
 
 if(MSVC)
-  find_package(Qt5 COMPONENTS Charts REQUIRED) # vcpkg doesn't include QtCharts.dll as dep of the qml module otherwise
   add_definitions(-D_USE_MATH_DEFINES)
   add_definitions(-DNOMINMAX)
   add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)
@@ -184,7 +193,7 @@ add_subdirectory(src/qml)
 add_subdirectory(src/app)
 
 if (ENABLE_TESTS)
-  find_package(Qt5 COMPONENTS Test QuickTest)
+  find_package(${QT_PKG} COMPONENTS Test QuickTest)
   enable_testing()
   add_subdirectory(test)
 endif()

--- a/cmake/FindQGIS.cmake
+++ b/cmake/FindQGIS.cmake
@@ -332,8 +332,7 @@ IF(${CMAKE_SYSTEM_NAME} STREQUAL "iOS")
   qgis_core_link_plugin(authmethod_pkcs12_a)
   qgis_core_link_plugin(authmethod_pkipaths_a)
 
-  # Versionless tagging of Qt, only supported from Qt5.15
-  if(NOT TARGET Qt::PrintSupport)
+  if(NOT TARGET ${QT_PKG}::PrintSupport)
     target_compile_definitions(qgis_core INTERFACE "-DQT_NO_PRINTER")
   endif()
 

--- a/cmake/Package.cmake
+++ b/cmake/Package.cmake
@@ -33,7 +33,7 @@ if(WIN32)
     list(APPEND CPACK_GENERATOR "NSIS")
 endif()
 
-get_target_property(qmake_executable Qt5::qmake IMPORTED_LOCATION)
+get_target_property(qmake_executable ${QT_PKG}::qmake IMPORTED_LOCATION)
 
 set(CPACK_OUTPUT_CONFIG_FILE "${CMAKE_BINARY_DIR}/BundleConfig.cmake")
 

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt5QuickCompiler QUIET)
+find_package(${QT_PKG}QuickCompiler QUIET)
 
 if(MSVC)
   configure_file("${CMAKE_SOURCE_DIR}/platform/windows/appicon.rc.in"
@@ -64,12 +64,12 @@ function(create_executable)
 
   target_link_libraries(${exe_TARGET} PRIVATE qfield_core qfield_qml
                                               ${QGIS_CORE_LIBRARY})
-  get_target_property(QT_TARGET_TYPE Qt5::Core TYPE)
+  get_target_property(QT_TARGET_TYPE ${QT_PKG}::Core TYPE)
   # This should be in src/qml/CMakeLists.txt but that's not possible with Qt5.
   # Retry with Qt6 Same is in tests/CMakeLists.txt
   # https://bugreports.qt.io/browse/QTBUG-80847
   if(${QT_TARGET_TYPE} STREQUAL "STATIC_LIBRARY")
-    find_package(Qt5 COMPONENTS QmlImportScanner)
+    find_package(${QT_PKG} COMPONENTS QmlImportScanner)
     file(GLOB qfield_qmlfiles "${CMAKE_SOURCE_DIR}/src/qml/*.qml")
     file(COPY ${qfield_qmlfiles}
          DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/qmldrop/app")

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -241,7 +241,7 @@ target_include_directories(
 if(IOS)
   # to include <qpa/qplatformnativeinterface.h>
   target_include_directories(qfield_core SYSTEM
-                             PRIVATE ${Qt5Gui_PRIVATE_INCLUDE_DIRS})
+                             PRIVATE ${${QT_PKG}Gui_PRIVATE_INCLUDE_DIRS})
 endif()
 
 target_include_directories(
@@ -273,21 +273,21 @@ endif()
 
 target_link_libraries(
   qfield_core
-  PUBLIC Qt5::Core
-         Qt5::Gui
-         Qt5::Xml
-         Qt5::Positioning
-         Qt5::Widgets
-         Qt5::Network
-         Qt5::Quick
-         Qt5::Svg
-         Qt5::OpenGL
-         Qt5::Sensors
-         Qt5::Positioning
-         Qt5::Sql
-         Qt5::Concurrent
-         Qt5::WebView
-         Qt5::Multimedia
+  PUBLIC ${QT_PKG}::Core
+         ${QT_PKG}::Gui
+         ${QT_PKG}::Xml
+         ${QT_PKG}::Positioning
+         ${QT_PKG}::Widgets
+         ${QT_PKG}::Network
+         ${QT_PKG}::Quick
+         ${QT_PKG}::Svg
+         ${QT_PKG}::OpenGL
+         ${QT_PKG}::Sensors
+         ${QT_PKG}::Positioning
+         ${QT_PKG}::Sql
+         ${QT_PKG}::Concurrent
+         ${QT_PKG}::WebView
+         ${QT_PKG}::Multimedia
          QGIS::Core
          QGIS::Analysis
          ${PROJ_LIBRARY}
@@ -295,10 +295,10 @@ target_link_libraries(
 
 if(WITH_BLUETOOTH)
   find_package(
-    Qt5
+    ${QT_PKG}
     COMPONENTS Bluetooth
     REQUIRED)
-  target_link_libraries(qfield_core PUBLIC Qt5::Bluetooth)
+  target_link_libraries(qfield_core PUBLIC ${QT_PKG}::Bluetooth)
 endif()
 
 if(WITH_SENTRY)
@@ -306,11 +306,11 @@ if(WITH_SENTRY)
 endif()
 
 if(ANDROID)
-  target_link_libraries(qfield_core PUBLIC Qt5::AndroidExtras)
+  target_link_libraries(qfield_core PUBLIC ${QT_PKG}::AndroidExtras)
 endif()
 
-if(TARGET Qt5::PrintSupport)
-  target_link_libraries(qfield_core PUBLIC Qt5::PrintSupport)
+if(TARGET ${QT_PKG}::PrintSupport)
+  target_link_libraries(qfield_core PUBLIC ${QT_PKG}::PrintSupport)
 endif()
 
 install(FILES ${QFIELD_CORE_HDRS} DESTINATION ${QFIELD_INCLUDE_DIR})

--- a/src/qml/CMakeLists.txt
+++ b/src/qml/CMakeLists.txt
@@ -1,7 +1,7 @@
-find_package(Qt5QuickCompiler QUIET)
-find_package(Qt5 COMPONENTS Quick)
+find_package(${QT_PKG}QuickCompiler QUIET)
+find_package(${QT_PKG} COMPONENTS Quick)
 
-if(Qt5QuickCompiler_FOUND
+if(${QT_PKG}QuickCompiler_FOUND
    AND NOT CMAKE_BUILD_TYPE MATCHES Debug
    AND NOT CMAKE_BUILD_TYPE MATCHES RelWithDebInfo)
   qtquick_compiler_add_resources(RESOURCES ${CMAKE_CURRENT_SOURCE_DIR}/qml.qrc)
@@ -11,7 +11,7 @@ endif()
 
 file(GLOB_RECURSE QML_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.qml")
 add_library(qfield_qml STATIC ${QML_SOURCES} ${RESOURCES})
-target_link_libraries(qfield_qml PRIVATE Qt5::Quick)
+target_link_libraries(qfield_qml PRIVATE ${QT_PKG}::Quick)
 
 target_compile_definitions(
   qfield_qml

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,11 +11,11 @@ function(ADD_CATCH2_TEST TESTNAME TESTSRC WITH_CATCH2_MAIN)
     qfield_core
     ${QGIS_CORE_LIBRARY}
     ${QGIS_ANALYSIS_LIBRARY}
-    Qt5::Test
-    Qt5::Core
-    Qt5::Gui
-    Qt5::Widgets
-    Qt5::Xml
+    ${QT_PKG}::Test
+    ${QT_PKG}::Core
+    ${QT_PKG}::Gui
+    ${QT_PKG}::Widgets
+    ${QT_PKG}::Xml
   )
   if(WITH_CATCH2_MAIN)
     target_link_libraries(${TESTNAME} PRIVATE
@@ -36,11 +36,11 @@ macro (ADD_QFIELD_TEST TESTNAME TESTSRC)
     qfield_core
     ${QGIS_CORE_LIBRARY}
     ${QGIS_ANALYSIS_LIBRARY}
-    Qt5::Test
-    Qt5::Core
-    Qt5::Gui
-    Qt5::Widgets
-    Qt5::Xml
+    ${QT_PKG}::Test
+    ${QT_PKG}::Core
+    ${QT_PKG}::Gui
+    ${QT_PKG}::Widgets
+    ${QT_PKG}::Xml
   )
 endmacro (ADD_QFIELD_TEST)
 
@@ -49,9 +49,9 @@ macro (ADD_QFIELD_QML_TEST TESTNAME TESTSRC)
   # This should be in src/qml/CMakeLists.txt but that's not possible with Qt5. Retry with Qt6
   # Same is in src/app/CMakeLists.txt
   # https://bugreports.qt.io/browse/QTBUG-80847
-  get_target_property(QT_TARGET_TYPE Qt5::Core TYPE)
+  get_target_property(QT_TARGET_TYPE ${QT_PKG}::Core TYPE)
   if(${QT_TARGET_TYPE} STREQUAL "STATIC_LIBRARY")
-    find_package(Qt5 COMPONENTS QmlImportScanner)
+    find_package(${QT_PKG} COMPONENTS QmlImportScanner)
     file(GLOB test_qmlfiles "${CMAKE_CURRENT_SOURCE_DIR}/qml/*.qml")
     file(GLOB qfield_qmlfiles "${CMAKE_SOURCE_DIR}/src/qml/*.qml")
     file(COPY ${test_qmlfiles}
@@ -72,12 +72,12 @@ macro (ADD_QFIELD_QML_TEST TESTNAME TESTSRC)
     qfield_qml
     ${QGIS_CORE_LIBRARY}
     ${QGIS_ANALYSIS_LIBRARY}
-    Qt5::Test
-    Qt5::Core
-    Qt5::Gui
-    Qt5::Widgets
-    Qt5::Xml
-    Qt5::QuickTest
+    ${QT_PKG}::Test
+    ${QT_PKG}::Core
+    ${QT_PKG}::Gui
+    ${QT_PKG}::Widgets
+    ${QT_PKG}::Xml
+    ${QT_PKG}::QuickTest
   )
   add_test(NAME ${TESTNAME} COMMAND ${TESTNAME} -import ${CMAKE_SOURCE_DIR}/src/qml/imports -input ${CMAKE_SOURCE_DIR}/test/qml)
 endmacro (ADD_QFIELD_QML_TEST)


### PR DESCRIPTION
Adds  a new `BUILD_WITH_QT6` option which defaults to `OFF`