### PR TITLE
Fix an out-of-bound crash when trying to get a layout name

### DIFF
--- a/src/core/printlayoutlistmodel.cpp
+++ b/src/core/printlayoutlistmodel.cpp
@@ -111,5 +111,8 @@ QVariant PrintLayoutListModel::data( const QModelIndex &index, int role ) const
 
 const QString PrintLayoutListModel::titleAt( int row ) const
 {
+  if ( row < 0 || row >= mPrintLayouts.size() )
+    return QString();
+
   return mPrintLayouts.at( row ).title;
 }


### PR DESCRIPTION
Fixes the following bug reported on sentry: https://sentry.io/organizations/opengisch/issues/3015822389/?project=6119013&query=is%3Aunresolved+release%3A%22ch.opengis.qfield%402.2.1+-+Coordinated+Capybara%2B2020199%2A%22&sort=freq&statsPeriod=7d

