### PR TITLE
[Backport release-2_5] Keep the feature form model alive when hiding form to digitize child geometry

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -230,7 +230,9 @@ Page {
                 }
 
                 Repeater {
-                  model: form.visible
+                  // Note: digitizing a child geometry will temporarily hide the feature form,
+                  // we need to preserve items so signal connections are kept alive
+                  model: form.visible || form.digitizingToolbar.geometryRequested
                          ? form.model.hasTabs
                            ? contentModel
                            : form.model


### PR DESCRIPTION
Backport #3705
 **Authored by:** @nirvn