### PR TITLE
Migrate QFieldCloud attachment upload to a background service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,9 @@ file(MAKE_DIRECTORY "${SHARE_DIR}")
 
 add_subdirectory(src/core)
 add_subdirectory(src/qml)
+if (ANDROID)
+  add_subdirectory(src/service)
+endif()
 add_subdirectory(src/app)
 
 if(WITH_SENTRY)

--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -277,6 +277,23 @@
     <meta-data android:name="io.sentry.environment" android:value="@SENTRY_ENV@" />
     <meta-data android:name="io.sentry.auto-init" android:value="false" />
 
+    <service android:process=":qt" android:name="ch.opengis.@APP_PACKAGE_NAME@.QFieldService">
+      <meta-data android:name="android.app.arguments" android:value="-service"/>
+      <meta-data android:name="android.app.lib_name" android:value="@string/lib_name"/>
+      <meta-data android:name="android.app.qt_sources_resource_id" android:resource="@array/qt_sources"/>
+      <meta-data android:name="android.app.repository" android:value="default"/>
+      <meta-data android:name="android.app.qt_libs_resource_id" android:resource="@array/qt_libs"/>
+      <meta-data android:name="android.app.bundled_libs_resource_id" android:resource="@array/bundled_libs"/>
+      <meta-data android:name="android.app.bundle_local_qt_libs" android:value="-- %%BUNDLE_LOCAL_QT_LIBS%% --"/>
+      <meta-data android:name="android.app.use_local_qt_libs" android:value="-- %%USE_LOCAL_QT_LIBS%% --"/>
+      <meta-data android:name="android.app.libs_prefix" android:value="/data/local/tmp/qt/"/>
+      <meta-data android:name="android.app.load_local_libs_resource_id" android:resource="@array/load_local_libs"/>
+      <meta-data android:name="android.app.load_local_libs" android:value="-- %%INSERT_LOCAL_LIBS%% --"/>
+      <meta-data android:name="android.app.load_local_jars" android:value="-- %%INSERT_LOCAL_JARS%% --"/>
+      <meta-data android:name="android.app.static_init_classes" android:value="-- %%INSERT_INIT_CLASSES%% --"/>
+
+      <meta-data android:name="android.app.background_running" android:value="true"/>
+    </service>
   </application>
   <queries>
     <!-- Camera -->

--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -278,7 +278,7 @@
     <meta-data android:name="io.sentry.auto-init" android:value="false" />
 
     <service android:process=":qt" android:name="ch.opengis.@APP_PACKAGE_NAME@.QFieldService">
-      <meta-data android:name="android.app.arguments" android:value="-service"/>
+      <meta-data android:name="android.app.arguments" android:value="--service"/>
       <meta-data android:name="android.app.lib_name" android:value="@string/lib_name"/>
       <meta-data android:name="android.app.qt_sources_resource_id" android:resource="@array/qt_sources"/>
       <meta-data android:name="android.app.repository" android:value="default"/>

--- a/platform/android/res/values/strings.xml
+++ b/platform/android/res/values/strings.xml
@@ -70,4 +70,5 @@
     <string name="storage_information_dismiss">I\'ll read later</string>
     <string name="import_project_wait">Please wait while QField is importing the project</string>
     <string name="import_dataset_wait">Please wait while QField is importing the dataset(s)</string>
+    <string name="upload_pending_attachments">Currently uploading attachments to QFieldCloud</string>
 </resources>

--- a/platform/android/src/ch/opengis/qfield/QFieldService.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldService.java
@@ -1,0 +1,62 @@
+/**
+ * QFieldService.java
+ * @author  Mathieu Pellerin - <mathieu@opengis.ch>
+ * @version 0.5
+ */
+/*
+ Copyright (c) 2021, Mathieu Pellerin <mathieu@opengis.ch>
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * Neither the name of the  Marco Bernasocchi <marco@opengis.ch> nor the
+ names of its contributors may be used to endorse or promote products
+ derived from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY Marco Bernasocchi <marco@opengis.ch> ''AS IS'' AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL Marco Bernasocchi <marco@opengis.ch> BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package ch.opengis.qfield;
+
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+import org.qtproject.qt5.android.bindings.QtService;
+
+public class QFieldService extends QtService {
+
+    public static native void testFunction();
+
+    public static void startQFieldService(Context context) {
+        Log.v("QField Service", "Starting QFieldService");
+        Intent intent = new Intent(context, QFieldService.class);
+        intent.putExtra("TOKEN", "TEST");
+        context.startService(intent);
+    }
+
+    @Override
+    public void onCreate() {
+        Log.v("QField Service", "onCreate triggered");
+        super.onCreate();
+    }
+
+    @Override
+    public void onDestroy() {
+        Log.v("QField Service", "onDestroy triggered");
+        super.onDestroy();
+    }
+}

--- a/platform/android/src/ch/opengis/qfield/QFieldService.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldService.java
@@ -45,16 +45,13 @@ public class QFieldService extends QtService {
 
     private NotificationManager notificationManager;
     private NotificationChannel notificationChannel;
-    private final String CHANNEL_ID = "qfield_service_01";
 
-    private String cloudToken;
-    private String cloudUser;
+    private final String CHANNEL_ID = "qfield_service_01";
+    private final int NOTIFICATION_ID = 101;
 
     public static void startQFieldService(Context context) {
         Log.v("QField Service", "Starting QFieldService");
         Intent intent = new Intent(context, QFieldService.class);
-        intent.putExtra("USER", "TEST_USER");
-        intent.putExtra("TOKEN", "TEST_TOKEN");
         context.startService(intent);
     }
 
@@ -81,38 +78,31 @@ public class QFieldService extends QtService {
     @Override
     public void onDestroy() {
         Log.v("QField Service", "onDestroy triggered");
+        notificationManager.cancel(NOTIFICATION_ID);
         super.onDestroy();
     }
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         int ret = super.onStartCommand(intent, flags, startId);
-
-        cloudUser = intent.getExtras().getString("USER");
-        cloudToken = intent.getExtras().getString("TOKEN");
-        Log.v("QField Service", cloudUser);
-        Log.v("QField Service", cloudToken);
-
         showNotification();
-
         return ret;
     }
 
     private void showNotification() {
-        Log.v("QField Service Notification", cloudUser);
-        Log.v("QField Service Notification", cloudToken); // setProgress
-        Notification.Builder builder = new Notification.Builder(this)
-                                           .setSmallIcon(R.drawable.qfield_logo)
-                                           .setWhen(System.currentTimeMillis())
-                                           .setContentTitle(cloudUser)
-                                           .setContentText(cloudToken)
-                                           .setProgress(0, 0, true);
+        Notification.Builder builder =
+            new Notification.Builder(this)
+                .setSmallIcon(R.drawable.qfield_logo)
+                .setWhen(System.currentTimeMillis())
+                .setContentTitle("QFieldCloud")
+                .setContentText(getString(R.string.upload_pending_attachments))
+                .setProgress(0, 0, true);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             builder.setChannelId(CHANNEL_ID);
         }
 
         Notification notification = builder.build();
-        notificationManager.notify(1, notification);
+        notificationManager.notify(NOTIFICATION_ID, notification);
     }
 }

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -62,6 +62,10 @@ function(create_executable)
 
   target_link_libraries(${exe_TARGET} PRIVATE qfield_core qfield_qml)
 
+  if(ANDROID)
+    target_link_libraries(${exe_TARGET} PRIVATE qfield_core qfield_service)
+  endif()
+
   if(WITH_SENTRY)
     target_link_libraries(${exe_TARGET} PRIVATE qfield_sentry)
   endif()

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -81,17 +81,6 @@ int main( int argc, char **argv )
 #if defined( Q_OS_ANDROID )
     QAndroidService app( argc, argv );
 
-    QAndroidJniObject intent = QtAndroid::androidService().callObjectMethod( "getIntent", "()Landroid/content/Intent;" );
-    QAndroidJniObject extras = intent.callObjectMethod( "getExtras", "()Landroid/os/Bundle;" );
-    QAndroidJniObject extraJni = QAndroidJniObject::fromString( QStringLiteral( "TOKEN" ) );
-    extraJni = extras.callObjectMethod( "getString", "(Ljava/lang/String;)Ljava/lang/String;", extraJni.object<jstring>() );
-    if ( extraJni.isValid() )
-    {
-      qInfo() << extraJni.toString();
-    }
-
-    QtAndroid::androidService().callMethod<void>( "stopSelf" );
-
     return app.exec();
 #else
     return 0;

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -72,8 +72,7 @@ void initGraphics()
 
 int main( int argc, char **argv )
 {
-  qInfo() << "main begins";
-  if ( argc > 1 && strcmp( argv[1], "-service" ) == 0 )
+  if ( argc > 1 && strcmp( argv[1], "--service" ) == 0 )
   {
 #if defined( Q_OS_ANDROID )
     QAndroidService app( argc, argv );
@@ -88,7 +87,7 @@ int main( int argc, char **argv )
 
     QEventLoop loop( &app );
     QFieldCloudConnection connection;
-    QObject::connect( &connection, &QFieldCloudConnection::pendingAttachmentsUploaded, &loop, &QEventLoop::quit );
+    QObject::connect( &connection, &QFieldCloudConnection::pendingAttachmentsUploadFinished, &loop, &QEventLoop::quit );
     int pendingAttachments = connection.uploadPendingAttachments();
     if ( pendingAttachments > 0 )
     {
@@ -100,10 +99,6 @@ int main( int argc, char **argv )
 #endif
 
     return 0;
-  }
-  else
-  {
-    qInfo() << "No argument";
   }
 
   initGraphics();

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -24,6 +24,7 @@
 #include "fileutils.h"
 #include "qfield.h"
 #include "qfield_android.h"
+#include "qfieldcloudconnection.h"
 
 #include <QAndroidJniEnvironment>
 #include <QAndroidJniObject>
@@ -38,6 +39,7 @@
 #include <QScreen>
 #include <QStandardPaths>
 #include <QString>
+#include <QTimer>
 #include <QtAndroid>
 #include <qgsfileutils.h>
 
@@ -555,6 +557,20 @@ QVariantMap AndroidPlatformUtilities::sceneMargins( QQuickWindow *window ) const
   margins[QLatin1String( "bottom" )] = 0.0;
   margins[QLatin1String( "left" )] = 0.0;
   return margins;
+}
+
+void AndroidPlatformUtilities::uploadPendingAttachments( QFieldCloudConnection *connection ) const
+{
+  QTimer::singleShot( 500, [connection]() {
+    if ( connection )
+    {
+      qInfo() << "Launching service from main...";
+      QAndroidJniObject::callStaticMethod<void>( "ch/opengis/" APP_PACKAGE_NAME "/QFieldService",
+                                                 "startQFieldService",
+                                                 "(Landroid/content/Context;)V",
+                                                 QtAndroid::androidActivity().object() );
+    }
+  } );
 }
 
 #ifdef __cplusplus

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -561,6 +561,7 @@ QVariantMap AndroidPlatformUtilities::sceneMargins( QQuickWindow *window ) const
 extern "C" {
 #endif
 
+// QFieldActivity class functions
 JNIEXPORT void JNICALL JNI_FUNCTION_NAME( APP_PACKAGE_JNI_NAME, QFieldActivity, openProject )( JNIEnv *env, jobject obj, jstring path )
 {
   if ( AppInterface::instance() )

--- a/src/core/platforms/android/androidplatformutilities.h
+++ b/src/core/platforms/android/androidplatformutilities.h
@@ -69,6 +69,8 @@ class AndroidPlatformUtilities : public PlatformUtilities
 
     double systemFontPointSize() const override { return 16.0; }
 
+    void uploadPendingAttachments( QFieldCloudConnection *connection ) const override;
+
   private:
     bool checkAndAcquirePermissions( const QString &permissionString ) const;
     QString getIntentExtra( const QString &, QAndroidJniObject = nullptr ) const;

--- a/src/core/platforms/platformutilities.cpp
+++ b/src/core/platforms/platformutilities.cpp
@@ -21,6 +21,7 @@
 #include "platformutilities.h"
 #include "projectsource.h"
 #include "qfield.h"
+#include "qfieldcloudconnection.h"
 #include "qgismobileapp.h"
 #include "qgsmessagelog.h"
 
@@ -325,6 +326,16 @@ QVariantMap PlatformUtilities::sceneMargins( QQuickWindow *window ) const
 double PlatformUtilities::systemFontPointSize() const
 {
   return QApplication::font().pointSizeF() + 2.0;
+}
+
+void PlatformUtilities::uploadPendingAttachments( QFieldCloudConnection *connection ) const
+{
+  QTimer::singleShot( 500, [connection]() {
+    if ( connection )
+    {
+      connection->uploadPendingAttachments();
+    }
+  } );
 }
 
 PlatformUtilities *PlatformUtilities::instance()

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -225,8 +225,14 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
      */
     Q_INVOKABLE virtual QVariantMap sceneMargins( QQuickWindow *window ) const;
 
+    /**
+     * Returns the default system font size.
+     */
     Q_INVOKABLE virtual double systemFontPointSize() const;
 
+    /**
+     * Uploads any pending attachments linked to the logged in user account.
+     */
     Q_INVOKABLE virtual void uploadPendingAttachments( QFieldCloudConnection *connection ) const;
 
     static PlatformUtilities *instance();

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -25,6 +25,7 @@
 #include <QObject>
 #include <qgsfield.h>
 
+class QFieldCloudConnection;
 class ProjectSource;
 class PictureSource;
 
@@ -225,6 +226,8 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
     Q_INVOKABLE virtual QVariantMap sceneMargins( QQuickWindow *window ) const;
 
     Q_INVOKABLE virtual double systemFontPointSize() const;
+
+    Q_INVOKABLE virtual void uploadPendingAttachments( QFieldCloudConnection *connection ) const;
 
     static PlatformUtilities *instance();
 

--- a/src/core/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloudconnection.cpp
@@ -126,6 +126,11 @@ void QFieldCloudConnection::setPassword( const QString &password )
   emit passwordChanged();
 }
 
+QString QFieldCloudConnection::token() const
+{
+  return mToken;
+}
+
 CloudUserInformation QFieldCloudConnection::userInformation() const
 {
   return mUserInformation;
@@ -209,9 +214,6 @@ void QFieldCloudConnection::login()
     emit userInformationChanged();
 
     setStatus( ConnectionStatus::LoggedIn );
-
-    // Resuming uploading any pending attachments from previous session(s)
-    uploadPendingAttachments();
   } );
 }
 
@@ -519,15 +521,17 @@ QFieldCloudConnection::CloudError::CloudError( QNetworkReply *reply )
   mMessage = errorMessage;
 }
 
-void QFieldCloudConnection::uploadPendingAttachments()
+int QFieldCloudConnection::uploadPendingAttachments()
 {
   if ( mUploadingAttachments )
-    return;
+    return 0;
 
   QMultiMap<QString, QString> attachments = QFieldCloudUtils::getPendingAttachments();
+  qDebug() << attachments;
   if ( attachments.isEmpty() )
   {
-    return;
+    emit pendingAttachmentsUploaded();
+    return 0;
   }
 
   mUploadCount = attachments.size();
@@ -578,4 +582,5 @@ void QFieldCloudConnection::uploadPendingAttachments()
 
     ++it;
   }
+  return mUploadCount;
 }

--- a/src/core/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloudconnection.cpp
@@ -527,10 +527,9 @@ int QFieldCloudConnection::uploadPendingAttachments()
     return 0;
 
   QMultiMap<QString, QString> attachments = QFieldCloudUtils::getPendingAttachments();
-  qDebug() << attachments;
   if ( attachments.isEmpty() )
   {
-    emit pendingAttachmentsUploaded();
+    emit pendingAttachmentsUploadFinished();
     return 0;
   }
 

--- a/src/core/qfieldcloudconnection.h
+++ b/src/core/qfieldcloudconnection.h
@@ -120,6 +120,8 @@ class QFieldCloudConnection : public QObject
     QString password() const;
     void setPassword( const QString &password );
 
+    QString token() const;
+
     QString avatarUrl() const;
 
     CloudUserInformation userInformation() const;
@@ -163,7 +165,11 @@ class QFieldCloudConnection : public QObject
      */
     void setAuthenticationToken( QNetworkRequest &request );
 
-    void uploadPendingAttachments();
+    /**
+     * Uploads any pending attachments linked to the logged in user account.
+     * \returns the number of attachments to be uploaded.
+     */
+    int uploadPendingAttachments();
 
   signals:
     void usernameChanged();
@@ -174,6 +180,7 @@ class QFieldCloudConnection : public QObject
     void stateChanged();
     void tokenChanged();
     void userInformationChanged();
+    void pendingAttachmentsUploaded();
     void error();
 
     void loginFailed( const QString &reason );

--- a/src/core/qfieldcloudconnection.h
+++ b/src/core/qfieldcloudconnection.h
@@ -180,7 +180,7 @@ class QFieldCloudConnection : public QObject
     void stateChanged();
     void tokenChanged();
     void userInformationChanged();
-    void pendingAttachmentsUploaded();
+    void pendingAttachmentsUploadFinished();
     void error();
 
     void loginFailed( const QString &reason );

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -1311,9 +1311,6 @@ void QFieldCloudProjectsModel::projectUpload( const QString &projectId, const bo
 
     delete networkDeltaUploadedParent;
 
-    // send attachment in a non-blocking fashion
-    mCloudConnection->uploadPendingAttachments();
-
     if ( shouldDownloadUpdates )
     {
       projectGetDeltaStatus( projectId );

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2961,6 +2961,8 @@ ApplicationWindow {
         displayToast(qsTr('Connecting...'))
       } else if (cloudConnection.status === QFieldCloudConnection.LoggedIn) {
         displayToast(qsTr('Signed in'))
+        // Go ahead and upload pending attachments in the background
+        platformUtilities.uploadPendingAttachments(cloudConnection);
       }
       previousStatus = cloudConnection.status
     }
@@ -2986,6 +2988,9 @@ ApplicationWindow {
       }
 
       displayToast( qsTr( "Changes successfully pushed to QFieldCloud" ) )
+
+      // Go ahead and upload pending attachments in the background
+      platformUtilities.uploadPendingAttachments(cloudConnection);
     }
 
     onWarning: displayToast( message )

--- a/src/service/CMakeLists.txt
+++ b/src/service/CMakeLists.txt
@@ -1,0 +1,35 @@
+set(QFIELD_SERVICE_SRCS qfieldservice.cpp)
+set(QFIELD_SERVICE_HDRS qfieldservice.h)
+
+add_library(qfield_service STATIC ${QFIELD_SERVICE_SRCS} ${QFIELD_SERVICE_HDRS})
+
+include(GenerateExportHeader)
+generate_export_header(qfield_service)
+
+target_include_directories(qfield_service SYSTEM
+                           PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+
+target_include_directories(qfield_service
+                           PUBLIC ${CMAKE_SOURCE_DIR}/src/service)
+
+target_compile_features(qfield_service PUBLIC cxx_std_17)
+set_target_properties(qfield_service PROPERTIES AUTOMOC TRUE)
+
+target_link_libraries(qfield_service PRIVATE qfield_core ${QGIS_CORE_LIBRARY})
+
+target_link_libraries(qfield_service PUBLIC ${QT_PKG}::Core
+                                            ${QT_PKG}::Positioning)
+
+if(ANDROID)
+  target_link_libraries(qfield_service PUBLIC ${QT_PKG}::AndroidExtras)
+endif()
+
+install(FILES ${QFIELD_SERVICE_HDRS} DESTINATION ${QFIELD_INCLUDE_DIR})
+install(
+  TARGETS qfield_service
+  BUNDLE DESTINATION ${QFIELD_BIN_DIR}
+  RUNTIME DESTINATION ${QFIELD_BIN_DIR}
+  LIBRARY DESTINATION ${QFIELD_LIB_DIR}
+  ARCHIVE DESTINATION ${QFIELD_LIB_DIR}
+  FRAMEWORK DESTINATION ${QFIELD_FW_SUBDIR}
+  PUBLIC_HEADER DESTINATION ${QFIELD_INCLUDE_DIR})

--- a/src/service/qfieldservice.cpp
+++ b/src/service/qfieldservice.cpp
@@ -1,0 +1,43 @@
+/***************************************************************************
+  qfieldservice.cpp - QFieldService
+
+ ---------------------
+ begin                : 04.12.2022
+ copyright            : (C) 2022 by Mathieu Pellerin
+ email                : mathieu at opengis dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qfield_android.h"
+#include "qfieldcloudconnection.h"
+#include "qfieldservice.h"
+
+#include <QtAndroid>
+
+QFieldService::QFieldService( int &argc, char **argv )
+  : QAndroidService( argc, argv )
+{
+  QSettings settings;
+  QEventLoop loop( this );
+  QFieldCloudConnection connection;
+  QObject::connect( &connection, &QFieldCloudConnection::pendingAttachmentsUploadFinished, &loop, &QEventLoop::quit );
+  int pendingAttachments = connection.uploadPendingAttachments();
+  if ( pendingAttachments > 0 )
+  {
+    loop.exec();
+  }
+
+  QtAndroid::androidService().callMethod<void>( "stopSelf" );
+
+  exit( 0 );
+}
+
+QFieldService::~QFieldService()
+{
+}

--- a/src/service/qfieldservice.h
+++ b/src/service/qfieldservice.h
@@ -1,0 +1,29 @@
+/***************************************************************************
+  qfieldservice.h - QFieldService
+
+ ---------------------
+ begin                : 04.12.2022
+ copyright            : (C) 2022 by Mathieu Pellerin
+ email                : mathieu at opengis dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qfield_service_export.h"
+
+#include <QAndroidService>
+
+class QFIELD_SERVICE_EXPORT QFieldService : public QAndroidService
+{
+    Q_OBJECT
+
+  public:
+    QFieldService( int &argc, char **argv );
+
+    ~QFieldService() override;
+};


### PR DESCRIPTION
This PR implements a basic background service through which attachments are uploaded to the cloud. This means that even if people's devices are locked or QField is not in the foreground, the upload will continue. 