### PR TITLE
Insure that the bluetooth combobox has the right item selected

### DIFF
--- a/src/core/positioning/abstractgnssreceiver.h
+++ b/src/core/positioning/abstractgnssreceiver.h
@@ -28,6 +28,7 @@ class AbstractGnssReceiver : public QObject
     Q_PROPERTY( GnssPositionInformation lastGnssPositionInformation READ lastGnssPositionInformation NOTIFY lastGnssPositionInformationChanged )
     Q_PROPERTY( QAbstractSocket::SocketState socketState READ socketState NOTIFY socketStateChanged )
     Q_PROPERTY( QString socketStateString READ socketStateString NOTIFY socketStateStringChanged )
+    Q_PROPERTY( QString lastError READ lastError NOTIFY lastErrorChanged )
 
   public:
     explicit AbstractGnssReceiver( QObject *parent = nullptr )
@@ -44,12 +45,14 @@ class AbstractGnssReceiver : public QObject
 
     QAbstractSocket::SocketState socketState() const { return mSocketState; }
     QString socketStateString() const { return mSocketStateString; }
+    QString lastError() const { return mLastError; }
 
   signals:
     void validChanged();
     void lastGnssPositionInformationChanged( GnssPositionInformation &lastGnssPositionInformation );
     void socketStateChanged( QAbstractSocket::SocketState socketState );
-    void socketStateStringChanged( QString socketStateString );
+    void socketStateStringChanged( QString &socketStateString );
+    void lastErrorChanged( QString &lastError );
 
   private:
     friend class BluetoothReceiver;
@@ -62,6 +65,7 @@ class AbstractGnssReceiver : public QObject
     GnssPositionInformation mLastGnssPositionInformation;
     QAbstractSocket::SocketState mSocketState = QAbstractSocket::UnconnectedState;
     QString mSocketStateString;
+    QString mLastError;
 };
 
 #endif // ABSTRACTGNSSRECEIVER_H

--- a/src/core/positioning/bluetoothreceiver.h
+++ b/src/core/positioning/bluetoothreceiver.h
@@ -64,6 +64,7 @@ class BluetoothReceiver : public AbstractGnssReceiver
   private:
     void handleConnectDevice() override;
     void handleDisconnectDevice() override;
+    void handleError( QBluetoothSocket::SocketError error );
 
 #ifdef Q_OS_LINUX
     void connectService( const QBluetoothAddress &address );

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -135,6 +135,7 @@ void Positioning::setupDevice()
 
   if ( mActive )
   {
+    qDebug() << "CONNN";
     mReceiver->connectDevice();
   }
 

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -135,7 +135,6 @@ void Positioning::setupDevice()
 
   if ( mActive )
   {
-    qDebug() << "CONNN";
     mReceiver->connectDevice();
   }
 

--- a/src/qml/BluetoothDeviceChooser.qml
+++ b/src/qml/BluetoothDeviceChooser.qml
@@ -51,7 +51,7 @@ GridLayout {
             }
 
             Component.onCompleted: {
-                currentIndex = positioningSettings.positioningDevice == '' ? 0 : find(positioningSettings.positioningDeviceName + ' (' + positioningSettings.positioningDevice + ')');
+                currentIndex = bluetoothDeviceModel.findAddressIndex(settings.value('positioningDevice',''))
             }
 
             Connections {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -209,7 +209,7 @@ ApplicationWindow {
     target: positionSource.device
 
     function onLastErrorChanged() {
-        displayToast(qsTr('Positioning error') + ': ' + positionSource.device.lastError, 'error')
+        displayToast(qsTr('Positioning error: %1').arg(positionSource.device.lastError), 'error')
     }
   }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -205,6 +205,13 @@ ApplicationWindow {
       skipAltitudeTransformation: positioningSettings.skipAltitudeCorrection
     }
   }
+  Connections {
+    target: positionSource.device
+
+    function onLastErrorChanged() {
+        displayToast(qsTr('Positioning error') + ': ' + positionSource.device.lastError, 'error')
+    }
+  }
 
   Timer {
     id: positionTimer


### PR DESCRIPTION
When the bluetooth device chooser combobox's Component.onCompleted is triggered, positioningSettings.positioningDevice isn't yet set to the actual value, resulting in the wrong combobox index being selected. The fix is to rely on the 'raw' settings object at that early stage.

Issue didn't impact positioning functionality per say (i.e. the bluetooth device is still picked), but does result in confusing UI/UX. 

@mbernasocchi , we had spotted this issue together while testing GNSS devices on the last hackfest day. 