### PR TITLE
Implement NULL state for checkbox editor widget

### DIFF
--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -26,10 +26,18 @@ EditorWidgetBase {
 
       topPadding: 10
       bottomPadding: 10
-      font: Theme.defaultFont
-      color: isEnabled ? 'black' : 'gray'
+      font.pointSize: Theme.defaultFont.pointSize
+      font.bold: Theme.defaultFont.bold
+      font.italic: checkBox.isNull
+      color: isEnabled && !checkBox.isNull ? 'black' : 'gray'
 
-      text: checkBox.checked ? checkedLabel : uncheckedLabel
+      text: !checkBox.isNull
+            ? checkBox.checked
+              ? checkedLabel
+              : uncheckedLabel
+            : isEnabled
+              ? qsTr('NULL')
+              : ''
 
       MouseArea {
           id: checkArea
@@ -57,17 +65,20 @@ EditorWidgetBase {
 
     //if the field type is boolean, ignore the configured 'CheckedState' and 'UncheckedState' values and work with true/false always
     readonly property bool isBool: field.type == 1 //needs type coercion
+    property bool isNull: value == undefined
 
     checked: {
         if( isBool ) {
-            return value !== undefined ? value : false;
+            return !isNull ? value : false;
         } else {
             return String(value) === config['CheckedState']
         }
     }
 
     onCheckedChanged: {
-        valueChangeRequested( isBool ? checked : checked ? config['CheckedState'] : config['UncheckedState'], false )
+        valueChangeRequested( isBool
+                             ? checked
+                             : checked ? config['CheckedState'] : config['UncheckedState'], false )
         forceActiveFocus()
     }
   }

--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -71,11 +71,11 @@ EditorWidgetBase {
         if( isBool ) {
             return !isNull ? value : false;
         } else {
-            return String(value) === config['CheckedState']
+            return !isNull ? String(value) === config['CheckedState'] : false;
         }
     }
 
-    onCheckedChanged: {
+    onClicked: {
         valueChangeRequested( isBool
                              ? checked
                              : checked ? config['CheckedState'] : config['UncheckedState'], false )


### PR DESCRIPTION
Up to now, QField's checkbox editor widget would look exactly then same when displaying a NULL value vs. a FALSE value. That's not great, looked especially odd when a non null constraint was on and QField would display "value can't be not null, current value: false" :)

This is how the widget looks now when the value being edited is NULL:
![image](https://user-images.githubusercontent.com/1728657/198812945-2b0fbf2c-262b-4a0d-a661-b477bc4175ab.png)
