### PR TITLE
Remember map layer styling (opacity, labels visibility) across QField sessions

### DIFF
--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -936,6 +936,9 @@ bool FlatLayerTreeModelBase::setData( const QModelIndex &index, const QVariant &
         mCollapsedItems.removeAll( sourceIndex );
       }
 
+      QgsLayerTreeNode *node = mLayerTreeModel->index2node( sourceIndex );
+      node->setExpanded( !collapsed );
+
       //the node's children are also impacted, use the tree level value to identify those
       int treeLevel = mTreeLevelMap[index.row()];
       int endRow = index.row();

--- a/src/core/projectinfo.cpp
+++ b/src/core/projectinfo.cpp
@@ -16,7 +16,6 @@
 
 
 #include "projectinfo.h"
-#include "qgismobileapp.h"
 
 #include <QDateTime>
 #include <QFileInfo>

--- a/src/core/projectinfo.cpp
+++ b/src/core/projectinfo.cpp
@@ -180,8 +180,7 @@ void ProjectInfo::saveLayerTreeState() const
     const QgsMapThemeCollection::MapThemeRecord rec = QgsMapThemeCollection::createThemeFromCurrentState( mLayerTree->layerTreeModel()->rootGroup(), mLayerTree->layerTreeModel() );
     mapCollection.insert( QStringLiteral( "::QFieldLayerTreeState" ), rec );
 
-    QDomImplementation DomImplementation;
-    const QDomDocumentType documentType = DomImplementation.createDocumentType( QStringLiteral( "qgis" ), QStringLiteral( "http://mrcc.com/qgis.dtd" ), QStringLiteral( "SYSTEM" ) );
+    const QDomDocumentType documentType = QDomImplementation().createDocumentType( QStringLiteral( "qgis" ), QStringLiteral( "http://mrcc.com/qgis.dtd" ), QStringLiteral( "SYSTEM" ) );
     QDomDocument document( documentType );
 
     document.appendChild( document.createElement( QStringLiteral( "qgis" ) ) );

--- a/src/core/projectinfo.h
+++ b/src/core/projectinfo.h
@@ -59,7 +59,12 @@ class ProjectInfo : public QObject
     /**
      * Saves the \a layer style to the current project information settings
      */
-    Q_INVOKABLE void saveLayerStyle( QgsMapLayer *layer );
+    Q_INVOKABLE void saveLayerStyle( QgsMapLayer *layer ) const;
+
+    /**
+     * Saves the current state (visibility and collapse status) of the layer tree
+     */
+    Q_INVOKABLE void saveLayerTreeState() const;
 
   signals:
 

--- a/src/core/projectinfo.h
+++ b/src/core/projectinfo.h
@@ -56,6 +56,11 @@ class ProjectInfo : public QObject
 
     FlatLayerTreeModel *layerTree() const;
 
+    /**
+     * Saves the \a layer style to the current project information settings
+     */
+    Q_INVOKABLE void saveLayerStyle( QgsMapLayer *layer );
+
   signals:
 
     void filePathChanged();

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -1192,9 +1192,7 @@ void QgisMobileapp::readProjectFile()
   const QStringList ids = settings.allKeys();
   if ( !ids.isEmpty() )
   {
-    qDebug() << ids;
     const bool isDataset = mProject->readBoolEntry( QStringLiteral( "QField" ), QStringLiteral( "isDataset" ), false );
-    qDebug() << ( isDataset ? "isDataset" : "not isDataset" );
     const QList<QgsMapLayer *> mapLayers = isDataset ? mProject->layerStore()->mapLayers().values() : QList<QgsMapLayer *>();
 
     for ( QString id : ids )
@@ -1211,9 +1209,6 @@ void QgisMobileapp::readProjectFile()
       {
         for ( QgsMapLayer *ml : mapLayers )
         {
-          qDebug() << ml->source();
-          qDebug() << id;
-          qDebug() << "--";
           if ( ml && ml->source() == id )
           {
             layer = ml;
@@ -1228,17 +1223,31 @@ void QgisMobileapp::readProjectFile()
 
       if ( layer )
       {
-        qDebug() << "MMMM";
         QgsMapLayerStyle style( xmlData );
         style.writeToLayer( layer );
       }
     }
   }
+  settings.endGroup();
 
-  // Restore last map theme
   const QString mapTheme = settings.value( QStringLiteral( "/qgis/projectInfo/%1/maptheme" ).arg( mProjectFilePath ), QString() ).toString();
+  const QString layerTreeState = settings.value( QStringLiteral( "/qgis/projectInfo/%1/layertreestate" ).arg( mProjectFilePath ), QString() ).toString();
   if ( !mapTheme.isEmpty() )
+  {
+    qDebug() << "XXX";
     mFlatLayerTree->setMapTheme( mapTheme );
+  }
+  else if ( !layerTreeState.isEmpty() )
+  {
+    qDebug() << "YYY";
+    QDomDocument document;
+    document.setContent( layerTreeState );
+    qDebug() << document.toString();
+
+    QgsMapThemeCollection mapCollection( mProject );
+    mapCollection.readXml( document );
+    mapCollection.applyTheme( QStringLiteral( "::QFieldLayerTreeState" ), mFlatLayerTree->layerTreeModel()->rootGroup(), mFlatLayerTree->layerTreeModel() );
+  }
 
   emit loadProjectEnded( mProjectFilePath, mProjectFileName );
 }

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -1234,15 +1234,12 @@ void QgisMobileapp::readProjectFile()
   const QString layerTreeState = settings.value( QStringLiteral( "/qgis/projectInfo/%1/layertreestate" ).arg( mProjectFilePath ), QString() ).toString();
   if ( !mapTheme.isEmpty() )
   {
-    qDebug() << "XXX";
     mFlatLayerTree->setMapTheme( mapTheme );
   }
   else if ( !layerTreeState.isEmpty() )
   {
-    qDebug() << "YYY";
     QDomDocument document;
     document.setContent( layerTreeState );
-    qDebug() << document.toString();
 
     QgsMapThemeCollection mapCollection( mProject );
     mapCollection.readXml( document );

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -142,6 +142,7 @@ Popup {
         onClicked: {
           layerTree.setData(index, checkState === Qt.Checked, FlatLayerTreeModel.Visible);
           flatLayerTree.mapTheme = '';
+          projectInfo.saveLayerTreeState();
           close();
         }
       }

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -161,6 +161,7 @@ Popup {
 
         onClicked: {
           layerTree.setData(index, checkState === Qt.Checked, FlatLayerTreeModel.LabelsVisible);
+          projectInfo.saveLayerStyle(layerTree.data(index, FlatLayerTreeModel.MapLayerPointer))
           close();
         }
       }
@@ -201,7 +202,10 @@ Popup {
             Layout.fillWidth: true
             id: slider
             value: index !== undefined ? layerTree.data(index, FlatLayerTreeModel.Opacity) : 0
-            onMoved: layerTree.setData(index, value, FlatLayerTreeModel.Opacity)
+            onMoved: {
+              layerTree.setData(index, value, FlatLayerTreeModel.Opacity)
+              projectInfo.saveLayerStyle(layerTree.data(index, FlatLayerTreeModel.MapLayerPointer))
+            }
           }
         }
       }

--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -250,6 +250,7 @@ ListView {
             if (layerTree.data(itemIndex, FlatLayerTreeModel.HasChildren)) {
               var isCollapsed = layerTree.data(itemIndex, FlatLayerTreeModel.IsCollapsed)
               layerTree.setData(itemIndex, !isCollapsed, FlatLayerTreeModel.IsCollapsed);
+              projectInfo.saveLayerTreeState();
             }
           }
       }


### PR DESCRIPTION
This PR implements functionality to save and restore customized a given project map layer styling across QField sessions. At this moment, it will properly save/restore layer opacity, label visibility, as well as individual layer's visibility (i.e. [x] show on map) state.

Note: The implementation covers both project and individual dataset contexts when it comes to opacity, label visibility, however the individual layer's [x] show on map are not remember when opening individual datasets.

Here's a video showcasing the enhancement:

https://user-images.githubusercontent.com/1728657/186128295-7d4886c5-d119-4b2c-ad62-9556d4dc85a6.mp4

You can see various styling attributes (layer opacity, layer visibility, and label visibility) are all remembered _across_ a given project sessions.