### PR TITLE
Disable bluetooth support on iOS, that's simply not supported by Qt

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -88,6 +88,7 @@ jobs:
                 -D VCPKG_TARGET_TRIPLET="${{ env.TRIPLET }}" \
                 -D WITH_VCPKG=ON \
                 -D WITH_SPIX=OFF \
+                -D WITH_BLUETOOTH=OFF \
                 -D APP_VERSION="${APP_VERSION}" \
                 -D APK_VERSION_CODE="${APK_VERSION_CODE}" \
                 -D APP_VERSION_STR="${APP_VERSION_STR}" \


### PR DESCRIPTION
As per Qt's QBluetoothSocket documentation (https://doc.qt.io/qt-5/qbluetoothsocket.html):

> On iOS, this class cannot be used because the platform does not expose an API which may permit access to QBluetoothSocket related features.

