### PR TITLE
Allow position tracking on point layers

### DIFF
--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -487,7 +487,7 @@ void FeatureModel::resetFeatureId()
   mFeature.setId( FID_NULL );
 }
 
-void FeatureModel::resetAttributes()
+void FeatureModel::resetAttributes( bool partialReset )
 {
   if ( !mLayer )
     return;
@@ -528,7 +528,7 @@ void FeatureModel::resetAttributes()
 
         mFeature.setAttribute( i, value );
       }
-      else
+      else if ( !partialReset )
       {
         mFeature.setAttribute( i, QVariant() );
       }
@@ -661,7 +661,6 @@ bool FeatureModel::create()
   connect( mLayer, &QgsVectorLayer::featureAdded, this, &FeatureModel::featureAdded );
 
   QgsFeature createdFeature = QgsVectorLayerUtils::createFeature( mLayer, mFeature.geometry(), mFeature.attributes().toMap() );
-
   if ( mLayer->addFeature( createdFeature ) )
   {
     if ( mProject && mProject->topologicalEditing() )

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -472,6 +472,21 @@ void FeatureModel::resetFeature()
   mFeature = QgsFeature( mLayer->fields() );
 }
 
+void FeatureModel::resetFeatureId()
+{
+  if ( !mLayer )
+    return;
+
+  if ( sRememberings->contains( mLayer ) )
+  {
+    QMutex *mutex = sMutex;
+    QMutexLocker locker( mutex );
+    ( *sRememberings )[mLayer].rememberedFeature = mFeature;
+  }
+
+  mFeature.setId( FID_NULL );
+}
+
 void FeatureModel::resetAttributes()
 {
   if ( !mLayer )

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -184,6 +184,8 @@ class FeatureModel : public QAbstractListModel
 
     Q_INVOKABLE void resetFeature();
 
+    Q_INVOKABLE void resetFeatureId();
+
     QVector<bool> rememberedAttributes() const;
 
     /**

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -180,7 +180,11 @@ class FeatureModel : public QAbstractListModel
 
     Q_INVOKABLE bool suppressFeatureForm() const;
 
-    Q_INVOKABLE void resetAttributes();
+    /**
+     * Resets the attribute values of the current feature
+     * \param partialReset when set to TRUE, only attributes with default or remembered values will be reset
+     */
+    Q_INVOKABLE void resetAttributes( bool partialReset = false );
 
     Q_INVOKABLE void resetFeature();
 

--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -671,7 +671,7 @@ QVariant FlatLayerTreeModelBase::data( const QModelIndex &index, int role ) cons
         QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( nodeLayer->layer() );
         if ( layer && layer->isValid() )
         {
-          return true;
+          return ( layer->geometryType() == QgsWkbTypes::PointGeometry || layer->geometryType() == QgsWkbTypes::LineGeometry || layer->geometryType() == QgsWkbTypes::PolygonGeometry );
         }
       }
       return false;

--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -671,7 +671,7 @@ QVariant FlatLayerTreeModelBase::data( const QModelIndex &index, int role ) cons
         QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( nodeLayer->layer() );
         if ( layer && layer->isValid() )
         {
-          return ( layer->geometryType() == QgsWkbTypes::LineGeometry || layer->geometryType() == QgsWkbTypes::PolygonGeometry );
+          return true;
         }
       }
       return false;

--- a/src/core/positioning/internalgnssreceiver.cpp
+++ b/src/core/positioning/internalgnssreceiver.cpp
@@ -17,6 +17,7 @@
 #include "internalgnssreceiver.h"
 
 #include <QGuiApplication>
+#include <QTimer>
 #include <qgsapplication.h>
 
 InternalGnssReceiver::InternalGnssReceiver( QObject *parent )
@@ -38,6 +39,20 @@ InternalGnssReceiver::InternalGnssReceiver( QObject *parent )
     mSocketState = QAbstractSocket::ConnectedState;
 
     setValid( true );
+
+    QTimer *timer = new QTimer();
+    timer->setInterval( 500 );
+    timer->setSingleShot( false );
+    connect( timer, &QTimer::timeout, this, [=] {
+      QGeoPositionInfo position;
+      double lat = 11.5566 + ( ( double ) ( std::rand() % 99 ) / 1000.0 );
+      double lon = 104.9118 + ( ( double ) ( std::rand() % 99 ) / 1000.0 );
+
+      position.setCoordinate( QGeoCoordinate( lat, lon ) );
+      position.setTimestamp( QDateTime::currentDateTime() );
+      handlePositionUpdated( position );
+    } );
+    timer->start();
   }
 
   mGeoSatelliteSource = std::unique_ptr<QGeoSatelliteInfoSource>( QGeoSatelliteInfoSource::createDefaultSource( nullptr ) );

--- a/src/core/positioning/internalgnssreceiver.cpp
+++ b/src/core/positioning/internalgnssreceiver.cpp
@@ -17,7 +17,6 @@
 #include "internalgnssreceiver.h"
 
 #include <QGuiApplication>
-#include <QTimer>
 #include <qgsapplication.h>
 
 InternalGnssReceiver::InternalGnssReceiver( QObject *parent )
@@ -39,20 +38,6 @@ InternalGnssReceiver::InternalGnssReceiver( QObject *parent )
     mSocketState = QAbstractSocket::ConnectedState;
 
     setValid( true );
-
-    QTimer *timer = new QTimer();
-    timer->setInterval( 500 );
-    timer->setSingleShot( false );
-    connect( timer, &QTimer::timeout, this, [=] {
-      QGeoPositionInfo position;
-      double lat = 11.5566 + ( ( double ) ( std::rand() % 99 ) / 1000.0 );
-      double lon = 104.9118 + ( ( double ) ( std::rand() % 99 ) / 1000.0 );
-
-      position.setCoordinate( QGeoCoordinate( lat, lon ) );
-      position.setTimestamp( QDateTime::currentDateTime() );
-      handlePositionUpdated( position );
-    } );
-    timer->start();
   }
 
   mGeoSatelliteSource = std::unique_ptr<QGeoSatelliteInfoSource>( QGeoSatelliteInfoSource::createDefaultSource( nullptr ) );

--- a/src/core/rubberband.cpp
+++ b/src/core/rubberband.cpp
@@ -155,17 +155,23 @@ QSGNode *Rubberband::updatePaintNode( QSGNode *n, QQuickItem::UpdatePaintNodeDat
     bool frozen = mRubberbandModel && mRubberbandModel->frozen();
 
     QVector<QgsPoint> allVertices = QVector<QgsPoint>();
-    QgsWkbTypes::GeometryType geomType = QgsWkbTypes::LineGeometry;
+    QgsWkbTypes::GeometryType geomType = mGeometryType;
 
     if ( mRubberbandModel && !mRubberbandModel->isEmpty() )
     {
       allVertices = mRubberbandModel->flatVertices();
-      geomType = mRubberbandModel->geometryType();
+      if ( geomType == QgsWkbTypes::NullGeometry )
+      {
+        geomType = mRubberbandModel->geometryType();
+      }
     }
     else if ( mVertexModel && mVertexModel->vertexCount() > 0 )
     {
       allVertices = mVertexModel->flatVertices();
-      geomType = mVertexModel->geometryType();
+      if ( geomType == QgsWkbTypes::NullGeometry )
+      {
+        geomType = mRubberbandModel->geometryType();
+      }
     }
 
     if ( !allVertices.isEmpty() )
@@ -190,6 +196,16 @@ QSGNode *Rubberband::updatePaintNode( QSGNode *n, QQuickItem::UpdatePaintNodeDat
 
   mDirty = false;
   return n;
+}
+
+void Rubberband::setGeometryType( const QgsWkbTypes::GeometryType geometryType )
+{
+  if ( mGeometryType == geometryType )
+    return;
+
+  mGeometryType = geometryType;
+
+  emit geometryTypeChanged();
 }
 
 float Rubberband::lineWidth() const

--- a/src/core/rubberband.h
+++ b/src/core/rubberband.h
@@ -17,6 +17,7 @@
 #define RUBBERBAND_H
 
 #include <QQuickItem>
+#include <qgswkbtypes.h>
 
 class RubberbandModel;
 class VertexModel;
@@ -42,6 +43,8 @@ class Rubberband : public QQuickItem
     Q_PROPERTY( QColor colorCurrentPoint READ colorCurrentPoint WRITE setColorCurrentPoint NOTIFY colorCurrentPointChanged )
     //! Line width  of the aleternative rubberband for current point
     Q_PROPERTY( qreal lineWidthCurrentPoint READ lineWidthCurrentPoint WRITE setLineWidthCurrentPoint NOTIFY lineWidthCurrentPointChanged )
+    //! Geometry type used to render the rubber band (if not provided or set to null geometry, the type provided by the rubber band or vertex model will be used)
+    Q_PROPERTY( QgsWkbTypes::GeometryType geometryType READ geometryType WRITE setGeometryType NOTIFY geometryTypeChanged )
 
   public:
     explicit Rubberband( QQuickItem *parent = nullptr );
@@ -75,6 +78,11 @@ class Rubberband : public QQuickItem
     //! \copydoc widthCurrentPoint
     void setLineWidthCurrentPoint( float width );
 
+    //! \copydoc geometryType
+    QgsWkbTypes::GeometryType geometryType() const { return mGeometryType; }
+    //! \copydoc geometryType
+    void setGeometryType( const QgsWkbTypes::GeometryType geometryType );
+
   signals:
     void modelChanged();
     void vertexModelChanged();
@@ -87,6 +95,8 @@ class Rubberband : public QQuickItem
     void colorCurrentPointChanged();
     //! \copydoc widthCurrentPoint
     void lineWidthCurrentPointChanged();
+    //! \copydoc geometryType
+    void geometryTypeChanged();
 
 
   private slots:
@@ -106,6 +116,7 @@ class Rubberband : public QQuickItem
     float mWidth = 1.8;
     QColor mColorCurrentPoint = QColor( 192, 57, 43, 150 );
     float mWidthCurrentPoint = 1.2;
+    QgsWkbTypes::GeometryType mGeometryType = QgsWkbTypes::NullGeometry;
 };
 
 

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -110,6 +110,9 @@ void Tracker::start()
 
 void Tracker::stop()
 {
+  //track last position
+  trackPosition();
+
   if ( mTimeInterval > 0 )
   {
     mTimer.stop();

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -362,6 +362,7 @@ Popup {
       return false
 
     return layerTree.data( index, FlatLayerTreeModel.Type ) === 'layer'
+        && !layerTree.data( index, FlatLayerTreeModel.ReadOnly )
         && layerTree.data( index, FlatLayerTreeModel.Trackable )
         && positionSource.active
   }

--- a/src/qml/Tracking.qml
+++ b/src/qml/Tracking.qml
@@ -67,6 +67,7 @@ Item {
 
     lineWidth: 4
     color: Qt.rgba(Math.random(),Math.random(),Math.random(),0.6);
+    geometryType: QgsWkbTypes.LineGeometry
 
     mapSettings: mapCanvas.mapSettings
     model: rubberbandModel

--- a/src/qml/Tracking.qml
+++ b/src/qml/Tracking.qml
@@ -425,7 +425,7 @@ Item {
                 track.rubberModel = rubberbandModel
 
                 trackInformationDialog.active = false
-                if (embeddedAttributeFormModel.rowCount() > 0) {
+                if (embeddedAttributeFormModel.rowCount() > 0 && !featureModel.suppressFeatureForm()) {
                   embeddedFeatureForm.active = true
                 } else {
                   trackingModel.startTracker(track.vectorLayer)

--- a/src/qml/Tracking.qml
+++ b/src/qml/Tracking.qml
@@ -8,419 +8,430 @@ import Theme 1.0
 
 import '.'
 
-Item{
-    id: tracking
+Item {
+  id: tracking
 
-    property var mainModel: model
+  property var track: model
 
-    Component.onCompleted: {
-        featureModel.resetAttributes()
-        embeddedFeatureForm.state = 'Add'
-        trackInformationDialog.active = true
-    }
+  Component.onCompleted: {
+    featureModel.resetAttributes()
+    embeddedFeatureForm.state = 'Add'
+    trackInformationDialog.active = true
+  }
 
-    RubberbandModel {
-        id: rubberbandModel
-        frozen: false
-        vectorLayer: mainModel.vectorLayer
-        currentCoordinate: positionSource.projectedPosition
-        measureValue: ( positionSource.positionInformation.utcDateTime - mainModel.startPositionTimestamp ) / 1000
-        currentPositionTimestamp: positionSource.positionInformation.utcDateTime
-        crs: mapCanvas.mapSettings.destinationCrs
+  RubberbandModel {
+    id: rubberbandModel
+    frozen: false
+    vectorLayer: track.vectorLayer
+    currentCoordinate: positionSource.projectedPosition
+    measureValue: ( positionSource.positionInformation.utcDateTime - track.startPositionTimestamp ) / 1000
+    currentPositionTimestamp: positionSource.positionInformation.utcDateTime
+    crs: mapCanvas.mapSettings.destinationCrs
 
-        onVertexCountChanged: {
-          if( ( geometryType === QgsWkbTypes.LineGeometry && vertexCount > 2 ) ||
-              ( geometryType === QgsWkbTypes.PolygonGeometry &&vertexCount > 3 ) )
+    onVertexCountChanged: {
+      if (vertexCount == 0) {
+        return;
+      }
+
+      if (geometryType === QgsWkbTypes.PointGeometry) {
+        featureModel.applyGeometry()
+        featureModel.create();
+        featureModel.resetFeatureId();
+      } else {
+        if ((geometryType === QgsWkbTypes.LineGeometry && vertexCount > 2) ||
+            (geometryType === QgsWkbTypes.PolygonGeometry &&vertexCount > 3))
+        {
+          featureModel.applyGeometry()
+
+          if ((geometryType === QgsWkbTypes.LineGeometry && vertexCount == 3) ||
+              (geometryType === QgsWkbTypes.PolygonGeometry && vertexCount == 4))
           {
-              featureModel.applyGeometry()
-
-              if( ( geometryType === QgsWkbTypes.LineGeometry && vertexCount == 3 ) ||
-                  ( geometryType === QgsWkbTypes.PolygonGeometry && vertexCount == 4 ) )
-              {
-                  // indirect action, no need to check for success and display a toast, the log is enough
-                  featureModel.create()
-                  mainModel.feature = featureModel.feature
-              }
-              else
-              {
-                  // indirect action, no need to check for success and display a toast, the log is enough
-                  featureModel.save()
-              }
+            // indirect action, no need to check for success and display a toast, the log is enough
+            featureModel.create()
+            track.feature = featureModel.feature
+          }
+          else
+          {
+            // indirect action, no need to check for success and display a toast, the log is enough
+            featureModel.save()
           }
         }
+      }
+    }
+  }
+
+  Rubberband {
+    id: rubberband
+    anchors.fill: parent
+    visible: track.visible
+
+    lineWidth: 4
+    color: Qt.rgba(Math.random(),Math.random(),Math.random(),0.6);
+
+    mapSettings: mapCanvas.mapSettings
+    model: rubberbandModel
+  }
+
+  FeatureModel {
+    id: featureModel
+    project: qgisProject
+    currentLayer: track.vectorLayer
+
+    geometry: Geometry {
+      id: featureModelGeometry
+      rubberbandModel: rubberbandModel
+      vectorLayer: track.vectorLayer
     }
 
-    Rubberband {
-        id: rubberband
-        lineWidth: 4
-        color: Qt.rgba(Math.random(),Math.random(),Math.random(),0.6);
+    positionInformation: coordinateLocator.positionInformation
+    positionLocked: coordinateLocator.overrideLocation !== undefined
+    cloudUserInformation: cloudConnection.userInformation
+  }
 
-        mapSettings: mapCanvas.mapSettings
 
-        model: rubberbandModel
+  // Feature form to set attributes
+  AttributeFormModel {
+    id: embeddedAttributeFormModel
+    featureModel: featureModel
+  }
+
+  Loader {
+    id: embeddedFeatureForm
+
+    sourceComponent: embeddedFeatureFormComponent
+    active: false
+    onLoaded: {
+      item.open()
+    }
+  }
+
+  Component {
+    id: embeddedFeatureFormComponent
+
+    Popup {
+      id: embeddedFeatureFormPopup
+      parent: ApplicationWindow.overlay
+
+      x: Theme.popupScreenEdgeMargin
+      y: Theme.popupScreenEdgeMargin
+      padding: 0
+      width: parent.width - Theme.popupScreenEdgeMargin * 2
+      height: parent.height - Theme.popupScreenEdgeMargin * 2
+      modal: true
+      closePolicy: Popup.CloseOnEscape
+
+      FeatureForm {
+        id: form
+        model: embeddedAttributeFormModel
+
+        focus: true
+        setupOnly: true
+        embedded: true
+        toolbarVisible: true
 
         anchors.fill: parent
 
-        visible: mainModel.visible
-    }
+        state: 'Add'
 
-    FeatureModel {
-        id: featureModel
-        project: qgisProject
-        currentLayer: mainModel.vectorLayer
-        geometry: Geometry {
-          id: featureModelGeometry
-          rubberbandModel: rubberbandModel
-          vectorLayer: mainModel.vectorLayer
-        }
-        cloudUserInformation: cloudConnection.userInformation
-    }
-
-
-    // Feature form to set attributes
-    AttributeFormModel {
-      id: embeddedAttributeFormModel
-      featureModel: featureModel
-    }
-
-    Loader {
-      id: embeddedFeatureForm
-
-      sourceComponent: embeddedFeatureFormComponent
-      active: false
-      onLoaded: {
-        item.open()
-      }
-    }
-
-    Component {
-      id: embeddedFeatureFormComponent
-
-      Popup {
-        id: embeddedFeatureFormPopup
-        parent: ApplicationWindow.overlay
-
-        x: 24
-        y: 24
-        padding: 0
-        width: parent.width - 48
-        height: parent.height - 48
-        modal: true
-        closePolicy: Popup.CloseOnEscape
-
-        FeatureForm {
-            id: form
-            model: embeddedAttributeFormModel
-
-            focus: true
-            setupOnly: true
-            embedded: true
-            toolbarVisible: true
-
-            anchors.fill: parent
-
-            state: 'Add'
-
-            onTemporaryStored: {
-                embeddedFeatureForm.active = false
-                trackingModel.startTracker( mainModel.vectorLayer )
-                displayToast( qsTr( 'Track on layer %1 started' ).arg( mainModel.vectorLayer.name  ) )
-            }
-
-            onCancelled: {
-                embeddedFeatureForm.active = false
-                embeddedFeatureForm.focus = false
-                trackingModel.stopTracker( mainModel.vectorLayer )
-            }
+        onTemporaryStored: {
+          embeddedFeatureForm.active = false
+          trackingModel.startTracker(track.vectorLayer)
+          displayToast(qsTr('Track on layer %1 started').arg(track.vectorLayer.name))
         }
 
-        onClosed: {
-          form.confirm()
+        onCancelled: {
+          embeddedFeatureForm.active = false
+          embeddedFeatureForm.focus = false
+          trackingModel.stopTracker(track.vectorLayer)
         }
       }
-    }
 
-
-    // Dialog to set tracker properties
-    Loader {
-      id: trackInformationDialog
-
-      sourceComponent: trackInformationDialogComponent
-      active: false
-      onLoaded: {
-        item.open()
+      onClosed: {
+        form.confirm()
       }
     }
+  }
 
-    Component {
-      id: trackInformationDialogComponent
 
-      Popup {
-        id: trackInformationPopup
-        parent: ApplicationWindow.overlay
+  // Dialog to set tracker properties
+  Loader {
+    id: trackInformationDialog
 
-        x: 24
-        y: 24
-        padding: 0
-        width: parent.width - 48
-        height: parent.height - 48
-        modal: true
-        closePolicy: Popup.CloseOnEscape
+    sourceComponent: trackInformationDialogComponent
+    active: false
+    onLoaded: {
+      item.open()
+    }
+  }
 
-        Page {
-            focus: true
-            anchors.fill: parent
+  Component {
+    id: trackInformationDialogComponent
 
-            header: PageHeader {
-                title: qsTr("Tracker Settings")
+    Popup {
+      id: trackInformationPopup
+      parent: ApplicationWindow.overlay
 
-                showApplyButton: false
-                showCancelButton: false
-                showBackButton: true
+      x: Theme.popupScreenEdgeMargin
+      y: Theme.popupScreenEdgeMargin
+      padding: 0
+      width: parent.width - Theme.popupScreenEdgeMargin * 2
+      height: parent.height - Theme.popupScreenEdgeMargin * 2
+      modal: true
+      closePolicy: Popup.CloseOnEscape
 
-                onBack: {
-                    trackInformationDialog.active = false
-                    trackingModel.stopTracker( mainModel.vectorLayer )
-                }
-            }
+      Page {
+        focus: true
+        anchors.fill: parent
 
-            ScrollView {
-                padding: 20
-                ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
-                ScrollBar.vertical.policy: ScrollBar.AsNeeded
-                contentWidth: trackerSettingsGrid.width
-                contentHeight: trackerSettingsGrid.height
+        header: PageHeader {
+          title: qsTr("Tracker Settings")
+
+          showApplyButton: false
+          showCancelButton: false
+          showBackButton: true
+
+          onBack: {
+            trackInformationDialog.active = false
+            trackingModel.stopTracker(track.vectorLayer)
+          }
+        }
+
+        ScrollView {
+          padding: 20
+          ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+          ScrollBar.vertical.policy: ScrollBar.AsNeeded
+          contentWidth: trackerSettingsGrid.width
+          contentHeight: trackerSettingsGrid.height
+          anchors.fill: parent
+          clip: true
+
+          GridLayout {
+            id: trackerSettingsGrid
+            width: parent.parent.width
+            Layout.fillWidth: true
+
+            columns: 2
+            columnSpacing: 0
+            rowSpacing: 5
+
+
+            Label {
+              text: qsTr("Activate time constraint")
+              font: Theme.defaultFont
+              wrapMode: Text.WordWrap
+              Layout.fillWidth: true
+
+              MouseArea {
                 anchors.fill: parent
-                clip: true
-
-            GridLayout {
-                id: trackerSettingsGrid
-                width: parent.parent.width
-                Layout.fillWidth: true
-
-                columns: 2
-                columnSpacing: 0
-                rowSpacing: 5
-
-
-                Label {
-                    text: qsTr("Activate time constraint")
-                    font: Theme.defaultFont
-                    wrapMode: Text.WordWrap
-                    Layout.fillWidth: true
-
-                    MouseArea {
-                        anchors.fill: parent
-                        onClicked: timeInterval.toggle()
-                    }
-                }
-
-                QfSwitch {
-                    id: timeInterval
-                    Layout.preferredWidth: implicitContentWidth
-                    Layout.alignment: Qt.AlignTop
-                    checked: positioningSettings.trackerTimeIntervalConstraint
-                    onCheckedChanged: {
-                        positioningSettings.trackerTimeIntervalConstraint = checked
-                    }
-                }
-
-                Label {
-                    text: qsTr("Minimum time [sec]")
-                    font: Theme.defaultFont
-                    wrapMode: Text.WordWrap
-                    enabled: timeInterval.checked
-                    visible: timeInterval.checked
-                    Layout.leftMargin: 8
-                    Layout.fillWidth: true
-                }
-
-                TextField {
-                    id: timeIntervalValue
-                    width: timeInterval.width
-                    font: Theme.defaultFont
-                    enabled: timeInterval.checked
-                    visible: timeInterval.checked
-                    horizontalAlignment: TextInput.AlignHCenter
-                    Layout.preferredWidth: 60
-                    Layout.preferredHeight: font.height + 20
-
-                    inputMethodHints: Qt.ImhFormattedNumbersOnly
-                    validator: DoubleValidator { locale: 'C' }
-
-                    background: Rectangle {
-                      y: parent.height - height - parent.bottomPadding / 2
-                      implicitWidth: 120
-                      height: parent.activeFocus ? 2: 1
-                      color: parent.activeFocus ? Theme.accentColor : Theme.accentLightColor
-                    }
-
-                    Component.onCompleted: {
-                        text = isNaN(positioningSettings.trackerTimeInterval) ? '' : positioningSettings.trackerTimeInterval
-                    }
-
-                    onTextChanged: {
-                        if( text.length === 0 || isNaN(text) ) {
-                            positioningSettings.trackerTimeInterval = NaN
-                        } else {
-                            positioningSettings.trackerTimeInterval = parseFloat( text )
-                        }
-                    }
-                }
-
-                Label {
-                    text: qsTr("Activate distance constraint")
-                    font: Theme.defaultFont
-                    wrapMode: Text.WordWrap
-                    Layout.fillWidth: true
-
-                    MouseArea {
-                        anchors.fill: parent
-                        onClicked: minimumDistance.toggle()
-                    }
-                }
-
-                QfSwitch {
-                    id: minimumDistance
-                    Layout.preferredWidth: implicitContentWidth
-                    Layout.alignment: Qt.AlignTop
-                    checked: positioningSettings.trackerMinimumDistanceConstraint
-                    onCheckedChanged: {
-                        positioningSettings.trackerMinimumDistanceConstraint = checked
-                    }
-                }
-
-                DistanceArea {
-                  id: infoDistanceArea
-                  property VectorLayer currentLayer: mainModel.vectorLayer
-                  project: qgisProject
-                  crs: qgisProject.crs
-                }
-
-                Label {
-                    text: qsTr("Minimum distance [%1]").arg( UnitTypes.toAbbreviatedString( infoDistanceArea.lengthUnits ) )
-                    font: Theme.defaultFont
-                    wrapMode: Text.WordWrap
-                    enabled: minimumDistance.checked
-                    visible: minimumDistance.checked
-                    Layout.leftMargin: 8
-                    Layout.fillWidth: true
-                }
-
-                TextField {
-                    id: minimumDistanceValue
-                    width: minimumDistance.width
-                    font: Theme.defaultFont
-                    enabled: minimumDistance.checked
-                    visible: minimumDistance.checked
-                    horizontalAlignment: TextInput.AlignHCenter
-                    Layout.preferredWidth: 60
-                    Layout.preferredHeight: font.height + 20
-
-                    inputMethodHints: Qt.ImhFormattedNumbersOnly
-                    validator: DoubleValidator { locale: 'C' }
-
-                    background: Rectangle {
-                      y: parent.height - height - parent.bottomPadding / 2
-                      implicitWidth: 120
-                      height: parent.activeFocus ? 2: 1
-                      color: parent.activeFocus ? Theme.accentColor : Theme.accentLightColor
-                    }
-
-                    Component.onCompleted: {
-                        text = isNaN( positioningSettings.trackerMinimumDistance) ? '' : positioningSettings.trackerMinimumDistance
-                    }
-
-                    onTextChanged: {
-                        if( text.length === 0 || isNaN(text) ) {
-                            positioningSettings.trackerMinimumDistance = NaN
-                        } else {
-                            positioningSettings.trackerMinimumDistance = parseFloat( text )
-                        }
-                    }
-                }
-
-                Label {
-                    text: qsTr("Record when both active constraints are met")
-                    font: Theme.defaultFont
-                    wrapMode: Text.WordWrap
-                    Layout.fillWidth: true
-                    enabled: timeInterval.checked && minimumDistance.checked
-                    visible: timeInterval.checked && minimumDistance.checked
-
-                    MouseArea {
-                        anchors.fill: parent
-                        onClicked: allConstraints.toggle()
-                    }
-                }
-
-                QfSwitch {
-                    id: allConstraints
-                    Layout.preferredWidth: implicitContentWidth
-                    Layout.alignment: Qt.AlignTop
-                    enabled: timeInterval.checked && minimumDistance.checked
-                    visible: timeInterval.checked && minimumDistance.checked
-                    checked: positioningSettings.trackerMeetAllConstraints
-                    onCheckedChanged: {
-                        positioningSettings.trackerMeetAllConstraints = checked
-                    }
-                }
-
-
-                Label {
-                    text: qsTr( "When enabled, vertices with only be recorded when both active constraints are met. If the setting is disabled, individual constraints met will trigger a vertex addition." )
-                    font: Theme.tipFont
-                    color: Theme.gray
-                    textFormat: Qt.RichText
-                    wrapMode: Text.WordWrap
-                    Layout.fillWidth: true
-                    enabled: timeInterval.checked && minimumDistance.checked
-                    visible: timeInterval.checked && minimumDistance.checked
-                }
-
-                Item {
-                    Layout.preferredWidth: allConstraints.width
-                }
-
-                QfButton {
-                  id: trackingButton
-                  Layout.topMargin: 8
-                  Layout.fillWidth: true
-                  Layout.columnSpan: 2
-                  font: Theme.defaultFont
-                  text: qsTr( "Start tracking")
-                  icon.source: Theme.getThemeVectorIcon( 'directions_walk_24dp' )
-
-                  onClicked: {
-                      if( Number(timeIntervalValue.text) + Number(minimumDistanceValue.text) === 0 ||
-                              ( timeInterval.checked && minimumDistance.checked && allConstraints.checked &&
-                               ( Number(timeIntervalValue.text) === 0 || Number(minimumDistanceValue.text) === 0 ) ) ||
-                              ( !timeInterval.checked && !minimumDistance.checked ) )
-                      {
-                          displayToast( qsTr( 'Cannot start track with empty values' ), 'warning' )
-                      }
-                      else
-                      {
-                          mainModel.timeInterval = timeIntervalValue.text.length == 0 || !timeInterval.checked ? 0 : timeIntervalValue.text
-                          mainModel.minimumDistance = minimumDistanceValue.text.length == 0 || !minimumDistance.checked ? 0 : minimumDistanceValue.text
-                          mainModel.conjunction = timeInterval.checked && minimumDistance.checked && allConstraints.checked
-                          mainModel.rubberModel = rubberbandModel
-
-                          trackInformationDialog.active = false
-                          embeddedFeatureForm.active = true
-                      }
-                  }
-                }
-
-                Item {
-                    // spacer item
-                    Layout.fillWidth: true
-                    Layout.fillHeight: true
-                }
+                onClicked: timeInterval.toggle()
+              }
             }
 
+            QfSwitch {
+              id: timeInterval
+              Layout.preferredWidth: implicitContentWidth
+              Layout.alignment: Qt.AlignTop
+              checked: positioningSettings.trackerTimeIntervalConstraint
+              onCheckedChanged: {
+                positioningSettings.trackerTimeIntervalConstraint = checked
+              }
             }
+
+            Label {
+              text: qsTr("Minimum time [sec]")
+              font: Theme.defaultFont
+              wrapMode: Text.WordWrap
+              enabled: timeInterval.checked
+              visible: timeInterval.checked
+              Layout.leftMargin: 8
+              Layout.fillWidth: true
+            }
+
+            TextField {
+              id: timeIntervalValue
+              width: timeInterval.width
+              font: Theme.defaultFont
+              enabled: timeInterval.checked
+              visible: timeInterval.checked
+              horizontalAlignment: TextInput.AlignHCenter
+              Layout.preferredWidth: 60
+              Layout.preferredHeight: font.height + 20
+
+              inputMethodHints: Qt.ImhFormattedNumbersOnly
+              validator: DoubleValidator { locale: 'C' }
+
+              background: Rectangle {
+                y: parent.height - height - parent.bottomPadding / 2
+                implicitWidth: 120
+                height: parent.activeFocus ? 2: 1
+                color: parent.activeFocus ? Theme.accentColor : Theme.accentLightColor
+              }
+
+              Component.onCompleted: {
+                text = isNaN(positioningSettings.trackerTimeInterval) ? '' : positioningSettings.trackerTimeInterval
+              }
+
+              onTextChanged: {
+                if( text.length === 0 || isNaN(text) ) {
+                  positioningSettings.trackerTimeInterval = NaN
+                } else {
+                  positioningSettings.trackerTimeInterval = parseFloat( text )
+                }
+              }
+            }
+
+            Label {
+              text: qsTr("Activate distance constraint")
+              font: Theme.defaultFont
+              wrapMode: Text.WordWrap
+              Layout.fillWidth: true
+
+              MouseArea {
+                anchors.fill: parent
+                onClicked: minimumDistance.toggle()
+              }
+            }
+
+            QfSwitch {
+              id: minimumDistance
+              Layout.preferredWidth: implicitContentWidth
+              Layout.alignment: Qt.AlignTop
+              checked: positioningSettings.trackerMinimumDistanceConstraint
+              onCheckedChanged: {
+                positioningSettings.trackerMinimumDistanceConstraint = checked
+              }
+            }
+
+            DistanceArea {
+              id: infoDistanceArea
+              property VectorLayer currentLayer: track.vectorLayer
+              project: qgisProject
+              crs: qgisProject.crs
+            }
+
+            Label {
+              text: qsTr("Minimum distance [%1]").arg( UnitTypes.toAbbreviatedString( infoDistanceArea.lengthUnits ) )
+              font: Theme.defaultFont
+              wrapMode: Text.WordWrap
+              enabled: minimumDistance.checked
+              visible: minimumDistance.checked
+              Layout.leftMargin: 8
+              Layout.fillWidth: true
+            }
+
+            TextField {
+              id: minimumDistanceValue
+              width: minimumDistance.width
+              font: Theme.defaultFont
+              enabled: minimumDistance.checked
+              visible: minimumDistance.checked
+              horizontalAlignment: TextInput.AlignHCenter
+              Layout.preferredWidth: 60
+              Layout.preferredHeight: font.height + 20
+
+              inputMethodHints: Qt.ImhFormattedNumbersOnly
+              validator: DoubleValidator { locale: 'C' }
+
+              background: Rectangle {
+                y: parent.height - height - parent.bottomPadding / 2
+                implicitWidth: 120
+                height: parent.activeFocus ? 2: 1
+                color: parent.activeFocus ? Theme.accentColor : Theme.accentLightColor
+              }
+
+              Component.onCompleted: {
+                text = isNaN(positioningSettings.trackerMinimumDistance) ? '' : positioningSettings.trackerMinimumDistance
+              }
+
+              onTextChanged: {
+                if( text.length === 0 || isNaN(text) ) {
+                  positioningSettings.trackerMinimumDistance = NaN
+                } else {
+                  positioningSettings.trackerMinimumDistance = parseFloat( text )
+                }
+              }
+            }
+
+            Label {
+              text: qsTr("Record when both active constraints are met")
+              font: Theme.defaultFont
+              wrapMode: Text.WordWrap
+              Layout.fillWidth: true
+              enabled: timeInterval.checked && minimumDistance.checked
+              visible: timeInterval.checked && minimumDistance.checked
+
+              MouseArea {
+                anchors.fill: parent
+                onClicked: allConstraints.toggle()
+              }
+            }
+
+            QfSwitch {
+              id: allConstraints
+              Layout.preferredWidth: implicitContentWidth
+              Layout.alignment: Qt.AlignTop
+              enabled: timeInterval.checked && minimumDistance.checked
+              visible: timeInterval.checked && minimumDistance.checked
+              checked: positioningSettings.trackerMeetAllConstraints
+              onCheckedChanged: {
+                positioningSettings.trackerMeetAllConstraints = checked
+              }
+            }
+
+
+            Label {
+              text: qsTr( "When enabled, vertices with only be recorded when both active constraints are met. If the setting is disabled, individual constraints met will trigger a vertex addition." )
+              font: Theme.tipFont
+              color: Theme.gray
+              textFormat: Qt.RichText
+              wrapMode: Text.WordWrap
+              Layout.fillWidth: true
+              enabled: timeInterval.checked && minimumDistance.checked
+              visible: timeInterval.checked && minimumDistance.checked
+            }
+
+            Item {
+              Layout.preferredWidth: allConstraints.width
+            }
+
+            QfButton {
+              id: trackingButton
+              Layout.topMargin: 8
+              Layout.fillWidth: true
+              Layout.columnSpan: 2
+              font: Theme.defaultFont
+              text: qsTr( "Start tracking")
+              icon.source: Theme.getThemeVectorIcon( 'directions_walk_24dp' )
+
+              onClicked: {
+                if (Number(timeIntervalValue.text) + Number(minimumDistanceValue.text) === 0 ||
+                    (timeInterval.checked && minimumDistance.checked && allConstraints.checked &&
+                     (Number(timeIntervalValue.text) === 0 || Number(minimumDistanceValue.text) === 0)) ||
+                    (!timeInterval.checked && !minimumDistance.checked))
+                {
+                  displayToast(qsTr( 'Cannot start track with both constaints switched off'), 'warning')
+                }
+                else
+                {
+                  track.timeInterval = timeIntervalValue.text.length == 0 || !timeInterval.checked ? 0 : timeIntervalValue.text
+                  track.minimumDistance = minimumDistanceValue.text.length == 0 || !minimumDistance.checked ? 0 : minimumDistanceValue.text
+                  track.conjunction = timeInterval.checked && minimumDistance.checked && allConstraints.checked
+                  track.rubberModel = rubberbandModel
+
+                  trackInformationDialog.active = false
+                  embeddedFeatureForm.active = true
+                }
+              }
+            }
+
+            Item {
+              // spacer item
+              Layout.fillWidth: true
+              Layout.fillHeight: true
+            }
+          }
         }
       }
     }
+  }
 }

--- a/src/qml/Tracking.qml
+++ b/src/qml/Tracking.qml
@@ -67,7 +67,10 @@ Item {
     visible: track.visible
 
     lineWidth: 4
-    color: Qt.rgba(Math.random(),Math.random(),Math.random(),0.6);
+    color: Qt.rgba(Math.min(0.75, Math.random()),
+                   Math.min(0.75,Math.random()),
+                   Math.min(0.75,Math.random()),
+                   0.6)
     geometryType: QgsWkbTypes.LineGeometry
 
     mapSettings: mapCanvas.mapSettings

--- a/src/qml/Tracking.qml
+++ b/src/qml/Tracking.qml
@@ -35,8 +35,9 @@ Item {
 
       if (geometryType === QgsWkbTypes.PointGeometry) {
         featureModel.applyGeometry()
-        featureModel.create();
         featureModel.resetFeatureId();
+        featureModel.resetAttributes(true);
+        featureModel.create();
       } else {
         if ((geometryType === QgsWkbTypes.LineGeometry && vertexCount > 2) ||
             (geometryType === QgsWkbTypes.PolygonGeometry &&vertexCount > 3))
@@ -85,7 +86,7 @@ Item {
     }
 
     positionInformation: coordinateLocator.positionInformation
-    positionLocked: coordinateLocator.overrideLocation !== undefined
+    positionLocked: true
     cloudUserInformation: cloudConnection.userInformation
   }
 

--- a/src/qml/Tracking.qml
+++ b/src/qml/Tracking.qml
@@ -383,7 +383,6 @@ Item {
               }
             }
 
-
             Label {
               text: qsTr( "When enabled, vertices with only be recorded when both active constraints are met. If the setting is disabled, individual constraints met will trigger a vertex addition." )
               font: Theme.tipFont
@@ -393,6 +392,17 @@ Item {
               Layout.fillWidth: true
               enabled: timeInterval.checked && minimumDistance.checked
               visible: timeInterval.checked && minimumDistance.checked
+            }
+
+
+            Label {
+              text: qsTr( "When both constraints are disabled, vertex additions will occur as frequently as delivered by the positioning device." )
+              font: Theme.tipFont
+              color: Theme.gray
+              textFormat: Qt.RichText
+              wrapMode: Text.WordWrap
+              Layout.fillWidth: true
+              visible: !timeInterval.checked && !minimumDistance.checked
             }
 
             Item {

--- a/src/qml/Tracking.qml
+++ b/src/qml/Tracking.qml
@@ -421,7 +421,12 @@ Item {
                   track.rubberModel = rubberbandModel
 
                   trackInformationDialog.active = false
-                  embeddedFeatureForm.active = true
+                  if (embeddedAttributeFormModel.rowCount() > 0) {
+                    embeddedFeatureForm.active = true
+                  } else {
+                    trackingModel.startTracker(track.vectorLayer)
+                    displayToast(qsTr('Track on layer %1 started').arg(track.vectorLayer.name))
+                  }
                 }
               }
             }

--- a/src/qml/Tracking.qml
+++ b/src/qml/Tracking.qml
@@ -406,27 +406,17 @@ Item {
               icon.source: Theme.getThemeVectorIcon( 'directions_walk_24dp' )
 
               onClicked: {
-                if (Number(timeIntervalValue.text) + Number(minimumDistanceValue.text) === 0 ||
-                    (timeInterval.checked && minimumDistance.checked && allConstraints.checked &&
-                     (Number(timeIntervalValue.text) === 0 || Number(minimumDistanceValue.text) === 0)) ||
-                    (!timeInterval.checked && !minimumDistance.checked))
-                {
-                  displayToast(qsTr( 'Cannot start track with both constaints switched off'), 'warning')
-                }
-                else
-                {
-                  track.timeInterval = timeIntervalValue.text.length == 0 || !timeInterval.checked ? 0 : timeIntervalValue.text
-                  track.minimumDistance = minimumDistanceValue.text.length == 0 || !minimumDistance.checked ? 0 : minimumDistanceValue.text
-                  track.conjunction = timeInterval.checked && minimumDistance.checked && allConstraints.checked
-                  track.rubberModel = rubberbandModel
+                track.timeInterval = timeIntervalValue.text.length == 0 || !timeInterval.checked ? 0 : timeIntervalValue.text
+                track.minimumDistance = minimumDistanceValue.text.length == 0 || !minimumDistance.checked ? 0 : minimumDistanceValue.text
+                track.conjunction = timeInterval.checked && minimumDistance.checked && allConstraints.checked
+                track.rubberModel = rubberbandModel
 
-                  trackInformationDialog.active = false
-                  if (embeddedAttributeFormModel.rowCount() > 0) {
-                    embeddedFeatureForm.active = true
-                  } else {
-                    trackingModel.startTracker(track.vectorLayer)
-                    displayToast(qsTr('Track on layer %1 started').arg(track.vectorLayer.name))
-                  }
+                trackInformationDialog.active = false
+                if (embeddedAttributeFormModel.rowCount() > 0) {
+                  embeddedFeatureForm.active = true
+                } else {
+                  trackingModel.startTracker(track.vectorLayer)
+                  displayToast(qsTr('Track on layer %1 started').arg(track.vectorLayer.name))
                 }
               }
             }


### PR DESCRIPTION
This PR unlocks position tracking for point layers (implements https://github.com/opengisch/QField/issues/1921).
![image](https://user-images.githubusercontent.com/1728657/186577172-366b8af8-e097-4005-bb6e-b819fb17bd8b.png)

Contrary to line of polygon layers, tracking against a point layer will create one feature per triggered tracking record. This allows for all @position_* variables exposed here (https://qfield.org/docs/prepare/gnss.html) to be used in attributes' default value expression.

When starting tracking on a point layer, a feature form will pop up. Attribute values entered that _do not_ have a default value expression (or provider-side default value like FIDs) will be remembered across the created features. This means that for e.g., an attribute could be used to identify a user name creating a given point track, and that attribute value will be remembered during the tracking session. 

In terms of on-canvas display, when tracking on a point layer, QField will still display a line rubberband connecting all the points, which gives a nice visual feedback of the path on top of individual points. Pro tip: use a datetime attribute with a default value expression set to `now()`, that will allow you order the collected points and create paths from those points. The spatio-temporal ST-DBSCAN clustering algorithm can also re-group those points into different sessions by clustering with a max. duration interval.

Additional improvements and cleanups have been applied along the way, including:
- I've removed the arbitrary prohibition on constraint-less tracking. When neither time nor distance constraints are on, the tracking will record one vertex/point per position received by the internal or external GNSS device.
- A nice little UX boost: if the vector layer used to track has an empty feature form (i.e. all attributes are hidden), we now just skip showing an empty feature form and instead start tracking right away. That's a nice usability improvement for people working with users who might be intimidated by a feature form there.

_(The first commit has a bunch of code formatting and variable renaming to try and help readability for newcomers, I apologize for the resulting diff nightmare.)_

_Funded by [QGIS usergroup Switzerland](https://www.qgis.ch/en), send your thanks to them! :)_