### PR TITLE
Fix resetting attributes on creation issue

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1453,7 +1453,7 @@ ApplicationWindow {
                 {
                     overlayFeatureFormDrawer.featureModel.geometry = digitizingFeature.geometry
                     overlayFeatureFormDrawer.featureModel.applyGeometry()
-                    overlayFeatureFormDrawer.featureForm.resetAttributes()
+                    overlayFeatureFormDrawer.featureModel.resetAttributes()
                     if( overlayFeatureFormDrawer.featureForm.model.constraintsHardValid ) {
                       // when the constrainst are fulfilled
                       // indirect action, no need to check for success and display a toast, the log is enough


### PR DESCRIPTION
```
qrc:/qml/qgismobileapp.qml:1455: TypeError: Property 'resetAttributes' of object FeatureForm_QMLTYPE_165_QML_285(0xb4000071eb31bd40) is not a function
{
file: qrc:/qml/qgismobileapp.qml, 
line: 1455
}
```