### PR TITLE
Do not rely on QGIS to set default values on update, it lacks QField-specific scopes

### DIFF
--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -289,6 +289,7 @@ class FeatureModel : public QAbstractListModel
     bool commit();
     bool startEditing();
     void setLinkedFeatureValues();
+    void updateDefaultValues();
 
     ModelModes mModelMode = SingleFeatureModel;
     QgsVectorLayer *mLayer = nullptr;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -91,6 +91,7 @@ endif ()
 
 ADD_CATCH2_TEST(layerobservertest test_layerobserver.cpp FALSE)
 ADD_CATCH2_TEST(featureutilstest test_featureutils.cpp TRUE)
+ADD_CATCH2_TEST(featuremodeltest test_featuremodel.cpp TRUE)
 ADD_CATCH2_TEST(vertexmodeltest test_vertexmodel.cpp TRUE)
 ADD_CATCH2_TEST(deltafilewrappertest test_deltafilewrapper.cpp FALSE)
 ADD_CATCH2_TEST(fileutilstest test_fileutils.cpp TRUE)

--- a/test/test_featuremodel.cpp
+++ b/test/test_featuremodel.cpp
@@ -1,0 +1,53 @@
+/***************************************************************************
+                        test_featuremodel.h
+                        --------------------
+  begin                : Oct 2022
+  copyright            : (C) 2022 by Mathieu Pellerin
+  email                : mathieu@opengis.ch
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "catch2.h"
+#include "featuremodel.h"
+#include "gnsspositioninformation.h"
+
+#include <qgsvectorlayer.h>
+
+TEST_CASE( "FeatureModel" )
+{
+  std::unique_ptr<QgsVectorLayer> layer = std::make_unique<QgsVectorLayer>( QStringLiteral( "Point?crs=EPSG:4326&field=name:text&field=horizontal_accuracy:double(12,6)&field=vertical_accuracy:double(12,6)" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) );
+  layer->setDefaultValueDefinition( 1, QgsDefaultValue( QStringLiteral( "@position_horizontal_accuracy" ), true ) );
+  layer->setDefaultValueDefinition( 2, QgsDefaultValue( QStringLiteral( "@position_vertical_accuracy" ), true ) );
+  std::unique_ptr<FeatureModel> featureModel = std::make_unique<FeatureModel>();
+
+  GnssPositionInformation position( 1.1, 2.2, 50.0, 50.0, 0.0, QList<QgsSatelliteInfo>(), 0, 0, 0, 5.5, 10.5, QDateTime(), QChar(), 0, 100 );
+
+  featureModel->setCurrentLayer( layer.get() );
+  featureModel->setPositionInformation( position );
+  featureModel->setPositionLocked( true );
+  featureModel->resetFeature();
+  featureModel->resetAttributes();
+  featureModel->setData( featureModel->index( 0, 0 ), QStringLiteral( "created" ), FeatureModel::AttributeValue );
+  featureModel->create();
+
+  QgsFeature feature = featureModel->feature();
+  REQUIRE( feature.attribute( 0 ).toString() == QStringLiteral( "created" ) );
+  REQUIRE( feature.attribute( 1 ).toDouble() == 5.5 );
+  REQUIRE( feature.attribute( 2 ).toDouble() == 10.5 );
+
+  featureModel->setData( featureModel->index( 0, 0 ), QStringLiteral( "updated" ), FeatureModel::AttributeValue );
+  featureModel->save();
+
+  feature = featureModel->feature();
+  REQUIRE( feature.attribute( 0 ).toString() == QStringLiteral( "updated" ) );
+  REQUIRE( feature.attribute( 1 ).toDouble() == 5.5 );
+  REQUIRE( feature.attribute( 2 ).toDouble() == 10.5 );
+}


### PR DESCRIPTION
This PR addresses issues with regards to default values relying on  positioning (or QFieldCloud) variables set to be applied on feature update. Until now, QField deferred the updating of such default value to QGIS code. The latter however does not have access to the full set of expression context QField injects (positioning, QFieldCloud user / email information, etc.).

We now take care of updating default values, resulting it access to the full set of variables QField exposes. The modification fixes #3380 and fixes #3485. 

A new test has been added to insure this functionality will work from now on until the end of times :wink: .

_Funded by [Egis](https://www.egis-group.com/)_
