### PR TITLE
Fix opacity slider shown in instances where we can't adjust opacity

### DIFF
--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -47,8 +47,7 @@ Popup {
         ? qsTr('Stop tracking')
         : qsTr('Setup tracking')
 
-    opacitySliderVisible = layerTree.data( index, FlatLayerTreeModel.Type ) !== 'group' &&
-                           layerTree.data(index, FlatLayerTreeModel.HasSpatialExtent)
+    opacitySliderVisible = layerTree.data(index, FlatLayerTreeModel.Opacity) > -1
   }
 
   Page {

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -47,6 +47,7 @@ Popup {
         ? qsTr('Stop tracking')
         : qsTr('Setup tracking')
 
+    // the layer tree model returns -1 for items that do not support the opacity setting
     opacitySliderVisible = layerTree.data(index, FlatLayerTreeModel.Opacity) > -1
   }
 


### PR DESCRIPTION
We can rely on the model logic here (https://github.com/opengisch/QField/blob/master/src/core/layertreemodel.cpp#L850) which sets the opacity to -1 for non spatial layer items (i.e. group items, legend items, geometryless table) to show/hide the opacity slider. We avoid create a parallel set of conditions.