### PR TITLE
Avoid hidding attribute linked to parent feature in relation, just disable

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -262,8 +262,11 @@ void AttributeFormModelBase::updateAttributeValue( QStandardItem *item )
     QVariant attributeValue = mFeatureModel->data( mFeatureModel->index( fieldIndex ), FeatureModel::AttributeValue );
     item->setData( attributeValue.isNull() ? QVariant() : attributeValue, AttributeFormModel::AttributeValue );
     item->setData( mFeatureModel->data( mFeatureModel->index( fieldIndex ), FeatureModel::AttributeAllowEdit ), AttributeFormModel::AttributeAllowEdit );
-    //set item visibility to false in case it's a linked attribute
-    item->setData( !mFeatureModel->data( mFeatureModel->index( fieldIndex ), FeatureModel::LinkedAttribute ).toBool(), AttributeFormModel::CurrentlyVisible );
+    // set item editable state to false in case it's a linked attribute
+    if ( mFeatureModel->data( mFeatureModel->index( fieldIndex ), FeatureModel::LinkedAttribute ).toBool() )
+    {
+      item->setData( false, AttributeFormModel::AttributeEditable );
+    }
   }
   else if ( item->data( AttributeFormModel::ElementType ) == QStringLiteral( "qml" ) || item->data( AttributeFormModel::ElementType ) == QStringLiteral( "html" ) )
   {


### PR DESCRIPTION
Fix https://github.com/opengisch/QField/issues/3857 and harmonize handling of child feature's attribute linked to a parent feature in feature form. 

Until now, we were hiding a child feature's attribute linked to a parent feature from the feature form. This can create confusion (see issue above), and doesn't match QGIS' behavior. This PR goes for _disabling_ editing on the attribute instead of completely hiding it. IMHO, this is a better option and deliver a better representative of underlying data and relations.