### PR TITLE
Avoid using range's min/max when increasing/decreasing from null value

### DIFF
--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -153,7 +153,7 @@ EditorWidgetBase {
           newValue = currentValue - rangeItem.step;
           valueChangeRequested(Math.max(rangeItem.min, newValue), false)
       } else {
-          newValue = Number.isFinite(rangeItem.min) ? rangeItem.min : 0;
+          newValue = 0;
           valueChangeRequested(newValue, false)
       }
   }
@@ -165,7 +165,7 @@ EditorWidgetBase {
           newValue = currentValue + rangeItem.step;
           valueChangeRequested(Math.min(rangeItem.max, newValue ), false)
       } else {
-          newValue = Number.isFinite(rangeItem.max) ? rangeItem.max : 0;
+          newValue = 0;
           valueChangeRequested(newValue, false)
       }
   }


### PR DESCRIPTION
This fixes https://github.com/opengisch/QField/issues/3446 -- long story short, I had first implemented the range editor widget's increase / decrease button such that when it was trying to add/remove from a null value, it'd use the editor configuration's minimum / maximum value.

That behavior ultimately turns out not to be so great in most scenarios (esp. when QGIS by default will set min/max values to the theoretical minimum and maximum value for an int. 

Instead, when pressing those buttons and the current value is null, it'll set the value to 0.