### PR TITLE
Layer properties popup reorganizing

### DIFF
--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -34,6 +34,9 @@ Popup {
     itemVisibleCheckBox.checked = layerTree.data(index, FlatLayerTreeModel.Visible);
     itemLabelsVisibleCheckBox.checked = layerTree.data(index, FlatLayerTreeModel.LabelsVisible);
 
+    expandCheckBox.text = layerTree.data( index, FlatLayerTreeModel.Type ) === 'group' ? qsTr('Expand group') : qsTr('Expand legend item')
+    expandCheckBox.checked = !layerTree.data(index, FlatLayerTreeModel.IsCollapsed)
+
     reloadDataButtonVisible = layerTree.data(index, FlatLayerTreeModel.CanReloadData)
     zoomToButtonVisible = layerTree.data(index, FlatLayerTreeModel.HasSpatialExtent)
     showFeaturesListButtonVisible = isShowFeaturesListButtonVisible();
@@ -105,6 +108,21 @@ Popup {
         text: '<img src="' + invalidIcon + '" width="' + invalidSize + '" height="' + invalidSize + '"> '
               + qsTr('This layer is invalid. This might be due to a network issue, a missing file or a misconfiguration of the project.')
         font: Theme.tipFont
+      }
+
+      CheckBox {
+        id: expandCheckBox
+        Layout.fillWidth: true
+        topPadding: 5
+        bottomPadding: 5
+        text: qsTr('Expand legend item')
+        font: Theme.defaultFont
+        visible: index && layerTree.data(index, FlatLayerTreeModel.HasChildren) ? true : false
+
+        onClicked: {
+          layerTree.setData(index, checkState === Qt.Unchecked, FlatLayerTreeModel.IsCollapsed);
+          close()
+        }
       }
 
       CheckBox {

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -47,21 +47,43 @@ Popup {
         ? qsTr('Stop tracking')
         : qsTr('Setup tracking')
 
-    opacitySliderVisible = layerTree.data(index, FlatLayerTreeModel.HasSpatialExtent)
+    opacitySliderVisible = layerTree.data( index, FlatLayerTreeModel.Type ) !== 'group' &&
+                           layerTree.data(index, FlatLayerTreeModel.HasSpatialExtent)
   }
 
   Page {
     width: parent.width
     padding: 10
-    header: Label {
-      padding: 10
-      topPadding: 15
-      bottomPadding: 0
-      width: parent.width - 20
-      text: title
-      font: Theme.strongFont
-      horizontalAlignment: Text.AlignHCenter
-      wrapMode: Text.WordWrap
+    header: RowLayout {
+      spacing: 2
+      Label {
+        id: titleLabel
+        Layout.fillWidth: true
+        Layout.leftMargin: 10
+        topPadding: 4
+        bottomPadding: 4
+        text: ''
+        font: Theme.strongFont
+        horizontalAlignment: Text.AlignLeft
+        wrapMode: Text.WordWrap
+      }
+      QfToolButton {
+        id: zoomInButton
+        Layout.alignment: Qt.AlignTop
+        Layout.rightMargin: 0
+        round: true
+        visible: reloadDataButtonVisible
+
+        bgcolor: "transparent"
+        iconSource: Theme.getThemeVectorIcon( 'refresh_24dp' )
+
+        onClicked: {
+          layerTree.data(index, FlatLayerTreeModel.MapLayerPointer).reload()
+          close()
+          dashBoard.visible = false
+          displayToast(qsTr('Reload of layer %1 triggered').arg(layerTree.data(index, Qt.DisplayName)))
+        }
+      }
     }
 
     ColumnLayout {
@@ -201,23 +223,6 @@ Popup {
           mapCanvas.mapSettings.extent = layerTree.nodeExtent(index, mapCanvas.mapSettings);
           close()
           dashBoard.visible = false
-        }
-      }
-
-      QfButton {
-        id: reloadDataButton
-        Layout.fillWidth: true
-        Layout.topMargin: 5
-        font: Theme.defaultFont
-        text: qsTr('Reload data')
-        visible: reloadDataButtonVisible
-        icon.source: Theme.getThemeVectorIcon( 'refresh_24dp' )
-
-        onClicked: {
-          layerTree.data(index, FlatLayerTreeModel.MapLayerPointer).reload()
-          close()
-          dashBoard.visible = false
-          displayToast(qsTr('Reload of layer %1 triggered').arg(layerTree.data(index, Qt.DisplayName)))
         }
       }
 
@@ -363,7 +368,7 @@ Popup {
       if (index === undefined)
           return
 
-      title = layerTree.data(index, Qt.Name)
+      titleLabel.text = layerTree.data(index, Qt.Name)
       var vl = layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer)
 
       if (vl && layerTree.data(index, FlatLayerTreeModel.IsValid) && layerTree.data( index, FlatLayerTreeModel.Type ) === 'layer') {
@@ -371,7 +376,7 @@ Popup {
           if (count !== undefined && count >= 0) {
               var countSuffix = ' [' + count + ']'
 
-              if ( !title.endsWith(countSuffix) )
+              if (!titleLabel.text.endsWith(countSuffix))
                   title += countSuffix
           }
       }

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -89,6 +89,21 @@ Popup {
       }
 
       CheckBox {
+        id: expandCheckBox
+        Layout.fillWidth: true
+        topPadding: 5
+        bottomPadding: 5
+        text: qsTr('Expand legend item')
+        font: Theme.defaultFont
+        visible: index && layerTree.data(index, FlatLayerTreeModel.HasChildren) ? true : false
+
+        onClicked: {
+          layerTree.setData(index, checkState === Qt.Unchecked, FlatLayerTreeModel.IsCollapsed);
+          close()
+        }
+      }
+
+      CheckBox {
         id: itemVisibleCheckBox
         Layout.fillWidth: true
         topPadding: 5
@@ -125,21 +140,6 @@ Popup {
         onClicked: {
           layerTree.setData(index, checkState === Qt.Checked, FlatLayerTreeModel.LabelsVisible);
           close();
-        }
-      }
-
-      CheckBox {
-        id: expandCheckBox
-        Layout.fillWidth: true
-        topPadding: 5
-        bottomPadding: 5
-        text: qsTr('Expand legend item')
-        font: Theme.defaultFont
-        visible: index && layerTree.data(index, FlatLayerTreeModel.HasChildren) ? true : false
-
-        onClicked: {
-          layerTree.setData(index, checkState === Qt.Unchecked, FlatLayerTreeModel.IsCollapsed);
-          close()
         }
       }
 

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -23,7 +23,7 @@ Popup {
 
   property bool opacitySliderVisible: false
 
-  width: Math.min( childrenRect.width, mainWindow.width - Theme.popupScreenEdgeMargin)
+  width: Math.min(childrenRect.width, mainWindow.width - Theme.popupScreenEdgeMargin)
   x: (parent.width - width) / 2
   y: (parent.height - height) / 2
   padding: 0
@@ -33,9 +33,6 @@ Popup {
 
     itemVisibleCheckBox.checked = layerTree.data(index, FlatLayerTreeModel.Visible);
     itemLabelsVisibleCheckBox.checked = layerTree.data(index, FlatLayerTreeModel.LabelsVisible);
-
-    expandCheckBox.text = layerTree.data( index, FlatLayerTreeModel.Type ) === 'group' ? qsTr('Expand group') : qsTr('Expand legend item')
-    expandCheckBox.checked = !layerTree.data(index, FlatLayerTreeModel.IsCollapsed)
 
     reloadDataButtonVisible = layerTree.data(index, FlatLayerTreeModel.CanReloadData)
     zoomToButtonVisible = layerTree.data(index, FlatLayerTreeModel.HasSpatialExtent)
@@ -108,21 +105,6 @@ Popup {
         text: '<img src="' + invalidIcon + '" width="' + invalidSize + '" height="' + invalidSize + '"> '
               + qsTr('This layer is invalid. This might be due to a network issue, a missing file or a misconfiguration of the project.')
         font: Theme.tipFont
-      }
-
-      CheckBox {
-        id: expandCheckBox
-        Layout.fillWidth: true
-        topPadding: 5
-        bottomPadding: 5
-        text: qsTr('Expand legend item')
-        font: Theme.defaultFont
-        visible: index && layerTree.data(index, FlatLayerTreeModel.HasChildren) ? true : false
-
-        onClicked: {
-          layerTree.setData(index, checkState === Qt.Unchecked, FlatLayerTreeModel.IsCollapsed);
-          close()
-        }
       }
 
       CheckBox {

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -15,7 +15,7 @@ Popup {
 
   property bool zoomToButtonVisible: false
   property bool showFeaturesListButtonVisible: false
-  property bool showVisibleFeaturesListButttonVisible: false
+  property bool showVisibleFeaturesListDropdownVisible: false
   property bool reloadDataButtonVisible: false
 
   property bool trackingButtonVisible: false
@@ -40,7 +40,7 @@ Popup {
     reloadDataButtonVisible = layerTree.data(index, FlatLayerTreeModel.CanReloadData)
     zoomToButtonVisible = layerTree.data(index, FlatLayerTreeModel.HasSpatialExtent)
     showFeaturesListButtonVisible = isShowFeaturesListButtonVisible();
-    showVisibleFeaturesListButttonVisible = isShowVisibleFeaturesListButtonVisible();
+    showVisibleFeaturesListDropdownVisible = isShowVisibleFeaturesListDropdownVisible();
 
     trackingButtonVisible = isTrackingButtonVisible()
     trackingButtonText = trackingModel.layerInTracking( layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer) )
@@ -225,6 +225,7 @@ Popup {
         id: showFeaturesList
         Layout.fillWidth: true
         Layout.topMargin: 5
+        dropdown: showVisibleFeaturesListDropdownVisible
         text: qsTr('Show features list')
         visible: showFeaturesListButtonVisible
         icon.source: Theme.getThemeVectorIcon( 'ic_list_black_24dp' )
@@ -249,32 +250,9 @@ Popup {
           close()
           dashBoard.visible = false
         }
-      }
 
-      QfButton {
-        id: showVisibleFeaturesList
-        Layout.fillWidth: true
-        Layout.topMargin: 5
-        text: qsTr('Show visible features list')
-        visible: showVisibleFeaturesListButttonVisible
-        icon.source: Theme.getThemeVectorIcon( 'ic_list_visible_black_24dp' )
-
-        onClicked: {
-          if ( parseInt(layerTree.data(index, FlatLayerTreeModel.FeatureCount)) === 0 ) {
-            displayToast( qsTr( "The layer has no features" ) )
-          } else {
-            var vl = layerTree.data( index, FlatLayerTreeModel.VectorLayerPointer )
-
-            if ( layerTree.data( index, FlatLayerTreeModel.Type ) === 'layer' ) {
-              featureForm.model.setFeaturesForExtent( vl, mapCanvas.mapSettings.visibleExtent )
-            } else {
-              // one day, we should be able to show only the features that correspond to the given legend item
-              featureForm.model.setFeaturesForExtent( vl, mapCanvas.mapSettings.visibleExtent )
-            }
-          }
-
-          close()
-          dashBoard.visible = false
+        onDropdownClicked: {
+          showFeaturesMenu.popup(showFeaturesList.width - showFeaturesMenu.width + 10, showFeaturesList.y + 10)
         }
       }
 
@@ -329,6 +307,48 @@ Popup {
     }
   }
 
+  Menu {
+    id: showFeaturesMenu
+    title: qsTr( "Show Features Menu" )
+
+    width: {
+      var result = 0;
+      var padding = 0;
+      for (var i = 0; i < count; ++i) {
+        var item = itemAt(i);
+        result = Math.max(item.contentItem.implicitWidth, result);
+        padding = Math.max(item.padding, padding);
+      }
+      return result + padding * 2;
+    }
+
+    MenuItem {
+      text: qsTr('Show visible features list')
+
+      font: Theme.defaultFont
+      height: 48
+      leftPadding: 10
+
+      onTriggered: {
+        if ( parseInt(layerTree.data(index, FlatLayerTreeModel.FeatureCount)) === 0 ) {
+          displayToast( qsTr( "The layer has no features" ) )
+        } else {
+          var vl = layerTree.data( index, FlatLayerTreeModel.VectorLayerPointer )
+
+          if ( layerTree.data( index, FlatLayerTreeModel.Type ) === 'layer' ) {
+            featureForm.model.setFeaturesForExtent( vl, mapCanvas.mapSettings.visibleExtent )
+          } else {
+            // one day, we should be able to show only the features that correspond to the given legend item
+            featureForm.model.setFeaturesForExtent( vl, mapCanvas.mapSettings.visibleExtent )
+          }
+        }
+
+        close()
+        dashBoard.visible = false
+      }
+    }
+  }
+
   Connections {
       target: layerTree
 
@@ -371,7 +391,7 @@ Popup {
         && layerTree.data( index, FlatLayerTreeModel.LayerType ) === 'vectorlayer'
   }
 
-  function isShowVisibleFeaturesListButtonVisible() {
+  function isShowVisibleFeaturesListDropdownVisible() {
     return isShowFeaturesListButtonVisible()
         && layerTree.data(index, FlatLayerTreeModel.HasSpatialExtent)
   }

--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -246,8 +246,11 @@ ListView {
       onDoubleClicked: {
           var item = legend.itemAt(legend.contentX + mouse.x, legend.contentY + mouse.y)
           if (item) {
-            itemProperties.index = legend.model.index(item.itemRow, 0)
-            itemProperties.open()
+            var itemIndex = legend.model.index(item.itemRow, 0)
+            if (layerTree.data(itemIndex, FlatLayerTreeModel.HasChildren)) {
+              var isCollapsed = layerTree.data(itemIndex, FlatLayerTreeModel.IsCollapsed)
+              layerTree.setData(itemIndex, !isCollapsed, FlatLayerTreeModel.IsCollapsed);
+            }
           }
       }
       onPressAndHold: {

--- a/src/qml/imports/Theme/QfButton.qml
+++ b/src/qml/imports/Theme/QfButton.qml
@@ -7,12 +7,16 @@ import QtQuick.Controls.Material.impl 2.14
 
 Button {
   id: button
+
   property color bgcolor: Theme.mainColor
   property alias color: label.color
+  property bool dropdown: false
+
+  signal dropdownClicked
 
   padding: 8
   leftPadding: 8
-  rightPadding: 8
+  rightPadding: dropdown ? 40 : 8
   leftInset: 4
   rightInset: 4
   topInset: 2
@@ -54,6 +58,82 @@ Button {
 
     alignment: Qt.AlignCenter | Qt.AlignVCenter
     text: parent.text
+  }
+
+  Rectangle {
+    id: dropdownArea
+    anchors.right: parent.right
+    anchors.verticalCenter: parent.verticalCenter
+    visible: button.dropdown
+
+    width: 36
+    height: parent.height
+
+    color: "transparent"
+
+    Rectangle {
+      anchors.left: parent.left
+      anchors.verticalCenter: parent.verticalCenter
+
+      width: 1.5
+      height: parent.height - 16
+
+      color: button.color
+    }
+
+    Canvas {
+      id: dropdownArrow
+      anchors.centerIn: parent
+      implicitWidth: 40
+      implicitHeight: 40
+      visible: true
+      opacity: 1
+
+      onPaint: {
+        var ctx = getContext("2d")
+        ctx.fillStyle = "white"
+        ctx.strokeStyle = "white"
+        ctx.lineWidth = 1
+        ctx.moveTo(14, 15)
+        ctx.lineTo(width - 16, 15)
+        ctx.lineTo((width / 2) - 1, height - 15)
+        ctx.stroke();
+        ctx.fill()
+      }
+    }
+
+
+    property bool pressed: false
+    states: [
+      State {
+        when: dropdownArea.pressed
+        PropertyChanges {
+          target: dropdownArea
+          opacity: 0.25
+        }
+      },
+      State {
+        when: !dropdownArea.pressed
+        PropertyChanges {
+          target: dropdownArea
+          opacity: 1
+        }
+      }
+    ]
+    transitions: [
+      Transition {
+        NumberAnimation { target: dropdownArea; properties: "opacity"; easing.type: Easing.InOutQuad; duration: 250 }
+      }
+    ]
+
+    MouseArea {
+      anchors.fill: parent
+
+      onClicked: button.dropdownClicked()
+      onPressed: dropdownArea.pressed = true
+      onReleased: dropdownArea.pressed = false
+      onCanceled: dropdownArea.pressed = false
+    }
   }
 }
 

--- a/src/qml/imports/Theme/QfButton.qml
+++ b/src/qml/imports/Theme/QfButton.qml
@@ -48,7 +48,10 @@ Button {
 
     icon: parent.icon
     color: "white"
-    font: Theme.tipFont
+    font {
+      pointSize: button.font.pointSize
+    }
+
     alignment: Qt.AlignCenter | Qt.AlignVCenter
     text: parent.text
   }


### PR DESCRIPTION
With the recent addition of the show label checkbox, the layer opacity, and the show visible features list, the layer properties popup has reached a state of overcrowdedness :)

This PR proposes some modest improvements:
![image](https://user-images.githubusercontent.com/1728657/186634435-fc5da734-f5bf-494e-87bf-4e59b439ef20.png)

The changes include:
- Moving the rarely-used 'reload data' to sit at the top-right of the popup as a label-less reload icon tool button
- Removing the expend legend items checkbox (which was cutting through styling-related items) and moving the functionality to a double-tap on legend item action (feels a lot more natural and de-crowds the popup)
- Putting the show >>visible<< features list action into a new dropdown menu attached to the show feature list button

I feel pretty good about all of these changes, and it's nice to have a new dropdown menu functionality coded into QfButton, can't wait to see how many more places end up using it in the coming months :)

On the expanding / collapsing of legend items, we had two possible actions to rely on: the double tap (felt natural), or the tap and hold. Both of these actions until this PR triggered the layer properties to pop up. If someone feels strongly about using the long tap to collapse and keep the double tap to open the pop up, let me know.