### PR TITLE
[Backport release-2_2] Fix crash when attribute form model tries to update a field index out of bound

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -490,7 +490,7 @@ void AttributeFormModelBase::flatten( QgsAttributeEditorContainer *container, QS
 void AttributeFormModelBase::updateDefaultValues( int fieldIndex )
 {
   const QgsFields fields = mFeatureModel->feature().fields();
-  if ( fieldIndex < 0 || fieldIndex > fields.size() )
+  if ( fieldIndex < 0 || fieldIndex >= fields.size() )
     return;
   const QString fieldName = fields.at( fieldIndex ).name();
 


### PR DESCRIPTION
Backport #3151
 **Authored by:** @nirvn