### PR TITLE
Avoid double std::unique_ptr::reset, long shot to fix sentry-reported crash

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -158,11 +158,10 @@ void AttributeFormModelBase::resetModel()
   if ( mLayer )
   {
     QgsAttributeEditorContainer *root;
-    mTemporaryContainer.reset();
-
     if ( mLayer->editFormConfig().layout() == QgsEditFormConfig::TabLayout )
     {
       root = mLayer->editFormConfig().invisibleRootContainer();
+      mTemporaryContainer.reset();
     }
     else
     {


### PR DESCRIPTION
E.g.
- https://sentry.io/organizations/opengisch/issues/3339596703/?project=6119013
- https://sentry.io/organizations/opengisch/issues/3525218534/?project=6119013
