### PR TITLE
Implement functionality to determine maximum number of items shown in the relation editor widget

### DIFF
--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -13,11 +13,13 @@ EditorWidgetBase {
     id: relationEditor
 
     property int itemHeight: 40
+    property int bottomMargin: 10
     property int maximumVisibleItems: 4
 
     Component.onCompleted: {
       if ( currentLayer && currentLayer.customProperty('QFieldSync/relationship_maximum_visible') !== undefined ) {
-        maximumVisibleItems = JSON.parse(currentLayer.customProperty('QFieldSync/relationship_maximum_visible'))[relationId]
+        var value = JSON.parse(currentLayer.customProperty('QFieldSync/relationship_maximum_visible'))[relationId]
+        maximumVisibleItems = value !== undefined ? value : 4
       } else {
         maximumVisibleItems = 4
       }
@@ -26,7 +28,7 @@ EditorWidgetBase {
     // because no additional addEntry item on readOnly (isEnabled false)
     height: (isEnabled
             ? referencingFeatureListView.height + itemHeight
-            : Math.max( referencingFeatureListView.height, itemHeight)) + 10
+            : Math.max( referencingFeatureListView.height, itemHeight)) + relationEditor.bottomMargin
     enabled: true
 
     ReferencingFeatureListModel {
@@ -50,7 +52,7 @@ EditorWidgetBase {
     Rectangle {
         anchors.top: parent.top
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: 10
+        anchors.bottomMargin: relationEditor.bottomMargin
         width: parent.width
         color: "transparent"
         border.color: 'lightgray'
@@ -62,7 +64,11 @@ EditorWidgetBase {
           id: referencingFeatureListView
           model: relationEditorModel
           width: parent.width
-          height: Math.min( maximumVisibleItems * itemHeight, referencingFeatureListView.count * itemHeight ) + ( referencingFeatureListView.count > maximumVisibleItems ? itemHeight / 2 : 0 )
+          height: maximumVisibleItems > 0
+                  ? Math.min(maximumVisibleItems * itemHeight,
+                             referencingFeatureListView.count * itemHeight)
+                    + (referencingFeatureListView.count > maximumVisibleItems ? itemHeight / 2 : 0)
+                  : referencingFeatureListView.count * itemHeight
           delegate: referencingFeatureDelegate
           focus: true
           clip: true

--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -13,77 +13,89 @@ EditorWidgetBase {
     id: relationEditor
 
     property int itemHeight: 40
+    property int maximumVisibleItems: 4
+
+    Component.onCompleted: {
+      if ( currentLayer && currentLayer.customProperty('QFieldSync/relationship_maximum_visible') !== undefined ) {
+        maximumVisibleItems = JSON.parse(currentLayer.customProperty('QFieldSync/relationship_maximum_visible'))[relationId]
+      } else {
+        maximumVisibleItems = 4
+      }
+    }
 
     // because no additional addEntry item on readOnly (isEnabled false)
-    height: isEnabled
+    height: (isEnabled
             ? referencingFeatureListView.height + itemHeight
-            : Math.max( referencingFeatureListView.height, itemHeight)
+            : Math.max( referencingFeatureListView.height, itemHeight)) + 10
     enabled: true
 
+    ReferencingFeatureListModel {
+      //containing the current (parent) feature, the relation to the children
+      //and the relation from the children to the other parent (if it's nm and cardinality is set)
+      //if cardinality is not set, the nmRelationId is empty
+      id: relationEditorModel
+      currentRelationId: relationId
+      currentNmRelationId: nmRelationId
+      feature: currentFeature
+
+      property int featureFocus: -1
+      onModelUpdated: {
+        if (featureFocus > -1) {
+          referencingFeatureListView.currentIndex = relationEditorModel.getFeatureIdRow(featureFocus)
+          featureFocus = -1
+        }
+      }
+    }
+
     Rectangle {
-        anchors.fill: parent
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: 10
+        width: parent.width
         color: "transparent"
         border.color: 'lightgray'
         border.width: 1
-    }
-
-    ReferencingFeatureListModel {
-        //containing the current (parent) feature, the relation to the children
-        //and the relation from the children to the other parent (if it's nm and cardinality is set)
-        //if cardinality is not set, the nmRelationId is empty
-        id: relationEditorModel
-        currentRelationId: relationId
-        currentNmRelationId: nmRelationId
-        feature: currentFeature
-
-        property int featureFocus: -1
-        onModelUpdated: {
-          if (featureFocus > -1) {
-            referencingFeatureListView.currentIndex = relationEditorModel.getFeatureIdRow(featureFocus)
-            featureFocus = -1
-          }
-        }
-    }
-
-    //the list
-    ListView {
-        id: referencingFeatureListView
-        model: relationEditorModel
-        width: parent.width
-        height: Math.min( 4 * itemHeight, referencingFeatureListView.count * itemHeight ) + ( referencingFeatureListView.count > 4 ? itemHeight / 2 : 0 )
-        delegate: referencingFeatureDelegate
-        focus: true
         clip: true
-        highlightRangeMode: ListView.StrictlyEnforceRange
 
-        ScrollBar.vertical: ScrollBar {
+        //the list
+        ListView {
+          id: referencingFeatureListView
+          model: relationEditorModel
+          width: parent.width
+          height: Math.min( maximumVisibleItems * itemHeight, referencingFeatureListView.count * itemHeight ) + ( referencingFeatureListView.count > maximumVisibleItems ? itemHeight / 2 : 0 )
+          delegate: referencingFeatureDelegate
+          focus: true
+          clip: true
+          highlightRangeMode: ListView.ApplyRange
+
+          ScrollBar.vertical: ScrollBar {
             width: 10
             policy: ScrollBar.AlwaysOn
 
             contentItem: Rectangle {
-                implicitWidth: 10
-                implicitHeight: itemHeight
-                color: Theme.mainColor
+              implicitWidth: 10
+              implicitHeight: itemHeight
+              color: Theme.mainColor
             }
+          }
         }
-    }
 
-    //the add entry "last row"
-    Item {
-      id: addEntry
-      anchors.top: referencingFeatureListView.bottom
-      height: itemHeight
-      width: parent.width
-      visible: isButtonEnabled('AddChildFeature')
+        //the add entry "last row"
+        Item {
+          id: addEntry
+          anchors.bottom: parent.bottom
+          height: itemHeight
+          width: parent.width
+          visible: isButtonEnabled('AddChildFeature')
 
-      focus: true
+          focus: true
 
-      Rectangle{
-          anchors.fill: parent
-          color: 'lightgrey'
-          visible: isEnabled
+          Rectangle {
+            anchors.fill: parent
+            color: 'lightgrey'
+            visible: isEnabled
 
-          Text {
+            Text {
               visible: isEnabled
               color: 'grey'
               text: isEnabled && !constraintsHardValid ? qsTr( 'Ensure contraints') : ''
@@ -91,56 +103,57 @@ EditorWidgetBase {
               font.bold: true
               font.italic: true
               font.pointSize: Theme.tipFont.pointSize
-          }
+            }
 
-          Row
-          {
-            id: addButtonRow
-            anchors { top: parent.top; right: parent.right; rightMargin: 10 }
-            height: parent.height
+            Row
+            {
+              id: addButtonRow
+              anchors { top: parent.top; right: parent.right; rightMargin: 10 }
+              height: parent.height
 
-            ToolButton {
+              ToolButton {
                 id: addButton
                 width: parent.height
                 height: parent.height
                 enabled: constraintsHardValid
 
                 contentItem: Rectangle {
+                  anchors.fill: parent
+                  color: parent.enabled ? nmRelationId ? 'blue' : 'black' : 'grey'
+                  Image {
                     anchors.fill: parent
-                    color: parent.enabled ? nmRelationId ? 'blue' : 'black' : 'grey'
-                    Image {
-                      anchors.fill: parent
-                      anchors.margins: 8
-                      fillMode: Image.PreserveAspectFit
-                      horizontalAlignment: Image.AlignHCenter
-                      verticalAlignment: Image.AlignVCenter
-                      source: Theme.getThemeIcon( 'ic_add_white_24dp' )
-                    }
+                    anchors.margins: 8
+                    fillMode: Image.PreserveAspectFit
+                    horizontalAlignment: Image.AlignHCenter
+                    verticalAlignment: Image.AlignVCenter
+                    source: Theme.getThemeIcon( 'ic_add_white_24dp' )
+                  }
                 }
+              }
             }
-          }
-          MouseArea {
-            anchors.fill: parent
-            onClicked: {
-              if( save() ) {
-                //this has to be checked after buffering because the primary could be a value that has been created on creating featurer (e.g. fid)
-                if( relationEditorModel.parentPrimariesAvailable ) {
+            MouseArea {
+              anchors.fill: parent
+              onClicked: {
+                if( save() ) {
+                  //this has to be checked after buffering because the primary could be a value that has been created on creating featurer (e.g. fid)
+                  if( relationEditorModel.parentPrimariesAvailable ) {
                     displayToast( qsTr( 'Adding child feature in layer %1' ).arg( relationEditorModel.relation.referencingLayer.name ) )
                     if ( relationEditorModel.relation.referencingLayer.geometryType() !== QgsWkbTypes.NullGeometry )
                     {
-                        requestGeometry( relationEditor, relationEditorModel.relation.referencingLayer );
-                        return;
+                      requestGeometry( relationEditor, relationEditorModel.relation.referencingLayer );
+                      return;
                     }
                     showAddFeaturePopup()
-                }
-                else
-                {
+                  }
+                  else
+                  {
                     displayToast (qsTr( 'Cannot add child feature: parent primary keys are not available' ), 'warning' )
+                  }
                 }
               }
             }
           }
-      }
+        }
     }
 
     //list components


### PR DESCRIPTION
This PR is the QField-side implementation of new functionality to allow users to customize the maximum number of items shown in the relation editor widget. For e.g., this is set to a maximum of 7:

![image](https://user-images.githubusercontent.com/1728657/198287684-7501be82-24ae-4d8b-8bb4-4a852ac9889c.png)

The configuration happens on the QGIS side of things through qfieldsync. A new table widget can be found in a vector layer properties dialog's QField section:

![image](https://user-images.githubusercontent.com/1728657/198287916-8d3b19c3-0cf7-4378-a6ba-8f6e000efa7f.png)

This allows for different relationships to have individual max. visible items count (which is quite nice when preparing complex feature forms).

_Funded by [Ministère des Forêts, de la Faune et des Parcs du Québec](https://mffp.gouv.qc.ca)._