### PR TITLE
Add columns support to the feature form

### DIFF
--- a/src/core/attributeformmodel.h
+++ b/src/core/attributeformmodel.h
@@ -47,7 +47,6 @@ class AttributeFormModel : public QSortFilterProxyModel
       RelationId,
       NmRelationId,
       FieldIndex,
-      Group,
       AttributeEditorElement,
       CurrentlyVisible,
       ConstraintHardValid,
@@ -56,7 +55,10 @@ class AttributeFormModel : public QSortFilterProxyModel
       AttributeAllowEdit,
       EditorWidgetCode, //<! Returns a QML or HTML code string used by the relevant widgets
       TabIndex,
-      FieldColor,
+      GroupColor,
+      GroupName,
+      GroupIndex,
+      ColumnCount,
     };
 
     Q_ENUM( FeatureRoles )

--- a/src/core/attributeformmodelbase.h
+++ b/src/core/attributeformmodelbase.h
@@ -84,7 +84,7 @@ class AttributeFormModelBase : public QStandardItemModel
                     const QString &parentVisibilityExpressions,
                     QVector<QStandardItem *> &items,
                     int currentTabIndex = 0,
-                    int columnsCount = 1 );
+                    int columnCount = 1 );
 
     void updateDefaultValues( int fieldIndex = -1, QVector<int> updatedFields = QVector<int>() );
 

--- a/src/core/attributeformmodelbase.h
+++ b/src/core/attributeformmodelbase.h
@@ -79,7 +79,12 @@ class AttributeFormModelBase : public QStandardItemModel
 
     void updateAttributeValue( QStandardItem *item );
 
-    void flatten( QgsAttributeEditorContainer *container, QStandardItem *parent, const QString &parentVisibilityExpressions, QVector<QStandardItem *> &items, int currentTabIndex = 0, const QColor &color = QColor() );
+    void buildForm( QgsAttributeEditorContainer *container,
+                    QStandardItem *parent,
+                    const QString &parentVisibilityExpressions,
+                    QVector<QStandardItem *> &items,
+                    int currentTabIndex = 0,
+                    int columnsCount = 1 );
 
     void updateDefaultValues( int fieldIndex = -1, QVector<int> updatedFields = QVector<int>() );
 

--- a/src/core/submodel.cpp
+++ b/src/core/submodel.cpp
@@ -22,12 +22,18 @@ SubModel::SubModel( QObject *parent )
 
 QModelIndex SubModel::index( int row, int column, const QModelIndex &parent ) const
 {
+  if ( !mModel )
+    return QModelIndex();
+
   QModelIndex sourceIndex = mModel->index( row, column, parent.isValid() ? mapToSource( parent ) : static_cast<QModelIndex>( mRootIndex ) );
   return mapFromSource( sourceIndex );
 }
 
 QModelIndex SubModel::parent( const QModelIndex &child ) const
 {
+  if ( !mModel )
+    return QModelIndex();
+
   QModelIndex idx = mModel->parent( child );
   if ( idx == mRootIndex )
     return QModelIndex();
@@ -37,27 +43,27 @@ QModelIndex SubModel::parent( const QModelIndex &child ) const
 
 int SubModel::rowCount( const QModelIndex &parent ) const
 {
-  return mModel->rowCount( parent.isValid() ? mapToSource( parent ) : static_cast<QModelIndex>( mRootIndex ) );
+  return mModel ? mModel->rowCount( parent.isValid() ? mapToSource( parent ) : static_cast<QModelIndex>( mRootIndex ) ) : 0;
 }
 
 int SubModel::columnCount( const QModelIndex &parent ) const
 {
-  return mModel->columnCount( parent.isValid() ? mapToSource( parent ) : static_cast<QModelIndex>( mRootIndex ) );
+  return mModel ? mModel->columnCount( parent.isValid() ? mapToSource( parent ) : static_cast<QModelIndex>( mRootIndex ) ) : 0;
 }
 
 QVariant SubModel::data( const QModelIndex &index, int role ) const
 {
-  return mModel->data( mapToSource( index ), role );
+  return mModel ? mModel->data( mapToSource( index ), role ) : QVariant();
 }
 
 bool SubModel::setData( const QModelIndex &index, const QVariant &value, int role )
 {
-  return mModel->setData( mapToSource( index ), value, role );
+  return mModel ? mModel->setData( mapToSource( index ), value, role ) : false;
 }
 
 QHash<int, QByteArray> SubModel::roleNames() const
 {
-  return mModel->roleNames();
+  return mModel ? mModel->roleNames() : QHash<int, QByteArray>();
 }
 
 QModelIndex SubModel::rootIndex() const


### PR DESCRIPTION
This PR implements columns support in QField's feature forms. Here's how it looks:

![image](https://user-images.githubusercontent.com/1728657/198229225-70c1ec86-5ebc-48b3-b207-e7ead5f83a45.png)

As QField is dedicated to be your friendly neighborhood, the implementation takes into account the available horizontal space; if the device offers a screen width that's too narrow, columns will display as it used to be until now. If space is available, the multi column support will kick in:

https://user-images.githubusercontent.com/1728657/198229949-07818cf6-5ebb-4097-8446-067ab1a07487.mp4

I've done a fair amount of testing as this changes a crucial part of QField. Two fundamental changes here:
- departing from a two level list (i.e. tabs + flattened attributes) into a full on tree
- switching from a ListView item to a Flow + Delegate pair of items

Kudos to QML for being awesome :)

Pro tip: the functional works very well when the maximize attribute form setting is turned on.

Fixes #191 , one of the oldest enhancement requests filed for QField :)

_Funded by [Ministère des Forêts, de la Faune et des Parcs du Québec](https://mffp.gouv.qc.ca)._