### PR TITLE
Add a new averaged positioning setting to disable the automatic end...

### DIFF
--- a/src/qml/DigitizingToolbar.qml
+++ b/src/qml/DigitizingToolbar.qml
@@ -186,7 +186,8 @@ VisibilityFadingRow {
 
       function onAveragedPositionCountChanged() {
         if (addVertexButton.averagedPositionAutoRelease && positionSource.averagedPosition
-            && positionSource.averagedPositionCount >= positioningSettings.averagedPositioningMinimumCount) {
+            && positionSource.averagedPositionCount >= positioningSettings.averagedPositioningMinimumCount
+            && positioningSettings.averagedPositioningAutomaticStop) {
           addVertexButton.averagedPositionPressAndHeld = true;
           addVertexButton.released()
         }
@@ -245,13 +246,14 @@ VisibilityFadingRow {
 
         if (coordinateLocator && coordinateLocator.positionLocked &&
             positioningSettings.averagedPositioning &&
-            positioningSettings.averagedPositioningMinimumCount > 1) {
+            (positioningSettings.averagedPositioningMinimumCount > 1
+             || !positioningSettings.averagedPositioningAutomaticStop)) {
           if (!positionSource.averagedPosition) {
             averagedPositionAutoRelease = true;
             positionSource.averagedPosition = true;
           } else {
-            averagedPositionAutoRelease = false;
-            canceled();
+            addVertexButton.averagedPositionPressAndHeld = true;
+            addVertexButton.released()
           }
           return;
         }

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -21,6 +21,7 @@ LabSettings.Settings {
 
     property bool averagedPositioning: false
     property int  averagedPositioningMinimumCount: 1
+    property bool averagedPositioningAutomaticStop: true
 
     property real antennaHeight: 0.0
     property bool antennaHeightActivated: false

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -610,6 +610,33 @@ Page {
                   }
 
                   Label {
+                      text: qsTr("Automatically end collection when minimum number is met")
+                      font: Theme.defaultFont
+                      wrapMode: Text.WordWrap
+                      Layout.fillWidth: true
+                      enabled: averagedPositioning.checked
+                      visible: averagedPositioning.checked
+                      Layout.leftMargin: 8
+
+                      MouseArea {
+                          anchors.fill: parent
+                          onClicked: averagedPositioningAutomaticEnd.toggle()
+                      }
+                  }
+
+                  QfSwitch {
+                      id: averagedPositioningAutomaticEnd
+                      Layout.preferredWidth: implicitContentWidth
+                      Layout.alignment: Qt.AlignTop
+                      enabled: averagedPositioning.checked
+                      visible: averagedPositioning.checked
+                      checked: positioningSettings.averagedPositioningAutomaticStop
+                      onCheckedChanged: {
+                          positioningSettings.averagedPositioningAutomaticStop = checked
+                      }
+                  }
+
+                  Label {
                       text: qsTr("When enabled, digitizing vertices with a cursor locked to position will only accepted an averaged position from a minimum number of collected positions. Digitizing using averaged positions is done by pressing and holding the add vertex button, which will collect positions until the press is released. Accuracy requirement settings are respected when enabled.")
                       font: Theme.tipFont
                       color: Theme.gray


### PR DESCRIPTION
…of position collection when the minimum count requirement is met.

The new toggle setting appears when the averaged positioning requirement is toggled on:
![image](https://user-images.githubusercontent.com/1728657/181240131-7f6827b3-dc6e-435a-8758-9d8574fc4326.png)

By default, QField will end the collection of positions when the count matches minimum number of positions and add a new vertex onto the geometry being digitized. If the user turns off the new setting, averaged positioning will require a _second_ click on the (+) add vertex button to _manually end_ the collection of positions. If the number of collected position does not match the minimum number required, the vertex addition will be canceled. If it matches _or exceeds_ the minimum, the vertex will be added.