### PR TITLE
Add meta link canonical

### DIFF
--- a/docs/af/case-studies/ecological-surveying.html
+++ b/docs/af/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/case-studies/geologic-mapping.html
+++ b/docs/af/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/case-studies/index.html
+++ b/docs/af/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/case-studies/lulc-mapping-fiji.html
+++ b/docs/af/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/af/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/af/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/case-studies/river-state-survey.html
+++ b/docs/af/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/case-studies/rwanda-rural-water.html
+++ b/docs/af/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/case-studies/vanilla-survey.html
+++ b/docs/af/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/data-formats/index.html
+++ b/docs/af/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/fieldwork/digitize.html
+++ b/docs/af/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/fieldwork/gps.html
+++ b/docs/af/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/fieldwork/index.html
+++ b/docs/af/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/fieldwork/live_default_value.html
+++ b/docs/af/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/fieldwork/map-interaction.html
+++ b/docs/af/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/fieldwork/map-themes.html
+++ b/docs/af/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/fieldwork/opening_individual_data.html
+++ b/docs/af/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/fieldwork/print-to-pdf.html
+++ b/docs/af/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/fieldwork/projects.html
+++ b/docs/af/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/fieldwork/search.html
+++ b/docs/af/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/fieldwork/track_lines_polygons.html
+++ b/docs/af/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/fieldwork/variables.html
+++ b/docs/af/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/genindex.html
+++ b/docs/af/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/af/getting-started/index.html
+++ b/docs/af/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/index.html
+++ b/docs/af/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/af/install/index.html
+++ b/docs/af/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/old-doc/case-studies/ecological-surveying.html
+++ b/docs/af/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/af/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/af/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/af/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/af/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/af/old-doc/case-studies/river-state-survey.html
+++ b/docs/af/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/af/old-doc/concepts/index.html
+++ b/docs/af/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/af/old-doc/development/index.html
+++ b/docs/af/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/af/old-doc/index.html
+++ b/docs/af/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/old-doc/installation-guide/index.html
+++ b/docs/af/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/af/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/af/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/af/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/af/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/af/old-doc/project-management/android-data-structure.html
+++ b/docs/af/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/af/old-doc/project-management/configure-search.html
+++ b/docs/af/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/af/old-doc/project-management/dataformat.html
+++ b/docs/af/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/af/old-doc/project-management/index.html
+++ b/docs/af/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/af/old-doc/project-management/map-themes.html
+++ b/docs/af/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/af/old-doc/project-management/portable-project.html
+++ b/docs/af/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/af/old-doc/project-management/print-to-pdf.html
+++ b/docs/af/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/af/old-doc/project-management/project-selection.html
+++ b/docs/af/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/af/old-doc/project-management/vector-layers.html
+++ b/docs/af/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/af/old-doc/qfieldsync/index.html
+++ b/docs/af/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/af/old-doc/user-guide/index.html
+++ b/docs/af/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/af/old-doc/user-guide/map-themes.html
+++ b/docs/af/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/af/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/af/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/af/old-doc/user-guide/variables.html
+++ b/docs/af/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/af/prepare/add-1-n-pictures.html
+++ b/docs/af/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/prepare/advanced.html
+++ b/docs/af/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/prepare/allow-hiding-legend-nodes.html
+++ b/docs/af/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/prepare/attributes-form.html
+++ b/docs/af/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/prepare/authentication.html
+++ b/docs/af/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/prepare/change-fonts.html
+++ b/docs/af/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/prepare/custom-svg.html
+++ b/docs/af/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/prepare/display-expression.html
+++ b/docs/af/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/prepare/gnss.html
+++ b/docs/af/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/prepare/index.html
+++ b/docs/af/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/prepare/live_default_value.html
+++ b/docs/af/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/prepare/map-styling-configuration.html
+++ b/docs/af/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/prepare/map-themes.html
+++ b/docs/af/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/prepare/outside-layers.html
+++ b/docs/af/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/prepare/picture_path.html
+++ b/docs/af/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/search.html
+++ b/docs/af/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/af/support/index.html
+++ b/docs/af/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/synchronise/basemaps.html
+++ b/docs/af/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/synchronise/index.html
+++ b/docs/af/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/synchronise/movable-project.html
+++ b/docs/af/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/synchronise/qfieldcloud.html
+++ b/docs/af/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/af/synchronise/qfieldsync.html
+++ b/docs/af/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/case-studies/ecological-surveying.html
+++ b/docs/bg/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/case-studies/geologic-mapping.html
+++ b/docs/bg/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/case-studies/index.html
+++ b/docs/bg/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/case-studies/lulc-mapping-fiji.html
+++ b/docs/bg/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/bg/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/bg/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/case-studies/river-state-survey.html
+++ b/docs/bg/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/case-studies/rwanda-rural-water.html
+++ b/docs/bg/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/case-studies/vanilla-survey.html
+++ b/docs/bg/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/data-formats/index.html
+++ b/docs/bg/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/fieldwork/digitize.html
+++ b/docs/bg/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/fieldwork/gps.html
+++ b/docs/bg/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/fieldwork/index.html
+++ b/docs/bg/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/fieldwork/live_default_value.html
+++ b/docs/bg/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/fieldwork/map-interaction.html
+++ b/docs/bg/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/fieldwork/map-themes.html
+++ b/docs/bg/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/fieldwork/opening_individual_data.html
+++ b/docs/bg/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/fieldwork/print-to-pdf.html
+++ b/docs/bg/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/fieldwork/projects.html
+++ b/docs/bg/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/fieldwork/search.html
+++ b/docs/bg/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/fieldwork/track_lines_polygons.html
+++ b/docs/bg/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/fieldwork/variables.html
+++ b/docs/bg/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/genindex.html
+++ b/docs/bg/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/bg/getting-started/index.html
+++ b/docs/bg/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/index.html
+++ b/docs/bg/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/bg/install/index.html
+++ b/docs/bg/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/old-doc/case-studies/ecological-surveying.html
+++ b/docs/bg/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/bg/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/bg/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/bg/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/bg/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/bg/old-doc/case-studies/river-state-survey.html
+++ b/docs/bg/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/bg/old-doc/concepts/index.html
+++ b/docs/bg/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/bg/old-doc/development/index.html
+++ b/docs/bg/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/bg/old-doc/index.html
+++ b/docs/bg/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/old-doc/installation-guide/index.html
+++ b/docs/bg/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/bg/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/bg/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/bg/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/bg/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/bg/old-doc/project-management/android-data-structure.html
+++ b/docs/bg/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/bg/old-doc/project-management/configure-search.html
+++ b/docs/bg/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/bg/old-doc/project-management/dataformat.html
+++ b/docs/bg/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/bg/old-doc/project-management/index.html
+++ b/docs/bg/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/bg/old-doc/project-management/map-themes.html
+++ b/docs/bg/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/bg/old-doc/project-management/portable-project.html
+++ b/docs/bg/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/bg/old-doc/project-management/print-to-pdf.html
+++ b/docs/bg/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/bg/old-doc/project-management/project-selection.html
+++ b/docs/bg/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/bg/old-doc/project-management/vector-layers.html
+++ b/docs/bg/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/bg/old-doc/qfieldsync/index.html
+++ b/docs/bg/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/bg/old-doc/user-guide/index.html
+++ b/docs/bg/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/bg/old-doc/user-guide/map-themes.html
+++ b/docs/bg/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/bg/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/bg/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/bg/old-doc/user-guide/variables.html
+++ b/docs/bg/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/bg/prepare/add-1-n-pictures.html
+++ b/docs/bg/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/prepare/advanced.html
+++ b/docs/bg/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/prepare/allow-hiding-legend-nodes.html
+++ b/docs/bg/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/prepare/attributes-form.html
+++ b/docs/bg/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/prepare/authentication.html
+++ b/docs/bg/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/prepare/change-fonts.html
+++ b/docs/bg/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/prepare/custom-svg.html
+++ b/docs/bg/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/prepare/display-expression.html
+++ b/docs/bg/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/prepare/gnss.html
+++ b/docs/bg/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/prepare/index.html
+++ b/docs/bg/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/prepare/live_default_value.html
+++ b/docs/bg/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/prepare/map-styling-configuration.html
+++ b/docs/bg/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/prepare/map-themes.html
+++ b/docs/bg/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/prepare/outside-layers.html
+++ b/docs/bg/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/prepare/picture_path.html
+++ b/docs/bg/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/search.html
+++ b/docs/bg/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/bg/support/index.html
+++ b/docs/bg/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/synchronise/basemaps.html
+++ b/docs/bg/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/synchronise/index.html
+++ b/docs/bg/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/synchronise/movable-project.html
+++ b/docs/bg/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/synchronise/qfieldcloud.html
+++ b/docs/bg/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/bg/synchronise/qfieldsync.html
+++ b/docs/bg/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/case-studies/ecological-surveying.html
+++ b/docs/ca/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/case-studies/geologic-mapping.html
+++ b/docs/ca/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/case-studies/index.html
+++ b/docs/ca/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/case-studies/lulc-mapping-fiji.html
+++ b/docs/ca/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/ca/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/ca/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/case-studies/river-state-survey.html
+++ b/docs/ca/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/case-studies/rwanda-rural-water.html
+++ b/docs/ca/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/case-studies/vanilla-survey.html
+++ b/docs/ca/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/data-formats/index.html
+++ b/docs/ca/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/fieldwork/digitize.html
+++ b/docs/ca/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/fieldwork/gps.html
+++ b/docs/ca/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/fieldwork/index.html
+++ b/docs/ca/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/fieldwork/live_default_value.html
+++ b/docs/ca/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/fieldwork/map-interaction.html
+++ b/docs/ca/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/fieldwork/map-themes.html
+++ b/docs/ca/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/fieldwork/opening_individual_data.html
+++ b/docs/ca/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/fieldwork/print-to-pdf.html
+++ b/docs/ca/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/fieldwork/projects.html
+++ b/docs/ca/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/fieldwork/search.html
+++ b/docs/ca/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/fieldwork/track_lines_polygons.html
+++ b/docs/ca/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/fieldwork/variables.html
+++ b/docs/ca/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/genindex.html
+++ b/docs/ca/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/ca/getting-started/index.html
+++ b/docs/ca/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/index.html
+++ b/docs/ca/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/ca/install/index.html
+++ b/docs/ca/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/old-doc/case-studies/ecological-surveying.html
+++ b/docs/ca/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ca/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/ca/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ca/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/ca/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ca/old-doc/case-studies/river-state-survey.html
+++ b/docs/ca/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ca/old-doc/concepts/index.html
+++ b/docs/ca/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ca/old-doc/development/index.html
+++ b/docs/ca/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ca/old-doc/index.html
+++ b/docs/ca/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/old-doc/installation-guide/index.html
+++ b/docs/ca/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ca/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/ca/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ca/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/ca/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ca/old-doc/project-management/android-data-structure.html
+++ b/docs/ca/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ca/old-doc/project-management/configure-search.html
+++ b/docs/ca/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ca/old-doc/project-management/dataformat.html
+++ b/docs/ca/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ca/old-doc/project-management/index.html
+++ b/docs/ca/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ca/old-doc/project-management/map-themes.html
+++ b/docs/ca/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ca/old-doc/project-management/portable-project.html
+++ b/docs/ca/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ca/old-doc/project-management/print-to-pdf.html
+++ b/docs/ca/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ca/old-doc/project-management/project-selection.html
+++ b/docs/ca/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ca/old-doc/project-management/vector-layers.html
+++ b/docs/ca/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ca/old-doc/qfieldsync/index.html
+++ b/docs/ca/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ca/old-doc/user-guide/index.html
+++ b/docs/ca/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ca/old-doc/user-guide/map-themes.html
+++ b/docs/ca/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ca/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/ca/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ca/old-doc/user-guide/variables.html
+++ b/docs/ca/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ca/prepare/add-1-n-pictures.html
+++ b/docs/ca/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/prepare/advanced.html
+++ b/docs/ca/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/prepare/allow-hiding-legend-nodes.html
+++ b/docs/ca/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/prepare/attributes-form.html
+++ b/docs/ca/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/prepare/authentication.html
+++ b/docs/ca/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/prepare/change-fonts.html
+++ b/docs/ca/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/prepare/custom-svg.html
+++ b/docs/ca/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/prepare/display-expression.html
+++ b/docs/ca/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/prepare/gnss.html
+++ b/docs/ca/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/prepare/index.html
+++ b/docs/ca/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/prepare/live_default_value.html
+++ b/docs/ca/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/prepare/map-styling-configuration.html
+++ b/docs/ca/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/prepare/map-themes.html
+++ b/docs/ca/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/prepare/outside-layers.html
+++ b/docs/ca/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/prepare/picture_path.html
+++ b/docs/ca/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/search.html
+++ b/docs/ca/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/ca/support/index.html
+++ b/docs/ca/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/synchronise/basemaps.html
+++ b/docs/ca/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/synchronise/index.html
+++ b/docs/ca/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/synchronise/movable-project.html
+++ b/docs/ca/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/synchronise/qfieldcloud.html
+++ b/docs/ca/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ca/synchronise/qfieldsync.html
+++ b/docs/ca/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/case-studies/ecological-surveying.html
+++ b/docs/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/case-studies/geologic-mapping.html
+++ b/docs/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/case-studies/index.html
+++ b/docs/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/case-studies/lulc-mapping-fiji.html
+++ b/docs/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/case-studies/river-state-survey.html
+++ b/docs/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/case-studies/rwanda-rural-water.html
+++ b/docs/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/case-studies/vanilla-survey.html
+++ b/docs/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/case-studies/ecological-surveying.html
+++ b/docs/cs/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/case-studies/geologic-mapping.html
+++ b/docs/cs/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/case-studies/index.html
+++ b/docs/cs/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/case-studies/lulc-mapping-fiji.html
+++ b/docs/cs/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/cs/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/cs/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/case-studies/river-state-survey.html
+++ b/docs/cs/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/case-studies/rwanda-rural-water.html
+++ b/docs/cs/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/case-studies/vanilla-survey.html
+++ b/docs/cs/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/data-formats/index.html
+++ b/docs/cs/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/fieldwork/digitize.html
+++ b/docs/cs/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/fieldwork/gps.html
+++ b/docs/cs/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/fieldwork/index.html
+++ b/docs/cs/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/fieldwork/live_default_value.html
+++ b/docs/cs/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/fieldwork/map-interaction.html
+++ b/docs/cs/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/fieldwork/map-themes.html
+++ b/docs/cs/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/fieldwork/opening_individual_data.html
+++ b/docs/cs/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/fieldwork/print-to-pdf.html
+++ b/docs/cs/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/fieldwork/projects.html
+++ b/docs/cs/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/fieldwork/search.html
+++ b/docs/cs/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/fieldwork/track_lines_polygons.html
+++ b/docs/cs/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/fieldwork/variables.html
+++ b/docs/cs/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/genindex.html
+++ b/docs/cs/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/cs/getting-started/index.html
+++ b/docs/cs/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/index.html
+++ b/docs/cs/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/cs/install/index.html
+++ b/docs/cs/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/old-doc/case-studies/ecological-surveying.html
+++ b/docs/cs/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/cs/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/cs/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/cs/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/cs/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/cs/old-doc/case-studies/river-state-survey.html
+++ b/docs/cs/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/cs/old-doc/concepts/index.html
+++ b/docs/cs/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/cs/old-doc/development/index.html
+++ b/docs/cs/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/cs/old-doc/index.html
+++ b/docs/cs/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/old-doc/installation-guide/index.html
+++ b/docs/cs/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/cs/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/cs/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/cs/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/cs/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/cs/old-doc/project-management/android-data-structure.html
+++ b/docs/cs/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/cs/old-doc/project-management/configure-search.html
+++ b/docs/cs/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/cs/old-doc/project-management/dataformat.html
+++ b/docs/cs/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/cs/old-doc/project-management/index.html
+++ b/docs/cs/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/cs/old-doc/project-management/map-themes.html
+++ b/docs/cs/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/cs/old-doc/project-management/portable-project.html
+++ b/docs/cs/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/cs/old-doc/project-management/print-to-pdf.html
+++ b/docs/cs/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/cs/old-doc/project-management/project-selection.html
+++ b/docs/cs/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/cs/old-doc/project-management/vector-layers.html
+++ b/docs/cs/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/cs/old-doc/qfieldsync/index.html
+++ b/docs/cs/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/cs/old-doc/user-guide/index.html
+++ b/docs/cs/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/cs/old-doc/user-guide/map-themes.html
+++ b/docs/cs/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/cs/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/cs/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/cs/old-doc/user-guide/variables.html
+++ b/docs/cs/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/cs/prepare/add-1-n-pictures.html
+++ b/docs/cs/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/prepare/advanced.html
+++ b/docs/cs/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/prepare/allow-hiding-legend-nodes.html
+++ b/docs/cs/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/prepare/attributes-form.html
+++ b/docs/cs/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/prepare/authentication.html
+++ b/docs/cs/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/prepare/change-fonts.html
+++ b/docs/cs/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/prepare/custom-svg.html
+++ b/docs/cs/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/prepare/display-expression.html
+++ b/docs/cs/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/prepare/gnss.html
+++ b/docs/cs/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/prepare/index.html
+++ b/docs/cs/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/prepare/live_default_value.html
+++ b/docs/cs/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/prepare/map-styling-configuration.html
+++ b/docs/cs/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/prepare/map-themes.html
+++ b/docs/cs/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/prepare/outside-layers.html
+++ b/docs/cs/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/prepare/picture_path.html
+++ b/docs/cs/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/search.html
+++ b/docs/cs/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/cs/support/index.html
+++ b/docs/cs/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/synchronise/basemaps.html
+++ b/docs/cs/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/synchronise/index.html
+++ b/docs/cs/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/synchronise/movable-project.html
+++ b/docs/cs/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/synchronise/qfieldcloud.html
+++ b/docs/cs/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/cs/synchronise/qfieldsync.html
+++ b/docs/cs/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/data-formats/index.html
+++ b/docs/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/case-studies/ecological-surveying.html
+++ b/docs/de/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/case-studies/geologic-mapping.html
+++ b/docs/de/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/case-studies/index.html
+++ b/docs/de/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/case-studies/lulc-mapping-fiji.html
+++ b/docs/de/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/de/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/de/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/case-studies/river-state-survey.html
+++ b/docs/de/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/case-studies/rwanda-rural-water.html
+++ b/docs/de/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/case-studies/vanilla-survey.html
+++ b/docs/de/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/data-formats/index.html
+++ b/docs/de/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/fieldwork/digitize.html
+++ b/docs/de/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/fieldwork/gps.html
+++ b/docs/de/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/fieldwork/index.html
+++ b/docs/de/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/fieldwork/live_default_value.html
+++ b/docs/de/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/fieldwork/map-interaction.html
+++ b/docs/de/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/fieldwork/map-themes.html
+++ b/docs/de/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/fieldwork/opening_individual_data.html
+++ b/docs/de/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/fieldwork/print-to-pdf.html
+++ b/docs/de/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/fieldwork/projects.html
+++ b/docs/de/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/fieldwork/search.html
+++ b/docs/de/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/fieldwork/track_lines_polygons.html
+++ b/docs/de/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/fieldwork/variables.html
+++ b/docs/de/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/genindex.html
+++ b/docs/de/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/de/getting-started/index.html
+++ b/docs/de/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/index.html
+++ b/docs/de/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/de/install/index.html
+++ b/docs/de/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/old-doc/case-studies/ecological-surveying.html
+++ b/docs/de/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/de/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/de/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/de/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/de/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/de/old-doc/case-studies/river-state-survey.html
+++ b/docs/de/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/de/old-doc/concepts/index.html
+++ b/docs/de/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/de/old-doc/development/index.html
+++ b/docs/de/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/de/old-doc/index.html
+++ b/docs/de/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/old-doc/installation-guide/index.html
+++ b/docs/de/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/de/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/de/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/de/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/de/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/de/old-doc/project-management/android-data-structure.html
+++ b/docs/de/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/de/old-doc/project-management/configure-search.html
+++ b/docs/de/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/de/old-doc/project-management/dataformat.html
+++ b/docs/de/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/de/old-doc/project-management/index.html
+++ b/docs/de/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/de/old-doc/project-management/map-themes.html
+++ b/docs/de/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/de/old-doc/project-management/portable-project.html
+++ b/docs/de/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/de/old-doc/project-management/print-to-pdf.html
+++ b/docs/de/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/de/old-doc/project-management/project-selection.html
+++ b/docs/de/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/de/old-doc/project-management/vector-layers.html
+++ b/docs/de/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/de/old-doc/qfieldsync/index.html
+++ b/docs/de/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/de/old-doc/user-guide/index.html
+++ b/docs/de/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/de/old-doc/user-guide/map-themes.html
+++ b/docs/de/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/de/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/de/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/de/old-doc/user-guide/variables.html
+++ b/docs/de/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/de/prepare/add-1-n-pictures.html
+++ b/docs/de/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/prepare/advanced.html
+++ b/docs/de/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/prepare/allow-hiding-legend-nodes.html
+++ b/docs/de/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/prepare/attributes-form.html
+++ b/docs/de/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/prepare/authentication.html
+++ b/docs/de/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/prepare/change-fonts.html
+++ b/docs/de/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/prepare/custom-svg.html
+++ b/docs/de/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/prepare/display-expression.html
+++ b/docs/de/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/prepare/gnss.html
+++ b/docs/de/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/prepare/index.html
+++ b/docs/de/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/prepare/live_default_value.html
+++ b/docs/de/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/prepare/map-styling-configuration.html
+++ b/docs/de/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/prepare/map-themes.html
+++ b/docs/de/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/prepare/outside-layers.html
+++ b/docs/de/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/prepare/picture_path.html
+++ b/docs/de/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/search.html
+++ b/docs/de/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/de/support/index.html
+++ b/docs/de/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/synchronise/basemaps.html
+++ b/docs/de/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/synchronise/index.html
+++ b/docs/de/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/synchronise/movable-project.html
+++ b/docs/de/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/synchronise/qfieldcloud.html
+++ b/docs/de/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/de/synchronise/qfieldsync.html
+++ b/docs/de/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/case-studies/ecological-surveying.html
+++ b/docs/el/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/case-studies/geologic-mapping.html
+++ b/docs/el/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/case-studies/index.html
+++ b/docs/el/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/case-studies/lulc-mapping-fiji.html
+++ b/docs/el/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/el/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/el/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/case-studies/river-state-survey.html
+++ b/docs/el/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/case-studies/rwanda-rural-water.html
+++ b/docs/el/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/case-studies/vanilla-survey.html
+++ b/docs/el/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/data-formats/index.html
+++ b/docs/el/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/fieldwork/digitize.html
+++ b/docs/el/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/fieldwork/gps.html
+++ b/docs/el/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/fieldwork/index.html
+++ b/docs/el/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/fieldwork/live_default_value.html
+++ b/docs/el/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/fieldwork/map-interaction.html
+++ b/docs/el/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/fieldwork/map-themes.html
+++ b/docs/el/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/fieldwork/opening_individual_data.html
+++ b/docs/el/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/fieldwork/print-to-pdf.html
+++ b/docs/el/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/fieldwork/projects.html
+++ b/docs/el/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/fieldwork/search.html
+++ b/docs/el/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/fieldwork/track_lines_polygons.html
+++ b/docs/el/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/fieldwork/variables.html
+++ b/docs/el/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/genindex.html
+++ b/docs/el/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/el/getting-started/index.html
+++ b/docs/el/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/index.html
+++ b/docs/el/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/el/install/index.html
+++ b/docs/el/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/old-doc/case-studies/ecological-surveying.html
+++ b/docs/el/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/el/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/el/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/el/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/el/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/el/old-doc/case-studies/river-state-survey.html
+++ b/docs/el/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/el/old-doc/concepts/index.html
+++ b/docs/el/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/el/old-doc/development/index.html
+++ b/docs/el/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/el/old-doc/index.html
+++ b/docs/el/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/old-doc/installation-guide/index.html
+++ b/docs/el/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/el/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/el/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/el/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/el/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/el/old-doc/project-management/android-data-structure.html
+++ b/docs/el/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/el/old-doc/project-management/configure-search.html
+++ b/docs/el/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/el/old-doc/project-management/dataformat.html
+++ b/docs/el/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/el/old-doc/project-management/index.html
+++ b/docs/el/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/el/old-doc/project-management/map-themes.html
+++ b/docs/el/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/el/old-doc/project-management/portable-project.html
+++ b/docs/el/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/el/old-doc/project-management/print-to-pdf.html
+++ b/docs/el/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/el/old-doc/project-management/project-selection.html
+++ b/docs/el/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/el/old-doc/project-management/vector-layers.html
+++ b/docs/el/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/el/old-doc/qfieldsync/index.html
+++ b/docs/el/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/el/old-doc/user-guide/index.html
+++ b/docs/el/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/el/old-doc/user-guide/map-themes.html
+++ b/docs/el/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/el/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/el/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/el/old-doc/user-guide/variables.html
+++ b/docs/el/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/el/prepare/add-1-n-pictures.html
+++ b/docs/el/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/prepare/advanced.html
+++ b/docs/el/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/prepare/allow-hiding-legend-nodes.html
+++ b/docs/el/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/prepare/attributes-form.html
+++ b/docs/el/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/prepare/authentication.html
+++ b/docs/el/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/prepare/change-fonts.html
+++ b/docs/el/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/prepare/custom-svg.html
+++ b/docs/el/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/prepare/display-expression.html
+++ b/docs/el/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/prepare/gnss.html
+++ b/docs/el/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/prepare/index.html
+++ b/docs/el/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/prepare/live_default_value.html
+++ b/docs/el/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/prepare/map-styling-configuration.html
+++ b/docs/el/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/prepare/map-themes.html
+++ b/docs/el/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/prepare/outside-layers.html
+++ b/docs/el/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/prepare/picture_path.html
+++ b/docs/el/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/search.html
+++ b/docs/el/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/el/support/index.html
+++ b/docs/el/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/synchronise/basemaps.html
+++ b/docs/el/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/synchronise/index.html
+++ b/docs/el/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/synchronise/movable-project.html
+++ b/docs/el/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/synchronise/qfieldcloud.html
+++ b/docs/el/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/el/synchronise/qfieldsync.html
+++ b/docs/el/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/case-studies/ecological-surveying.html
+++ b/docs/en/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/case-studies/geologic-mapping.html
+++ b/docs/en/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/case-studies/index.html
+++ b/docs/en/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/case-studies/lulc-mapping-fiji.html
+++ b/docs/en/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/en/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/en/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/case-studies/river-state-survey.html
+++ b/docs/en/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/case-studies/rwanda-rural-water.html
+++ b/docs/en/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/case-studies/vanilla-survey.html
+++ b/docs/en/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/data-formats/index.html
+++ b/docs/en/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/fieldwork/digitize.html
+++ b/docs/en/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/fieldwork/gps.html
+++ b/docs/en/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/fieldwork/index.html
+++ b/docs/en/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/fieldwork/live_default_value.html
+++ b/docs/en/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/fieldwork/map-interaction.html
+++ b/docs/en/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/fieldwork/map-themes.html
+++ b/docs/en/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/fieldwork/opening_individual_data.html
+++ b/docs/en/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/fieldwork/print-to-pdf.html
+++ b/docs/en/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/fieldwork/projects.html
+++ b/docs/en/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/fieldwork/search.html
+++ b/docs/en/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/fieldwork/track_lines_polygons.html
+++ b/docs/en/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/fieldwork/variables.html
+++ b/docs/en/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/genindex.html
+++ b/docs/en/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/en/getting-started/index.html
+++ b/docs/en/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/index.html
+++ b/docs/en/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/en/install/index.html
+++ b/docs/en/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/old-doc/case-studies/ecological-surveying.html
+++ b/docs/en/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/en/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/en/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/en/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/en/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/en/old-doc/case-studies/river-state-survey.html
+++ b/docs/en/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/en/old-doc/concepts/index.html
+++ b/docs/en/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/en/old-doc/development/index.html
+++ b/docs/en/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/en/old-doc/index.html
+++ b/docs/en/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/old-doc/installation-guide/index.html
+++ b/docs/en/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/en/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/en/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/en/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/en/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/en/old-doc/project-management/android-data-structure.html
+++ b/docs/en/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/en/old-doc/project-management/configure-search.html
+++ b/docs/en/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/en/old-doc/project-management/dataformat.html
+++ b/docs/en/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/en/old-doc/project-management/index.html
+++ b/docs/en/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/en/old-doc/project-management/map-themes.html
+++ b/docs/en/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/en/old-doc/project-management/portable-project.html
+++ b/docs/en/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/en/old-doc/project-management/print-to-pdf.html
+++ b/docs/en/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/en/old-doc/project-management/project-selection.html
+++ b/docs/en/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/en/old-doc/project-management/vector-layers.html
+++ b/docs/en/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/en/old-doc/qfieldsync/index.html
+++ b/docs/en/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/en/old-doc/user-guide/index.html
+++ b/docs/en/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/en/old-doc/user-guide/map-themes.html
+++ b/docs/en/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/en/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/en/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/en/old-doc/user-guide/variables.html
+++ b/docs/en/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/en/prepare/add-1-n-pictures.html
+++ b/docs/en/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/prepare/advanced.html
+++ b/docs/en/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/prepare/allow-hiding-legend-nodes.html
+++ b/docs/en/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/prepare/attributes-form.html
+++ b/docs/en/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/prepare/authentication.html
+++ b/docs/en/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/prepare/change-fonts.html
+++ b/docs/en/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/prepare/custom-svg.html
+++ b/docs/en/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/prepare/display-expression.html
+++ b/docs/en/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/prepare/gnss.html
+++ b/docs/en/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/prepare/index.html
+++ b/docs/en/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/prepare/live_default_value.html
+++ b/docs/en/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/prepare/map-styling-configuration.html
+++ b/docs/en/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/prepare/map-themes.html
+++ b/docs/en/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/prepare/outside-layers.html
+++ b/docs/en/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/prepare/picture_path.html
+++ b/docs/en/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/search.html
+++ b/docs/en/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/en/support/index.html
+++ b/docs/en/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/synchronise/basemaps.html
+++ b/docs/en/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/synchronise/index.html
+++ b/docs/en/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/synchronise/movable-project.html
+++ b/docs/en/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/synchronise/qfieldcloud.html
+++ b/docs/en/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/en/synchronise/qfieldsync.html
+++ b/docs/en/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/case-studies/ecological-surveying.html
+++ b/docs/es/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/case-studies/geologic-mapping.html
+++ b/docs/es/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/case-studies/index.html
+++ b/docs/es/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/case-studies/lulc-mapping-fiji.html
+++ b/docs/es/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/es/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/es/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/case-studies/river-state-survey.html
+++ b/docs/es/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/case-studies/rwanda-rural-water.html
+++ b/docs/es/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/case-studies/vanilla-survey.html
+++ b/docs/es/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/data-formats/index.html
+++ b/docs/es/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/fieldwork/digitize.html
+++ b/docs/es/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/fieldwork/gps.html
+++ b/docs/es/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/fieldwork/index.html
+++ b/docs/es/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/fieldwork/live_default_value.html
+++ b/docs/es/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/fieldwork/map-interaction.html
+++ b/docs/es/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/fieldwork/map-themes.html
+++ b/docs/es/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/fieldwork/opening_individual_data.html
+++ b/docs/es/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/fieldwork/print-to-pdf.html
+++ b/docs/es/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/fieldwork/projects.html
+++ b/docs/es/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/fieldwork/search.html
+++ b/docs/es/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/fieldwork/track_lines_polygons.html
+++ b/docs/es/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/fieldwork/variables.html
+++ b/docs/es/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/genindex.html
+++ b/docs/es/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/es/getting-started/index.html
+++ b/docs/es/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/index.html
+++ b/docs/es/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/es/install/index.html
+++ b/docs/es/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/old-doc/case-studies/ecological-surveying.html
+++ b/docs/es/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/es/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/es/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/es/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/es/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/es/old-doc/case-studies/river-state-survey.html
+++ b/docs/es/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/es/old-doc/concepts/index.html
+++ b/docs/es/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/es/old-doc/development/index.html
+++ b/docs/es/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/es/old-doc/index.html
+++ b/docs/es/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/old-doc/installation-guide/index.html
+++ b/docs/es/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/es/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/es/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/es/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/es/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/es/old-doc/project-management/android-data-structure.html
+++ b/docs/es/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/es/old-doc/project-management/configure-search.html
+++ b/docs/es/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/es/old-doc/project-management/dataformat.html
+++ b/docs/es/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/es/old-doc/project-management/index.html
+++ b/docs/es/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/es/old-doc/project-management/map-themes.html
+++ b/docs/es/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/es/old-doc/project-management/portable-project.html
+++ b/docs/es/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/es/old-doc/project-management/print-to-pdf.html
+++ b/docs/es/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/es/old-doc/project-management/project-selection.html
+++ b/docs/es/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/es/old-doc/project-management/vector-layers.html
+++ b/docs/es/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/es/old-doc/qfieldsync/index.html
+++ b/docs/es/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/es/old-doc/user-guide/index.html
+++ b/docs/es/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/es/old-doc/user-guide/map-themes.html
+++ b/docs/es/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/es/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/es/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/es/old-doc/user-guide/variables.html
+++ b/docs/es/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/es/prepare/add-1-n-pictures.html
+++ b/docs/es/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/prepare/advanced.html
+++ b/docs/es/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/prepare/allow-hiding-legend-nodes.html
+++ b/docs/es/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/prepare/attributes-form.html
+++ b/docs/es/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/prepare/authentication.html
+++ b/docs/es/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/prepare/change-fonts.html
+++ b/docs/es/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/prepare/custom-svg.html
+++ b/docs/es/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/prepare/display-expression.html
+++ b/docs/es/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/prepare/gnss.html
+++ b/docs/es/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/prepare/index.html
+++ b/docs/es/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/prepare/live_default_value.html
+++ b/docs/es/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/prepare/map-styling-configuration.html
+++ b/docs/es/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/prepare/map-themes.html
+++ b/docs/es/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/prepare/outside-layers.html
+++ b/docs/es/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/prepare/picture_path.html
+++ b/docs/es/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/search.html
+++ b/docs/es/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/es/support/index.html
+++ b/docs/es/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/synchronise/basemaps.html
+++ b/docs/es/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/synchronise/index.html
+++ b/docs/es/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/synchronise/movable-project.html
+++ b/docs/es/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/synchronise/qfieldcloud.html
+++ b/docs/es/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/es/synchronise/qfieldsync.html
+++ b/docs/es/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/case-studies/ecological-surveying.html
+++ b/docs/et/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/case-studies/geologic-mapping.html
+++ b/docs/et/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/case-studies/index.html
+++ b/docs/et/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/case-studies/lulc-mapping-fiji.html
+++ b/docs/et/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/et/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/et/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/case-studies/river-state-survey.html
+++ b/docs/et/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/case-studies/rwanda-rural-water.html
+++ b/docs/et/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/case-studies/vanilla-survey.html
+++ b/docs/et/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/data-formats/index.html
+++ b/docs/et/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/fieldwork/digitize.html
+++ b/docs/et/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/fieldwork/gps.html
+++ b/docs/et/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/fieldwork/index.html
+++ b/docs/et/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/fieldwork/live_default_value.html
+++ b/docs/et/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/fieldwork/map-interaction.html
+++ b/docs/et/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/fieldwork/map-themes.html
+++ b/docs/et/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/fieldwork/opening_individual_data.html
+++ b/docs/et/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/fieldwork/print-to-pdf.html
+++ b/docs/et/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/fieldwork/projects.html
+++ b/docs/et/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/fieldwork/search.html
+++ b/docs/et/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/fieldwork/track_lines_polygons.html
+++ b/docs/et/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/fieldwork/variables.html
+++ b/docs/et/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/genindex.html
+++ b/docs/et/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/et/getting-started/index.html
+++ b/docs/et/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/index.html
+++ b/docs/et/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/et/install/index.html
+++ b/docs/et/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/old-doc/case-studies/ecological-surveying.html
+++ b/docs/et/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/et/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/et/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/et/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/et/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/et/old-doc/case-studies/river-state-survey.html
+++ b/docs/et/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/et/old-doc/concepts/index.html
+++ b/docs/et/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/et/old-doc/development/index.html
+++ b/docs/et/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/et/old-doc/index.html
+++ b/docs/et/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/old-doc/installation-guide/index.html
+++ b/docs/et/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/et/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/et/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/et/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/et/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/et/old-doc/project-management/android-data-structure.html
+++ b/docs/et/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/et/old-doc/project-management/configure-search.html
+++ b/docs/et/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/et/old-doc/project-management/dataformat.html
+++ b/docs/et/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/et/old-doc/project-management/index.html
+++ b/docs/et/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/et/old-doc/project-management/map-themes.html
+++ b/docs/et/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/et/old-doc/project-management/portable-project.html
+++ b/docs/et/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/et/old-doc/project-management/print-to-pdf.html
+++ b/docs/et/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/et/old-doc/project-management/project-selection.html
+++ b/docs/et/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/et/old-doc/project-management/vector-layers.html
+++ b/docs/et/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/et/old-doc/qfieldsync/index.html
+++ b/docs/et/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/et/old-doc/user-guide/index.html
+++ b/docs/et/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/et/old-doc/user-guide/map-themes.html
+++ b/docs/et/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/et/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/et/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/et/old-doc/user-guide/variables.html
+++ b/docs/et/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/et/prepare/add-1-n-pictures.html
+++ b/docs/et/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/prepare/advanced.html
+++ b/docs/et/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/prepare/allow-hiding-legend-nodes.html
+++ b/docs/et/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/prepare/attributes-form.html
+++ b/docs/et/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/prepare/authentication.html
+++ b/docs/et/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/prepare/change-fonts.html
+++ b/docs/et/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/prepare/custom-svg.html
+++ b/docs/et/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/prepare/display-expression.html
+++ b/docs/et/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/prepare/gnss.html
+++ b/docs/et/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/prepare/index.html
+++ b/docs/et/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/prepare/live_default_value.html
+++ b/docs/et/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/prepare/map-styling-configuration.html
+++ b/docs/et/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/prepare/map-themes.html
+++ b/docs/et/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/prepare/outside-layers.html
+++ b/docs/et/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/prepare/picture_path.html
+++ b/docs/et/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/search.html
+++ b/docs/et/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/et/support/index.html
+++ b/docs/et/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/synchronise/basemaps.html
+++ b/docs/et/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/synchronise/index.html
+++ b/docs/et/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/synchronise/movable-project.html
+++ b/docs/et/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/synchronise/qfieldcloud.html
+++ b/docs/et/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/et/synchronise/qfieldsync.html
+++ b/docs/et/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/case-studies/ecological-surveying.html
+++ b/docs/eu/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/case-studies/geologic-mapping.html
+++ b/docs/eu/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/case-studies/index.html
+++ b/docs/eu/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/case-studies/lulc-mapping-fiji.html
+++ b/docs/eu/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/eu/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/eu/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/case-studies/river-state-survey.html
+++ b/docs/eu/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/case-studies/rwanda-rural-water.html
+++ b/docs/eu/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/case-studies/vanilla-survey.html
+++ b/docs/eu/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/data-formats/index.html
+++ b/docs/eu/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/fieldwork/digitize.html
+++ b/docs/eu/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/fieldwork/gps.html
+++ b/docs/eu/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/fieldwork/index.html
+++ b/docs/eu/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/fieldwork/live_default_value.html
+++ b/docs/eu/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/fieldwork/map-interaction.html
+++ b/docs/eu/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/fieldwork/map-themes.html
+++ b/docs/eu/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/fieldwork/opening_individual_data.html
+++ b/docs/eu/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/fieldwork/print-to-pdf.html
+++ b/docs/eu/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/fieldwork/projects.html
+++ b/docs/eu/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/fieldwork/search.html
+++ b/docs/eu/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/fieldwork/track_lines_polygons.html
+++ b/docs/eu/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/fieldwork/variables.html
+++ b/docs/eu/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/genindex.html
+++ b/docs/eu/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/eu/getting-started/index.html
+++ b/docs/eu/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/index.html
+++ b/docs/eu/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/eu/install/index.html
+++ b/docs/eu/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/old-doc/case-studies/ecological-surveying.html
+++ b/docs/eu/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/eu/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/eu/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/eu/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/eu/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/eu/old-doc/case-studies/river-state-survey.html
+++ b/docs/eu/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/eu/old-doc/concepts/index.html
+++ b/docs/eu/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/eu/old-doc/development/index.html
+++ b/docs/eu/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/eu/old-doc/index.html
+++ b/docs/eu/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/old-doc/installation-guide/index.html
+++ b/docs/eu/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/eu/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/eu/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/eu/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/eu/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/eu/old-doc/project-management/android-data-structure.html
+++ b/docs/eu/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/eu/old-doc/project-management/configure-search.html
+++ b/docs/eu/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/eu/old-doc/project-management/dataformat.html
+++ b/docs/eu/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/eu/old-doc/project-management/index.html
+++ b/docs/eu/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/eu/old-doc/project-management/map-themes.html
+++ b/docs/eu/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/eu/old-doc/project-management/portable-project.html
+++ b/docs/eu/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/eu/old-doc/project-management/print-to-pdf.html
+++ b/docs/eu/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/eu/old-doc/project-management/project-selection.html
+++ b/docs/eu/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/eu/old-doc/project-management/vector-layers.html
+++ b/docs/eu/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/eu/old-doc/qfieldsync/index.html
+++ b/docs/eu/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/eu/old-doc/user-guide/index.html
+++ b/docs/eu/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/eu/old-doc/user-guide/map-themes.html
+++ b/docs/eu/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/eu/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/eu/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/eu/old-doc/user-guide/variables.html
+++ b/docs/eu/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/eu/prepare/add-1-n-pictures.html
+++ b/docs/eu/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/prepare/advanced.html
+++ b/docs/eu/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/prepare/allow-hiding-legend-nodes.html
+++ b/docs/eu/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/prepare/attributes-form.html
+++ b/docs/eu/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/prepare/authentication.html
+++ b/docs/eu/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/prepare/change-fonts.html
+++ b/docs/eu/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/prepare/custom-svg.html
+++ b/docs/eu/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/prepare/display-expression.html
+++ b/docs/eu/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/prepare/gnss.html
+++ b/docs/eu/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/prepare/index.html
+++ b/docs/eu/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/prepare/live_default_value.html
+++ b/docs/eu/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/prepare/map-styling-configuration.html
+++ b/docs/eu/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/prepare/map-themes.html
+++ b/docs/eu/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/prepare/outside-layers.html
+++ b/docs/eu/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/prepare/picture_path.html
+++ b/docs/eu/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/search.html
+++ b/docs/eu/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/eu/support/index.html
+++ b/docs/eu/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/synchronise/basemaps.html
+++ b/docs/eu/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/synchronise/index.html
+++ b/docs/eu/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/synchronise/movable-project.html
+++ b/docs/eu/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/synchronise/qfieldcloud.html
+++ b/docs/eu/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/eu/synchronise/qfieldsync.html
+++ b/docs/eu/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/case-studies/ecological-surveying.html
+++ b/docs/fa/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/case-studies/geologic-mapping.html
+++ b/docs/fa/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/case-studies/index.html
+++ b/docs/fa/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/case-studies/lulc-mapping-fiji.html
+++ b/docs/fa/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/fa/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/fa/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/case-studies/river-state-survey.html
+++ b/docs/fa/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/case-studies/rwanda-rural-water.html
+++ b/docs/fa/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/case-studies/vanilla-survey.html
+++ b/docs/fa/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/data-formats/index.html
+++ b/docs/fa/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/fieldwork/digitize.html
+++ b/docs/fa/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/fieldwork/gps.html
+++ b/docs/fa/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/fieldwork/index.html
+++ b/docs/fa/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/fieldwork/live_default_value.html
+++ b/docs/fa/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/fieldwork/map-interaction.html
+++ b/docs/fa/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/fieldwork/map-themes.html
+++ b/docs/fa/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/fieldwork/opening_individual_data.html
+++ b/docs/fa/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/fieldwork/print-to-pdf.html
+++ b/docs/fa/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/fieldwork/projects.html
+++ b/docs/fa/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/fieldwork/search.html
+++ b/docs/fa/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/fieldwork/track_lines_polygons.html
+++ b/docs/fa/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/fieldwork/variables.html
+++ b/docs/fa/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/genindex.html
+++ b/docs/fa/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/fa/getting-started/index.html
+++ b/docs/fa/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/index.html
+++ b/docs/fa/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/fa/install/index.html
+++ b/docs/fa/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/old-doc/case-studies/ecological-surveying.html
+++ b/docs/fa/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fa/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/fa/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fa/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/fa/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fa/old-doc/case-studies/river-state-survey.html
+++ b/docs/fa/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fa/old-doc/concepts/index.html
+++ b/docs/fa/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fa/old-doc/development/index.html
+++ b/docs/fa/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fa/old-doc/index.html
+++ b/docs/fa/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/old-doc/installation-guide/index.html
+++ b/docs/fa/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fa/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/fa/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fa/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/fa/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fa/old-doc/project-management/android-data-structure.html
+++ b/docs/fa/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fa/old-doc/project-management/configure-search.html
+++ b/docs/fa/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fa/old-doc/project-management/dataformat.html
+++ b/docs/fa/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fa/old-doc/project-management/index.html
+++ b/docs/fa/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fa/old-doc/project-management/map-themes.html
+++ b/docs/fa/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fa/old-doc/project-management/portable-project.html
+++ b/docs/fa/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fa/old-doc/project-management/print-to-pdf.html
+++ b/docs/fa/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fa/old-doc/project-management/project-selection.html
+++ b/docs/fa/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fa/old-doc/project-management/vector-layers.html
+++ b/docs/fa/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fa/old-doc/qfieldsync/index.html
+++ b/docs/fa/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fa/old-doc/user-guide/index.html
+++ b/docs/fa/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fa/old-doc/user-guide/map-themes.html
+++ b/docs/fa/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fa/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/fa/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fa/old-doc/user-guide/variables.html
+++ b/docs/fa/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fa/prepare/add-1-n-pictures.html
+++ b/docs/fa/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/prepare/advanced.html
+++ b/docs/fa/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/prepare/allow-hiding-legend-nodes.html
+++ b/docs/fa/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/prepare/attributes-form.html
+++ b/docs/fa/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/prepare/authentication.html
+++ b/docs/fa/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/prepare/change-fonts.html
+++ b/docs/fa/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/prepare/custom-svg.html
+++ b/docs/fa/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/prepare/display-expression.html
+++ b/docs/fa/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/prepare/gnss.html
+++ b/docs/fa/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/prepare/index.html
+++ b/docs/fa/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/prepare/live_default_value.html
+++ b/docs/fa/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/prepare/map-styling-configuration.html
+++ b/docs/fa/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/prepare/map-themes.html
+++ b/docs/fa/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/prepare/outside-layers.html
+++ b/docs/fa/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/prepare/picture_path.html
+++ b/docs/fa/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/search.html
+++ b/docs/fa/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/fa/support/index.html
+++ b/docs/fa/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/synchronise/basemaps.html
+++ b/docs/fa/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/synchronise/index.html
+++ b/docs/fa/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/synchronise/movable-project.html
+++ b/docs/fa/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/synchronise/qfieldcloud.html
+++ b/docs/fa/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fa/synchronise/qfieldsync.html
+++ b/docs/fa/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/case-studies/ecological-surveying.html
+++ b/docs/fi/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/case-studies/geologic-mapping.html
+++ b/docs/fi/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/case-studies/index.html
+++ b/docs/fi/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/case-studies/lulc-mapping-fiji.html
+++ b/docs/fi/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/fi/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/fi/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/case-studies/river-state-survey.html
+++ b/docs/fi/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/case-studies/rwanda-rural-water.html
+++ b/docs/fi/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/case-studies/vanilla-survey.html
+++ b/docs/fi/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/data-formats/index.html
+++ b/docs/fi/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/fieldwork/digitize.html
+++ b/docs/fi/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/fieldwork/gps.html
+++ b/docs/fi/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/fieldwork/index.html
+++ b/docs/fi/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/fieldwork/live_default_value.html
+++ b/docs/fi/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/fieldwork/map-interaction.html
+++ b/docs/fi/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/fieldwork/map-themes.html
+++ b/docs/fi/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/fieldwork/opening_individual_data.html
+++ b/docs/fi/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/fieldwork/print-to-pdf.html
+++ b/docs/fi/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/fieldwork/projects.html
+++ b/docs/fi/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/fieldwork/search.html
+++ b/docs/fi/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/fieldwork/track_lines_polygons.html
+++ b/docs/fi/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/fieldwork/variables.html
+++ b/docs/fi/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/genindex.html
+++ b/docs/fi/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/fi/getting-started/index.html
+++ b/docs/fi/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/index.html
+++ b/docs/fi/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/fi/install/index.html
+++ b/docs/fi/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/old-doc/case-studies/ecological-surveying.html
+++ b/docs/fi/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fi/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/fi/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fi/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/fi/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fi/old-doc/case-studies/river-state-survey.html
+++ b/docs/fi/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fi/old-doc/concepts/index.html
+++ b/docs/fi/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fi/old-doc/development/index.html
+++ b/docs/fi/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fi/old-doc/index.html
+++ b/docs/fi/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/old-doc/installation-guide/index.html
+++ b/docs/fi/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fi/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/fi/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fi/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/fi/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fi/old-doc/project-management/android-data-structure.html
+++ b/docs/fi/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fi/old-doc/project-management/configure-search.html
+++ b/docs/fi/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fi/old-doc/project-management/dataformat.html
+++ b/docs/fi/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fi/old-doc/project-management/index.html
+++ b/docs/fi/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fi/old-doc/project-management/map-themes.html
+++ b/docs/fi/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fi/old-doc/project-management/portable-project.html
+++ b/docs/fi/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fi/old-doc/project-management/print-to-pdf.html
+++ b/docs/fi/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fi/old-doc/project-management/project-selection.html
+++ b/docs/fi/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fi/old-doc/project-management/vector-layers.html
+++ b/docs/fi/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fi/old-doc/qfieldsync/index.html
+++ b/docs/fi/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fi/old-doc/user-guide/index.html
+++ b/docs/fi/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fi/old-doc/user-guide/map-themes.html
+++ b/docs/fi/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fi/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/fi/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fi/old-doc/user-guide/variables.html
+++ b/docs/fi/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fi/prepare/add-1-n-pictures.html
+++ b/docs/fi/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/prepare/advanced.html
+++ b/docs/fi/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/prepare/allow-hiding-legend-nodes.html
+++ b/docs/fi/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/prepare/attributes-form.html
+++ b/docs/fi/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/prepare/authentication.html
+++ b/docs/fi/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/prepare/change-fonts.html
+++ b/docs/fi/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/prepare/custom-svg.html
+++ b/docs/fi/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/prepare/display-expression.html
+++ b/docs/fi/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/prepare/gnss.html
+++ b/docs/fi/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/prepare/index.html
+++ b/docs/fi/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/prepare/live_default_value.html
+++ b/docs/fi/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/prepare/map-styling-configuration.html
+++ b/docs/fi/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/prepare/map-themes.html
+++ b/docs/fi/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/prepare/outside-layers.html
+++ b/docs/fi/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/prepare/picture_path.html
+++ b/docs/fi/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/search.html
+++ b/docs/fi/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/fi/support/index.html
+++ b/docs/fi/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/synchronise/basemaps.html
+++ b/docs/fi/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/synchronise/index.html
+++ b/docs/fi/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/synchronise/movable-project.html
+++ b/docs/fi/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/synchronise/qfieldcloud.html
+++ b/docs/fi/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fi/synchronise/qfieldsync.html
+++ b/docs/fi/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fieldwork/digitize.html
+++ b/docs/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fieldwork/gps.html
+++ b/docs/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fieldwork/index.html
+++ b/docs/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fieldwork/live_default_value.html
+++ b/docs/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fieldwork/map-interaction.html
+++ b/docs/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fieldwork/map-themes.html
+++ b/docs/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fieldwork/opening_individual_data.html
+++ b/docs/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fieldwork/print-to-pdf.html
+++ b/docs/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fieldwork/projects.html
+++ b/docs/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fieldwork/search.html
+++ b/docs/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fieldwork/track_lines_polygons.html
+++ b/docs/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fieldwork/variables.html
+++ b/docs/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/case-studies/ecological-surveying.html
+++ b/docs/fr/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/case-studies/geologic-mapping.html
+++ b/docs/fr/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/case-studies/index.html
+++ b/docs/fr/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/case-studies/lulc-mapping-fiji.html
+++ b/docs/fr/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/fr/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/fr/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/case-studies/river-state-survey.html
+++ b/docs/fr/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/case-studies/rwanda-rural-water.html
+++ b/docs/fr/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/case-studies/vanilla-survey.html
+++ b/docs/fr/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/data-formats/index.html
+++ b/docs/fr/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/fieldwork/digitize.html
+++ b/docs/fr/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/fieldwork/gps.html
+++ b/docs/fr/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/fieldwork/index.html
+++ b/docs/fr/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/fieldwork/live_default_value.html
+++ b/docs/fr/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/fieldwork/map-interaction.html
+++ b/docs/fr/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/fieldwork/map-themes.html
+++ b/docs/fr/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/fieldwork/opening_individual_data.html
+++ b/docs/fr/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/fieldwork/print-to-pdf.html
+++ b/docs/fr/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/fieldwork/projects.html
+++ b/docs/fr/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/fieldwork/search.html
+++ b/docs/fr/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/fieldwork/track_lines_polygons.html
+++ b/docs/fr/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/fieldwork/variables.html
+++ b/docs/fr/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/genindex.html
+++ b/docs/fr/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/fr/getting-started/index.html
+++ b/docs/fr/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/index.html
+++ b/docs/fr/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/fr/install/index.html
+++ b/docs/fr/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/old-doc/case-studies/ecological-surveying.html
+++ b/docs/fr/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fr/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/fr/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fr/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/fr/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fr/old-doc/case-studies/river-state-survey.html
+++ b/docs/fr/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fr/old-doc/concepts/index.html
+++ b/docs/fr/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fr/old-doc/development/index.html
+++ b/docs/fr/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fr/old-doc/index.html
+++ b/docs/fr/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/old-doc/installation-guide/index.html
+++ b/docs/fr/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fr/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/fr/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fr/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/fr/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fr/old-doc/project-management/android-data-structure.html
+++ b/docs/fr/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fr/old-doc/project-management/configure-search.html
+++ b/docs/fr/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fr/old-doc/project-management/dataformat.html
+++ b/docs/fr/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fr/old-doc/project-management/index.html
+++ b/docs/fr/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fr/old-doc/project-management/map-themes.html
+++ b/docs/fr/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fr/old-doc/project-management/portable-project.html
+++ b/docs/fr/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fr/old-doc/project-management/print-to-pdf.html
+++ b/docs/fr/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fr/old-doc/project-management/project-selection.html
+++ b/docs/fr/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fr/old-doc/project-management/vector-layers.html
+++ b/docs/fr/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fr/old-doc/qfieldsync/index.html
+++ b/docs/fr/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fr/old-doc/user-guide/index.html
+++ b/docs/fr/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fr/old-doc/user-guide/map-themes.html
+++ b/docs/fr/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fr/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/fr/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fr/old-doc/user-guide/variables.html
+++ b/docs/fr/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/fr/prepare/add-1-n-pictures.html
+++ b/docs/fr/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/prepare/advanced.html
+++ b/docs/fr/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/prepare/allow-hiding-legend-nodes.html
+++ b/docs/fr/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/prepare/attributes-form.html
+++ b/docs/fr/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/prepare/authentication.html
+++ b/docs/fr/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/prepare/change-fonts.html
+++ b/docs/fr/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/prepare/custom-svg.html
+++ b/docs/fr/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/prepare/display-expression.html
+++ b/docs/fr/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/prepare/gnss.html
+++ b/docs/fr/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/prepare/index.html
+++ b/docs/fr/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/prepare/live_default_value.html
+++ b/docs/fr/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/prepare/map-styling-configuration.html
+++ b/docs/fr/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/prepare/map-themes.html
+++ b/docs/fr/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/prepare/outside-layers.html
+++ b/docs/fr/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/prepare/picture_path.html
+++ b/docs/fr/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/search.html
+++ b/docs/fr/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/fr/support/index.html
+++ b/docs/fr/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/synchronise/basemaps.html
+++ b/docs/fr/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/synchronise/index.html
+++ b/docs/fr/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/synchronise/movable-project.html
+++ b/docs/fr/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/synchronise/qfieldcloud.html
+++ b/docs/fr/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/fr/synchronise/qfieldsync.html
+++ b/docs/fr/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/genindex.html
+++ b/docs/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/getting-started/index.html
+++ b/docs/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/case-studies/ecological-surveying.html
+++ b/docs/gl/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/case-studies/geologic-mapping.html
+++ b/docs/gl/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/case-studies/index.html
+++ b/docs/gl/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/case-studies/lulc-mapping-fiji.html
+++ b/docs/gl/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/gl/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/gl/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/case-studies/river-state-survey.html
+++ b/docs/gl/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/case-studies/rwanda-rural-water.html
+++ b/docs/gl/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/case-studies/vanilla-survey.html
+++ b/docs/gl/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/data-formats/index.html
+++ b/docs/gl/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/fieldwork/digitize.html
+++ b/docs/gl/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/fieldwork/gps.html
+++ b/docs/gl/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/fieldwork/index.html
+++ b/docs/gl/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/fieldwork/live_default_value.html
+++ b/docs/gl/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/fieldwork/map-interaction.html
+++ b/docs/gl/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/fieldwork/map-themes.html
+++ b/docs/gl/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/fieldwork/opening_individual_data.html
+++ b/docs/gl/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/fieldwork/print-to-pdf.html
+++ b/docs/gl/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/fieldwork/projects.html
+++ b/docs/gl/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/fieldwork/search.html
+++ b/docs/gl/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/fieldwork/track_lines_polygons.html
+++ b/docs/gl/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/fieldwork/variables.html
+++ b/docs/gl/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/genindex.html
+++ b/docs/gl/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/gl/getting-started/index.html
+++ b/docs/gl/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/index.html
+++ b/docs/gl/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/gl/install/index.html
+++ b/docs/gl/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/old-doc/case-studies/ecological-surveying.html
+++ b/docs/gl/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/gl/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/gl/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/gl/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/gl/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/gl/old-doc/case-studies/river-state-survey.html
+++ b/docs/gl/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/gl/old-doc/concepts/index.html
+++ b/docs/gl/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/gl/old-doc/development/index.html
+++ b/docs/gl/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/gl/old-doc/index.html
+++ b/docs/gl/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/old-doc/installation-guide/index.html
+++ b/docs/gl/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/gl/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/gl/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/gl/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/gl/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/gl/old-doc/project-management/android-data-structure.html
+++ b/docs/gl/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/gl/old-doc/project-management/configure-search.html
+++ b/docs/gl/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/gl/old-doc/project-management/dataformat.html
+++ b/docs/gl/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/gl/old-doc/project-management/index.html
+++ b/docs/gl/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/gl/old-doc/project-management/map-themes.html
+++ b/docs/gl/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/gl/old-doc/project-management/portable-project.html
+++ b/docs/gl/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/gl/old-doc/project-management/print-to-pdf.html
+++ b/docs/gl/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/gl/old-doc/project-management/project-selection.html
+++ b/docs/gl/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/gl/old-doc/project-management/vector-layers.html
+++ b/docs/gl/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/gl/old-doc/qfieldsync/index.html
+++ b/docs/gl/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/gl/old-doc/user-guide/index.html
+++ b/docs/gl/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/gl/old-doc/user-guide/map-themes.html
+++ b/docs/gl/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/gl/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/gl/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/gl/old-doc/user-guide/variables.html
+++ b/docs/gl/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/gl/prepare/add-1-n-pictures.html
+++ b/docs/gl/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/prepare/advanced.html
+++ b/docs/gl/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/prepare/allow-hiding-legend-nodes.html
+++ b/docs/gl/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/prepare/attributes-form.html
+++ b/docs/gl/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/prepare/authentication.html
+++ b/docs/gl/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/prepare/change-fonts.html
+++ b/docs/gl/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/prepare/custom-svg.html
+++ b/docs/gl/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/prepare/display-expression.html
+++ b/docs/gl/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/prepare/gnss.html
+++ b/docs/gl/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/prepare/index.html
+++ b/docs/gl/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/prepare/live_default_value.html
+++ b/docs/gl/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/prepare/map-styling-configuration.html
+++ b/docs/gl/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/prepare/map-themes.html
+++ b/docs/gl/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/prepare/outside-layers.html
+++ b/docs/gl/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/prepare/picture_path.html
+++ b/docs/gl/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/search.html
+++ b/docs/gl/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/gl/support/index.html
+++ b/docs/gl/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/synchronise/basemaps.html
+++ b/docs/gl/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/synchronise/index.html
+++ b/docs/gl/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/synchronise/movable-project.html
+++ b/docs/gl/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/synchronise/qfieldcloud.html
+++ b/docs/gl/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/gl/synchronise/qfieldsync.html
+++ b/docs/gl/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/case-studies/ecological-surveying.html
+++ b/docs/he/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/case-studies/geologic-mapping.html
+++ b/docs/he/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/case-studies/index.html
+++ b/docs/he/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/case-studies/lulc-mapping-fiji.html
+++ b/docs/he/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/he/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/he/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/case-studies/river-state-survey.html
+++ b/docs/he/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/case-studies/rwanda-rural-water.html
+++ b/docs/he/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/case-studies/vanilla-survey.html
+++ b/docs/he/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/data-formats/index.html
+++ b/docs/he/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/fieldwork/digitize.html
+++ b/docs/he/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/fieldwork/gps.html
+++ b/docs/he/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/fieldwork/index.html
+++ b/docs/he/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/fieldwork/live_default_value.html
+++ b/docs/he/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/fieldwork/map-interaction.html
+++ b/docs/he/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/fieldwork/map-themes.html
+++ b/docs/he/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/fieldwork/opening_individual_data.html
+++ b/docs/he/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/fieldwork/print-to-pdf.html
+++ b/docs/he/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/fieldwork/projects.html
+++ b/docs/he/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/fieldwork/search.html
+++ b/docs/he/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/fieldwork/track_lines_polygons.html
+++ b/docs/he/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/fieldwork/variables.html
+++ b/docs/he/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/genindex.html
+++ b/docs/he/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/he/getting-started/index.html
+++ b/docs/he/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/index.html
+++ b/docs/he/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/he/install/index.html
+++ b/docs/he/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/old-doc/case-studies/ecological-surveying.html
+++ b/docs/he/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/he/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/he/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/he/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/he/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/he/old-doc/case-studies/river-state-survey.html
+++ b/docs/he/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/he/old-doc/concepts/index.html
+++ b/docs/he/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/he/old-doc/development/index.html
+++ b/docs/he/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/he/old-doc/index.html
+++ b/docs/he/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/old-doc/installation-guide/index.html
+++ b/docs/he/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/he/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/he/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/he/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/he/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/he/old-doc/project-management/android-data-structure.html
+++ b/docs/he/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/he/old-doc/project-management/configure-search.html
+++ b/docs/he/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/he/old-doc/project-management/dataformat.html
+++ b/docs/he/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/he/old-doc/project-management/index.html
+++ b/docs/he/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/he/old-doc/project-management/map-themes.html
+++ b/docs/he/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/he/old-doc/project-management/portable-project.html
+++ b/docs/he/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/he/old-doc/project-management/print-to-pdf.html
+++ b/docs/he/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/he/old-doc/project-management/project-selection.html
+++ b/docs/he/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/he/old-doc/project-management/vector-layers.html
+++ b/docs/he/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/he/old-doc/qfieldsync/index.html
+++ b/docs/he/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/he/old-doc/user-guide/index.html
+++ b/docs/he/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/he/old-doc/user-guide/map-themes.html
+++ b/docs/he/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/he/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/he/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/he/old-doc/user-guide/variables.html
+++ b/docs/he/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/he/prepare/add-1-n-pictures.html
+++ b/docs/he/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/prepare/advanced.html
+++ b/docs/he/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/prepare/allow-hiding-legend-nodes.html
+++ b/docs/he/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/prepare/attributes-form.html
+++ b/docs/he/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/prepare/authentication.html
+++ b/docs/he/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/prepare/change-fonts.html
+++ b/docs/he/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/prepare/custom-svg.html
+++ b/docs/he/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/prepare/display-expression.html
+++ b/docs/he/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/prepare/gnss.html
+++ b/docs/he/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/prepare/index.html
+++ b/docs/he/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/prepare/live_default_value.html
+++ b/docs/he/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/prepare/map-styling-configuration.html
+++ b/docs/he/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/prepare/map-themes.html
+++ b/docs/he/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/prepare/outside-layers.html
+++ b/docs/he/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/prepare/picture_path.html
+++ b/docs/he/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/search.html
+++ b/docs/he/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/he/support/index.html
+++ b/docs/he/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/synchronise/basemaps.html
+++ b/docs/he/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/synchronise/index.html
+++ b/docs/he/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/synchronise/movable-project.html
+++ b/docs/he/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/synchronise/qfieldcloud.html
+++ b/docs/he/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/he/synchronise/qfieldsync.html
+++ b/docs/he/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/case-studies/ecological-surveying.html
+++ b/docs/hi/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/case-studies/geologic-mapping.html
+++ b/docs/hi/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/case-studies/index.html
+++ b/docs/hi/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/case-studies/lulc-mapping-fiji.html
+++ b/docs/hi/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/hi/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/hi/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/case-studies/river-state-survey.html
+++ b/docs/hi/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/case-studies/rwanda-rural-water.html
+++ b/docs/hi/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/case-studies/vanilla-survey.html
+++ b/docs/hi/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/data-formats/index.html
+++ b/docs/hi/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/fieldwork/digitize.html
+++ b/docs/hi/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/fieldwork/gps.html
+++ b/docs/hi/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/fieldwork/index.html
+++ b/docs/hi/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/fieldwork/live_default_value.html
+++ b/docs/hi/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/fieldwork/map-interaction.html
+++ b/docs/hi/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/fieldwork/map-themes.html
+++ b/docs/hi/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/fieldwork/opening_individual_data.html
+++ b/docs/hi/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/fieldwork/print-to-pdf.html
+++ b/docs/hi/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/fieldwork/projects.html
+++ b/docs/hi/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/fieldwork/search.html
+++ b/docs/hi/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/fieldwork/track_lines_polygons.html
+++ b/docs/hi/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/fieldwork/variables.html
+++ b/docs/hi/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/genindex.html
+++ b/docs/hi/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/hi/getting-started/index.html
+++ b/docs/hi/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/index.html
+++ b/docs/hi/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/hi/install/index.html
+++ b/docs/hi/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/old-doc/case-studies/ecological-surveying.html
+++ b/docs/hi/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hi/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/hi/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hi/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/hi/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hi/old-doc/case-studies/river-state-survey.html
+++ b/docs/hi/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hi/old-doc/concepts/index.html
+++ b/docs/hi/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hi/old-doc/development/index.html
+++ b/docs/hi/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hi/old-doc/index.html
+++ b/docs/hi/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/old-doc/installation-guide/index.html
+++ b/docs/hi/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hi/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/hi/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hi/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/hi/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hi/old-doc/project-management/android-data-structure.html
+++ b/docs/hi/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hi/old-doc/project-management/configure-search.html
+++ b/docs/hi/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hi/old-doc/project-management/dataformat.html
+++ b/docs/hi/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hi/old-doc/project-management/index.html
+++ b/docs/hi/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hi/old-doc/project-management/map-themes.html
+++ b/docs/hi/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hi/old-doc/project-management/portable-project.html
+++ b/docs/hi/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hi/old-doc/project-management/print-to-pdf.html
+++ b/docs/hi/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hi/old-doc/project-management/project-selection.html
+++ b/docs/hi/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hi/old-doc/project-management/vector-layers.html
+++ b/docs/hi/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hi/old-doc/qfieldsync/index.html
+++ b/docs/hi/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hi/old-doc/user-guide/index.html
+++ b/docs/hi/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hi/old-doc/user-guide/map-themes.html
+++ b/docs/hi/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hi/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/hi/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hi/old-doc/user-guide/variables.html
+++ b/docs/hi/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hi/prepare/add-1-n-pictures.html
+++ b/docs/hi/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/prepare/advanced.html
+++ b/docs/hi/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/prepare/allow-hiding-legend-nodes.html
+++ b/docs/hi/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/prepare/attributes-form.html
+++ b/docs/hi/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/prepare/authentication.html
+++ b/docs/hi/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/prepare/change-fonts.html
+++ b/docs/hi/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/prepare/custom-svg.html
+++ b/docs/hi/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/prepare/display-expression.html
+++ b/docs/hi/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/prepare/gnss.html
+++ b/docs/hi/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/prepare/index.html
+++ b/docs/hi/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/prepare/live_default_value.html
+++ b/docs/hi/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/prepare/map-styling-configuration.html
+++ b/docs/hi/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/prepare/map-themes.html
+++ b/docs/hi/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/prepare/outside-layers.html
+++ b/docs/hi/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/prepare/picture_path.html
+++ b/docs/hi/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/search.html
+++ b/docs/hi/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/hi/support/index.html
+++ b/docs/hi/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/synchronise/basemaps.html
+++ b/docs/hi/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/synchronise/index.html
+++ b/docs/hi/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/synchronise/movable-project.html
+++ b/docs/hi/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/synchronise/qfieldcloud.html
+++ b/docs/hi/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hi/synchronise/qfieldsync.html
+++ b/docs/hi/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/case-studies/ecological-surveying.html
+++ b/docs/hr/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/case-studies/geologic-mapping.html
+++ b/docs/hr/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/case-studies/index.html
+++ b/docs/hr/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/case-studies/lulc-mapping-fiji.html
+++ b/docs/hr/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/hr/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/hr/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/case-studies/river-state-survey.html
+++ b/docs/hr/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/case-studies/rwanda-rural-water.html
+++ b/docs/hr/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/case-studies/vanilla-survey.html
+++ b/docs/hr/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/data-formats/index.html
+++ b/docs/hr/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/fieldwork/digitize.html
+++ b/docs/hr/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/fieldwork/gps.html
+++ b/docs/hr/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/fieldwork/index.html
+++ b/docs/hr/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/fieldwork/live_default_value.html
+++ b/docs/hr/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/fieldwork/map-interaction.html
+++ b/docs/hr/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/fieldwork/map-themes.html
+++ b/docs/hr/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/fieldwork/opening_individual_data.html
+++ b/docs/hr/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/fieldwork/print-to-pdf.html
+++ b/docs/hr/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/fieldwork/projects.html
+++ b/docs/hr/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/fieldwork/search.html
+++ b/docs/hr/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/fieldwork/track_lines_polygons.html
+++ b/docs/hr/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/fieldwork/variables.html
+++ b/docs/hr/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/genindex.html
+++ b/docs/hr/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/hr/getting-started/index.html
+++ b/docs/hr/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/index.html
+++ b/docs/hr/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/hr/install/index.html
+++ b/docs/hr/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/old-doc/case-studies/ecological-surveying.html
+++ b/docs/hr/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hr/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/hr/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hr/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/hr/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hr/old-doc/case-studies/river-state-survey.html
+++ b/docs/hr/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hr/old-doc/concepts/index.html
+++ b/docs/hr/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hr/old-doc/development/index.html
+++ b/docs/hr/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hr/old-doc/index.html
+++ b/docs/hr/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/old-doc/installation-guide/index.html
+++ b/docs/hr/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hr/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/hr/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hr/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/hr/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hr/old-doc/project-management/android-data-structure.html
+++ b/docs/hr/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hr/old-doc/project-management/configure-search.html
+++ b/docs/hr/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hr/old-doc/project-management/dataformat.html
+++ b/docs/hr/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hr/old-doc/project-management/index.html
+++ b/docs/hr/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hr/old-doc/project-management/map-themes.html
+++ b/docs/hr/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hr/old-doc/project-management/portable-project.html
+++ b/docs/hr/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hr/old-doc/project-management/print-to-pdf.html
+++ b/docs/hr/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hr/old-doc/project-management/project-selection.html
+++ b/docs/hr/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hr/old-doc/project-management/vector-layers.html
+++ b/docs/hr/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hr/old-doc/qfieldsync/index.html
+++ b/docs/hr/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hr/old-doc/user-guide/index.html
+++ b/docs/hr/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hr/old-doc/user-guide/map-themes.html
+++ b/docs/hr/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hr/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/hr/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hr/old-doc/user-guide/variables.html
+++ b/docs/hr/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hr/prepare/add-1-n-pictures.html
+++ b/docs/hr/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/prepare/advanced.html
+++ b/docs/hr/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/prepare/allow-hiding-legend-nodes.html
+++ b/docs/hr/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/prepare/attributes-form.html
+++ b/docs/hr/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/prepare/authentication.html
+++ b/docs/hr/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/prepare/change-fonts.html
+++ b/docs/hr/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/prepare/custom-svg.html
+++ b/docs/hr/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/prepare/display-expression.html
+++ b/docs/hr/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/prepare/gnss.html
+++ b/docs/hr/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/prepare/index.html
+++ b/docs/hr/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/prepare/live_default_value.html
+++ b/docs/hr/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/prepare/map-styling-configuration.html
+++ b/docs/hr/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/prepare/map-themes.html
+++ b/docs/hr/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/prepare/outside-layers.html
+++ b/docs/hr/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/prepare/picture_path.html
+++ b/docs/hr/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/search.html
+++ b/docs/hr/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/hr/support/index.html
+++ b/docs/hr/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/synchronise/basemaps.html
+++ b/docs/hr/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/synchronise/index.html
+++ b/docs/hr/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/synchronise/movable-project.html
+++ b/docs/hr/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/synchronise/qfieldcloud.html
+++ b/docs/hr/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hr/synchronise/qfieldsync.html
+++ b/docs/hr/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/case-studies/ecological-surveying.html
+++ b/docs/hu/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/case-studies/geologic-mapping.html
+++ b/docs/hu/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/case-studies/index.html
+++ b/docs/hu/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/case-studies/lulc-mapping-fiji.html
+++ b/docs/hu/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/hu/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/hu/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/case-studies/river-state-survey.html
+++ b/docs/hu/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/case-studies/rwanda-rural-water.html
+++ b/docs/hu/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/case-studies/vanilla-survey.html
+++ b/docs/hu/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/data-formats/index.html
+++ b/docs/hu/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/fieldwork/digitize.html
+++ b/docs/hu/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/fieldwork/gps.html
+++ b/docs/hu/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/fieldwork/index.html
+++ b/docs/hu/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/fieldwork/live_default_value.html
+++ b/docs/hu/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/fieldwork/map-interaction.html
+++ b/docs/hu/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/fieldwork/map-themes.html
+++ b/docs/hu/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/fieldwork/opening_individual_data.html
+++ b/docs/hu/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/fieldwork/print-to-pdf.html
+++ b/docs/hu/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/fieldwork/projects.html
+++ b/docs/hu/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/fieldwork/search.html
+++ b/docs/hu/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/fieldwork/track_lines_polygons.html
+++ b/docs/hu/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/fieldwork/variables.html
+++ b/docs/hu/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/genindex.html
+++ b/docs/hu/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/hu/getting-started/index.html
+++ b/docs/hu/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/index.html
+++ b/docs/hu/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/hu/install/index.html
+++ b/docs/hu/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/old-doc/case-studies/ecological-surveying.html
+++ b/docs/hu/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hu/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/hu/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hu/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/hu/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hu/old-doc/case-studies/river-state-survey.html
+++ b/docs/hu/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hu/old-doc/concepts/index.html
+++ b/docs/hu/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hu/old-doc/development/index.html
+++ b/docs/hu/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hu/old-doc/index.html
+++ b/docs/hu/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/old-doc/installation-guide/index.html
+++ b/docs/hu/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hu/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/hu/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hu/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/hu/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hu/old-doc/project-management/android-data-structure.html
+++ b/docs/hu/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hu/old-doc/project-management/configure-search.html
+++ b/docs/hu/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hu/old-doc/project-management/dataformat.html
+++ b/docs/hu/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hu/old-doc/project-management/index.html
+++ b/docs/hu/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hu/old-doc/project-management/map-themes.html
+++ b/docs/hu/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hu/old-doc/project-management/portable-project.html
+++ b/docs/hu/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hu/old-doc/project-management/print-to-pdf.html
+++ b/docs/hu/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hu/old-doc/project-management/project-selection.html
+++ b/docs/hu/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hu/old-doc/project-management/vector-layers.html
+++ b/docs/hu/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hu/old-doc/qfieldsync/index.html
+++ b/docs/hu/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hu/old-doc/user-guide/index.html
+++ b/docs/hu/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hu/old-doc/user-guide/map-themes.html
+++ b/docs/hu/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hu/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/hu/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hu/old-doc/user-guide/variables.html
+++ b/docs/hu/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/hu/prepare/add-1-n-pictures.html
+++ b/docs/hu/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/prepare/advanced.html
+++ b/docs/hu/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/prepare/allow-hiding-legend-nodes.html
+++ b/docs/hu/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/prepare/attributes-form.html
+++ b/docs/hu/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/prepare/authentication.html
+++ b/docs/hu/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/prepare/change-fonts.html
+++ b/docs/hu/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/prepare/custom-svg.html
+++ b/docs/hu/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/prepare/display-expression.html
+++ b/docs/hu/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/prepare/gnss.html
+++ b/docs/hu/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/prepare/index.html
+++ b/docs/hu/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/prepare/live_default_value.html
+++ b/docs/hu/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/prepare/map-styling-configuration.html
+++ b/docs/hu/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/prepare/map-themes.html
+++ b/docs/hu/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/prepare/outside-layers.html
+++ b/docs/hu/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/prepare/picture_path.html
+++ b/docs/hu/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/search.html
+++ b/docs/hu/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/hu/support/index.html
+++ b/docs/hu/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/synchronise/basemaps.html
+++ b/docs/hu/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/synchronise/index.html
+++ b/docs/hu/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/synchronise/movable-project.html
+++ b/docs/hu/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/synchronise/qfieldcloud.html
+++ b/docs/hu/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/hu/synchronise/qfieldsync.html
+++ b/docs/hu/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/install/index.html
+++ b/docs/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/case-studies/ecological-surveying.html
+++ b/docs/it/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/case-studies/geologic-mapping.html
+++ b/docs/it/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/case-studies/index.html
+++ b/docs/it/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/case-studies/lulc-mapping-fiji.html
+++ b/docs/it/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/it/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/it/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/case-studies/river-state-survey.html
+++ b/docs/it/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/case-studies/rwanda-rural-water.html
+++ b/docs/it/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/case-studies/vanilla-survey.html
+++ b/docs/it/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/data-formats/index.html
+++ b/docs/it/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/fieldwork/digitize.html
+++ b/docs/it/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/fieldwork/gps.html
+++ b/docs/it/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/fieldwork/index.html
+++ b/docs/it/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/fieldwork/live_default_value.html
+++ b/docs/it/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/fieldwork/map-interaction.html
+++ b/docs/it/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/fieldwork/map-themes.html
+++ b/docs/it/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/fieldwork/opening_individual_data.html
+++ b/docs/it/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/fieldwork/print-to-pdf.html
+++ b/docs/it/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/fieldwork/projects.html
+++ b/docs/it/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/fieldwork/search.html
+++ b/docs/it/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/fieldwork/track_lines_polygons.html
+++ b/docs/it/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/fieldwork/variables.html
+++ b/docs/it/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/genindex.html
+++ b/docs/it/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/it/getting-started/index.html
+++ b/docs/it/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/index.html
+++ b/docs/it/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/it/install/index.html
+++ b/docs/it/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/old-doc/case-studies/ecological-surveying.html
+++ b/docs/it/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/it/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/it/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/it/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/it/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/it/old-doc/case-studies/river-state-survey.html
+++ b/docs/it/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/it/old-doc/concepts/index.html
+++ b/docs/it/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/it/old-doc/development/index.html
+++ b/docs/it/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/it/old-doc/index.html
+++ b/docs/it/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/old-doc/installation-guide/index.html
+++ b/docs/it/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/it/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/it/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/it/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/it/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/it/old-doc/project-management/android-data-structure.html
+++ b/docs/it/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/it/old-doc/project-management/configure-search.html
+++ b/docs/it/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/it/old-doc/project-management/dataformat.html
+++ b/docs/it/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/it/old-doc/project-management/index.html
+++ b/docs/it/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/it/old-doc/project-management/map-themes.html
+++ b/docs/it/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/it/old-doc/project-management/portable-project.html
+++ b/docs/it/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/it/old-doc/project-management/print-to-pdf.html
+++ b/docs/it/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/it/old-doc/project-management/project-selection.html
+++ b/docs/it/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/it/old-doc/project-management/vector-layers.html
+++ b/docs/it/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/it/old-doc/qfieldsync/index.html
+++ b/docs/it/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/it/old-doc/user-guide/index.html
+++ b/docs/it/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/it/old-doc/user-guide/map-themes.html
+++ b/docs/it/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/it/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/it/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/it/old-doc/user-guide/variables.html
+++ b/docs/it/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/it/prepare/add-1-n-pictures.html
+++ b/docs/it/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/prepare/advanced.html
+++ b/docs/it/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/prepare/allow-hiding-legend-nodes.html
+++ b/docs/it/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/prepare/attributes-form.html
+++ b/docs/it/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/prepare/authentication.html
+++ b/docs/it/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/prepare/change-fonts.html
+++ b/docs/it/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/prepare/custom-svg.html
+++ b/docs/it/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/prepare/display-expression.html
+++ b/docs/it/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/prepare/gnss.html
+++ b/docs/it/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/prepare/index.html
+++ b/docs/it/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/prepare/live_default_value.html
+++ b/docs/it/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/prepare/map-styling-configuration.html
+++ b/docs/it/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/prepare/map-themes.html
+++ b/docs/it/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/prepare/outside-layers.html
+++ b/docs/it/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/prepare/picture_path.html
+++ b/docs/it/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/search.html
+++ b/docs/it/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/it/support/index.html
+++ b/docs/it/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/synchronise/basemaps.html
+++ b/docs/it/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/synchronise/index.html
+++ b/docs/it/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/synchronise/movable-project.html
+++ b/docs/it/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/synchronise/qfieldcloud.html
+++ b/docs/it/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/it/synchronise/qfieldsync.html
+++ b/docs/it/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/case-studies/ecological-surveying.html
+++ b/docs/ja/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/case-studies/geologic-mapping.html
+++ b/docs/ja/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/case-studies/index.html
+++ b/docs/ja/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/case-studies/lulc-mapping-fiji.html
+++ b/docs/ja/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/ja/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/ja/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/case-studies/river-state-survey.html
+++ b/docs/ja/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/case-studies/rwanda-rural-water.html
+++ b/docs/ja/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/case-studies/vanilla-survey.html
+++ b/docs/ja/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/data-formats/index.html
+++ b/docs/ja/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/fieldwork/digitize.html
+++ b/docs/ja/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/fieldwork/gps.html
+++ b/docs/ja/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/fieldwork/index.html
+++ b/docs/ja/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/fieldwork/live_default_value.html
+++ b/docs/ja/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/fieldwork/map-interaction.html
+++ b/docs/ja/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/fieldwork/map-themes.html
+++ b/docs/ja/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/fieldwork/opening_individual_data.html
+++ b/docs/ja/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/fieldwork/print-to-pdf.html
+++ b/docs/ja/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/fieldwork/projects.html
+++ b/docs/ja/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/fieldwork/search.html
+++ b/docs/ja/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/fieldwork/track_lines_polygons.html
+++ b/docs/ja/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/fieldwork/variables.html
+++ b/docs/ja/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/genindex.html
+++ b/docs/ja/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/ja/getting-started/index.html
+++ b/docs/ja/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/index.html
+++ b/docs/ja/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/ja/install/index.html
+++ b/docs/ja/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/old-doc/case-studies/ecological-surveying.html
+++ b/docs/ja/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ja/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/ja/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ja/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/ja/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ja/old-doc/case-studies/river-state-survey.html
+++ b/docs/ja/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ja/old-doc/concepts/index.html
+++ b/docs/ja/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ja/old-doc/development/index.html
+++ b/docs/ja/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ja/old-doc/index.html
+++ b/docs/ja/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/old-doc/installation-guide/index.html
+++ b/docs/ja/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ja/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/ja/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ja/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/ja/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ja/old-doc/project-management/android-data-structure.html
+++ b/docs/ja/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ja/old-doc/project-management/configure-search.html
+++ b/docs/ja/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ja/old-doc/project-management/dataformat.html
+++ b/docs/ja/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ja/old-doc/project-management/index.html
+++ b/docs/ja/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ja/old-doc/project-management/map-themes.html
+++ b/docs/ja/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ja/old-doc/project-management/portable-project.html
+++ b/docs/ja/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ja/old-doc/project-management/print-to-pdf.html
+++ b/docs/ja/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ja/old-doc/project-management/project-selection.html
+++ b/docs/ja/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ja/old-doc/project-management/vector-layers.html
+++ b/docs/ja/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ja/old-doc/qfieldsync/index.html
+++ b/docs/ja/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ja/old-doc/user-guide/index.html
+++ b/docs/ja/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ja/old-doc/user-guide/map-themes.html
+++ b/docs/ja/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ja/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/ja/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ja/old-doc/user-guide/variables.html
+++ b/docs/ja/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ja/prepare/add-1-n-pictures.html
+++ b/docs/ja/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/prepare/advanced.html
+++ b/docs/ja/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/prepare/allow-hiding-legend-nodes.html
+++ b/docs/ja/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/prepare/attributes-form.html
+++ b/docs/ja/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/prepare/authentication.html
+++ b/docs/ja/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/prepare/change-fonts.html
+++ b/docs/ja/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/prepare/custom-svg.html
+++ b/docs/ja/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/prepare/display-expression.html
+++ b/docs/ja/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/prepare/gnss.html
+++ b/docs/ja/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/prepare/index.html
+++ b/docs/ja/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/prepare/live_default_value.html
+++ b/docs/ja/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/prepare/map-styling-configuration.html
+++ b/docs/ja/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/prepare/map-themes.html
+++ b/docs/ja/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/prepare/outside-layers.html
+++ b/docs/ja/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/prepare/picture_path.html
+++ b/docs/ja/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/search.html
+++ b/docs/ja/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/ja/support/index.html
+++ b/docs/ja/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/synchronise/basemaps.html
+++ b/docs/ja/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/synchronise/index.html
+++ b/docs/ja/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/synchronise/movable-project.html
+++ b/docs/ja/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/synchronise/qfieldcloud.html
+++ b/docs/ja/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ja/synchronise/qfieldsync.html
+++ b/docs/ja/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/case-studies/ecological-surveying.html
+++ b/docs/ko/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/case-studies/geologic-mapping.html
+++ b/docs/ko/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/case-studies/index.html
+++ b/docs/ko/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/case-studies/lulc-mapping-fiji.html
+++ b/docs/ko/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/ko/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/ko/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/case-studies/river-state-survey.html
+++ b/docs/ko/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/case-studies/rwanda-rural-water.html
+++ b/docs/ko/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/case-studies/vanilla-survey.html
+++ b/docs/ko/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/data-formats/index.html
+++ b/docs/ko/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/fieldwork/digitize.html
+++ b/docs/ko/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/fieldwork/gps.html
+++ b/docs/ko/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/fieldwork/index.html
+++ b/docs/ko/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/fieldwork/live_default_value.html
+++ b/docs/ko/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/fieldwork/map-interaction.html
+++ b/docs/ko/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/fieldwork/map-themes.html
+++ b/docs/ko/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/fieldwork/opening_individual_data.html
+++ b/docs/ko/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/fieldwork/print-to-pdf.html
+++ b/docs/ko/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/fieldwork/projects.html
+++ b/docs/ko/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/fieldwork/search.html
+++ b/docs/ko/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/fieldwork/track_lines_polygons.html
+++ b/docs/ko/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/fieldwork/variables.html
+++ b/docs/ko/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/genindex.html
+++ b/docs/ko/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/ko/getting-started/index.html
+++ b/docs/ko/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/index.html
+++ b/docs/ko/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/ko/install/index.html
+++ b/docs/ko/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/old-doc/case-studies/ecological-surveying.html
+++ b/docs/ko/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ko/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/ko/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ko/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/ko/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ko/old-doc/case-studies/river-state-survey.html
+++ b/docs/ko/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ko/old-doc/concepts/index.html
+++ b/docs/ko/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ko/old-doc/development/index.html
+++ b/docs/ko/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ko/old-doc/index.html
+++ b/docs/ko/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/old-doc/installation-guide/index.html
+++ b/docs/ko/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ko/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/ko/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ko/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/ko/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ko/old-doc/project-management/android-data-structure.html
+++ b/docs/ko/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ko/old-doc/project-management/configure-search.html
+++ b/docs/ko/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ko/old-doc/project-management/dataformat.html
+++ b/docs/ko/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ko/old-doc/project-management/index.html
+++ b/docs/ko/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ko/old-doc/project-management/map-themes.html
+++ b/docs/ko/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ko/old-doc/project-management/portable-project.html
+++ b/docs/ko/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ko/old-doc/project-management/print-to-pdf.html
+++ b/docs/ko/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ko/old-doc/project-management/project-selection.html
+++ b/docs/ko/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ko/old-doc/project-management/vector-layers.html
+++ b/docs/ko/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ko/old-doc/qfieldsync/index.html
+++ b/docs/ko/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ko/old-doc/user-guide/index.html
+++ b/docs/ko/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ko/old-doc/user-guide/map-themes.html
+++ b/docs/ko/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ko/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/ko/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ko/old-doc/user-guide/variables.html
+++ b/docs/ko/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ko/prepare/add-1-n-pictures.html
+++ b/docs/ko/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/prepare/advanced.html
+++ b/docs/ko/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/prepare/allow-hiding-legend-nodes.html
+++ b/docs/ko/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/prepare/attributes-form.html
+++ b/docs/ko/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/prepare/authentication.html
+++ b/docs/ko/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/prepare/change-fonts.html
+++ b/docs/ko/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/prepare/custom-svg.html
+++ b/docs/ko/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/prepare/display-expression.html
+++ b/docs/ko/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/prepare/gnss.html
+++ b/docs/ko/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/prepare/index.html
+++ b/docs/ko/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/prepare/live_default_value.html
+++ b/docs/ko/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/prepare/map-styling-configuration.html
+++ b/docs/ko/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/prepare/map-themes.html
+++ b/docs/ko/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/prepare/outside-layers.html
+++ b/docs/ko/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/prepare/picture_path.html
+++ b/docs/ko/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/search.html
+++ b/docs/ko/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/ko/support/index.html
+++ b/docs/ko/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/synchronise/basemaps.html
+++ b/docs/ko/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/synchronise/index.html
+++ b/docs/ko/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/synchronise/movable-project.html
+++ b/docs/ko/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/synchronise/qfieldcloud.html
+++ b/docs/ko/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ko/synchronise/qfieldsync.html
+++ b/docs/ko/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/case-studies/ecological-surveying.html
+++ b/docs/lt/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/case-studies/geologic-mapping.html
+++ b/docs/lt/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/case-studies/index.html
+++ b/docs/lt/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/case-studies/lulc-mapping-fiji.html
+++ b/docs/lt/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/lt/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/lt/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/case-studies/river-state-survey.html
+++ b/docs/lt/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/case-studies/rwanda-rural-water.html
+++ b/docs/lt/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/case-studies/vanilla-survey.html
+++ b/docs/lt/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/data-formats/index.html
+++ b/docs/lt/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/fieldwork/digitize.html
+++ b/docs/lt/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/fieldwork/gps.html
+++ b/docs/lt/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/fieldwork/index.html
+++ b/docs/lt/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/fieldwork/live_default_value.html
+++ b/docs/lt/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/fieldwork/map-interaction.html
+++ b/docs/lt/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/fieldwork/map-themes.html
+++ b/docs/lt/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/fieldwork/opening_individual_data.html
+++ b/docs/lt/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/fieldwork/print-to-pdf.html
+++ b/docs/lt/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/fieldwork/projects.html
+++ b/docs/lt/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/fieldwork/search.html
+++ b/docs/lt/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/fieldwork/track_lines_polygons.html
+++ b/docs/lt/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/fieldwork/variables.html
+++ b/docs/lt/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/genindex.html
+++ b/docs/lt/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/lt/getting-started/index.html
+++ b/docs/lt/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/index.html
+++ b/docs/lt/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/lt/install/index.html
+++ b/docs/lt/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/old-doc/case-studies/ecological-surveying.html
+++ b/docs/lt/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lt/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/lt/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lt/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/lt/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lt/old-doc/case-studies/river-state-survey.html
+++ b/docs/lt/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lt/old-doc/concepts/index.html
+++ b/docs/lt/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lt/old-doc/development/index.html
+++ b/docs/lt/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lt/old-doc/index.html
+++ b/docs/lt/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/old-doc/installation-guide/index.html
+++ b/docs/lt/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lt/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/lt/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lt/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/lt/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lt/old-doc/project-management/android-data-structure.html
+++ b/docs/lt/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lt/old-doc/project-management/configure-search.html
+++ b/docs/lt/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lt/old-doc/project-management/dataformat.html
+++ b/docs/lt/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lt/old-doc/project-management/index.html
+++ b/docs/lt/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lt/old-doc/project-management/map-themes.html
+++ b/docs/lt/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lt/old-doc/project-management/portable-project.html
+++ b/docs/lt/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lt/old-doc/project-management/print-to-pdf.html
+++ b/docs/lt/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lt/old-doc/project-management/project-selection.html
+++ b/docs/lt/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lt/old-doc/project-management/vector-layers.html
+++ b/docs/lt/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lt/old-doc/qfieldsync/index.html
+++ b/docs/lt/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lt/old-doc/user-guide/index.html
+++ b/docs/lt/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lt/old-doc/user-guide/map-themes.html
+++ b/docs/lt/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lt/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/lt/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lt/old-doc/user-guide/variables.html
+++ b/docs/lt/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lt/prepare/add-1-n-pictures.html
+++ b/docs/lt/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/prepare/advanced.html
+++ b/docs/lt/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/prepare/allow-hiding-legend-nodes.html
+++ b/docs/lt/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/prepare/attributes-form.html
+++ b/docs/lt/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/prepare/authentication.html
+++ b/docs/lt/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/prepare/change-fonts.html
+++ b/docs/lt/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/prepare/custom-svg.html
+++ b/docs/lt/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/prepare/display-expression.html
+++ b/docs/lt/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/prepare/gnss.html
+++ b/docs/lt/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/prepare/index.html
+++ b/docs/lt/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/prepare/live_default_value.html
+++ b/docs/lt/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/prepare/map-styling-configuration.html
+++ b/docs/lt/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/prepare/map-themes.html
+++ b/docs/lt/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/prepare/outside-layers.html
+++ b/docs/lt/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/prepare/picture_path.html
+++ b/docs/lt/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/search.html
+++ b/docs/lt/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/lt/support/index.html
+++ b/docs/lt/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/synchronise/basemaps.html
+++ b/docs/lt/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/synchronise/index.html
+++ b/docs/lt/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/synchronise/movable-project.html
+++ b/docs/lt/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/synchronise/qfieldcloud.html
+++ b/docs/lt/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lt/synchronise/qfieldsync.html
+++ b/docs/lt/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/case-studies/ecological-surveying.html
+++ b/docs/lv/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/case-studies/geologic-mapping.html
+++ b/docs/lv/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/case-studies/index.html
+++ b/docs/lv/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/case-studies/lulc-mapping-fiji.html
+++ b/docs/lv/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/lv/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/lv/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/case-studies/river-state-survey.html
+++ b/docs/lv/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/case-studies/rwanda-rural-water.html
+++ b/docs/lv/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/case-studies/vanilla-survey.html
+++ b/docs/lv/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/data-formats/index.html
+++ b/docs/lv/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/fieldwork/digitize.html
+++ b/docs/lv/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/fieldwork/gps.html
+++ b/docs/lv/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/fieldwork/index.html
+++ b/docs/lv/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/fieldwork/live_default_value.html
+++ b/docs/lv/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/fieldwork/map-interaction.html
+++ b/docs/lv/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/fieldwork/map-themes.html
+++ b/docs/lv/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/fieldwork/opening_individual_data.html
+++ b/docs/lv/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/fieldwork/print-to-pdf.html
+++ b/docs/lv/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/fieldwork/projects.html
+++ b/docs/lv/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/fieldwork/search.html
+++ b/docs/lv/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/fieldwork/track_lines_polygons.html
+++ b/docs/lv/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/fieldwork/variables.html
+++ b/docs/lv/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/genindex.html
+++ b/docs/lv/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/lv/getting-started/index.html
+++ b/docs/lv/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/index.html
+++ b/docs/lv/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/lv/install/index.html
+++ b/docs/lv/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/old-doc/case-studies/ecological-surveying.html
+++ b/docs/lv/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lv/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/lv/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lv/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/lv/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lv/old-doc/case-studies/river-state-survey.html
+++ b/docs/lv/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lv/old-doc/concepts/index.html
+++ b/docs/lv/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lv/old-doc/development/index.html
+++ b/docs/lv/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lv/old-doc/index.html
+++ b/docs/lv/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/old-doc/installation-guide/index.html
+++ b/docs/lv/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lv/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/lv/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lv/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/lv/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lv/old-doc/project-management/android-data-structure.html
+++ b/docs/lv/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lv/old-doc/project-management/configure-search.html
+++ b/docs/lv/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lv/old-doc/project-management/dataformat.html
+++ b/docs/lv/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lv/old-doc/project-management/index.html
+++ b/docs/lv/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lv/old-doc/project-management/map-themes.html
+++ b/docs/lv/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lv/old-doc/project-management/portable-project.html
+++ b/docs/lv/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lv/old-doc/project-management/print-to-pdf.html
+++ b/docs/lv/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lv/old-doc/project-management/project-selection.html
+++ b/docs/lv/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lv/old-doc/project-management/vector-layers.html
+++ b/docs/lv/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lv/old-doc/qfieldsync/index.html
+++ b/docs/lv/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lv/old-doc/user-guide/index.html
+++ b/docs/lv/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lv/old-doc/user-guide/map-themes.html
+++ b/docs/lv/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lv/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/lv/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lv/old-doc/user-guide/variables.html
+++ b/docs/lv/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/lv/prepare/add-1-n-pictures.html
+++ b/docs/lv/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/prepare/advanced.html
+++ b/docs/lv/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/prepare/allow-hiding-legend-nodes.html
+++ b/docs/lv/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/prepare/attributes-form.html
+++ b/docs/lv/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/prepare/authentication.html
+++ b/docs/lv/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/prepare/change-fonts.html
+++ b/docs/lv/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/prepare/custom-svg.html
+++ b/docs/lv/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/prepare/display-expression.html
+++ b/docs/lv/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/prepare/gnss.html
+++ b/docs/lv/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/prepare/index.html
+++ b/docs/lv/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/prepare/live_default_value.html
+++ b/docs/lv/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/prepare/map-styling-configuration.html
+++ b/docs/lv/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/prepare/map-themes.html
+++ b/docs/lv/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/prepare/outside-layers.html
+++ b/docs/lv/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/prepare/picture_path.html
+++ b/docs/lv/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/search.html
+++ b/docs/lv/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/lv/support/index.html
+++ b/docs/lv/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/synchronise/basemaps.html
+++ b/docs/lv/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/synchronise/index.html
+++ b/docs/lv/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/synchronise/movable-project.html
+++ b/docs/lv/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/synchronise/qfieldcloud.html
+++ b/docs/lv/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/lv/synchronise/qfieldsync.html
+++ b/docs/lv/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/case-studies/ecological-surveying.html
+++ b/docs/mn/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/case-studies/geologic-mapping.html
+++ b/docs/mn/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/case-studies/index.html
+++ b/docs/mn/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/case-studies/lulc-mapping-fiji.html
+++ b/docs/mn/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/mn/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/mn/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/case-studies/river-state-survey.html
+++ b/docs/mn/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/case-studies/rwanda-rural-water.html
+++ b/docs/mn/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/case-studies/vanilla-survey.html
+++ b/docs/mn/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/data-formats/index.html
+++ b/docs/mn/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/fieldwork/digitize.html
+++ b/docs/mn/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/fieldwork/gps.html
+++ b/docs/mn/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/fieldwork/index.html
+++ b/docs/mn/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/fieldwork/live_default_value.html
+++ b/docs/mn/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/fieldwork/map-interaction.html
+++ b/docs/mn/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/fieldwork/map-themes.html
+++ b/docs/mn/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/fieldwork/opening_individual_data.html
+++ b/docs/mn/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/fieldwork/print-to-pdf.html
+++ b/docs/mn/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/fieldwork/projects.html
+++ b/docs/mn/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/fieldwork/search.html
+++ b/docs/mn/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/fieldwork/track_lines_polygons.html
+++ b/docs/mn/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/fieldwork/variables.html
+++ b/docs/mn/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/genindex.html
+++ b/docs/mn/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/mn/getting-started/index.html
+++ b/docs/mn/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/index.html
+++ b/docs/mn/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/mn/install/index.html
+++ b/docs/mn/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/old-doc/case-studies/ecological-surveying.html
+++ b/docs/mn/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/mn/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/mn/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/mn/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/mn/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/mn/old-doc/case-studies/river-state-survey.html
+++ b/docs/mn/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/mn/old-doc/concepts/index.html
+++ b/docs/mn/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/mn/old-doc/development/index.html
+++ b/docs/mn/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/mn/old-doc/index.html
+++ b/docs/mn/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/old-doc/installation-guide/index.html
+++ b/docs/mn/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/mn/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/mn/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/mn/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/mn/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/mn/old-doc/project-management/android-data-structure.html
+++ b/docs/mn/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/mn/old-doc/project-management/configure-search.html
+++ b/docs/mn/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/mn/old-doc/project-management/dataformat.html
+++ b/docs/mn/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/mn/old-doc/project-management/index.html
+++ b/docs/mn/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/mn/old-doc/project-management/map-themes.html
+++ b/docs/mn/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/mn/old-doc/project-management/portable-project.html
+++ b/docs/mn/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/mn/old-doc/project-management/print-to-pdf.html
+++ b/docs/mn/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/mn/old-doc/project-management/project-selection.html
+++ b/docs/mn/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/mn/old-doc/project-management/vector-layers.html
+++ b/docs/mn/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/mn/old-doc/qfieldsync/index.html
+++ b/docs/mn/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/mn/old-doc/user-guide/index.html
+++ b/docs/mn/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/mn/old-doc/user-guide/map-themes.html
+++ b/docs/mn/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/mn/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/mn/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/mn/old-doc/user-guide/variables.html
+++ b/docs/mn/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/mn/prepare/add-1-n-pictures.html
+++ b/docs/mn/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/prepare/advanced.html
+++ b/docs/mn/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/prepare/allow-hiding-legend-nodes.html
+++ b/docs/mn/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/prepare/attributes-form.html
+++ b/docs/mn/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/prepare/authentication.html
+++ b/docs/mn/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/prepare/change-fonts.html
+++ b/docs/mn/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/prepare/custom-svg.html
+++ b/docs/mn/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/prepare/display-expression.html
+++ b/docs/mn/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/prepare/gnss.html
+++ b/docs/mn/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/prepare/index.html
+++ b/docs/mn/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/prepare/live_default_value.html
+++ b/docs/mn/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/prepare/map-styling-configuration.html
+++ b/docs/mn/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/prepare/map-themes.html
+++ b/docs/mn/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/prepare/outside-layers.html
+++ b/docs/mn/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/prepare/picture_path.html
+++ b/docs/mn/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/search.html
+++ b/docs/mn/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/mn/support/index.html
+++ b/docs/mn/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/synchronise/basemaps.html
+++ b/docs/mn/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/synchronise/index.html
+++ b/docs/mn/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/synchronise/movable-project.html
+++ b/docs/mn/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/synchronise/qfieldcloud.html
+++ b/docs/mn/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/mn/synchronise/qfieldsync.html
+++ b/docs/mn/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/case-studies/ecological-surveying.html
+++ b/docs/nl/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/case-studies/geologic-mapping.html
+++ b/docs/nl/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/case-studies/index.html
+++ b/docs/nl/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/case-studies/lulc-mapping-fiji.html
+++ b/docs/nl/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/nl/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/nl/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/case-studies/river-state-survey.html
+++ b/docs/nl/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/case-studies/rwanda-rural-water.html
+++ b/docs/nl/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/case-studies/vanilla-survey.html
+++ b/docs/nl/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/data-formats/index.html
+++ b/docs/nl/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/fieldwork/digitize.html
+++ b/docs/nl/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/fieldwork/gps.html
+++ b/docs/nl/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/fieldwork/index.html
+++ b/docs/nl/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/fieldwork/live_default_value.html
+++ b/docs/nl/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/fieldwork/map-interaction.html
+++ b/docs/nl/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/fieldwork/map-themes.html
+++ b/docs/nl/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/fieldwork/opening_individual_data.html
+++ b/docs/nl/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/fieldwork/print-to-pdf.html
+++ b/docs/nl/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/fieldwork/projects.html
+++ b/docs/nl/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/fieldwork/search.html
+++ b/docs/nl/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/fieldwork/track_lines_polygons.html
+++ b/docs/nl/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/fieldwork/variables.html
+++ b/docs/nl/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/genindex.html
+++ b/docs/nl/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/nl/getting-started/index.html
+++ b/docs/nl/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/index.html
+++ b/docs/nl/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/nl/install/index.html
+++ b/docs/nl/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/old-doc/case-studies/ecological-surveying.html
+++ b/docs/nl/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/nl/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/nl/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/nl/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/nl/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/nl/old-doc/case-studies/river-state-survey.html
+++ b/docs/nl/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/nl/old-doc/concepts/index.html
+++ b/docs/nl/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/nl/old-doc/development/index.html
+++ b/docs/nl/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/nl/old-doc/index.html
+++ b/docs/nl/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/old-doc/installation-guide/index.html
+++ b/docs/nl/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/nl/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/nl/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/nl/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/nl/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/nl/old-doc/project-management/android-data-structure.html
+++ b/docs/nl/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/nl/old-doc/project-management/configure-search.html
+++ b/docs/nl/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/nl/old-doc/project-management/dataformat.html
+++ b/docs/nl/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/nl/old-doc/project-management/index.html
+++ b/docs/nl/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/nl/old-doc/project-management/map-themes.html
+++ b/docs/nl/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/nl/old-doc/project-management/portable-project.html
+++ b/docs/nl/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/nl/old-doc/project-management/print-to-pdf.html
+++ b/docs/nl/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/nl/old-doc/project-management/project-selection.html
+++ b/docs/nl/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/nl/old-doc/project-management/vector-layers.html
+++ b/docs/nl/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/nl/old-doc/qfieldsync/index.html
+++ b/docs/nl/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/nl/old-doc/user-guide/index.html
+++ b/docs/nl/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/nl/old-doc/user-guide/map-themes.html
+++ b/docs/nl/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/nl/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/nl/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/nl/old-doc/user-guide/variables.html
+++ b/docs/nl/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/nl/prepare/add-1-n-pictures.html
+++ b/docs/nl/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/prepare/advanced.html
+++ b/docs/nl/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/prepare/allow-hiding-legend-nodes.html
+++ b/docs/nl/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/prepare/attributes-form.html
+++ b/docs/nl/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/prepare/authentication.html
+++ b/docs/nl/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/prepare/change-fonts.html
+++ b/docs/nl/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/prepare/custom-svg.html
+++ b/docs/nl/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/prepare/display-expression.html
+++ b/docs/nl/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/prepare/gnss.html
+++ b/docs/nl/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/prepare/index.html
+++ b/docs/nl/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/prepare/live_default_value.html
+++ b/docs/nl/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/prepare/map-styling-configuration.html
+++ b/docs/nl/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/prepare/map-themes.html
+++ b/docs/nl/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/prepare/outside-layers.html
+++ b/docs/nl/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/prepare/picture_path.html
+++ b/docs/nl/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/search.html
+++ b/docs/nl/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/nl/support/index.html
+++ b/docs/nl/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/synchronise/basemaps.html
+++ b/docs/nl/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/synchronise/index.html
+++ b/docs/nl/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/synchronise/movable-project.html
+++ b/docs/nl/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/synchronise/qfieldcloud.html
+++ b/docs/nl/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/nl/synchronise/qfieldsync.html
+++ b/docs/nl/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/old-doc/case-studies/ecological-surveying.html
+++ b/docs/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/old-doc/case-studies/river-state-survey.html
+++ b/docs/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/old-doc/concepts/index.html
+++ b/docs/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/old-doc/development/index.html
+++ b/docs/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/old-doc/index.html
+++ b/docs/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/old-doc/installation-guide/index.html
+++ b/docs/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/old-doc/project-management/android-data-structure.html
+++ b/docs/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/old-doc/project-management/configure-search.html
+++ b/docs/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/old-doc/project-management/dataformat.html
+++ b/docs/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/old-doc/project-management/index.html
+++ b/docs/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/old-doc/project-management/map-themes.html
+++ b/docs/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/old-doc/project-management/portable-project.html
+++ b/docs/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/old-doc/project-management/print-to-pdf.html
+++ b/docs/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/old-doc/project-management/project-selection.html
+++ b/docs/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/old-doc/project-management/vector-layers.html
+++ b/docs/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/old-doc/qfieldsync/index.html
+++ b/docs/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/old-doc/user-guide/index.html
+++ b/docs/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/old-doc/user-guide/map-themes.html
+++ b/docs/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/old-doc/user-guide/variables.html
+++ b/docs/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pl/case-studies/ecological-surveying.html
+++ b/docs/pl/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/case-studies/geologic-mapping.html
+++ b/docs/pl/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/case-studies/index.html
+++ b/docs/pl/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/case-studies/lulc-mapping-fiji.html
+++ b/docs/pl/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/pl/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/pl/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/case-studies/river-state-survey.html
+++ b/docs/pl/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/case-studies/rwanda-rural-water.html
+++ b/docs/pl/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/case-studies/vanilla-survey.html
+++ b/docs/pl/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/data-formats/index.html
+++ b/docs/pl/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/fieldwork/digitize.html
+++ b/docs/pl/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/fieldwork/gps.html
+++ b/docs/pl/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/fieldwork/index.html
+++ b/docs/pl/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/fieldwork/live_default_value.html
+++ b/docs/pl/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/fieldwork/map-interaction.html
+++ b/docs/pl/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/fieldwork/map-themes.html
+++ b/docs/pl/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/fieldwork/opening_individual_data.html
+++ b/docs/pl/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/fieldwork/print-to-pdf.html
+++ b/docs/pl/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/fieldwork/projects.html
+++ b/docs/pl/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/fieldwork/search.html
+++ b/docs/pl/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/fieldwork/track_lines_polygons.html
+++ b/docs/pl/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/fieldwork/variables.html
+++ b/docs/pl/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/genindex.html
+++ b/docs/pl/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/pl/getting-started/index.html
+++ b/docs/pl/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/index.html
+++ b/docs/pl/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/pl/install/index.html
+++ b/docs/pl/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/old-doc/case-studies/ecological-surveying.html
+++ b/docs/pl/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pl/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/pl/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pl/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/pl/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pl/old-doc/case-studies/river-state-survey.html
+++ b/docs/pl/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pl/old-doc/concepts/index.html
+++ b/docs/pl/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pl/old-doc/development/index.html
+++ b/docs/pl/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pl/old-doc/index.html
+++ b/docs/pl/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/old-doc/installation-guide/index.html
+++ b/docs/pl/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pl/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/pl/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pl/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/pl/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pl/old-doc/project-management/android-data-structure.html
+++ b/docs/pl/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pl/old-doc/project-management/configure-search.html
+++ b/docs/pl/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pl/old-doc/project-management/dataformat.html
+++ b/docs/pl/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pl/old-doc/project-management/index.html
+++ b/docs/pl/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pl/old-doc/project-management/map-themes.html
+++ b/docs/pl/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pl/old-doc/project-management/portable-project.html
+++ b/docs/pl/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pl/old-doc/project-management/print-to-pdf.html
+++ b/docs/pl/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pl/old-doc/project-management/project-selection.html
+++ b/docs/pl/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pl/old-doc/project-management/vector-layers.html
+++ b/docs/pl/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pl/old-doc/qfieldsync/index.html
+++ b/docs/pl/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pl/old-doc/user-guide/index.html
+++ b/docs/pl/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pl/old-doc/user-guide/map-themes.html
+++ b/docs/pl/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pl/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/pl/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pl/old-doc/user-guide/variables.html
+++ b/docs/pl/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pl/prepare/add-1-n-pictures.html
+++ b/docs/pl/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/prepare/advanced.html
+++ b/docs/pl/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/prepare/allow-hiding-legend-nodes.html
+++ b/docs/pl/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/prepare/attributes-form.html
+++ b/docs/pl/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/prepare/authentication.html
+++ b/docs/pl/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/prepare/change-fonts.html
+++ b/docs/pl/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/prepare/custom-svg.html
+++ b/docs/pl/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/prepare/display-expression.html
+++ b/docs/pl/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/prepare/gnss.html
+++ b/docs/pl/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/prepare/index.html
+++ b/docs/pl/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/prepare/live_default_value.html
+++ b/docs/pl/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/prepare/map-styling-configuration.html
+++ b/docs/pl/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/prepare/map-themes.html
+++ b/docs/pl/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/prepare/outside-layers.html
+++ b/docs/pl/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/prepare/picture_path.html
+++ b/docs/pl/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/search.html
+++ b/docs/pl/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/pl/support/index.html
+++ b/docs/pl/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/synchronise/basemaps.html
+++ b/docs/pl/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/synchronise/index.html
+++ b/docs/pl/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/synchronise/movable-project.html
+++ b/docs/pl/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/synchronise/qfieldcloud.html
+++ b/docs/pl/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pl/synchronise/qfieldsync.html
+++ b/docs/pl/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/prepare/add-1-n-pictures.html
+++ b/docs/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/prepare/advanced.html
+++ b/docs/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/prepare/allow-hiding-legend-nodes.html
+++ b/docs/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/prepare/attributes-form.html
+++ b/docs/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/prepare/authentication.html
+++ b/docs/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/prepare/change-fonts.html
+++ b/docs/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/prepare/custom-svg.html
+++ b/docs/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/prepare/display-expression.html
+++ b/docs/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/prepare/gnss.html
+++ b/docs/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/prepare/index.html
+++ b/docs/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/prepare/live_default_value.html
+++ b/docs/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/prepare/map-styling-configuration.html
+++ b/docs/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/prepare/map-themes.html
+++ b/docs/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/prepare/outside-layers.html
+++ b/docs/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/prepare/picture_path.html
+++ b/docs/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/case-studies/ecological-surveying.html
+++ b/docs/pt/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/case-studies/geologic-mapping.html
+++ b/docs/pt/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/case-studies/index.html
+++ b/docs/pt/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/case-studies/lulc-mapping-fiji.html
+++ b/docs/pt/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/pt/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/pt/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/case-studies/river-state-survey.html
+++ b/docs/pt/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/case-studies/rwanda-rural-water.html
+++ b/docs/pt/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/case-studies/vanilla-survey.html
+++ b/docs/pt/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/data-formats/index.html
+++ b/docs/pt/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/fieldwork/digitize.html
+++ b/docs/pt/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/fieldwork/gps.html
+++ b/docs/pt/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/fieldwork/index.html
+++ b/docs/pt/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/fieldwork/live_default_value.html
+++ b/docs/pt/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/fieldwork/map-interaction.html
+++ b/docs/pt/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/fieldwork/map-themes.html
+++ b/docs/pt/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/fieldwork/opening_individual_data.html
+++ b/docs/pt/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/fieldwork/print-to-pdf.html
+++ b/docs/pt/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/fieldwork/projects.html
+++ b/docs/pt/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/fieldwork/search.html
+++ b/docs/pt/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/fieldwork/track_lines_polygons.html
+++ b/docs/pt/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/fieldwork/variables.html
+++ b/docs/pt/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/genindex.html
+++ b/docs/pt/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/pt/getting-started/index.html
+++ b/docs/pt/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/index.html
+++ b/docs/pt/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/pt/install/index.html
+++ b/docs/pt/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/old-doc/case-studies/ecological-surveying.html
+++ b/docs/pt/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pt/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/pt/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pt/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/pt/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pt/old-doc/case-studies/river-state-survey.html
+++ b/docs/pt/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pt/old-doc/concepts/index.html
+++ b/docs/pt/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pt/old-doc/development/index.html
+++ b/docs/pt/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pt/old-doc/index.html
+++ b/docs/pt/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/old-doc/installation-guide/index.html
+++ b/docs/pt/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pt/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/pt/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pt/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/pt/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pt/old-doc/project-management/android-data-structure.html
+++ b/docs/pt/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pt/old-doc/project-management/configure-search.html
+++ b/docs/pt/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pt/old-doc/project-management/dataformat.html
+++ b/docs/pt/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pt/old-doc/project-management/index.html
+++ b/docs/pt/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pt/old-doc/project-management/map-themes.html
+++ b/docs/pt/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pt/old-doc/project-management/portable-project.html
+++ b/docs/pt/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pt/old-doc/project-management/print-to-pdf.html
+++ b/docs/pt/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pt/old-doc/project-management/project-selection.html
+++ b/docs/pt/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pt/old-doc/project-management/vector-layers.html
+++ b/docs/pt/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pt/old-doc/qfieldsync/index.html
+++ b/docs/pt/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pt/old-doc/user-guide/index.html
+++ b/docs/pt/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pt/old-doc/user-guide/map-themes.html
+++ b/docs/pt/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pt/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/pt/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pt/old-doc/user-guide/variables.html
+++ b/docs/pt/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/pt/prepare/add-1-n-pictures.html
+++ b/docs/pt/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/prepare/advanced.html
+++ b/docs/pt/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/prepare/allow-hiding-legend-nodes.html
+++ b/docs/pt/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/prepare/attributes-form.html
+++ b/docs/pt/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/prepare/authentication.html
+++ b/docs/pt/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/prepare/change-fonts.html
+++ b/docs/pt/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/prepare/custom-svg.html
+++ b/docs/pt/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/prepare/display-expression.html
+++ b/docs/pt/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/prepare/gnss.html
+++ b/docs/pt/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/prepare/index.html
+++ b/docs/pt/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/prepare/live_default_value.html
+++ b/docs/pt/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/prepare/map-styling-configuration.html
+++ b/docs/pt/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/prepare/map-themes.html
+++ b/docs/pt/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/prepare/outside-layers.html
+++ b/docs/pt/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/prepare/picture_path.html
+++ b/docs/pt/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/search.html
+++ b/docs/pt/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/pt/support/index.html
+++ b/docs/pt/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/synchronise/basemaps.html
+++ b/docs/pt/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/synchronise/index.html
+++ b/docs/pt/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/synchronise/movable-project.html
+++ b/docs/pt/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/synchronise/qfieldcloud.html
+++ b/docs/pt/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/pt/synchronise/qfieldsync.html
+++ b/docs/pt/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/case-studies/ecological-surveying.html
+++ b/docs/rm/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/case-studies/geologic-mapping.html
+++ b/docs/rm/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/case-studies/index.html
+++ b/docs/rm/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/case-studies/lulc-mapping-fiji.html
+++ b/docs/rm/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/rm/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/rm/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/case-studies/river-state-survey.html
+++ b/docs/rm/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/case-studies/rwanda-rural-water.html
+++ b/docs/rm/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/case-studies/vanilla-survey.html
+++ b/docs/rm/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/data-formats/index.html
+++ b/docs/rm/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/fieldwork/digitize.html
+++ b/docs/rm/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/fieldwork/gps.html
+++ b/docs/rm/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/fieldwork/index.html
+++ b/docs/rm/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/fieldwork/live_default_value.html
+++ b/docs/rm/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/fieldwork/map-interaction.html
+++ b/docs/rm/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/fieldwork/map-themes.html
+++ b/docs/rm/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/fieldwork/opening_individual_data.html
+++ b/docs/rm/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/fieldwork/print-to-pdf.html
+++ b/docs/rm/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/fieldwork/projects.html
+++ b/docs/rm/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/fieldwork/search.html
+++ b/docs/rm/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/fieldwork/track_lines_polygons.html
+++ b/docs/rm/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/fieldwork/variables.html
+++ b/docs/rm/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/genindex.html
+++ b/docs/rm/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/rm/getting-started/index.html
+++ b/docs/rm/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/index.html
+++ b/docs/rm/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/rm/install/index.html
+++ b/docs/rm/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/old-doc/case-studies/ecological-surveying.html
+++ b/docs/rm/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rm/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/rm/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rm/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/rm/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rm/old-doc/case-studies/river-state-survey.html
+++ b/docs/rm/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rm/old-doc/concepts/index.html
+++ b/docs/rm/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rm/old-doc/development/index.html
+++ b/docs/rm/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rm/old-doc/index.html
+++ b/docs/rm/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/old-doc/installation-guide/index.html
+++ b/docs/rm/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rm/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/rm/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rm/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/rm/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rm/old-doc/project-management/android-data-structure.html
+++ b/docs/rm/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rm/old-doc/project-management/configure-search.html
+++ b/docs/rm/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rm/old-doc/project-management/dataformat.html
+++ b/docs/rm/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rm/old-doc/project-management/index.html
+++ b/docs/rm/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rm/old-doc/project-management/map-themes.html
+++ b/docs/rm/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rm/old-doc/project-management/portable-project.html
+++ b/docs/rm/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rm/old-doc/project-management/print-to-pdf.html
+++ b/docs/rm/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rm/old-doc/project-management/project-selection.html
+++ b/docs/rm/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rm/old-doc/project-management/vector-layers.html
+++ b/docs/rm/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rm/old-doc/qfieldsync/index.html
+++ b/docs/rm/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rm/old-doc/user-guide/index.html
+++ b/docs/rm/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rm/old-doc/user-guide/map-themes.html
+++ b/docs/rm/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rm/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/rm/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rm/old-doc/user-guide/variables.html
+++ b/docs/rm/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rm/prepare/add-1-n-pictures.html
+++ b/docs/rm/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/prepare/advanced.html
+++ b/docs/rm/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/prepare/allow-hiding-legend-nodes.html
+++ b/docs/rm/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/prepare/attributes-form.html
+++ b/docs/rm/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/prepare/authentication.html
+++ b/docs/rm/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/prepare/change-fonts.html
+++ b/docs/rm/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/prepare/custom-svg.html
+++ b/docs/rm/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/prepare/display-expression.html
+++ b/docs/rm/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/prepare/gnss.html
+++ b/docs/rm/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/prepare/index.html
+++ b/docs/rm/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/prepare/live_default_value.html
+++ b/docs/rm/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/prepare/map-styling-configuration.html
+++ b/docs/rm/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/prepare/map-themes.html
+++ b/docs/rm/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/prepare/outside-layers.html
+++ b/docs/rm/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/prepare/picture_path.html
+++ b/docs/rm/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/search.html
+++ b/docs/rm/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/rm/support/index.html
+++ b/docs/rm/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/synchronise/basemaps.html
+++ b/docs/rm/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/synchronise/index.html
+++ b/docs/rm/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/synchronise/movable-project.html
+++ b/docs/rm/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/synchronise/qfieldcloud.html
+++ b/docs/rm/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rm/synchronise/qfieldsync.html
+++ b/docs/rm/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/case-studies/ecological-surveying.html
+++ b/docs/ro/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/case-studies/geologic-mapping.html
+++ b/docs/ro/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/case-studies/index.html
+++ b/docs/ro/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/case-studies/lulc-mapping-fiji.html
+++ b/docs/ro/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/ro/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/ro/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/case-studies/river-state-survey.html
+++ b/docs/ro/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/case-studies/rwanda-rural-water.html
+++ b/docs/ro/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/case-studies/vanilla-survey.html
+++ b/docs/ro/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/data-formats/index.html
+++ b/docs/ro/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/fieldwork/digitize.html
+++ b/docs/ro/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/fieldwork/gps.html
+++ b/docs/ro/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/fieldwork/index.html
+++ b/docs/ro/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/fieldwork/live_default_value.html
+++ b/docs/ro/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/fieldwork/map-interaction.html
+++ b/docs/ro/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/fieldwork/map-themes.html
+++ b/docs/ro/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/fieldwork/opening_individual_data.html
+++ b/docs/ro/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/fieldwork/print-to-pdf.html
+++ b/docs/ro/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/fieldwork/projects.html
+++ b/docs/ro/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/fieldwork/search.html
+++ b/docs/ro/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/fieldwork/track_lines_polygons.html
+++ b/docs/ro/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/fieldwork/variables.html
+++ b/docs/ro/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/genindex.html
+++ b/docs/ro/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/ro/getting-started/index.html
+++ b/docs/ro/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/index.html
+++ b/docs/ro/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/ro/install/index.html
+++ b/docs/ro/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/old-doc/case-studies/ecological-surveying.html
+++ b/docs/ro/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ro/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/ro/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ro/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/ro/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ro/old-doc/case-studies/river-state-survey.html
+++ b/docs/ro/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ro/old-doc/concepts/index.html
+++ b/docs/ro/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ro/old-doc/development/index.html
+++ b/docs/ro/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ro/old-doc/index.html
+++ b/docs/ro/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/old-doc/installation-guide/index.html
+++ b/docs/ro/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ro/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/ro/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ro/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/ro/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ro/old-doc/project-management/android-data-structure.html
+++ b/docs/ro/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ro/old-doc/project-management/configure-search.html
+++ b/docs/ro/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ro/old-doc/project-management/dataformat.html
+++ b/docs/ro/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ro/old-doc/project-management/index.html
+++ b/docs/ro/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ro/old-doc/project-management/map-themes.html
+++ b/docs/ro/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ro/old-doc/project-management/portable-project.html
+++ b/docs/ro/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ro/old-doc/project-management/print-to-pdf.html
+++ b/docs/ro/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ro/old-doc/project-management/project-selection.html
+++ b/docs/ro/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ro/old-doc/project-management/vector-layers.html
+++ b/docs/ro/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ro/old-doc/qfieldsync/index.html
+++ b/docs/ro/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ro/old-doc/user-guide/index.html
+++ b/docs/ro/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ro/old-doc/user-guide/map-themes.html
+++ b/docs/ro/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ro/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/ro/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ro/old-doc/user-guide/variables.html
+++ b/docs/ro/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ro/prepare/add-1-n-pictures.html
+++ b/docs/ro/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/prepare/advanced.html
+++ b/docs/ro/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/prepare/allow-hiding-legend-nodes.html
+++ b/docs/ro/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/prepare/attributes-form.html
+++ b/docs/ro/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/prepare/authentication.html
+++ b/docs/ro/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/prepare/change-fonts.html
+++ b/docs/ro/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/prepare/custom-svg.html
+++ b/docs/ro/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/prepare/display-expression.html
+++ b/docs/ro/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/prepare/gnss.html
+++ b/docs/ro/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/prepare/index.html
+++ b/docs/ro/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/prepare/live_default_value.html
+++ b/docs/ro/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/prepare/map-styling-configuration.html
+++ b/docs/ro/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/prepare/map-themes.html
+++ b/docs/ro/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/prepare/outside-layers.html
+++ b/docs/ro/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/prepare/picture_path.html
+++ b/docs/ro/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/search.html
+++ b/docs/ro/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/ro/support/index.html
+++ b/docs/ro/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/synchronise/basemaps.html
+++ b/docs/ro/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/synchronise/index.html
+++ b/docs/ro/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/synchronise/movable-project.html
+++ b/docs/ro/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/synchronise/qfieldcloud.html
+++ b/docs/ro/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ro/synchronise/qfieldsync.html
+++ b/docs/ro/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/case-studies/ecological-surveying.html
+++ b/docs/ru/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/case-studies/geologic-mapping.html
+++ b/docs/ru/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/case-studies/index.html
+++ b/docs/ru/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/case-studies/lulc-mapping-fiji.html
+++ b/docs/ru/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/ru/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/ru/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/case-studies/river-state-survey.html
+++ b/docs/ru/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/case-studies/rwanda-rural-water.html
+++ b/docs/ru/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/case-studies/vanilla-survey.html
+++ b/docs/ru/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/data-formats/index.html
+++ b/docs/ru/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/fieldwork/digitize.html
+++ b/docs/ru/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/fieldwork/gps.html
+++ b/docs/ru/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/fieldwork/index.html
+++ b/docs/ru/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/fieldwork/live_default_value.html
+++ b/docs/ru/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/fieldwork/map-interaction.html
+++ b/docs/ru/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/fieldwork/map-themes.html
+++ b/docs/ru/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/fieldwork/opening_individual_data.html
+++ b/docs/ru/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/fieldwork/print-to-pdf.html
+++ b/docs/ru/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/fieldwork/projects.html
+++ b/docs/ru/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/fieldwork/search.html
+++ b/docs/ru/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/fieldwork/track_lines_polygons.html
+++ b/docs/ru/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/fieldwork/variables.html
+++ b/docs/ru/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/genindex.html
+++ b/docs/ru/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/ru/getting-started/index.html
+++ b/docs/ru/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/index.html
+++ b/docs/ru/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/ru/install/index.html
+++ b/docs/ru/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/old-doc/case-studies/ecological-surveying.html
+++ b/docs/ru/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ru/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/ru/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ru/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/ru/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ru/old-doc/case-studies/river-state-survey.html
+++ b/docs/ru/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ru/old-doc/concepts/index.html
+++ b/docs/ru/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ru/old-doc/development/index.html
+++ b/docs/ru/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ru/old-doc/index.html
+++ b/docs/ru/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/old-doc/installation-guide/index.html
+++ b/docs/ru/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ru/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/ru/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ru/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/ru/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ru/old-doc/project-management/android-data-structure.html
+++ b/docs/ru/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ru/old-doc/project-management/configure-search.html
+++ b/docs/ru/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ru/old-doc/project-management/dataformat.html
+++ b/docs/ru/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ru/old-doc/project-management/index.html
+++ b/docs/ru/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ru/old-doc/project-management/map-themes.html
+++ b/docs/ru/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ru/old-doc/project-management/portable-project.html
+++ b/docs/ru/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ru/old-doc/project-management/print-to-pdf.html
+++ b/docs/ru/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ru/old-doc/project-management/project-selection.html
+++ b/docs/ru/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ru/old-doc/project-management/vector-layers.html
+++ b/docs/ru/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ru/old-doc/qfieldsync/index.html
+++ b/docs/ru/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ru/old-doc/user-guide/index.html
+++ b/docs/ru/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ru/old-doc/user-guide/map-themes.html
+++ b/docs/ru/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ru/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/ru/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ru/old-doc/user-guide/variables.html
+++ b/docs/ru/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/ru/prepare/add-1-n-pictures.html
+++ b/docs/ru/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/prepare/advanced.html
+++ b/docs/ru/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/prepare/allow-hiding-legend-nodes.html
+++ b/docs/ru/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/prepare/attributes-form.html
+++ b/docs/ru/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/prepare/authentication.html
+++ b/docs/ru/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/prepare/change-fonts.html
+++ b/docs/ru/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/prepare/custom-svg.html
+++ b/docs/ru/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/prepare/display-expression.html
+++ b/docs/ru/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/prepare/gnss.html
+++ b/docs/ru/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/prepare/index.html
+++ b/docs/ru/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/prepare/live_default_value.html
+++ b/docs/ru/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/prepare/map-styling-configuration.html
+++ b/docs/ru/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/prepare/map-themes.html
+++ b/docs/ru/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/prepare/outside-layers.html
+++ b/docs/ru/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/prepare/picture_path.html
+++ b/docs/ru/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/search.html
+++ b/docs/ru/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/ru/support/index.html
+++ b/docs/ru/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/synchronise/basemaps.html
+++ b/docs/ru/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/synchronise/index.html
+++ b/docs/ru/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/synchronise/movable-project.html
+++ b/docs/ru/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/synchronise/qfieldcloud.html
+++ b/docs/ru/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/ru/synchronise/qfieldsync.html
+++ b/docs/ru/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/case-studies/ecological-surveying.html
+++ b/docs/rw/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/case-studies/geologic-mapping.html
+++ b/docs/rw/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/case-studies/index.html
+++ b/docs/rw/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/case-studies/lulc-mapping-fiji.html
+++ b/docs/rw/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/rw/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/rw/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/case-studies/river-state-survey.html
+++ b/docs/rw/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/case-studies/rwanda-rural-water.html
+++ b/docs/rw/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/case-studies/vanilla-survey.html
+++ b/docs/rw/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/data-formats/index.html
+++ b/docs/rw/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/fieldwork/digitize.html
+++ b/docs/rw/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/fieldwork/gps.html
+++ b/docs/rw/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/fieldwork/index.html
+++ b/docs/rw/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/fieldwork/live_default_value.html
+++ b/docs/rw/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/fieldwork/map-interaction.html
+++ b/docs/rw/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/fieldwork/map-themes.html
+++ b/docs/rw/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/fieldwork/opening_individual_data.html
+++ b/docs/rw/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/fieldwork/print-to-pdf.html
+++ b/docs/rw/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/fieldwork/projects.html
+++ b/docs/rw/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/fieldwork/search.html
+++ b/docs/rw/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/fieldwork/track_lines_polygons.html
+++ b/docs/rw/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/fieldwork/variables.html
+++ b/docs/rw/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/genindex.html
+++ b/docs/rw/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/rw/getting-started/index.html
+++ b/docs/rw/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/index.html
+++ b/docs/rw/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/rw/install/index.html
+++ b/docs/rw/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/old-doc/case-studies/ecological-surveying.html
+++ b/docs/rw/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rw/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/rw/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rw/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/rw/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rw/old-doc/case-studies/river-state-survey.html
+++ b/docs/rw/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rw/old-doc/concepts/index.html
+++ b/docs/rw/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rw/old-doc/development/index.html
+++ b/docs/rw/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rw/old-doc/index.html
+++ b/docs/rw/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/old-doc/installation-guide/index.html
+++ b/docs/rw/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rw/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/rw/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rw/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/rw/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rw/old-doc/project-management/android-data-structure.html
+++ b/docs/rw/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rw/old-doc/project-management/configure-search.html
+++ b/docs/rw/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rw/old-doc/project-management/dataformat.html
+++ b/docs/rw/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rw/old-doc/project-management/index.html
+++ b/docs/rw/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rw/old-doc/project-management/map-themes.html
+++ b/docs/rw/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rw/old-doc/project-management/portable-project.html
+++ b/docs/rw/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rw/old-doc/project-management/print-to-pdf.html
+++ b/docs/rw/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rw/old-doc/project-management/project-selection.html
+++ b/docs/rw/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rw/old-doc/project-management/vector-layers.html
+++ b/docs/rw/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rw/old-doc/qfieldsync/index.html
+++ b/docs/rw/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rw/old-doc/user-guide/index.html
+++ b/docs/rw/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rw/old-doc/user-guide/map-themes.html
+++ b/docs/rw/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rw/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/rw/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rw/old-doc/user-guide/variables.html
+++ b/docs/rw/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/rw/prepare/add-1-n-pictures.html
+++ b/docs/rw/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/prepare/advanced.html
+++ b/docs/rw/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/prepare/allow-hiding-legend-nodes.html
+++ b/docs/rw/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/prepare/attributes-form.html
+++ b/docs/rw/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/prepare/authentication.html
+++ b/docs/rw/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/prepare/change-fonts.html
+++ b/docs/rw/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/prepare/custom-svg.html
+++ b/docs/rw/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/prepare/display-expression.html
+++ b/docs/rw/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/prepare/gnss.html
+++ b/docs/rw/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/prepare/index.html
+++ b/docs/rw/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/prepare/live_default_value.html
+++ b/docs/rw/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/prepare/map-styling-configuration.html
+++ b/docs/rw/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/prepare/map-themes.html
+++ b/docs/rw/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/prepare/outside-layers.html
+++ b/docs/rw/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/prepare/picture_path.html
+++ b/docs/rw/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/search.html
+++ b/docs/rw/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/rw/support/index.html
+++ b/docs/rw/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/synchronise/basemaps.html
+++ b/docs/rw/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/synchronise/index.html
+++ b/docs/rw/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/synchronise/movable-project.html
+++ b/docs/rw/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/synchronise/qfieldcloud.html
+++ b/docs/rw/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/rw/synchronise/qfieldsync.html
+++ b/docs/rw/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/search.html
+++ b/docs/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/sl/case-studies/ecological-surveying.html
+++ b/docs/sl/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/case-studies/geologic-mapping.html
+++ b/docs/sl/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/case-studies/index.html
+++ b/docs/sl/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/case-studies/lulc-mapping-fiji.html
+++ b/docs/sl/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/sl/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/sl/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/case-studies/river-state-survey.html
+++ b/docs/sl/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/case-studies/rwanda-rural-water.html
+++ b/docs/sl/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/case-studies/vanilla-survey.html
+++ b/docs/sl/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/data-formats/index.html
+++ b/docs/sl/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/fieldwork/digitize.html
+++ b/docs/sl/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/fieldwork/gps.html
+++ b/docs/sl/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/fieldwork/index.html
+++ b/docs/sl/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/fieldwork/live_default_value.html
+++ b/docs/sl/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/fieldwork/map-interaction.html
+++ b/docs/sl/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/fieldwork/map-themes.html
+++ b/docs/sl/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/fieldwork/opening_individual_data.html
+++ b/docs/sl/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/fieldwork/print-to-pdf.html
+++ b/docs/sl/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/fieldwork/projects.html
+++ b/docs/sl/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/fieldwork/search.html
+++ b/docs/sl/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/fieldwork/track_lines_polygons.html
+++ b/docs/sl/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/fieldwork/variables.html
+++ b/docs/sl/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/genindex.html
+++ b/docs/sl/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/sl/getting-started/index.html
+++ b/docs/sl/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/index.html
+++ b/docs/sl/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/sl/install/index.html
+++ b/docs/sl/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/old-doc/case-studies/ecological-surveying.html
+++ b/docs/sl/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sl/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/sl/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sl/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/sl/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sl/old-doc/case-studies/river-state-survey.html
+++ b/docs/sl/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sl/old-doc/concepts/index.html
+++ b/docs/sl/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sl/old-doc/development/index.html
+++ b/docs/sl/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sl/old-doc/index.html
+++ b/docs/sl/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/old-doc/installation-guide/index.html
+++ b/docs/sl/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sl/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/sl/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sl/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/sl/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sl/old-doc/project-management/android-data-structure.html
+++ b/docs/sl/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sl/old-doc/project-management/configure-search.html
+++ b/docs/sl/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sl/old-doc/project-management/dataformat.html
+++ b/docs/sl/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sl/old-doc/project-management/index.html
+++ b/docs/sl/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sl/old-doc/project-management/map-themes.html
+++ b/docs/sl/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sl/old-doc/project-management/portable-project.html
+++ b/docs/sl/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sl/old-doc/project-management/print-to-pdf.html
+++ b/docs/sl/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sl/old-doc/project-management/project-selection.html
+++ b/docs/sl/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sl/old-doc/project-management/vector-layers.html
+++ b/docs/sl/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sl/old-doc/qfieldsync/index.html
+++ b/docs/sl/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sl/old-doc/user-guide/index.html
+++ b/docs/sl/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sl/old-doc/user-guide/map-themes.html
+++ b/docs/sl/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sl/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/sl/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sl/old-doc/user-guide/variables.html
+++ b/docs/sl/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sl/prepare/add-1-n-pictures.html
+++ b/docs/sl/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/prepare/advanced.html
+++ b/docs/sl/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/prepare/allow-hiding-legend-nodes.html
+++ b/docs/sl/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/prepare/attributes-form.html
+++ b/docs/sl/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/prepare/authentication.html
+++ b/docs/sl/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/prepare/change-fonts.html
+++ b/docs/sl/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/prepare/custom-svg.html
+++ b/docs/sl/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/prepare/display-expression.html
+++ b/docs/sl/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/prepare/gnss.html
+++ b/docs/sl/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/prepare/index.html
+++ b/docs/sl/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/prepare/live_default_value.html
+++ b/docs/sl/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/prepare/map-styling-configuration.html
+++ b/docs/sl/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/prepare/map-themes.html
+++ b/docs/sl/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/prepare/outside-layers.html
+++ b/docs/sl/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/prepare/picture_path.html
+++ b/docs/sl/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/search.html
+++ b/docs/sl/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/sl/support/index.html
+++ b/docs/sl/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/synchronise/basemaps.html
+++ b/docs/sl/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/synchronise/index.html
+++ b/docs/sl/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/synchronise/movable-project.html
+++ b/docs/sl/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/synchronise/qfieldcloud.html
+++ b/docs/sl/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sl/synchronise/qfieldsync.html
+++ b/docs/sl/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/support/index.html
+++ b/docs/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/case-studies/ecological-surveying.html
+++ b/docs/sv/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/case-studies/geologic-mapping.html
+++ b/docs/sv/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/case-studies/index.html
+++ b/docs/sv/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/case-studies/lulc-mapping-fiji.html
+++ b/docs/sv/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/sv/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/sv/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/case-studies/river-state-survey.html
+++ b/docs/sv/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/case-studies/rwanda-rural-water.html
+++ b/docs/sv/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/case-studies/vanilla-survey.html
+++ b/docs/sv/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/data-formats/index.html
+++ b/docs/sv/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/fieldwork/digitize.html
+++ b/docs/sv/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/fieldwork/gps.html
+++ b/docs/sv/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/fieldwork/index.html
+++ b/docs/sv/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/fieldwork/live_default_value.html
+++ b/docs/sv/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/fieldwork/map-interaction.html
+++ b/docs/sv/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/fieldwork/map-themes.html
+++ b/docs/sv/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/fieldwork/opening_individual_data.html
+++ b/docs/sv/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/fieldwork/print-to-pdf.html
+++ b/docs/sv/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/fieldwork/projects.html
+++ b/docs/sv/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/fieldwork/search.html
+++ b/docs/sv/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/fieldwork/track_lines_polygons.html
+++ b/docs/sv/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/fieldwork/variables.html
+++ b/docs/sv/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/genindex.html
+++ b/docs/sv/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/sv/getting-started/index.html
+++ b/docs/sv/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/index.html
+++ b/docs/sv/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/sv/install/index.html
+++ b/docs/sv/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/old-doc/case-studies/ecological-surveying.html
+++ b/docs/sv/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sv/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/sv/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sv/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/sv/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sv/old-doc/case-studies/river-state-survey.html
+++ b/docs/sv/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sv/old-doc/concepts/index.html
+++ b/docs/sv/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sv/old-doc/development/index.html
+++ b/docs/sv/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sv/old-doc/index.html
+++ b/docs/sv/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/old-doc/installation-guide/index.html
+++ b/docs/sv/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sv/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/sv/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sv/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/sv/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sv/old-doc/project-management/android-data-structure.html
+++ b/docs/sv/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sv/old-doc/project-management/configure-search.html
+++ b/docs/sv/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sv/old-doc/project-management/dataformat.html
+++ b/docs/sv/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sv/old-doc/project-management/index.html
+++ b/docs/sv/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sv/old-doc/project-management/map-themes.html
+++ b/docs/sv/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sv/old-doc/project-management/portable-project.html
+++ b/docs/sv/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sv/old-doc/project-management/print-to-pdf.html
+++ b/docs/sv/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sv/old-doc/project-management/project-selection.html
+++ b/docs/sv/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sv/old-doc/project-management/vector-layers.html
+++ b/docs/sv/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sv/old-doc/qfieldsync/index.html
+++ b/docs/sv/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sv/old-doc/user-guide/index.html
+++ b/docs/sv/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sv/old-doc/user-guide/map-themes.html
+++ b/docs/sv/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sv/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/sv/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sv/old-doc/user-guide/variables.html
+++ b/docs/sv/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/sv/prepare/add-1-n-pictures.html
+++ b/docs/sv/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/prepare/advanced.html
+++ b/docs/sv/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/prepare/allow-hiding-legend-nodes.html
+++ b/docs/sv/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/prepare/attributes-form.html
+++ b/docs/sv/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/prepare/authentication.html
+++ b/docs/sv/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/prepare/change-fonts.html
+++ b/docs/sv/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/prepare/custom-svg.html
+++ b/docs/sv/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/prepare/display-expression.html
+++ b/docs/sv/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/prepare/gnss.html
+++ b/docs/sv/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/prepare/index.html
+++ b/docs/sv/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/prepare/live_default_value.html
+++ b/docs/sv/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/prepare/map-styling-configuration.html
+++ b/docs/sv/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/prepare/map-themes.html
+++ b/docs/sv/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/prepare/outside-layers.html
+++ b/docs/sv/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/prepare/picture_path.html
+++ b/docs/sv/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/search.html
+++ b/docs/sv/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/sv/support/index.html
+++ b/docs/sv/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/synchronise/basemaps.html
+++ b/docs/sv/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/synchronise/index.html
+++ b/docs/sv/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/synchronise/movable-project.html
+++ b/docs/sv/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/synchronise/qfieldcloud.html
+++ b/docs/sv/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/sv/synchronise/qfieldsync.html
+++ b/docs/sv/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/synchronise/basemaps.html
+++ b/docs/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/synchronise/index.html
+++ b/docs/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/synchronise/movable-project.html
+++ b/docs/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/synchronise/qfieldcloud.html
+++ b/docs/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/synchronise/qfieldsync.html
+++ b/docs/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/case-studies/ecological-surveying.html
+++ b/docs/tr/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/case-studies/geologic-mapping.html
+++ b/docs/tr/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/case-studies/index.html
+++ b/docs/tr/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/case-studies/lulc-mapping-fiji.html
+++ b/docs/tr/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/tr/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/tr/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/case-studies/river-state-survey.html
+++ b/docs/tr/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/case-studies/rwanda-rural-water.html
+++ b/docs/tr/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/case-studies/vanilla-survey.html
+++ b/docs/tr/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/data-formats/index.html
+++ b/docs/tr/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/fieldwork/digitize.html
+++ b/docs/tr/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/fieldwork/gps.html
+++ b/docs/tr/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/fieldwork/index.html
+++ b/docs/tr/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/fieldwork/live_default_value.html
+++ b/docs/tr/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/fieldwork/map-interaction.html
+++ b/docs/tr/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/fieldwork/map-themes.html
+++ b/docs/tr/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/fieldwork/opening_individual_data.html
+++ b/docs/tr/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/fieldwork/print-to-pdf.html
+++ b/docs/tr/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/fieldwork/projects.html
+++ b/docs/tr/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/fieldwork/search.html
+++ b/docs/tr/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/fieldwork/track_lines_polygons.html
+++ b/docs/tr/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/fieldwork/variables.html
+++ b/docs/tr/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/genindex.html
+++ b/docs/tr/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/tr/getting-started/index.html
+++ b/docs/tr/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/index.html
+++ b/docs/tr/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/tr/install/index.html
+++ b/docs/tr/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/old-doc/case-studies/ecological-surveying.html
+++ b/docs/tr/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/tr/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/tr/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/tr/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/tr/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/tr/old-doc/case-studies/river-state-survey.html
+++ b/docs/tr/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/tr/old-doc/concepts/index.html
+++ b/docs/tr/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/tr/old-doc/development/index.html
+++ b/docs/tr/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/tr/old-doc/index.html
+++ b/docs/tr/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/old-doc/installation-guide/index.html
+++ b/docs/tr/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/tr/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/tr/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/tr/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/tr/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/tr/old-doc/project-management/android-data-structure.html
+++ b/docs/tr/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/tr/old-doc/project-management/configure-search.html
+++ b/docs/tr/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/tr/old-doc/project-management/dataformat.html
+++ b/docs/tr/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/tr/old-doc/project-management/index.html
+++ b/docs/tr/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/tr/old-doc/project-management/map-themes.html
+++ b/docs/tr/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/tr/old-doc/project-management/portable-project.html
+++ b/docs/tr/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/tr/old-doc/project-management/print-to-pdf.html
+++ b/docs/tr/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/tr/old-doc/project-management/project-selection.html
+++ b/docs/tr/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/tr/old-doc/project-management/vector-layers.html
+++ b/docs/tr/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/tr/old-doc/qfieldsync/index.html
+++ b/docs/tr/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/tr/old-doc/user-guide/index.html
+++ b/docs/tr/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/tr/old-doc/user-guide/map-themes.html
+++ b/docs/tr/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/tr/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/tr/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/tr/old-doc/user-guide/variables.html
+++ b/docs/tr/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/tr/prepare/add-1-n-pictures.html
+++ b/docs/tr/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/prepare/advanced.html
+++ b/docs/tr/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/prepare/allow-hiding-legend-nodes.html
+++ b/docs/tr/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/prepare/attributes-form.html
+++ b/docs/tr/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/prepare/authentication.html
+++ b/docs/tr/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/prepare/change-fonts.html
+++ b/docs/tr/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/prepare/custom-svg.html
+++ b/docs/tr/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/prepare/display-expression.html
+++ b/docs/tr/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/prepare/gnss.html
+++ b/docs/tr/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/prepare/index.html
+++ b/docs/tr/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/prepare/live_default_value.html
+++ b/docs/tr/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/prepare/map-styling-configuration.html
+++ b/docs/tr/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/prepare/map-themes.html
+++ b/docs/tr/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/prepare/outside-layers.html
+++ b/docs/tr/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/prepare/picture_path.html
+++ b/docs/tr/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/search.html
+++ b/docs/tr/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/tr/support/index.html
+++ b/docs/tr/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/synchronise/basemaps.html
+++ b/docs/tr/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/synchronise/index.html
+++ b/docs/tr/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/synchronise/movable-project.html
+++ b/docs/tr/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/synchronise/qfieldcloud.html
+++ b/docs/tr/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/tr/synchronise/qfieldsync.html
+++ b/docs/tr/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/case-studies/ecological-surveying.html
+++ b/docs/uk/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/case-studies/geologic-mapping.html
+++ b/docs/uk/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/case-studies/index.html
+++ b/docs/uk/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/case-studies/lulc-mapping-fiji.html
+++ b/docs/uk/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/uk/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/uk/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/case-studies/river-state-survey.html
+++ b/docs/uk/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/case-studies/rwanda-rural-water.html
+++ b/docs/uk/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/case-studies/vanilla-survey.html
+++ b/docs/uk/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/data-formats/index.html
+++ b/docs/uk/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/fieldwork/digitize.html
+++ b/docs/uk/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/fieldwork/gps.html
+++ b/docs/uk/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/fieldwork/index.html
+++ b/docs/uk/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/fieldwork/live_default_value.html
+++ b/docs/uk/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/fieldwork/map-interaction.html
+++ b/docs/uk/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/fieldwork/map-themes.html
+++ b/docs/uk/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/fieldwork/opening_individual_data.html
+++ b/docs/uk/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/fieldwork/print-to-pdf.html
+++ b/docs/uk/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/fieldwork/projects.html
+++ b/docs/uk/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/fieldwork/search.html
+++ b/docs/uk/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/fieldwork/track_lines_polygons.html
+++ b/docs/uk/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/fieldwork/variables.html
+++ b/docs/uk/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/genindex.html
+++ b/docs/uk/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/uk/getting-started/index.html
+++ b/docs/uk/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/index.html
+++ b/docs/uk/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/uk/install/index.html
+++ b/docs/uk/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/old-doc/case-studies/ecological-surveying.html
+++ b/docs/uk/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/uk/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/uk/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/uk/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/uk/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/uk/old-doc/case-studies/river-state-survey.html
+++ b/docs/uk/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/uk/old-doc/concepts/index.html
+++ b/docs/uk/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/uk/old-doc/development/index.html
+++ b/docs/uk/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/uk/old-doc/index.html
+++ b/docs/uk/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/old-doc/installation-guide/index.html
+++ b/docs/uk/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/uk/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/uk/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/uk/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/uk/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/uk/old-doc/project-management/android-data-structure.html
+++ b/docs/uk/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/uk/old-doc/project-management/configure-search.html
+++ b/docs/uk/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/uk/old-doc/project-management/dataformat.html
+++ b/docs/uk/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/uk/old-doc/project-management/index.html
+++ b/docs/uk/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/uk/old-doc/project-management/map-themes.html
+++ b/docs/uk/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/uk/old-doc/project-management/portable-project.html
+++ b/docs/uk/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/uk/old-doc/project-management/print-to-pdf.html
+++ b/docs/uk/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/uk/old-doc/project-management/project-selection.html
+++ b/docs/uk/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/uk/old-doc/project-management/vector-layers.html
+++ b/docs/uk/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/uk/old-doc/qfieldsync/index.html
+++ b/docs/uk/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/uk/old-doc/user-guide/index.html
+++ b/docs/uk/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/uk/old-doc/user-guide/map-themes.html
+++ b/docs/uk/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/uk/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/uk/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/uk/old-doc/user-guide/variables.html
+++ b/docs/uk/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/uk/prepare/add-1-n-pictures.html
+++ b/docs/uk/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/prepare/advanced.html
+++ b/docs/uk/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/prepare/allow-hiding-legend-nodes.html
+++ b/docs/uk/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/prepare/attributes-form.html
+++ b/docs/uk/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/prepare/authentication.html
+++ b/docs/uk/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/prepare/change-fonts.html
+++ b/docs/uk/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/prepare/custom-svg.html
+++ b/docs/uk/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/prepare/display-expression.html
+++ b/docs/uk/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/prepare/gnss.html
+++ b/docs/uk/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/prepare/index.html
+++ b/docs/uk/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/prepare/live_default_value.html
+++ b/docs/uk/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/prepare/map-styling-configuration.html
+++ b/docs/uk/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/prepare/map-themes.html
+++ b/docs/uk/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/prepare/outside-layers.html
+++ b/docs/uk/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/prepare/picture_path.html
+++ b/docs/uk/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/search.html
+++ b/docs/uk/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/uk/support/index.html
+++ b/docs/uk/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/synchronise/basemaps.html
+++ b/docs/uk/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/synchronise/index.html
+++ b/docs/uk/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/synchronise/movable-project.html
+++ b/docs/uk/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/synchronise/qfieldcloud.html
+++ b/docs/uk/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/uk/synchronise/qfieldsync.html
+++ b/docs/uk/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/case-studies/ecological-surveying.html
+++ b/docs/zh/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/case-studies/geologic-mapping.html
+++ b/docs/zh/case-studies/geologic-mapping.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/case-studies/index.html
+++ b/docs/zh/case-studies/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/case-studies/lulc-mapping-fiji.html
+++ b/docs/zh/case-studies/lulc-mapping-fiji.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/zh/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/zh/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/case-studies/river-state-survey.html
+++ b/docs/zh/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/case-studies/rwanda-rural-water.html
+++ b/docs/zh/case-studies/rwanda-rural-water.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/case-studies/vanilla-survey.html
+++ b/docs/zh/case-studies/vanilla-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/data-formats/index.html
+++ b/docs/zh/data-formats/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/fieldwork/digitize.html
+++ b/docs/zh/fieldwork/digitize.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/fieldwork/gps.html
+++ b/docs/zh/fieldwork/gps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/fieldwork/index.html
+++ b/docs/zh/fieldwork/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/fieldwork/live_default_value.html
+++ b/docs/zh/fieldwork/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/fieldwork/map-interaction.html
+++ b/docs/zh/fieldwork/map-interaction.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/fieldwork/map-themes.html
+++ b/docs/zh/fieldwork/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/fieldwork/opening_individual_data.html
+++ b/docs/zh/fieldwork/opening_individual_data.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/fieldwork/print-to-pdf.html
+++ b/docs/zh/fieldwork/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/fieldwork/projects.html
+++ b/docs/zh/fieldwork/projects.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/fieldwork/search.html
+++ b/docs/zh/fieldwork/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/fieldwork/track_lines_polygons.html
+++ b/docs/zh/fieldwork/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/fieldwork/variables.html
+++ b/docs/zh/fieldwork/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/genindex.html
+++ b/docs/zh/genindex.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/zh/getting-started/index.html
+++ b/docs/zh/getting-started/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/index.html
+++ b/docs/zh/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/zh/install/index.html
+++ b/docs/zh/install/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/old-doc/case-studies/ecological-surveying.html
+++ b/docs/zh/old-doc/case-studies/ecological-surveying.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/zh/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
+++ b/docs/zh/old-doc/case-studies/mapping-breeding-birds-in-the-Wadden-Sea.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/zh/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
+++ b/docs/zh/old-doc/case-studies/mosquito-malario-ground-truth-data-collection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/zh/old-doc/case-studies/river-state-survey.html
+++ b/docs/zh/old-doc/case-studies/river-state-survey.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/zh/old-doc/concepts/index.html
+++ b/docs/zh/old-doc/concepts/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/zh/old-doc/development/index.html
+++ b/docs/zh/old-doc/development/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/zh/old-doc/index.html
+++ b/docs/zh/old-doc/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/old-doc/installation-guide/index.html
+++ b/docs/zh/old-doc/installation-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/zh/old-doc/project-management/add-1-n-pictures.html
+++ b/docs/zh/old-doc/project-management/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/zh/old-doc/project-management/allow-hiding-legend-nodes.html
+++ b/docs/zh/old-doc/project-management/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/zh/old-doc/project-management/android-data-structure.html
+++ b/docs/zh/old-doc/project-management/android-data-structure.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/zh/old-doc/project-management/configure-search.html
+++ b/docs/zh/old-doc/project-management/configure-search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/zh/old-doc/project-management/dataformat.html
+++ b/docs/zh/old-doc/project-management/dataformat.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/zh/old-doc/project-management/index.html
+++ b/docs/zh/old-doc/project-management/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/zh/old-doc/project-management/map-themes.html
+++ b/docs/zh/old-doc/project-management/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/zh/old-doc/project-management/portable-project.html
+++ b/docs/zh/old-doc/project-management/portable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/zh/old-doc/project-management/print-to-pdf.html
+++ b/docs/zh/old-doc/project-management/print-to-pdf.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/zh/old-doc/project-management/project-selection.html
+++ b/docs/zh/old-doc/project-management/project-selection.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/zh/old-doc/project-management/vector-layers.html
+++ b/docs/zh/old-doc/project-management/vector-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/zh/old-doc/qfieldsync/index.html
+++ b/docs/zh/old-doc/qfieldsync/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/zh/old-doc/user-guide/index.html
+++ b/docs/zh/old-doc/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/zh/old-doc/user-guide/map-themes.html
+++ b/docs/zh/old-doc/user-guide/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/zh/old-doc/user-guide/track_lines_polygons.html
+++ b/docs/zh/old-doc/user-guide/track_lines_polygons.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/zh/old-doc/user-guide/variables.html
+++ b/docs/zh/old-doc/user-guide/variables.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../../" src="../../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../../_static/jquery.js"></script>
     <script type="text/javascript" src="../../_static/underscore.js"></script>

--- a/docs/zh/prepare/add-1-n-pictures.html
+++ b/docs/zh/prepare/add-1-n-pictures.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/prepare/advanced.html
+++ b/docs/zh/prepare/advanced.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/prepare/allow-hiding-legend-nodes.html
+++ b/docs/zh/prepare/allow-hiding-legend-nodes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/prepare/attributes-form.html
+++ b/docs/zh/prepare/attributes-form.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/prepare/authentication.html
+++ b/docs/zh/prepare/authentication.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/prepare/change-fonts.html
+++ b/docs/zh/prepare/change-fonts.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/prepare/custom-svg.html
+++ b/docs/zh/prepare/custom-svg.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/prepare/display-expression.html
+++ b/docs/zh/prepare/display-expression.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/prepare/gnss.html
+++ b/docs/zh/prepare/gnss.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/prepare/index.html
+++ b/docs/zh/prepare/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/prepare/live_default_value.html
+++ b/docs/zh/prepare/live_default_value.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/prepare/map-styling-configuration.html
+++ b/docs/zh/prepare/map-styling-configuration.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/prepare/map-themes.html
+++ b/docs/zh/prepare/map-themes.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/prepare/outside-layers.html
+++ b/docs/zh/prepare/outside-layers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/prepare/picture_path.html
+++ b/docs/zh/prepare/picture_path.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/search.html
+++ b/docs/zh/search.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="_static/style.css" />
     <link rel="stylesheet" type="text/css" href="_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>

--- a/docs/zh/support/index.html
+++ b/docs/zh/support/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/synchronise/basemaps.html
+++ b/docs/zh/synchronise/basemaps.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/synchronise/index.html
+++ b/docs/zh/synchronise/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/synchronise/movable-project.html
+++ b/docs/zh/synchronise/movable-project.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/synchronise/qfieldcloud.html
+++ b/docs/zh/synchronise/qfieldcloud.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>

--- a/docs/zh/synchronise/qfieldsync.html
+++ b/docs/zh/synchronise/qfieldsync.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="../_static/style.css" />
     <link rel="stylesheet" type="text/css" href="../_static/qfield.css" />
+    <link rel="canonical" href="https://docs.qfield.org" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>


### PR DESCRIPTION
this is the legacy doc, the new one is on docs.qfield.org.
to make search engines index the new page instead

```bash
find . -name '*.html' | xargs sed -i '/link.*qfield.css/a \    <link rel="canonical" href="https:\/\/docs.qfield.org" \/>'
```