### PR TITLE
Fix regression with exernal GNSS receiver not respecting the ellisoidal elevation setting

### DIFF
--- a/src/core/positioning/bluetoothreceiver.cpp
+++ b/src/core/positioning/bluetoothreceiver.cpp
@@ -15,6 +15,7 @@
  ***************************************************************************/
 
 #include "bluetoothreceiver.h"
+#include "positioning.h"
 
 #include <QDebug>
 #include <QSettings>
@@ -118,11 +119,16 @@ void BluetoothReceiver::stateChanged( const QgsGpsInformation &info )
     return;
   }
   mLastGnssPositionValid = !std::isnan( info.latitude );
-
   emit lastGnssPositionInformationChanged( mLastGnssPositionInformation );
 
+  bool ellipsoidalElevation = false;
+  if ( Positioning *positioning = qobject_cast<Positioning *>( parent() ) )
+  {
+    ellipsoidalElevation = positioning->ellipsoidalElevation();
+  }
+
   // QgsGpsInformation's speed is served in km/h, translate to m/s
-  mLastGnssPositionInformation = GnssPositionInformation( info.latitude, info.longitude, mEllipsoidalElevation ? info.elevation + info.elevation_diff : info.elevation,
+  mLastGnssPositionInformation = GnssPositionInformation( info.latitude, info.longitude, ellipsoidalElevation ? info.elevation + info.elevation_diff : info.elevation,
                                                           info.speed * 1000 / 60 / 60, info.direction, info.satellitesInView, info.pdop, info.hdop, info.vdop,
                                                           info.hacc, info.vacc, info.utcDateTime, info.fixMode, info.fixType, info.quality, info.satellitesUsed, info.status,
                                                           info.satPrn, info.satInfoComplete, std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN(),
@@ -167,14 +173,6 @@ void BluetoothReceiver::setSocketState( const QBluetoothSocket::SocketState sock
   mSocketState = static_cast<QAbstractSocket::SocketState>( socketState );
   emit socketStateChanged( mSocketState );
   emit socketStateStringChanged( mSocketStateString );
-}
-
-void BluetoothReceiver::setEllipsoidalElevation( const bool ellipsoidalElevation )
-{
-  if ( mEllipsoidalElevation == ellipsoidalElevation )
-    return;
-
-  mEllipsoidalElevation = ellipsoidalElevation;
 }
 
 #ifdef Q_OS_LINUX

--- a/src/core/positioning/bluetoothreceiver.h
+++ b/src/core/positioning/bluetoothreceiver.h
@@ -17,7 +17,6 @@
 #define BLUETOOTHRECEIVER_H
 
 #include "abstractgnssreceiver.h"
-#include "gnsspositioninformation.h"
 #include "qgsnmeaconnection.h"
 
 #include <QObject>
@@ -35,16 +34,6 @@ class BluetoothReceiver : public AbstractGnssReceiver
   public:
     explicit BluetoothReceiver( const QString &address = QString(), QObject *parent = nullptr );
     ~BluetoothReceiver() override {}
-
-    /**
-     * Sets whether the elevation value provided will be ellipsoidal or, if not, orthometric
-     */
-    void setEllipsoidalElevation( const bool ellipsoidalElevation );
-
-    /**
-     * Returns whether the elevation value provided will be ellipsoidal or orthometric
-     */
-    bool ellipsoidalElevation() const { return mEllipsoidalElevation; }
 
   private slots:
     /**
@@ -83,8 +72,6 @@ class BluetoothReceiver : public AbstractGnssReceiver
 
     bool mDisconnecting = false;
     bool mConnectOnDisconnect;
-
-    bool mEllipsoidalElevation = true;
 };
 
 #endif // BLUETOOTHRECEIVER_H

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -94,6 +94,16 @@ void Positioning::setAveragedPosition( bool averaged )
   emit averagedPositionChanged();
 }
 
+void Positioning::setEllipsoidalElevation( bool ellipsoidal )
+{
+  if ( mEllipsoidalElevation == ellipsoidal )
+    return;
+
+  mEllipsoidalElevation = ellipsoidal;
+
+  emit ellipsoidalElevationChanged();
+}
+
 void Positioning::setCoordinateTransformer( QgsQuickCoordinateTransformer *coordinateTransformer )
 {
   if ( mCoordinateTransformer == coordinateTransformer )

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -50,6 +50,8 @@ class Positioning : public QObject
     Q_PROPERTY( bool averagedPosition READ averagedPosition WRITE setAveragedPosition NOTIFY averagedPositionChanged )
     Q_PROPERTY( int averagedPositionCount READ averagedPositionCount NOTIFY averagedPositionCountChanged )
 
+    Q_PROPERTY( bool ellipsoidalElevation READ ellipsoidalElevation WRITE setEllipsoidalElevation NOTIFY ellipsoidalElevationChanged )
+
   public:
     explicit Positioning( QObject *parent = nullptr );
 
@@ -139,6 +141,10 @@ class Positioning : public QObject
      */
     int averagedPositionCount() const { return mCollectedPositionInformations.size(); }
 
+    bool ellipsoidalElevation() const { return mEllipsoidalElevation; }
+
+    void setEllipsoidalElevation( bool ellipsoidal );
+
   signals:
 
     void activeChanged();
@@ -150,6 +156,7 @@ class Positioning : public QObject
     void averagedPositionChanged();
     void averagedPositionCountChanged();
     void projectedPositionChanged();
+    void ellipsoidalElevationChanged();
 
   private slots:
 
@@ -177,6 +184,8 @@ class Positioning : public QObject
     double mProjectedHorizontalAccuracy = 0.0;
 
     bool mAveragedPosition = false;
+
+    bool mEllipsoidalElevation = false;
 
     std::unique_ptr<AbstractGnssReceiver> mReceiver;
 };

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -204,6 +204,8 @@ ApplicationWindow {
       deltaZ: positioningSettings.antennaHeightActivated ? positioningSettings.antennaHeight * -1 : 0
       skipAltitudeTransformation: positioningSettings.skipAltitudeCorrection
     }
+
+    ellipsoidalElevation: positioningSettings.ellipsoidalElevation
   }
   Connections {
     target: positionSource.device


### PR DESCRIPTION
While testing external GNSS devices during the October hackfest, I noticed our elevation wasn't matching what was reported by the device manifacturers' own apps. Turns out our ellipsoidal elevation setting wasn't being respected anymore (a regression from the rework of the positioning framework).

This PR fixes that.