### PR TITLE
QR (et cie) code reader <-> feature form's text edit widget integration 

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -11,6 +11,8 @@
         <file alias="qfield-love.png">pictures/qfield-love.png</file>
     </qresource>
     <qresource prefix="/">
+        <file>themes/qfield/nodpi/ic_copy_black_24dp.svg</file>
+        <file>themes/qfield/nodpi/ic_paste_black_24dp.svg</file>
         <file>themes/qfield/hdpi/ic_add_circle_outline_white_24dp.png</file>
         <file>themes/qfield/hdpi/ic_add_circle_white_24dp.png</file>
         <file>themes/qfield/hdpi/ic_remove_white_24dp.png</file>

--- a/images/themes/qfield/nodpi/ic_copy_black_24dp.svg
+++ b/images/themes/qfield/nodpi/ic_copy_black_24dp.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="content_copy_FILL0_wght400_GRAD0_opsz24.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="2.7513373"
+     inkscape:cx="124.12146"
+     inkscape:cy="53.792023"
+     inkscape:window-width="1866"
+     inkscape:window-height="1016"
+     inkscape:window-x="54"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <path
+     d="M5 22q-.825 0-1.413-.587Q3 20.825 3 20V6h2v14h11v2Zm4-4q-.825 0-1.412-.587Q7 16.825 7 16V4q0-.825.588-1.413Q8.175 2 9 2h9q.825 0 1.413.587Q20 3.175 20 4v12q0 .825-.587 1.413Q18.825 18 18 18Zm0-2h9V4H9v12Zm0 0V4v12Z"
+     id="path2" />
+</svg>

--- a/images/themes/qfield/nodpi/ic_paste_black_24dp.svg
+++ b/images/themes/qfield/nodpi/ic_paste_black_24dp.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="content_paste_FILL0_wght400_GRAD0_opsz24.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="35.041667"
+     inkscape:cx="12"
+     inkscape:cy="12.014269"
+     inkscape:window-width="1866"
+     inkscape:window-height="1016"
+     inkscape:window-x="54"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <path
+     d="M5 21q-.825 0-1.413-.587Q3 19.825 3 19V5q0-.825.587-1.413Q4.175 3 5 3h4.175q.275-.875 1.075-1.438Q11.05 1 12 1q1 0 1.788.562.787.563 1.062 1.438H19q.825 0 1.413.587Q21 4.175 21 5v14q0 .825-.587 1.413Q19.825 21 19 21Zm0-2h14V5h-2v3H7V5H5v14Zm7-14q.425 0 .713-.288Q13 4.425 13 4t-.287-.713Q12.425 3 12 3t-.712.287Q11 3.575 11 4t.288.712Q11.575 5 12 5Z"
+     id="path2" />
+</svg>

--- a/src/qml/BarcodeReader.qml
+++ b/src/qml/BarcodeReader.qml
@@ -13,7 +13,7 @@ Popup {
 
   signal decoded(var string)
 
-  property var barcodeRequestedItem: undefined
+  property var barcodeRequestedItem: undefined //<! when a feature form is requesting a bardcode, this will be set to attribute editor widget which triggered the request
   property int popupWidth: mainWindow.width <= mainWindow.height ? mainWindow.width - Theme.popupScreenEdgeMargin : mainWindow.height - Theme.popupScreenEdgeMargin
 
   width: popupWidth
@@ -260,7 +260,7 @@ Popup {
 
           onClicked: {
             if (barcodeReader.barcodeRequestedItem != undefined) {
-                barcodeReader.barcodeRequestedItem.requestedBarcode(barcodeDecoder.decodedString)
+                barcodeReader.barcodeRequestedItem.requestedBarcodeReceived(barcodeDecoder.decodedString)
                 barcodeReader.barcodeRequestedItem = undefined;
             } else {
                 barcodeReader.decoded(barcodeDecoder.decodedString);

--- a/src/qml/BarcodeReader.qml
+++ b/src/qml/BarcodeReader.qml
@@ -13,6 +13,7 @@ Popup {
 
   signal decoded(var string)
 
+  property var barcodeRequestedItem: undefined
   property int popupWidth: mainWindow.width <= mainWindow.height ? mainWindow.width - Theme.popupScreenEdgeMargin : mainWindow.height - Theme.popupScreenEdgeMargin
 
   width: popupWidth
@@ -258,8 +259,13 @@ Popup {
           opacity: enabled ? 1 : 0.2
 
           onClicked: {
+            if (barcodeReader.barcodeRequestedItem != undefined) {
+                barcodeReader.barcodeRequestedItem.requestedBarcode(barcodeDecoder.decodedString)
+                barcodeReader.barcodeRequestedItem = undefined;
+            } else {
+                barcodeReader.decoded(barcodeDecoder.decodedString);
+            }
             barcodeReader.close();
-            barcodeReader.decoded(barcodeDecoder.decodedString);
           }
         }
       }

--- a/src/qml/EmbeddedFeatureForm.qml
+++ b/src/qml/EmbeddedFeatureForm.qml
@@ -17,6 +17,7 @@ Popup {
     property alias feature: formFeatureModel.feature
     property alias attributeFormModel: formAttributeFormModel
     property alias digitizingToolbar: form.digitizingToolbar
+    property alias barcodeReader: form.barcodeReader
 
     Connections {
         target: digitizingToolbar

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -19,10 +19,13 @@ Page {
   signal cancelled
   signal temporaryStored
   signal valueChanged(var field, var oldValue, var newValue)
-  signal requestGeometry(var item, var layer)
   signal aboutToSave
 
+  signal requestGeometry(var item, var layer)
+  signal requestBarcode(var item)
+
   property DigitizingToolbar digitizingToolbar
+  property BarcodeReader barcodeReader
 
   property AttributeFormModel model
   property alias currentTab: swipeView.currentIndex
@@ -409,7 +412,7 @@ Page {
             Item {
               id: placeholder
               height: childrenRect.height
-              anchors { left: parent.left; right: rememberCheckbox.left; top: constraintDescriptionLabel.bottom; rightMargin: 10; }
+              anchors { left: parent.left; right: menuButton.left; top: constraintDescriptionLabel.bottom; rightMargin: 10; }
 
               Loader {
                 id: attributeEditorLoader
@@ -510,7 +513,27 @@ Page {
                     form.digitizingToolbar.geometryRequestedItem = item
                     form.digitizingToolbar.geometryRequestedLayer = layer
                 }
+
+                function onRequestBarcode(item) {
+                    form.barcodeReader.barcodeRequestedItem = item
+                    form.barcodeReader.open()
+                }
               }
+            }
+
+            QfToolButton {
+                id: menuButton
+                anchors { right: rememberCheckbox.left; top: constraintDescriptionLabel.bottom }
+
+                visible: attributeEditorLoader.isEnabled && attributeEditorLoader.item.menu !== undefined
+                enabled: visible
+                width: visible ? 48 : 0
+                bgcolor: "transparent"
+                iconSource: Theme.getThemeIcon("ic_dot_menu_gray_24dp")
+
+                onClicked: {
+                    attributeEditorLoader.item.menu.popup(menuButton.x, menuButton.y)
+                }
             }
 
             CheckBox {
@@ -519,7 +542,7 @@ Page {
               visible: form.state === "Add" && EditorWidget !== "Hidden" && EditorWidget !== 'RelationEditor'
               width: visible ? undefined : 0
 
-              anchors { right: parent.right; top: constraintDescriptionLabel.bottom }
+              anchors { right: parent.right; top: constraintDescriptionLabel.bottom; verticalCenter: menuButton.verticalCenter }
 
               onCheckedChanged: {
                 RememberValue = checked

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -525,7 +525,7 @@ Page {
                 id: menuButton
                 anchors { right: rememberCheckbox.left; top: constraintDescriptionLabel.bottom }
 
-                visible: attributeEditorLoader.isEnabled && attributeEditorLoader.item.menu !== undefined
+                visible: attributeEditorLoader.isEnabled && attributeEditorLoader.item.hasMenu
                 enabled: visible
                 width: visible ? 48 : 0
                 bgcolor: "transparent"

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -412,7 +412,7 @@ Page {
             Item {
               id: placeholder
               height: childrenRect.height
-              anchors { left: parent.left; right: menuButton.left; top: constraintDescriptionLabel.bottom; rightMargin: 10; }
+              anchors { left: parent.left; right: menuButton.left; top: constraintDescriptionLabel.bottom; }
 
               Loader {
                 id: attributeEditorLoader
@@ -523,7 +523,7 @@ Page {
 
             QfToolButton {
                 id: menuButton
-                anchors { right: rememberCheckbox.left; top: constraintDescriptionLabel.bottom }
+                anchors { right: rememberCheckbox.left; top: constraintDescriptionLabel.bottom; rightMargin: 10; }
 
                 visible: attributeEditorLoader.isEnabled && attributeEditorLoader.item.hasMenu
                 enabled: visible

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -32,6 +32,7 @@ Rectangle {
   property MapSettings mapSettings
   property DigitizingToolbar digitizingToolbar
   property ConfirmationToolbar moveFeaturesToolbar
+  property BarcodeReader barcodeReader
 
   property color selectionColor
   property alias model: globalFeaturesList.model
@@ -333,6 +334,7 @@ Rectangle {
     height: parent.height - globalFeaturesList.height
 
     digitizingToolbar: featureForm.digitizingToolbar
+    barcodeReader: featureForm.barcodeReader
 
     model: AttributeFormModel {
       featureModel: FeatureModel {

--- a/src/qml/OverlayFeatureFormDrawer.qml
+++ b/src/qml/OverlayFeatureFormDrawer.qml
@@ -10,7 +10,8 @@ Drawer {
   property alias featureModel: overlayFeatureForm.featureModel
   property alias state: overlayFeatureForm.state
   property alias featureForm: overlayFeatureForm
-  property DigitizingToolbar digitizingToolbar
+  property alias digitizingToolbar: overlayFeatureForm.digitizingToolbar
+  property alias barcodeReader: overlayFeatureForm.barcodeReader
   property bool isAdding: false
 
   edge: parent.width < parent.height ? Qt.BottomEdge : Qt.RightEdge
@@ -76,6 +77,8 @@ Drawer {
     property bool isSaved: false
 
     digitizingToolbar: overlayFeatureFormDrawer.digitizingToolbar
+    barcodeReader: overlayFeatureFormDrawer.barcodeReader
+
     model: AttributeFormModel {
         id: attributeFormModel
         featureModel: FeatureModel {

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -40,6 +40,7 @@ Item {
 
         embeddedLevel: form.embeddedLevel + 1
         digitizingToolbar: form.digitizingToolbar
+        barcodeReader: form.barcodeReader
 
         onFeatureSaved: {
             var referencedValue = addFeaturePopup.attributeFormModel.attribute(relationCombobox._relation.resolveReferencedField(field.name))
@@ -563,6 +564,7 @@ Item {
 
         embeddedLevel: form.embeddedLevel + 1
         digitizingToolbar: form.digitizingToolbar
+        barcodeReader: form.barcodeReader
 
         onFeatureSaved: {
             var referencedValue = embeddedPopup.attributeFormModel.attribute(relationCombobox._relation.resolveReferencedField(field.name))

--- a/src/qml/editorwidgets/EditorWidgetBase.qml
+++ b/src/qml/editorwidgets/EditorWidgetBase.qml
@@ -6,6 +6,7 @@ Item {
      * propagated.
      */
     property bool isLoaded: false
+    property var menu: undefined
 
     /* This signal is emmited when an editor widget has changed the value.
      */
@@ -17,4 +18,11 @@ Item {
      * handler is \c onRequestGeometry.
      */
     signal requestGeometry(var item, var layer)
+
+    /* This signal is emitted when an editor widget is requesting a barcode value. The
+     * decoded barcode value will be returned as a string through calling a requestedBarcode(string) function
+     * attached to editor widget which signaled the request. The corresponding
+     * handler is \c onRequestBarcode.
+     */
+    signal requestBarcode(var item)
 }

--- a/src/qml/editorwidgets/EditorWidgetBase.qml
+++ b/src/qml/editorwidgets/EditorWidgetBase.qml
@@ -29,14 +29,14 @@ Item {
     signal valueChangeRequested(var value, bool isNull)
 
     /* This signal is emitted when an editor widget is in need of a digitized geometry. The
-     * geometry will be returned through calling a requestedGeometry(geometry) function
+     * geometry will be returned through calling a requestedGeometryReceived(geometry) function
      * attached to editor widget which signaled the request. The corresponding
      * handler is \c onRequestGeometry.
      */
     signal requestGeometry(var item, var layer)
 
     /* This signal is emitted when an editor widget is requesting a barcode value. The
-     * decoded barcode value will be returned as a string through calling a requestedBarcode(string) function
+     * decoded barcode value will be returned as a string through calling a requestedBarcodeReceived(string) function
      * attached to editor widget which signaled the request. The corresponding
      * handler is \c onRequestBarcode.
      */

--- a/src/qml/editorwidgets/EditorWidgetBase.qml
+++ b/src/qml/editorwidgets/EditorWidgetBase.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.14
+import QtQuick.Controls 2.14
 
 Item {
     /* This property indicates whether the editor widget has been fully loaded by its Loader.
@@ -6,7 +7,22 @@ Item {
      * propagated.
      */
     property bool isLoaded: false
-    property var menu: undefined
+    property bool hasMenu: false
+    property Menu menu: Menu {
+      id: itemMenu
+      title: qsTr( "Item Menu" )
+
+      width: {
+          var result = 0;
+          var padding = 0;
+          for (var i = 0; i < count; ++i) {
+              var item = itemAt(i);
+              result = Math.max(item.contentItem.implicitWidth, result);
+              padding = Math.max(item.padding, padding);
+          }
+          return result + padding * 2;
+      }
+    }
 
     /* This signal is emmited when an editor widget has changed the value.
      */

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -124,4 +124,37 @@ EditorWidgetBase {
     id: fontMetrics
     font: textField.font
   }
+
+  menu: Menu {
+    id: itemMenu
+    title: qsTr( "Text Edit Menu" )
+
+    width: {
+        var result = 0;
+        var padding = 0;
+        for (var i = 0; i < count; ++i) {
+            var item = itemAt(i);
+            result = Math.max(item.contentItem.implicitWidth, result);
+            padding = Math.max(item.padding, padding);
+        }
+        return result + padding * 2;
+    }
+
+    MenuItem {
+      text: qsTr( 'Scan Code' )
+
+      font: Theme.defaultFont
+      icon.source: Theme.getThemeVectorIcon( "ic_qrcode_black_24dp" )
+      height: 48
+      leftPadding: 10
+
+      onTriggered: {
+        requestBarcode(topItem)
+      }
+    }
+  }
+
+  function requestedBarcode(string) {
+    valueChangeRequested(string, string == '')
+  }
 }

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -141,6 +141,34 @@ EditorWidgetBase {
     }
 
     MenuItem {
+      text: qsTr( 'Copy Text' )
+
+      font: Theme.defaultFont
+      height: 48
+      leftPadding: 50
+
+      onTriggered: {
+        platformUtilities.copyTextToClipboard(value)
+      }
+    }
+
+    MenuItem {
+      text: qsTr( 'Paste Text' )
+
+      font: Theme.defaultFont
+      height: 48
+      leftPadding: 50
+
+      onTriggered: {
+        var text = platformUtilities.getTextFromClipboard();
+        text = text.trim()
+        valueChangeRequested(text, text == '')
+      }
+    }
+
+    MenuSeparator { width: parent.width }
+
+    MenuItem {
       text: qsTr( 'Scan Code' )
 
       font: Theme.defaultFont

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -144,8 +144,9 @@ EditorWidgetBase {
       text: qsTr( 'Copy Text' )
 
       font: Theme.defaultFont
+      icon.source: Theme.getThemeVectorIcon( "ic_copy_black_24dp" )
       height: 48
-      leftPadding: 50
+      leftPadding: 10
 
       onTriggered: {
         platformUtilities.copyTextToClipboard(value)
@@ -156,8 +157,9 @@ EditorWidgetBase {
       text: qsTr( 'Paste Text' )
 
       font: Theme.defaultFont
+      icon.source: Theme.getThemeVectorIcon( "ic_paste_black_24dp" )
       height: 48
-      leftPadding: 50
+      leftPadding: 10
 
       onTriggered: {
         var text = platformUtilities.getTextFromClipboard();

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -181,6 +181,6 @@ EditorWidgetBase {
   }
 
   function requestedBarcodeReceived(string) {
-    valueChangeRequested(string, string == '')
+    valueChangeRequested(string, false)
   }
 }

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -125,62 +125,58 @@ EditorWidgetBase {
     font: textField.font
   }
 
-  menu: Menu {
-    id: itemMenu
-    title: qsTr( "Text Edit Menu" )
+  Component.onCompleted: {
+    menu.addItem( copyTextItem );
+    menu.addItem( pasteTextItem );
+    menu.addItem( separatorItem );
+    menu.addItem( scanCodeItem );
 
-    width: {
-        var result = 0;
-        var padding = 0;
-        for (var i = 0; i < count; ++i) {
-            var item = itemAt(i);
-            result = Math.max(item.contentItem.implicitWidth, result);
-            padding = Math.max(item.padding, padding);
-        }
-        return result + padding * 2;
+    hasMenu = true;
+  }
+
+
+  MenuItem {
+    id: copyTextItem
+    text: qsTr( 'Copy Text' )
+
+    font: Theme.defaultFont
+    icon.source: Theme.getThemeVectorIcon( "ic_copy_black_24dp" )
+    height: 48
+    leftPadding: 10
+
+    onTriggered: {
+      platformUtilities.copyTextToClipboard(value)
     }
+  }
+  MenuItem {
+    id: pasteTextItem
+    text: qsTr( 'Paste Text' )
 
-    MenuItem {
-      text: qsTr( 'Copy Text' )
+    font: Theme.defaultFont
+    icon.source: Theme.getThemeVectorIcon( "ic_paste_black_24dp" )
+    height: 48
+    leftPadding: 10
 
-      font: Theme.defaultFont
-      icon.source: Theme.getThemeVectorIcon( "ic_copy_black_24dp" )
-      height: 48
-      leftPadding: 10
-
-      onTriggered: {
-        platformUtilities.copyTextToClipboard(value)
-      }
+    onTriggered: {
+      var text = platformUtilities.getTextFromClipboard();
+      text = text.trim()
+      valueChangeRequested(text, text == '')
     }
+  }
 
-    MenuItem {
-      text: qsTr( 'Paste Text' )
+  MenuSeparator { id: separatorItem; width: parent.width }
 
-      font: Theme.defaultFont
-      icon.source: Theme.getThemeVectorIcon( "ic_paste_black_24dp" )
-      height: 48
-      leftPadding: 10
+  MenuItem {
+    id: scanCodeItem
+    text: qsTr( 'Scan Code' )
 
-      onTriggered: {
-        var text = platformUtilities.getTextFromClipboard();
-        text = text.trim()
-        valueChangeRequested(text, text == '')
-      }
-    }
+    font: Theme.defaultFont
+    icon.source: Theme.getThemeVectorIcon( "ic_qrcode_black_24dp" )
+    height: 48
+    leftPadding: 10
 
-    MenuSeparator { width: parent.width }
-
-    MenuItem {
-      text: qsTr( 'Scan Code' )
-
-      font: Theme.defaultFont
-      icon.source: Theme.getThemeVectorIcon( "ic_qrcode_black_24dp" )
-      height: 48
-      leftPadding: 10
-
-      onTriggered: {
-        requestBarcode(topItem)
-      }
+    onTriggered: {
+      requestBarcode(topItem)
     }
   }
 

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -180,7 +180,7 @@ EditorWidgetBase {
     }
   }
 
-  function requestedBarcode(string) {
+  function requestedBarcodeReceived(string) {
     valueChangeRequested(string, string == '')
   }
 }

--- a/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
@@ -430,6 +430,7 @@ EditorWidgetBase {
 
     embeddedLevel: form.embeddedLevel + 1
     digitizingToolbar: form.digitizingToolbar
+    barcodeReader: form.barcodeReader
 
     onFeatureCancelled: {
       if( autoSave ) {

--- a/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
@@ -444,7 +444,7 @@ EditorWidgetBase {
     }
   }
 
-  function requestedGeometry(geometry) {
+  function requestedGeometryReceived(geometry) {
     showAddFeaturePopup(geometry)
   }
 

--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -292,6 +292,7 @@ EditorWidgetBase {
 
         embeddedLevel: form.embeddedLevel + 1
         digitizingToolbar: form.digitizingToolbar
+        barcodeReader: form.barcodeReader
 
         onFeatureCancelled: {
             if( autoSave )

--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -320,7 +320,7 @@ EditorWidgetBase {
       return false
     }
 
-    function requestedGeometry(geometry) {
+    function requestedGeometryReceived(geometry) {
         showAddFeaturePopup(geometry)
     }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1490,7 +1490,7 @@ ApplicationWindow {
 
             coordinateLocator.flash()
             digitizingFeature.geometry.applyRubberband()
-            geometryRequestedItem.requestedGeometry(digitizingFeature.geometry)
+            geometryRequestedItem.requestedGeometryReceived(digitizingFeature.geometry)
             digitizingRubberband.model.reset()
             geometryRequested = false
             return;

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2306,6 +2306,7 @@ ApplicationWindow {
     mapSettings: mapCanvas.mapSettings
     digitizingToolbar: digitizingToolbar
     moveFeaturesToolbar: moveFeaturesToolbar
+    barcodeReader: barcodeReader
 
     visible: state != "Hidden"
     focus: visible
@@ -2370,6 +2371,7 @@ ApplicationWindow {
   OverlayFeatureFormDrawer {
     id: overlayFeatureFormDrawer
     digitizingToolbar: digitizingToolbar
+    barcodeReader: barcodeReader
     featureModel.currentLayer: dashBoard.currentLayer
   }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1941,8 +1941,9 @@ ApplicationWindow {
       id: copyCoordinatesItem
       text: qsTr( "Copy Coordinates" )
       height: 48
-      leftPadding: 50
+      leftPadding: 10
       font: Theme.defaultFont
+      icon.source: Theme.getThemeVectorIcon( "ic_copy_black_24dp" )
 
       onTriggered: {
         var displayPoint = projectInfo.reprojectDisplayCoordinatesToWGS84
@@ -2275,8 +2276,9 @@ ApplicationWindow {
     MenuItem {
       text: qsTr( "Copy Location Coordinates" )
       height: 48
-      leftPadding: 50
+      leftPadding: 10
       font: Theme.defaultFont
+      icon.source: Theme.getThemeVectorIcon( "ic_copy_black_24dp" )
 
       onTriggered: {
         if (!positioningSettings.positioningActivated || positionSource.positionInformation === undefined || !positionSource.positionInformation.latitudeValid) {


### PR DESCRIPTION
This PR integrates QField's brand new code reader functionality with the feature form's text edit widget. 

The fill value with decoded code action resides in a brand new menu attached to the text edit widget when editing is turned on:
![image](https://user-images.githubusercontent.com/1728657/181877274-ef7c8516-6023-498c-8b00-36cd0856cc1e.png)
_Notice the 3-dot icon button at the right end of the Beekeeper attribute_

When clicking on the 3-dot icon button, a menu appears with three possible actions, including 'Scan Code':
![image](https://user-images.githubusercontent.com/1728657/181877294-1f67a03d-4e34-447b-919f-6a2c0243a792.png)

Selecting the action will open QField's code reader and begin scanning for {QR,bar}codes to decode:
![image](https://user-images.githubusercontent.com/1728657/181877336-e775fe58-1c99-42b6-ac70-3dfc163dcda2.png)

Users then click on the (:heavy_check_mark:) OK button to fill the attribute with the decoded value:
![image](https://user-images.githubusercontent.com/1728657/181877340-ef3e7808-a335-443a-b49f-6ffe694862fa.png)

:magic_wand: 

This new 3-dot menu was implemented in such a way that allows for other editor widgets to implement their own specific menu actions, as well as allowing for the feature form itself to inject elements (e.g. our rather infamous remember value checkbox :smile: ) Because of its non-intrusive nature, I think it also permits us to always have a scan code action for text edits as it doesn't overcrowd the UI.

Also, as the screenshot above shows, we get a brand new 'copy/paste text' pair of action for text fields, which is a nice workaround a Qt limitation that prevented people from pasting text into a text attribute. That fixes #66.