### PR TITLE
Allow for atlases to be printed from the main menu, respect pre-existing filtering

### DIFF
--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -30,6 +30,7 @@
 #include <QApplication>
 #include <QDebug>
 #include <QFile>
+#include <QFileInfo>
 #include <QMap>
 #include <QMimeDatabase>
 #include <QQmlApplicationEngine>
@@ -412,6 +413,9 @@ PictureSource *AndroidPlatformUtilities::getGalleryPicture( QQuickItem *parent, 
 
 ViewStatus *AndroidPlatformUtilities::open( const QString &uri, bool editing )
 {
+  if ( QFileInfo( uri ).isDir() )
+    return nullptr;
+
   checkWriteExternalStoragePermissions();
 
   QAndroidJniObject activity = QAndroidJniObject::fromString( QStringLiteral( "ch.opengis." APP_PACKAGE_NAME ".QFieldOpenExternallyActivity" ) );

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -1320,12 +1320,10 @@ bool QgisMobileapp::print( const QString &layoutName )
       {
         PlatformUtilities::instance()->open( destination );
       }
-#ifndef Q_OS_ANDROID
       else
       {
         PlatformUtilities::instance()->open( mProject->homePath() );
       }
-#endif
     }
     return success;
   }
@@ -1377,12 +1375,10 @@ bool QgisMobileapp::printAtlasFeatures( const QString &layoutName, const QList<l
     {
       PlatformUtilities::instance()->open( destination );
     }
-#ifndef Q_OS_ANDROID
     else
     {
       PlatformUtilities::instance()->open( mProject->homePath() );
     }
-#endif
   }
   return success;
 #else

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -54,6 +54,7 @@ class LocatorFiltersModel;
 class QgsProject;
 class LayerObserver;
 class MessageLogModel;
+class QgsPrintLayout;
 
 #define REGISTER_SINGLETON( uri, _class, name ) qmlRegisterSingletonType<_class>( uri, 1, 0, name, []( QQmlEngine *engine, QJSEngine *scriptEngine ) -> QObject * { Q_UNUSED(engine); Q_UNUSED(scriptEngine); return new _class(); } )
 
@@ -200,8 +201,8 @@ class QFIELD_CORE_EXPORT QgisMobileapp : public QQmlApplicationEngine
 
   private:
     void initDeclarative();
-
     void loadProjectQuirks();
+    bool printAtlas( QgsPrintLayout *layoutToPrint, const QString &destination );
 
     QgsOfflineEditing *mOfflineEditing = nullptr;
     LayerTreeMapCanvasBridge *mLayerTreeCanvasBridge = nullptr;


### PR DESCRIPTION
This PR improves handling of print atlases when printed through the main menu button, i.e.:
![image](https://user-images.githubusercontent.com/1728657/194039746-f3cc4abf-a7f7-4954-98bb-e4a78360e4ae.png)

Prior to this PR, the behavior would be random. If no feature atlas had been printed yet, it would be handled as a non-atlas layout and show broken atlas references, e.g.:
![image](https://user-images.githubusercontent.com/1728657/194040033-aea3f46b-f494-48e2-86ec-6b2217530f81.png)

With the PR, QField now respect the atlas context. It can come in handy with filter expressions whereas a user could print all features created within the last 24 hours, etc.

This UX shortcoming was discovered while improving the bee sample project.