### PR TITLE
Implement basic iOS local files / project support

### DIFF
--- a/platform/ios/Info.plist.in
+++ b/platform/ios/Info.plist.in
@@ -99,8 +99,14 @@
 
     <key>ITSAppUsesNonExemptEncryption</key><false/>
 
-    <!-- File sharing -->
+    <!-- Files handling -->
     <key>UIFileSharingEnabled</key>
+    <true/>
+
+    <key>UISupportsDocumentBrowser</key>
+    <true/>
+
+    <key>LSSupportsOpeningDocumentsInPlace</key>
     <true/>
 
 </dict>

--- a/platform/ios/Info.plist.in
+++ b/platform/ios/Info.plist.in
@@ -99,5 +99,9 @@
 
     <key>ITSAppUsesNonExemptEncryption</key><false/>
 
+    <!-- File sharing -->
+    <key>UIFileSharingEnabled</key>
+    <true/>
+
 </dict>
 </plist>

--- a/src/core/platforms/ios/iosplatformutilities.h
+++ b/src/core/platforms/ios/iosplatformutilities.h
@@ -33,6 +33,8 @@ class IosPlatformUtilities : public PlatformUtilities
 
     QString systemSharedDataLocation() const override;
     QString applicationDirectory() const override;
+    QStringList appDataDirs() const override;
+
     bool checkPositioningPermissions() const override;
     bool checkCameraPermissions() const override;
     void setScreenLockPermission( const bool allowLock ) override;

--- a/src/core/platforms/ios/iosplatformutilities.h
+++ b/src/core/platforms/ios/iosplatformutilities.h
@@ -29,6 +29,7 @@ class IosPlatformUtilities : public PlatformUtilities
     IosPlatformUtilities();
     PlatformUtilities::Capabilities capabilities() const override;
     QString systemSharedDataLocation() const override;
+    QString applicationDirectory() const override;
     bool checkPositioningPermissions() const override;
     bool checkCameraPermissions() const override;
     void setScreenLockPermission( const bool allowLock ) override;

--- a/src/core/platforms/ios/iosplatformutilities.h
+++ b/src/core/platforms/ios/iosplatformutilities.h
@@ -27,7 +27,10 @@ class IosPlatformUtilities : public PlatformUtilities
 {
   public:
     IosPlatformUtilities();
+
     PlatformUtilities::Capabilities capabilities() const override;
+    void afterUpdate() override;
+
     QString systemSharedDataLocation() const override;
     QString applicationDirectory() const override;
     bool checkPositioningPermissions() const override;

--- a/src/core/platforms/ios/iosplatformutilities.mm
+++ b/src/core/platforms/ios/iosplatformutilities.mm
@@ -27,6 +27,7 @@
 #import <UIKit/UIKit.h>
 
 #include <QGuiApplication>
+#include <QStandardPaths>
 #include <qpa/qplatformnativeinterface.h>
 
 #include <QtGui>
@@ -36,7 +37,7 @@ IosPlatformUtilities::IosPlatformUtilities() : PlatformUtilities() {}
 
 PlatformUtilities::Capabilities IosPlatformUtilities::capabilities() const {
   PlatformUtilities::Capabilities capabilities =
-      Capabilities() | NativeCamera | AdjustBrightness;
+      Capabilities() | NativeCamera | AdjustBrightness | CustomLocalDataPicker;
 #ifdef WITH_SENTRY
   capabilities |= SentryFramework;
 #endif
@@ -48,6 +49,10 @@ QString IosPlatformUtilities::systemSharedDataLocation() const {
   NSString *bundlePath = [main bundlePath];
   QString path = [bundlePath UTF8String];
   return path + "/share";
+}
+
+QString IosPlatformUtilities::applicationDirectory() const {
+  return QStandardPaths::writableLocation(QStandardPaths::DataLocation);
 }
 
 bool IosPlatformUtilities::checkPositioningPermissions() const { return true; }

--- a/src/core/platforms/ios/iosplatformutilities.mm
+++ b/src/core/platforms/ios/iosplatformutilities.mm
@@ -52,7 +52,7 @@ QString IosPlatformUtilities::systemSharedDataLocation() const {
 }
 
 QString IosPlatformUtilities::applicationDirectory() const {
-  return QStandardPaths::writableLocation(QStandardPaths::DataLocation);
+  return QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
 }
 
 bool IosPlatformUtilities::checkPositioningPermissions() const { return true; }

--- a/src/core/platforms/ios/iosplatformutilities.mm
+++ b/src/core/platforms/ios/iosplatformutilities.mm
@@ -44,6 +44,13 @@ PlatformUtilities::Capabilities IosPlatformUtilities::capabilities() const {
   return capabilities;
 }
 
+void IosPlatformUtilities::afterUpdate() {
+  // Create imported projects and datasets folders
+  QDir appDir(applicationDirectory());
+  appDir.mkdir("Imported Projects");
+  appDir.mkdir("Imported Datasets");
+}
+
 QString IosPlatformUtilities::systemSharedDataLocation() const {
   NSBundle *main = [NSBundle mainBundle];
   NSString *bundlePath = [main bundlePath];

--- a/src/core/platforms/ios/iosplatformutilities.mm
+++ b/src/core/platforms/ios/iosplatformutilities.mm
@@ -47,8 +47,12 @@ PlatformUtilities::Capabilities IosPlatformUtilities::capabilities() const {
 void IosPlatformUtilities::afterUpdate() {
   // Create imported projects and datasets folders
   QDir appDir(applicationDirectory());
-  appDir.mkdir("Imported Projects");
-  appDir.mkdir("Imported Datasets");
+  appDir.mkdir(QStringLiteral("Imported Projects"));
+  appDir.mkdir(QStringLiteral("Imported Datasets"));
+  appDir.mkpath(QStringLiteral("QField/proj"));
+  appDir.mkpath(QStringLiteral("QField/auth"));
+  appDir.mkpath(QStringLiteral("QField/fonts"));
+  appDir.mkpath(QStringLiteral("QField/basemaps"));
 }
 
 QString IosPlatformUtilities::systemSharedDataLocation() const {
@@ -60,6 +64,12 @@ QString IosPlatformUtilities::systemSharedDataLocation() const {
 
 QString IosPlatformUtilities::applicationDirectory() const {
   return QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+}
+
+QStringList IosPlatformUtilities::appDataDirs() const {
+  return QStringList() << QStringLiteral("%1/QField/")
+                              .arg(QStandardPaths::writableLocation(
+                                  QStandardPaths::DocumentsLocation));
 }
 
 bool IosPlatformUtilities::checkPositioningPermissions() const { return true; }

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -403,7 +403,6 @@ Page {
         }
         QfButton {
           id: localProjectButton
-          visible: Qt.platform.os !== "ios" // iOS does not allow random file access. Disable local data picker until we have a proper import/export workflow like on Android
           Layout.fillWidth: true
           text: qsTr( "Open local file" )
           onClicked: {


### PR DESCRIPTION
This PR unlocks local files (datasets and full project) support on iOS:
![image](https://user-images.githubusercontent.com/1728657/189471693-5008e301-0e97-4684-98cb-c40ca1f29d5f.png)

Files can be copied into the QField's Documents storage via the iPhone's Files app or via iTunes on a desktop (mac, windows, linux):
![image](https://user-images.githubusercontent.com/1728657/189471699-d56b6121-58de-4f94-b6fc-91c1966a0e8f.png)
