### PR TITLE
Add azimuth details to measuring tool (and digitizing when set to show details)

### DIFF
--- a/src/core/distancearea.cpp
+++ b/src/core/distancearea.cpp
@@ -85,6 +85,7 @@ void DistanceArea::setRubberbandModel( RubberbandModel *rubberbandModel )
     disconnect( mRubberbandModel, &RubberbandModel::vertexChanged, this, &DistanceArea::perimeterChanged );
     disconnect( mRubberbandModel, &RubberbandModel::vertexChanged, this, &DistanceArea::areaChanged );
     disconnect( mRubberbandModel, &RubberbandModel::vertexChanged, this, &DistanceArea::segmentLengthChanged );
+    disconnect( mRubberbandModel, &RubberbandModel::vertexChanged, this, &DistanceArea::azimuthChanged );
   }
 
   mRubberbandModel = rubberbandModel;
@@ -95,6 +96,7 @@ void DistanceArea::setRubberbandModel( RubberbandModel *rubberbandModel )
     connect( mRubberbandModel, &RubberbandModel::vertexChanged, this, &DistanceArea::perimeterChanged );
     connect( mRubberbandModel, &RubberbandModel::vertexChanged, this, &DistanceArea::areaChanged );
     connect( mRubberbandModel, &RubberbandModel::vertexChanged, this, &DistanceArea::segmentLengthChanged );
+    connect( mRubberbandModel, &RubberbandModel::vertexChanged, this, &DistanceArea::azimuthChanged );
   }
 
   emit rubberbandModelChanged();
@@ -242,6 +244,21 @@ qreal DistanceArea::segmentLength() const
   flatPoints << *pointIt;
 
   return mDistanceArea.measureLine( flatPoints );
+}
+
+qreal DistanceArea::azimuth() const
+{
+  if ( !mRubberbandModel )
+    return qQNaN();
+
+  if ( mRubberbandModel->vertexCount() < 2 )
+    return qQNaN();
+
+  QVector<QgsPointXY> points = mRubberbandModel->flatPointSequence( mCrs );
+  QgsPoint startPoint( points.at( points.size() - 2 ) );
+  QgsPoint endPoint( points.at( points.size() - 1 ) );
+
+  return startPoint.azimuth( endPoint );
 }
 
 QgsUnitTypes::DistanceUnit DistanceArea::lengthUnits() const

--- a/src/core/distancearea.h
+++ b/src/core/distancearea.h
@@ -41,9 +41,15 @@ class DistanceArea : public QObject
     Q_PROPERTY( QgsUnitTypes::AreaUnit areaUnits READ areaUnits NOTIFY areaUnitsChanged )
 
     /**
-     * Contains the length of the last segment
+     * Returns the length of the last segment
      */
     Q_PROPERTY( qreal segmentLength READ segmentLength NOTIFY segmentLengthChanged )
+
+    /**
+     * Returns the Cartesian azimuth (in degrees) between the second to last point and last point
+     * of the rubber band model (clockwise in degree, starting from north)
+     */
+    Q_PROPERTY( qreal azimuth READ azimuth NOTIFY azimuthChanged )
 
   public:
     explicit DistanceArea( QObject *parent = nullptr );
@@ -54,7 +60,9 @@ class DistanceArea : public QObject
     bool perimeterValid() const;
     qreal area() const;
     bool areaValid() const;
+
     qreal segmentLength() const;
+    qreal azimuth() const;
 
     QgsUnitTypes::DistanceUnit lengthUnits() const;
     QgsUnitTypes::AreaUnit areaUnits() const;
@@ -80,6 +88,7 @@ class DistanceArea : public QObject
     void perimeterChanged();
     void areaChanged();
     void segmentLengthChanged();
+    void azimuthChanged();
     void lengthUnitsChanged();
     void areaUnitsChanged();
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -775,16 +775,21 @@ ApplicationWindow {
                         .arg(point.x.toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 5 : 2 ));
         }
 
-        return '%1%2%3%4%5'
+        return '%1%2%3%4%5%6'
                 .arg(stateMachine.state === 'digitize' || !digitizingToolbar.isDigitizing
                      ? coordinates
                      : '')
 
                 .arg(digitizingGeometryMeasure.lengthValid && digitizingGeometryMeasure.segmentLength != 0.0
-                     && digitizingGeometryMeasure.segmentLength != digitizingGeometryMeasure.length
                      ? '<p>%1: %2</p>'
-                       .arg( qsTr( 'Segment') )
+                       .arg( digitizingGeometryMeasure.segmentLength != digitizingGeometryMeasure.length ? qsTr( 'Segment') : qsTr( 'Length' ) )
                        .arg(UnitTypes.formatDistance( digitizingGeometryMeasure.convertLengthMeansurement( digitizingGeometryMeasure.segmentLength, projectInfo.distanceUnits ) , 3, projectInfo.distanceUnits ) )
+                     : '')
+
+                .arg(digitizingGeometryMeasure.lengthValid && digitizingGeometryMeasure.segmentLength != 0.0
+                     ? '<p>%1: %2</p>'
+                       .arg( qsTr( 'Azimuth') )
+                       .arg( UnitTypes.formatAngle( digitizingGeometryMeasure.azimuth < 0 ? digitizingGeometryMeasure.azimuth + 360 : digitizingGeometryMeasure.azimuth, 2, QgsUnitTypes.AngleDegrees ) )
                      : '')
 
                 .arg(currentRubberband.model && currentRubberband.model.geometryType === QgsWkbTypes.PolygonGeometry
@@ -793,7 +798,7 @@ ApplicationWindow {
                          .arg( qsTr( 'Perimeter') )
                          .arg(UnitTypes.formatDistance( digitizingGeometryMeasure.convertLengthMeansurement( digitizingGeometryMeasure.perimeter, projectInfo.distanceUnits ), 3, projectInfo.distanceUnits ) )
                        : ''
-                     : digitizingGeometryMeasure.lengthValid
+                     : digitizingGeometryMeasure.lengthValid && digitizingGeometryMeasure.segmentLength != digitizingGeometryMeasure.length
                      ? '<p>%1: %2</p>'
                        .arg( qsTr( 'Length') )
                        .arg(UnitTypes.formatDistance( digitizingGeometryMeasure.convertLengthMeansurement( digitizingGeometryMeasure.length, projectInfo.distanceUnits ),3, projectInfo.distanceUnits ) )


### PR DESCRIPTION
This PR adds an azimuth detail to the information overlay when using the measuring tool (or while digitizing when the "show digitizing information" toggle is turned on).

In action:

https://user-images.githubusercontent.com/1728657/197734785-9605c550-13ce-49d7-aa20-9a4f238fc412.mp4

_Funded by [Groupements Forestiers Québec](https://groupementsforestiers.quebec/)_
