### PR TITLE
Fix freeze (on slower device it can be 1-2sec) regression when clicking on layer tree items

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -229,7 +229,11 @@ Page {
                 }
 
                 Repeater {
-                  model: form.model.hasTabs ? contentModel : form.model
+                  model: form.visible
+                         ? form.model.hasTabs
+                           ? contentModel
+                           : form.model
+                         : 0
                   delegate: fieldItem
                 }
               }

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -198,7 +198,7 @@ Page {
             id: formPage
             property int currentIndex: index
 
-            ScrollView {
+            Flickable {
               id: contentView
 
               anchors.fill: parent
@@ -206,13 +206,14 @@ Page {
               contentHeight: content.height
               clip: true
 
-              ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
-              ScrollBar.vertical.policy: content.height > contentView.height ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff
-              ScrollBar.vertical.width: 6
-              ScrollBar.vertical.contentItem: Rectangle {
-                implicitWidth: 6
-                implicitHeight: 25
-                color: Theme.mainColor
+              ScrollBar.vertical: ScrollBar {
+                policy: content.height > contentView.height ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff
+                width: 6
+                contentItem: Rectangle {
+                  implicitWidth: 6
+                  implicitHeight: 25
+                  color: Theme.mainColor
+                }
               }
 
               /**


### PR DESCRIPTION
So, TIL moment: a ListView QML item will not create model delegate items until the ListView item is visible, whereas Flow QML items will create model delegate items all the time.

In QField 2.5, this resulted in the add feature overlay drawer's feature form to populate the Flow item when the form itself was invisible, which in turn meant that selecting layers in the layer tree would lead to noticeable UI freeze on older devices. This PR fixes that by deferring the creation of the feature form items when the feature form itself is visible. This brings us back to 2.4 speeds.