### PR TITLE
Improve root directory labels in the local data file picker

### DIFF
--- a/src/core/localfilesmodel.cpp
+++ b/src/core/localfilesmodel.cpp
@@ -202,7 +202,7 @@ void LocalFilesModel::reloadModel()
       QFileInfo fi( item );
       if ( fi.exists() )
       {
-        mItems << Item( ItemMetaType::Folder, ItemType::SimpleFolder, fi.fileName(), QString(), fi.absoluteFilePath() );
+        mItems << Item( ItemMetaType::Folder, ItemType::SimpleFolder, fi.absoluteFilePath(), QString(), fi.absoluteFilePath() );
       }
     }
 


### PR DESCRIPTION
@3nids , small improvement to show root directories using "/storage/emulated/0" instead of "0" in the all access APKs.