### PR TITLE
Fix USB copying photos captured by QField Android in a project subfolder created during capture

### DIFF
--- a/platform/android/src/ch/opengis/qfield/QFieldCameraPictureActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldCameraPictureActivity.java
@@ -103,13 +103,8 @@ public class QFieldCameraPictureActivity extends Activity {
         if (requestCode == CAMERA_ACTIVITY) {
             if (resultCode == RESULT_OK) {
                 File result = new File(prefix + pictureFilePath);
-                File path = result.getParentFile();
-                path.mkdirs();
-                path.setExecutable(true);
-                path.setReadable(true);
-                path.setWritable(true);
-
                 File pictureFile = new File(pictureTempFilePath);
+
                 Log.d(TAG, "Taken picture: " + pictureFile.getAbsolutePath());
                 try {
                     InputStream in = new FileInputStream(pictureFile);
@@ -118,13 +113,6 @@ public class QFieldCameraPictureActivity extends Activity {
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
-
-                // Let the android scan new media folders/files to make them
-                // visible through MTP
-                result.setReadable(true);
-                result.setWritable(true);
-                MediaScannerConnection.scanFile(
-                    this, new String[] {path.toString()}, null, null);
 
                 Intent intent = this.getIntent();
                 intent.putExtra("PICTURE_IMAGE_FILENAME",

--- a/platform/android/src/ch/opengis/qfield/QFieldGalleryPictureActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldGalleryPictureActivity.java
@@ -67,11 +67,6 @@ public class QFieldGalleryPictureActivity extends Activity {
         if (requestCode == GALLERY_ACTIVITY) {
             if (resultCode == RESULT_OK) {
                 File result = new File(prefix + pictureFilePath);
-                File path = result.getParentFile();
-                path.mkdirs();
-                path.setExecutable(true);
-                path.setReadable(true);
-                path.setWritable(true);
 
                 Log.d(TAG, "Selected picture: " + data.getData().toString());
                 try {
@@ -84,13 +79,6 @@ public class QFieldGalleryPictureActivity extends Activity {
                 } catch (Exception e) {
                     Log.d(TAG, e.getMessage());
                 }
-
-                // Let the android scan new media folders/files to make them
-                // visible through MTP
-                result.setReadable(true);
-                result.setWritable(true);
-                MediaScannerConnection.scanFile(
-                    this, new String[] {path.toString()}, null, null);
 
                 Intent intent = this.getIntent();
                 intent.putExtra("PICTURE_IMAGE_FILENAME",

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -30,6 +30,7 @@
 #include <QAndroidJniObject>
 #include <QApplication>
 #include <QDebug>
+#include <QDir>
 #include <QFile>
 #include <QFileInfo>
 #include <QMap>
@@ -345,6 +346,10 @@ PictureSource *AndroidPlatformUtilities::getCameraPicture( QQuickItem *parent, c
   if ( !checkCameraPermissions() )
     return nullptr;
 
+  const QFileInfo destinationInfo( prefix + pictureFilePath );
+  const QDir prefixDir( prefix );
+  prefixDir.mkpath( destinationInfo.absolutePath() );
+
   QAndroidJniObject activity = QAndroidJniObject::fromString( QStringLiteral( "ch.opengis." APP_PACKAGE_NAME ".QFieldCameraPictureActivity" ) );
   QAndroidJniObject intent = QAndroidJniObject( "android/content/Intent", "(Ljava/lang/String;)V", activity.object<jstring>() );
   QAndroidJniObject packageName = QAndroidJniObject::fromString( QStringLiteral( "ch.opengis." APP_PACKAGE_NAME ) );
@@ -383,6 +388,10 @@ PictureSource *AndroidPlatformUtilities::getCameraPicture( QQuickItem *parent, c
 PictureSource *AndroidPlatformUtilities::getGalleryPicture( QQuickItem *parent, const QString &prefix, const QString &pictureFilePath )
 {
   Q_UNUSED( parent )
+
+  const QFileInfo destinationInfo( prefix + pictureFilePath );
+  const QDir prefixDir( prefix );
+  prefixDir.mkpath( destinationInfo.absolutePath() );
 
   QAndroidJniObject activity = QAndroidJniObject::fromString( QStringLiteral( "ch.opengis." APP_PACKAGE_NAME ".QFieldGalleryPictureActivity" ) );
   QAndroidJniObject intent = QAndroidJniObject( "android/content/Intent", "(Ljava/lang/String;)V", activity.object<jstring>() );


### PR DESCRIPTION
This PR fixes #3736 and #3799 , whereas photos captured in QField Android with an expression that would create a folder not present during the initial project import would fail to copy via USB cable.