### PR TITLE
When triggering show (visible/all) features list, respect selected sub-layer symbol filter

### DIFF
--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -866,6 +866,22 @@ QVariant FlatLayerTreeModelBase::data( const QModelIndex &index, int role ) cons
       return layer->opacity();
     }
 
+    case FlatLayerTreeModel::FilterExpression:
+    {
+      QgsLayerTreeModelLegendNode *node = mLayerTreeModel->index2legendNode( sourceIndex );
+      if ( QgsSymbolLegendNode *symbolNode = qobject_cast<QgsSymbolLegendNode *>( node ) )
+      {
+        QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( QgsLayerTree::toLayer( node->layerNode() )->layer() );
+        if ( layer && layer->renderer() )
+        {
+          bool ok = false;
+          return layer->renderer()->legendKeyToExpression( symbolNode->data( QgsLayerTreeModelLegendNode::RuleKeyRole ).toString(),
+                                                           layer, ok );
+        }
+      }
+      return QString();
+    }
+
     default:
       return QAbstractProxyModel::data( index, role );
   }
@@ -1001,6 +1017,7 @@ QHash<int, QByteArray> FlatLayerTreeModelBase::roleNames() const
   roleNames[FlatLayerTreeModel::HasLabels] = "HasLabels";
   roleNames[FlatLayerTreeModel::LabelsVisible] = "LabelsVisible";
   roleNames[FlatLayerTreeModel::Opacity] = "Opacity";
+  roleNames[FlatLayerTreeModel::FilterExpression] = "FilterExpression";
   return roleNames;
 }
 

--- a/src/core/layertreemodel.h
+++ b/src/core/layertreemodel.h
@@ -136,6 +136,7 @@ class FlatLayerTreeModel : public QSortFilterProxyModel
       HasLabels,
       LabelsVisible,
       Opacity,
+      FilterExpression,
     };
     Q_ENUM( Roles )
 

--- a/src/core/multifeaturelistmodel.cpp
+++ b/src/core/multifeaturelistmodel.cpp
@@ -41,16 +41,17 @@ void MultiFeatureListModel::setFeatures( const QMap<QgsVectorLayer *, QgsFeature
   mSourceModel->setFeatures( requests );
 }
 
-void MultiFeatureListModel::setFeatures( QgsVectorLayer *vl )
-{
-  QMap<QgsVectorLayer *, QgsFeatureRequest> requests( { { vl, QgsFeatureRequest() } } );
-  mSourceModel->setFeatures( requests );
-}
-
-void MultiFeatureListModel::setFeaturesForExtent( QgsVectorLayer *vl, const QgsRectangle &rectangle )
+void MultiFeatureListModel::setFeatures( QgsVectorLayer *vl, const QString &filter, const QgsRectangle &extent )
 {
   QgsFeatureRequest request;
-  request.setFilterRect( rectangle );
+  if ( !filter.isEmpty() )
+  {
+    request.setFilterExpression( filter );
+  }
+  if ( !extent.isEmpty() )
+  {
+    request.setFilterRect( extent );
+  }
   QMap<QgsVectorLayer *, QgsFeatureRequest> requests( { { vl, request } } );
   mSourceModel->setFeatures( requests );
 }

--- a/src/core/multifeaturelistmodel.h
+++ b/src/core/multifeaturelistmodel.h
@@ -61,14 +61,10 @@ class MultiFeatureListModel : public QSortFilterProxyModel
     void setFeatures( const QMap<QgsVectorLayer *, QgsFeatureRequest> requests );
 
     /**
-     * Resets the model to contain features found from a \a vl.
+     * Resets the model to contain features found from a \a vl with the possibility of filtering by a \a filter expression
+     * and/or an \a extent.
      */
-    Q_INVOKABLE void setFeatures( QgsVectorLayer *vl );
-
-    /**
-     * Resets the model to contain features found from a \a vl and inside a \a rectangle.
-     */
-    Q_INVOKABLE void setFeaturesForExtent( QgsVectorLayer *vl, const QgsRectangle &rectangle );
+    Q_INVOKABLE void setFeatures( QgsVectorLayer *vl, const QString &filter, const QgsRectangle &extent = QgsRectangle() );
 
     /**
      * Appends features from a list of \a results.

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -60,8 +60,8 @@ Popup {
         id: titleLabel
         Layout.fillWidth: true
         Layout.leftMargin: 10
-        topPadding: 4
-        bottomPadding: 4
+        topPadding: 10
+        bottomPadding: 10
         text: ''
         font: Theme.strongFont
         horizontalAlignment: Text.AlignLeft
@@ -358,10 +358,13 @@ Popup {
       if (index === undefined)
           return
 
-      titleLabel.text = layerTree.data(index, Qt.Name)
+      var title = layerTree.data(index, Qt.Name)
+      var type = layerTree.data(index, FlatLayerTreeModel.Type)
       var vl = layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer)
-
-      if (vl && layerTree.data(index, FlatLayerTreeModel.IsValid) && layerTree.data( index, FlatLayerTreeModel.Type ) === 'layer') {
+      if (vl) {
+        if (type === 'legend') {
+          title += ' (' + vl.name + ')'
+        } else if (type === 'layer' && layerTree.data(index, FlatLayerTreeModel.IsValid)) {
           var count = layerTree.data(index, FlatLayerTreeModel.FeatureCount)
           if (count !== undefined && count >= 0) {
               var countSuffix = ' [' + count + ']'
@@ -369,7 +372,9 @@ Popup {
               if (!titleLabel.text.endsWith(countSuffix))
                   title += countSuffix
           }
+        }
       }
+      titleLabel.text = title
   }
 
   function isTrackingButtonVisible() {

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -239,16 +239,11 @@ Popup {
           if ( parseInt(layerTree.data(index, FlatLayerTreeModel.FeatureCount)) === 0 ) {
             displayToast( qsTr( "The layer has no features" ) )
           } else {
-            var vl = layerTree.data( index, FlatLayerTreeModel.VectorLayerPointer )
-
-            if ( layerTree.data( index, FlatLayerTreeModel.Type ) === 'layer' ) {
-              featureForm.model.setFeatures( vl )
-            } else {
-              // one day, we should be able to show only the features that correspond to the given legend item
-              featureForm.model.setFeatures( vl )
-            }
+            var vl = layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer)
+            var filter = layerTree.data(index, FlatLayerTreeModel.FilterExpression)
+            featureForm.model.setFeatures(vl, filter)
             if (layerTree.data(index, FlatLayerTreeModel.HasSpatialExtent)) {
-              mapCanvas.mapSettings.extent = layerTree.nodeExtent( index, mapCanvas.mapSettings )
+              mapCanvas.mapSettings.extent = layerTree.nodeExtent(index, mapCanvas.mapSettings)
             }
           }
 
@@ -339,13 +334,8 @@ Popup {
           displayToast( qsTr( "The layer has no features" ) )
         } else {
           var vl = layerTree.data( index, FlatLayerTreeModel.VectorLayerPointer )
-
-          if ( layerTree.data( index, FlatLayerTreeModel.Type ) === 'layer' ) {
-            featureForm.model.setFeaturesForExtent( vl, mapCanvas.mapSettings.visibleExtent )
-          } else {
-            // one day, we should be able to show only the features that correspond to the given legend item
-            featureForm.model.setFeaturesForExtent( vl, mapCanvas.mapSettings.visibleExtent )
-          }
+          var filter = layerTree.data(index, FlatLayerTreeModel.FilterExpression)
+          featureForm.model.setFeatures( vl, filter, mapCanvas.mapSettings.visibleExtent )
         }
 
         close()


### PR DESCRIPTION
This PR makes the show (visible/all) features list actions found in the layer properties popup that much more useful by respecting the sub-layer legend symbol item's filter expression.

For e.g., say you have a vector layer with a categorized renderer that has three categories (status=GOOD, status=UNSURE, status=BAD), you can trigger a features list that will filter features by the long-pressed category in the legend tree.  It is :magic_wand: 

E.g.:

https://user-images.githubusercontent.com/1728657/187057176-81b6a1c2-5516-4abd-8b57-334aca16f867.mp4

Thanks to @nyalldawson for the inspiration through his QGIS feature selection implementation.

(Fixes #2272)