### PR TITLE
Revert customized default format sampling on Android

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -56,10 +56,13 @@ void initGraphics()
   qputenv( "QSG_ANTIALIASING_METHOD", "vertex" );
 #endif
 
+#if not defined( Q_OS_ANDROID )
   // Enables antialiasing in QML scenes
+  // Avoid enabling on Android OS as it leads to serious regressions on old devices
   QSurfaceFormat format;
   format.setSamples( 4 );
   QSurfaceFormat::setDefaultFormat( format );
+#endif
   QGuiApplication::setAttribute( Qt::AA_EnableHighDpiScaling );
 }
 


### PR DESCRIPTION
Backport to 2.5 branch. IMHO would be worth releasing a final 2.5 with this fix included.