### PR TITLE
Respect feature form's attribute label font and color override

### DIFF
--- a/src/core/attributeformmodel.h
+++ b/src/core/attributeformmodel.h
@@ -59,6 +59,10 @@ class AttributeFormModel : public QSortFilterProxyModel
       GroupName,
       GroupIndex,
       ColumnCount,
+      LabelOverrideColor,
+      LabelColor,
+      LabelOverrideFont,
+      LabelFont,
     };
 
     Q_ENUM( FeatureRoles )

--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -71,6 +71,10 @@ QHash<int, QByteArray> AttributeFormModelBase::roleNames() const
   roles[AttributeFormModel::GroupName] = "GroupName";
   roles[AttributeFormModel::GroupIndex] = "GroupIndex";
   roles[AttributeFormModel::ColumnCount] = "ColumnCount";
+  roles[AttributeFormModel::LabelOverrideColor] = "LabelOverrideColor";
+  roles[AttributeFormModel::LabelColor] = "LabelColor";
+  roles[AttributeFormModel::LabelOverrideFont] = "LabelOverrideFont";
+  roles[AttributeFormModel::LabelFont] = "LabelFont";
 
   return roles;
 }
@@ -327,6 +331,12 @@ void AttributeFormModelBase::buildForm( QgsAttributeEditorContainer *container, 
     item->setData( currentTabIndex, AttributeFormModel::TabIndex );
     item->setData( QString(), AttributeFormModel::GroupName );
     item->setData( QVariant(), AttributeFormModel::GroupIndex );
+
+    QgsAttributeEditorElement::LabelStyle labelStyle = element->labelStyle();
+    item->setData( labelStyle.overrideColor, AttributeFormModel::LabelOverrideColor );
+    item->setData( labelStyle.overrideColor ? labelStyle.color : QColor(), AttributeFormModel::LabelColor );
+    item->setData( labelStyle.overrideFont, AttributeFormModel::LabelOverrideFont );
+    item->setData( labelStyle.overrideFont ? labelStyle.font : QFont(), AttributeFormModel::LabelFont );
 
     switch ( element->type() )
     {

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -461,17 +461,18 @@ Page {
               width: parent.width
               text: Name || ''
               wrapMode: Text.WordWrap
+              font.family: LabelOverrideFont ? LabelFont.family : Theme.tinyFont.family
               font.pointSize: Theme.tinyFont.pointSize
-              font.bold: true
+              font.bold: LabelOverrideFont ? LabelFont.bold : true
+              font.italic: LabelOverrideFont ? LabelFont.italic : false
+              font.underline: LabelOverrideFont ? LabelFont.underline : false
+              font.strikeout: LabelOverrideFont ? LabelFont.strikeout : false
               topPadding: 10
               bottomPadding: 5
-              color: ConstraintHardValid
-                     ? ( form.state === 'ReadOnly' || !AttributeEditable ) || embedded && EditorWidget === 'RelationEditor'
-                         ? 'grey'
-                         : ConstraintSoftValid
-                           ? 'black'
-                           : Theme.warningColor
-                     : Theme.errorColor
+              opacity: (form.state === 'ReadOnly' || !AttributeEditable) || embedded && EditorWidget === 'RelationEditor'
+                       ? 0.45
+                       : 1
+              color: LabelOverrideColor ? LabelColor : 'black'
             }
 
             Label {
@@ -489,10 +490,10 @@ Page {
 
                 return ConstraintDescription || '';
               }
-              height:  !ConstraintHardValid || !ConstraintSoftValid ? undefined : 0
+              height: !ConstraintHardValid || !ConstraintSoftValid ? undefined : 0
               visible: !ConstraintHardValid || !ConstraintSoftValid
-
-              color: !ConstraintHardValid ? Theme.errorColor : Theme.darkGray
+              opacity: fieldLabel.opacity
+              color: !ConstraintHardValid ? Theme.errorColor : Theme.warningColor
             }
 
             Item {


### PR DESCRIPTION
This PR implements feature form's attribute label font and color override:
![image](https://user-images.githubusercontent.com/1728657/221139716-1d5c9b83-2d19-4632-8b27-20c0af27490b.png)

