### PR TITLE
Fix delta generation on NULL and 0

### DIFF
--- a/doc/dev.md
+++ b/doc/dev.md
@@ -52,6 +52,9 @@ cmake -S QField -B build
 If you use a locally built QGIS installed to a different
 location, use `-DQGIS_ROOT=` to specify this path.
 
+If you need to build with tests, you should specify `-DENABLE_TESTS=ON`.
+Note the testing framework `Catch2` has minimal version 3, so you might need to install it separately and pass it with `-DCatch2_ROOT=/home/user/vcpkg/packages/catch2_x64-linux`.
+
 ### Using vcpkg
 
 This will build the complete dependency chain from scratch.

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -52,9 +52,6 @@ cmake -S QField -B build
 If you use a locally built QGIS installed to a different
 location, use `-DQGIS_ROOT=` to specify this path.
 
-If you need to build with tests, you should specify `-DENABLE_TESTS=ON`.
-Note the testing framework `Catch2` has minimal version 3, so you might need to install it separately and pass it with `-DCatch2_ROOT=/home/user/vcpkg/packages/catch2_x64-linux`.
-
 ### Using vcpkg
 
 This will build the complete dependency chain from scratch.
@@ -75,6 +72,13 @@ Now build the application.
 ```sh
 cmake --build build
 ```
+
+### Tests
+
+To build with tests, you can specify `-DENABLE_TESTS=ON`.
+To run the tests, run `ctest` in the build folder.
+
+The testing framework `Catch2` has minimal version 3, so you might need to install it separately and pass it with `-DCatch2_ROOT=/home/user/vcpkg/packages/catch2_x64-linux`.
 
 ## Macos
 

--- a/src/core/deltafilewrapper.cpp
+++ b/src/core/deltafilewrapper.cpp
@@ -581,7 +581,8 @@ void DeltaFileWrapper::addPatch( const QString &localLayerId, const QString &sou
     const QVariant oldVal = oldAttrs.at( oldFieldIdx );
     const QVariant newVal = newAttrs.at( newFieldIdx );
 
-    if ( newVal != oldVal )
+    // if the values are different OR one is null and the other has nullable value (e.g. integers: NULL and 0)
+    if ( newVal != oldVal || oldVal.isNull() != newVal.isNull() )
     {
       tmpOldAttrs.insert( name, oldVal.isNull() ? QJsonValue::Null : QJsonValue::fromVariant( oldVal ) );
       tmpNewAttrs.insert( name, newVal.isNull() ? QJsonValue::Null : QJsonValue::fromVariant( newVal ) );

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Catch2 REQUIRED)
+find_package(Catch2 3 REQUIRED)
 
 include(CTest)
 include(Catch)

--- a/test/test_deltafilewrapper.cpp
+++ b/test/test_deltafilewrapper.cpp
@@ -1100,6 +1100,71 @@ TEST_CASE( "Delta File Wrapper" )
     dfw.addPatch( layer->id(), layer->id(), QStringLiteral( "fid" ), QStringLiteral( "fid" ), oldFeature, newFeature, false );
 
     REQUIRE( QJsonDocument( getDeltasArray( dfw.toString() ) ) == QJsonDocument::fromJson( "[]" ) );
+
+    // Patch null values
+    dfw.reset();
+    newFeature.setAttribute( QStringLiteral( "dbl" ), QVariant() );
+    newFeature.setAttribute( QStringLiteral( "int" ), QVariant() );
+    newFeature.setAttribute( QStringLiteral( "fid" ), QVariant() );
+    newFeature.setAttribute( QStringLiteral( "str" ), QVariant() );
+    newFeature.setAttribute( QStringLiteral( "attachment" ), QVariant() );
+    oldFeature.setGeometry( QgsGeometry( new QgsPoint( 25.9657, 43.8356 ) ) );
+
+    dfw.addPatch( layer->id(), layer->id(), QStringLiteral( "fid" ), QStringLiteral( "fid" ), oldFeature, newFeature, true );
+
+    expectedDoc = QJsonDocument::fromJson( R""""(
+        [
+          {
+            "uuid": "11111111-1111-1111-1111-111111111111",
+            "clientId": "22222222-2222-2222-2222-222222222222",
+            "exportId": "33333333-3333-3333-3333-333333333333",
+            "localLayerCrs": "EPSG:3857",
+            "localLayerId": "dummyLayerIdL1",
+            "localLayerName": "layer_name",
+            "localPk": "100",
+            "sourceLayerId": "dummyLayerIdS1",
+            "sourcePk": "100",
+            "method": "patch",
+            "new": {
+              "attributes": {
+                "dbl": null,
+                "fid": null,
+                "int": null,
+                "str": null
+              },
+              "is_snapshot": false
+            },
+            "old": {
+              "attributes": {
+                "attachment": null,
+                "dbl": 3.14,
+                "fid": 100,
+                "int": 42,
+                "str": "stringy"
+              },
+              "geometry": "Point (25.96569999999999823 43.83559999999999945)",
+              "is_snapshot": true
+            }
+          }
+        ]
+      )"""" );
+    REQUIRE( QJsonDocument( getDeltasArray( dfw.toString() ) ) == expectedDoc );
+
+
+    // Do not patch equal features
+    dfw.reset();
+    newFeature.setAttribute( QStringLiteral( "dbl" ), 3.14 );
+    newFeature.setAttribute( QStringLiteral( "int" ), 42 );
+    newFeature.setAttribute( QStringLiteral( "fid" ), 100 );
+    newFeature.setAttribute( QStringLiteral( "str" ), QStringLiteral( "stringy" ) );
+    newFeature.setAttribute( QStringLiteral( "attachment" ), QVariant() );
+    newFeature.setGeometry( QgsGeometry( new QgsPoint( 23.398819, 41.7672147 ) ) );
+    oldFeature.setGeometry( QgsGeometry( new QgsPoint( 25.9657, 43.8356 ) ) );
+    newFeature.setGeometry( QgsGeometry( new QgsPoint( 25.9657, 43.8356 ) ) );
+
+    dfw.addPatch( layer->id(), layer->id(), QStringLiteral( "fid" ), QStringLiteral( "fid" ), oldFeature, newFeature, false );
+
+    REQUIRE( QJsonDocument( getDeltasArray( dfw.toString() ) ) == QJsonDocument::fromJson( "[]" ) );
   }
 
   SECTION( "AddDeleteWithStringPk" )


### PR DESCRIPTION
When a field is nullable and it's value is changed to zero or other way
around, QField deltafilewrapper check the difference using a simple
`QVariant(1) == QVariant(2)`. However, there are special cases such as
`QVariant(0) == QVariant( QJsonValue::Null )` that return TRUE, even
though one of the values has undefined NULL value.

This fix checks explicitly about such cases and fixes the issue.

Also added appropriate test case.