### PR TITLE
Improve QField's use of feature form group color

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -300,8 +300,10 @@ Page {
 
           Item {
             id: innerContainer
-            visible: GroupIndex != undefined && Type === 'container'
-            height: visible ? innerContainerContent.childrenRect.height : 0
+
+            property bool isVisible: GroupIndex != undefined && Type === 'container'
+            visible: isVisible
+            height: isVisible ? innerContainerContent.childrenRect.height : 0
             anchors {
               left: parent.left
               right: parent.right
@@ -327,11 +329,13 @@ Page {
           }
 
           Item {
+            id: qmlContainer
+
+            property bool isVisible: Type == 'qml' && form.model.featureModel.modelMode != FeatureModel.MultiFeatureModel
             property string qmlCode: EditorWidgetCode !== undefined ? EditorWidgetCode : ''
 
-            id: qmlContainer
-            visible: Type == 'qml' && form.model.featureModel.modelMode != FeatureModel.MultiFeatureModel
-            height: visible ? childrenRect.height : 0
+            visible: isVisible
+            height: isVisible ? childrenRect.height : 0
             anchors {
               left: parent.left
               right: parent.right
@@ -367,11 +371,13 @@ Page {
           }
 
           Item {
+            id: htmlContainer
+
+            property bool isVisible: Type == 'html' && form.model.featureModel.modelMode != FeatureModel.MultiFeatureModel
             property string htmlCode: EditorWidgetCode !== undefined ? EditorWidgetCode : ''
 
-            id: htmlContainer
-            visible: Type == 'html' && form.model.featureModel.modelMode != FeatureModel.MultiFeatureModel
-            height: visible ? childrenRect.height : 0
+            visible: isVisible
+            height: isVisible ? childrenRect.height : 0
             anchors {
               left: parent.left
               right: parent.right
@@ -412,8 +418,11 @@ Page {
 
           Item {
             id: fieldContainer
-            visible: Type === 'field' || Type === 'relation'
-            height: visible ? childrenRect.height : 0
+
+            property bool isVisible: Type === 'field' || Type === 'relation'
+
+            visible: isVisible
+            height: isVisible ? childrenRect.height : 0
             anchors {
               left: parent.left
               right: parent.right

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -254,12 +254,12 @@ Page {
           : undefined
         height: childrenRect.height
 
-        // Configured color of the container
         Rectangle {
-            color: GroupColor ? GroupColor : "transparent"
-            width: 8
-            height: parent.height
-            anchors.left: parent.left
+          id: fieldGroupBackground
+
+          anchors.fill: parent
+          visible: GroupColor ? true : false
+          color: GroupColor ? Qt.hsla(GroupColor.hslHue, GroupColor.hslSaturation, GroupColor.hslLightness, 0.05) : "transparent"
         }
 
         Rectangle {
@@ -267,7 +267,7 @@ Page {
 
           width: parent.width
           height: GroupName !== '' ? childrenRect.height : 0
-          color: Theme.lightestGray
+          color: GroupColor ? Qt.hsla(GroupColor.hslHue, GroupColor.hslSaturation, GroupColor.hslLightness, 0.5) : Theme.lightestGray
 
           Text {
             leftPadding: 10
@@ -280,6 +280,14 @@ Page {
             text: GroupName || ''
             wrapMode: Text.WordWrap
           }
+        }
+
+        Rectangle {
+          width: 5
+          height: fieldGroupTitle.height
+          anchors.top: parent.top
+          anchors.left: parent.left
+          color: GroupColor ? GroupColor : "transparent"
         }
 
         Item {

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -522,7 +522,7 @@ Item {
             Layout.preferredWidth: enabled ? 48 : 0
             Layout.preferredHeight: 48
 
-            bgcolor: "white"
+            bgcolor: "transparent"
             iconSource: Theme.getThemeIcon("ic_baseline_search_black")
 
             visible: enabled

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -266,7 +266,7 @@ EditorWidgetBase {
     anchors.right: galleryButton.left
     anchors.top: parent.top
 
-    bgcolor: "white"
+    bgcolor: "transparent"
     visible: isImage && isEnabled && isCameraAvailable
 
     onClicked: {
@@ -291,7 +291,7 @@ EditorWidgetBase {
     anchors.right: parent.right
     anchors.top: parent.top
 
-    bgcolor: "white"
+    bgcolor: "transparent"
     visible: isImage && isEnabled
 
     onClicked: {

--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -71,7 +71,7 @@ EditorWidgetBase {
 
           anchors.verticalCenter: textField.verticalCenter
 
-          bgcolor: "white"
+          bgcolor: "transparent"
           visible: enabled
 
           onClicked: {
@@ -102,7 +102,7 @@ EditorWidgetBase {
 
           anchors.verticalCenter: textField.verticalCenter
 
-          bgcolor: "white"
+          bgcolor: "transparent"
           visible: enabled
 
           onClicked: {

--- a/src/qml/editorwidgets/RelationReference.qml
+++ b/src/qml/editorwidgets/RelationReference.qml
@@ -56,7 +56,7 @@ EditorWidgetBase {
     width: enabled ? 48 : 0
     height: 48
 
-    bgcolor: "white"
+    bgcolor: "transparent"
     iconSource: Theme.getThemeIcon("ic_view_green_48dp")
 
     onClicked: {

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -79,7 +79,7 @@ EditorWidgetBase {
     background: Rectangle {
         width: parent.width
         height: parent.height
-        color: "white";
+        color: "transparent";
     }
 
     onTextChanged: {
@@ -103,7 +103,7 @@ EditorWidgetBase {
     background: Rectangle {
         width: parent.width
         height: parent.height
-        color: "white";
+        color: "transparent";
     }
 
     onTextChanged: {


### PR DESCRIPTION
Now that we deal with feature form groups as containers, we can come up with a better visual representation of  a given group's background color. This is especially important when we groups with more than one column.

This PR has colored groups look like this:
![image](https://user-images.githubusercontent.com/1728657/200159109-d98714d6-c9c2-4140-bdf1-ef7ea02e4886.png)

For comparison's sake, here's how it used to look like:

![image](https://user-images.githubusercontent.com/1728657/200159121-4b218238-7222-41c7-afb7-9447eaa2c0c0.png)

---

PSA: this background color is customizable in QGIS:

![image](https://user-images.githubusercontent.com/1728657/200159202-681120a6-405d-4b40-b536-b421e2eedba8.png)

In this PR, we take that color and tweak its alpha value to offer a nicer blend effect with QField's feature form.