### PR TITLE
Fix missing Nyuki avatar when user avatar image is invalid, part 2

### DIFF
--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -133,6 +133,13 @@ Popup {
                   maskSource: cloudAvatarMask
               }
 
+              onStatusChanged: {
+                // In case the avatar URL fails to load or the image is corrupted, revert to our lovely Nyuki
+                if (status == Image.Error) {
+                  source = 'qrc:/images/qfieldcloud_logo.svg';
+                }
+              }
+
               MouseArea {
                 anchors.fill: parent
 


### PR DESCRIPTION
The PR fixes a blank avatar where our beloved Nyuki shows in the (fixed) screenshot below:
![image](https://user-images.githubusercontent.com/1728657/187014585-02f15d65-22e6-4b22-9e55-f681e62b2dff.png)

I pushed the same fix for the cloud projects list panel but forgot to apply it to the project synch panel.