### PR TITLE
Fix crash when entering geometry editing mode of a point and show topo edit on point editing

### DIFF
--- a/src/core/rubberband.cpp
+++ b/src/core/rubberband.cpp
@@ -165,7 +165,7 @@ QSGNode *Rubberband::updatePaintNode( QSGNode *n, QQuickItem::UpdatePaintNodeDat
         geomType = mRubberbandModel->geometryType();
       }
     }
-    else if ( mVertexModel && mVertexModel->vertexCount() > 0 )
+    else if ( mRubberbandModel && mVertexModel && mVertexModel->vertexCount() > 0 )
     {
       allVertices = mVertexModel->flatVertices();
       if ( geomType == QgsWkbTypes::NullGeometry )

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1052,7 +1052,11 @@ ApplicationWindow {
       visible: stateMachine.state === "digitize"
           && dashBoard.currentLayer
           && dashBoard.currentLayer.isValid
-          && ( dashBoard.currentLayer.geometryType() === QgsWkbTypes.PolygonGeometry || dashBoard.currentLayer.geometryType() === QgsWkbTypes.LineGeometry )
+          && (
+                   dashBoard.currentLayer.geometryType() === QgsWkbTypes.PolygonGeometry
+                   || dashBoard.currentLayer.geometryType() === QgsWkbTypes.LineGeometry
+                   || dashBoard.currentLayer.geometryType() === QgsWkbTypes.PointGeometry
+        )
       state: qgisProject && qgisProject.topologicalEditing ? "On" : "Off"
       iconSource: Theme.getThemeIcon( "ic_topology_white_24dp" )
 


### PR DESCRIPTION
I was looking into https://github.com/opengisch/QField/issues/3266 and I got a really bad crash here:
![Peek 2022-08-30 23-30](https://user-images.githubusercontent.com/2820439/187539873-bdb3a226-728e-41f0-b2a2-ba14219f8578.gif)

I also think topological editing should be visible for point layers, so we can disable and enable it.

I still believe the buttons on the bottom right behave in a weird way, continue investigating.