### PR TITLE
The attribute form model isn't a 2-level situation anymore, adjust root-tab constraint data

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -606,7 +606,14 @@ void AttributeFormModelBase::updateVisibilityAndConstraints( int fieldIndex )
       {
         allConstraintsHardValid = false;
         if ( mHasTabs && item->parent() )
-          item->parent()->setData( false, AttributeFormModel::ConstraintHardValid );
+        {
+          QStandardItem *parentItem = item->parent();
+          while ( parentItem->parent() )
+          {
+            parentItem = parentItem->parent();
+          }
+          parentItem->setData( false, AttributeFormModel::ConstraintHardValid );
+        }
       }
 
       QStringList softErrors;
@@ -619,7 +626,14 @@ void AttributeFormModelBase::updateVisibilityAndConstraints( int fieldIndex )
       {
         allConstraintsSoftValid = false;
         if ( mHasTabs && item->parent() )
-          item->parent()->setData( false, AttributeFormModel::ConstraintSoftValid );
+        {
+          QStandardItem *parentItem = item->parent();
+          while ( parentItem->parent() )
+          {
+            parentItem = parentItem->parent();
+          }
+          parentItem->setData( false, AttributeFormModel::ConstraintSoftValid );
+        }
       }
     }
     else


### PR DESCRIPTION
Without this fix, the 2nd tab here (main cover/node) wouldn't show a constraint error badge:
![image](https://user-images.githubusercontent.com/1728657/201468535-20846e37-5e6b-43f3-b79a-6fdf1320e488.png)

