### PR TITLE
Don't crash on Android when no ACTION_OPEN_DOCUMENT_TREE activity is available

### DIFF
--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -40,6 +40,7 @@ import android.app.AlertDialog;
 import android.app.Application;
 import android.app.Dialog;
 import android.app.ProgressDialog;
+import android.content.ActivityNotFoundException;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -456,7 +457,11 @@ public class QFieldActivity extends QtActivity {
                         Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
         intent.addFlags(Intent.FLAG_GRANT_PREFIX_URI_PERMISSION);
         intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
-        startActivityForResult(intent, R.id.import_project_folder);
+        try {
+            startActivityForResult(intent, R.id.import_project_folder);
+        } catch (ActivityNotFoundException e) {
+            Log.w("QField", "No activity found for ACTION_OPEN_DOCUMENT_TREE.");
+        }
         return;
     }
 
@@ -493,7 +498,11 @@ public class QFieldActivity extends QtActivity {
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
         intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
-        startActivityForResult(intent, R.id.export_to_folder);
+        try {
+            startActivityForResult(intent, R.id.export_to_folder);
+        } catch (ActivityNotFoundException e) {
+            Log.w("QField", "No activity found for ACTION_OPEN_DOCUMENT_TREE.");
+        }
         return;
     }
 


### PR DESCRIPTION
Reported on sentry: https://sentry.io/organizations/opengisch/issues/3428431498/?project=6119013&query=is%3Aunresolved+release%3A%22ch.opengis.qfield%402.2.1+-+Coordinated+Capybara%2B2020199%2A%22&sort=freq&statsPeriod=7d

There's more to this than merely fixing the crash (i.e., we need to figure out a way on handling devices like Xiaomi who don't implement all of Android API promises). But for now I think no crash > crash :wink: