### PR TITLE
Better initial extent when opening individual datasets with single-point (or multiple points at same location) datasets

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -1155,8 +1155,30 @@ void QgisMobileapp::readProjectFile()
     extent.setYMaximum( parts[3].toDouble() );
     emit setMapExtent( extent );
   }
-  else if ( !extent.isEmpty() && extent.width() != 0.0 )
+  else if ( !extent.isNull() )
   {
+    if ( extent.width() == 0.0 || extent.height() == 0.0 )
+    {
+      // If all of the features are at the one point, buffer the
+      // rectangle a bit. If they are all at zero, do something a bit
+      // more crude.
+      if ( extent.xMinimum() == 0.0 && extent.xMaximum() == 0.0 && extent.yMinimum() == 0.0 && extent.yMaximum() == 0.0 )
+      {
+        extent.set( -1.0, -1.0, 1.0, 1.0 );
+      }
+      else
+      {
+        const double padFactor = 1e-8;
+        const double widthPad = extent.xMinimum() * padFactor;
+        const double heightPad = extent.yMinimum() * padFactor;
+        const double xmin = extent.xMinimum() - widthPad;
+        const double xmax = extent.xMaximum() + widthPad;
+        const double ymin = extent.yMinimum() - heightPad;
+        const double ymax = extent.yMaximum() + heightPad;
+        extent.set( xmin, ymin, xmax, ymax );
+      }
+    }
+
     // Add a bit of buffer so datasets don't touch the very edge of the map on the screen
     emit setMapExtent( extent.buffered( extent.width() * 0.02 ) );
   }


### PR DESCRIPTION
This PR fixes an issue with single-point datasets (or multiple points _at same location_ datasets) whereas in those scenarios, _no default extent was set_, leading to unexpected results (such as carrying on the extent of the previous project, which can cause chaos and can end up with a frozen canvas).

As a nice bonus, the code is taken from QGIS' QgsMapSettings::fullExtent() (https://github.com/qgis/QGIS/blob/master/src/core/qgsmapsettings.cpp#L719) which means QField's opening of datasets will now result in the same default extent as you would get on QGIS.