### PR TITLE
Go back to 22 to be crash free

### DIFF
--- a/.docker/android_dev/Dockerfile
+++ b/.docker/android_dev/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:22.04
-ARG NDK_VERSION=25.0.8775105
+ARG NDK_VERSION=22.1.7171670
 
 ENV ANDROID_SDK_HOME /opt/android-sdk-linux
 ENV ANDROID_SDK_ROOT /opt/android-sdk-linux

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -154,8 +154,8 @@ jobs:
           STOREPASS: ${{ secrets.STOREPASS }}
         run: |
           # Qt 5.x androiddeployqt is not compatible with r25, a bit of cheating
-          rm ${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-readobj
-          ln -s /usr/local/lib/android/sdk/ndk/23.2.8568313/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-readobj ${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-readobj
+          # rm ${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-readobj
+          # ln -s /usr/local/lib/android/sdk/ndk/23.2.8568313/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-readobj ${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-readobj
           cmake --build  "${{ env.CMAKE_BUILD_DIR }}" --target bundle --config Release
 
       - name: 📦 Upload artifacts

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -36,9 +36,10 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "ANDROID_NDK_VERSION=${ANDROID_NDK_HOME##*/}" >> $GITHUB_ENV
+          echo "ANDROID_NDK_VERSION=22.1.7171670" >> $GITHUB_ENV
           echo "ANDROID_BUILD_TOOLS_VERSION=29.0.2" >> $GITHUB_ENV
-          echo "ndk.dir=$ANDROID_NDK_HOME" >> platform/android/local.properties
+          echo "ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk/22.1.7171670" >> $GITHUB_ENV
+          echo "ndk.dir=$ANDROID_NDK_HOME" >> local.properties
           ALL_FILES_ACCESS=${{ matrix.all_files_access }} ./scripts/ci/env_gh.sh
 
           BUILD_ROOT="/home/runner"
@@ -79,6 +80,13 @@ jobs:
           mkdir /tmp/sentry-android-ndk
           wget https://repo1.maven.org/maven2/io/sentry/sentry-android-ndk/5.5.2/sentry-android-ndk-5.5.2.aar -O /tmp/sentry.zip
           unzip /tmp/sentry.zip -d /tmp/sentry-android-ndk
+
+      - name: 🌱 Update ndk
+        run: |
+          echo "ndk.dir=$ANDROID_NDK_HOME" >> local.properties
+          echo "yes" | sudo /usr/local/lib/android/sdk/tools/bin/sdkmanager --uninstall "ndk-bundle"
+          echo "yes" | sudo /usr/local/lib/android/sdk/tools/bin/sdkmanager "platforms;android-30" "build-tools;$ANDROID_BUILD_TOOLS_VERSION" "ndk;$ANDROID_NDK_VERSION" tools platform-tools
+          echo "yes" | sudo /usr/local/lib/android/sdk/tools/bin/sdkmanager --licenses
 
       - name: 🌱 Install dependencies and generate project files
         env:

--- a/cmake/qgis-cmake-wrapper.cmake
+++ b/cmake/qgis-cmake-wrapper.cmake
@@ -107,7 +107,10 @@ if(TRUE) # Should possibly have a "static only" check
   if(ANDROID)
     find_library(libdl dl)
     get_filename_component(arch_path ${libdl} DIRECTORY)
-    set(pkgcfg_lib_PC_SPATIALITE_c++ "${arch_path}/libc++.so")
+    set(pkgcfg_lib_PC_SPATIALITE_c++ "${arch_path}/${ANDROID_PLATFORM_LEVEL}/libc++.so")
+    if(NOT EXISTS ${pkgcfg_lib_PC_SPATIALITE_c++})
+      set(pkgcfg_lib_PC_SPATIALITE_c++ "${arch_path}/libc++.so")
+    endif()
 
     # libspatialite needs log (needed when building with docker)
     target_link_libraries(QGIS::Core INTERFACE log)

--- a/vcpkg/overlay/json-c/pkgconfig.patch
+++ b/vcpkg/overlay/json-c/pkgconfig.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ffb1db3dc..a82ed8619 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -273,7 +273,7 @@ install(
+     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+ )
+ 
+-if (UNIX OR MINGW OR CYGWIN)
++if (1)
+     SET(prefix ${CMAKE_INSTALL_PREFIX})
+     # exec_prefix is prefix by default and CMake does not have the
+     # concept.

--- a/vcpkg/overlay/json-c/portfile.cmake
+++ b/vcpkg/overlay/json-c/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO json-c/json-c
+    REF eae040a84a479ccad1d1c48314345c51ecf1a4a4
+    SHA512 18d8a31b341830b04676cad13fbc0608fb75a323522161ac8fd0bb5058db82c1c261d504696a1e12f4b03eb0967632885580ff81d808adf2f1dff7e32d131ba0
+    HEAD_REF master
+    PATCHES pkgconfig.patch
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/${PORT})
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+# Handle copyright
+configure_file(${SOURCE_PATH}/COPYING ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)

--- a/vcpkg/overlay/json-c/vcpkg.json
+++ b/vcpkg/overlay/json-c/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "json-c",
+  "version-string": "2019-09-10",
+  "port-version": 2,
+  "description": "A JSON implementation in C",
+  "homepage": "https://github.com/json-c/json-c"
+}

--- a/vcpkg/triplets/arm-android.cmake
+++ b/vcpkg/triplets/arm-android.cmake
@@ -4,5 +4,7 @@ set(VCPKG_LIBRARY_LINKAGE static)
 set(VCPKG_CMAKE_SYSTEM_NAME Android)
 set(VCPKG_BUILD_TYPE release)
 
-set(VCPKG_CXX_FLAGS "-fstack-protector-strong")
-set(VCPKG_C_FLAGS "-fstack-protector-strong")
+set(ENV{VCPKG_ANDROID_NATIVE_API_LEVEL} "detect")
+
+set(VCPKG_CXX_FLAGS "-fstack-protector-strong -lunwind -Wl,--exclude-libs=libunwind.a")
+set(VCPKG_C_FLAGS "-fstack-protector-strong -lunwind -Wl,--exclude-libs=libunwind.a")

--- a/vcpkg/triplets/arm-android.cmake
+++ b/vcpkg/triplets/arm-android.cmake
@@ -4,7 +4,6 @@ set(VCPKG_LIBRARY_LINKAGE static)
 set(VCPKG_CMAKE_SYSTEM_NAME Android)
 set(VCPKG_BUILD_TYPE release)
 
-set(ENV{VCPKG_ANDROID_NATIVE_API_LEVEL} "detect")
 
 set(VCPKG_CXX_FLAGS "-fstack-protector-strong -lunwind -Wl,--exclude-libs=libunwind.a")
 set(VCPKG_C_FLAGS "-fstack-protector-strong -lunwind -Wl,--exclude-libs=libunwind.a")

--- a/vcpkg/triplets/arm64-android.cmake
+++ b/vcpkg/triplets/arm64-android.cmake
@@ -4,5 +4,7 @@ set(VCPKG_LIBRARY_LINKAGE static)
 set(VCPKG_CMAKE_SYSTEM_NAME Android)
 set(VCPKG_BUILD_TYPE release)
 
+set(ENV{VCPKG_ANDROID_NATIVE_API_LEVEL} "detect")
+
 set(VCPKG_CXX_FLAGS "-fstack-protector-strong")
 set(VCPKG_C_FLAGS "-fstack-protector-strong")

--- a/vcpkg/triplets/arm64-android.cmake
+++ b/vcpkg/triplets/arm64-android.cmake
@@ -4,7 +4,6 @@ set(VCPKG_LIBRARY_LINKAGE static)
 set(VCPKG_CMAKE_SYSTEM_NAME Android)
 set(VCPKG_BUILD_TYPE release)
 
-set(ENV{VCPKG_ANDROID_NATIVE_API_LEVEL} "detect")
 
 set(VCPKG_CXX_FLAGS "-fstack-protector-strong")
 set(VCPKG_C_FLAGS "-fstack-protector-strong")


### PR DESCRIPTION
Gives me crash-free local APKs again, and ~~hopefully~~ the unwind flags will work on armv7.

Edit: @marioba confirmed the APKs here are crash-free again.