### PR TITLE
Add useful text field hints to TCP/UDP device configuration widgets

### DIFF
--- a/src/qml/TcpDeviceChooser.qml
+++ b/src/qml/TcpDeviceChooser.qml
@@ -44,6 +44,7 @@ Item {
         Layout.fillWidth: true
         font: Theme.defaultFont
         text: 'localhost'
+        inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhPreferLowercase
     }
 
     Label {
@@ -58,6 +59,7 @@ Item {
         Layout.fillWidth: true
         font: Theme.defaultFont
         text: '9000'
+        inputMethodHints: Qt.ImhFormattedNumbersOnly
     }
   }
 }

--- a/src/qml/TcpDeviceChooser.qml
+++ b/src/qml/TcpDeviceChooser.qml
@@ -22,7 +22,7 @@ Item {
   }
 
   function getSettings() {
-    return {'address': deviceAddress,
+    return {'address': deviceAddress.trim(),
             'port': parseInt(devicePort)};
   }
 

--- a/src/qml/UdpDeviceChooser.qml
+++ b/src/qml/UdpDeviceChooser.qml
@@ -44,6 +44,7 @@ Item {
         Layout.fillWidth: true
         font: Theme.defaultFont
         text: 'localhost'
+        inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhPreferLowercase
     }
 
     Label {
@@ -58,6 +59,7 @@ Item {
         Layout.fillWidth: true
         font: Theme.defaultFont
         text: '11111'
+        inputMethodHints: Qt.ImhFormattedNumbersOnly
     }
   }
 }

--- a/src/qml/UdpDeviceChooser.qml
+++ b/src/qml/UdpDeviceChooser.qml
@@ -22,7 +22,7 @@ Item {
   }
 
   function getSettings() {
-    return {'address': deviceAddress,
+    return {'address': deviceAddress.trim(),
             'port': parseInt(devicePort)};
   }
 


### PR DESCRIPTION
That way, we get a nice virtual digits-only keyboard for ports and no auto uppercasing mess for host address.