### PR TITLE
Remove shapefile file association, it'll _always_ require full storage access due to sidecar files

### DIFF
--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -127,14 +127,6 @@
         <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.gpkg" />
         <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.gpkg" />
         <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\.gpkg" />
-        <data android:pathPattern=".*\\.shp" />
-        <data android:pathPattern=".*\\..*\\.shp" />
-        <data android:pathPattern=".*\\..*\\..*\\.shp" />
-        <data android:pathPattern=".*\\..*\\..*\\..*\\.shp" />
-        <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.shp" />
-        <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.shp" />
-        <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.shp" />
-        <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\.shp" />
         <data android:pathPattern=".*\\.kml" />
         <data android:pathPattern=".*\\..*\\.kml" />
         <data android:pathPattern=".*\\..*\\..*\\.kml" />


### PR DESCRIPTION
This PR removes file association with .shp files (only file association via file browser, you can still open these in QField's local datasets screen). The rational is that a .shp will _always_ have sidecar, and therefore can never work as a standalone file being opened via file association. 