### PR TITLE
[Backport release-2_5] Do not upload "all-access" to playstore

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -156,7 +156,7 @@ jobs:
 
       - name: Upload release assets
         uses: AButler/upload-release-assets@v2.0
-        if: ${{ github.event_name == 'release' }}
+        if: ${{ github.event_name == 'release' }} && ${{ matrix.all_files_access }} == "OFF"
         with:
           files: /tmp/qfield-*.apk
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Backport #3586
 **Authored by:** @m-kuhn