### PR TITLE
Remove needless QtBluetooth QML dependency which is gone in Qt6

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -494,6 +494,7 @@ void QgisMobileapp::initDeclarative()
   qmlRegisterType<BarcodeDecoder>( "org.qfield", 1, 0, "BarcodeDecoder" );
   qmlRegisterType<BarcodeVideoFilter>( "org.qfield", 1, 0, "BarcodeVideoFilter" );
 
+  qmlRegisterUncreatableType<QAbstractSocket>( "org.qfield", 1, 0, "QAbstractSocket", "" );
   qmlRegisterUncreatableType<AbstractGnssReceiver>( "org.qfield", 1, 0, "AbstractGnssReceiver", "" );
   qRegisterMetaType<GnssPositionInformation>( "GnssPositionInformation" );
 

--- a/src/qml/BluetoothDeviceChooser.qml
+++ b/src/qml/BluetoothDeviceChooser.qml
@@ -2,8 +2,6 @@ import QtQuick 2.14
 import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
 
-import QtBluetooth 5.12
-
 import org.qfield 1.0
 
 import Theme 1.0
@@ -160,15 +158,15 @@ GridLayout {
         font: Theme.defaultFont
         text: {
             switch (positionSource.device.socketState) {
-                case BluetoothSocket.Connected:
+                case QAbstractSocket.ConnectedState:
                     return qsTr('Connected to %1').arg(positioningSettings.positioningDeviceName)
-                case BluetoothSocket.Unconnected:
+                case QAbstractSocket.UnconnectedState:
                     return qsTr('Connect to %1').arg(positioningSettings.positioningDeviceName)
                 default:
                     return qsTr('Connecting to %1').arg(positioningSettings.positioningDeviceName)
             }
         }
-        enabled: positionSource.device.socketState === BluetoothSocket.Unconnected
+        enabled: positionSource.device.socketState === QAbstractSocket.UnconnectedState
         visible: positionSource.deviceId !== ''
 
         onClicked: {


### PR DESCRIPTION
We were forcing a qml-module-qbluetooth dependency merely to get an enum, let's avoid that. Kills an issue on Qt6.