### PR TITLE
Location marker cleanup and compass relocation

### DIFF
--- a/src/qml/LocationMarker.qml
+++ b/src/qml/LocationMarker.qml
@@ -8,7 +8,7 @@ import Theme 1.0
 import "."
 
 Item {
-  id: item
+  id: locationMarker
 
   property variant location // QgsPoint
 
@@ -16,6 +16,10 @@ Item {
   property real direction: -1 // A -1 value indicates absence of movement direction information
   property real speed: -1 // A -1 value indicates absence of speed information
   property real orientation: -1 // A -1 value indicates absence of compass orientation
+
+  property color color: Theme.positionColor
+  property color darkerColor: Qt.darker(color, 1.75)
+  property color semiOpaqueColor: Qt.hsla(color.hslHue, color.hslSaturation, color.hslLightness, 0.2)
 
   property MapSettings mapSettings
 
@@ -46,8 +50,8 @@ Item {
 
     radius: width/2
 
-    color: Theme.positionColorSemiOpaque
-    border.color: Theme.darkPositionColorSemiOpaque
+    color: locationMarker.semiOpaqueColor
+    border.color: locationMarker.darkerColor
     border.width: 0.7
   }
 
@@ -84,7 +88,7 @@ Item {
       strokeWidth: 3
       strokeColor: "white"
       strokeStyle: ShapePath.SolidLine
-      fillColor: Theme.positionColor
+      fillColor: locationMarker.color
       joinStyle: ShapePath.MiterJoin
       startX: 10
       startY: 2
@@ -95,8 +99,8 @@ Item {
 
       SequentialAnimation on fillColor  {
         loops: Animation.Infinite
-        ColorAnimation  { from: Theme.positionColor; to: Theme.darkPositionColor; duration: 2000; easing.type: Easing.InOutQuad }
-        ColorAnimation  { from: Theme.darkPositionColor; to: Theme.positionColor; duration: 1000; easing.type: Easing.InOutQuad }
+        ColorAnimation  { from: locationMarker.color; to: locationMarker.darkerColor; duration: 2000; easing.type: Easing.InOutQuad }
+        ColorAnimation  { from: locationMarker.darkerColor; to: locationMarker.color; duration: 1000; easing.type: Easing.InOutQuad }
       }
     }
 
@@ -123,14 +127,14 @@ Item {
 
     radius: width / 2
 
-    color: Theme.positionColor
+    color: locationMarker.color
     border.color: "white"
     border.width: 3
 
     SequentialAnimation on color  {
       loops: Animation.Infinite
-      ColorAnimation  { from: Theme.positionColor; to: Theme.darkPositionColor; duration: 2000; easing.type: Easing.InOutQuad }
-      ColorAnimation  { from: Theme.darkPositionColor; to: Theme.positionColor; duration: 1000; easing.type: Easing.InOutQuad }
+      ColorAnimation  { from: locationMarker.color; to: locationMarker.darkerColor; duration: 2000; easing.type: Easing.InOutQuad }
+      ColorAnimation  { from: locationMarker.darkerColor; to: locationMarker.color; duration: 1000; easing.type: Easing.InOutQuad }
     }
 
     layer.enabled: true
@@ -163,7 +167,7 @@ Item {
       strokeWidth: 3
       strokeColor: "white"
       strokeStyle: ShapePath.SolidLine
-      fillColor: Theme.positionColor
+      fillColor: locationMarker.color
       joinStyle: ShapePath.MiterJoin
       startX: 10
       startY: 0
@@ -173,8 +177,8 @@ Item {
 
       SequentialAnimation on fillColor  {
         loops: Animation.Infinite
-        ColorAnimation  { from: Theme.positionColor; to: Theme.darkPositionColor; duration: 2000; easing.type: Easing.InOutQuad }
-        ColorAnimation  { from: Theme.darkPositionColor; to: Theme.positionColor; duration: 1000; easing.type: Easing.InOutQuad }
+        ColorAnimation  { from: locationMarker.color; to: locationMarker.darkerColor; duration: 2000; easing.type: Easing.InOutQuad }
+        ColorAnimation  { from: locationMarker.darkerColor; to: locationMarker.color; duration: 1000; easing.type: Easing.InOutQuad }
       }
     }
 

--- a/src/qml/PositioningPreciseView.qml
+++ b/src/qml/PositioningPreciseView.qml
@@ -17,8 +17,8 @@ Item {
   property bool hasReachedTarget: hasAcceptableAccuracy && navigation.distance - positionSource.positionInformation.hacc - (precision / 10) <= 0
   property bool hasAlarmSnoozed: false
 
-  property double positionX: Math.min(precision, navigation.distance) * Math.cos((navigation.bearing - locationMarker.compassOrientation - 90) * Math.PI / 180) * (preciseTarget.width / 2) / precision
-  property double positionY: Math.min(precision, navigation.distance) * Math.sin((navigation.bearing - locationMarker.compassOrientation - 90) * Math.PI / 180) * (preciseTarget.width / 2) / precision
+  property double positionX: Math.min(precision, navigation.distance) * Math.cos((navigation.bearing - magnetometer.orientation - 90) * Math.PI / 180) * (preciseTarget.width / 2) / precision
+  property double positionY: Math.min(precision, navigation.distance) * Math.sin((navigation.bearing - magnetometer.orientation - 90) * Math.PI / 180) * (preciseTarget.width / 2) / precision
   property double positionZ: hasZ ? Math.min(precision, Math.max(-precision, -navigation.verticalDistance)) * ((preciseElevation.height - 15) / 2) / precision : 0.0
   property point positionCenter: Qt.point(preciseTarget.width / 2 + preciseTarget.x + preciseTarget.parent.x,
                                           preciseTarget.height / 2 + preciseTarget.y + preciseTarget.parent.y)
@@ -53,7 +53,7 @@ Item {
       width: Math.min(positioningPreciseView.height - 10,
                       positioningPreciseView.width - preciseElevation.width - labelTarget.contentWidth - labelElevation.width - 20)
       height: width
-      rotation: locationMarker.compassHasValue ? -locationMarker.compassOrientation : 0
+      rotation: magnetometer.hasValue ? -magnetometer.orientation : 0
 
       ShapePath {
         strokeWidth: 1
@@ -322,7 +322,7 @@ Item {
     y: positionCenter.y + positionY - width / 2
     width: 28
     height: width
-    rotation: navigation.bearing - locationMarker.compassOrientation
+    rotation: navigation.bearing - magnetometer.orientation
 
     ShapePath {
       strokeWidth: 1
@@ -387,7 +387,7 @@ Item {
   Text {
     id: preciseHorizontalPositionInfo
 
-    property bool leftOfPoint: locationMarker.compassHasValue && positionX >= 0
+    property bool leftOfPoint: magnetometer.hasValue && positionX >= 0
     x: positionCenter.x + positionX + (positionX >= 0 ? -contentWidth - 10 : preciseHorizontalPosition.width / 2)
     y: positionCenter.y + positionY + (positionY >= 0 ? -preciseHorizontalPosition.height : preciseHorizontalPosition.height / 2)
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -216,6 +216,19 @@ ApplicationWindow {
         gnssButton.followLocation(false);
       }
     }
+
+
+    onActiveChanged: {
+      if (active) {
+        magnetometer.active = true
+        magnetometer.start()
+      } else {
+        magnetometer.stop()
+        magnetometer.active = false
+        magnetometer.hasValue = false
+        magnetometer.orientation = 0.0
+      }
+    }
   }
 
   Connections {
@@ -262,22 +275,6 @@ ApplicationWindow {
     Component.onCompleted: {
       if (Screen.orientationUpdateMask) {
         Screen.orientationUpdateMask = Qt.PortraitOrientation | Qt.InvertedPortraitOrientation | Qt.LandscapeOrientation | Qt.InvertedLandscapeOrientation
-      }
-    }
-  }
-
-  Connections {
-    target: positionSource
-
-    function onActiveChanged() {
-      if (positionSource.active) {
-        magnetometer.active = true
-        magnetometer.start()
-      } else {
-        magnetometer.stop()
-        magnetometer.active = false
-        magnetometer.hasValue = false
-        magnetometer.orientation = 0.0
       }
     }
   }
@@ -676,7 +673,6 @@ ApplicationWindow {
     LocationMarker {
       id: locationMarker
       visible: positionSource.active && positionSource.positionInformation && positionSource.positionInformation.latitudeValid
-      anchors.fill: parent
 
       mapSettings: mapCanvas.mapSettings
 


### PR DESCRIPTION
This PR cleans up the location marker by removing the "compass" magnetometer away from the marker into the main qgismobileapp file. The relocation makes sense since it's used not only by the location marker but also the precise "stakeout" view.

The goal here is to eventually allow for the location marker to be used as part of a model of locations, where the location marker could be used to display live location from various sources. To that end, a color property was added to the location marker to add markers with custom colors.