### PR TITLE
Respect system font size on windows, linux, and macos

### DIFF
--- a/src/core/platforms/android/androidplatformutilities.h
+++ b/src/core/platforms/android/androidplatformutilities.h
@@ -67,6 +67,8 @@ class AndroidPlatformUtilities : public PlatformUtilities
 
     QVariantMap sceneMargins( QQuickWindow *window ) const override;
 
+    double systemFontPointSize() const override { return 16.0; }
+
   private:
     bool checkAndAcquirePermissions( const QString &permissionString ) const;
     QString getIntentExtra( const QString &, QAndroidJniObject = nullptr ) const;

--- a/src/core/platforms/ios/iosplatformutilities.h
+++ b/src/core/platforms/ios/iosplatformutilities.h
@@ -41,6 +41,8 @@ class IosPlatformUtilities : public PlatformUtilities
     virtual PictureSource *getCameraPicture( QQuickItem *parent, const QString &prefix, const QString &pictureFilePath, const QString &suffix ) override;
     virtual PictureSource *getGalleryPicture( QQuickItem *parent, const QString &prefix, const QString &pictureFilePath ) override;
     virtual ProjectSource *openProject( QObject *parent = nullptr ) override;
+
+    double systemFontPointSize() const override { return 16.0; }
 };
 
 #endif

--- a/src/core/platforms/platformutilities.cpp
+++ b/src/core/platforms/platformutilities.cpp
@@ -321,6 +321,11 @@ QVariantMap PlatformUtilities::sceneMargins( QQuickWindow *window ) const
   return margins;
 }
 
+double PlatformUtilities::systemFontPointSize() const
+{
+  return QApplication::font().pointSizeF() + 2.0;
+}
+
 PlatformUtilities *PlatformUtilities::instance()
 {
   return sPlatformUtils;

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -224,6 +224,8 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
      */
     Q_INVOKABLE virtual QVariantMap sceneMargins( QQuickWindow *window ) const;
 
+    Q_INVOKABLE virtual double systemFontPointSize() const;
+
     static PlatformUtilities *instance();
 
   private:

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -525,6 +525,7 @@ void QgisMobileapp::initDeclarative()
 
   // Register some globally available variables
   rootContext()->setContextProperty( "ppi", dpi );
+  rootContext()->setContextProperty( "systemFontPointSize", PlatformUtilities::instance()->systemFontPointSize() );
   rootContext()->setContextProperty( "mouseDoubleClickInterval", QApplication::styleHints()->mouseDoubleClickInterval() );
   rootContext()->setContextProperty( "qgisProject", mProject );
   rootContext()->setContextProperty( "bookmarkModel", mBookmarkModel.get() );

--- a/src/qml/imports/Theme/Theme.qml
+++ b/src/qml/imports/Theme/Theme.qml
@@ -39,14 +39,14 @@ QtObject {
     readonly property color accentColor: '#4CAF50'
     readonly property color accentLightColor: '#C8E6C9'
 
-    property font defaultFont: Qt.font({pointSize: 16, weight: Font.Normal})
-    property font tinyFont: Qt.font({pointSize: 12, weight: Font.Normal})
-    property font tipFont: Qt.font({pointSize: 14, weight: Font.Normal})
-    property font resultFont: Qt.font({pointSize: 13, weight: Font.Normal})
-    property font strongFont: Qt.font({pointSize: defaultFont.pointSize, bold: true, weight: Font.Bold})
-    property font strongTipFont: Qt.font({pointSize: tipFont.pointSize, bold: true, weight: Font.Bold})
-    property font secondaryTitleFont: Qt.font({pointSize: 18, weight: Font.Normal})
-    property font titleFont: Qt.font({pointSize: 20, weight: Font.Normal})
+    property font defaultFont: Qt.font({pointSize: systemFontPointSize, weight: Font.Normal})
+    property font tinyFont: Qt.font({pointSize: systemFontPointSize * 0.75, weight: Font.Normal})
+    property font tipFont: Qt.font({pointSize: systemFontPointSize * 0.875, weight: Font.Normal})
+    property font resultFont: Qt.font({pointSize: systemFontPointSize * 0.8125, weight: Font.Normal})
+    property font strongFont: Qt.font({pointSize: systemFontPointSize, bold: true, weight: Font.Bold})
+    property font strongTipFont: Qt.font({pointSize: systemFontPointSize * 0.875, bold: true, weight: Font.Bold})
+    property font secondaryTitleFont: Qt.font({pointSize: systemFontPointSize * 1.125, weight: Font.Normal})
+    property font titleFont: Qt.font({pointSize: systemFontPointSize * 1.25, weight: Font.Normal})
 
     readonly property int popupScreenEdgeMargin: 40
 


### PR DESCRIPTION
This implements a solution for #3289, whereas QField now sizes its fonts based on the default system font size (on windows, linux, and macos).