### PR TITLE
[Backport release-2_5] Fix crash when activating measuring tool in a number of projects

### DIFF
--- a/src/core/qgsquick/qgsquickelevationprofilecanvas.cpp
+++ b/src/core/qgsquick/qgsquickelevationprofilecanvas.cpp
@@ -525,7 +525,7 @@ void QgsQuickElevationProfileCanvas::populateLayersFromProject()
   auto filteredList = sortedLayers;
   filteredList.erase( std::remove_if( filteredList.begin(), filteredList.end(),
                                       []( QgsMapLayer *layer ) {
-                                        return !layer || !layer->isValid() || !layer->elevationProperties() && !layer->elevationProperties()->showByDefaultInElevationProfilePlots();
+                                        return !layer || !layer->isValid() || !layer->elevationProperties() || !layer->elevationProperties()->showByDefaultInElevationProfilePlots();
                                       } ),
                       filteredList.end() );
 


### PR DESCRIPTION
Backport #3596
 **Authored by:** @nirvn

_Sentry: https://sentry.io/organizations/opengisch/issues/3726630215/?project=6119013&referrer=release-issue-stream_