### PR TITLE
Measuring tool should respect the project's distance and area units type

### DIFF
--- a/src/core/distancearea.cpp
+++ b/src/core/distancearea.cpp
@@ -253,3 +253,13 @@ QgsUnitTypes::AreaUnit DistanceArea::areaUnits() const
 {
   return mDistanceArea.areaUnits();
 }
+
+double DistanceArea::convertLengthMeansurement( double length, QgsUnitTypes::DistanceUnit toUnits ) const
+{
+  return mDistanceArea.convertLengthMeasurement( length, toUnits );
+}
+
+double DistanceArea::convertAreaMeansurement( double area, QgsUnitTypes::AreaUnit toUnits ) const
+{
+  return mDistanceArea.convertAreaMeasurement( area, toUnits );
+}

--- a/src/core/distancearea.h
+++ b/src/core/distancearea.h
@@ -68,6 +68,9 @@ class DistanceArea : public QObject
     QgsProject *project() const;
     void setProject( QgsProject *project );
 
+    Q_INVOKABLE double convertLengthMeansurement( double length, QgsUnitTypes::DistanceUnit toUnits ) const;
+    Q_INVOKABLE double convertAreaMeansurement( double area, QgsUnitTypes::AreaUnit toUnits ) const;
+
   signals:
     void rubberbandModelChanged();
     void crsChanged();

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -1035,7 +1035,6 @@ void QgisMobileapp::readProjectFile()
     mProject->setTitle( mProjectFileName );
     mProject->writeEntry( QStringLiteral( "QField" ), QStringLiteral( "isDataset" ), true );
 
-
     for ( QgsMapLayer *l : std::as_const( rasterLayers ) )
     {
       QgsRasterLayer *rlayer = qobject_cast<QgsRasterLayer *>( l );

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -766,25 +766,25 @@ ApplicationWindow {
                      && digitizingGeometryMeasure.segmentLength != digitizingGeometryMeasure.length
                      ? '<p>%1: %2</p>'
                        .arg( qsTr( 'Segment') )
-                       .arg(UnitTypes.formatDistance( digitizingGeometryMeasure.segmentLength, 3, digitizingGeometryMeasure.lengthUnits ) )
+                       .arg(UnitTypes.formatDistance( digitizingGeometryMeasure.convertLengthMeansurement( digitizingGeometryMeasure.segmentLength, projectInfo.distanceUnits ) , 3, projectInfo.distanceUnits ) )
                      : '')
 
                 .arg(currentRubberband.model && currentRubberband.model.geometryType === QgsWkbTypes.PolygonGeometry
                      ? digitizingGeometryMeasure.perimeterValid
                        ? '<p>%1: %2</p>'
                          .arg( qsTr( 'Perimeter') )
-                         .arg(UnitTypes.formatDistance( digitizingGeometryMeasure.perimeter, 3, digitizingGeometryMeasure.lengthUnits ) )
+                         .arg(UnitTypes.formatDistance( digitizingGeometryMeasure.convertLengthMeansurement( digitizingGeometryMeasure.perimeter, projectInfo.distanceUnits ), 3, projectInfo.distanceUnits ) )
                        : ''
                      : digitizingGeometryMeasure.lengthValid
                      ? '<p>%1: %2</p>'
                        .arg( qsTr( 'Length') )
-                       .arg(UnitTypes.formatDistance( digitizingGeometryMeasure.length, 3, digitizingGeometryMeasure.lengthUnits ) )
+                       .arg(UnitTypes.formatDistance( digitizingGeometryMeasure.convertLengthMeansurement( digitizingGeometryMeasure.length, projectInfo.distanceUnits ),3, projectInfo.distanceUnits ) )
                      : '')
 
                 .arg(digitizingGeometryMeasure.areaValid
                      ? '<p>%1: %2</p>'
                      .arg( qsTr( 'Area') )
-                     .arg(UnitTypes.formatArea( digitizingGeometryMeasure.area, 3, digitizingGeometryMeasure.areaUnits ) )
+                     .arg(UnitTypes.formatArea( digitizingGeometryMeasure.convertAreaMeansurement( digitizingGeometryMeasure.area, projectInfo.areaUnits), 3, projectInfo.areaUnits ) )
                      : '')
 
                 .arg(stateMachine.state === 'measure' && digitizingToolbar.isDigitizing
@@ -2558,6 +2558,11 @@ ApplicationWindow {
             dashBoard.ensureEditableLayerSelected();
         }
 
+        var distanceString = iface.readProjectEntry("Measurement" ,"/DistanceUnits", "")
+        projectInfo.distanceUnits = distanceString !== "" ? UnitTypes.decodeDistanceUnit(distanceString) : UnitTypes.DistanceMeters
+        var areaString = iface.readProjectEntry("Measurement" ,"/AreaeUnits", "")
+        projectInfo.areaUnits = areaString !== "" ? UnitTypes.decodeAreaUnit(areaString) : UnitTypes.AreaSquareMeters
+
         projectInfo.reprojectDisplayCoordinatesToWGS84 = !mapCanvas.mapSettings.destinationCrs.isGeographic
                                                          && iface.readProjectEntry("PositionPrecision", "/DegreeFormat", "MU") !== "MU"
 
@@ -2581,6 +2586,9 @@ ApplicationWindow {
     layerTree: dashBoard.layerTree
 
     property bool reprojectDisplayCoordinatesToWGS84: false
+
+    property var distanceUnits: UnitTypes.DistanceMeters
+    property var areaUnits: UnitTypes.AreaSquareMeters
 
     property bool hasInsertRights: true
     property bool hasEditRights: true


### PR DESCRIPTION
QField's measuring tool now respects these project settings:
![image](https://user-images.githubusercontent.com/1728657/187620887-411e284f-3202-4ba3-b478-4eb21f65de03.png)

We also now have sensible defaults (i.e. meters for distance and square meters for area)

@mbernasocchi , here we are :)