### PR TITLE
As we do with Android and iOS, create QField's app data directory's subfolders

### DIFF
--- a/src/core/platforms/platformutilities.cpp
+++ b/src/core/platforms/platformutilities.cpp
@@ -89,7 +89,17 @@ void PlatformUtilities::initSystem()
 }
 
 void PlatformUtilities::afterUpdate()
-{}
+{
+  const QStringList dirs = appDataDirs();
+  for ( const QString &dir : dirs )
+  {
+    QDir appDir( dir );
+    appDir.mkpath( QStringLiteral( "proj" ) );
+    appDir.mkpath( QStringLiteral( "auth" ) );
+    appDir.mkpath( QStringLiteral( "fonts" ) );
+    appDir.mkpath( QStringLiteral( "basemaps" ) );
+  }
+}
 
 QString PlatformUtilities::systemSharedDataLocation() const
 {


### PR DESCRIPTION
This will help inform people as to where they should be their grids, etc.