### PR TITLE
Test names harmony and revivals

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -90,7 +90,6 @@ if (WITH_SPIX)
 endif ()
 
 ADD_QFIELD_TEST(referencingfeaturelistmodeltest test_referencingfeaturelistmodel.cpp)
-ADD_QFIELD_TEST(orderedrelationmodeltest test_orderedrelationmodel.cpp)
 
 ADD_CATCH2_TEST(layerobservertest test_layerobserver.cpp FALSE)
 ADD_CATCH2_TEST(featureutilstest test_featureutils.cpp TRUE)
@@ -103,5 +102,6 @@ ADD_CATCH2_TEST(stringutilstest test_stringutils.cpp TRUE)
 ADD_CATCH2_TEST(urlutilstest test_urlutils.cpp TRUE)
 ADD_CATCH2_TEST(digitizingloggertest test_digitizinglogger.cpp FALSE)
 ADD_CATCH2_TEST(attributeformmodeltest test_attributeformmodel.cpp FALSE)
+ADD_CATCH2_TEST(orderedrelationmodeltest test_orderedrelationmodel.cpp TRUE)
 
 ADD_QFIELD_QML_TEST(qmltest test_qml_editorwidgets.cpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -89,8 +89,6 @@ if (WITH_SPIX)
   add_subdirectory(spix)
 endif ()
 
-ADD_QFIELD_TEST(referencingfeaturelistmodeltest test_referencingfeaturelistmodel.cpp)
-
 ADD_CATCH2_TEST(layerobservertest test_layerobserver.cpp FALSE)
 ADD_CATCH2_TEST(featureutilstest test_featureutils.cpp TRUE)
 ADD_CATCH2_TEST(vertexmodeltest test_vertexmodel.cpp TRUE)
@@ -102,6 +100,7 @@ ADD_CATCH2_TEST(stringutilstest test_stringutils.cpp TRUE)
 ADD_CATCH2_TEST(urlutilstest test_urlutils.cpp TRUE)
 ADD_CATCH2_TEST(digitizingloggertest test_digitizinglogger.cpp FALSE)
 ADD_CATCH2_TEST(attributeformmodeltest test_attributeformmodel.cpp FALSE)
-ADD_CATCH2_TEST(orderedrelationmodeltest test_orderedrelationmodel.cpp TRUE)
+ADD_CATCH2_TEST(orderedrelationmodeltest test_orderedrelationmodel.cpp FALSE)
+ADD_CATCH2_TEST(referencingfeaturelistmodeltest test_referencingfeaturelistmodel.cpp FALSE)
 
 ADD_QFIELD_QML_TEST(qmltest test_qml_editorwidgets.cpp)

--- a/test/spix/smoke_test.py
+++ b/test/spix/smoke_test.py
@@ -10,6 +10,7 @@ import time
 import os
 import shutil
 from pathlib import Path
+from PIL import Image
 
 
 @pytest.fixture
@@ -39,6 +40,12 @@ def diff_path():
 @pytest.fixture
 def screenshot_check(image_diff, image_diff_dir, screenshot_path, diff_path, extra):
     def inner(test_name, image_name):
+        # insure no alpha channel present in the screenshot being compared
+        png = Image.open(
+            os.path.join(screenshot_path, "{}.png".format(image_name))
+        ).convert("RGB")
+        png.save(os.path.join(screenshot_path, "{}.png".format(image_name)))
+
         result = image_diff(
             os.path.join(screenshot_path, "{}.png".format(image_name)),
             str(

--- a/test/test_attributeformmodel.cpp
+++ b/test/test_attributeformmodel.cpp
@@ -21,7 +21,7 @@
 #include "featuremodel.h"
 
 
-TEST_CASE( "Attribute form model" )
+TEST_CASE( "AttributeFormModel" )
 {
   std::unique_ptr<QgsVectorLayer> layer = std::make_unique<QgsVectorLayer>( QStringLiteral( "Point?crs=EPSG:3857&field=fid:integer&field=str:string&field=str2:string" ), QStringLiteral( "Input Layer" ), QStringLiteral( "memory" ) );
   REQUIRE( layer->isValid() );

--- a/test/test_deltafilewrapper.cpp
+++ b/test/test_deltafilewrapper.cpp
@@ -129,7 +129,7 @@ QJsonArray getDeltasArray( const QString &json )
 }
 
 
-TEST_CASE( "Delta File Wrapper" )
+TEST_CASE( "DeltaFileWrapper" )
 {
   QgsProject *project = QgsProject::instance();
   QTemporaryDir settingsDir;

--- a/test/test_digitizinglogger.cpp
+++ b/test/test_digitizinglogger.cpp
@@ -22,7 +22,7 @@
 #include <qgscoordinatereferencesystem.h>
 
 
-TEST_CASE( "Digitizing logger" )
+TEST_CASE( "DigitizingLogger" )
 {
   std::unique_ptr<QgsVectorLayer> logsLayer = std::make_unique<QgsVectorLayer>( QStringLiteral( "Point?crs=EPSG:3857&field=fid:integer&field=digitizing_action:string&field=digitizing_layer_name:string&field=digitizing_layer_id:string&field=digitizing_datetime:datetime" ), QStringLiteral( "Logs Layer" ), QStringLiteral( "memory" ) );
   REQUIRE( logsLayer->isValid() );

--- a/test/test_layerobserver.cpp
+++ b/test/test_layerobserver.cpp
@@ -57,7 +57,7 @@ QString getId( QString fileName )
   return doc.object().value( QStringLiteral( "id" ) ).toString();
 }
 
-TEST_CASE( "TestLayerObserver" )
+TEST_CASE( "LayerObserver" )
 {
   QTemporaryDir settingsDir;
 

--- a/test/test_orderedrelationmodel.cpp
+++ b/test/test_orderedrelationmodel.cpp
@@ -1,149 +1,147 @@
-#include "orderedrelationmodel.h"
-#include "qfield_testbase.h"
+/***************************************************************************
+                        test_orderedrelationmodel.h
+                        --------------------
+  begin                : June 2021
+  copyright            : (C) 2021 by Ivan Ivanov
+  email                : ivan@opengis.ch
+***************************************************************************/
 
-#include <QtTest>
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#define QFIELDTEST_MAIN
+#include "catch2.h"
+#include "orderedrelationmodel.h"
+
 #include <qgsapplication.h>
 #include <qgsproject.h>
 #include <qgsrelationmanager.h>
 #include <qgsvectorlayer.h>
 
-class TestOrderedRelationModel : public QObject
+#include <QSignalSpy>
+
+TEST_CASE( "OrderedRelationModel" )
 {
-    Q_OBJECT
-  private slots:
-    void init()
-    {
-      //create layers
-      mReferencingLayer.reset( new QgsVectorLayer( QStringLiteral( "NoGeometry?field=id:integer&field=foreignkey:integer&field=rank:integer" ), QStringLiteral( "king" ), QStringLiteral( "memory" ) ) );
-      mReferencingLayer->setDisplayExpression( "name" );
-      QVERIFY( mReferencingLayer->isValid() );
-      QgsProject::instance()->addMapLayer( mReferencingLayer.get(), false, false );
+  //create layers
+  std::unique_ptr<QgsVectorLayer> mReferencingLayer( new QgsVectorLayer( QStringLiteral( "NoGeometry?field=id:integer&field=foreignkey:integer&field=rank:integer" ), QStringLiteral( "king" ), QStringLiteral( "memory" ) ) );
+  mReferencingLayer->setDisplayExpression( "name" );
+  REQUIRE( mReferencingLayer->isValid() );
+  QgsProject::instance()->addMapLayer( mReferencingLayer.get(), false, false );
 
-      mReferencedLayer.reset( new QgsVectorLayer( QStringLiteral( "NoGeometry?field=id:integer" ), QStringLiteral( "land" ), QStringLiteral( "memory" ) ) );
-      mReferencedLayer->setDisplayExpression( "name" );
-      QVERIFY( mReferencedLayer->isValid() );
-      QgsProject::instance()->addMapLayer( mReferencedLayer.get(), false, false );
+  std::unique_ptr<QgsVectorLayer> mReferencedLayer( new QgsVectorLayer( QStringLiteral( "NoGeometry?field=id:integer" ), QStringLiteral( "land" ), QStringLiteral( "memory" ) ) );
+  mReferencedLayer->setDisplayExpression( "name" );
+  REQUIRE( mReferencedLayer->isValid() );
+  QgsProject::instance()->addMapLayer( mReferencedLayer.get(), false, false );
 
-      //create relations
-      mRelation.setId( QStringLiteral( "referenced.referencing" ) );
-      mRelation.setName( QStringLiteral( "referenced.referencing" ) );
-      mRelation.setReferencingLayer( mReferencingLayer->id() );
-      mRelation.setReferencedLayer( mReferencedLayer->id() );
-      mRelation.addFieldPair( QStringLiteral( "foreignkey" ), QStringLiteral( "id" ) );
-      QVERIFY( mRelation.isValid() );
-      QgsProject::instance()->relationManager()->addRelation( mRelation );
+  //create relations
+  QgsRelation mRelation;
+  mRelation.setId( QStringLiteral( "referenced.referencing" ) );
+  mRelation.setName( QStringLiteral( "referenced.referencing" ) );
+  mRelation.setReferencingLayer( mReferencingLayer->id() );
+  mRelation.setReferencedLayer( mReferencedLayer->id() );
+  mRelation.addFieldPair( QStringLiteral( "foreignkey" ), QStringLiteral( "id" ) );
+  REQUIRE( mRelation.isValid() );
+  QgsProject::instance()->relationManager()->addRelation( mRelation );
 
-      // add features to the referencing layer
-      QgsFeature referencing_f1( mReferencingLayer->fields() );
-      referencing_f1.setAttribute( QStringLiteral( "id" ), 1 );
-      referencing_f1.setAttribute( QStringLiteral( "foreignkey" ), 1 );
-      referencing_f1.setAttribute( QStringLiteral( "rank" ), 1 );
-      QgsFeature referencing_f2( mReferencingLayer->fields() );
-      referencing_f2.setAttribute( QStringLiteral( "id" ), 2 );
-      referencing_f2.setAttribute( QStringLiteral( "foreignkey" ), 1 );
-      referencing_f2.setAttribute( QStringLiteral( "rank" ), 2 );
-      QgsFeature referencing_f3( mReferencingLayer->fields() );
-      referencing_f3.setAttribute( QStringLiteral( "id" ), 3 );
-      referencing_f3.setAttribute( QStringLiteral( "foreignkey" ), 1 );
-      referencing_f3.setAttribute( QStringLiteral( "rank" ), 3 );
-      QgsFeature referencing_f4( mReferencingLayer->fields() );
-      referencing_f4.setAttribute( QStringLiteral( "id" ), 4 );
-      referencing_f4.setAttribute( QStringLiteral( "foreignkey" ), 1 );
-      referencing_f4.setAttribute( QStringLiteral( "rank" ), 4 );
-      mReferencingLayer->startEditing();
-      mReferencingLayer->addFeature( referencing_f1 );
-      mReferencingLayer->addFeature( referencing_f2 );
-      mReferencingLayer->addFeature( referencing_f3 );
-      mReferencingLayer->addFeature( referencing_f4 );
-      mReferencingLayer->commitChanges();
-      QCOMPARE( mReferencingLayer->featureCount(), 4L );
+  // add features to the referencing layer
+  QgsFeature referencing_f1( mReferencingLayer->fields() );
+  referencing_f1.setAttribute( QStringLiteral( "id" ), 1 );
+  referencing_f1.setAttribute( QStringLiteral( "foreignkey" ), 1 );
+  referencing_f1.setAttribute( QStringLiteral( "rank" ), 1 );
+  QgsFeature referencing_f2( mReferencingLayer->fields() );
+  referencing_f2.setAttribute( QStringLiteral( "id" ), 2 );
+  referencing_f2.setAttribute( QStringLiteral( "foreignkey" ), 1 );
+  referencing_f2.setAttribute( QStringLiteral( "rank" ), 2 );
+  QgsFeature referencing_f3( mReferencingLayer->fields() );
+  referencing_f3.setAttribute( QStringLiteral( "id" ), 3 );
+  referencing_f3.setAttribute( QStringLiteral( "foreignkey" ), 1 );
+  referencing_f3.setAttribute( QStringLiteral( "rank" ), 3 );
+  QgsFeature referencing_f4( mReferencingLayer->fields() );
+  referencing_f4.setAttribute( QStringLiteral( "id" ), 4 );
+  referencing_f4.setAttribute( QStringLiteral( "foreignkey" ), 1 );
+  referencing_f4.setAttribute( QStringLiteral( "rank" ), 4 );
+  mReferencingLayer->startEditing();
+  mReferencingLayer->addFeature( referencing_f1 );
+  mReferencingLayer->addFeature( referencing_f2 );
+  mReferencingLayer->addFeature( referencing_f3 );
+  mReferencingLayer->addFeature( referencing_f4 );
+  mReferencingLayer->commitChanges();
+  REQUIRE( mReferencingLayer->featureCount() == 4L );
 
-      // add features to the referenced layer
-      QgsFeature referenced_ft1( mReferencedLayer->fields() );
-      referenced_ft1.setAttribute( QStringLiteral( "id" ), 1 );
+  // add features to the referenced layer
+  QgsFeature referenced_ft1( mReferencedLayer->fields() );
+  referenced_ft1.setAttribute( QStringLiteral( "id" ), 1 );
 
-      mReferencedLayer->startEditing();
-      mReferencedLayer->addFeature( referenced_ft1 );
-      mReferencedLayer->commitChanges();
-      QCOMPARE( mReferencedLayer->featureCount(), 1L );
+  mReferencedLayer->startEditing();
+  mReferencedLayer->addFeature( referenced_ft1 );
+  mReferencedLayer->commitChanges();
+  REQUIRE( mReferencedLayer->featureCount() == 1L );
 
-      mModel = new OrderedRelationModel();
-    }
+  std::unique_ptr<OrderedRelationModel> mModel( new OrderedRelationModel() );
 
-    void cleanup()
-    {
-      delete mModel;
+  SECTION( "DeleteFeature" )
+  {
+    REQUIRE( mModel->rowCount() == 0 );
 
-      QgsProject::instance()->removeMapLayer( mReferencedLayer.get() );
-      QgsProject::instance()->removeMapLayer( mReferencingLayer.get() );
-    }
+    mModel->setRelation( mRelation );
+    mModel->setOrderingField( QStringLiteral( "rank" ) );
+    mModel->setFeature( mReferencedLayer->getFeature( 1 ) );
 
-    void testDeleteFeature()
-    {
-      QCOMPARE( mModel->rowCount(), 0 );
+    REQUIRE(QSignalSpy( mModel.get(), &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
 
-      mModel->setRelation( mRelation );
-      mModel->setOrderingField( QStringLiteral( "rank" ) );
-      mModel->setFeature( mReferencedLayer->getFeature( 1 ) );
+    REQUIRE( mModel->rowCount() == 4 );
+    REQUIRE( mModel->deleteFeature( 2 ) );
+    REQUIRE( QSignalSpy( mModel.get(), &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
+    REQUIRE( mModel->rowCount() == 3 );
+    REQUIRE( !mReferencingLayer->getFeature( 2 ).isValid() );
+    REQUIRE( mReferencingLayer->getFeature( 1 ).attribute( QStringLiteral( "rank" ) ).toInt() == 1 );
+    REQUIRE( mReferencingLayer->getFeature( 3 ).attribute( QStringLiteral( "rank" ) ).toInt() == 2 );
+    REQUIRE( mReferencingLayer->getFeature( 4 ).attribute( QStringLiteral( "rank" ) ).toInt() == 3 );
+  }
 
-      QVERIFY( QSignalSpy( mModel, &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
+  SECTION ( "MoveFeature" )
+  {
+    REQUIRE( mModel->rowCount() == 0 );
 
-      QCOMPARE( mModel->rowCount(), 4 );
-      QVERIFY( mModel->deleteFeature( 2 ) );
-      QVERIFY( QSignalSpy( mModel, &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
-      QCOMPARE( mModel->rowCount(), 3 );
-      QVERIFY( !mReferencingLayer->getFeature( 2 ).isValid() );
-      QCOMPARE( mReferencingLayer->getFeature( 1 ).attribute( QStringLiteral( "rank" ) ).toInt(), 1 );
-      QCOMPARE( mReferencingLayer->getFeature( 3 ).attribute( QStringLiteral( "rank" ) ).toInt(), 2 );
-      QCOMPARE( mReferencingLayer->getFeature( 4 ).attribute( QStringLiteral( "rank" ) ).toInt(), 3 );
-    }
+    mModel->setRelation( mRelation );
+    mModel->setOrderingField( QStringLiteral( "rank" ) );
+    mModel->setFeature( mReferencedLayer->getFeature( 1 ) );
 
-    void testMoveFeature()
-    {
-      QCOMPARE( mModel->rowCount(), 0 );
+    REQUIRE( QSignalSpy( mModel.get(), &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
 
-      mModel->setRelation( mRelation );
-      mModel->setOrderingField( QStringLiteral( "rank" ) );
-      mModel->setFeature( mReferencedLayer->getFeature( 1 ) );
+    REQUIRE( mModel->rowCount() == 4 );
+    // try to move items out of range
+    REQUIRE( !mModel->moveItems( 2, 40 ) );
+    REQUIRE( mReferencingLayer->getFeature( 1 ).attribute( QStringLiteral( "rank" ) ).toInt() == 1 );
+    REQUIRE( mReferencingLayer->getFeature( 2 ).attribute( QStringLiteral( "rank" ) ).toInt() == 2 );
+    REQUIRE( mReferencingLayer->getFeature( 3 ).attribute( QStringLiteral( "rank" ) ).toInt() == 3 );
+    REQUIRE( mReferencingLayer->getFeature( 4 ).attribute( QStringLiteral( "rank" ) ).toInt() == 4 );
 
-      QVERIFY( QSignalSpy( mModel, &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
+    // try to move items out of range
+    REQUIRE( !mModel->moveItems( -2, 2 ) );
+    REQUIRE( mReferencingLayer->getFeature( 1 ).attribute( QStringLiteral( "rank" ) ).toInt() == 1 );
+    REQUIRE( mReferencingLayer->getFeature( 2 ).attribute( QStringLiteral( "rank" ) ).toInt() == 2 );
+    REQUIRE( mReferencingLayer->getFeature( 3 ).attribute( QStringLiteral( "rank" ) ).toInt() == 3 );
+    REQUIRE( mReferencingLayer->getFeature( 4 ).attribute( QStringLiteral( "rank" ) ).toInt() == 4 );
 
-      QCOMPARE( mModel->rowCount(), 4 );
-      // try to move items out of range
-      QVERIFY( !mModel->moveItems( 2, 40 ) );
-      QCOMPARE( mReferencingLayer->getFeature( 1 ).attribute( QStringLiteral( "rank" ) ).toInt(), 1 );
-      QCOMPARE( mReferencingLayer->getFeature( 2 ).attribute( QStringLiteral( "rank" ) ).toInt(), 2 );
-      QCOMPARE( mReferencingLayer->getFeature( 3 ).attribute( QStringLiteral( "rank" ) ).toInt(), 3 );
-      QCOMPARE( mReferencingLayer->getFeature( 4 ).attribute( QStringLiteral( "rank" ) ).toInt(), 4 );
+    REQUIRE( mModel->moveItems( 1, 3 ) );
+    REQUIRE( QSignalSpy( mModel.get(), &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
+    REQUIRE( mModel->rowCount() == 4 );
+    REQUIRE( mReferencingLayer->getFeature( 1 ).attribute( QStringLiteral( "rank" ) ).toInt() == 1 );
+    REQUIRE( mReferencingLayer->getFeature( 2 ).attribute( QStringLiteral( "rank" ) ).toInt() == 4 );
+    REQUIRE( mReferencingLayer->getFeature( 3 ).attribute( QStringLiteral( "rank" ) ).toInt() == 2 );
+    REQUIRE( mReferencingLayer->getFeature( 4 ).attribute( QStringLiteral( "rank" ) ).toInt() == 3 );
 
-      // try to move items out of range
-      QVERIFY( !mModel->moveItems( -2, 2 ) );
-      QCOMPARE( mReferencingLayer->getFeature( 1 ).attribute( QStringLiteral( "rank" ) ).toInt(), 1 );
-      QCOMPARE( mReferencingLayer->getFeature( 2 ).attribute( QStringLiteral( "rank" ) ).toInt(), 2 );
-      QCOMPARE( mReferencingLayer->getFeature( 3 ).attribute( QStringLiteral( "rank" ) ).toInt(), 3 );
-      QCOMPARE( mReferencingLayer->getFeature( 4 ).attribute( QStringLiteral( "rank" ) ).toInt(), 4 );
-
-      QVERIFY( mModel->moveItems( 1, 3 ) );
-      QVERIFY( QSignalSpy( mModel, &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
-      QCOMPARE( mModel->rowCount(), 4 );
-      QCOMPARE( mReferencingLayer->getFeature( 1 ).attribute( QStringLiteral( "rank" ) ).toInt(), 1 );
-      QCOMPARE( mReferencingLayer->getFeature( 2 ).attribute( QStringLiteral( "rank" ) ).toInt(), 4 );
-      QCOMPARE( mReferencingLayer->getFeature( 3 ).attribute( QStringLiteral( "rank" ) ).toInt(), 2 );
-      QCOMPARE( mReferencingLayer->getFeature( 4 ).attribute( QStringLiteral( "rank" ) ).toInt(), 3 );
-
-      // check feature ordering
-      QCOMPARE( mModel->data( mModel->index( 0, 0 ), OrderedRelationModel::FeatureIdRole ), 1 );
-      QCOMPARE( mModel->data( mModel->index( 1, 0 ), OrderedRelationModel::FeatureIdRole ), 3 );
-      QCOMPARE( mModel->data( mModel->index( 2, 0 ), OrderedRelationModel::FeatureIdRole ), 4 );
-      QCOMPARE( mModel->data( mModel->index( 3, 0 ), OrderedRelationModel::FeatureIdRole ), 2 );
-    }
-
-  private:
-    std::unique_ptr<QgsVectorLayer> mReferencedLayer;
-    std::unique_ptr<QgsVectorLayer> mReferencingLayer;
-    QgsRelation mRelation;
-    OrderedRelationModel *mModel;
-};
-
-QFIELDTEST_MAIN( TestOrderedRelationModel )
-#include "test_orderedrelationmodel.moc"
+    // check feature ordering
+    REQUIRE( mModel->data( mModel->index( 0, 0 ), OrderedRelationModel::FeatureIdRole ) == 1 );
+    REQUIRE( mModel->data( mModel->index( 1, 0 ), OrderedRelationModel::FeatureIdRole ) == 3 );
+    REQUIRE( mModel->data( mModel->index( 2, 0 ), OrderedRelationModel::FeatureIdRole ) == 4 );
+    REQUIRE( mModel->data( mModel->index( 3, 0 ), OrderedRelationModel::FeatureIdRole ) == 2 );
+  }
+}

--- a/test/test_orderedrelationmodel.cpp
+++ b/test/test_orderedrelationmodel.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
-                        test_orderedrelationmodel.h
+                        test_orderedrelationmodel.cpp
                         --------------------
   begin                : June 2021
   copyright            : (C) 2021 by Ivan Ivanov

--- a/test/test_orderedrelationmodel.cpp
+++ b/test/test_orderedrelationmodel.cpp
@@ -19,12 +19,11 @@
 #include "catch2.h"
 #include "orderedrelationmodel.h"
 
+#include <QSignalSpy>
 #include <qgsapplication.h>
 #include <qgsproject.h>
 #include <qgsrelationmanager.h>
 #include <qgsvectorlayer.h>
-
-#include <QSignalSpy>
 
 TEST_CASE( "OrderedRelationModel" )
 {
@@ -93,7 +92,7 @@ TEST_CASE( "OrderedRelationModel" )
     mModel->setOrderingField( QStringLiteral( "rank" ) );
     mModel->setFeature( mReferencedLayer->getFeature( 1 ) );
 
-    REQUIRE(QSignalSpy( mModel.get(), &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
+    REQUIRE( QSignalSpy( mModel.get(), &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
 
     REQUIRE( mModel->rowCount() == 4 );
     REQUIRE( mModel->deleteFeature( 2 ) );
@@ -105,7 +104,7 @@ TEST_CASE( "OrderedRelationModel" )
     REQUIRE( mReferencingLayer->getFeature( 4 ).attribute( QStringLiteral( "rank" ) ).toInt() == 3 );
   }
 
-  SECTION ( "MoveFeature" )
+  SECTION( "MoveFeature" )
   {
     REQUIRE( mModel->rowCount() == 0 );
 

--- a/test/test_referencingfeaturelistmodel.cpp
+++ b/test/test_referencingfeaturelistmodel.cpp
@@ -1,20 +1,36 @@
-#include "qfield_testbase.h"
+/***************************************************************************
+                        test_referencingfeaturelistmodel.cpp
+                        --------------------
+  begin                : October 2019
+  copyright            : (C) 2019 by David Signer
+  email                : david (at) opengis.ch
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#define QFIELDTEST_MAIN
+#include "catch2.h"
 #include "qgsquickmapsettings.h"
 #include "referencingfeaturelistmodel.h"
 
-#include <QtTest>
 #include <qgsapplication.h>
 #include <qgsproject.h>
 #include <qgsrelationmanager.h>
 #include <qgsvectorlayer.h>
 
-class TestReferencingFeatureListModel : public QObject
+#include <QSignalSpy>
+
+TEST_CASE( "ReferencingFeatureListModel" )
 {
-    Q_OBJECT
-  private slots:
-    void initTestCase()
-    {
-      /* TEST PROJECT
+
+  /* TEST PROJECT
       *
       * LAYERS
       * land (id, name, king_id)
@@ -45,286 +61,267 @@ class TestReferencingFeatureListModel : public QObject
       * - shareofoneland (shares m--1 land)
       */
 
-      //create layers
-      mL_Land.reset( new QgsVectorLayer( QStringLiteral( "Polygon?crs=EPSG:3857&field=id:int&field=name:string&field=king_id:int" ), QStringLiteral( "land" ), QStringLiteral( "memory" ) ) );
-      mL_Land->setDisplayExpression( "name" );
-      QVERIFY( mL_Land->isValid() );
-      QgsProject::instance()->addMapLayer( mL_Land.get(), false, false );
+  //create layers
+  std::unique_ptr<QgsVectorLayer> mL_Land( new QgsVectorLayer( QStringLiteral( "Polygon?crs=EPSG:3857&field=id:int&field=name:string&field=king_id:int" ), QStringLiteral( "land" ), QStringLiteral( "memory" ) ) );
+  mL_Land->setDisplayExpression( "name" );
+  REQUIRE( mL_Land->isValid() );
+  QgsProject::instance()->addMapLayer( mL_Land.get(), false, false );
 
-      mL_King.reset( new QgsVectorLayer( QStringLiteral( "Point?crs=EPSG:3857&field=id:int&field=name:string" ), QStringLiteral( "king" ), QStringLiteral( "memory" ) ) );
-      mL_King->setDisplayExpression( "name" );
-      QVERIFY( mL_King->isValid() );
-      QgsProject::instance()->addMapLayer( mL_King.get(), false, false );
+  std::unique_ptr<QgsVectorLayer> mL_King( new QgsVectorLayer( QStringLiteral( "Point?crs=EPSG:3857&field=id:int&field=name:string" ), QStringLiteral( "king" ), QStringLiteral( "memory" ) ) );
+  mL_King->setDisplayExpression( "name" );
+  REQUIRE( mL_King->isValid() );
+  QgsProject::instance()->addMapLayer( mL_King.get(), false, false );
 
-      mL_Share.reset( new QgsVectorLayer( QStringLiteral( "Point?crs=EPSG:3857&field=id:integer&field=share:int&field=king_id:int&field=land_id:int" ), QStringLiteral( "share" ), QStringLiteral( "memory" ) ) );
-      mL_Share->setDisplayExpression( "share" );
-      QVERIFY( mL_Share->isValid() );
-      QgsProject::instance()->addMapLayer( mL_Share.get(), false, false );
+  std::unique_ptr<QgsVectorLayer> mL_Share( new QgsVectorLayer( QStringLiteral( "Point?crs=EPSG:3857&field=id:integer&field=share:int&field=king_id:int&field=land_id:int" ), QStringLiteral( "share" ), QStringLiteral( "memory" ) ) );
+  mL_Share->setDisplayExpression( "share" );
+  REQUIRE( mL_Share->isValid() );
+  QgsProject::instance()->addMapLayer( mL_Share.get(), false, false );
 
-      //create relations
-      mR_Landhasoneking.setId( QStringLiteral( "land.king" ) );
-      mR_Landhasoneking.setName( QStringLiteral( "land.king" ) );
-      mR_Landhasoneking.setReferencingLayer( mL_Land->id() );
-      mR_Landhasoneking.setReferencedLayer( mL_King->id() );
-      mR_Landhasoneking.addFieldPair( QStringLiteral( "king_id" ), QStringLiteral( "id" ) );
-      QVERIFY( mR_Landhasoneking.isValid() );
-      QgsProject::instance()->relationManager()->addRelation( mR_Landhasoneking );
+  //create relations
+  QgsRelation mR_Landhasoneking;
+  mR_Landhasoneking.setId( QStringLiteral( "land.king" ) );
+  mR_Landhasoneking.setName( QStringLiteral( "land.king" ) );
+  mR_Landhasoneking.setReferencingLayer( mL_Land->id() );
+  mR_Landhasoneking.setReferencedLayer( mL_King->id() );
+  mR_Landhasoneking.addFieldPair( QStringLiteral( "king_id" ), QStringLiteral( "id" ) );
+  REQUIRE( mR_Landhasoneking.isValid() );
+  QgsProject::instance()->relationManager()->addRelation( mR_Landhasoneking );
 
-      mR_Sharehasoneking.setId( QStringLiteral( "share.king" ) );
-      mR_Sharehasoneking.setName( QStringLiteral( "share.king" ) );
-      mR_Sharehasoneking.setReferencingLayer( mL_Share->id() );
-      mR_Sharehasoneking.setReferencedLayer( mL_King->id() );
-      mR_Sharehasoneking.addFieldPair( QStringLiteral( "king_id" ), QStringLiteral( "id" ) );
-      QVERIFY( mR_Sharehasoneking.isValid() );
-      QgsProject::instance()->relationManager()->addRelation( mR_Sharehasoneking );
+  QgsRelation mR_Sharehasoneking;
+  mR_Sharehasoneking.setId( QStringLiteral( "share.king" ) );
+  mR_Sharehasoneking.setName( QStringLiteral( "share.king" ) );
+  mR_Sharehasoneking.setReferencingLayer( mL_Share->id() );
+  mR_Sharehasoneking.setReferencedLayer( mL_King->id() );
+  mR_Sharehasoneking.addFieldPair( QStringLiteral( "king_id" ), QStringLiteral( "id" ) );
+  REQUIRE( mR_Sharehasoneking.isValid() );
+  QgsProject::instance()->relationManager()->addRelation( mR_Sharehasoneking );
 
-      mR_Shareofoneland.setId( QStringLiteral( "share.land" ) );
-      mR_Shareofoneland.setName( QStringLiteral( "share.land" ) );
-      mR_Shareofoneland.setReferencingLayer( mL_Share->id() );
-      mR_Shareofoneland.setReferencedLayer( mL_Land->id() );
-      mR_Shareofoneland.addFieldPair( QStringLiteral( "land_id" ), QStringLiteral( "id" ) );
-      QVERIFY( mR_Shareofoneland.isValid() );
-      QgsProject::instance()->relationManager()->addRelation( mR_Shareofoneland );
+  QgsRelation mR_Shareofoneland;
+  mR_Shareofoneland.setId( QStringLiteral( "share.land" ) );
+  mR_Shareofoneland.setName( QStringLiteral( "share.land" ) );
+  mR_Shareofoneland.setReferencingLayer( mL_Share->id() );
+  mR_Shareofoneland.setReferencedLayer( mL_Land->id() );
+  mR_Shareofoneland.addFieldPair( QStringLiteral( "land_id" ), QStringLiteral( "id" ) );
+  REQUIRE( mR_Shareofoneland.isValid() );
+  QgsProject::instance()->relationManager()->addRelation( mR_Shareofoneland );
 
-      // add features on land
-      QgsFeature land_ft0( mL_Land->fields() );
-      land_ft0.setAttribute( QStringLiteral( "id" ), 0 );
-      land_ft0.setAttribute( QStringLiteral( "name" ), "Mordor" );
-      land_ft0.setAttribute( QStringLiteral( "king_id" ), 1 );
-      QgsFeature land_ft1( mL_Land->fields() );
-      land_ft1.setAttribute( QStringLiteral( "id" ), 1 );
-      land_ft1.setAttribute( QStringLiteral( "name" ), "Gondor" );
-      land_ft1.setAttribute( QStringLiteral( "king_id" ), 0 );
-      QgsFeature land_ft2( mL_Land->fields() );
-      land_ft2.setAttribute( QStringLiteral( "id" ), 2 );
-      land_ft2.setAttribute( QStringLiteral( "name" ), "Rohan" );
-      land_ft2.setAttribute( QStringLiteral( "king_id" ), 0 );
-      QgsFeature land_ft3( mL_Land->fields() );
-      land_ft3.setAttribute( QStringLiteral( "id" ), 3 );
-      land_ft3.setAttribute( QStringLiteral( "name" ), "Eriador" );
-      land_ft3.setAttribute( QStringLiteral( "king_id" ), 0 );
-      mL_Land->startEditing();
-      mL_Land->addFeature( land_ft0 );
-      mL_Land->addFeature( land_ft1 );
-      mL_Land->addFeature( land_ft2 );
-      mL_Land->addFeature( land_ft3 );
-      mL_Land->commitChanges();
-      QCOMPARE( mL_Land->featureCount(), 4L );
+  // add features on land
+  QgsFeature land_ft0( mL_Land->fields() );
+  land_ft0.setAttribute( QStringLiteral( "id" ), 0 );
+  land_ft0.setAttribute( QStringLiteral( "name" ), "Mordor" );
+  land_ft0.setAttribute( QStringLiteral( "king_id" ), 1 );
+  QgsFeature land_ft1( mL_Land->fields() );
+  land_ft1.setAttribute( QStringLiteral( "id" ), 1 );
+  land_ft1.setAttribute( QStringLiteral( "name" ), "Gondor" );
+  land_ft1.setAttribute( QStringLiteral( "king_id" ), 0 );
+  QgsFeature land_ft2( mL_Land->fields() );
+  land_ft2.setAttribute( QStringLiteral( "id" ), 2 );
+  land_ft2.setAttribute( QStringLiteral( "name" ), "Rohan" );
+  land_ft2.setAttribute( QStringLiteral( "king_id" ), 0 );
+  QgsFeature land_ft3( mL_Land->fields() );
+  land_ft3.setAttribute( QStringLiteral( "id" ), 3 );
+  land_ft3.setAttribute( QStringLiteral( "name" ), "Eriador" );
+  land_ft3.setAttribute( QStringLiteral( "king_id" ), 0 );
+  mL_Land->startEditing();
+  mL_Land->addFeature( land_ft0 );
+  mL_Land->addFeature( land_ft1 );
+  mL_Land->addFeature( land_ft2 );
+  mL_Land->addFeature( land_ft3 );
+  mL_Land->commitChanges();
+  REQUIRE( mL_Land->featureCount() == 4L );
 
-      // add features on king
-      QgsFeature king_ft0( mL_King->fields() );
-      king_ft0.setAttribute( QStringLiteral( "id" ), 0 );
-      king_ft0.setAttribute( QStringLiteral( "name" ), "Frodo" );
-      QgsFeature king_ft1( mL_King->fields() );
-      king_ft1.setAttribute( QStringLiteral( "id" ), 1 );
-      king_ft1.setAttribute( QStringLiteral( "name" ), "Gollum" );
-      mL_King->startEditing();
-      mL_King->addFeature( king_ft0 );
-      mL_King->addFeature( king_ft1 );
-      mL_King->commitChanges();
-      QCOMPARE( mL_King->featureCount(), 2L );
+  // add features on king
+  QgsFeature king_ft0( mL_King->fields() );
+  king_ft0.setAttribute( QStringLiteral( "id" ), 0 );
+  king_ft0.setAttribute( QStringLiteral( "name" ), "Frodo" );
+  QgsFeature king_ft1( mL_King->fields() );
+  king_ft1.setAttribute( QStringLiteral( "id" ), 1 );
+  king_ft1.setAttribute( QStringLiteral( "name" ), "Gollum" );
+  mL_King->startEditing();
+  mL_King->addFeature( king_ft0 );
+  mL_King->addFeature( king_ft1 );
+  mL_King->commitChanges();
+  REQUIRE( mL_King->featureCount() == 2L );
 
-      // add features on share
-      QgsFeature share_ft0( mL_Share->fields() );
-      share_ft0.setAttribute( QStringLiteral( "id" ), 0 );
-      share_ft0.setAttribute( QStringLiteral( "king_id" ), 0 );
-      share_ft0.setAttribute( QStringLiteral( "land_id" ), 0 );
-      share_ft0.setAttribute( QStringLiteral( "share" ), 20 );
-      QgsFeature share_ft1( mL_Share->fields() );
-      share_ft1.setAttribute( QStringLiteral( "id" ), 1 );
-      share_ft1.setAttribute( QStringLiteral( "king_id" ), 0 );
-      share_ft1.setAttribute( QStringLiteral( "land_id" ), 1 );
-      share_ft1.setAttribute( QStringLiteral( "share" ), 40 );
-      QgsFeature share_ft2( mL_Share->fields() );
-      share_ft2.setAttribute( QStringLiteral( "id" ), 2 );
-      share_ft2.setAttribute( QStringLiteral( "king_id" ), 0 );
-      share_ft2.setAttribute( QStringLiteral( "land_id" ), 2 );
-      share_ft2.setAttribute( QStringLiteral( "share" ), 60 );
-      QgsFeature share_ft3( mL_Share->fields() );
-      share_ft3.setAttribute( QStringLiteral( "id" ), 3 );
-      share_ft3.setAttribute( QStringLiteral( "king_id" ), 0 );
-      share_ft3.setAttribute( QStringLiteral( "land_id" ), 3 );
-      share_ft3.setAttribute( QStringLiteral( "share" ), 100 );
-      QgsFeature share_ft4( mL_Share->fields() );
-      share_ft4.setAttribute( QStringLiteral( "id" ), 4 );
-      share_ft4.setAttribute( QStringLiteral( "king_id" ), 1 );
-      share_ft4.setAttribute( QStringLiteral( "land_id" ), 0 );
-      share_ft4.setAttribute( QStringLiteral( "share" ), 80 );
-      QgsFeature share_ft5( mL_Share->fields() );
-      share_ft5.setAttribute( QStringLiteral( "id" ), 5 );
-      share_ft5.setAttribute( QStringLiteral( "king_id" ), 1 );
-      share_ft5.setAttribute( QStringLiteral( "land_id" ), 1 );
-      share_ft5.setAttribute( QStringLiteral( "share" ), 60 );
-      QgsFeature share_ft6( mL_Share->fields() );
-      share_ft6.setAttribute( QStringLiteral( "id" ), 6 );
-      share_ft6.setAttribute( QStringLiteral( "king_id" ), 1 );
-      share_ft6.setAttribute( QStringLiteral( "land_id" ), 2 );
-      share_ft6.setAttribute( QStringLiteral( "share" ), 40 );
+  // add features on share
+  QgsFeature share_ft0( mL_Share->fields() );
+  share_ft0.setAttribute( QStringLiteral( "id" ), 0 );
+  share_ft0.setAttribute( QStringLiteral( "king_id" ), 0 );
+  share_ft0.setAttribute( QStringLiteral( "land_id" ), 0 );
+  share_ft0.setAttribute( QStringLiteral( "share" ), 20 );
+  QgsFeature share_ft1( mL_Share->fields() );
+  share_ft1.setAttribute( QStringLiteral( "id" ), 1 );
+  share_ft1.setAttribute( QStringLiteral( "king_id" ), 0 );
+  share_ft1.setAttribute( QStringLiteral( "land_id" ), 1 );
+  share_ft1.setAttribute( QStringLiteral( "share" ), 40 );
+  QgsFeature share_ft2( mL_Share->fields() );
+  share_ft2.setAttribute( QStringLiteral( "id" ), 2 );
+  share_ft2.setAttribute( QStringLiteral( "king_id" ), 0 );
+  share_ft2.setAttribute( QStringLiteral( "land_id" ), 2 );
+  share_ft2.setAttribute( QStringLiteral( "share" ), 60 );
+  QgsFeature share_ft3( mL_Share->fields() );
+  share_ft3.setAttribute( QStringLiteral( "id" ), 3 );
+  share_ft3.setAttribute( QStringLiteral( "king_id" ), 0 );
+  share_ft3.setAttribute( QStringLiteral( "land_id" ), 3 );
+  share_ft3.setAttribute( QStringLiteral( "share" ), 100 );
+  QgsFeature share_ft4( mL_Share->fields() );
+  share_ft4.setAttribute( QStringLiteral( "id" ), 4 );
+  share_ft4.setAttribute( QStringLiteral( "king_id" ), 1 );
+  share_ft4.setAttribute( QStringLiteral( "land_id" ), 0 );
+  share_ft4.setAttribute( QStringLiteral( "share" ), 80 );
+  QgsFeature share_ft5( mL_Share->fields() );
+  share_ft5.setAttribute( QStringLiteral( "id" ), 5 );
+  share_ft5.setAttribute( QStringLiteral( "king_id" ), 1 );
+  share_ft5.setAttribute( QStringLiteral( "land_id" ), 1 );
+  share_ft5.setAttribute( QStringLiteral( "share" ), 60 );
+  QgsFeature share_ft6( mL_Share->fields() );
+  share_ft6.setAttribute( QStringLiteral( "id" ), 6 );
+  share_ft6.setAttribute( QStringLiteral( "king_id" ), 1 );
+  share_ft6.setAttribute( QStringLiteral( "land_id" ), 2 );
+  share_ft6.setAttribute( QStringLiteral( "share" ), 40 );
 
-      mL_Share->startEditing();
-      mL_Share->addFeature( share_ft0 );
-      mL_Share->addFeature( share_ft1 );
-      mL_Share->addFeature( share_ft2 );
-      mL_Share->addFeature( share_ft3 );
-      mL_Share->addFeature( share_ft4 );
-      mL_Share->addFeature( share_ft5 );
-      mL_Share->addFeature( share_ft6 );
-      mL_Share->commitChanges();
-      QCOMPARE( mL_Share->featureCount(), 7L );
+  mL_Share->startEditing();
+  mL_Share->addFeature( share_ft0 );
+  mL_Share->addFeature( share_ft1 );
+  mL_Share->addFeature( share_ft2 );
+  mL_Share->addFeature( share_ft3 );
+  mL_Share->addFeature( share_ft4 );
+  mL_Share->addFeature( share_ft5 );
+  mL_Share->addFeature( share_ft6 );
+  mL_Share->commitChanges();
+  REQUIRE( mL_Share->featureCount() == 7L );
 
-      mModel = new ReferencingFeatureListModel();
-    }
+  std::unique_ptr<ReferencingFeatureListModel> mModel( new ReferencingFeatureListModel() );
 
-    /*
-      testGetReferencingFeatures
+  /*
+      GetReferencingFeatures
       - load project
       - create model (set relation, set feature)
       - count list / compare list
       - change parent feature
       - count list / compare list
     */
-    void testGetReferencingFeatures()
-    {
-      mModel->setRelation( mR_Landhasoneking );
-      QSignalSpy( mModel, &ReferencingFeatureListModel::modelUpdated ).wait( 500 );
-      mModel->setNmRelation( QgsRelation() );
-      QSignalSpy( mModel, &ReferencingFeatureListModel::modelUpdated ).wait( 500 );
+  SECTION( "GetReferencingFeatures" )
+  {
+    mModel->setRelation( mR_Landhasoneking );
+    QSignalSpy( mModel.get(), &ReferencingFeatureListModel::modelUpdated ).wait( 500 );
+    mModel->setNmRelation( QgsRelation() );
+    QSignalSpy( mModel.get(), &ReferencingFeatureListModel::modelUpdated ).wait( 500 );
 
-      //check out Frodo
-      mModel->setFeature( mL_King->getFeature( 1 ) );
-      QVERIFY( QSignalSpy( mModel, &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
-      //Frodo rules 3 lands (Gondor, Rohan, Eriador)
-      QCOMPARE( mModel->rowCount(), 3 );
+    //check out Frodo
+    mModel->setFeature( mL_King->getFeature( 1 ) );
+    REQUIRE( QSignalSpy( mModel.get(), &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
+    //Frodo rules 3 lands (Gondor, Rohan, Eriador)
+    REQUIRE( mModel->rowCount() == 3 );
 
-      //check out Gollum
-      mModel->setFeature( mL_King->getFeature( 2 ) );
-      QVERIFY( QSignalSpy( mModel, &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
-      //Gollum rules 1 land (Mordor)
-      QCOMPARE( mModel->rowCount(), 1 );
-    }
+    //check out Gollum
+    mModel->setFeature( mL_King->getFeature( 2 ) );
+    REQUIRE( QSignalSpy( mModel.get(), &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
+    //Gollum rules 1 land (Mordor)
+    REQUIRE( mModel->rowCount() == 1 );
+  }
 
-    /*
-      testGetManyToManyReferencedFeatures
+  /*
+      GetManyToManyReferencedFeatures
       - load project
       - create model (set relation, set nmrelation, set feature)
       - count list / compare list
       - change parent feature
       - count list / compare list
     */
-    void testGetManyToManyReferencedFeatures()
-    {
-      mModel->setRelation( mR_Sharehasoneking );
-      QSignalSpy( mModel, &ReferencingFeatureListModel::modelUpdated ).wait( 500 );
-      mModel->setNmRelation( mR_Shareofoneland );
-      QSignalSpy( mModel, &ReferencingFeatureListModel::modelUpdated ).wait( 500 );
+  SECTION( "GetManyToManyReferencedFeatures" )
+  {
+    mModel->setRelation( mR_Sharehasoneking );
+    QSignalSpy( mModel.get(), &ReferencingFeatureListModel::modelUpdated ).wait( 500 );
+    mModel->setNmRelation( mR_Shareofoneland );
+    QSignalSpy( mModel.get(), &ReferencingFeatureListModel::modelUpdated ).wait( 500 );
 
-      //check out Frodo
-      mModel->setFeature( mL_King->getFeature( 1 ) );
-      QVERIFY( QSignalSpy( mModel, &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
-      //Frodo has shares of 4 lands (Mordor, Gondor, Rohan, Eriador)
-      QCOMPARE( mModel->rowCount(), 4 );
+    //check out Frodo
+    mModel->setFeature( mL_King->getFeature( 1 ) );
+    REQUIRE( QSignalSpy( mModel.get(), &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
+    //Frodo has shares of 4 lands (Mordor, Gondor, Rohan, Eriador)
+    REQUIRE( mModel->rowCount() == 4 );
 
-      //check out Gollum
-      mModel->setFeature( mL_King->getFeature( 2 ) );
-      QVERIFY( QSignalSpy( mModel, &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
-      //Gollum has shares of 3 lands (Mordor, Gondor, Rohan)
-      QCOMPARE( mModel->rowCount(), 3 );
-    }
+    //check out Gollum
+    mModel->setFeature( mL_King->getFeature( 2 ) );
+    REQUIRE( QSignalSpy( mModel.get(), &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
+    //Gollum has shares of 3 lands (Mordor, Gondor, Rohan)
+    REQUIRE( mModel->rowCount() == 3 );
+  }
 
-    /*
-      testDeleteReferencingFeature
+  /*
+      DeleteReferencingFeature
       - load project
       - create model (set relation, set feature)
       - count list / compare list
       - delete child features
       - count list / compare list
     */
-    void testDeleteReferencingFeature()
-    {
-      mModel->setNmRelation( QgsRelation() );
-      QSignalSpy( mModel, &ReferencingFeatureListModel::modelUpdated ).wait( 500 );
-      mModel->setRelation( mR_Landhasoneking );
-      QSignalSpy( mModel, &ReferencingFeatureListModel::modelUpdated ).wait( 500 );
+  SECTION( "DeleteReferencingFeature" )
+  {
+    mModel->setNmRelation( QgsRelation() );
+    QSignalSpy( mModel.get(), &ReferencingFeatureListModel::modelUpdated ).wait( 500 );
+    mModel->setRelation( mR_Landhasoneking );
+    QSignalSpy( mModel.get(), &ReferencingFeatureListModel::modelUpdated ).wait( 500 );
 
-      //check out Frodo
-      mModel->setFeature( mL_King->getFeature( 1 ) );
-      QVERIFY( QSignalSpy( mModel, &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
-      //Frodo rules 3 lands (Gondor, Rohan, Eriador)
-      QCOMPARE( mModel->rowCount(), 3 );
+    //check out Frodo
+    mModel->setFeature( mL_King->getFeature( 1 ) );
+    REQUIRE( QSignalSpy( mModel.get(), &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
+    //Frodo rules 3 lands (Gondor, Rohan, Eriador)
+    REQUIRE( mModel->rowCount() == 3 );
 
-      //check display string of rohan
-      QString displayString = mModel->data( mModel->index( 1, 0 ), ReferencingFeatureListModel::DisplayString ).toString();
-      QCOMPARE( displayString, QStringLiteral( "Gondor" ) );
+    //check display string of rohan
+    QString displayString = mModel->data( mModel->index( 1, 0 ), ReferencingFeatureListModel::DisplayString ).toString();
+    REQUIRE( displayString == QStringLiteral( "Gondor" ) );
 
-      //delete Rohan
-      mModel->deleteFeature( qvariant_cast<QgsFeature>( mModel->data( mModel->index( 1, 0 ), ReferencingFeatureListModel::ReferencingFeature ) ).id() );
-      QVERIFY( QSignalSpy( mModel, &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
-      //Frodo rules 2 lands (Gondor, Eriador) no Rohan anymore
-      QCOMPARE( mModel->rowCount(), 2 );
-    }
+    //delete Rohan
+    mModel->deleteFeature( qvariant_cast<QgsFeature>( mModel->data( mModel->index( 1, 0 ), ReferencingFeatureListModel::ReferencingFeature ) ).id() );
+    REQUIRE( QSignalSpy( mModel.get(), &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
+    //Frodo rules 2 lands (Gondor, Eriador) no Rohan anymore
+    REQUIRE( mModel->rowCount() == 2 );
+  }
 
-    /*
-      testDdeleteReferenceToManyToManyReferencedFeature
+  /*
+      DeleteReferenceToManyToManyReferencedFeature
       - load project
       - create model (set relation, set feature)
       - count list / compare list
       - delete (unlink) child features
       - count list / compare list
     */
-    void testDeleteReferenceToManyToManyReferencedFeature()
-    {
-      mModel->setRelation( mR_Sharehasoneking );
-      QSignalSpy( mModel, &ReferencingFeatureListModel::modelUpdated ).wait( 500 );
-      mModel->setNmRelation( mR_Shareofoneland );
-      QSignalSpy( mModel, &ReferencingFeatureListModel::modelUpdated ).wait( 500 );
+  SECTION( "DeleteReferenceToManyToManyReferencedFeature" )
+  {
+    mModel->setRelation( mR_Sharehasoneking );
+    QSignalSpy( mModel.get(), &ReferencingFeatureListModel::modelUpdated ).wait( 500 );
+    mModel->setNmRelation( mR_Shareofoneland );
+    QSignalSpy( mModel.get(), &ReferencingFeatureListModel::modelUpdated ).wait( 500 );
 
-      //check out Frodo
-      mModel->setFeature( mL_King->getFeature( 1 ) );
-      QVERIFY( QSignalSpy( mModel, &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
-      //Frodo has shares of 4 lands (Mordor, Gondor, Eriador, Rohan)
-      QCOMPARE( mModel->rowCount(), 4 );
+    //check out Frodo
+    mModel->setFeature( mL_King->getFeature( 1 ) );
+    REQUIRE( QSignalSpy( mModel.get(), &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
+    //Frodo has shares of 4 lands (Mordor, Gondor, Eriador, Rohan)
+    REQUIRE( mModel->rowCount() == 4 );
 
-      //check out Gollum
-      mModel->setFeature( mL_King->getFeature( 2 ) );
-      QVERIFY( QSignalSpy( mModel, &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
-      //Gollum has shares of 3 lands (Mordor, Gondor, Rohan)
-      QCOMPARE( mModel->rowCount(), 3 );
+    //check out Gollum
+    mModel->setFeature( mL_King->getFeature( 2 ) );
+    REQUIRE( QSignalSpy( mModel.get(), &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
+    //Gollum has shares of 3 lands (Mordor, Gondor, Rohan)
+    REQUIRE( mModel->rowCount() == 3 );
 
-      //check display string of Gollums Mordor share (80)
-      QString displayString = mModel->data( mModel->index( 0, 0 ), ReferencingFeatureListModel::DisplayString ).toString();
-      QCOMPARE( displayString, QStringLiteral( "40" ) );
+    //check display string of Gollums Mordor share (80)
+    QString displayString = mModel->data( mModel->index( 0, 0 ), ReferencingFeatureListModel::DisplayString ).toString();
+    REQUIRE( displayString == QStringLiteral( "40" ) );
 
-      //delete Gollums share on Mordor
-      mModel->deleteFeature( qvariant_cast<QgsFeature>( mModel->data( mModel->index( 0, 0 ), ReferencingFeatureListModel::ReferencingFeature ) ).id() );
-      QVERIFY( QSignalSpy( mModel, &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
-      //Gollum has shares of 2 landd (Gondor, Rohan)
-      QCOMPARE( mModel->rowCount(), 2 );
+    //delete Gollums share on Mordor
+    mModel->deleteFeature( qvariant_cast<QgsFeature>( mModel->data( mModel->index( 0, 0 ), ReferencingFeatureListModel::ReferencingFeature ) ).id() );
+    REQUIRE( QSignalSpy( mModel.get(), &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
+    //Gollum has shares of 2 landd (Gondor, Rohan)
+    REQUIRE( mModel->rowCount() == 2 );
 
-      //check out Frodo again
-      mModel->setFeature( mL_King->getFeature( 1 ) );
-      QVERIFY( QSignalSpy( mModel, &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
-      //Frodo has still shares of 4 lands (Mordor, Gondor, Eriador, Rohan) because his shares are untouched
-      QCOMPARE( mModel->rowCount(), 4 );
-    }
-
-    void cleanupTestCase()
-    {
-      delete mModel;
-
-      QgsProject::instance()->removeMapLayer( mL_Land.get() );
-      QgsProject::instance()->removeMapLayer( mL_King.get() );
-      QgsProject::instance()->removeMapLayer( mL_Share.get() );
-    }
-
-  private:
-    std::unique_ptr<QgsVectorLayer> mL_Land;
-    std::unique_ptr<QgsVectorLayer> mL_King;
-    std::unique_ptr<QgsVectorLayer> mL_Share;
-    QgsRelation mR_Landhasoneking;
-    QgsRelation mR_Sharehasoneking;
-    QgsRelation mR_Shareofoneland;
-    ReferencingFeatureListModel *mModel;
-};
-
-QFIELDTEST_MAIN( TestReferencingFeatureListModel )
-#include "test_referencingfeaturelistmodel.moc"
+    //check out Frodo again
+    mModel->setFeature( mL_King->getFeature( 1 ) );
+    REQUIRE( QSignalSpy( mModel.get(), &ReferencingFeatureListModel::modelUpdated ).wait( 1000 ) );
+    //Frodo has still shares of 4 lands (Mordor, Gondor, Eriador, Rohan) because his shares are untouched
+    REQUIRE( mModel->rowCount() == 4 );
+  }
+}

--- a/test/test_referencingfeaturelistmodel.cpp
+++ b/test/test_referencingfeaturelistmodel.cpp
@@ -20,16 +20,14 @@
 #include "qgsquickmapsettings.h"
 #include "referencingfeaturelistmodel.h"
 
+#include <QSignalSpy>
 #include <qgsapplication.h>
 #include <qgsproject.h>
 #include <qgsrelationmanager.h>
 #include <qgsvectorlayer.h>
 
-#include <QSignalSpy>
-
 TEST_CASE( "ReferencingFeatureListModel" )
 {
-
   /* TEST PROJECT
       *
       * LAYERS


### PR DESCRIPTION
This PR harmonizes C++ test names (CamelCase, without a "Test" prefix). While doing so, I realized two tests hadn't been ported to catch 2 and were simply not being run anymore. They have been revived.

I've also disabled spix test on Qt6 builds has images there as saved with an alpha band (whereas Qt5 doesn't), which leads to screenshot comparison failures. To revisit later (we'd probably want to submit a patch to spix so it behaves the same on Qt5 and Qt6)