### PR TITLE
Do not add saved Bluetooth device name + address to the discovered devices model …

### DIFF
--- a/src/qml/BluetoothDeviceChooser.qml
+++ b/src/qml/BluetoothDeviceChooser.qml
@@ -19,8 +19,6 @@ Item {
   function setSettings(settings) {
     deviceName = settings['name'];
     deviceAddress = settings['address'];
-    var index = bluetoothDeviceModel.addDevice(deviceName, deviceAddress);
-    bluetoothDeviceComboBox.currentIndex = index;
   }
 
   function getSettings() {

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -1151,11 +1151,8 @@ Page {
       }
 
       var index = positioningDeviceModel.addDevice(type, name, settings);
-      if (index !== positioningDeviceComboBox.currentIndex) {
-        positioningDeviceComboBox.currentIndex = index;
-      } else {
-        positioningDeviceComboBox.onCurrentIndexChanged();
-      }
+      positioningDeviceComboBox.currentIndex = index;
+      positioningDeviceComboBox.onCurrentIndexChanged();
     }
   }
 


### PR DESCRIPTION
… device might have had its address randomized/changed. 

By not auto adding it to the list, users will be able to re-select the device with a new address in the discovered devices list.