### PR TITLE
[Backport release-2_3] Insure that the text edit widget's menu always appears on top of feature forms

### DIFF
--- a/src/qml/editorwidgets/EditorWidgetBase.qml
+++ b/src/qml/editorwidgets/EditorWidgetBase.qml
@@ -11,6 +11,7 @@ Item {
     property Menu menu: Menu {
       id: itemMenu
       title: qsTr( "Item Menu" )
+      z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes
 
       width: {
           var result = 0;


### PR DESCRIPTION
Backport #3419
 **Authored by:** @nirvn