### PR TITLE
Fix status bar margin on a number of devices

### DIFF
--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -528,7 +528,7 @@ QVariantMap AndroidPlatformUtilities::sceneMargins( QQuickWindow *window ) const
   Q_UNUSED( window )
 
   const QAndroidJniObject activity = QtAndroid::androidActivity();
-  double statusBarMargin = static_cast<double>( activity.callMethod<jdouble>( "statusBarMargin" ) );
+  double statusBarMargin = std::abs( static_cast<double>( activity.callMethod<jdouble>( "statusBarMargin" ) ) );
 
   statusBarMargin /= QGuiApplication::primaryScreen()->devicePixelRatio();
 


### PR DESCRIPTION
Two fixes in there:
1/ only try to get the display cutout when minimum version requirement is met (ANDROID >= 9)
2/ while the inter tubes are vague, I think the status_bar_height dimensions need to be fetched within the onCreate function of our activity

I've also added a fail-safe whereas a default margin will be served if everything else doesn't.