### PR TITLE
Fix UUID edit widget not creating UUIDs when in read-only mode

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -511,6 +511,8 @@ Page {
                 // - not set to editable in the widget configuration
                 // - not in edit mode (ReadOnly)
                 // - a relation in multi edit mode
+                property bool isAdding: form.state === 'Add'
+                property bool isEditing: form.state === 'Edit'
                 property bool isEnabled: !!AttributeEditable
                                          && form.state !== 'ReadOnly'
                                          && !( Type === 'relation' && form.model.featureModel.modelMode == FeatureModel.MultiFeatureModel )

--- a/src/qml/editorwidgets/UuidGenerator.qml
+++ b/src/qml/editorwidgets/UuidGenerator.qml
@@ -28,12 +28,13 @@ EditorWidgetBase {
       color: 'gray'
       text: {
         var displayValue = value !== undefined ? value : ''
-        if (isLoaded && isEnabled && (value === undefined || value == '')) {
+        if (isLoaded && isAdding && (value == undefined || value === '')) {
             displayValue = StringUtils.createUuid();
             valueChangeRequested(displayValue ,false);
         }
         return displayValue;
       }
+      elide: Text.ElideMiddle
   }
 
   Rectangle {


### PR DESCRIPTION
In QGIS, the UUID edit widget will create a unique UUID whether it's [x] editable or not, let's do the same, otherwise ppl are left with broken UUID widgets.

Seen while dissecting https://github.com/opengisch/QField/issues/3857.