### PR TITLE
[Backport release-2_5] Avoid double attribute form model reset (revert needless change)

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -149,8 +149,6 @@ void AttributeFormModelBase::resetModel()
 {
   clear();
 
-  beginResetModel();
-
   mVisibilityExpressions.clear();
   mConstraints.clear();
 
@@ -215,8 +213,6 @@ void AttributeFormModelBase::resetModel()
 
     mExpressionContext = mLayer->createExpressionContext();
   }
-
-  endResetModel();
 }
 
 void AttributeFormModelBase::applyFeatureModel()


### PR DESCRIPTION
Backport #3646
 **Authored by:** @nirvn