### PR TITLE
Avoid double attribute form model reset (revert needless change)

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -149,8 +149,6 @@ void AttributeFormModelBase::resetModel()
 {
   clear();
 
-  beginResetModel();
-
   mVisibilityExpressions.clear();
   mConstraints.clear();
 
@@ -215,8 +213,6 @@ void AttributeFormModelBase::resetModel()
 
     mExpressionContext = mLayer->createExpressionContext();
   }
-
-  endResetModel();
 }
 
 void AttributeFormModelBase::applyFeatureModel()


### PR DESCRIPTION
The beginResetModel() / endResetModel() signals were not only not needed but results in a double model reset (once when calling clear(), then once when calling endResetModel().

One more optimization following implementation of the multi-column feature form.