### PR TITLE
[Backport release-2_5] Avoid feature model's double setFeature() calls when creating a new feature

### DIFF
--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -282,9 +282,6 @@ class FeatureModel : public QAbstractListModel
 
     void warning( const QString &text );
 
-  private slots:
-    void featureAdded( QgsFeatureId fid );
-
   private:
     bool commit();
     bool startEditing();


### PR DESCRIPTION
Backport #3685
 **Authored by:** @nirvn