### PR TITLE
[Backport release-2_3] Tracker should not access its rubber band model when null

### DIFF
--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -39,7 +39,7 @@ void Tracker::setModel( RubberbandModel *model )
 
 void Tracker::trackPosition()
 {
-  if ( std::isnan( model()->currentCoordinate().x() ) || std::isnan( model()->currentCoordinate().y() ) )
+  if ( !model() || std::isnan( model()->currentCoordinate().x() ) || std::isnan( model()->currentCoordinate().y() ) )
   {
     return;
   }


### PR DESCRIPTION
Backport #3404
 **Authored by:** @nirvn