### PR TITLE
Update project coordinate display CRS to rely on QGIS 3.28 niceties

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -154,10 +154,11 @@
 #include <qgsproject.h>
 #include <qgsprojectstorage.h>
 #include <qgsprojectstorageregistry.h>
-#if _QGIS_VERSION_INT >= 32500
 #include <qgsprojectstylesettings.h>
-#endif
 #include <qgsprojectviewsettings.h>
+#if _QGIS_VERSION_INT >= 32700
+#include <qgsprojectdisplaysettings.h>
+#endif
 #include <qgsrasterlayer.h>
 #include <qgsrasterresamplefilter.h>
 #include <qgsrelationmanager.h>
@@ -378,9 +379,7 @@ void QgisMobileapp::initDeclarative()
   qRegisterMetaType<QgsUnitTypes::DistanceUnit>( "QgsUnitTypes::DistanceUnit" );
   qRegisterMetaType<QgsUnitTypes::AreaUnit>( "QgsUnitTypes::AreaUnit" );
   qRegisterMetaType<QgsRelation>( "QgsRelation" );
-#if _QGIS_VERSION_INT >= 31900
   qRegisterMetaType<QgsPolymorphicRelation>( "QgsPolymorphicRelation" );
-#endif
   qRegisterMetaType<PlatformUtilities::Capabilities>( "PlatformUtilities::Capabilities" );
   qRegisterMetaType<QgsField>( "QgsField" );
   qRegisterMetaType<QVariant::Type>( "QVariant::Type" );
@@ -394,6 +393,9 @@ void QgisMobileapp::initDeclarative()
   qRegisterMetaType<QFieldCloudProjectsModel::ProjectModification>( "QFieldCloudProjectsModel::ProjectModification" );
 
   qmlRegisterUncreatableType<QgsProject>( "org.qgis", 1, 0, "Project", "" );
+#if _QGIS_VERSION_INT >= 32700
+  qmlRegisterUncreatableType<QgsProjectDisplaySettings>( "org.qgis", 1, 0, "ProjectDisplaySettings", "" );
+#endif
   qmlRegisterUncreatableType<QgsCoordinateReferenceSystem>( "org.qgis", 1, 0, "CoordinateReferenceSystem", "" );
   qmlRegisterUncreatableType<QgsUnitTypes>( "org.qgis", 1, 0, "QgsUnitTypes", "" );
   qmlRegisterUncreatableType<QgsRelationManager>( "org.qgis", 1, 0, "RelationManager", "The relation manager is available from the QgsProject. Try `qgisProject.relationManager`" );

--- a/src/core/utils/geometryutils.cpp
+++ b/src/core/utils/geometryutils.cpp
@@ -162,3 +162,26 @@ QgsPoint GeometryUtils::reprojectPointToWgs84( const QgsPoint &point, const QgsC
                    point.is3D() ? point.z() : std::numeric_limits<double>::quiet_NaN(),
                    point.isMeasure() ? point.m() : std::numeric_limits<double>::quiet_NaN() );
 }
+
+QgsPoint GeometryUtils::reprojectPoint( const QgsPoint &point, const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs )
+{
+  if ( sourceCrs == destinationCrs )
+    return point;
+
+  const QgsCoordinateTransform ct( sourceCrs, destinationCrs, QgsProject::instance() );
+  QgsPointXY reprojectedPoint;
+  try
+  {
+    ct.transform( point.x(), point.y() );
+    reprojectedPoint = ct.transform( point );
+  }
+  catch ( QgsCsException & )
+  {
+    return QgsPoint();
+  }
+
+  return QgsPoint( reprojectedPoint.x(),
+                   reprojectedPoint.y(),
+                   point.is3D() ? point.z() : std::numeric_limits<double>::quiet_NaN(),
+                   point.isMeasure() ? point.m() : std::numeric_limits<double>::quiet_NaN() );
+}

--- a/src/core/utils/geometryutils.h
+++ b/src/core/utils/geometryutils.h
@@ -82,6 +82,9 @@ class QFIELD_CORE_EXPORT GeometryUtils : public QObject
     //! Returns a reprojected \a point from the stated \a crs to WGS84.
     static Q_INVOKABLE QgsPoint reprojectPointToWgs84( const QgsPoint &point, const QgsCoordinateReferenceSystem &crs );
 
+    //! Returns a reprojected \a point from the stated \a sourceCrs to a \a destinationCrs
+    static Q_INVOKABLE QgsPoint reprojectPoint( const QgsPoint &point, const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs );
+
     //! Returns an empty (i.e. null) point
     static Q_INVOKABLE QgsPoint emptyPoint() { return QgsPoint(); }
 };

--- a/src/qml/NavigationInformationView.qml
+++ b/src/qml/NavigationInformationView.qml
@@ -9,15 +9,12 @@ import Theme 1.0
 Rectangle {
   id: navigationInformationView
 
-  property var coordinates: projectInfo.reprojectDisplayCoordinatesToWGS84
-                            ? GeometryUtils.reprojectPointToWgs84(navigation.destination, navigation.mapSettings.destinationCrs)
-                            : navigation.destination
-  property bool coordinatesIsXY: !projectInfo.reprojectDisplayCoordinatesToWGS84
-                                 && CoordinateReferenceSystemUtils.defaultCoordinateOrderForCrsIsXY(navigation.mapSettings.destinationCrs)
-  property bool coordinatesIsGeographic: projectInfo.reprojectDisplayCoordinatesToWGS84
-                                         || navigation.mapSettings.destinationCrs.isGeographic
-
   property Navigation navigation
+
+  property var coordinates: GeometryUtils.reprojectPoint(navigation.destination, navigation.mapSettings.destinationCrs, projectInfo.coordinateDisplayCrs)
+  property bool coordinatesIsXY: CoordinateReferenceSystemUtils.defaultCoordinateOrderForCrsIsXY(projectInfo.coordinateDisplayCrs)
+  property bool coordinatesIsGeographic: projectInfo.coordinateDisplayCrs.isGeographic
+
   property int ceilsCount: 4
   property double rowHeight: 30
   property color backgroundColor: "white"

--- a/src/qml/PositioningInformationView.qml
+++ b/src/qml/PositioningInformationView.qml
@@ -10,13 +10,9 @@ Rectangle {
   id: positioningInformationView
 
   property Positioning positionSource
-  property var coordinates: projectInfo.reprojectDisplayCoordinatesToWGS84
-                                    ? positionSource.sourcePosition
-                                    : positionSource.projectedPosition
-  property bool coordinatesIsXY: !projectInfo.reprojectDisplayCoordinatesToWGS84
-                                && CoordinateReferenceSystemUtils.defaultCoordinateOrderForCrsIsXY(mapCanvas.mapSettings.destinationCrs)
-  property bool coordinatesIsGeographic: projectInfo.reprojectDisplayCoordinatesToWGS84
-                                        || positionSource.destinationCrs.isGeographic
+  property var coordinates: GeometryUtils.reprojectPoint(positionSource.sourcePosition, CoordinateReferenceSystemUtils.wgs84Crs(), projectInfo.coordinateDisplayCrs)
+  property bool coordinatesIsXY: CoordinateReferenceSystemUtils.defaultCoordinateOrderForCrsIsXY(projectInfo.coordinateDisplayCrs)
+  property bool coordinatesIsGeographic: projectInfo.coordinateDisplayCrs.isGeographic
 
   property double antennaHeight: NaN
   property double rowHeight: 30


### PR DESCRIPTION
Without this, QField won't respect coordinate display settings when opening a project saved under QGIS >= 3.28. 

Long story short, before QGIS 3.28, the handling of coordinate display CRS was a mess, and it's now powerful. :)