### PR TITLE
Brand new elevatin profile support for QField's measurement tool

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -521,6 +521,8 @@
         <file>themes/qfield/nodpi/ic_meshlayer_18dp.svg</file>
         <file>themes/qfield/nodpi/ic_vectortilelayer_18dp.svg</file>
         <file>themes/qfield/nodpi/ic_annotationlayer_18dp.svg</file>
+        <file>themes/qfield/nodpi/ic_elevation_white_24dp.svg</file>
+        <file>themes/qfield/nodpi/ic_elevation_green_24dp.svg</file>
         <file>themes/qfield/nodpi/ic_error_outline_24dp.svg</file>
         <file>themes/qfield/nodpi/refresh_24dp.svg</file>
         <file>themes/qfield/nodpi/directions_walk_24dp.svg</file>

--- a/images/themes/qfield/nodpi/ic_elevation_green_24dp.svg
+++ b/images/themes/qfield/nodpi/ic_elevation_green_24dp.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24" height="24" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <g fill="#80cc28">
+  <path d="m12 21-4-4 1-1 2 2v-12l-2 2-1-1 4-4 4 4-1 1-2-2v12l2-2 1 1z"/>
+  <path d="m3 15h-2l6-6 3 3v2l-3-3z"/>
+  <path d="m14 13v-2l4-4 5 5h-2l-3-3z"/>
+ </g>
+</svg>

--- a/images/themes/qfield/nodpi/ic_elevation_white_24dp.svg
+++ b/images/themes/qfield/nodpi/ic_elevation_white_24dp.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24" height="24" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <g fill="#fff">
+  <path d="m12 21-4-4 1.4-1.4 1.6 1.6V6.8L9.4 8.4 8 7l4-4 4 4-1.4 1.4L13 6.8v10.4l1.6-1.6L16 17Z"/>
+  <path d="m3 15h-2l6-6 3 3v2l-3-3z"/>
+  <path d="m14 13v-2l4-4 5 5h-2l-3-3z"/>
+ </g>
+</svg>

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -13,6 +13,7 @@ set(QFIELD_CORE_SRCS
     utils/urlutils.cpp
     qgsquick/qgsquickcoordinatetransformer.cpp
     qgsquick/qgsquickmapcanvasmap.cpp
+    qgsquick/qgsquickelevationprofilecanvas.cpp
     qgsquick/qgsquickmapsettings.cpp
     qgsquick/qgsquickmaptransform.cpp
     locator/bookmarklocatorfilter.cpp
@@ -107,6 +108,7 @@ set(QFIELD_CORE_HDRS
     utils/urlutils.h
     qgsquick/qgsquickcoordinatetransformer.h
     qgsquick/qgsquickmapcanvasmap.h
+    qgsquick/qgsquickelevationprofilecanvas.h
     qgsquick/qgsquickmapsettings.h
     qgsquick/qgsquickmaptransform.h
     locator/bookmarklocatorfilter.h

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -106,6 +106,7 @@
 #include "qgismobileapp.h"
 #include "qgsgeometrywrapper.h"
 #include "qgsquickcoordinatetransformer.h"
+#include "qgsquickelevationprofilecanvas.h"
 #include "qgsquickmapcanvasmap.h"
 #include "qgsquickmapsettings.h"
 #include "qgsquickmaptransform.h"
@@ -443,6 +444,7 @@ void QgisMobileapp::initDeclarative()
   qmlRegisterType<QgsQuickMapCanvasMap>( "org.qgis", 1, 0, "MapCanvasMap" );
   qmlRegisterType<QgsQuickMapSettings>( "org.qgis", 1, 0, "MapSettings" );
   qmlRegisterType<QgsQuickCoordinateTransformer>( "org.qfield", 1, 0, "CoordinateTransformer" );
+  qmlRegisterType<QgsQuickElevationProfileCanvas>( "org.qgis", 1, 0, "ElevationProfileCanvas" );
 
   qmlRegisterType<QgsQuickMapTransform>( "org.qgis", 1, 0, "MapTransform" );
 

--- a/src/core/qgsquick/qgsquickelevationprofilecanvas.cpp
+++ b/src/core/qgsquick/qgsquickelevationprofilecanvas.cpp
@@ -61,7 +61,7 @@ inline QgsWeakMapLayerPointerList _qgis_listRawToQPointer( const QList<QgsMapLay
 class QgsElevationProfilePlotItem : public Qgs2DPlot
 {
   public:
-    QgsElevationProfilePlotItem( QgsQuickElevationProfileCanvas *canvas )
+    explicit QgsElevationProfilePlotItem( QgsQuickElevationProfileCanvas *canvas )
       : mCanvas( canvas )
     {
       setYMinimum( 0 );

--- a/src/core/qgsquick/qgsquickelevationprofilecanvas.cpp
+++ b/src/core/qgsquick/qgsquickelevationprofilecanvas.cpp
@@ -1,9 +1,9 @@
 /***************************************************************************
                           QgsQuickElevationProfileCanvas.cpp
                           -----------------
-    begin                : March 2022
-    copyright            : (C) 2022 by Nyall Dawson
-    email                : nyall dot dawson at gmail dot com
+    begin                : October 2022
+    copyright            : (C) 2022 by Mathieu Pellerin
+    email                : mathieu at opengis dot ch
 ***************************************************************************/
 
 
@@ -33,7 +33,6 @@
 #include <QSGSimpleTextureNode>
 #include <QScreen>
 #include <QTimer>
-
 
 inline QList<QgsMapLayer *> _qgis_listQPointerToRaw( const QgsWeakMapLayerPointerList &layers )
 {

--- a/src/core/qgsquick/qgsquickelevationprofilecanvas.cpp
+++ b/src/core/qgsquick/qgsquickelevationprofilecanvas.cpp
@@ -532,8 +532,15 @@ QList<QgsMapLayer *> QgsQuickElevationProfileCanvas::layers() const
   return _qgis_listQPointerToRaw( mLayers );
 }
 
+#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
 void QgsQuickElevationProfileCanvas::geometryChanged( const QRectF &newGeometry, const QRectF &oldGeometry )
 {
+  QQuickItem::geometryChanged( newGeometry, oldGeometry );
+#else
+void QgsQuickElevationProfileCanvas::geometryChange( const QRectF &newGeometry, const QRectF &oldGeometry )
+{
+  QQuickItem::geometryChange( newGeometry, oldGeometry );
+#endif
   mPlotItem->updateRect();
   mDirty = true;
   refresh();

--- a/src/core/qgsquick/qgsquickelevationprofilecanvas.cpp
+++ b/src/core/qgsquick/qgsquickelevationprofilecanvas.cpp
@@ -1,0 +1,716 @@
+/***************************************************************************
+                          QgsQuickElevationProfileCanvas.cpp
+                          -----------------
+    begin                : March 2022
+    copyright            : (C) 2022 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+***************************************************************************/
+
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsabstractprofilegenerator.h"
+#include "qgsabstractprofilesource.h"
+#include "qgsexpressioncontextutils.h"
+#include "qgsmaplayerelevationproperties.h"
+#include "qgsmaplayerutils.h"
+#include "qgsplot.h"
+#include "qgsprofilerenderer.h"
+#include "qgsprofilerequest.h"
+#include "qgsprojectelevationproperties.h"
+#include "qgsquickelevationprofilecanvas.h"
+#include "qgsterrainprovider.h"
+
+#include <QQuickWindow>
+#include <QSGSimpleRectNode>
+#include <QSGSimpleTextureNode>
+#include <QScreen>
+#include <QTimer>
+
+
+inline QList<QgsMapLayer *> _qgis_listQPointerToRaw( const QgsWeakMapLayerPointerList &layers )
+{
+  QList<QgsMapLayer *> lst;
+  lst.reserve( layers.count() );
+  for ( const QgsWeakMapLayerPointer &layerPtr : layers )
+  {
+    if ( layerPtr )
+      lst.append( layerPtr.data() );
+  }
+  return lst;
+}
+
+inline QgsWeakMapLayerPointerList _qgis_listRawToQPointer( const QList<QgsMapLayer *> &layers )
+{
+  QgsWeakMapLayerPointerList lst;
+  lst.reserve( layers.count() );
+  for ( QgsMapLayer *layer : layers )
+  {
+    lst.append( layer );
+  }
+  return lst;
+}
+
+
+class QgsElevationProfilePlotItem : public Qgs2DPlot
+{
+  public:
+    QgsElevationProfilePlotItem( QgsQuickElevationProfileCanvas *canvas )
+      : mCanvas( canvas )
+    {
+      setYMinimum( 0 );
+      setYMaximum( 100 );
+      setSize( mCanvas->boundingRect().size() );
+    }
+
+    void setRenderer( QgsProfilePlotRenderer *renderer )
+    {
+      mRenderer = renderer;
+    }
+
+    void updateRect()
+    {
+      setSize( mCanvas->boundingRect().size() );
+      mCachedImages.clear();
+      mPlotArea = QRectF();
+    }
+
+    void updatePlot()
+    {
+      mCachedImages.clear();
+      mPlotArea = QRectF();
+    }
+
+    bool redrawResults( const QString &sourceId )
+    {
+      auto it = mCachedImages.find( sourceId );
+      if ( it == mCachedImages.end() )
+        return false;
+
+      mCachedImages.erase( it );
+      return true;
+    }
+
+    QRectF plotArea()
+    {
+      if ( !mPlotArea.isNull() )
+        return mPlotArea;
+
+      // force immediate recalculation of plot area
+      QgsRenderContext context;
+      context.setScaleFactor( ( mCanvas->window()->screen()->physicalDotsPerInch() * mCanvas->window()->screen()->devicePixelRatio() ) / 25.4 );
+
+      calculateOptimisedIntervals( context );
+      mPlotArea = interiorPlotArea( context );
+      return mPlotArea;
+    }
+
+    void renderContent( QgsRenderContext &rc, const QRectF &plotArea ) override
+    {
+      mPlotArea = plotArea;
+
+      if ( !mRenderer )
+        return;
+
+      const QStringList sourceIds = mRenderer->sourceIds();
+      for ( const QString &source : sourceIds )
+      {
+        QImage plot;
+        auto it = mCachedImages.constFind( source );
+        if ( it != mCachedImages.constEnd() )
+        {
+          plot = it.value();
+        }
+        else
+        {
+          plot = mRenderer->renderToImage( plotArea.width(), plotArea.height(), xMinimum(), xMaximum(), yMinimum(), yMaximum(), source );
+          mCachedImages.insert( source, plot );
+        }
+        rc.painter()->drawImage( plotArea.left(), plotArea.top(), plot );
+      }
+    }
+
+  private:
+    QgsQuickElevationProfileCanvas *mCanvas = nullptr;
+    QgsProfilePlotRenderer *mRenderer = nullptr;
+
+    QRectF mPlotArea;
+    QMap<QString, QImage> mCachedImages;
+};
+
+
+QgsQuickElevationProfileCanvas::QgsQuickElevationProfileCanvas( QQuickItem *parent )
+  : QQuickItem( parent )
+{
+  // updating the profile plot is deferred on a timer, so that we don't trigger it too often
+  mDeferredRegenerationTimer = new QTimer( this );
+  mDeferredRegenerationTimer->setSingleShot( true );
+  mDeferredRegenerationTimer->stop();
+  connect( mDeferredRegenerationTimer, &QTimer::timeout, this, &QgsQuickElevationProfileCanvas::startDeferredRegeneration );
+
+  mDeferredRedrawTimer = new QTimer( this );
+  mDeferredRedrawTimer->setSingleShot( true );
+  mDeferredRedrawTimer->stop();
+  connect( mDeferredRedrawTimer, &QTimer::timeout, this, &QgsQuickElevationProfileCanvas::startDeferredRedraw );
+
+  mPlotItem = new QgsElevationProfilePlotItem( this );
+
+  setTransformOrigin( QQuickItem::TopLeft );
+  setFlags( QQuickItem::ItemHasContents );
+}
+
+QgsQuickElevationProfileCanvas::~QgsQuickElevationProfileCanvas()
+{
+  if ( mCurrentJob )
+  {
+    mPlotItem->setRenderer( nullptr );
+    mCurrentJob->deleteLater();
+    mCurrentJob = nullptr;
+  }
+}
+
+void QgsQuickElevationProfileCanvas::cancelJobs()
+{
+  if ( mCurrentJob )
+  {
+    mPlotItem->setRenderer( nullptr );
+    disconnect( mCurrentJob, &QgsProfilePlotRenderer::generationFinished, this, &QgsQuickElevationProfileCanvas::generationFinished );
+    mCurrentJob->cancelGeneration();
+    mCurrentJob->deleteLater();
+    mCurrentJob = nullptr;
+  }
+}
+
+void QgsQuickElevationProfileCanvas::setupLayerConnections( QgsMapLayer *layer, bool isDisconnect )
+{
+  if ( !layer )
+    return;
+
+  if ( isDisconnect )
+  {
+    disconnect( layer->elevationProperties(), &QgsMapLayerElevationProperties::profileGenerationPropertyChanged, this, &QgsQuickElevationProfileCanvas::onLayerProfileGenerationPropertyChanged );
+    disconnect( layer->elevationProperties(), &QgsMapLayerElevationProperties::profileRenderingPropertyChanged, this, &QgsQuickElevationProfileCanvas::onLayerProfileRendererPropertyChanged );
+    disconnect( layer, &QgsMapLayer::dataChanged, this, &QgsQuickElevationProfileCanvas::regenerateResultsForLayer );
+  }
+  else
+  {
+    connect( layer->elevationProperties(), &QgsMapLayerElevationProperties::profileGenerationPropertyChanged, this, &QgsQuickElevationProfileCanvas::onLayerProfileGenerationPropertyChanged );
+    connect( layer->elevationProperties(), &QgsMapLayerElevationProperties::profileRenderingPropertyChanged, this, &QgsQuickElevationProfileCanvas::onLayerProfileRendererPropertyChanged );
+    connect( layer, &QgsMapLayer::dataChanged, this, &QgsQuickElevationProfileCanvas::regenerateResultsForLayer );
+  }
+
+  switch ( layer->type() )
+  {
+    case QgsMapLayerType::VectorLayer:
+    {
+      QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( layer );
+      if ( isDisconnect )
+      {
+        disconnect( vl, &QgsVectorLayer::featureAdded, this, &QgsQuickElevationProfileCanvas::regenerateResultsForLayer );
+        disconnect( vl, &QgsVectorLayer::featureDeleted, this, &QgsQuickElevationProfileCanvas::regenerateResultsForLayer );
+        disconnect( vl, &QgsVectorLayer::geometryChanged, this, &QgsQuickElevationProfileCanvas::regenerateResultsForLayer );
+        disconnect( vl, &QgsVectorLayer::attributeValueChanged, this, &QgsQuickElevationProfileCanvas::regenerateResultsForLayer );
+      }
+      else
+      {
+        connect( vl, &QgsVectorLayer::featureAdded, this, &QgsQuickElevationProfileCanvas::regenerateResultsForLayer );
+        connect( vl, &QgsVectorLayer::featureDeleted, this, &QgsQuickElevationProfileCanvas::regenerateResultsForLayer );
+        connect( vl, &QgsVectorLayer::geometryChanged, this, &QgsQuickElevationProfileCanvas::regenerateResultsForLayer );
+        connect( vl, &QgsVectorLayer::attributeValueChanged, this, &QgsQuickElevationProfileCanvas::regenerateResultsForLayer );
+      }
+      break;
+    }
+    case QgsMapLayerType::RasterLayer:
+    case QgsMapLayerType::PluginLayer:
+    case QgsMapLayerType::MeshLayer:
+    case QgsMapLayerType::VectorTileLayer:
+    case QgsMapLayerType::AnnotationLayer:
+    case QgsMapLayerType::PointCloudLayer:
+    case QgsMapLayerType::GroupLayer:
+      break;
+  }
+}
+
+void QgsQuickElevationProfileCanvas::refresh()
+{
+  if ( !mCrs.isValid() || !mProject || mProfileCurve.isEmpty() )
+    return;
+
+  if ( mCurrentJob )
+  {
+    mPlotItem->setRenderer( nullptr );
+    disconnect( mCurrentJob, &QgsProfilePlotRenderer::generationFinished, this, &QgsQuickElevationProfileCanvas::generationFinished );
+    mCurrentJob->deleteLater();
+    mCurrentJob = nullptr;
+  }
+
+  QgsProfileRequest request( static_cast<QgsCurve *>( mProfileCurve.get()->clone() ) );
+  request.setCrs( mCrs );
+  request.setTolerance( mTolerance );
+  request.setTransformContext( mProject->transformContext() );
+  request.setTerrainProvider( mProject->elevationProperties()->terrainProvider() ? mProject->elevationProperties()->terrainProvider()->clone() : nullptr );
+
+  QgsExpressionContext context;
+  context.appendScope( QgsExpressionContextUtils::globalScope() );
+  context.appendScope( QgsExpressionContextUtils::projectScope( mProject ) );
+  request.setExpressionContext( context );
+
+  const QList<QgsMapLayer *> layersToGenerate = layers();
+  QList<QgsAbstractProfileSource *> sources;
+  sources.reserve( layersToGenerate.size() );
+  for ( QgsMapLayer *layer : layersToGenerate )
+  {
+    if ( QgsAbstractProfileSource *source = dynamic_cast<QgsAbstractProfileSource *>( layer ) )
+      sources.append( source );
+  }
+
+  mCurrentJob = new QgsProfilePlotRenderer( sources, request );
+  connect( mCurrentJob, &QgsProfilePlotRenderer::generationFinished, this, &QgsQuickElevationProfileCanvas::generationFinished );
+
+  QgsProfileGenerationContext generationContext;
+  generationContext.setDpi( window()->screen()->physicalDotsPerInch() * window()->screen()->devicePixelRatio() );
+  generationContext.setMaximumErrorMapUnits( MAX_ERROR_PIXELS * ( mProfileCurve.get()->length() ) / mPlotItem->plotArea().width() );
+  generationContext.setMapUnitsPerDistancePixel( mProfileCurve.get()->length() / mPlotItem->plotArea().width() );
+  mCurrentJob->setContext( generationContext );
+
+  mPlotItem->updatePlot();
+  mCurrentJob->startGeneration();
+  mPlotItem->setRenderer( mCurrentJob );
+
+  emit activeJobCountChanged( 1 );
+}
+
+void QgsQuickElevationProfileCanvas::generationFinished()
+{
+  if ( !mCurrentJob )
+    return;
+
+  emit activeJobCountChanged( 0 );
+
+  if ( mZoomFullWhenJobFinished )
+  {
+    mZoomFullWhenJobFinished = false;
+    zoomFull();
+  }
+
+  QRectF rect = boundingRect();
+  mImage = QImage( rect.width(), rect.height(), QImage::Format_ARGB32_Premultiplied );
+  mImage.fill( Qt::transparent );
+
+  QPainter imagePainter( &mImage );
+  imagePainter.setRenderHint( QPainter::Antialiasing, true );
+  QgsRenderContext rc = QgsRenderContext::fromQPainter( &imagePainter );
+
+  rc.expressionContext().appendScope( QgsExpressionContextUtils::globalScope() );
+  rc.expressionContext().appendScope( QgsExpressionContextUtils::projectScope( mProject ) );
+
+  mPlotItem->calculateOptimisedIntervals( rc );
+  mPlotItem->render( rc );
+  imagePainter.end();
+
+  mDirty = true;
+  update();
+
+  if ( mForceRegenerationAfterCurrentJobCompletes )
+  {
+    mForceRegenerationAfterCurrentJobCompletes = false;
+    mCurrentJob->invalidateAllRefinableSources();
+    scheduleDeferredRegeneration();
+  }
+}
+
+void QgsQuickElevationProfileCanvas::onLayerProfileGenerationPropertyChanged()
+{
+  // TODO -- handle nicely when existing job is in progress
+  if ( !mCurrentJob || mCurrentJob->isActive() )
+    return;
+
+  QgsMapLayerElevationProperties *properties = qobject_cast<QgsMapLayerElevationProperties *>( sender() );
+  if ( !properties )
+    return;
+
+  if ( QgsMapLayer *layer = qobject_cast<QgsMapLayer *>( properties->parent() ) )
+  {
+    if ( QgsAbstractProfileSource *source = dynamic_cast<QgsAbstractProfileSource *>( layer ) )
+    {
+      if ( mCurrentJob->invalidateResults( source ) )
+        scheduleDeferredRegeneration();
+    }
+  }
+}
+
+void QgsQuickElevationProfileCanvas::onLayerProfileRendererPropertyChanged()
+{
+  // TODO -- handle nicely when existing job is in progress
+  if ( !mCurrentJob || mCurrentJob->isActive() )
+    return;
+
+  QgsMapLayerElevationProperties *properties = qobject_cast<QgsMapLayerElevationProperties *>( sender() );
+  if ( !properties )
+    return;
+
+  if ( QgsMapLayer *layer = qobject_cast<QgsMapLayer *>( properties->parent() ) )
+  {
+    if ( QgsAbstractProfileSource *source = dynamic_cast<QgsAbstractProfileSource *>( layer ) )
+    {
+      mCurrentJob->replaceSource( source );
+    }
+    if ( mPlotItem->redrawResults( layer->id() ) )
+      scheduleDeferredRedraw();
+  }
+}
+
+void QgsQuickElevationProfileCanvas::regenerateResultsForLayer()
+{
+  if ( QgsMapLayer *layer = qobject_cast<QgsMapLayer *>( sender() ) )
+  {
+    if ( QgsAbstractProfileSource *source = dynamic_cast<QgsAbstractProfileSource *>( layer ) )
+    {
+      if ( mCurrentJob->invalidateResults( source ) )
+        scheduleDeferredRegeneration();
+    }
+  }
+}
+
+void QgsQuickElevationProfileCanvas::scheduleDeferredRegeneration()
+{
+  if ( !mDeferredRegenerationScheduled )
+  {
+    mDeferredRegenerationTimer->start( 1 );
+    mDeferredRegenerationScheduled = true;
+  }
+}
+
+void QgsQuickElevationProfileCanvas::scheduleDeferredRedraw()
+{
+  if ( !mDeferredRedrawScheduled )
+  {
+    mDeferredRedrawTimer->start( 1 );
+    mDeferredRedrawScheduled = true;
+  }
+}
+
+void QgsQuickElevationProfileCanvas::startDeferredRegeneration()
+{
+  if ( mCurrentJob && !mCurrentJob->isActive() )
+  {
+    emit activeJobCountChanged( 1 );
+    mCurrentJob->regenerateInvalidatedResults();
+  }
+  else if ( mCurrentJob )
+  {
+    mForceRegenerationAfterCurrentJobCompletes = true;
+  }
+
+  mDeferredRegenerationScheduled = false;
+}
+
+void QgsQuickElevationProfileCanvas::startDeferredRedraw()
+{
+  refresh();
+  mDeferredRedrawScheduled = false;
+}
+
+void QgsQuickElevationProfileCanvas::refineResults()
+{
+  if ( mCurrentJob )
+  {
+    QgsProfileGenerationContext context;
+    context.setDpi( window()->screen()->physicalDotsPerInch() * window()->screen()->devicePixelRatio() );
+    const double plotDistanceRange = mPlotItem->xMaximum() - mPlotItem->xMinimum();
+    const double plotElevationRange = mPlotItem->yMaximum() - mPlotItem->yMinimum();
+    const double plotDistanceUnitsPerPixel = plotDistanceRange / mPlotItem->plotArea().width();
+
+    // we round the actual desired map error down to just one significant figure, to avoid tiny differences
+    // as the plot is panned
+    const double targetMaxErrorInMapUnits = MAX_ERROR_PIXELS * plotDistanceUnitsPerPixel;
+    const double factor = std::pow( 10.0, 1 - std::ceil( std::log10( std::fabs( targetMaxErrorInMapUnits ) ) ) );
+    const double roundedErrorInMapUnits = std::floor( targetMaxErrorInMapUnits * factor ) / factor;
+    context.setMaximumErrorMapUnits( roundedErrorInMapUnits );
+
+    context.setMapUnitsPerDistancePixel( plotDistanceUnitsPerPixel );
+
+    // for similar reasons we round the minimum distance off to multiples of the maximum error in map units
+    const double distanceMin = std::floor( ( mPlotItem->xMinimum() - plotDistanceRange * 0.05 ) / context.maximumErrorMapUnits() ) * context.maximumErrorMapUnits();
+    context.setDistanceRange( QgsDoubleRange( std::max( 0.0, distanceMin ),
+                                              mPlotItem->xMaximum() + plotDistanceRange * 0.05 ) );
+
+    context.setElevationRange( QgsDoubleRange( mPlotItem->yMinimum() - plotElevationRange * 0.05,
+                                               mPlotItem->yMaximum() + plotElevationRange * 0.05 ) );
+    mCurrentJob->setContext( context );
+  }
+  scheduleDeferredRegeneration();
+}
+
+void QgsQuickElevationProfileCanvas::setProject( QgsProject *project )
+{
+  if ( mProject == project )
+    return;
+
+  mProject = project;
+
+  emit projectChanged();
+}
+
+void QgsQuickElevationProfileCanvas::setCrs( const QgsCoordinateReferenceSystem &crs )
+{
+  if ( mCrs == crs )
+    return;
+
+  mCrs = crs;
+
+  emit crsChanged();
+}
+
+void QgsQuickElevationProfileCanvas::setProfileCurve( QgsGeometry curve )
+{
+  if ( mProfileCurve.equals( curve ) )
+    return;
+
+  mProfileCurve = curve.type() == QgsWkbTypes::LineGeometry ? curve : QgsGeometry();
+
+  emit profileCurveChanged();
+}
+
+void QgsQuickElevationProfileCanvas::setTolerance( double tolerance )
+{
+  if ( mTolerance == tolerance )
+    return;
+
+  mTolerance = tolerance;
+
+  emit toleranceChanged();
+}
+
+void QgsQuickElevationProfileCanvas::populateLayersFromProject()
+{
+  for ( QgsMapLayer *layer : std::as_const( mLayers ) )
+  {
+    setupLayerConnections( layer, true );
+  }
+
+  if ( !mProject )
+  {
+    mLayers.clear();
+    return;
+  }
+
+  const QList<QgsMapLayer *> projectLayers = QgsProject::instance()->layers<QgsMapLayer *>().toList();
+  // sort layers so that types which are more likely to obscure others are rendered below
+  // e.g. vector features should be drawn above raster DEMS, or the DEM line may completely obscure
+  // the vector feature
+  QList<QgsMapLayer *> sortedLayers = QgsMapLayerUtils::sortLayersByType( projectLayers,
+                                                                          { QgsMapLayerType::RasterLayer,
+                                                                            QgsMapLayerType::MeshLayer,
+                                                                            QgsMapLayerType::VectorLayer,
+                                                                            QgsMapLayerType::PointCloudLayer } );
+
+  // filter list, removing null layers and invalid layers
+  auto filteredList = sortedLayers;
+  filteredList.erase( std::remove_if( filteredList.begin(), filteredList.end(),
+                                      []( QgsMapLayer *layer ) {
+                                        return !layer || !layer->isValid() || !layer->elevationProperties() && !layer->elevationProperties()->showByDefaultInElevationProfilePlots();
+                                      } ),
+                      filteredList.end() );
+
+  mLayers = _qgis_listRawToQPointer( filteredList );
+  for ( QgsMapLayer *layer : std::as_const( mLayers ) )
+  {
+    setupLayerConnections( layer, false );
+  }
+}
+
+QList<QgsMapLayer *> QgsQuickElevationProfileCanvas::layers() const
+{
+  return _qgis_listQPointerToRaw( mLayers );
+}
+
+void QgsQuickElevationProfileCanvas::geometryChanged( const QRectF &newGeometry, const QRectF &oldGeometry )
+{
+  mPlotItem->updateRect();
+  mDirty = true;
+  refresh();
+}
+
+QSGNode *QgsQuickElevationProfileCanvas::updatePaintNode( QSGNode *oldNode, QQuickItem::UpdatePaintNodeData * )
+{
+  if ( mDirty )
+  {
+    delete oldNode;
+    oldNode = nullptr;
+    mDirty = false;
+  }
+
+  QSGNode *newNode = nullptr;
+  if ( !mImage.isNull() )
+  {
+    QSGSimpleTextureNode *node = static_cast<QSGSimpleTextureNode *>( oldNode );
+    if ( !node )
+    {
+      node = new QSGSimpleTextureNode();
+      QSGTexture *texture = window()->createTextureFromImage( mImage );
+      node->setTexture( texture );
+      node->setOwnsTexture( true );
+    }
+
+    QRectF rect( boundingRect() );
+    QSizeF size = mImage.size();
+    if ( !size.isEmpty() )
+      size /= window()->screen()->devicePixelRatio();
+
+    // Check for resizes that change the w/h ratio
+    if ( !rect.isEmpty() && !size.isEmpty() && !qgsDoubleNear( rect.width() / rect.height(), ( size.width() ) / static_cast<double>( size.height() ), 3 ) )
+    {
+      if ( qgsDoubleNear( rect.height(), mImage.height() ) )
+      {
+        rect.setHeight( rect.width() / size.width() * size.height() );
+      }
+      else
+      {
+        rect.setWidth( rect.height() / size.height() * size.width() );
+      }
+    }
+    node->setRect( rect );
+    newNode = node;
+  }
+  else
+  {
+    QSGSimpleRectNode *node = static_cast<QSGSimpleRectNode *>( oldNode );
+    if ( !node )
+    {
+      node = new QSGSimpleRectNode();
+      node->setColor( Qt::transparent );
+    }
+    node->setRect( boundingRect() );
+    newNode = node;
+  }
+
+  return newNode;
+}
+
+void QgsQuickElevationProfileCanvas::zoomFull()
+{
+  if ( !mCurrentJob )
+    return;
+
+  const QgsDoubleRange zRange = mCurrentJob->zRange();
+
+  if ( zRange.upper() < zRange.lower() )
+  {
+    // invalid range, e.g. no features found in plot!
+    mPlotItem->setYMinimum( 0 );
+    mPlotItem->setYMaximum( 10 );
+  }
+  else if ( qgsDoubleNear( zRange.lower(), zRange.upper(), 0.0000001 ) )
+  {
+    // corner case ... a zero height plot! Just pick an arbitrary +/- 5 height range.
+    mPlotItem->setYMinimum( zRange.lower() - 5 );
+    mPlotItem->setYMaximum( zRange.lower() + 5 );
+  }
+  else
+  {
+    // add 5% margin to height range
+    const double margin = ( zRange.upper() - zRange.lower() ) * 0.05;
+    mPlotItem->setYMinimum( zRange.lower() - margin );
+    mPlotItem->setYMaximum( zRange.upper() + margin );
+  }
+
+  const double profileLength = mProfileCurve.get()->length();
+  mPlotItem->setXMinimum( 0 );
+  // just 2% margin to max distance -- any more is overkill and wasted space
+  mPlotItem->setXMaximum( profileLength * 1.02 );
+
+  refineResults();
+}
+
+void QgsQuickElevationProfileCanvas::zoomFullInRatio()
+{
+  if ( !mCurrentJob )
+    return;
+
+  const QgsDoubleRange zRange = mCurrentJob->zRange();
+  double xLength = mProfileCurve.get()->length();
+  double yLength = zRange.upper() - zRange.lower();
+  qDebug() << yLength;
+  if ( yLength < 0.0 )
+  {
+    // invalid range, e.g. no features found in plot!
+    mPlotItem->setYMinimum( 0 );
+    mPlotItem->setYMaximum( 10 );
+
+    mPlotItem->setXMinimum( 0 );
+    // just 2% margin to max distance -- any more is overkill and wasted space
+    mPlotItem->setXMaximum( xLength * 1.02 );
+  }
+  else
+  {
+    double yInRatioLength = xLength * mPlotItem->size().height() / mPlotItem->size().width();
+    double xInRatioLength = yLength * mPlotItem->size().width() / mPlotItem->size().height();
+    if ( yInRatioLength > yLength )
+    {
+      qDebug() << "yInRatioLength";
+      mPlotItem->setYMinimum( zRange.lower() - ( yInRatioLength / 2 ) );
+      qDebug() << mPlotItem->yMinimum();
+      mPlotItem->setYMaximum( zRange.upper() + ( yInRatioLength / 2 ) );
+      qDebug() << mPlotItem->yMaximum();
+
+      mPlotItem->setXMinimum( 0 );
+      // just 2% margin to max distance -- any more is overkill and wasted space
+      mPlotItem->setXMaximum( xLength * 1.02 );
+    }
+    else
+    {
+      qDebug() << "xInRatioLength";
+      // add 5% margin to height range
+      const double margin = yLength * 0.05;
+      mPlotItem->setYMinimum( zRange.lower() - margin );
+      qDebug() << mPlotItem->yMinimum();
+      mPlotItem->setYMaximum( zRange.upper() + margin );
+      qDebug() << mPlotItem->yMaximum();
+
+      mPlotItem->setXMinimum( 0 - ( xInRatioLength / 2 ) );
+      mPlotItem->setXMaximum( xLength + ( xInRatioLength / 2 ) );
+    }
+  }
+
+  refineResults();
+}
+
+void QgsQuickElevationProfileCanvas::setVisiblePlotRange( double minimumDistance, double maximumDistance, double minimumElevation, double maximumElevation )
+{
+  mPlotItem->setYMinimum( minimumElevation );
+  mPlotItem->setYMaximum( maximumElevation );
+  mPlotItem->setXMinimum( minimumDistance );
+  mPlotItem->setXMaximum( maximumDistance );
+  refineResults();
+}
+
+QgsDoubleRange QgsQuickElevationProfileCanvas::visibleDistanceRange() const
+{
+  return QgsDoubleRange( mPlotItem->xMinimum(), mPlotItem->xMaximum() );
+}
+
+QgsDoubleRange QgsQuickElevationProfileCanvas::visibleElevationRange() const
+{
+  return QgsDoubleRange( mPlotItem->yMinimum(), mPlotItem->yMaximum() );
+}
+
+void QgsQuickElevationProfileCanvas::clear()
+{
+  setProfileCurve( QgsGeometry() );
+  mCurrentJob = nullptr;
+  mPlotItem->setRenderer( nullptr );
+
+  mZoomFullWhenJobFinished = true;
+
+  mImage = QImage();
+  mDirty = true;
+  update();
+}

--- a/src/core/qgsquick/qgsquickelevationprofilecanvas.h
+++ b/src/core/qgsquick/qgsquickelevationprofilecanvas.h
@@ -1,0 +1,246 @@
+/***************************************************************************
+                          qgselevationprofilecanvas.h
+                          ---------------
+    begin                : March 2022
+    copyright            : (C) 2022 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSELEVATIONPROFILECANVAS_H
+#define QGSELEVATIONPROFILECANVAS_H
+
+#include "qgscoordinatereferencesystem.h"
+#include "qgsgeometry.h"
+#include "qgsmaplayer.h"
+
+#include <QQuickItem>
+
+class QgsProfilePlotRenderer;
+class QgsElevationProfilePlotItem;
+
+class QgsQuickElevationProfileCanvas : public QQuickItem
+{
+    Q_OBJECT
+
+    Q_PROPERTY( QgsProject *project READ project WRITE setProject NOTIFY projectChanged )
+
+    Q_PROPERTY( QgsCoordinateReferenceSystem crs READ crs WRITE setCrs NOTIFY crsChanged )
+
+    Q_PROPERTY( QgsGeometry profileCurve READ profileCurve WRITE setProfileCurve NOTIFY profileCurveChanged )
+
+    Q_PROPERTY( double tolerance READ tolerance WRITE setTolerance NOTIFY toleranceChanged )
+
+  public:
+    /**
+     * Constructor for QgsElevationProfileCanvas, with the specified \a parent widget.
+     */
+    QgsQuickElevationProfileCanvas( QQuickItem *parent = nullptr );
+    ~QgsQuickElevationProfileCanvas();
+
+    QSGNode *updatePaintNode( QSGNode *oldNode, QQuickItem::UpdatePaintNodeData * ) override;
+
+    void cancelJobs();
+
+    /**
+     * Triggers a complete regeneration of the profile, causing the profile extraction to perform in the
+     * background.
+     */
+    Q_INVOKABLE void refresh();
+
+    /**
+     * Returns the project associated with the profile.
+     */
+    QgsProject *project() const { return mProject; }
+
+    /**
+     * Sets the \a project associated with the profile.
+     *
+     * This must be set before any layers which utilize terrain based elevation settings can be
+     * included in the canvas.
+     */
+    void setProject( QgsProject *project );
+
+    /**
+     * Populates the current profile with elevation-enabled layers from the associated project.
+     */
+    Q_INVOKABLE void populateLayersFromProject();
+
+    /**
+     * Returns the list of layers included in the profile.
+     *
+     * \see layers()
+     */
+    QList<QgsMapLayer *> layers() const;
+
+    /**
+     * Returns the crs associated with map coordinates
+     */
+    QgsCoordinateReferenceSystem crs() const { return mCrs; }
+
+    /**
+     * Sets the \a crs associated with the map coordinates.
+     *
+     * \see crs()
+     */
+    void setCrs( const QgsCoordinateReferenceSystem &crs );
+
+    /**
+     * Sets the profile \a curve geometry.
+     *
+     * The CRS associated with \a curve is set via setCrs().
+     *
+     * \see profileCurve()
+     */
+    void setProfileCurve( QgsGeometry curve );
+
+    /**
+     * Returns the profile curve geometry.
+     *
+     * The CRS associated with the curve is retrieved via crs().
+     *
+     * \see setProfileCurve()
+     */
+    QgsGeometry profileCurve() const { return mProfileCurve; };
+
+    /**
+     * Sets the profile tolerance (in crs() units).
+     *
+     * This value determines how far from the profileCurve() is appropriate for inclusion of results. For instance,
+     * when a profile is generated for a point vector layer this tolerance distance will dictate how far from the
+     * actual profile curve a point can reside within to be included in the results.
+     *
+     * \see tolerance()
+     */
+    void setTolerance( double tolerance );
+
+    /**
+     * Returns the tolerance of the profile (in crs() units).
+     *
+     * This value determines how far from the profileCurve() is appropriate for inclusion of results. For instance,
+     * when a profile is generated for a point vector layer this tolerance distance will dictate how far from the
+     * actual profile curve a point can reside within to be included in the results.
+     *
+     * \see setTolerance()
+     */
+    double tolerance() const { return mTolerance; }
+
+    /**
+     * Sets the visible area of the plot.
+     *
+     * \see visibleDistanceRange()
+     * \see visibleElevationRange()
+     */
+    void setVisiblePlotRange( double minimumDistance, double maximumDistance, double minimumElevation, double maximumElevation );
+
+    /**
+     * Returns the distance range currently visible in the plot.
+     *
+     * \see visibleElevationRange()
+     * \see setVisiblePlotRange()
+     */
+    QgsDoubleRange visibleDistanceRange() const;
+
+    /**
+     * Returns the elevation range currently visible in the plot.
+     *
+     * \see visibleDistanceRange()
+     * \see setVisiblePlotRange()
+     */
+    QgsDoubleRange visibleElevationRange() const;
+
+  signals:
+
+    //! Emitted when the number of active background jobs changes.
+    void activeJobCountChanged( int count );
+
+    //! Emitted when the associated project changes.
+    void projectChanged();
+
+    //! Emitted when the CRS linked to the profile curve geometry changes.
+    void crsChanged();
+
+    //! Emitted when the profile curve geometry changes.
+    void profileCurveChanged();
+
+    //! Emitted when the tolerance changes.
+    void toleranceChanged();
+
+  protected:
+#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
+    void geometryChanged( const QRectF &newGeometry, const QRectF &oldGeometry ) override;
+#else
+    void geometryChange( const QRectF &newGeometry, const QRectF &oldGeometry ) override;
+#endif
+
+  public slots:
+
+    /**
+     * Zooms to the full extent of the profile.
+     */
+    Q_INVOKABLE void zoomFull();
+
+    /**
+     * Zooms to the full extent of the profile while maintaining X and Y axes' length ratio.
+     * \note This method only makes sense with CRSes having matching map units and elevation units types.
+     */
+    Q_INVOKABLE void zoomFullInRatio();
+
+    /**
+     * Clears the current profile.
+     */
+    Q_INVOKABLE void clear();
+
+  private slots:
+
+    void generationFinished();
+    void onLayerProfileGenerationPropertyChanged();
+    void onLayerProfileRendererPropertyChanged();
+    void regenerateResultsForLayer();
+    void scheduleDeferredRegeneration();
+    void scheduleDeferredRedraw();
+    void startDeferredRegeneration();
+    void startDeferredRedraw();
+    void refineResults();
+
+  private:
+    void setupLayerConnections( QgsMapLayer *layer, bool isDisconnect );
+
+    QgsCoordinateReferenceSystem mCrs;
+    QgsProject *mProject = nullptr;
+
+    QgsWeakMapLayerPointerList mLayers;
+
+    QImage mImage;
+
+    QgsElevationProfilePlotItem *mPlotItem = nullptr;
+    QgsProfilePlotRenderer *mCurrentJob = nullptr;
+
+    QTimer *mDeferredRegenerationTimer = nullptr;
+    bool mDeferredRegenerationScheduled = false;
+    QTimer *mDeferredRedrawTimer = nullptr;
+    bool mDeferredRedrawScheduled = false;
+
+    QgsGeometry mProfileCurve;
+    double mTolerance = 0;
+
+    bool mFirstDrawOccurred = false;
+
+    bool mZoomFullWhenJobFinished = true;
+
+    bool mForceRegenerationAfterCurrentJobCompletes = false;
+
+    static constexpr double MAX_ERROR_PIXELS = 2;
+
+    bool mDirty = false;
+};
+
+#endif // QGSELEVATIONPROFILECANVAS_H

--- a/src/core/qgsquick/qgsquickelevationprofilecanvas.h
+++ b/src/core/qgsquick/qgsquickelevationprofilecanvas.h
@@ -43,7 +43,7 @@ class QgsQuickElevationProfileCanvas : public QQuickItem
     /**
      * Constructor for QgsElevationProfileCanvas, with the specified \a parent widget.
      */
-    QgsQuickElevationProfileCanvas( QQuickItem *parent = nullptr );
+    explicit QgsQuickElevationProfileCanvas( QQuickItem *parent = nullptr );
     ~QgsQuickElevationProfileCanvas();
 
     QSGNode *updatePaintNode( QSGNode *oldNode, QQuickItem::UpdatePaintNodeData * ) override;

--- a/src/core/qgsquick/qgsquickelevationprofilecanvas.h
+++ b/src/core/qgsquick/qgsquickelevationprofilecanvas.h
@@ -1,9 +1,9 @@
 /***************************************************************************
                           qgselevationprofilecanvas.h
                           ---------------
-    begin                : March 2022
-    copyright            : (C) 2022 by Nyall Dawson
-    email                : nyall dot dawson at gmail dot com
+    begin                : October 2022
+    copyright            : (C) 2022 by Mathieu Pellerin
+    email                : mathieu at opengis dot ch
 ***************************************************************************/
 
 /***************************************************************************

--- a/src/core/utils/geometryutils.cpp
+++ b/src/core/utils/geometryutils.cpp
@@ -28,7 +28,6 @@ GeometryUtils::GeometryUtils( QObject *parent )
 {
 }
 
-
 QgsGeometry GeometryUtils::polygonFromRubberband( RubberbandModel *rubberBandModel, const QgsCoordinateReferenceSystem &crs )
 {
   QgsPointSequence ring = rubberBandModel->pointSequence( crs, QgsWkbTypes::Point, true );
@@ -36,6 +35,14 @@ QgsGeometry GeometryUtils::polygonFromRubberband( RubberbandModel *rubberBandMod
   std::unique_ptr<QgsPolygon> polygon = std::make_unique<QgsPolygon>();
   polygon->setExteriorRing( ext.clone() );
   QgsGeometry g( std::move( polygon ) );
+  return g;
+}
+
+QgsGeometry GeometryUtils::lineFromRubberband( RubberbandModel *rubberBandModel, const QgsCoordinateReferenceSystem &crs )
+{
+  QgsPointSequence points = rubberBandModel->pointSequence( crs, QgsWkbTypes::Point, false );
+  std::unique_ptr<QgsLineString> line = std::make_unique<QgsLineString>( points );
+  QgsGeometry g( std::move( line ) );
   return g;
 }
 

--- a/src/core/utils/geometryutils.h
+++ b/src/core/utils/geometryutils.h
@@ -61,6 +61,9 @@ class QFIELD_CORE_EXPORT GeometryUtils : public QObject
     //! Returns a QgsGeometry with a polygon by using the point sequence in the rubberband model.
     static Q_INVOKABLE QgsGeometry polygonFromRubberband( RubberbandModel *rubberBandModel, const QgsCoordinateReferenceSystem &crs );
 
+    //! Returns a QgsGeometry with a line by using the point sequence in the rubberband model.
+    static Q_INVOKABLE QgsGeometry lineFromRubberband( RubberbandModel *rubberBandModel, const QgsCoordinateReferenceSystem &crs );
+
     //! Reshape a polyon with given \a fid using the ring in the rubberband model.
     static Q_INVOKABLE GeometryOperationResult reshapeFromRubberband( QgsVectorLayer *layer, QgsFeatureId fid, RubberbandModel *rubberBandModel );
 

--- a/src/qml/ElevationProfile.qml
+++ b/src/qml/ElevationProfile.qml
@@ -1,0 +1,59 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQml 2.14
+
+import org.qgis 1.0
+import org.qfield 1.0
+
+import Theme 1.0
+
+Item {
+  id: elevationProfile
+
+  property alias project: elevationProfileCanvas.project
+  property alias crs: elevationProfileCanvas.crs
+  property alias profileCurve: elevationProfileCanvas.profileCurve
+  property alias tolerance: elevationProfileCanvas.tolerance
+
+  function populateLayersFromProject() {
+    elevationProfileCanvas.populateLayersFromProject();
+  }
+
+  function refresh() {
+    elevationProfileCanvas.refresh();
+  }
+
+  function clear() {
+    elevationProfileCanvas.clear();
+  }
+
+  Rectangle {
+      width: elevationProfile.width
+      height: elevationProfile.height
+      color: "#ffffff"
+      radius: 6
+  }
+
+  ElevationProfileCanvas {
+    id: elevationProfileCanvas
+
+    width: elevationProfile.width
+    height: elevationProfile.height
+
+    tolerance: crs.isGeographic ? 0.00005 : 5
+  }
+
+  Text {
+    id: instrutionLabel
+    visible: elevationProfileCanvas.profileCurve.isNull
+    anchors.centerIn: parent
+    width: parent.width
+    color: Theme.gray
+    font: Theme.tinyFont
+    horizontalAlignment: Text.AlignHCenter
+    wrapMode: Text.WordWrap
+    text: qsTr('Digitize a path to render the elevation profile')
+    style: Text.Outline
+    styleColor: "white"
+  }
+}

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -675,7 +675,7 @@ ApplicationWindow {
     anchors.bottom: parent.bottom
     anchors.left: parent.left
     anchors.right: parent.right
-    visible: navigation.isActive || positioningSettings.showPositionInformation || positioningPreciseView.visible
+    visible: navigation.isActive || positioningSettings.showPositionInformation || positioningPreciseView.visible || elevationProfile.visible
 
     width: parent.width
 

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -11,6 +11,7 @@
         <file>CoordinateLocator.qml</file>
         <file>DashBoard.qml</file>
         <file>DigitizingToolbar.qml</file>
+        <file>ElevationProfile.qml</file>
         <file>FeatureForm.qml</file>
         <file>FeatureListForm.qml</file>
         <file>LayerSelector.qml</file>

--- a/vcpkg/overlay/qgis-qt6/mesh.patch
+++ b/vcpkg/overlay/qgis-qt6/mesh.patch
@@ -1,0 +1,29 @@
+From 64d9c72d1a08960e80625898d6d0e3d0e3405419 Mon Sep 17 00:00:00 2001
+From: Mathieu Pellerin <nirvn.asia@gmail.com>
+Date: Wed, 26 Oct 2022 14:04:12 +0700
+Subject: Remove template declarations
+
+---
+ src/core/mesh/qgstopologicalmesh.h | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/src/core/mesh/qgstopologicalmesh.h b/src/core/mesh/qgstopologicalmesh.h
+index 1cf79eb359..93b1ab4ebc 100644
+--- a/src/core/mesh/qgstopologicalmesh.h
++++ b/src/core/mesh/qgstopologicalmesh.h
+@@ -20,12 +20,6 @@
+ 
+ #include "qgsmeshdataprovider.h"
+ 
+-#if defined(_MSC_VER)
+-template CORE_EXPORT QVector<int> SIP_SKIP;
+-template CORE_EXPORT QList<int> SIP_SKIP;
+-template CORE_EXPORT QVector<QVector<int>> SIP_SKIP;
+-#endif
+-
+ SIP_NO_FILE
+ 
+ class QgsMeshEditingError;
+-- 
+2.37.2
+

--- a/vcpkg/overlay/qgis-qt6/portfile.cmake
+++ b/vcpkg/overlay/qgis-qt6/portfile.cmake
@@ -20,6 +20,7 @@ vcpkg_from_github(
         poly2tri.patch
         pgprovider.patch
         qgsvariantutils.patch
+        mesh.patch
 )
 
 file(REMOVE ${SOURCE_PATH}/cmake/FindQtKeychain.cmake)

--- a/vcpkg/overlay/qgis/mesh.patch
+++ b/vcpkg/overlay/qgis/mesh.patch
@@ -1,0 +1,29 @@
+From 64d9c72d1a08960e80625898d6d0e3d0e3405419 Mon Sep 17 00:00:00 2001
+From: Mathieu Pellerin <nirvn.asia@gmail.com>
+Date: Wed, 26 Oct 2022 14:04:12 +0700
+Subject: Remove template declarations
+
+---
+ src/core/mesh/qgstopologicalmesh.h | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/src/core/mesh/qgstopologicalmesh.h b/src/core/mesh/qgstopologicalmesh.h
+index 1cf79eb359..93b1ab4ebc 100644
+--- a/src/core/mesh/qgstopologicalmesh.h
++++ b/src/core/mesh/qgstopologicalmesh.h
+@@ -20,12 +20,6 @@
+ 
+ #include "qgsmeshdataprovider.h"
+ 
+-#if defined(_MSC_VER)
+-template CORE_EXPORT QVector<int> SIP_SKIP;
+-template CORE_EXPORT QList<int> SIP_SKIP;
+-template CORE_EXPORT QVector<QVector<int>> SIP_SKIP;
+-#endif
+-
+ SIP_NO_FILE
+ 
+ class QgsMeshEditingError;
+-- 
+2.37.2
+

--- a/vcpkg/overlay/qgis/portfile.cmake
+++ b/vcpkg/overlay/qgis/portfile.cmake
@@ -21,6 +21,7 @@ vcpkg_from_github(
         poly2tri.patch
         pgprovider.patch
         qgsvariantutils.patch # https://github.com/qgis/QGIS/pull/50662
+        mesh.patch
 )
 
 file(REMOVE ${SOURCE_PATH}/cmake/FindQtKeychain.cmake)


### PR DESCRIPTION
This PR adds basic elevation profiling functionality to QField's measurement tool (a screencast of the UI/UX in action is available here: https://twitter.com/QFieldForQGIS/status/1584441812592119808).

Once this foundation is laid, a bunch of interesting features could be added. To name a few:
- tap on profile canvas to identify features
- tap along elevation profile to highlight location along the profiling curve on the map canvas
- overlay device/external GNSS location on the elevation profile
- draw elevation profile of a layer feature's line geometry from the feature form menu action
- etc.

