### PR TITLE
Do not set package data path on non-relative prefix path setup

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -126,7 +126,9 @@ int main( int argc, char **argv )
 #endif
   app.initQgis();
   app.setThemeName( settings.value( "/Themes", "default" ).toString() );
+#ifdef RELATIVE_PREFIX_PATH
   app.setPkgDataPath( PlatformUtilities::instance()->systemSharedDataLocation() + QStringLiteral( "/qgis" ) );
+#endif
   app.createDatabase();
 
   QSettings::setDefaultFormat( QSettings::NativeFormat );


### PR DESCRIPTION
Follow up to https://github.com/opengisch/QField/commit/9300e0f474216512530f3e7edfb33b0f11103202 , which while fixing an important regression on relative paths broke home builds against system-installed QGIS.

Hope it's the last time we tweak this part of the code for the foreseeable future :)