### PR TITLE
Fix dashboard buttons glitch on iOS

### DIFF
--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -44,8 +44,9 @@ Drawer {
     anchors.fill: parent
 
     Rectangle {
-      Layout.fillWidth: true
       height: mainWindow.sceneTopMargin + Math.max(buttonsRow.height, buttonsRow.childrenRect.height)
+      Layout.fillWidth: true
+      Layout.preferredHeight: height
 
       color: mainColor
 

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -45,15 +45,17 @@ Drawer {
 
     Rectangle {
       Layout.fillWidth: true
-      height: mainWindow.sceneTopMargin + 56
+      height: mainWindow.sceneTopMargin + Math.max(buttonsRow.height, buttonsRow.childrenRect.height)
 
       color: mainColor
 
       Row {
         id: buttonsRow
-        height: 56
-        anchors.fill: parent
+        anchors.top: parent.top
+        anchors.left: parent.left
         anchors.topMargin: mainWindow.sceneTopMargin
+        width: parent.width
+        height: 56
         spacing: 1
 
         QfToolButton {


### PR DESCRIPTION
This PR fixes a glitch on iOS with dashboard top buttons wrongly placed / overlapping legend:
![image](https://user-images.githubusercontent.com/1728657/189471987-1501b8c8-d1f1-406b-b9ec-ce919d9ceab0.png)
