### PR TITLE
Prevent random sorting of the cloud projects

### DIFF
--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -2092,6 +2092,11 @@ QVariant QFieldCloudProjectsModel::data( const QModelIndex &index, int role ) co
   if ( index.row() >= mProjects.size() || index.row() < 0 )
     return QVariant();
 
+  if ( role == Qt::DisplayRole )
+  {
+    return QStringLiteral( "%1/%2" ).arg( mProjects.at( index.row() )->owner, mProjects.at( index.row() )->name );
+  }
+
   switch ( static_cast<ColumnRole>( role ) )
   {
     case IdRole:
@@ -2277,6 +2282,7 @@ QStringList QFieldCloudProjectsModel::projectFileNames( const QString &projectPa
 QFieldCloudProjectsFilterModel::QFieldCloudProjectsFilterModel( QObject *parent )
   : QSortFilterProxyModel( parent )
 {
+  sort( 0 );
 }
 
 void QFieldCloudProjectsFilterModel::setProjectsModel( QFieldCloudProjectsModel *projectsModel )


### PR DESCRIPTION
Prevent situations like this:
![image](https://user-images.githubusercontent.com/2820439/188289936-4b586b60-2bfc-4d5c-9e3e-a59f9c9d8f33.png)

While I can choose whether I use the default `Qt::DisplayRole` for sorting, or create a new role and use `QSortFilterProxyModel::setRole` for that, I preferred the latter as it gives a nice default display name everywhere. 
