### PR TITLE
Avoid text overlap artifacts when non multiline attribute has \n characters

### DIFF
--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -30,7 +30,7 @@ EditorWidgetBase {
     wrapMode: Text.Wrap
     textFormat: config['IsMultiline'] === true && config['UseHtml'] ? TextEdit.RichText : TextEdit.AutoText
 
-    text: value == null ? '' : stringUtilities.insertLinks(value)
+    text: value == null ? '' : config['IsMultiline'] === true ? stringUtilities.insertLinks(value) : stringUtilities.insertLinks(value).replace('\n','')
 
     onLinkActivated: Qt.openUrlExternally(link)
   }


### PR DESCRIPTION
PR fixes this ugly situation:
![image](https://user-images.githubusercontent.com/1728657/193634143-49b1d100-af91-43c8-ace7-e014c5f371d6.png)
_Look at the input_label / output_label overlap with values_