### PR TITLE
Insure that child containers of a tab with an expession-based visibility carry on the parent expression

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -194,13 +194,15 @@ void AttributeFormModelBase::resetModel()
           item->setData( true, AttributeFormModel::ConstraintSoftValid );
           invisibleRootItem()->appendRow( item );
 
+          QString visibilityExpression;
           if ( container->visibilityExpression().enabled() )
           {
             mVisibilityExpressions.append( qMakePair( container->visibilityExpression().data(), QVector<QStandardItem *>() << item ) );
+            visibilityExpression = container->visibilityExpression().data().expression();
           }
 
           QVector<QStandardItem *> dummy;
-          buildForm( container, item, QString(), dummy, currentTab, columnCount );
+          buildForm( container, item, visibilityExpression, dummy, currentTab, columnCount );
           currentTab++;
         }
       }


### PR DESCRIPTION
This PR fixes an issue that's been lingering in our code for a long time whereas feature form tabs with expression-based visibility are not attaching their expression strings to children containers, leading to invisible container items still reporting failing constraints even though those should be ignored.