### PR TITLE
Handling login error caused by redirect

### DIFF
--- a/src/core/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloudconnection.cpp
@@ -148,6 +148,18 @@ void QFieldCloudConnection::login()
 
   setStatus( ConnectionStatus::Connecting );
 
+  // Handle login redirect as an error state
+  connect( reply, &NetworkReply::redirected, this, [=]() {
+    QNetworkReply *rawReply = reply->reply();
+    reply->deleteLater();
+    rawReply->deleteLater();
+
+    emit loginFailed( tr( "Login error due to unexpected redirect, please retry later" ) );
+
+    setStatus( ConnectionStatus::Disconnected );
+    return;
+  } );
+
   connect( reply, &NetworkReply::finished, this, [=]() {
     QNetworkReply *rawReply = reply->reply();
 


### PR DESCRIPTION
@mbernasocchi , this is an answer to what you pointed out yesterday. QField didn't handle the 'maintenance' redirect scenario triggered by the outage, ending up in an infinite logging screen that never resolved to a success or failure.