### PR TITLE
Use native separator when linked to vertical grid file

### DIFF
--- a/src/core/qgsquick/qgsquickcoordinatetransformer.cpp
+++ b/src/core/qgsquick/qgsquickcoordinatetransformer.cpp
@@ -16,6 +16,7 @@
 #include "platformutilities.h"
 #include "qgsquickcoordinatetransformer.h"
 
+#include <QDir>
 #include <QFile>
 #include <QSettings>
 #include <qgslogger.h>
@@ -259,7 +260,7 @@ void QgsQuickCoordinateTransformer::setVerticalGrid( const QString &grid )
         const QString verticalGridPath = QStringLiteral( "%1proj/%2" ).arg( dataDir, mVerticalGrid );
         if ( QFile::exists( verticalGridPath ) )
         {
-          mVerticalGridPath = verticalGridPath;
+          mVerticalGridPath = QDir::toNativeSeparators( verticalGridPath );
           break;
         }
       }


### PR DESCRIPTION
This _could_ fix https://github.com/opengisch/QField/issues/3929 

