### PR TITLE
Configure the timeout to dim screen, rather than simple disabling it

### DIFF
--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -89,9 +89,9 @@ void AppInterface::openFeatureForm()
   emit openFeatureFormRequested();
 }
 
-void AppInterface::setScreenDimmerActive( bool active )
+void AppInterface::setScreenDimmerTimeout( int timeoutSeconds )
 {
-  mApp->setScreenDimmerActive( active );
+  mApp->setScreenDimmerTimeout( timeoutSeconds );
 }
 
 QVariantMap AppInterface::availableLanguages() const

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -51,7 +51,7 @@ class AppInterface : public QObject
     Q_INVOKABLE bool print( const QString &layoutName );
     Q_INVOKABLE bool printAtlasFeatures( const QString &layoutName, const QList<long long> &featureIds );
 
-    Q_INVOKABLE void setScreenDimmerActive( bool active );
+    Q_INVOKABLE void setScreenDimmerTimeout( int timeoutSeconds );
 
     Q_INVOKABLE QVariantMap availableLanguages() const;
 

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -200,7 +200,7 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   if ( PlatformUtilities::instance()->capabilities() & PlatformUtilities::AdjustBrightness )
   {
     mScreenDimmer = std::make_unique<ScreenDimmer>( app );
-    mScreenDimmer->setActive( settings.value( QStringLiteral( "dimBrightness" ), true ).toBool() );
+    mScreenDimmer->setTimeout( settings.value( QStringLiteral( "dimTimeoutSeconds" ), 40 ).toInt() );
   }
 
   AppInterface::setInstance( mIface );
@@ -1397,11 +1397,11 @@ bool QgisMobileapp::printAtlasFeatures( const QString &layoutName, const QList<l
 #endif
 }
 
-void QgisMobileapp::setScreenDimmerActive( bool active )
+void QgisMobileapp::setScreenDimmerTimeout( int timeoutSeconds )
 {
   if ( mScreenDimmer )
   {
-    mScreenDimmer->setActive( active );
+    mScreenDimmer->setTimeout( timeoutSeconds );
   }
 }
 

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -159,10 +159,10 @@ class QFIELD_CORE_EXPORT QgisMobileapp : public QQmlApplicationEngine
     bool printAtlasFeatures( const QString &layoutName, const QList<long long> &featureIds );
 
     /**
-     * Sets whether the screen dimmer will be active or not
-     * \param active set to TRUE to activate screen dimmer
+     * Sets the screen dimmer timeout in seconds
+     * \note setting the timeout value to 0 will disable the screen dimmer
      */
-    void setScreenDimmerActive( bool active );
+    void setScreenDimmerTimeout( int timeoutSeconds );
 
     bool event( QEvent *event ) override;
 

--- a/src/core/screendimmer.h
+++ b/src/core/screendimmer.h
@@ -30,9 +30,9 @@ class ScreenDimmer : public QObject
     explicit ScreenDimmer( QgsApplication *app );
 
     /**
-     * Sets whether the screen dimmer is \a active or not.
+     * Sets dim timeout as \a timeoutSeconds in seconds. Disables dim screen if 0.
      */
-    void setActive( bool active );
+    void setTimeout( int timeoutSeconds );
 
     /**
      * Temporarily suspends the screen dimmer when \a suspend is set to TRUE.
@@ -47,7 +47,7 @@ class ScreenDimmer : public QObject
 
     QTimer mTimer;
 
-    bool mActive = false;
+    int mTimeoutSeconds = 0;
     bool mSuspend = false;
     bool mDimmed = false;
 };

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -324,7 +324,7 @@ Page {
                               model = items.concat(Object.values(languages));
 
                               currentIndex = languageCodes.indexOf(customLanguageCode);
-                              currentLanguageCode = customLanguageCode
+                              currentLanguageCode = customLanguageCode || ''
                               languageTip.visible = false
                           }
                       }

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -20,7 +20,6 @@ Page {
   property alias nativeCamera: registry.nativeCamera
   property alias autoSave: registry.autoSave
   property alias mouseAsTouchScreen: registry.mouseAsTouchScreen
-  property alias dimBrightness: registry.dimBrightness
   property alias enableInfoCollection: registry.enableInfoCollection
 
   Settings {
@@ -33,7 +32,6 @@ Page {
     property bool nativeCamera: platformUtilities.capabilities & PlatformUtilities.NativeCamera
     property bool autoSave: false
     property bool mouseAsTouchScreen: false
-    property bool dimBrightness: platformUtilities.capabilities & PlatformUtilities.AdjustBrightness
     property bool enableInfoCollection: true
 
     onEnableInfoCollectionChanged: {
@@ -82,11 +80,6 @@ Page {
           settingAlias: "autoSave"
       }
       ListElement {
-          title: qsTr( "Dim screen when idling" )
-          description: qsTr( "If enabled, the screen brightness will be dimmed after 20 seconds of inactivity to preserve battery." )
-          settingAlias: "dimBrightness"
-      }
-      ListElement {
           title: qsTr( "Consider mouse as a touchscreen device" )
           description: qsTr( "If disabled, the mouse will act as a stylus pen." )
           settingAlias: "mouseAsTouchScreen"
@@ -100,8 +93,6 @@ Page {
           for (var i = 0; i < settingsModel.count; i++) {
               if (settingsModel.get(i).settingAlias === 'nativeCamera') {
                   settingsModel.setProperty(i, 'isVisible', platformUtilities.capabilities & PlatformUtilities.NativeCamera ? true : false)
-              } else if (settingsModel.get(i).settingAlias === 'dimBrightness') {
-                  settingsModel.setProperty(i, 'isVisible', platformUtilities.capabilities & PlatformUtilities.AdjustBrightness ? true : false)
               } else if (settingsModel.get(i).settingAlias === 'enableInfoCollection') {
                   settingsModel.setProperty(i, 'isVisible', platformUtilities.capabilities & PlatformUtilities.SentryFramework ? true : false)
               } else {
@@ -263,6 +254,54 @@ Page {
                               onCheckedChanged: registry[settingAlias] = checked
                           }
                       }
+                  }
+
+                  GridLayout {
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 20
+                    Layout.rightMargin: 20
+                    Layout.topMargin: 5
+                    Layout.bottomMargin: 5
+
+                    columns: 1
+                    columnSpacing: 0
+                    rowSpacing: 0
+
+                    visible: platformUtilities.capabilities & PlatformUtilities.AdjustBrightness
+
+                    Label {
+                      Layout.fillWidth: true
+
+                      text: qsTr('Dim screen when idling')
+                      font: Theme.defaultFont
+                      wrapMode: Text.WordWrap
+                    }
+
+                    QfSlider {
+                      Layout.fillWidth: true
+
+                      id: slider
+                      value: settings ? settings.value('dimTimeoutSeconds', 40) : undefined
+                      from: 0
+                      to: 180
+                      stepSize: 10
+                      suffixText: " s"
+                      implicitHeight: 40
+
+                      onMoved: function () {
+                        iface.setScreenDimmerTimeout(value)
+                        settings.setValue('dimTimeoutSeconds', value)
+                      }
+                    }
+
+                    Label {
+                      Layout.fillWidth: true
+                      text: qsTr('Time of inactivity in seconds before the screen brightness get be dimmed to preserve battery.')
+
+                      font: Theme.tipFont
+                      color: Theme.gray
+                      wrapMode: Text.WordWrap
+                    }
                   }
 
                   GridLayout {

--- a/src/qml/imports/Theme/QfSlider.qml
+++ b/src/qml/imports/Theme/QfSlider.qml
@@ -1,0 +1,57 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+Item {
+  property alias from: slider.from;
+  property alias to: slider.to
+  property alias stepSize: slider.stepSize
+  property alias value: slider.value
+  property string prefixText: ""
+  property string suffixText: ""
+
+  signal moved
+
+  id: wrapper
+
+  implicitHeight: childrenRect.height
+
+  RowLayout {
+    id: layout
+    anchors.fill: parent
+
+    Slider {
+      Layout.fillWidth: true
+
+      id: slider
+      value: 50
+      from: 0
+      to: 100
+      stepSize: 1
+      onMoved: wrapper.moved()
+    }
+
+    Label {
+      Layout.maximumWidth: layout.width / 4
+      // prevent the slider width to change as the number increases, if the number is up to three digits
+      Layout.minimumWidth: suffixMetrics.width
+
+      id: suffix
+      text: prefixText + value + suffixText
+
+      font: Theme.tipFont
+      color: Theme.gray
+    }
+
+    TextMetrics {
+      id: suffixMetrics
+      font: suffix.font
+      text: prefixText + getSampleOfNumberOfLength(Math.min(slider.to, 999)) + suffixText
+
+
+      function getSampleOfNumberOfLength(number) {
+        return new Array(number.toString().length + 1).join(9)
+      }
+    }
+  }
+}

--- a/src/qml/imports/Theme/qmldir
+++ b/src/qml/imports/Theme/qmldir
@@ -1,5 +1,6 @@
 module Theme
 singleton Theme 1.0 Theme.qml
+QfSlider 1.0 QfSlider.qml
 QfSwitch 1.0 QfSwitch.qml
 QfButton 1.0 QfButton.qml
 QfToolButton 1.0 QfToolButton.qml

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2788,7 +2788,6 @@ ApplicationWindow {
       }
     }
 
-    onDimBrightnessChanged: iface.setScreenDimmerActive( qfieldSettings.dimBrightness )
     Component.onCompleted: focusstack.addFocusTaker( this )
   }
 

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -83,5 +83,6 @@
         <file>QFieldCloudDeltaHistory.qml</file>
         <file>QFieldCloudPackageLayersFeedback.qml</file>
         <file>QFieldLocalDataPickerScreen.qml</file>
+        <file>imports/Theme/QfSlider.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Some people, including me, find the default timeout inconvinient. Therefore, let the users decide how long that should be.

![image](https://user-images.githubusercontent.com/2820439/187159377-153fc22a-1ae4-40bc-9006-39a440e1afe6.png)

A future improvement can be https://github.com/opengisch/QField/issues/3264 .

For now... Fairy, let us see if it works as expected.