### PR TITLE
Remove QTEST_ADD_GPU_BLACKLIST_SUPPORT[_DEFS] so tests can compile under Qt6

### DIFF
--- a/test/qfield_testbase.h
+++ b/test/qfield_testbase.h
@@ -2,9 +2,6 @@
 #include <qgsapplication.h>
 
 #define QFIELDTEST_MAIN( TestObject )                \
-  QT_BEGIN_NAMESPACE                                 \
-  QTEST_ADD_GPU_BLACKLIST_SUPPORT_DEFS               \
-  QT_END_NAMESPACE                                   \
   int main( int argc, char *argv[] )                 \
   {                                                  \
     QgsApplication app( argc, argv, false );         \
@@ -13,7 +10,6 @@
     app.initQgis();                                  \
     app.setAttribute( Qt::AA_Use96Dpi, true );       \
     QTEST_DISABLE_KEYPAD_NAVIGATION                  \
-    QTEST_ADD_GPU_BLACKLIST_SUPPORT                  \
     TestObject tc;                                   \
     QTEST_SET_MAIN_SOURCE_PATH                       \
     return QTest::qExec( &tc, argc, argv );          \


### PR DESCRIPTION
A bunch of tests are failing, but at least they compile (inc. spix)