### PR TITLE
Let's get QField to draw outside of the box

### DIFF
--- a/platform/android/build.gradle.in
+++ b/platform/android/build.gradle.in
@@ -39,6 +39,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.documentfile:documentfile:1.0.1'
     implementation "androidx.fragment:fragment:1.3.4"
+    implementation 'com.android.support:appcompat-v7:25.3.1'
 }
 
 android {

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -238,10 +238,10 @@ target_include_directories(qfield_core SYSTEM
                            PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
 target_include_directories(qfield_core SYSTEM PRIVATE ${GDAL_INCLUDE_DIR})
+# to include <qpa/qplatformnativeinterface.h and qpa/qplatformwindow.h>
+target_include_directories(qfield_core SYSTEM
+                           PRIVATE ${${QT_PKG}Gui_PRIVATE_INCLUDE_DIRS})
 if(IOS)
-  # to include <qpa/qplatformnativeinterface.h>
-  target_include_directories(qfield_core SYSTEM
-                             PRIVATE ${${QT_PKG}Gui_PRIVATE_INCLUDE_DIRS})
   target_compile_definitions(qfield_core PRIVATE -DQT_NO_PRINTER)
 endif()
 

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -34,6 +34,7 @@
 #include <QMimeDatabase>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
+#include <QScreen>
 #include <QStandardPaths>
 #include <QString>
 #include <QtAndroid>
@@ -534,6 +535,21 @@ void AndroidPlatformUtilities::initiateSentry()
       }
     } );
   }
+}
+
+QVariantMap AndroidPlatformUtilities::sceneMargins() const
+{
+  const QAndroidJniObject activity = QtAndroid::androidActivity();
+  double statusBarMargin = static_cast<double>( activity.callMethod<jdouble>( "statusBarMargin" ) );
+
+  statusBarMargin /= QGuiApplication::primaryScreen()->devicePixelRatio();
+
+  QVariantMap margins;
+  margins[QLatin1String( "top" )] = statusBarMargin;
+  margins[QLatin1String( "right" )] = 0.0;
+  margins[QLatin1String( "bottom" )] = 0.0;
+  margins[QLatin1String( "left" )] = 0.0;
+  return margins;
 }
 
 #ifdef __cplusplus

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -537,8 +537,10 @@ void AndroidPlatformUtilities::initiateSentry()
   }
 }
 
-QVariantMap AndroidPlatformUtilities::sceneMargins() const
+QVariantMap AndroidPlatformUtilities::sceneMargins( QQuickWindow *window ) const
 {
+  Q_UNUSED( window )
+
   const QAndroidJniObject activity = QtAndroid::androidActivity();
   double statusBarMargin = static_cast<double>( activity.callMethod<jdouble>( "statusBarMargin" ) );
 

--- a/src/core/platforms/android/androidplatformutilities.h
+++ b/src/core/platforms/android/androidplatformutilities.h
@@ -67,6 +67,8 @@ class AndroidPlatformUtilities : public PlatformUtilities
 
     void initiateSentry() override;
 
+    QVariantMap sceneMargins() const override;
+
   private:
     bool checkAndAcquirePermissions( const QString &permissionString ) const;
     QString getIntentExtra( const QString &, QAndroidJniObject = nullptr ) const;

--- a/src/core/platforms/android/androidplatformutilities.h
+++ b/src/core/platforms/android/androidplatformutilities.h
@@ -67,7 +67,7 @@ class AndroidPlatformUtilities : public PlatformUtilities
 
     void initiateSentry() override;
 
-    QVariantMap sceneMargins() const override;
+    QVariantMap sceneMargins( QQuickWindow *window ) const override;
 
   private:
     bool checkAndAcquirePermissions( const QString &permissionString ) const;

--- a/src/core/platforms/platformutilities.cpp
+++ b/src/core/platforms/platformutilities.cpp
@@ -29,9 +29,12 @@
 #include <QDesktopServices>
 #include <QDir>
 #include <QFileDialog>
+#include <QMargins>
+#include <QQuickWindow>
 #include <QStandardPaths>
 #include <QTimer>
 #include <QUrl>
+#include <QtGui/qpa/qplatformwindow.h>
 
 #if WITH_SENTRY
 #include <sentry.h>
@@ -316,13 +319,20 @@ QString PlatformUtilities::getTextFromClipboard() const
   return QGuiApplication::clipboard()->text();
 }
 
-QVariantMap PlatformUtilities::sceneMargins() const
+QVariantMap PlatformUtilities::sceneMargins( QQuickWindow *window ) const
 {
   QVariantMap margins;
   margins[QLatin1String( "top" )] = 0.0;
   margins[QLatin1String( "right" )] = 0.0;
   margins[QLatin1String( "bottom" )] = 0.0;
   margins[QLatin1String( "left" )] = 0.0;
+
+  QPlatformWindow *platformWindow = static_cast<QPlatformWindow *>( window->handle() );
+  if ( platformWindow )
+  {
+    margins[QLatin1String( "top" )] = platformWindow->safeAreaMargins().top();
+  }
+
   return margins;
 }
 

--- a/src/core/platforms/platformutilities.cpp
+++ b/src/core/platforms/platformutilities.cpp
@@ -97,13 +97,13 @@ QString PlatformUtilities::systemSharedDataLocation() const
 
      [prefix_path]
      |-- bin
-     |   |-- qfield.exe
+     |   |-- qfield.exe
      |-- share
      |   |-- qfield
-     |   |   |-- sample_projects 
+     |   |   |-- sample_projects
      |   |-- proj
-     |   |   |-- data
-     |   |   |   |--  proj.db
+     |   |   |-- data
+     |   |   |   |--  proj.db
   */
   const static QString sharePath = QDir( QCoreApplication::applicationDirPath() + QLatin1String( "/../share" ) ).absolutePath();
   return sharePath;
@@ -314,6 +314,16 @@ void PlatformUtilities::copyTextToClipboard( const QString &string ) const
 QString PlatformUtilities::getTextFromClipboard() const
 {
   return QGuiApplication::clipboard()->text();
+}
+
+QVariantMap PlatformUtilities::sceneMargins() const
+{
+  QVariantMap margins;
+  margins[QLatin1String( "top" )] = 0.0;
+  margins[QLatin1String( "right" )] = 0.0;
+  margins[QLatin1String( "bottom" )] = 0.0;
+  margins[QLatin1String( "left" )] = 0.0;
+  return margins;
 }
 
 PlatformUtilities *PlatformUtilities::instance()

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -228,6 +228,11 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
      */
     Q_INVOKABLE virtual QString getTextFromClipboard() const;
 
+    /**
+     * Returns margins ("top", "right", "bottom", "left") within which interactive elements should not be drawn.
+     */
+    Q_INVOKABLE virtual QVariantMap sceneMargins() const;
+
     static PlatformUtilities *instance();
 
   private:

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -29,6 +29,7 @@ class ProjectSource;
 class PictureSource;
 
 class QQuickItem;
+class QQuickWindow;
 
 class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
 {
@@ -231,7 +232,7 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
     /**
      * Returns margins ("top", "right", "bottom", "left") within which interactive elements should not be drawn.
      */
-    Q_INVOKABLE virtual QVariantMap sceneMargins() const;
+    Q_INVOKABLE virtual QVariantMap sceneMargins( QQuickWindow *window ) const;
 
     static PlatformUtilities *instance();
 

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -46,12 +46,15 @@ Drawer {
 
     Rectangle {
       Layout.fillWidth: true
-      height: childrenRect.height
+      height: mainWindow.sceneTopMargin + 56
 
       color: mainColor
 
       Row {
+        id: buttonsRow
         height: 56
+        anchors.fill: parent
+        anchors.topMargin: mainWindow.sceneTopMargin
         spacing: 1
 
         QfToolButton {
@@ -140,6 +143,7 @@ Drawer {
         height: 56
         width: ( 56 + 36 )
         anchors.right: parent.right
+        anchors.verticalCenter: buttonsRow.verticalCenter
         indicator: Rectangle {
           implicitHeight: 36
           implicitWidth: 36 * 2

--- a/src/qml/EmbeddedFeatureForm.qml
+++ b/src/qml/EmbeddedFeatureForm.qml
@@ -47,12 +47,13 @@ Popup {
     parent: ApplicationWindow.overlay
     closePolicy: Popup.NoAutoClose // prevent accidental feature addition and editing
 
-    x: 24
-    y: 24
+    x: Math.max(mainWindow.sceneTopMargin, Theme.popupScreenEdgeMargin)
+    y: x
     z: 1000 + embeddedLevel
+
     padding: 0
-    width: parent.width - Theme.popupScreenEdgeMargin
-    height: parent.height - Theme.popupScreenEdgeMargin
+    width: parent.width - x * 2
+    height: parent.height - y * 2
     modal: true
 
     FeatureForm {

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -37,6 +37,8 @@ Page {
   property bool setupOnly: false
   property bool featureCreated: false
 
+  property double topMargin: 0.0
+
   function reset() {
     master.reset()
   }
@@ -649,7 +651,7 @@ Page {
   /** The title toolbar **/
   ToolBar {
     id: toolbar
-    height: visible ? 48: 0
+    height: visible ? form.topMargin + 48 : 0
     visible: form.state === 'Add'
 
     anchors {
@@ -667,6 +669,7 @@ Page {
 
     RowLayout {
       anchors.fill: parent
+      anchors.topMargin: form.topMargin
       Layout.margins: 0
 
       QfToolButton {

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -362,6 +362,9 @@ Rectangle {
 
   NavigationBar {
     id: featureListToolBar
+
+    topMargin: featureForm.y == 0 ? mainWindow.sceneTopMargin : 0.0
+
     allowDelete: allowDelete
     model: globalFeaturesList.model
     selection: featureForm.selection

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -32,6 +32,8 @@ Rectangle {
   property FeatureListModelSelection selection
   property FeaturelistExtentController extentController
 
+  property double topMargin: 0.0
+
   signal backClicked
   signal statusIndicatorClicked
   signal statusIndicatorSwiped(var direction)
@@ -55,7 +57,7 @@ Rectangle {
   anchors.top:parent.top
   anchors.left: parent.left
   anchors.right: parent.right
-  height: 48
+  height: toolBar.topMargin + 48
 
   clip: true
 
@@ -76,7 +78,8 @@ Rectangle {
   Rectangle {
     id: navigationStatusIndicator
     anchors.fill: parent
-    height: 48
+
+    height: toolBar.topMargin + 48
 
     color: ( featureFormList.model.constraintsHardValid && featureFormList.model.constraintsSoftValid ) || parent.state !== "Edit" ? Theme.mainColor : !featureFormList.model.constraintsHardValid ? Theme.errorColor : Theme.warningColor
 
@@ -98,9 +101,11 @@ Rectangle {
       color: Theme.light
       anchors.left: parent.left
       anchors.right: parent.right
+      anchors.top: parent.top
       anchors.leftMargin: 0 + balancedMargin
       anchors.rightMargin: 0 + balancedMargin
-      height: parent.height
+      anchors.topMargin: toolBar.topMargin
+      height: parent.height - toolBar.topMargin
 
       text: {
         if ( model && selection && selection.focusedItem > -1 && (toolBar.state === 'Navigation' || toolBar.state === 'Edit') ) {
@@ -169,6 +174,8 @@ Rectangle {
     id: nextButton
 
     anchors.left: previousButton.right
+    anchors.top: parent.top
+    anchors.topMargin: toolBar.topMargin
 
     width: ( parent.state == "Navigation" ? 48: 0 )
     height: 48
@@ -198,6 +205,8 @@ Rectangle {
     id: previousButton
 
     anchors.left: parent.left
+    anchors.top: parent.top
+    anchors.topMargin: toolBar.topMargin
 
     width: parent.state != "Edit" && !toolBar.multiSelection ? 48: 0
     height: 48
@@ -227,7 +236,11 @@ Rectangle {
 
   QfToolButton {
     id: saveButton
+
     anchors.left: parent.left
+    anchors.top: parent.top
+    anchors.topMargin: toolBar.topMargin
+
     width: ( parent.state == "Edit" ? 48: 0 )
     height: 48
     clip: true
@@ -254,6 +267,8 @@ Rectangle {
     visible: !qfieldSettings.autoSave
 
     anchors.right: parent.right
+    anchors.top: parent.top
+    anchors.topMargin: toolBar.topMargin
 
     width: ( parent.state == "Edit" ? 48: 0 )
     height: 48
@@ -283,6 +298,8 @@ Rectangle {
              && ( projectInfo.editRights || editButton.isCreatedCloudFeature )
 
     anchors.right: editButton.left
+    anchors.top: parent.top
+    anchors.topMargin: toolBar.topMargin
 
     iconSource: Theme.getThemeIcon( "ic_edit_geometry_white" )
 
@@ -317,6 +334,8 @@ Rectangle {
     property bool isCreatedCloudFeature: false
 
     anchors.right: menuButton.left
+    anchors.top: parent.top
+    anchors.topMargin: toolBar.topMargin
 
     width: ( parent.state == "Navigation" && supportsEditing && ( projectInfo.editRights || isCreatedCloudFeature ) ? 48: 0 )
     height: 48
@@ -353,6 +372,8 @@ Rectangle {
     id: menuButton
 
     anchors.right: parent.right
+    anchors.top: parent.top
+    anchors.topMargin: toolBar.topMargin
 
     visible: parent.state != "Edit"
     width: visible ? 48 : 0
@@ -380,6 +401,8 @@ Rectangle {
     id: multiClearButton
 
     anchors.left: parent.left
+    anchors.top: parent.top
+    anchors.topMargin: toolBar.topMargin
 
     width: ( parent.state == "Indication" && toolBar.multiSelection && toolBar.model ? 48: 0 )
     height: 48
@@ -402,6 +425,8 @@ Rectangle {
     id: multiSelectCount
 
     anchors.left: multiClearButton.right
+    anchors.top: parent.top
+    anchors.topMargin: toolBar.topMargin
 
     width: ( parent.state == "Indication" && toolBar.multiSelection && toolBar.model ? 48: 0 )
     visible: width > 0
@@ -419,6 +444,8 @@ Rectangle {
     id: multiEditButton
 
     anchors.right: menuButton.left
+    anchors.top: parent.top
+    anchors.topMargin: toolBar.topMargin
 
     width: parent.state == "Indication"
            && toolBar.model && toolBar.model.canEditAttributesSelection && toolBar.model.selectedCount > 1

--- a/src/qml/OverlayFeatureFormDrawer.qml
+++ b/src/qml/OverlayFeatureFormDrawer.qml
@@ -73,6 +73,9 @@ Drawer {
     height: parent.height
     width: parent.width
     visible: true
+
+    topMargin: overlayFeatureFormDrawer.y == 0 ? mainWindow.sceneTopMargin : 0.0
+
     property alias featureModel: attributeFormModel.featureModel
     property bool isSaved: false
 

--- a/src/qml/PageHeader.qml
+++ b/src/qml/PageHeader.qml
@@ -14,7 +14,9 @@ ToolBar {
 
   property alias busyIndicatorState: busyIndicator.state
 
-  height: 48
+  property double topMargin: 0.0
+
+  height: topMargin + 48
 
   signal cancel
   signal apply
@@ -73,7 +75,7 @@ ToolBar {
 
   RowLayout {
     anchors.fill: parent
-
+    anchors.topMargin: topMargin
     Layout.margins: 0
 
     QfToolButton {

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -19,11 +19,14 @@ Popup {
       showBackButton: true
       showCancelButton: false
       showApplyButton: false
+
       busyIndicatorState: cloudConnection.status === QFieldCloudConnection.Connecting
             || cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Uploading
             || cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Downloading
             ? 'on'
             : 'off'
+
+      topMargin: mainWindow.sceneTopMargin
 
       onFinished: {
         if (connectionSettings.visible) {

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -20,9 +20,12 @@ Page {
       showBackButton: true
       showApplyButton: false
       showCancelButton: false
+
       busyIndicatorState: cloudConnection.status === QFieldCloudConnection.Connecting ||
                          cloudConnection.state === QFieldCloudConnection.Busy ? 'on' : 'off' ||
                          cloudProjectsModel.busyProjectIds.length > 0
+
+      topMargin: mainWindow.sceneTopMargin
 
       onFinished: parent.finished()
     }

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -24,6 +24,8 @@ Page {
     showApplyButton: false
     showCancelButton: false
 
+    topMargin: mainWindow.sceneTopMargin
+
     onBack: {
       if (table.model.currentDepth > 1) {
         table.model.moveUp();

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -824,6 +824,8 @@ Page {
       showApplyButton: false
       showCancelButton: false
 
+      topMargin: mainWindow.sceneTopMargin
+
       onFinished: {
           parent.finished()
           variableEditor.apply()

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -622,6 +622,7 @@ Page {
     anchors {
       top: parent.top
       left: parent.left
+      topMargin: mainWindow.sceneTopMargin
     }
     iconSource: Theme.getThemeIcon( 'ic_chevron_left_black_24dp' )
     bgcolor: "transparent"

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -34,8 +34,10 @@ ApplicationWindow {
   id: mainWindow
   objectName: 'mainWindow'
   visible: true
+  flags: Qt.Window | Qt.WindowTitleHint | Qt.WindowSystemMenuHint |
+         (Qt.platform.os === "ios" ? Qt.MaximizeUsingFullscreenGeometryHint : 0)
 
-  property double sceneTopMargin: platformUtilities.sceneMargins()["top"]
+  property double sceneTopMargin: platformUtilities.sceneMargins(mainWindow)["top"]
 
   Timer{
     id: refreshSceneMargins
@@ -50,7 +52,7 @@ ApplicationWindow {
     }
 
     onTriggered: {
-      mainWindow.sceneTopMargin = platformUtilities.sceneMargins()["top"];
+      mainWindow.sceneTopMargin = platformUtilities.sceneMargins(mainWindow)["top"];
     }
   }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -35,6 +35,25 @@ ApplicationWindow {
   objectName: 'mainWindow'
   visible: true
 
+  property double sceneTopMargin: platformUtilities.sceneMargins()["top"]
+
+  Timer{
+    id: refreshSceneMargins
+    running: false
+    repeat: false
+    interval: 50
+
+    readonly property bool screenIsPortrait: (Screen.primaryOrientation === Qt.PortraitOrientation ||
+                                              Screen.primaryOrientation === Qt.InvertedPortraitOrientation)
+    onScreenIsPortraitChanged:{
+      start()
+    }
+
+    onTriggered: {
+      mainWindow.sceneTopMargin = platformUtilities.sceneMargins()["top"];
+    }
+  }
+
   LabSettings.Settings {
       property alias x: mainWindow.x
       property alias y: mainWindow.y

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -892,7 +892,8 @@ ApplicationWindow {
 
     anchors.right: parent.right
     anchors.top: parent.top
-    anchors.margins: 4
+    anchors.topMargin: mainWindow.sceneTopMargin + 4
+    anchors.rightMargin: 4
 
     visible: stateMachine.state !== 'measure'
 
@@ -999,7 +1000,7 @@ ApplicationWindow {
     id: mainMenuBar
     width: childrenRect.width + 8
     height: childrenRect.height + 8
-    topPadding: 4
+    topPadding: mainWindow.sceneTopMargin + 4
     leftPadding: 4
     spacing: 4
 
@@ -2572,8 +2573,8 @@ ApplicationWindow {
     id: busyIndicator
     anchors.left: mainMenuBar.left
     anchors.top: mainToolbar.bottom
-    width: mainMenuBar.height
-    height: mainMenuBar.height
+    width: menuButton.width + 10
+    height: width
     running: mapCanvasMap.isRendering
   }
 


### PR DESCRIPTION
This PR upgrades QField Android to allow for elements to be drawn under the top status bar. Here's how it looks:
![image](https://user-images.githubusercontent.com/1728657/184469587-0b780c49-f1c5-4dff-835a-fddf97401f66.png)

Beyond making QField behave like modern Android apps, it expands the canvas extent by quite a few pixels which is always welcome :)

Note: the implementation is futureproof and allows for scene left,right,bottom margins even though ATM we don't need to rely on that.