### PR TITLE
[Backport release-2_5] When using the camera or gallery on iOS to fetch a photo, insure destination path is created

### DIFF
--- a/src/core/platforms/ios/iospicturesource.mm
+++ b/src/core/platforms/ios/iospicturesource.mm
@@ -15,6 +15,8 @@
 
 #include <UIKit/UIKit.h>
 
+#include <QDir>
+#include <QFileInfo>
 #include <QGuiApplication>
 #include <QQuickItem>
 #include <QQuickWindow>
@@ -78,6 +80,12 @@ IosPictureSource::IosPictureSource(QObject *parent, const QString &prefix,
   Q_ASSERT(mParent);
   mPrefixPath = prefix;
   mPictureFilePath = pictureFilePath;
+
+  QString destinationFile = prefix + pictureFilePath;
+  QFileInfo destinationInfo(destinationFile);
+  QDir prefixDir(prefix);
+  prefixDir.mkpath(destinationInfo.absolutePath());
+
   mDelegate->_cameraDelegate =
       [[CameraDelegate alloc] initWithIosPictureSource:this];
 }


### PR DESCRIPTION
Backport #3696
 **Authored by:** @nirvn