### PR TITLE
Fetch public projects with a separate request

### DIFF
--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -205,13 +205,14 @@ QVariantMap QFieldCloudProjectsModel::getProjectData( const QString &projectId )
   return data;
 }
 
-void QFieldCloudProjectsModel::refreshProjectsList()
+void QFieldCloudProjectsModel::refreshProjectsList( bool shouldRefreshPublic )
 {
   switch ( mCloudConnection->status() )
   {
     case QFieldCloudConnection::ConnectionStatus::LoggedIn:
     {
-      NetworkReply *reply = mCloudConnection->get( QStringLiteral( "/api/v1/projects/?include-public=true" ) );
+      QString url = shouldRefreshPublic ? QStringLiteral( "/api/v1/projects/public/" ) : QStringLiteral( "/api/v1/projects/" );
+      NetworkReply *reply = mCloudConnection->get( url );
       connect( reply, &NetworkReply::finished, this, &QFieldCloudProjectsModel::projectListReceived );
       break;
     }

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -232,8 +232,8 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     //! Returns the cloud project data for given \a projectId.
     Q_INVOKABLE QVariantMap getProjectData( const QString &projectId ) const;
 
-    //! Requests the cloud projects list from the server.
-    Q_INVOKABLE void refreshProjectsList();
+    //! Requests the cloud projects list from the server. If \a shouldRefreshPublic is false, it will refresh only user's project, otherwise will refresh the public projects only.
+    Q_INVOKABLE void refreshProjectsList( bool shouldRefreshPublic = false );
 
     //! Pushes all local deltas for given \a projectId. If \a shouldDownloadUpdates is true, also calls `downloadProject`.
     Q_INVOKABLE void projectUpload( const QString &projectId, const bool shouldDownloadUpdates );

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -166,12 +166,14 @@ Page {
           text: qsTr("My Projects")
           height: 48
           font: Theme.defaultFont
+          enabled: (cloudConnection.state === QFieldCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0)
           anchors.verticalCenter : parent.verticalCenter
         }
         TabButton {
           text: qsTr("Community")
           height: 48
           font: Theme.defaultFont
+          enabled: (cloudConnection.state === QFieldCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0)
           anchors.verticalCenter : parent.verticalCenter
         }
       }
@@ -194,6 +196,12 @@ Page {
                     ? QFieldCloudProjectsFilterModel.PrivateProjects
                     : QFieldCloudProjectsFilterModel.PublicProjects
                 showLocalOnly: cloudConnection.status !== QFieldCloudConnection.LoggedIn
+
+                onFilterChanged: {
+                  if (cloudConnection.state === QFieldCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0) {
+                    refreshProjectsList(filterBar.currentIndex !== 0);
+                  }
+                }
             }
 
             anchors.fill: parent
@@ -219,7 +227,7 @@ Page {
 
             onMovingChanged: {
               if ( !moving && overshootRefresh && cloudConnection.state === QFieldCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0 ) {
-                refreshProjectsList();
+                refreshProjectsList(filterBar.currentIndex !== 0);
               }
               overshootRefresh = false;
             }
@@ -561,7 +569,7 @@ Page {
                    && cloudConnection.state === QFieldCloudConnection.Idle
                    && cloudProjectsModel.busyProjectIds.length === 0
 
-          onClicked: refreshProjectsList()
+          onClicked: refreshProjectsList(filterBar.currentIndex !== 0)
       }
     }
   }
@@ -575,12 +583,12 @@ Page {
     }
   }
 
-  function refreshProjectsList() {
+  function refreshProjectsList(shouldRefreshPublic) {
     if ( cloudConnection.state !== QFieldCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0 ) {
       return;
     }
 
-    cloudProjectsModel.refreshProjectsList();
+    cloudProjectsModel.refreshProjectsList(shouldRefreshPublic);
     displayToast( qsTr( "Refreshing projects list" ) );
   }
 


### PR DESCRIPTION
While this is not the nicest solution, it is good enough until `QFieldCloudProjectsModel` looks as it looks now.

In a good day the API will support pagination and it would not be that painfully slow.