### PR TITLE
Fix serious brokenness with vertex editor mishandling ZM geometries

### DIFF
--- a/src/core/vertexmodel.cpp
+++ b/src/core/vertexmodel.cpp
@@ -78,6 +78,7 @@ void VertexModel::setGeometry( const QgsGeometry &geometry )
   mVerticesDeleted.clear();
   mOriginalGeometry = geometry;
   mGeometryType = geometry.type();
+  mGeometryWkbType = geometry.wkbType();
   mRingCount = 0;
   refreshGeometry();
   setCurrentVertex( -1 );
@@ -176,6 +177,10 @@ void VertexModel::createCandidates()
     {
       QVector<QgsPoint> points = { mVertices.at( r + 1 ).point, vertex.point };
       QgsPoint centroid = QgsLineString( points ).centroid();
+      if ( QgsWkbTypes::hasZ( mGeometryWkbType ) )
+        centroid.addZValue();
+      if ( QgsWkbTypes::hasM( mGeometryWkbType ) )
+        centroid.addMValue();
 
       Vertex newVertex;
       newVertex.point = centroid;
@@ -561,6 +566,10 @@ void VertexModel::setCurrentPoint( const QgsPoint &point )
   beginResetModel();
 
   vertex.point = point;
+  if ( QgsWkbTypes::hasZ( mGeometryWkbType ) )
+    vertex.point.addZValue();
+  if ( QgsWkbTypes::hasM( mGeometryWkbType ) )
+    vertex.point.addMValue();
 
   if ( mMode == AddVertex )
   {

--- a/src/core/vertexmodel.cpp
+++ b/src/core/vertexmodel.cpp
@@ -17,7 +17,6 @@
 #include "qgsquickmapsettings.h"
 #include "vertexmodel.h"
 
-#include <QDebug>
 #include <qgsgeometry.h>
 #include <qgslinestring.h>
 #include <qgsmessagelog.h>

--- a/src/core/vertexmodel.cpp
+++ b/src/core/vertexmodel.cpp
@@ -197,6 +197,10 @@ void VertexModel::createCandidates()
     {
       // last point is an existing vertex, the next one is a candidate (created just before)
       QgsPoint extendingPoint = mVertices.at( r ).point - ( mVertices.at( 1 ).point - mVertices.at( r ).point ) / 2;
+      if ( QgsWkbTypes::hasZ( mGeometryWkbType ) )
+        extendingPoint.addZValue();
+      if ( QgsWkbTypes::hasM( mGeometryWkbType ) )
+        extendingPoint.addMValue();
 
       Vertex newVertex;
       newVertex.point = extendingPoint;
@@ -224,6 +228,10 @@ void VertexModel::createCandidates()
       }
       QVector<QgsPoint> points = { lastVertex.point, vertex.point };
       QgsPoint centroid = QgsLineString( points ).centroid();
+      if ( QgsWkbTypes::hasZ( mGeometryWkbType ) )
+        centroid.addZValue();
+      if ( QgsWkbTypes::hasM( mGeometryWkbType ) )
+        centroid.addMValue();
 
       Vertex newVertex;
       newVertex.point = centroid;
@@ -244,6 +252,10 @@ void VertexModel::createCandidates()
   {
     // last point is an existing vertex, the previous one is a candidate
     QgsPoint extendingPoint = mVertices.at( r ).point - ( mVertices.at( r - 1 ).point - mVertices.at( r ).point ) / 2;
+    if ( QgsWkbTypes::hasZ( mGeometryWkbType ) )
+      extendingPoint.addZValue();
+    if ( QgsWkbTypes::hasM( mGeometryWkbType ) )
+      extendingPoint.addMValue();
 
     Vertex newVertex;
     newVertex.point = extendingPoint;

--- a/src/core/vertexmodel.h
+++ b/src/core/vertexmodel.h
@@ -302,6 +302,7 @@ class QFIELD_CORE_EXPORT VertexModel : public QAbstractListModel
     int mCurrentIndex = -1;
     int mRingCount = 0;
     QgsWkbTypes::GeometryType mGeometryType = QgsWkbTypes::LineGeometry;
+    QgsWkbTypes::Type mGeometryWkbType = QgsWkbTypes::Unknown;
     QgsQuickMapSettings *mMapSettings = nullptr;
     bool mCanRemoveVertex = false;
     bool mCanAddVertex = false;

--- a/test/test_vertexmodel.cpp
+++ b/test/test_vertexmodel.cpp
@@ -26,6 +26,7 @@
 #include <qgsmessagelog.h>
 #include <qgspoint.h>
 #include <qgspointxy.h>
+#include <qgspolygon.h>
 
 using Catch::Approx;
 
@@ -67,7 +68,12 @@ TEST_CASE( "VertexModel" )
                                                                      << QgsPointXY( 3, 3 )
                                                                      << QgsPointXY( 1, 3 )
                                                                      << QgsPointXY( 1, 1 ) ) );
-
+  QgsPolygon *polygon = new QgsPolygon( new QgsLineString( QVector<QgsPoint>() << QgsPoint( 0, 0, 0, 0 )
+                                                                               << QgsPoint( 4, 0, 0, 0 )
+                                                                               << QgsPoint( 4, 4, 0, 0 )
+                                                                               << QgsPoint( 0, 4, 0, 0 )
+                                                                               << QgsPoint( 0, 0, 0, 0 ) ) );
+  QgsGeometry polygonZMGeometry = QgsGeometry( polygon );
 
   QgsGeometry point2056Geometry = QgsGeometry::fromPointXY( QgsPointXY( 2500000, 1200000 ) );
 
@@ -111,6 +117,17 @@ TEST_CASE( "VertexModel" )
     REQUIRE( model->vertices().at( 13 ).point == QgsPoint( 1, 3 ) );
     REQUIRE( model->vertices().at( 14 ).point == QgsPoint( 1, 2 ) );
     REQUIRE( model->vertices().at( 15 ).point == QgsPoint( 1, 1 ) );
+
+    model->setGeometry( polygonZMGeometry );
+    REQUIRE( model->vertexCount() == 8 );
+    REQUIRE( model->vertices().at( 0 ).point == QgsPoint( 2, 0, 0, 0 ) );
+    REQUIRE( model->vertices().at( 1 ).point == QgsPoint( 4, 0, 0, 0 ) );
+    REQUIRE( model->vertices().at( 2 ).point == QgsPoint( 4, 2, 0, 0 ) );
+    REQUIRE( model->vertices().at( 3 ).point == QgsPoint( 4, 4, 0, 0 ) );
+    REQUIRE( model->vertices().at( 4 ).point == QgsPoint( 2, 4, 0, 0 ) );
+    REQUIRE( model->vertices().at( 5 ).point == QgsPoint( 0, 4, 0, 0 ) );
+    REQUIRE( model->vertices().at( 6 ).point == QgsPoint( 0, 2, 0, 0 ) );
+    REQUIRE( model->vertices().at( 7 ).point == QgsPoint( 0, 0, 0, 0 ) );
   }
 
   SECTION( "CanRemoveVertex" )
@@ -150,6 +167,15 @@ TEST_CASE( "VertexModel" )
     VertexModelTest::setCurrentVertex( model, 0 );
     model->setCurrentPoint( QgsPoint( -3, 0 ) );
     REQUIRE( model->vertexCount() == 10 );
+
+    model->setGeometry( polygonZMGeometry );
+    REQUIRE( model->vertexCount() == 8 );
+    model->setEditingMode( VertexModel::AddVertex );
+    VertexModelTest::setCurrentVertex( model, 0 );
+    model->setCurrentPoint( QgsPoint( -3, 0 ) );
+    REQUIRE( model->vertexCount() == 10 );
+    // Test that the added vertex has the extra Z and M dimensions
+    REQUIRE( model->vertices().at( 1 ).point == QgsPoint( -3, 0, 0, 0 ) );
 
     model->setGeometry( lineGeometry );
     model->setEditingMode( VertexModel::AddVertex );


### PR DESCRIPTION
This PR fixes #3128 -- while QGIS should improve its handling of nan values, QField should _not_ break geometries to begin with :)