### PR TITLE
Add positioning device model, implement combobox UI

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -24,6 +24,7 @@ set(QFIELD_CORE_SRCS
     positioning/gnsspositioninformation.cpp
     positioning/internalgnssreceiver.cpp
     positioning/positioning.cpp
+    positioning/positioningdevicemodel.cpp
     appcoordinateoperationhandlers.cpp
     appinterface.cpp
     attributeformmodel.cpp
@@ -119,6 +120,7 @@ set(QFIELD_CORE_HDRS
     positioning/abstractgnssreceiver.h
     positioning/gnsspositioninformation.h
     positioning/positioning.h
+    positioning/positioningdevicemodel.h
     positioning/internalgnssreceiver.h
     appcoordinateoperationhandlers.h
     appinterface.h

--- a/src/core/positioning/bluetoothdevicemodel.cpp
+++ b/src/core/positioning/bluetoothdevicemodel.cpp
@@ -38,19 +38,6 @@ BluetoothDeviceModel::BluetoothDeviceModel( QObject *parent )
   connect( &mServiceDiscoveryAgent, &QBluetoothServiceDiscoveryAgent::canceled, [=]() {
     setScanningStatus( Canceled );
   } );
-
-  beginResetModel();
-  mDiscoveredDevices.clear();
-  mDiscoveredDevices.append( qMakePair( tr( "Internal device" ), QString() ) );
-
-  QSettings settings;
-  const QString deviceAddress = settings.value( QStringLiteral( "positioningDevice" ), QString( "" ) ).toString();
-  if ( !deviceAddress.isEmpty() )
-  {
-    const QString deviceName = settings.value( QStringLiteral( "positioningDeviceName" ), QStringLiteral( "Unknown device" ) ).toString();
-    mDiscoveredDevices.append( qMakePair( deviceName, deviceAddress ) );
-  }
-  endResetModel();
 }
 
 void BluetoothDeviceModel::startServiceDiscovery( const bool fullDiscovery )
@@ -87,19 +74,17 @@ void BluetoothDeviceModel::serviceDiscovered( const QBluetoothServiceInfo &servi
   endInsertRows();
 }
 
-int BluetoothDeviceModel::findAddressIndex( const QString &address ) const
+int BluetoothDeviceModel::findIndexFromAddress( const QString &address ) const
 {
-  int idx = 0;
-  for ( const QPair<QString, QString> &device : mDiscoveredDevices )
+  for ( int i = 0; i < mDiscoveredDevices.size(); i++ )
   {
-    if ( device.second == address )
+    if ( mDiscoveredDevices.at( i ).second == address )
     {
-      return idx;
+      return i;
     }
-    ++idx;
   }
-  //if not found, then switch to the internal device (by index 0)
-  return 0;
+
+  return -1;
 }
 
 int BluetoothDeviceModel::rowCount( const QModelIndex &parent ) const

--- a/src/core/positioning/bluetoothdevicemodel.cpp
+++ b/src/core/positioning/bluetoothdevicemodel.cpp
@@ -142,3 +142,24 @@ void BluetoothDeviceModel::setLastError( const QString &lastError )
   mLastError = lastError;
   emit lastErrorChanged( mLastError );
 }
+
+int BluetoothDeviceModel::addDevice( const QString &name, const QString &address )
+{
+  if ( name.isEmpty() || address.isEmpty() )
+    return -1;
+
+  for ( int i = 0; i < mDiscoveredDevices.size(); i++ )
+  {
+    if ( mDiscoveredDevices.at( i ).first == name && mDiscoveredDevices.at( i ).second == address )
+    {
+      return i;
+    }
+  }
+
+  int index = mDiscoveredDevices.size();
+  beginInsertRows( QModelIndex(), index, index );
+  mDiscoveredDevices << qMakePair( name, address );
+  endInsertRows();
+
+  return index;
+}

--- a/src/core/positioning/bluetoothdevicemodel.h
+++ b/src/core/positioning/bluetoothdevicemodel.h
@@ -61,9 +61,23 @@ class BluetoothDeviceModel : public QAbstractListModel
 
     QHash<int, QByteArray> roleNames() const override;
 
+    /**
+     * Adds a Bluetooth device if not already in the model
+     * \param name friendly device name used as identifier in the user interface
+     * \param address Bluetooth address of the device
+     * \returns returns index of the Bluetooth device
+     */
     Q_INVOKABLE int addDevice( const QString &name, const QString &address );
 
+    /**
+     * Starts a scan to discovery nearby Bluetooth devices
+     * \param fullDisocvery set to TRUE to trigger a more expensive scan
+     */
     Q_INVOKABLE void startServiceDiscovery( const bool fullDiscovery );
+
+    /**
+     * Returns the row index for a given Bluetooth device address
+     */
     Q_INVOKABLE int findIndexFromAddress( const QString &address ) const;
 
     ScanningStatus scanningStatus() const { return mScanningStatus; };

--- a/src/core/positioning/bluetoothdevicemodel.h
+++ b/src/core/positioning/bluetoothdevicemodel.h
@@ -62,7 +62,7 @@ class BluetoothDeviceModel : public QAbstractListModel
     QHash<int, QByteArray> roleNames() const override;
 
     Q_INVOKABLE void startServiceDiscovery( const bool fullDiscovery );
-    Q_INVOKABLE int findAddressIndex( const QString &address ) const;
+    Q_INVOKABLE int findIndexFromAddress( const QString &address ) const;
 
     ScanningStatus scanningStatus() const { return mScanningStatus; };
     QString lastError() const { return mLastError; };

--- a/src/core/positioning/bluetoothdevicemodel.h
+++ b/src/core/positioning/bluetoothdevicemodel.h
@@ -61,6 +61,8 @@ class BluetoothDeviceModel : public QAbstractListModel
 
     QHash<int, QByteArray> roleNames() const override;
 
+    Q_INVOKABLE int addDevice( const QString &name, const QString &address );
+
     Q_INVOKABLE void startServiceDiscovery( const bool fullDiscovery );
     Q_INVOKABLE int findIndexFromAddress( const QString &address ) const;
 

--- a/src/core/positioning/positioningdevicemodel.cpp
+++ b/src/core/positioning/positioningdevicemodel.cpp
@@ -1,0 +1,182 @@
+/***************************************************************************
+  positioningdevicemodel.cpp
+
+ ---------------------
+ begin                : 24.12.2022
+ copyright            : (C) 2022 by Mathieu Pellerin
+ email                : mathieu at opengis dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "positioningdevicemodel.h"
+
+#include <QSettings>
+
+PositioningDeviceModel::PositioningDeviceModel( QObject *parent )
+  : QAbstractListModel( parent )
+{
+  reloadModel();
+}
+
+QHash<int, QByteArray> PositioningDeviceModel::roleNames() const
+{
+  QHash<int, QByteArray> roles = QAbstractListModel::roleNames();
+  roles[DeviceType] = "DeviceType";
+  roles[DeviceId] = "DeviceId";
+  roles[DeviceName] = "DeviceName";
+  roles[DeviceSettings] = "DeviceSettings";
+
+  return roles;
+}
+
+void PositioningDeviceModel::reloadModel()
+{
+  beginResetModel();
+  mDevices.clear();
+
+  // Add internal device, assume it is always present
+  mDevices << Device( InternalDevice, tr( "Internal device" ), QVariantMap() );
+
+  QSettings settings;
+  settings.beginGroup( "/qfield/positioningDevices" );
+  const QStringList deviceKeys = settings.childGroups();
+  for ( int i = 0; i < deviceKeys.count(); i++ )
+  {
+    settings.beginGroup( deviceKeys.at( i ) );
+    mDevices << Device( static_cast<Type>( settings.value( QStringLiteral( "type" ), InternalDevice ).toInt() ),
+                        deviceKeys.at( i ),
+                        settings.value( QStringLiteral( "settings" ), QVariantMap() ).toMap() );
+    settings.endGroup();
+  }
+  settings.endGroup();
+
+  endResetModel();
+}
+
+int PositioningDeviceModel::rowCount( const QModelIndex &parent ) const
+{
+  if ( !parent.isValid() )
+    return mDevices.size();
+  else
+    return 0;
+}
+
+QVariant PositioningDeviceModel::data( const QModelIndex &index, int role ) const
+{
+  if ( index.row() >= mDevices.size() || index.row() < 0 )
+    return QVariant();
+
+  switch ( role )
+  {
+    case Qt::DisplayRole:
+      return mDevices.at( index.row() ).name;
+
+    case DeviceType:
+      return mDevices.at( index.row() ).type;
+
+    case DeviceId:
+      return deviceId( mDevices.at( index.row() ) );
+
+    case DeviceName:
+      return mDevices.at( index.row() ).name;
+
+    case DeviceSettings:
+      return mDevices.at( index.row() ).settings;
+  }
+
+  return QVariant();
+}
+
+const QString PositioningDeviceModel::addDevice( const Type &type, const QString &name, const QVariantMap &deviceSettings )
+{
+  if ( name.isEmpty() )
+    return QString();
+
+  QSettings settings;
+  settings.beginGroup( "/qfield/positioningDevices" );
+  const QStringList deviceKeys = settings.childGroups();
+  if ( deviceKeys.contains( name ) )
+  {
+    // Remove pre-existing positioning device details
+    settings.beginGroup( name );
+    settings.remove( QString() );
+    settings.endGroup();
+  }
+
+  settings.beginGroup( name );
+  settings.setValue( "type", static_cast<int>( type ) );
+  settings.setValue( "settings", deviceSettings );
+  settings.endGroup();
+
+  settings.endGroup();
+
+  beginInsertRows( QModelIndex(), mDevices.size(), mDevices.size() );
+  Device device( type, name, deviceSettings );
+  mDevices << device;
+  endInsertRows();
+
+  return deviceId( device );
+}
+
+void PositioningDeviceModel::removeDevice( const QString &name )
+{
+  if ( name.isEmpty() )
+    return;
+
+  QSettings settings;
+  settings.beginGroup( "/qfield/positioningDevices" );
+  const QStringList deviceKeys = settings.childGroups();
+  if ( deviceKeys.contains( name ) )
+  {
+    // Remove pre-existing positioning device details
+    settings.beginGroup( name );
+    settings.remove( QString() );
+    settings.endGroup();
+  }
+  settings.endGroup();
+
+  for ( int i = 0; i < mDevices.size(); i++ )
+  {
+    if ( mDevices.at( 0 ).name == name )
+    {
+      beginRemoveRows( QModelIndex(), i, i );
+      mDevices.removeAt( i );
+      endRemoveRows();
+    }
+  }
+}
+
+const QString PositioningDeviceModel::deviceId( const Device &device ) const
+{
+  if ( device.type == InternalDevice )
+  {
+    return QString();
+  }
+
+  return QString();
+}
+
+int PositioningDeviceModel::findIndexFromDeviceId( const QString &id )
+{
+  if ( id.isEmpty() )
+  {
+    // empty ID is the internal device, hard-coded to be the first row
+    return 0;
+  }
+
+  for ( int i = 0; i < mDevices.size(); i++ )
+  {
+    if ( deviceId( mDevices.at( i ) ) == id )
+    {
+      return i;
+    }
+  }
+
+  return -1;
+}

--- a/src/core/positioning/positioningdevicemodel.cpp
+++ b/src/core/positioning/positioningdevicemodel.cpp
@@ -144,7 +144,7 @@ void PositioningDeviceModel::removeDevice( const QString &name )
 
   for ( int i = 0; i < mDevices.size(); i++ )
   {
-    if ( mDevices.at( 0 ).name == name )
+    if ( mDevices.at( i ).name == name )
     {
       beginRemoveRows( QModelIndex(), i, i );
       mDevices.removeAt( i );

--- a/src/core/positioning/positioningdevicemodel.h
+++ b/src/core/positioning/positioningdevicemodel.h
@@ -74,6 +74,7 @@ class PositioningDeviceModel : public QAbstractListModel
      * \param type device type
      * \param name friendly device name used as identifier in the user interface
      * \param settings settings map (used to generate the positioning device ID, editing, etc.)
+     * \returns returns index of the added device
      */
     Q_INVOKABLE int addDevice( const Type &type, const QString &name, const QVariantMap &deviceSettings );
 

--- a/src/core/positioning/positioningdevicemodel.h
+++ b/src/core/positioning/positioningdevicemodel.h
@@ -1,0 +1,81 @@
+/***************************************************************************
+  positioningdevicemodel.h
+
+ ---------------------
+ begin                : 24.12.2022
+ copyright            : (C) 2022 by Mathieu Pellerin
+ email                : mathieu at opengis dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef POSITIONINGDEVICEMODEL_H
+#define POSITIONINGDEVICEMODEL_H
+
+#include <QAbstractListModel>
+
+class PositioningDeviceModel : public QAbstractListModel
+{
+    Q_OBJECT
+
+  public:
+    enum Type
+    {
+      InternalDevice,
+      BluetoothDevice,
+      TcpDevice,
+      UdpDevice,
+    };
+    Q_ENUM( Type )
+
+    struct Device
+    {
+        Device() = default;
+
+        Device( Type type, const QString &name, const QVariantMap &settings )
+          : type( type )
+          , name( name )
+          , settings( settings )
+        {}
+
+        Type type = Type::InternalDevice;
+        QString name;
+        QVariantMap settings;
+    };
+
+    enum Role
+    {
+      DeviceType = Qt::UserRole,
+      DeviceId,
+      DeviceName,
+      DeviceSettings,
+    };
+    Q_ENUM( Role )
+
+
+    explicit PositioningDeviceModel( QObject *parent = nullptr );
+
+    QHash<int, QByteArray> roleNames() const override;
+
+    int rowCount( const QModelIndex &parent ) const override;
+    QVariant data( const QModelIndex &index, int role ) const override;
+
+    Q_INVOKABLE void reloadModel();
+
+    Q_INVOKABLE const QString addDevice( const Type &type, const QString &name, const QVariantMap &deviceSettings );
+
+    Q_INVOKABLE void removeDevice( const QString &name );
+
+    Q_INVOKABLE const QString deviceId( const Device &device ) const;
+
+    Q_INVOKABLE int findIndexFromDeviceId( const QString &id );
+
+  private:
+    QList<Device> mDevices;
+};
+
+#endif // POSITIONINGDEVICEMODEL_H

--- a/src/core/positioning/positioningdevicemodel.h
+++ b/src/core/positioning/positioningdevicemodel.h
@@ -66,7 +66,7 @@ class PositioningDeviceModel : public QAbstractListModel
 
     Q_INVOKABLE void reloadModel();
 
-    Q_INVOKABLE const QString addDevice( const Type &type, const QString &name, const QVariantMap &deviceSettings );
+    Q_INVOKABLE int addDevice( const Type &type, const QString &name, const QVariantMap &deviceSettings );
 
     Q_INVOKABLE void removeDevice( const QString &name );
 

--- a/src/core/positioning/positioningdevicemodel.h
+++ b/src/core/positioning/positioningdevicemodel.h
@@ -64,14 +64,33 @@ class PositioningDeviceModel : public QAbstractListModel
     int rowCount( const QModelIndex &parent ) const override;
     QVariant data( const QModelIndex &index, int role ) const override;
 
+    /**
+     * Reloads the model from the user settings
+     */
     Q_INVOKABLE void reloadModel();
 
+    /**
+     * Adds a positioning device to the user settings
+     * \param type device type
+     * \param name friendly device name used as identifier in the user interface
+     * \param settings settings map (used to generate the positioning device ID, editing, etc.)
+     */
     Q_INVOKABLE int addDevice( const Type &type, const QString &name, const QVariantMap &deviceSettings );
 
+    /**
+     * Removes the positioning device \a name from the user settings
+     */
     Q_INVOKABLE void removeDevice( const QString &name );
 
+    /**
+     * Returns the device ID string for a specific \a device
+     * \note this is the string to be used with the Positioning deviceId property
+     */
     Q_INVOKABLE const QString deviceId( const Device &device ) const;
 
+    /**
+     * Returns the row index for a given device ID
+     */
     Q_INVOKABLE int findIndexFromDeviceId( const QString &id );
 
   private:

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -77,6 +77,7 @@
 #include "orderedrelationmodel.h"
 #include "picturesource.h"
 #include "positioning.h"
+#include "positioningdevicemodel.h"
 #include "positioningutils.h"
 #include "printlayoutlistmodel.h"
 #include "projectinfo.h"
@@ -461,6 +462,7 @@ void QgisMobileapp::initDeclarative()
   qmlRegisterType<Navigation>( "org.qfield", 1, 0, "Navigation" );
   qmlRegisterType<NavigationModel>( "org.qfield", 1, 0, "NavigationModel" );
   qmlRegisterType<Positioning>( "org.qfield", 1, 0, "Positioning" );
+  qmlRegisterType<PositioningDeviceModel>( "org.qfield", 1, 0, "PositioningDeviceModel" );
   qmlRegisterType<BarcodeDecoder>( "org.qfield", 1, 0, "BarcodeDecoder" );
 #if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
   qmlRegisterType<BarcodeVideoFilter>( "org.qfield", 1, 0, "BarcodeVideoFilter" );

--- a/src/qml/BluetoothDeviceChooser.qml
+++ b/src/qml/BluetoothDeviceChooser.qml
@@ -6,201 +6,180 @@ import org.qfield 1.0
 
 import Theme 1.0
 
-GridLayout {
-    Layout.fillWidth: true
+Item {
+  width: parent.width
 
+  property string deviceName: ''
+  property string deviceAddress: ''
+
+  function generateName() {
+    return deviceName;
+  }
+
+  function setSettings(settings) {
+    deviceName = settings['name'];
+    deviceAddress = settings['address'];
+  }
+
+  function getSettings() {
+    return {'name': deviceName,
+            'address': deviceAddress};
+  }
+
+  GridLayout {
+    width: parent.width
     columns: 2
     columnSpacing: 0
     rowSpacing: 5
 
     Label {
-        Layout.fillWidth: true
-        Layout.columnSpan: 2
-        text: qsTr( "Positioning device in use:" )
-        font: Theme.defaultFont
+      Layout.fillWidth: true
+      Layout.columnSpan: 2
+      text: qsTr( "Select the Bluetooth device from the list below:" )
+      font: Theme.defaultFont
 
-        wrapMode: Text.WordWrap
+      wrapMode: Text.WordWrap
     }
 
     RowLayout {
+      Layout.fillWidth: true
+      Layout.columnSpan: 2
+
+      ComboBox {
+        id: bluetoothDeviceComboBox
         Layout.fillWidth: true
-        Layout.columnSpan: 2
+        Layout.alignment: Qt.AlignVCenter
+        font: Theme.defaultFont
+        popup.font: Theme.defaultFont
 
-        ComboBox {
-            id: bluetoothDeviceComboBox
-            enabled: bluetoothDeviceModel.scanningStatus !== BluetoothDeviceModel.Scanning
-            Layout.fillWidth: true
-            Layout.alignment: Qt.AlignVCenter
-            font: Theme.defaultFont
-            popup.font: Theme.defaultFont
-            textRole: 'display'
-            model: BluetoothDeviceModel {
-                id: bluetoothDeviceModel
-            }
-
-            property string selectedPositioningDevice
-
-            onCurrentIndexChanged: {
-                if( bluetoothDeviceModel.scanningStatus !== BluetoothDeviceModel.Scanning )
-                {
-                    selectedPositioningDevice = bluetoothDeviceModel.data(bluetoothDeviceModel.index(currentIndex, 0), BluetoothDeviceModel.DeviceAddressRole );
-                }
-                if( positioningSettings.positioningDevice !== selectedPositioningDevice )
-                {
-                    positioningSettings.positioningDevice = selectedPositioningDevice
-                    positioningSettings.positioningDeviceName = bluetoothDeviceModel.data(bluetoothDeviceModel.index(currentIndex, 0), BluetoothDeviceModel.DeviceNameRole );
-                }
-            }
-
-            Component.onCompleted: {
-                currentIndex = bluetoothDeviceModel.findAddressIndex(settings.value('positioningDevice',''))
-            }
-
-            Connections {
-                target: bluetoothDeviceModel
-
-                function onModelReset() {
-                    bluetoothDeviceComboBox.currentIndex = bluetoothDeviceModel.findAddressIndex(positioningSettings.positioningDevice)
-                }
-
-                function onScanningStatusChanged(scanningStatus) {
-                    if( scanningStatus === BluetoothDeviceModel.Scanning )
-                    {
-                        displayToast( qsTr('Scanning for paired devices') )
-                    }
-                    if( scanningStatus === BluetoothDeviceModel.Failed )
-                    {
-                        displayToast( qsTr('Scanning failed: %1').arg( bluetoothDeviceModel.lastError ), 'error' )
-                    }
-                    if( scanningStatus === BluetoothDeviceModel.Succeeded )
-                    {
-                        var message = qsTr('Scanning done')
-                        if ( bluetoothDeviceModel.rowCount() > 1 )
-                        {
-                            message += ': ' + qsTr( '%n device(s) found', '', bluetoothDeviceModel.rowCount() - 1 )
-                        }
-                        displayToast( message )
-                    }
-                    if( scanningStatus === BluetoothDeviceModel.Canceled )
-                    {
-                        displayToast( qsTr('Scanning canceled') )
-                    }
-                }
-            }
+        enabled: bluetoothDeviceModel.scanningStatus !== BluetoothDeviceModel.Scanning
+        model: BluetoothDeviceModel {
+          id: bluetoothDeviceModel
         }
 
-        Rectangle {
-            color: "transparent"
-            Layout.preferredWidth: childrenRect.width
-            Layout.preferredHeight: childrenRect.height
-            Layout.alignment: Qt.AlignVCenter
+        property string selectedBluetoothDevice
 
-            QfButton {
-                id: scanButton
-                leftPadding: 10
-                rightPadding: 10
-                text: qsTr('Scan')
-
-                onClicked: {
-                    bluetoothDeviceModel.startServiceDiscovery( false )
-                }
-                onPressAndHold: {
-                    fullDiscoveryDialog.open()
-                }
-
-                enabled: bluetoothDeviceModel.scanningStatus !== BluetoothDeviceModel.Scanning
-                opacity: enabled ? 1 : 0
-            }
-
-
-            BusyIndicator {
-                id: busyIndicator
-                anchors.centerIn: scanButton
-                width: 36
-                height: 36
-                running: bluetoothDeviceModel.scanningStatus === BluetoothDeviceModel.Scanning
-            }
+        onCurrentIndexChanged: {
+          var modelIndex = bluetoothDeviceModel.index(currentIndex, 0);
+          deviceName = bluetoothDeviceModel.data(modelIndex, BluetoothDeviceModel.DeviceNameRole);
+          deviceAddress = bluetoothDeviceModel.data(modelIndex, BluetoothDeviceModel.DeviceAddressRole);
+          selectedBluetoothDevice = bluetoothDeviceAddress.text;
         }
 
-        Dialog {
-            id: fullDiscoveryDialog
-            parent: mainWindow.contentItem
+        Connections {
+          target: bluetoothDeviceModel
 
-            visible: false
-            modal: true
-            font: Theme.defaultFont
+          function onModelReset() {
+            bluetoothDeviceComboBox.currentIndex = selectedBluetoothDevice
+          }
 
-            x: ( mainWindow.width - width ) / 2
-            y: ( mainWindow.height - height ) / 2
-
-            title: qsTr( "Make a full service discovery" )
-            Label {
-                width: parent.width
-                wrapMode: Text.WordWrap
-                text: qsTr( 'A full device scan can take longer. You really want to do it?\nCancel to make a minimal device scan instead.')
+          function onScanningStatusChanged(scanningStatus) {
+            if( scanningStatus === BluetoothDeviceModel.Scanning )
+            {
+              displayToast( qsTr('Scanning for paired devices') )
             }
-
-            standardButtons: Dialog.Ok | Dialog.Cancel
-            onAccepted: {
-                bluetoothDeviceModel.startServiceDiscovery( true )
-                visible = false
+            if( scanningStatus === BluetoothDeviceModel.Failed )
+            {
+              displayToast( qsTr('Scanning failed: %1').arg( bluetoothDeviceModel.lastError ), 'error' )
             }
-            onRejected: {
-                bluetoothDeviceModel.startServiceDiscovery( false )
-                visible = false
+            if( scanningStatus === BluetoothDeviceModel.Succeeded )
+            {
+              var message = qsTr('Scanning done')
+              if ( bluetoothDeviceModel.rowCount() > 1 )
+              {
+                message += ': ' + qsTr( '%n device(s) found', '', bluetoothDeviceModel.rowCount() - 1 )
+              }
+              displayToast( message )
             }
+            if( scanningStatus === BluetoothDeviceModel.Canceled )
+            {
+              displayToast( qsTr('Scanning canceled') )
+            }
+          }
         }
-    }
+      }
 
-    QfButton {
-        id: connectButton
-        Layout.fillWidth: true
-        Layout.columnSpan: 2
-        Layout.topMargin: 5
-        text: {
-            switch (positionSource.device.socketState) {
-                case QAbstractSocket.ConnectedState:
-                    return qsTr('Connected to %1').arg(positioningSettings.positioningDeviceName)
-                case QAbstractSocket.UnconnectedState:
-                    return qsTr('Connect to %1').arg(positioningSettings.positioningDeviceName)
-                default:
-                    return qsTr('Connecting to %1').arg(positioningSettings.positioningDeviceName)
-            }
-        }
-        enabled: positionSource.device.socketState === QAbstractSocket.UnconnectedState
-        visible: positionSource.deviceId !== ''
+      Rectangle {
+        color: "transparent"
+        Layout.preferredWidth: childrenRect.width
+        Layout.preferredHeight: childrenRect.height
+        Layout.alignment: Qt.AlignVCenter
 
-        onClicked: {
-            // make sure positioning is active when connecting to the bluetooth device
-            if (!positioningSettings.positioningActivated) {
-                positioningSettings.positioningActivated = true
-            } else {
-                positionSource.device.connectDevice()
-            }
+        QfButton {
+          id: scanButton
+          leftPadding: 10
+          rightPadding: 10
+          text: qsTr('Scan')
+
+          onClicked: {
+            bluetoothDeviceModel.startServiceDiscovery( false )
+          }
+          onPressAndHold: {
+            fullDiscoveryDialog.open()
+          }
+
+          enabled: bluetoothDeviceModel.scanningStatus !== BluetoothDeviceModel.Scanning
+          opacity: enabled ? 1 : 0
         }
+
+
+        BusyIndicator {
+          id: busyIndicator
+          anchors.centerIn: scanButton
+          width: 36
+          height: 36
+          running: bluetoothDeviceModel.scanningStatus === BluetoothDeviceModel.Scanning
+        }
+      }
     }
 
     Label {
-        text: qsTr("Use orthometric altitude from device")
-        font: Theme.defaultFont
-        wrapMode: Text.WordWrap
+        id: bluetoothDeviceName
         Layout.fillWidth: true
-        visible: positioningSettings.positioningDevice !== ''
-
-        MouseArea {
-            anchors.fill: parent
-            onClicked: reportOrthometricAltitude.toggle()
-        }
+        Layout.columnSpan: 2
+        font: Theme.defaultFont
+        color: Theme.gray
+        text: qsTr('Bluetooth device name:') + '\n' + (deviceName !== '' ? deviceName : qsTr(' N/A'))
+        wrapMode: Text.WordWrap
     }
 
-    QfSwitch {
-        id: reportOrthometricAltitude
-        Layout.preferredWidth: implicitContentWidth
-        Layout.alignment: Qt.AlignTop
-        visible: positioningSettings.positioningDevice !== ''
-        checked: !positioningSettings.ellipsoidalElevation
-        onCheckedChanged: {
-            positioningSettings.ellipsoidalElevation = !checked
-        }
+    Label {
+        id: bluetoothDeviceAddress
+        Layout.fillWidth: true
+        Layout.columnSpan: 2
+        font: Theme.defaultFont
+        color: Theme.gray
+        text: qsTr('Bluetooth device address:') + '\n' + (deviceAddress !== '' ? deviceAddress : qsTr(' N/A'))
+        wrapMode: Text.WordWrap
     }
+  }
+
+  Dialog {
+    id: fullDiscoveryDialog
+    parent: mainWindow.contentItem
+
+    visible: false
+    modal: true
+    font: Theme.defaultFont
+
+    x: ( mainWindow.width - width ) / 2
+    y: ( mainWindow.height - height ) / 2
+
+    title: qsTr( "Make a full service discovery" )
+    Label {
+      width: parent.width
+      wrapMode: Text.WordWrap
+      text: qsTr( 'A full device scan can take longer. You really want to do it?\nCancel to make a minimal device scan instead.')
+    }
+
+    standardButtons: Dialog.Ok | Dialog.Cancel
+    onAccepted: {
+      bluetoothDeviceModel.startServiceDiscovery( true )
+      visible = false
+    }
+    onRejected: {
+      bluetoothDeviceModel.startServiceDiscovery( false )
+      visible = false
+    }
+  }
 }

--- a/src/qml/BluetoothDeviceChooser.qml
+++ b/src/qml/BluetoothDeviceChooser.qml
@@ -9,8 +9,8 @@ import Theme 1.0
 Item {
   width: parent.width
 
-  property string deviceName: 'AAAAAAAAAA'//''
-  property string deviceAddress: 'BB::CC'//''
+  property string deviceName: ''
+  property string deviceAddress: ''
 
   function generateName() {
     return deviceName;
@@ -19,6 +19,8 @@ Item {
   function setSettings(settings) {
     deviceName = settings['name'];
     deviceAddress = settings['address'];
+    var index = bluetoothDeviceModel.addDevice(deviceName, deviceAddress);
+    bluetoothDeviceComboBox.currentIndex = index;
   }
 
   function getSettings() {
@@ -53,6 +55,8 @@ Item {
         popup.font: Theme.defaultFont
 
         enabled: bluetoothDeviceModel.scanningStatus !== BluetoothDeviceModel.Scanning
+
+        textRole: 'display'
         model: BluetoothDeviceModel {
           id: bluetoothDeviceModel
         }

--- a/src/qml/BluetoothDeviceChooser.qml
+++ b/src/qml/BluetoothDeviceChooser.qml
@@ -143,7 +143,7 @@ Item {
         Layout.columnSpan: 2
         font: Theme.defaultFont
         color: Theme.gray
-        text: qsTr('Bluetooth device name:') + '\n' + (deviceName !== '' ? deviceName : qsTr(' N/A'))
+        text: qsTr('Bluetooth device name:') + '\n ' + (deviceName !== '' ? deviceName : qsTr('N/A'))
         wrapMode: Text.WordWrap
     }
 
@@ -153,7 +153,7 @@ Item {
         Layout.columnSpan: 2
         font: Theme.defaultFont
         color: Theme.gray
-        text: qsTr('Bluetooth device address:') + '\n' + (deviceAddress !== '' ? deviceAddress : qsTr(' N/A'))
+        text: qsTr('Bluetooth device address:') + '\n ' + (deviceAddress !== '' ? deviceAddress : qsTr('N/A'))
         wrapMode: Text.WordWrap
     }
   }

--- a/src/qml/BluetoothDeviceChooser.qml
+++ b/src/qml/BluetoothDeviceChooser.qml
@@ -9,8 +9,8 @@ import Theme 1.0
 Item {
   width: parent.width
 
-  property string deviceName: ''
-  property string deviceAddress: ''
+  property string deviceName: 'AAAAAAAAAA'//''
+  property string deviceAddress: 'BB::CC'//''
 
   function generateName() {
     return deviceName;

--- a/src/qml/PositioningDeviceSettings.qml
+++ b/src/qml/PositioningDeviceSettings.qml
@@ -1,0 +1,106 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import org.qgis 1.0
+import org.qfield 1.0
+
+import Theme 1.0
+
+Popup {
+    id: popup
+    parent: ApplicationWindow.overlay
+
+    signal apply
+
+    width: mainWindow.width - Theme.popupScreenEdgeMargin * 2
+    height: mainWindow.height - Theme.popupScreenEdgeMargin * 2
+    x: Theme.popupScreenEdgeMargin
+    y: Theme.popupScreenEdgeMargin
+    padding: 0
+
+    property alias name: positioningDeviceName.text
+    property alias type: positioningDeviceType.currentValue
+
+    function generateName() {
+      return positioningDeviceItem.item.generateName();
+    }
+
+    function setSettings(settings) {
+      positioningDeviceItem.item.setSettings(settings);
+    }
+
+    function getSettings() {
+      return positioningDeviceItem.item.getSettings();
+    }
+
+    Page {
+        id: page
+        width: parent.width
+        height: parent.height
+        padding: 10
+        header: PageHeader {
+          id: pageHeader
+          title: qsTr("Positioning Device Settings")
+
+          showBackButton: false
+          showApplyButton: true
+          showCancelButton: true
+
+          onCancel: {
+            popup.close()
+          }
+
+          onApply: {
+            popup.apply()
+            popup.close()
+          }
+        }
+
+        ColumnLayout {
+            spacing: 5
+            width: parent.width
+
+            Label {
+                Layout.fillWidth: true
+                text: qsTr("Name:")
+                font: Theme.defaultFont
+                wrapMode: Text.WordWrap
+            }
+
+            QfTextField {
+                id: positioningDeviceName
+                Layout.fillWidth: true
+                font: Theme.defaultFont
+                placeholderText: qsTr('Leave empty to auto-fill')
+            }
+
+            Label {
+                Layout.fillWidth: true
+                text: qsTr("Connection type:")
+                font: Theme.defaultFont
+                wrapMode: Text.WordWrap
+            }
+
+            ComboBox {
+                id: positioningDeviceType
+                Layout.fillWidth: true
+
+                textRole: "name"
+                valueRole: "value"
+                model: ListModel {
+                  ListElement { name: qsTr('Bluetooth'); value: PositioningDeviceModel.BluetoothDevice }
+                }
+            }
+
+            Loader {
+                id: positioningDeviceItem
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                source: positioningDeviceType.currentValue === PositioningDeviceModel.BluetoothDevice
+                        ? "qrc:/qml/BluetoothDeviceChooser.qml"
+                        : ""
+            }
+        }
+    }
+}

--- a/src/qml/PositioningDeviceSettings.qml
+++ b/src/qml/PositioningDeviceSettings.qml
@@ -94,6 +94,8 @@ Popup {
             ComboBox {
                 id: positioningDeviceType
                 Layout.fillWidth: true
+                font: Theme.defaultFont
+                popup.font: Theme.defaultFont
 
                 textRole: "name"
                 valueRole: "value"

--- a/src/qml/PositioningDeviceSettings.qml
+++ b/src/qml/PositioningDeviceSettings.qml
@@ -26,6 +26,15 @@ Popup {
       return positioningDeviceItem.item.generateName();
     }
 
+    function setType(type) {
+      for(var i = 0; i < positioningDeviceType.model.count; i++) {
+        if (positioningDeviceType.model.get(i)["value"] === type) {
+          positioningDeviceType.currentIndex = i;
+          break;
+        }
+      }
+    }
+
     function setSettings(settings) {
       positioningDeviceItem.item.setSettings(settings);
     }

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -464,6 +464,8 @@ Page {
                         text: qsTr('Add')
 
                         onClicked: {
+                          positioningDeviceSettings.originalName = '';
+                          positioningDeviceSettings.name = '';
                           positioningDeviceSettings.open()
                         }
                       }
@@ -477,7 +479,17 @@ Page {
                         leftPadding: 10
                         rightPadding: 10
                         text: qsTr('Edit')
-                        enabled: false
+                        enabled: positioningDeviceComboBox.currentIndex > 0
+
+                        onClicked: {
+                          var modelIndex = positioningDeviceModel.index(positioningDeviceComboBox.currentIndex, 0);
+                          var name = positioningDeviceModel.data(modelIndex, PositioningDeviceModel.DeviceName);
+                          positioningDeviceSettings.originalName = name;
+                          positioningDeviceSettings.name = name;
+                          positioningDeviceSettings.setType(positioningDeviceModel.data(modelIndex, PositioningDeviceModel.DeviceType))
+                          positioningDeviceSettings.setSettings(positioningDeviceModel.data(modelIndex, PositioningDeviceModel.DeviceSettings))
+                          positioningDeviceSettings.open();
+                        }
                       }
 
                       QfButton {
@@ -1060,7 +1072,13 @@ Page {
   PositioningDeviceSettings {
     id: positioningDeviceSettings
 
+    property string originalName: ''
+
     onApply: {
+      if (originalName != '') {
+        positioningDeviceModel.removeDevice(originalName);
+      }
+
       var name = positioningDeviceSettings.name;
       var type = positioningDeviceSettings.type;
       var settings = positioningDeviceSettings.getSettings();

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -404,11 +404,86 @@ Page {
               width: parent.parent.width
               spacing: 10
 
-            Loader {
-                Layout.fillWidth: true
-                active: withBluetooth
-                source: "qrc:/qml/BluetoothDeviceChooser.qml"
-            }
+              GridLayout {
+                  Layout.fillWidth: true
+
+                  columns: 2
+                  columnSpacing: 0
+                  rowSpacing: 5
+
+                  Label {
+                      Layout.fillWidth: true
+                      Layout.columnSpan: 2
+                      text: qsTr( "Positioning device in use:" )
+                      font: Theme.defaultFont
+
+                      wrapMode: Text.WordWrap
+                  }
+
+                  RowLayout {
+                      Layout.fillWidth: true
+                      Layout.columnSpan: 2
+
+                      ComboBox {
+                          id: positioningDeviceComboBox
+                          Layout.fillWidth: true
+                          Layout.alignment: Qt.AlignVCenter
+                          font: Theme.defaultFont
+                          popup.font: Theme.defaultFont
+                          textRole: 'display'
+                          model: PositioningDeviceModel {
+                              id: positioningDeviceModel
+                          }
+
+                          property string selectedPositioningDevice
+
+                          onCurrentIndexChanged: {
+                              var modelIndex = positioningDeviceModel.index(currentIndex, 0);
+                              selectedPositioningDevice = positioningDeviceModel.data(modelIndex, PositioningDeviceModel.DeviceId);
+                              if( positioningSettings.positioningDevice !== selectedPositioningDevice )
+                              {
+                                  positioningSettings.positioningDevice = selectedPositioningDevice
+                                  positioningSettings.positioningDeviceName = positioningDeviceModel.data(modelIndex, PositioningDeviceModel.DeviceName);
+                              }
+                          }
+
+                          Component.onCompleted: {
+                              currentIndex = positioningDeviceModel.findIndexFromDeviceId(settings.value('positioningDevice',''))
+                          }
+                      }
+                  }
+
+                  RowLayout {
+                      Layout.fillWidth: true
+                      Layout.columnSpan: 2
+
+                      QfButton {
+                        leftPadding: 10
+                        rightPadding: 10
+                        text: qsTr('Add')
+                        enabled: false
+                      }
+
+                      Item {
+                          Layout.fillWidth: true
+                          Layout.alignment: Qt.AlignVCenter
+                      }
+
+                      QfButton {
+                        leftPadding: 10
+                        rightPadding: 10
+                        text: qsTr('Edit')
+                        enabled: false
+                      }
+
+                      QfButton {
+                        leftPadding: 10
+                        rightPadding: 10
+                        text: qsTr('Remove')
+                        enabled: false
+                      }
+                  }
+              }
 
               GridLayout {
                   Layout.fillWidth: true

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -484,7 +484,13 @@ Page {
                         leftPadding: 10
                         rightPadding: 10
                         text: qsTr('Remove')
-                        enabled: false
+                        enabled: positioningDeviceComboBox.currentIndex > 0
+
+                        onClicked: {
+                          var modelIndex = positioningDeviceModel.index(positioningDeviceComboBox.currentIndex, 0);
+                          positioningDeviceComboBox.currentIndex = 0;
+                          positioningDeviceModel.removeDevice(positioningDeviceModel.data(modelIndex, PositioningDeviceModel.DeviceName));
+                        }
                       }
                   }
 

--- a/src/qml/imports/Theme/QfTextField.qml
+++ b/src/qml/imports/Theme/QfTextField.qml
@@ -6,6 +6,7 @@ Item {
 
   property alias font: textField.font
   property alias text: textField.text
+  property alias placeholderText: textField.placeholderText
   property alias horizontalAlignment: textField.horizontalAlignment
   property alias inputMethodHints: textField.inputMethodHints
   property alias inputMask: textField.inputMask
@@ -29,6 +30,7 @@ Item {
     echoMode: textFieldWrapper.echoMode
     width: textFieldWrapper.width
     font: Theme.defaultFont
+    placeholderTextColor: Theme.accentLightColor
     rightPadding: showPasswordButton.visible ? 2 * showPasswordButton.width : 0
     inputMethodHints: Qt.ImhNone
 

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -22,6 +22,7 @@
         <file>NavigationHighlight.qml</file>
         <file>NavigationInformationView.qml</file>
         <file>NavigationRenderer.qml</file>
+        <file>PositioningDeviceSettings.qml</file>
         <file>PositioningSettings.qml</file>
         <file>PositioningInformationView.qml</file>
         <file>PositioningPreciseView.qml</file>


### PR DESCRIPTION
This PR is the first step towards moving away from a Bluetooth-centric positioning device settings UI into an emancipated world where TCP/UDP/Bluetooth/etc. devices are handled.

Settings now looks like this:
![image](https://user-images.githubusercontent.com/1728657/209425535-1e4bef7f-9c4d-43db-8203-972621f99b93.png)

The add / edit / remove buttons are all implemented, which means Bluetooth devices can be added and the UI tested. That looks like this:
![image](https://user-images.githubusercontent.com/1728657/209430949-15121c50-ef33-4ad5-b245-3f464f607dbd.png)


A big positive of this revamped approach is that someone will be able to setup multiple devices and will simply require to switch item in the combobox to hop from one to the other instead of going through a round of setup. This is beneficial even for Bluetooth devices, e.g. instead of having to do re-scans every time a user wants to switch from one Bluetooth device to the other, he/she/they will rely on saved device details. *Much faster*.