### PR TITLE
Fix QML container not loading regression

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -367,6 +367,7 @@ Page {
               wrapMode: Text.WordWrap
               font.pointSize: Theme.tinyFont.pointSize
               font.bold: true
+              topPadding: 10
               bottomPadding: 5
               color: 'grey'
             }
@@ -383,8 +384,9 @@ Page {
             }
 
             onQmlCodeChanged: {
-              if ( visible )
+              if (isVisible) {
                 var obj = Qt.createQmlObject(qmlContainer.qmlCode,qmlItem,'qmlContent');
+              }
             }
           }
 
@@ -409,6 +411,7 @@ Page {
               wrapMode: Text.WordWrap
               font.pointSize: Theme.tinyFont.pointSize
               font.bold: true
+              topPadding: 10
               bottomPadding: 5
               color: 'grey'
             }
@@ -425,8 +428,7 @@ Page {
             }
 
             onHtmlCodeChanged: {
-              if ( visible )
-              {
+              if (isVisible) {
                 var htmlItem = Qt.createQmlObject('import QtWebView 1.14; WebView { id: htmlItem; anchors { left: parent.left; rightMargin: 12; right: parent.right; } onLoadingChanged: if ( !loading ) runJavaScript("document.body.offsetHeight", function(result) { htmlItem.height = ( result + 30 ) } ); }',
                                                   htmlLoader);
                 htmlItem.loadHtml(htmlContainer.htmlCode);


### PR DESCRIPTION
This PR fixes a regression introduced in 2.5 whereas neither QML nor HTML containers end up loading their content. 

Proof of resurrection:
![image](https://user-images.githubusercontent.com/1728657/202831171-72c3aa4e-751e-4f93-a391-e97c2503fd74.png)

Fixes #3661
Fixes #3659.