### PR TITLE
Avoid connecting to model signals when submodel is disabled

### DIFF
--- a/src/core/submodel.cpp
+++ b/src/core/submodel.cpp
@@ -120,9 +120,11 @@ void SubModel::setModel( QAbstractItemModel *model )
   // Disconnect previous model connections
   handleModelConnection( true );
 
+  beginResetModel();
   mModel = model;
   mMappings.clear();
   handleModelConnection();
+  endResetModel();
 
   emit modelChanged();
 }
@@ -132,11 +134,13 @@ void SubModel::setEnabled( bool enabled )
   if ( enabled == mEnabled )
     return;
 
+  beginResetModel();
   mEnabled = enabled;
   mMappings.clear();
   handleModelConnection();
+  endResetModel();
 
-  emit modelChanged();
+  emit enabledChanged();
 }
 
 void SubModel::onRowsInserted( const QModelIndex &parent, int first, int last )

--- a/src/core/submodel.h
+++ b/src/core/submodel.h
@@ -60,10 +60,11 @@ class SubModel : public QAbstractItemModel
     void onDataChanged( const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles = QVector<int>() );
 
   private:
-    bool mEnabled = true;
     QModelIndex mapFromSource( const QModelIndex &sourceIndex ) const;
     QModelIndex mapToSource( const QModelIndex &index ) const;
+    void handleModelConnection( bool disconnecting = false ) const;
 
+    bool mEnabled = true;
     QPointer<QAbstractItemModel> mModel;
     QPersistentModelIndex mRootIndex;
 

--- a/src/core/submodel.h
+++ b/src/core/submodel.h
@@ -23,7 +23,7 @@ class SubModel : public QAbstractItemModel
 {
     Q_OBJECT
 
-    Q_PROPERTY( bool enabled READ enabled WRITE setEnabled NOTIFY modelChanged )
+    Q_PROPERTY( bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged )
     Q_PROPERTY( QAbstractItemModel *model READ model WRITE setModel NOTIFY modelChanged )
     Q_PROPERTY( QModelIndex rootIndex READ rootIndex WRITE setRootIndex NOTIFY rootIndexChanged )
 


### PR DESCRIPTION
We don't need to connect to model signals when a submodel enabled property is set to false, let's just not connect (that'll save us a few CPU cycles, and will likely prevent unforeseen situations)