### PR TITLE
Update default values when editing a new feature to match QGIS behavior

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -494,7 +494,8 @@ void AttributeFormModelBase::updateDefaultValues( int fieldIndex, QVector<int> u
   {
     QStandardItem *item = constraintIterator.key();
     int fidx = item->data( AttributeFormModel::FieldIndex ).toInt();
-    if ( fidx == fieldIndex || !fields.at( fidx ).defaultValueDefinition().isValid() || !fields.at( fidx ).defaultValueDefinition().applyOnUpdate() )
+    const bool isNewFeature = mFeatureModel->feature().id() == FID_NULL;
+    if ( fidx == fieldIndex || !fields.at( fidx ).defaultValueDefinition().isValid() || ( !isNewFeature && !fields.at( fidx ).defaultValueDefinition().applyOnUpdate() ) )
       continue;
 
     QgsExpression exp( fields.at( fidx ).defaultValueDefinition().expression() );


### PR DESCRIPTION
It does make sense to do "live" update of default values when the [ ] apply default value on update checkbox isn't on for new features that haven't been created (i.e. saved) yet while editing the feature form post digitizing.

This fixes #3509 and in doing so harmonizes QField's behavior with that of QGIS.