### PR TITLE
Fix freeze when quitting QField while the bees demo feature form is open

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -149,6 +149,8 @@ void AttributeFormModelBase::resetModel()
 {
   clear();
 
+  beginResetModel();
+
   mVisibilityExpressions.clear();
   mConstraints.clear();
 
@@ -171,10 +173,10 @@ void AttributeFormModelBase::resetModel()
       mTemporaryContainer.reset( root );
     }
 
-    setHasTabs( !root->children().isEmpty() && QgsAttributeEditorElement::AeTypeContainer == root->children().first()->type() );
+    const bool hasTabs = !root->children().isEmpty() && QgsAttributeEditorElement::AeTypeContainer == root->children().first()->type();
 
     invisibleRootItem()->setColumnCount( 1 );
-    if ( mHasTabs )
+    if ( hasTabs )
     {
       const QList<QgsAttributeEditorElement *> children { root->children() };
       int currentTab = 0;
@@ -211,7 +213,10 @@ void AttributeFormModelBase::resetModel()
     }
 
     mExpressionContext = mLayer->createExpressionContext();
+    setHasTabs( hasTabs );
   }
+
+  endResetModel();
 }
 
 void AttributeFormModelBase::applyFeatureModel()

--- a/src/core/submodel.cpp
+++ b/src/core/submodel.cpp
@@ -22,7 +22,7 @@ SubModel::SubModel( QObject *parent )
 
 QModelIndex SubModel::index( int row, int column, const QModelIndex &parent ) const
 {
-  if ( !mModel )
+  if ( !mEnabled || !mModel )
     return QModelIndex();
 
   QModelIndex sourceIndex = mModel->index( row, column, parent.isValid() ? mapToSource( parent ) : static_cast<QModelIndex>( mRootIndex ) );
@@ -31,7 +31,7 @@ QModelIndex SubModel::index( int row, int column, const QModelIndex &parent ) co
 
 QModelIndex SubModel::parent( const QModelIndex &child ) const
 {
-  if ( !mModel )
+  if ( !mEnabled || !mModel )
     return QModelIndex();
 
   QModelIndex idx = mModel->parent( child );
@@ -43,27 +43,27 @@ QModelIndex SubModel::parent( const QModelIndex &child ) const
 
 int SubModel::rowCount( const QModelIndex &parent ) const
 {
-  return mModel ? mModel->rowCount( parent.isValid() ? mapToSource( parent ) : static_cast<QModelIndex>( mRootIndex ) ) : 0;
+  return mEnabled && mModel ? mModel->rowCount( parent.isValid() ? mapToSource( parent ) : static_cast<QModelIndex>( mRootIndex ) ) : 0;
 }
 
 int SubModel::columnCount( const QModelIndex &parent ) const
 {
-  return mModel ? mModel->columnCount( parent.isValid() ? mapToSource( parent ) : static_cast<QModelIndex>( mRootIndex ) ) : 0;
+  return mEnabled && mModel ? mModel->columnCount( parent.isValid() ? mapToSource( parent ) : static_cast<QModelIndex>( mRootIndex ) ) : 0;
 }
 
 QVariant SubModel::data( const QModelIndex &index, int role ) const
 {
-  return mModel ? mModel->data( mapToSource( index ), role ) : QVariant();
+  return mEnabled && mModel ? mModel->data( mapToSource( index ), role ) : QVariant();
 }
 
 bool SubModel::setData( const QModelIndex &index, const QVariant &value, int role )
 {
-  return mModel ? mModel->setData( mapToSource( index ), value, role ) : false;
+  return mEnabled && mModel ? mModel->setData( mapToSource( index ), value, role ) : false;
 }
 
 QHash<int, QByteArray> SubModel::roleNames() const
 {
-  return mModel ? mModel->roleNames() : QHash<int, QByteArray>();
+  return mEnabled && mModel ? mModel->roleNames() : QHash<int, QByteArray>();
 }
 
 QModelIndex SubModel::rootIndex() const
@@ -73,10 +73,14 @@ QModelIndex SubModel::rootIndex() const
 
 void SubModel::setRootIndex( const QModelIndex &rootIndex )
 {
+  if ( rootIndex == mRootIndex )
+    return;
+
   beginResetModel();
   mRootIndex = rootIndex;
   mMappings.clear();
   endResetModel();
+
   emit rootIndexChanged();
 }
 
@@ -98,12 +102,28 @@ void SubModel::setModel( QAbstractItemModel *model )
 
   mModel = model;
   mMappings.clear();
+
+  emit modelChanged();
+}
+
+void SubModel::setEnabled( bool enabled )
+{
+  if ( enabled == mEnabled )
+    return;
+
+  mEnabled = enabled;
+
+  beginResetModel();
+  mMappings.clear();
+  endResetModel();
+
+  emit modelChanged();
 }
 
 void SubModel::onRowsInserted( const QModelIndex &parent, int first, int last )
 {
   Q_UNUSED( last )
-  if ( isInSubModel( mModel->index( first, 0, parent ) ) )
+  if ( mEnabled && isInSubModel( mModel->index( first, 0, parent ) ) )
   {
     emit beginInsertRows( mapFromSource( parent ), first, last );
     emit endInsertRows();
@@ -113,7 +133,7 @@ void SubModel::onRowsInserted( const QModelIndex &parent, int first, int last )
 void SubModel::onRowsAboutToBeRemoved( const QModelIndex &parent, int first, int last )
 {
   Q_UNUSED( last )
-  if ( isInSubModel( mModel->index( first, 0, parent ) ) )
+  if ( mEnabled && isInSubModel( mModel->index( first, 0, parent ) ) )
   {
     emit beginRemoveRows( mapFromSource( parent ), first, last );
     emit endRemoveRows();
@@ -127,7 +147,7 @@ void SubModel::onModelAboutToBeReset()
 
 void SubModel::onDataChanged( const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles )
 {
-  if ( isInSubModel( topLeft ) )
+  if ( mEnabled && isInSubModel( topLeft ) )
     emit dataChanged( mapFromSource( topLeft ), mapFromSource( bottomRight ), roles );
 }
 
@@ -155,7 +175,7 @@ bool SubModel::isInSubModel( const QModelIndex &sourceIndex ) const
 
 QModelIndex SubModel::mapFromSource( const QModelIndex &sourceIndex ) const
 {
-  if ( !isInSubModel( sourceIndex ) )
+  if ( !mEnabled || !isInSubModel( sourceIndex ) )
     return QModelIndex();
 
   if ( !mMappings.contains( sourceIndex.internalId() ) )
@@ -168,6 +188,9 @@ QModelIndex SubModel::mapFromSource( const QModelIndex &sourceIndex ) const
 
 QModelIndex SubModel::mapToSource( const QModelIndex &index ) const
 {
+  if ( !mEnabled || !mModel )
+    return QModelIndex();
+
   if ( !index.isValid() )
     return mRootIndex;
 

--- a/src/core/submodel.cpp
+++ b/src/core/submodel.cpp
@@ -70,7 +70,7 @@ QModelIndex SubModel::rootIndex() const
 {
   return mRootIndex;
 }
-
+#include <QDebug>
 void SubModel::setRootIndex( const QModelIndex &rootIndex )
 {
   if ( rootIndex == mRootIndex )

--- a/src/core/submodel.h
+++ b/src/core/submodel.h
@@ -22,6 +22,7 @@ class SubModel : public QAbstractItemModel
 {
     Q_OBJECT
 
+    Q_PROPERTY( bool enabled READ enabled WRITE setEnabled NOTIFY modelChanged )
     Q_PROPERTY( QAbstractItemModel *model READ model WRITE setModel NOTIFY modelChanged )
     Q_PROPERTY( QModelIndex rootIndex READ rootIndex WRITE setRootIndex NOTIFY rootIndexChanged )
 
@@ -41,10 +42,14 @@ class SubModel : public QAbstractItemModel
     QAbstractItemModel *model() const;
     void setModel( QAbstractItemModel *model );
 
+    bool enabled() const { return mEnabled; }
+    void setEnabled( bool enabled );
+
     bool isInSubModel( const QModelIndex &sourceIndex ) const;
 
   signals:
     void modelChanged();
+    void enabledChanged();
     void rootIndexChanged();
 
   private slots:
@@ -54,6 +59,7 @@ class SubModel : public QAbstractItemModel
     void onDataChanged( const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles = QVector<int>() );
 
   private:
+    bool mEnabled = true;
     QModelIndex mapFromSource( const QModelIndex &sourceIndex ) const;
     QModelIndex mapToSource( const QModelIndex &index ) const;
 

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -240,7 +240,7 @@ Page {
     id: fieldItem
 
     Item {
-        width: parent.width / ColumnCount > 200 ? parent.width / ColumnCount : parent.width
+        width: parent ? parent.width / ColumnCount > 200 ? parent.width / ColumnCount : parent.width : undefined
         height: childrenRect.height
 
         // Configured color of the container

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -240,7 +240,11 @@ Page {
     id: fieldItem
 
     Item {
-        width: parent ? parent.width / ColumnCount > 200 ? parent.width / ColumnCount : parent.width : undefined
+        width: parent
+          ? parent.width / ColumnCount > 200
+            ? parent.width / ColumnCount
+            : parent.width
+          : undefined
         height: childrenRect.height
 
         // Configured color of the container

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -266,7 +266,7 @@ Page {
             width: parent.width
             font.pointSize: 12
             font.bold: true
-            text: GroupName
+            text: GroupName || ''
             wrapMode: Text.WordWrap
           }
         }
@@ -281,7 +281,7 @@ Page {
 
           Item {
             id: innerContainer
-            visible: Type == 'container'
+            visible: GroupIndex != undefined && Type === 'container'
             height: visible ? innerContainerContent.childrenRect.height : 0
             anchors {
               left: parent.left
@@ -297,9 +297,10 @@ Page {
               }
 
               Repeater {
-                model:  SubModel {
-                  model: innerContainer.visible ? form.model : null
-                  rootIndex: innerContainer.visible ? form.model.mapFromSource(GroupIndex) : GroupIndex
+                model: SubModel {
+                  enabled: GroupIndex != undefined && Type === 'container'
+                  model: form.model
+                  rootIndex: GroupIndex != undefined ? form.model.mapFromSource(GroupIndex) : form.model.index(-1, 0)
                 }
                 delegate: fieldItem
               }


### PR DESCRIPTION
PR involves adding an enabled/disabled state to our SubModel class, and insure that we never end up handling root tabs as group containers when QField unloads itself (and somehow the feature form model ends up in a state where tabs become items of the form, which is bad).

Did quite a few of tests today in preparation to QField 2.5, that's the only regression from the work done last week I spotted :partying_face: 

Edit: root cause of the issue found (fixed in the 3rd commit). The other changes are good changes in any case.