### PR TITLE
Handle static link to QCA ossl plugin on static builds

### DIFF
--- a/cmake/qgis-cmake-wrapper.cmake
+++ b/cmake/qgis-cmake-wrapper.cmake
@@ -112,6 +112,11 @@ if(TRUE) # Should possibly have a "static only" check
     # libspatialite needs log (needed when building with docker)
     target_link_libraries(QGIS::Core INTERFACE log)
   endif()
+
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    find_library(Qca-ossl_LIBRARIES NAMES qca-ossl PATH_SUFFIXES Qca/crypto)
+    target_link_libraries(QGIS::Core INTERFACE ${Qca-ossl_LIBRARIES})
+  endif()
   # End Terrible hack
   _qgis_core_add_dependency(GDAL::GDAL GDAL)
 

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -92,6 +92,15 @@ function(create_executable)
     qt5_import_plugins(${exe_TARGET} INCLUDE ${QT_PKG}::QSvgPlugin)
   endif()
 
+  if(WITH_VCPKG AND NOT CMAKE_SYSTEM_NAME STREQUAL "iOS") # this triggers the
+                                                          # initialisation of
+                                                          # static ossl plugin
+                                                          # for qca. It's not
+                                                          # currently included
+                                                          # for ios.
+    target_compile_definitions(${exe_TARGET} PUBLIC HAVE_STATIC_QCA_PLUGINS)
+  endif()
+
   set_target_properties(${exe_TARGET} PROPERTIES AUTORCC TRUE)
   if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     set_target_properties(

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -45,6 +45,11 @@
 
 #include <proj.h>
 
+#if HAVE_STATIC_QCA_PLUGINS
+#include <QtPlugin>
+Q_IMPORT_PLUGIN( opensslPlugin )
+#endif
+
 void initGraphics()
 {
   // Enables antialiasing in QML scenes

--- a/vcpkg/overlay/qca/portfile.cmake
+++ b/vcpkg/overlay/qca/portfile.cmake
@@ -51,8 +51,12 @@ if("botan" IN_LIST FEATURES)
 else()
     list(APPEND QCA_OPTIONS -DWITH_botan_PLUGIN=no)
 endif()
-    list(APPEND QCA_OPTIONS -DWITH_gnupg_PLUGIN=no)
-    list(APPEND QCA_OPTIONS -DWITH_ossl_PLUGIN=no)
+list(APPEND QCA_OPTIONS -DWITH_gnupg_PLUGIN=no)
+if(VCPKG_TARGET_IS_IOS)
+  list(APPEND QCA_OPTIONS -DWITH_ossl_PLUGIN=no)
+else()
+  list(APPEND QCA_OPTIONS -DWITH_ossl_PLUGIN=yes)
+endif()
 
 # Configure and build
 vcpkg_cmake_configure(


### PR DESCRIPTION
This PR fixes the authentication manager on Android, which had regressed since our move to a vcpkg static build setup.