### PR TITLE
Avoid showing bad black ShaderEffect item in QFieldCloud log in panel…

### DIFF
--- a/src/qml/QFieldCloudLogin.qml
+++ b/src/qml/QFieldCloudLogin.qml
@@ -26,6 +26,7 @@ Item {
       anchors.top: parent.top
       width: parent.width
       height: 200
+      visible: sourceImg.status === Image.Ready
       property variant source: sourceImg
       property real frequency: 1
       property real amplitude: 0.1


### PR DESCRIPTION
… when the linked background image is missing.

Fixes this kind of scenario:
![image](https://user-images.githubusercontent.com/1728657/180723429-9e41784c-fa0a-4c91-a378-82a5d196539d.png)
