### PR TITLE
[Backport release-2_3] Avoid text overlap artifacts when non multiline attribute has \n characters

### DIFF
--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -30,7 +30,7 @@ EditorWidgetBase {
     wrapMode: Text.Wrap
     textFormat: config['IsMultiline'] === true && config['UseHtml'] ? TextEdit.RichText : TextEdit.AutoText
 
-    text: value == null ? '' : stringUtilities.insertLinks(value)
+    text: value == null ? '' : config['IsMultiline'] === true ? stringUtilities.insertLinks(value) : stringUtilities.insertLinks(value).replace('\n','')
 
     onLinkActivated: Qt.openUrlExternally(link)
   }


### PR DESCRIPTION
Backport #3395
 **Authored by:** @nirvn