### PR TITLE
Fix crash when adding features on a vector layer that had been drawn onto an elevation profile

### DIFF
--- a/src/core/qgsquick/qgsquickelevationprofilecanvas.cpp
+++ b/src/core/qgsquick/qgsquickelevationprofilecanvas.cpp
@@ -378,6 +378,9 @@ void QgsQuickElevationProfileCanvas::onLayerProfileRendererPropertyChanged()
 
 void QgsQuickElevationProfileCanvas::regenerateResultsForLayer()
 {
+  if ( !mCurrentJob )
+    return;
+
   if ( QgsMapLayer *layer = qobject_cast<QgsMapLayer *>( sender() ) )
   {
     if ( QgsAbstractProfileSource *source = dynamic_cast<QgsAbstractProfileSource *>( layer ) )


### PR DESCRIPTION
Alright, we'll have enough crash fixes for a 2.5.1

_Sentry: https://sentry.io/organizations/opengisch/issues/3715900875/?project=6119013&referrer=release-issue-stream_