### PR TITLE
[Backport release-2_4] Remove shapefile file association, it'll _always_ require full storage access due to sidecar files

### DIFF
--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -127,14 +127,6 @@
         <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.gpkg" />
         <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.gpkg" />
         <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\.gpkg" />
-        <data android:pathPattern=".*\\.shp" />
-        <data android:pathPattern=".*\\..*\\.shp" />
-        <data android:pathPattern=".*\\..*\\..*\\.shp" />
-        <data android:pathPattern=".*\\..*\\..*\\..*\\.shp" />
-        <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.shp" />
-        <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.shp" />
-        <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.shp" />
-        <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\.shp" />
         <data android:pathPattern=".*\\.kml" />
         <data android:pathPattern=".*\\..*\\.kml" />
         <data android:pathPattern=".*\\..*\\..*\\.kml" />


### PR DESCRIPTION
Backport #3441
 **Authored by:** @nirvn