### PR TITLE
Hardcode a DPI value of 300 for PDFs as most PDFs fail to register thr proper resolution

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -924,7 +924,13 @@ void QgisMobileapp::readProjectFile()
     // Load raster dataset
     if ( SUPPORTED_RASTER_EXTENSIONS.contains( fileSuffix ) )
     {
-      QgsRasterLayer *layer = new QgsRasterLayer( filePath, mProjectFileName, QLatin1String( "gdal" ) );
+      QString fileUri = filePath;
+      if ( fileSuffix.compare( QLatin1String( "pdf" ) ) == 0 )
+      {
+        // Hardcode a DPI value of 300 for PDFs as most PDFs fail to register their proper resolution
+        fileUri += QStringLiteral( "|option:DPI=300" );
+      }
+      QgsRasterLayer *layer = new QgsRasterLayer( fileUri, mProjectFileName, QLatin1String( "gdal" ) );
       if ( layer->isValid() )
       {
         const QStringList sublayers = layer->dataProvider()->subLayers();


### PR DESCRIPTION
Most PDFs are handled by default by gdal as having a DPI of 96 even when the real value is much higher. Since we've added gdal driver options support in QGIS' gdal provider a few versions ago, we can go ahead and hardcode a DPI value of 300. This will insure nice high-res GeoPDFs will render beautifully. If a PDF has a DPI of 96, it changes absolutely nothing.

A GeoPDF without this fix:
![Screenshot from 2022-10-28 21-44-04](https://user-images.githubusercontent.com/1728657/198654626-ee408a74-1d32-43b2-88f1-bb0499183aca.png)

Exact same GeoPDF with this fix in:
![Screenshot from 2022-10-28 21-43-02](https://user-images.githubusercontent.com/1728657/198654725-07447e32-c6e9-483c-82ae-ed151a901ffc.png)
