### PR TITLE
Support graphicaleffects for both Qt5 and Qt6

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -74,6 +74,11 @@ int main( int argc, char **argv )
 #endif
 
   Q_INIT_RESOURCE( qml );
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 )
+  Q_INIT_RESOURCE( qmlqt6 );
+#else
+  Q_INIT_RESOURCE( qmlqt5 );
+#endif
 
   QtWebView::initialize();
 

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -123,6 +123,7 @@
 
 #include <QFileInfo>
 #include <QFontDatabase>
+#include <QQmlFileSelector>
 #include <QResource>
 #include <QStyleHints>
 #include <QTemporaryFile>
@@ -176,6 +177,15 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   , mFirstRenderingFlag( true )
   , mApp( app )
 {
+  QQmlFileSelector *fs = new QQmlFileSelector( this );
+  QStringList selectors;
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 )
+  selectors << QStringLiteral( "Qt6" );
+#else
+  selectors << QStringLiteral( "Qt5" );
+#endif
+  fs->setExtraSelectors( selectors );
+
   // Set a nicer default hyperlink color to be used in QML Text items
   QPalette palette = app->palette();
   palette.setColor( QPalette::Link, QColor( 128, 204, 40 ) );

--- a/src/qml/BookmarkRenderer.qml
+++ b/src/qml/BookmarkRenderer.qml
@@ -1,6 +1,5 @@
 import QtQuick 2.14
 import QtQuick.Shapes 1.14
-import QtGraphicalEffects 1.14
 
 import org.qgis 1.0
 import org.qfield 1.0
@@ -115,10 +114,9 @@ Item {
 
                     layer.enabled: true
                     layer.samples: 4
-                    layer.effect: DropShadow {
+                    layer.effect: QfDropShadow {
                         transparentBorder: true
                         radius: 8
-                        samples: 25
                         color: "#99000000"
                         horizontalOffset: 0
                         verticalOffset: 0

--- a/src/qml/CMakeLists.txt
+++ b/src/qml/CMakeLists.txt
@@ -5,13 +5,22 @@ file(GLOB_RECURSE QML_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.qml")
 if(${QT_PKG}QuickCompiler_FOUND
    AND NOT CMAKE_BUILD_TYPE MATCHES Debug
    AND NOT CMAKE_BUILD_TYPE MATCHES RelWithDebInfo)
-  qtquick_compiler_add_resources(QML_SOURCES
-                                 ${CMAKE_CURRENT_SOURCE_DIR}/qml.qrc)
+  if(BUILD_WITH_QT6)
+    qtquick_compiler_add_resources(
+      QML_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/qml.qrc
+      ${CMAKE_CURRENT_SOURCE_DIR}/qmlqt6.qrc)
+  else()
+    qtquick_compiler_add_resources(
+      QML_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/qml.qrc
+      ${CMAKE_CURRENT_SOURCE_DIR}/qmlqt5.qrc)
+  endif()
 else()
   if(BUILD_WITH_QT6)
     qt_add_resources(QML_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/qml.qrc)
+    qt_add_resources(QML_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/qmlqt6.qrc)
   else()
     qt5_add_resources(QML_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/qml.qrc)
+    qt5_add_resources(QML_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/qmlqt5.qrc)
   endif()
 endif()
 

--- a/src/qml/LocationMarker.qml
+++ b/src/qml/LocationMarker.qml
@@ -1,11 +1,12 @@
 import QtQuick 2.14
 import QtQuick.Shapes 1.14
 import QtQuick.Window 2.14
-import QtGraphicalEffects 1.14
 import QtSensors 5.14
 
 import org.qgis 1.0
 import Theme 1.0
+
+import "."
 
 Item {
   id: item
@@ -130,10 +131,9 @@ Item {
 
     layer.enabled: true
     layer.samples: 4
-    layer.effect: DropShadow {
+    layer.effect: QfDropShadow {
         transparentBorder: true
         radius: 8
-        samples: 25
         color: "#99000000"
         horizontalOffset: 0
         verticalOffset: 0
@@ -164,10 +164,9 @@ Item {
 
     layer.enabled: true
     layer.samples: 4
-    layer.effect: DropShadow {
+    layer.effect: QfDropShadow {
         transparentBorder: true
         radius: 8
-        samples: 25
         color: "#99000000"
         horizontalOffset: 0
         verticalOffset: 0
@@ -210,10 +209,9 @@ Item {
 
     layer.enabled: true
     layer.samples: 4
-    layer.effect: DropShadow {
+    layer.effect: QfDropShadow {
         transparentBorder: true
         radius: 8
-        samples: 25
         color: "#99000000"
         horizontalOffset: 0
         verticalOffset: 0

--- a/src/qml/NavigationRenderer.qml
+++ b/src/qml/NavigationRenderer.qml
@@ -1,6 +1,5 @@
 import QtQuick 2.14
 import QtQuick.Shapes 1.14
-import QtGraphicalEffects 1.14
 
 import org.qgis 1.0
 import org.qfield 1.0
@@ -71,10 +70,9 @@ Item {
 
                     layer.enabled: true
                     layer.samples: 4
-                    layer.effect: DropShadow {
+                    layer.effect: QfDropShadow {
                         transparentBorder: true
                         radius: 8
-                        samples: 25
                         color: "#99000000"
                         horizontalOffset: 0
                         verticalOffset: 0
@@ -111,10 +109,9 @@ Item {
 
                   layer.enabled: true
                   layer.samples: 4
-                  layer.effect: DropShadow {
+                  layer.effect: QfDropShadow {
                       transparentBorder: true
                       radius: 8
-                      samples: 25
                       color: "#99000000"
                       horizontalOffset: 0
                       verticalOffset: 0

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.14
 import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
-import QtGraphicalEffects 1.14
 
 import org.qfield 1.0
 import Theme 1.0
@@ -130,7 +129,7 @@ Popup {
               sourceSize.width: width * screen.devicePixelRatio
               sourceSize.height: height * screen.devicePixelRatio
               layer.enabled: true
-              layer.effect: OpacityMask {
+              layer.effect: QfOpacityMask {
                   maskSource: cloudAvatarMask
               }
 

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -2,10 +2,11 @@ import QtQuick 2.14
 import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
 import QtQml.Models 2.14
-import QtGraphicalEffects 1.14
 
 import org.qfield 1.0
 import Theme 1.0
+
+import "."
 
 Page {
   id: qfieldcloudScreen
@@ -88,7 +89,7 @@ Page {
             sourceSize.width: width * screen.devicePixelRatio
             sourceSize.height: height * screen.devicePixelRatio
             layer.enabled: true
-            layer.effect: OpacityMask {
+            layer.effect: QfOpacityMask {
                 maskSource: cloudAvatarMask
             }
 

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -1,6 +1,5 @@
 import QtQuick 2.14
 import QtQuick.Controls 2.14
-import QtGraphicalEffects 1.14
 import QtQuick.Window 2.14
 import QtMultimedia 5.14
 
@@ -235,13 +234,12 @@ EditorWidgetBase {
               sourceSize.height: 24 * Screen.devicePixelRatio
           }
 
-          DropShadow {
+          QfDropShadow {
               anchors.fill: geoTagBadge
               visible: geoTagBadge.visible
               horizontalOffset: 0
               verticalOffset: 0
               radius: 6.0
-              samples: 17
               color: "#DD000000"
               source: geoTagBadge
           }

--- a/src/qml/imports/Theme/+Qt5/QfDropShadow.qml
+++ b/src/qml/imports/Theme/+Qt5/QfDropShadow.qml
@@ -1,0 +1,4 @@
+import QtQuick 2.14
+import QtGraphicalEffects 1.14
+
+DropShadow {}

--- a/src/qml/imports/Theme/+Qt5/QfOpacityMask.qml
+++ b/src/qml/imports/Theme/+Qt5/QfOpacityMask.qml
@@ -1,0 +1,4 @@
+import QtQuick 2.14
+import QtGraphicalEffects 1.14
+
+OpacityMask {}

--- a/src/qml/imports/Theme/+Qt6/QfDropShadow.qml
+++ b/src/qml/imports/Theme/+Qt6/QfDropShadow.qml
@@ -1,0 +1,4 @@
+import QtQuick 2.14
+import Qt5Compat.GraphicalEffects
+
+DropShadow {}

--- a/src/qml/imports/Theme/+Qt6/QfOpacityMask.qml
+++ b/src/qml/imports/Theme/+Qt6/QfOpacityMask.qml
@@ -1,0 +1,4 @@
+import QtQuick 2.14
+import Qt5Compat.GraphicalEffects
+
+OpacityMask {}

--- a/src/qml/imports/Theme/QfToolButton.qml
+++ b/src/qml/imports/Theme/QfToolButton.qml
@@ -2,7 +2,6 @@ import QtQuick 2.14
 import QtQuick.Controls 2.14
 import QtQuick.Controls.Material 2.14
 import QtQuick.Controls.Material.impl 2.14
-import QtGraphicalEffects 1.14
 
 import Theme 1.0
 
@@ -55,7 +54,7 @@ RoundButton {
       color: bgcolor == "#ffffff" || bgcolor == "#00000000" ? "#10000000" : "#22ffffff"
 
       layer.enabled: true
-      layer.effect: OpacityMask {
+      layer.effect: QfOpacityMask {
         maskSource: Rectangle
         {
           width: ripple.width

--- a/src/qml/imports/Theme/qmldir
+++ b/src/qml/imports/Theme/qmldir
@@ -5,3 +5,5 @@ QfButton 1.0 QfButton.qml
 QfToolButton 1.0 QfToolButton.qml
 QfTextField 1.0 QfTextField.qml
 QfCollapsibleMessage 1.0 QfCollapsibleMessage.qml
+QfDropShadow 1.0 QfDropShadow.qml
+QfOpacityMask 1.0 QfOpacityMask.qml

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -18,9 +18,7 @@
 import QtQuick 2.14
 import QtQuick.Controls 2.14
 import QtQuick.Window 2.14
-import QtGraphicalEffects 1.14
 import QtQml 2.14
-
 import Qt.labs.settings 1.0 as LabSettings
 
 import org.qgis 1.0
@@ -690,12 +688,11 @@ ApplicationWindow {
     }
   }
 
-  DropShadow {
+  QfDropShadow {
     anchors.fill: informationView
     visible: informationView.visible
     verticalOffset: -2
     radius: 6.0
-    samples: 17
     color: "#30000000"
     source: informationView
   }
@@ -810,12 +807,11 @@ ApplicationWindow {
     anchors.margins: 10
   }
 
-  DropShadow {
+  QfDropShadow {
     anchors.fill: featureForm
     horizontalOffset: mainWindow.width >= mainWindow.height ? -2: 0
     verticalOffset: mainWindow.width < mainWindow.height ? -2: 0
     radius: 6.0
-    samples: 17
     color: "#80000000"
     source: featureForm
   }
@@ -928,12 +924,11 @@ ApplicationWindow {
       parent: ApplicationWindow.overlay
   }
 
-  DropShadow {
+  QfDropShadow {
     anchors.fill: locatorItem
     visible: locatorItem.searchFieldVisible
     verticalOffset: 2
     radius: 10
-    samples: 17
     color: "#66212121"
     source: locatorItem
   }

--- a/src/qml/qmlqt5.qrc
+++ b/src/qml/qmlqt5.qrc
@@ -1,0 +1,6 @@
+<RCC>
+    <qresource prefix="/qml">
+        <file>imports/Theme/+Qt5/QfDropShadow.qml</file>
+        <file>imports/Theme/+Qt5/QfOpacityMask.qml</file>
+    </qresource>
+</RCC>

--- a/src/qml/qmlqt6.qrc
+++ b/src/qml/qmlqt6.qrc
@@ -1,0 +1,6 @@
+<RCC>
+    <qresource prefix="/qml">
+        <file>imports/Theme/+Qt6/QfDropShadow.qml</file>
+        <file>imports/Theme/+Qt6/QfOpacityMask.qml</file>
+    </qresource>
+</RCC>

--- a/test/test_qml_editorwidgets.cpp
+++ b/test/test_qml_editorwidgets.cpp
@@ -19,6 +19,7 @@
 
 #include <QQmlContext>
 #include <QQmlEngine>
+#include <QQmlFileSelector>
 #include <QtQuickTest>
 
 #define REGISTER_SINGLETON( uri, _class, name ) qmlRegisterSingletonType<_class>( uri, 1, 0, name, []( QQmlEngine *engine, QJSEngine *scriptEngine ) -> QObject * { Q_UNUSED(engine); Q_UNUSED(scriptEngine); return new _class(); } )
@@ -36,6 +37,15 @@ class Setup : public QObject
   public slots:
     void qmlEngineAvailable( QQmlEngine *engine )
     {
+      QQmlFileSelector *fs = new QQmlFileSelector( engine );
+      QStringList selectors;
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 )
+      selectors << QStringLiteral( "Qt6" );
+#else
+      selectors << QStringLiteral( "Qt5" );
+#endif
+      fs->setExtraSelectors( selectors );
+
       qmlInit( engine );
     }
 };


### PR DESCRIPTION
Playing a nice little trick so we can maintain support for both Qt5 and Qt6 when it comes to graphical effects.

_(This trick also means we can maintain both a Qt5 barcode reader and a Qt6 bardcode reader and not lock QField into an overly-early Qt6-only stage for our src/ tree)_