### PR TITLE
Add a bunch of measure types attached to vertices M value when tracking as well as digitizing and locked to position

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -395,6 +395,7 @@ void QgisMobileapp::initDeclarative()
   qRegisterMetaType<QFieldCloudProjectsModel::ProjectStatus>( "QFieldCloudProjectsModel::ProjectStatus" );
   qRegisterMetaType<QFieldCloudProjectsModel::ProjectCheckout>( "QFieldCloudProjectsModel::ProjectCheckout" );
   qRegisterMetaType<QFieldCloudProjectsModel::ProjectModification>( "QFieldCloudProjectsModel::ProjectModification" );
+  qRegisterMetaType<Tracker::MeasureType>( "Tracker::MeasureType" );
 
   qmlRegisterUncreatableType<QgsProject>( "org.qgis", 1, 0, "Project", "" );
 #if _QGIS_VERSION_INT >= 32700
@@ -478,6 +479,7 @@ void QgisMobileapp::initDeclarative()
 #endif
   qmlRegisterUncreatableType<QAbstractSocket>( "org.qfield", 1, 0, "QAbstractSocket", "" );
   qmlRegisterUncreatableType<AbstractGnssReceiver>( "org.qfield", 1, 0, "AbstractGnssReceiver", "" );
+  qmlRegisterUncreatableType<Tracker>( "org.qfield", 1, 0, "Tracker", "" );
   qRegisterMetaType<GnssPositionInformation>( "GnssPositionInformation" );
 
   REGISTER_SINGLETON( "org.qfield", GeometryEditorsModel, "GeometryEditorsModelSingleton" );

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -102,7 +102,11 @@ void Tracker::start()
 
   //set the start time
   setStartPositionTimestamp( QDateTime::currentDateTime() );
-  model()->setMeasureValue( 0 );
+
+  if ( mMeasureType == Tracker::SecondsSinceStart )
+  {
+    model()->setMeasureValue( 0 );
+  }
 
   //track first position
   trackPosition();

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -33,6 +33,7 @@ class Tracker : public QObject
     enum MeasureType
     {
       SecondsSinceStart = 0,
+      Timestamp,
       GroundSpeed,
       Bearing,
       HorizontalAccuracy,

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -30,6 +30,19 @@ class Tracker : public QObject
     Q_PROPERTY( QDateTime startPositionTimestamp READ startPositionTimestamp WRITE setStartPositionTimestamp NOTIFY startPositionTimestampChanged )
 
   public:
+    enum MeasureType
+    {
+      SecondsSinceStart = 0,
+      GroundSpeed,
+      Bearing,
+      HorizontalAccuracy,
+      VerticalAccuracy,
+      PDOP,
+      HDOP,
+      VDOP
+    };
+    Q_ENUM( MeasureType )
+
     explicit Tracker( QgsVectorLayer *layer, bool visible );
 
     RubberbandModel *model() const;
@@ -68,6 +81,9 @@ class Tracker : public QObject
     //! if the layer (and the rubberband ) is visible
     void setVisible( const bool visible ) { mVisible = visible; }
 
+    MeasureType measureType() const { return mMeasureType; }
+    void setMeasureType( MeasureType type ) { mMeasureType = type; }
+
     void start();
     void stop();
 
@@ -94,6 +110,8 @@ class Tracker : public QObject
     bool mVisible = true;
 
     QDateTime mStartPositionTimestamp;
+
+    MeasureType mMeasureType = Tracker::SecondsSinceStart;
 
     void trackPosition();
 };

--- a/src/core/trackingmodel.cpp
+++ b/src/core/trackingmodel.cpp
@@ -39,6 +39,7 @@ QHash<int, QByteArray> TrackingModel::roleNames() const
   roles[RubberModel] = "rubberModel";
   roles[Visible] = "visible";
   roles[StartPositionTimestamp] = "startPositionTimestamp";
+  roles[MeasureType] = "measureType";
 
   return roles;
 }
@@ -82,6 +83,8 @@ QVariant TrackingModel::data( const QModelIndex &index, int role ) const
       return mTrackers.at( index.row() )->visible();
     case StartPositionTimestamp:
       return mTrackers.at( index.row() )->startPositionTimestamp();
+    case MeasureType:
+      return mTrackers.at( index.row() )->measureType();
     default:
       return QVariant();
   }
@@ -110,6 +113,8 @@ bool TrackingModel::setData( const QModelIndex &index, const QVariant &value, in
     case Visible:
       currentTracker->setVisible( value.toBool() );
       break;
+    case MeasureType:
+      currentTracker->setMeasureType( static_cast<Tracker::MeasureType>( value.toInt() ) );
     default:
       return false;
   }

--- a/src/core/trackingmodel.h
+++ b/src/core/trackingmodel.h
@@ -35,14 +35,15 @@ class TrackingModel : public QAbstractItemModel
     enum TrackingRoles
     {
       DisplayString = Qt::UserRole,
-      VectorLayer,           //! the layer in the current tracking session
-      RubberModel,           //! the rubberbandmodel used in the current tracking session
-      TimeInterval,          //! the (minimum) time interval between setting trackpoints
-      MinimumDistance,       //! the minimum distance between setting trackpoints
-      Conjunction,           //! if both, the minimum distance and the time interval, needs to be fulfilled before setting trackpoints
-      Visible,               //! if the layer and so the tracking components like rubberband is visible
-      Feature,               //! the feature in the current tracking session
-      StartPositionTimestamp //!
+      VectorLayer,            //! the layer in the current tracking session
+      RubberModel,            //! the rubberbandmodel used in the current tracking session
+      TimeInterval,           //! the (minimum) time interval between setting trackpoints
+      MinimumDistance,        //! the minimum distance between setting trackpoints
+      Conjunction,            //! if both, the minimum distance and the time interval, needs to be fulfilled before setting trackpoints
+      Visible,                //! if the layer and so the tracking components like rubberband is visible
+      Feature,                //! the feature in the current tracking session
+      StartPositionTimestamp, //! the timestamp when the current tracking session started
+      MeasureType             //! the measurement type used to set the measure value
     };
 
     QHash<int, QByteArray> roleNames() const override;

--- a/src/core/utils/layerutils.cpp
+++ b/src/core/utils/layerutils.cpp
@@ -219,7 +219,7 @@ void LayerUtils::selectFeaturesInLayer( QgsVectorLayer *layer, const QList<int> 
   layer->selectByIds( qgsFids, behavior );
 }
 
-QString LayerUtils::fieldType( const QgsField &field ) const
+QString LayerUtils::fieldType( const QgsField &field )
 {
   return QVariant( field.type() ).typeName();
 }
@@ -359,4 +359,12 @@ QgsFeature LayerUtils::duplicateFeature( QgsVectorLayer *layer, const QgsFeature
   }
 
   return duplicatedFeature;
+}
+
+bool LayerUtils::hasMValue( QgsVectorLayer *layer )
+{
+  if ( !layer )
+    return false;
+
+  return QgsWkbTypes::hasM( layer->wkbType() );
 }

--- a/src/core/utils/layerutils.h
+++ b/src/core/utils/layerutils.h
@@ -76,7 +76,12 @@ class LayerUtils : public QObject
      * Returns the QVariant typeName of a \a field.
      * This is a stable identifier (compared to the provider field name).
      */
-    Q_INVOKABLE QString fieldType( const QgsField &field ) const;
+    Q_INVOKABLE static QString fieldType( const QgsField &field );
+
+    /**
+     * Returns TRUE if the vector \a layer geometry has an M value.
+     */
+    Q_INVOKABLE static bool hasMValue( QgsVectorLayer *layer );
 };
 
 #endif // LAYERUTILS_H

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -35,5 +35,7 @@ LabSettings.Settings {
     property bool trackerMinimumDistanceConstraint: false
     property double trackerMinimumDistance: 30
     property bool trackerMeetAllConstraints: false
+
     property int trackerMeasureType: 0
+    property int digitizingMeasureType: 1
 }

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -21,7 +21,7 @@ LabSettings.Settings {
     property bool accuracyRequirement: false
 
     property bool averagedPositioning: false
-    property int  averagedPositioningMinimumCount: 1
+    property int averagedPositioningMinimumCount: 1
     property bool averagedPositioningAutomaticStop: true
 
     property real antennaHeight: 0.0
@@ -35,4 +35,5 @@ LabSettings.Settings {
     property bool trackerMinimumDistanceConstraint: false
     property double trackerMinimumDistance: 30
     property bool trackerMeetAllConstraints: false
+    property int trackerMeasureType: 0
 }

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -440,6 +440,66 @@ Page {
                   }
 
                   Label {
+                      id: measureLabel
+                      Layout.fillWidth: true
+                      Layout.columnSpan: 2
+                      text: qsTr( "Measure (M) value attached to vertices:" )
+                      font: Theme.defaultFont
+
+                      wrapMode: Text.WordWrap
+                  }
+
+                  ComboBox {
+                      id: measureComboBox
+                      Layout.fillWidth: true
+                      Layout.columnSpan: 2
+                      Layout.alignment: Qt.AlignVCenter
+                      font: Theme.defaultFont
+                      popup.font: Theme.defaultFont
+
+                      property bool loaded: false
+                      Component.onCompleted: {
+                          // This list matches the Tracker::MeasureType enum, with SecondsSinceStart removed
+                          var measurements = [
+                            qsTr("Timestamp (milliseconds since epoch)"),
+                            qsTr("Ground speed"),
+                            qsTr("Bearing"),
+                            qsTr("Horizontal accuracy"),
+                            qsTr("Vertical accuracy"),
+                            qsTr("PDOP"),
+                            qsTr("HDOP"),
+                            qsTr("VDOP")
+                          ];
+
+                          model = measurements;
+                          currentIndex = positioningSettings.digitizingMeasureType - 1;
+                          loaded = true;
+                      }
+
+                      onCurrentIndexChanged: {
+                        if (loaded) {
+                          positioningSettings.digitizingMeasureType = currentIndex + 1;
+                        }
+                      }
+                  }
+
+                  Label {
+                      id: measureTipLabel
+                      Layout.fillWidth: true
+                      text: qsTr( "When digitizing features with the coordinate cursor locked to the current position, the measurement type selected above will be added to the geometry provided it has an M dimension." )
+                      font: Theme.tipFont
+                      color: Theme.gray
+
+                      wrapMode: Text.WordWrap
+                  }
+
+                  Item {
+                      // spacer item
+                      Layout.fillWidth: true
+                      Layout.fillHeight: true
+                  }
+
+                  Label {
                       text: qsTr("Activate accuracy indicator")
                       font: Theme.defaultFont
                       wrapMode: Text.WordWrap

--- a/src/qml/Tracking.qml
+++ b/src/qml/Tracking.qml
@@ -437,10 +437,9 @@ Item {
 
             Label {
                 id: measureLabel
-                visible: LayerUtils.hasMValue(track.vectorLayer)
                 Layout.fillWidth: true
                 Layout.columnSpan: 2
-                text: qsTr( "Measurement value to attach to individual vertices:" )
+                text: qsTr( "Measure (M) value attached to individual vertices:" )
                 font: Theme.defaultFont
 
                 wrapMode: Text.WordWrap
@@ -448,7 +447,7 @@ Item {
 
             ComboBox {
                 id: measureComboBox
-                visible: LayerUtils.hasMValue(track.vectorLayer)
+                enabled: LayerUtils.hasMValue(track.vectorLayer)
                 Layout.fillWidth: true
                 Layout.columnSpan: 2
                 Layout.alignment: Qt.AlignVCenter
@@ -480,6 +479,18 @@ Item {
                     positioningSettings.trackerMeasureType = currentIndex;
                   }
                 }
+            }
+
+            Label {
+                id: measureTipLabel
+                visible: !LayerUtils.hasMValue(track.vectorLayer)
+                Layout.fillWidth: true
+                Layout.columnSpan: 2
+                text: qsTr( "To active the measurement functionality, make sure the vector layer's geometry type used for the tracking session has an M dimension." )
+                font: Theme.tipFont
+                color: Theme.gray
+
+                wrapMode: Text.WordWrap
             }
 
             QfButton {

--- a/src/qml/Tracking.qml
+++ b/src/qml/Tracking.qml
@@ -439,7 +439,7 @@ Item {
                 id: measureLabel
                 Layout.fillWidth: true
                 Layout.columnSpan: 2
-                text: qsTr( "Measure (M) value attached to individual vertices:" )
+                text: qsTr( "Measure (M) value attached to vertices:" )
                 font: Theme.defaultFont
 
                 wrapMode: Text.WordWrap
@@ -485,12 +485,17 @@ Item {
                 id: measureTipLabel
                 visible: !LayerUtils.hasMValue(track.vectorLayer)
                 Layout.fillWidth: true
-                Layout.columnSpan: 2
                 text: qsTr( "To active the measurement functionality, make sure the vector layer's geometry type used for the tracking session has an M dimension." )
                 font: Theme.tipFont
                 color: Theme.gray
 
                 wrapMode: Text.WordWrap
+            }
+
+            Item {
+                // spacer item
+                Layout.fillWidth: true
+                Layout.fillHeight: true
             }
 
             QfButton {

--- a/src/qml/Tracking.qml
+++ b/src/qml/Tracking.qml
@@ -30,6 +30,8 @@ Item {
       switch(measureType) {
         case Tracker.SecondsSinceStart:
           return ( positionSource.positionInformation.utcDateTime - track.startPositionTimestamp ) / 1000
+        case Tracker.Timestamp:
+          return positionSource.positionInformation.utcDateTime.getTime()
         case Tracker.GroundSpeed:
           return positionSource.positionInformation.speed
         case Tracker.Bearing:
@@ -457,7 +459,8 @@ Item {
                 Component.onCompleted: {
                     // This list matches the Tracker::MeasureType enum
                     var measurements = [
-                      qsTr("Time since beginning of recording"),
+                      qsTr("Elapsed time (seconds since start of tracking)"),
+                      qsTr("Timestamp (milliseconds since epoch)"),
                       qsTr("Ground speed"),
                       qsTr("Bearing"),
                       qsTr("Horizontal accuracy"),

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -493,8 +493,8 @@ ApplicationWindow {
     Repeater {
         id: trackings
         model: trackingModel
-        Tracking {
-        }
+
+        Tracking {}
     }
 
     /** A rubberband for ditizing **/

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -507,6 +507,30 @@ ApplicationWindow {
       model: RubberbandModel {
         frozen: false
         currentCoordinate: coordinateLocator.currentCoordinate
+        measureValue: {
+          if (coordinateLocator.positionLocked) {
+            switch(positioningSettings.digitizingMeasureType) {
+              case Tracker.Timestamp:
+                return coordinateLocator.positionInformation.utcDateTime.getTime()
+              case Tracker.GroundSpeed:
+                return coordinateLocator.positionInformation.speed
+              case Tracker.Bearing:
+                return coordinateLocator.positionInformation.direction
+              case Tracker.HorizontalAccuracy:
+                return coordinateLocator.positionInformation.hacc
+              case Tracker.VerticalAccuracy:
+                return coordinateLocator.positionInformation.vacc
+              case Tracker.PDOP:
+                return coordinateLocator.positionInformation.pdop
+              case Tracker.HDOP:
+                return coordinateLocator.positionInformation.hdop
+              case Tracker.VDOP:
+                return coordinateLocator.positionInformation.vdop
+            }
+          } else {
+            return Number.NaN;
+          }
+        }
         vectorLayer: digitizingToolbar.geometryRequested ? digitizingToolbar.geometryRequestedLayer : dashBoard.currentLayer
         crs: mapCanvas.mapSettings.destinationCrs
       }


### PR DESCRIPTION
This PR extents QField's tracking measure value support by adding new measure types and exposing the capability in the tracking UI:

When a layer's geometry used to track position has an M value, the UI will display a combobox allowing for users to specify which measure value to attach to vertices. The measure type are:
- seconds since the start of the tracking session (pre-existing)
- speed
- bearing / direction
- horizontal accuracy
- vertical accuracy
- PDOP
- HDOP
- VDOP

| Screenshot 1 | Screenshot 2 |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1728657/206883523-9c2dd989-e2d7-4604-82d3-8b27f587b217.png) | ![image](https://user-images.githubusercontent.com/1728657/206883515-52ba758a-4f9d-49c5-8663-9d60c8eb2bce.png) |

Alright, because this thing is actually quite useful, why don't we add it when users are digitizing new features and their cursor is locked to the current position:

![image](https://user-images.githubusercontent.com/1728657/206883935-0e0307c2-13d4-43a3-9fe8-862d6ac57bda.png)
