### PR TITLE
Fix fullscreen toggle when dragging feature form title, allow for horizontal directions

### DIFF
--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -44,7 +44,7 @@ Rectangle {
 
   property bool multiSelection: false
   property bool fullScreenView: qfieldSettings.fullScreenIdentifyView
-  property bool isVertical: false
+  property bool isVertical: parent.width < parent.height || parent.width < 300
 
   property bool canvasOperationRequested: digitizingToolbar.geometryRequested ||
                                           moveFeaturesToolbar.moveFeaturesRequested
@@ -59,13 +59,12 @@ Rectangle {
   width: {
       if ( props.isVisible || featureForm.canvasOperationRequested )
       {
-          if (qfieldSettings.fullScreenIdentifyView || parent.width < parent.height || parent.width < 300)
+          if (fullScreenView || parent.width < parent.height || parent.width < 300)
           {
               parent.width
           }
           else
           {
-              isVertical = false
               Math.min(Math.max( 200, parent.width / 2.6), parent.width)
           }
       }
@@ -393,17 +392,26 @@ Rectangle {
       featureForm.state = "FeatureList"
     }
 
-    onStatusIndicatorSwiped: {
-      if ( !isVertical )
-        return
-
-      if (direction === 'up') {
-        fullScreenView = true
-      } else if (direction === 'down') {
-        if ( fullScreenView ) {
-          fullScreenView = false
-        } else {
-          featureForm.state = 'Hidden'
+    onStatusIndicatorSwiped: (direction) => {
+      if (isVertical) {
+        if (direction === 'up') {
+          fullScreenView = true
+        } else if (direction === 'down') {
+          if ( fullScreenView ) {
+            fullScreenView = false
+          } else {
+            featureForm.state = 'Hidden'
+          }
+        }
+      } else {
+        if (direction === 'left') {
+          fullScreenView = true
+        } else if (direction === 'right') {
+          if ( fullScreenView ) {
+            fullScreenView = false
+          } else {
+            featureForm.state = 'Hidden'
+          }
         }
       }
     }

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -131,7 +131,9 @@ Rectangle {
         anchors.fill: parent
 
         property real velocity: 0.0
+        property int startX: 0
         property int startY: 0
+        property int lastX: 0
         property int lastY: 0
         property int distance: 0
         property bool isTracing: false
@@ -139,7 +141,9 @@ Rectangle {
         preventStealing: true
 
         onPressed: {
+          startX = mouse.x
           startY = mouse.y
+          lastX = mouse.x
           lastY = mouse.y
           velocity = 0
           distance = 0
@@ -150,6 +154,7 @@ Rectangle {
             return
 
           var currentVelocity = Math.abs(mouse.y - lastY)
+          lastX = mouse.x
           lastY = mouse.y
           velocity = (velocity + currentVelocity) / 2.0
           distance = Math.abs(mouse.y - startY)
@@ -164,6 +169,11 @@ Rectangle {
         }
 
         function getDirection() {
+          var diffX = lastX - startX
+          var diffY = lastY - startY
+          if (Math.abs(diffX) > Math.abs(diffY)) {
+            return lastX < startX ? 'left' : 'right'
+          }
           return lastY < startY ? 'up' : 'down'
         }
       }


### PR DESCRIPTION
This PR fixes #3517 , making fullscreen toggling of feature form via dragging of navigation bar bulletproof. I've also added the possibility to toggle fullscreen by dragging left/right when the feature form is displayed on the right side of the screen (i.e. tablet in landscape mode).

(It's a pretty important fix to maximize benefits of the new feature form's multi-column capability)