### PR TITLE
Revert app-wide antialiasing on QML surfaces on Android

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -61,10 +61,13 @@ void initGraphics()
   qputenv( "QSG_ANTIALIASING_METHOD", "vertex" );
 #endif
 
+#if not defined( Q_OS_ANDROID )
   // Enables antialiasing in QML scenes
+  // Avoid enabling on Android OS as it leads to serious regressions on old devices
   QSurfaceFormat format;
   format.setSamples( 4 );
   QSurfaceFormat::setDefaultFormat( format );
+#endif
   QGuiApplication::setAttribute( Qt::AA_EnableHighDpiScaling );
 }
 


### PR DESCRIPTION
This PR fixes #3309 (and likely other obscure bugs on older devices).