### PR TITLE
Add appropriate input method flags to the layer login popup's user and password fields

### DIFF
--- a/src/qml/LayerLoginDialog.qml
+++ b/src/qml/LayerLoginDialog.qml
@@ -58,7 +58,7 @@ Page {
       id: username
       Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
       Layout.preferredWidth: Math.max( parent.width / 2, usernamelabel.width )
-      inputMethodHints: Qt.ImhPreferLowercase
+      inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhPreferLowercase
     }
 
     Item {
@@ -78,6 +78,7 @@ Page {
       Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
       Layout.preferredWidth: Math.max( parent.width / 2, usernamelabel.width )
       echoMode: TextInput.Password
+      inputMethodHints: Qt.ImhHiddenText | Qt.ImhNoPredictiveText | Qt.ImhSensitiveData | Qt.ImhNoAutoUppercase | Qt.ImhPreferLowercase
     }
 
     Item {


### PR DESCRIPTION
This PR does everything we can possibly do to fix https://github.com/opengisch/QField/issues/3888 by adding flags which good virtual keyboards will take into account. 