### PR TITLE
Protect from random crashes when unloading a project

### DIFF
--- a/src/core/attributeformmodelbase.h
+++ b/src/core/attributeformmodelbase.h
@@ -108,7 +108,7 @@ class AttributeFormModelBase : public QStandardItemModel
     void onMapThemeCollectionChanged();
 
     FeatureModel *mFeatureModel = nullptr;
-    QgsVectorLayer *mLayer = nullptr;
+    QPointer<QgsVectorLayer> mLayer;
     std::unique_ptr<QgsAttributeEditorContainer> mTemporaryContainer;
     bool mHasTabs = false;
 

--- a/src/core/featurelistmodel.cpp
+++ b/src/core/featurelistmodel.cpp
@@ -104,7 +104,7 @@ QHash<int, QByteArray> FeatureListModel::roleNames() const
 
 QgsVectorLayer *FeatureListModel::currentLayer() const
 {
-  return mCurrentLayer;
+  return mCurrentLayer.data();
 }
 
 void FeatureListModel::setCurrentLayer( QgsVectorLayer *currentLayer )

--- a/src/core/featurelistmodel.h
+++ b/src/core/featurelistmodel.h
@@ -230,7 +230,7 @@ class FeatureListModel : public QAbstractItemModel
 
     void cleanupGatherer();
 
-    QgsVectorLayer *mCurrentLayer = nullptr;
+    QPointer<QgsVectorLayer> mCurrentLayer;
 
     FeatureExpressionValuesGatherer *mGatherer = nullptr;
 

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -143,7 +143,7 @@ void FeatureModel::setCurrentLayer( QgsVectorLayer *layer )
 
 QgsVectorLayer *FeatureModel::layer() const
 {
-  return mLayer;
+  return mLayer.data();
 }
 
 VertexModel *FeatureModel::vertexModel()

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -292,7 +292,7 @@ class FeatureModel : public QAbstractListModel
     void updateDefaultValues();
 
     ModelModes mModelMode = SingleFeatureModel;
-    QgsVectorLayer *mLayer = nullptr;
+    QPointer<QgsVectorLayer> mLayer;
     QgsFeature mFeature;
     QList<QgsFeature> mFeatures;
     QList<bool> mAttributesAllowEdit;

--- a/src/core/geometry.cpp
+++ b/src/core/geometry.cpp
@@ -99,7 +99,7 @@ void Geometry::updateRubberband( const QgsGeometry &geometry )
 
 QgsVectorLayer *Geometry::vectorLayer() const
 {
-  return mVectorLayer;
+  return mVectorLayer.data();
 }
 
 void Geometry::setVectorLayer( QgsVectorLayer *vectorLayer )

--- a/src/core/geometry.h
+++ b/src/core/geometry.h
@@ -17,6 +17,7 @@
 
 #include "rubberbandmodel.h"
 
+#include <QPointer>
 #include <QtPositioning/QGeoCoordinate>
 #include <qgsgeometry.h>
 
@@ -47,7 +48,7 @@ class Geometry : public QObject
 
   private:
     RubberbandModel *mRubberbandModel = nullptr;
-    QgsVectorLayer *mVectorLayer = nullptr;
+    QPointer<QgsVectorLayer> mVectorLayer;
 };
 
 #endif // GEOMETRY_H

--- a/src/core/layerresolver.cpp
+++ b/src/core/layerresolver.cpp
@@ -100,7 +100,7 @@ void LayerResolver::setLayerProviderName( const QString &layerProviderName )
 
 QgsVectorLayer *LayerResolver::currentLayer() const
 {
-  return mLayer;
+  return mLayer.data();
 }
 
 void LayerResolver::setLayer( QgsVectorLayer *layer )

--- a/src/core/layerresolver.h
+++ b/src/core/layerresolver.h
@@ -19,6 +19,7 @@
 #define LAYERRESOLVER_H
 
 #include <QObject>
+#include <QPointer>
 
 class QgsVectorLayer;
 class QgsProject;
@@ -98,7 +99,7 @@ class LayerResolver : public QObject
     QString mLayerSource;
     QString mLayerProviderName;
     QgsProject *mProject = nullptr;
-    QgsVectorLayer *mLayer = nullptr;
+    QPointer<QgsVectorLayer> mLayer;
 };
 
 #endif // LAYERRESOLVER_H

--- a/src/core/multifeaturelistmodel.cpp
+++ b/src/core/multifeaturelistmodel.cpp
@@ -183,7 +183,7 @@ QList<QgsFeature> MultiFeatureListModel::selectedFeatures()
 
 QgsVectorLayer *MultiFeatureListModel::selectedLayer()
 {
-  return mFilterLayer;
+  return mFilterLayer.data();
 }
 
 bool MultiFeatureListModel::filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const

--- a/src/core/multifeaturelistmodel.h
+++ b/src/core/multifeaturelistmodel.h
@@ -173,7 +173,7 @@ class MultiFeatureListModel : public QSortFilterProxyModel
   private:
     MultiFeatureListModelBase *mSourceModel = nullptr;
 
-    QgsVectorLayer *mFilterLayer = nullptr;
+    QPointer<QgsVectorLayer> mFilterLayer;
 };
 
 #endif // MULTIFEATURELISTMODEL_H

--- a/src/core/rubberbandmodel.cpp
+++ b/src/core/rubberbandmodel.cpp
@@ -356,7 +356,7 @@ void RubberbandModel::setCrs( const QgsCoordinateReferenceSystem &crs )
 
 QgsVectorLayer *RubberbandModel::vectorLayer() const
 {
-  return mLayer;
+  return mLayer.data();
 }
 
 void RubberbandModel::setVectorLayer( QgsVectorLayer *vectorLayer )

--- a/src/core/rubberbandmodel.h
+++ b/src/core/rubberbandmodel.h
@@ -21,6 +21,7 @@
 #include <QDateTime>
 #include <QObject>
 #include <QPointF>
+#include <QPointer>
 #include <QVector>
 #include <qgis.h>
 #include <qgsabstractgeometry.h>
@@ -154,7 +155,7 @@ class QFIELD_CORE_EXPORT RubberbandModel : public QObject
     int mCurrentCoordinateIndex;
     QDateTime mCurrentPositionTimestamp;
     QgsWkbTypes::GeometryType mGeometryType;
-    QgsVectorLayer *mLayer = nullptr;
+    QPointer<QgsVectorLayer> mLayer;
     QgsCoordinateReferenceSystem mCrs;
     bool mFrozen = false;
 };

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -18,6 +18,7 @@
 
 #include "qgsvectorlayer.h"
 
+#include <QPointer>
 #include <QTimer>
 
 class RubberbandModel;
@@ -55,7 +56,7 @@ class Tracker : public QObject
     void setStartPositionTimestamp( const QDateTime &startPositionTimestamp ) { mStartPositionTimestamp = startPositionTimestamp; }
 
     //! the current layer
-    QgsVectorLayer *layer() const { return mLayer; }
+    QgsVectorLayer *layer() const { return mLayer.data(); }
     //! the current layer
     void setLayer( QgsVectorLayer *layer ) { mLayer = layer; }
     //! the created feature
@@ -87,7 +88,7 @@ class Tracker : public QObject
     bool mTimeIntervalFulfilled = false;
     bool mMinimumDistanceFulfilled = false;
 
-    QgsVectorLayer *mLayer = nullptr;
+    QPointer<QgsVectorLayer> mLayer;
     QgsFeature mFeature;
 
     bool mVisible = true;


### PR DESCRIPTION
Reliable way to crash QField:
1. Load the waste waters sample project
2. In the legend, select the point layer
3. Open the home screen
4. Select waste waters in the recent projects
5. *boom*

The crash happens here:
![image](https://user-images.githubusercontent.com/1728657/200227635-3bca5c29-5409-4515-8cde-f5f87182505a.png)

Cause: when selecting the point layer, QField builds the layer's feature form, which includes relation values widgets. When we re-load the waste waters (step 4), we end up clearing the current project, which means removing all layers. At which point, the feature form's relation values have raw vector layer pointers to removed/deleted project vector layers. Then worlds collide.

We can protect ourselves by using QPointer instead of raw pointers. I've took the liberty to upgrade a few raw pointers in addition to the one that fixes the crash described above.