### PR TITLE
convert sh to unix files, if needed

### DIFF
--- a/.docker/android_dev/Dockerfile
+++ b/.docker/android_dev/Dockerfile
@@ -58,6 +58,9 @@ RUN groupadd android && useradd -d /opt/android-sdk-linux -g android -u 1000 and
 
 COPY tools /opt/tools
 
+# convert to unix linebreaks if project is exported to Windows
+RUN sed -i.bak 's/\r$//' /opt/tools/*.sh
+
 COPY licenses /opt/licenses
 
 WORKDIR /opt/android-sdk-linux


### PR DESCRIPTION
When I cloned the project to Windows, sh files got windows line breaks.
This conversion would revert them back to unix line breaks. Perhaps not the optimal solution but the best one I could find.