### PR TITLE
When loading a project that has a flat terrain, auto setup an online elevation layer

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -158,6 +158,8 @@
 #include <qgsprojectviewsettings.h>
 #if _QGIS_VERSION_INT >= 32700
 #include <qgsprojectdisplaysettings.h>
+#include <qgsprojectelevationproperties.h>
+#include <qgsterrainprovider.h>
 #endif
 #include <qgsrasterlayer.h>
 #include <qgsrasterresamplefilter.h>
@@ -1128,6 +1130,17 @@ void QgisMobileapp::readProjectFile()
       }
     }
   }
+
+#if _QGIS_VERSION_INT >= 32700
+  if ( mProject->elevationProperties()->terrainProvider()->type() == QStringLiteral( "flat" ) )
+  {
+    QgsRasterLayer *elevationLayer = LayerUtils::createOnlineElevationLayer();
+    mProject->addMapLayer( elevationLayer, false, true );
+    QgsRasterDemTerrainProvider *terrainProvider = new QgsRasterDemTerrainProvider();
+    terrainProvider->setLayer( elevationLayer );
+    mProject->elevationProperties()->setTerrainProvider( terrainProvider );
+  }
+#endif
 
   loadProjectQuirks();
 

--- a/src/core/utils/layerutils.cpp
+++ b/src/core/utils/layerutils.cpp
@@ -30,6 +30,7 @@
 #include <qgspallabeling.h>
 #include <qgsprintlayout.h>
 #include <qgsproject.h>
+#include <qgsrasterlayer.h>
 #include <qgssinglesymbolrenderer.h>
 #include <qgssymbol.h>
 #include <qgssymbollayer.h>
@@ -38,6 +39,10 @@
 #include <qgsvectorlayerlabeling.h>
 #include <qgsvectorlayerutils.h>
 #include <qgswkbtypes.h>
+#if _QGIS_VERSION_INT >= 32700
+#include <qgsmaplayerelevationproperties.h>
+#include <qgsrasterlayerelevationproperties.h>
+#endif
 
 LayerUtils::LayerUtils( QObject *parent )
   : QObject( parent )
@@ -167,6 +172,19 @@ QgsAbstractVectorLayerLabeling *LayerUtils::defaultLabeling( QgsVectorLayer *lay
   labeling = new QgsVectorLayerSimpleLabeling( settings );
 
   return labeling;
+}
+
+QgsRasterLayer *LayerUtils::createOnlineElevationLayer()
+{
+  QgsRasterLayer *layer = new QgsRasterLayer( QStringLiteral( "interpretation=terrariumterrain&type=xyz&url=https://s3.amazonaws.com/elevation-tiles-prod/terrarium/%7Bz%7D/%7Bx%7D/%7By%7D.png&zmax=15&zmin=0" ),
+                                              QStringLiteral( "elevation" ), QStringLiteral( "wms" ) );
+#if _QGIS_VERSION_INT >= 32700
+  QgsRasterLayerElevationProperties *elevationProperties = static_cast<QgsRasterLayerElevationProperties *>( layer->elevationProperties() );
+  elevationProperties->setEnabled( true );
+  elevationProperties->setProfileSymbology( Qgis::ProfileSurfaceSymbology::FillBelow );
+  elevationProperties->profileFillSymbol()->setColor( QColor( 130, 130, 130 ) );
+#endif
+  return layer;
 }
 
 bool LayerUtils::isAtlasCoverageLayer( QgsVectorLayer *layer )

--- a/src/core/utils/layerutils.h
+++ b/src/core/utils/layerutils.h
@@ -23,6 +23,7 @@
 #include <qgsvectorlayer.h>
 
 class QgsVectorLayer;
+class QgsRasterLayer;
 class QgsSymbol;
 
 class LayerUtils : public QObject
@@ -39,6 +40,8 @@ class LayerUtils : public QObject
     static QgsSymbol *defaultSymbol( QgsVectorLayer *layer );
 
     static QgsAbstractVectorLayerLabeling *defaultLabeling( QgsVectorLayer *layer, QgsTextFormat textFormat = QgsTextFormat() );
+
+    static QgsRasterLayer *createOnlineElevationLayer();
 
     /**
     * Returns TRUE if the vector layer is used as an atlas coverage layer in


### PR DESCRIPTION
This PR unlocks elevation profiling on _all projects_ by default by automatically setting up an online elevation layer for projects having a 'flat' terrain (i.e., no DEM / mesh setup).

This means that users can do elevation profiling with preexisting projects without a need to change anything, or against individual datasets being opened in QField. 

Bringing elevation profiling to the masses! :)

To work properly, it requires the following QGIS fixes (https://github.com/qgis/QGIS/pull/50795 and https://github.com/qgis/QGIS/pull/50778), which will be taken care of in a different PR.