### PR TITLE
[Backport release-2_2] Fix an out-of-bound crash when trying to get a layout name

### DIFF
--- a/src/core/printlayoutlistmodel.cpp
+++ b/src/core/printlayoutlistmodel.cpp
@@ -111,5 +111,8 @@ QVariant PrintLayoutListModel::data( const QModelIndex &index, int role ) const
 
 const QString PrintLayoutListModel::titleAt( int row ) const
 {
+  if ( row < 0 || row >= mPrintLayouts.size() )
+    return QString();
+
   return mPrintLayouts.at( row ).title;
 }


### PR DESCRIPTION
Backport #3144
 **Authored by:** @nirvn