### PR TITLE
Non-native QML camera enhancements

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -11,6 +11,9 @@
         <file alias="qfield-love.png">pictures/qfield-love.png</file>
     </qresource>
     <qresource prefix="/">
+        <file>themes/qfield/nodpi/ic_flash_auto_black_24dp.svg</file>
+        <file>themes/qfield/nodpi/ic_flash_on_black_24dp.svg</file>
+        <file>themes/qfield/nodpi/ic_flash_off_black_24dp.svg</file>
         <file>themes/qfield/nodpi/ic_pause_black_24dp.svg</file>
         <file>themes/qfield/nodpi/ic_play_black_24dp.svg</file>
         <file>themes/qfield/nodpi/ic_internal_receiver_black_24dp.svg</file>

--- a/images/themes/qfield/nodpi/ic_flash_auto_black_24dp.svg
+++ b/images/themes/qfield/nodpi/ic_flash_auto_black_24dp.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24" height="24" version="1.1" viewBox="0 96 960 960" xmlns="http://www.w3.org/2000/svg">
+ <path d="m280 720 128-184H294l80-280H160v320h120v144Zm-80 256V656H80V176h400l-80 280h160L200 976Zm80-400H160h120Zm305-40 135-360h64l137 360h-62l-32-92H679l-32 92h-62Zm112-144h110l-53-150h-2l-55 150Z"/>
+</svg>

--- a/images/themes/qfield/nodpi/ic_flash_off_black_24dp.svg
+++ b/images/themes/qfield/nodpi/ic_flash_off_black_24dp.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24" height="24" version="1.1" viewBox="0 96 960 960" xmlns="http://www.w3.org/2000/svg">
+ <path d="m280 176h400l-80 280h160l-117 169-57-57 22-32h-54l-47-47 67-233h-214v86l-80-80v-86zm120 800v-320h-120v-166l-225-225 57-57 736 736-57 57-241-241-150 216z"/>
+</svg>

--- a/images/themes/qfield/nodpi/ic_flash_on_black_24dp.svg
+++ b/images/themes/qfield/nodpi/ic_flash_on_black_24dp.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24" height="24" version="1.1" viewBox="0 96 960 960" xmlns="http://www.w3.org/2000/svg">
+ <path d="m480 720 128-184H494l80-280H360v320h120v144Zm-80 256V656H280V176h400l-80 280h160L400 976Zm80-400H360h120Z"/>
+</svg>

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -38,6 +38,7 @@
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
 #include <QScreen>
+#include <QSettings>
 #include <QStandardPaths>
 #include <QString>
 #include <QTimer>
@@ -385,6 +386,8 @@ ResourceSource *AndroidPlatformUtilities::processCameraActivity( const QString &
                            "(Ljava/lang/String;Ljava/lang/String;)Landroid/content/Intent;",
                            suffix_label.object<jstring>(),
                            suffix_value.object<jstring>() );
+
+  QSettings().setValue( QStringLiteral( "QField/nativeCameraLaunched" ), true );
 
   AndroidResourceSource *pictureSource = new AndroidResourceSource( prefix );
 

--- a/src/core/platforms/android/androidresourcesource.cpp
+++ b/src/core/platforms/android/androidresourcesource.cpp
@@ -21,6 +21,7 @@
 #include <QDebug>
 #include <QDir>
 #include <QFile>
+#include <QSettings>
 #include <QtAndroid>
 
 AndroidResourceSource::AndroidResourceSource( const QString &prefix )
@@ -34,6 +35,12 @@ void AndroidResourceSource::handleActivityResult( int receiverRequestCode, int r
 {
   if ( receiverRequestCode == 171 )
   {
+    const bool nativeCameraLaunched = QSettings().value( QStringLiteral( "QField/nativeCameraLaunched" ), false ).toBool();
+    if ( nativeCameraLaunched )
+    {
+      QSettings().setValue( QStringLiteral( "QField/nativeCameraLaunched" ), false );
+    }
+
     jint RESULT_OK = QAndroidJniObject::getStaticField<jint>( "android/app/Activity", "RESULT_OK" );
     if ( resultCode == RESULT_OK )
     {

--- a/src/qml/Changelog.qml
+++ b/src/qml/Changelog.qml
@@ -68,7 +68,7 @@ Popup {
                         Layout.maximumHeight: contentHeight
                         visible: changelogContents.status != ChangelogContents.LoadingStatus
 
-                        color: '#95000000'
+                        color: Theme.mainTextColor
                         font: Theme.tipFont
 
                         fontSizeMode: Text.VerticalFit

--- a/src/qml/QFieldCamera.qml
+++ b/src/qml/QFieldCamera.qml
@@ -155,7 +155,6 @@ Popup {
       onActiveChanged: {
         if (active) {
           oldScale = 1.0
-        } else {
         }
       }
 
@@ -175,15 +174,15 @@ Popup {
       grabPermissions: PointerHandler.CanTakeOverFromHandlersOfDifferentType | PointerHandler.ApprovesTakeOverByItems
 
       onWheel: (event) => {
-                 if (event.angleDelta.y > 0)
-                 {
-                   camera.zoomIn(0.25)
-                 }
-                 else
-                 {
-                   camera.zoomOut(0.25)
-                 }
-               }
+        if (event.angleDelta.y > 0)
+        {
+          camera.zoomIn(0.25)
+        }
+        else
+        {
+          camera.zoomOut(0.25)
+        }
+      }
     }
 
     Video {
@@ -228,7 +227,8 @@ Popup {
         radius: 32
         color: Qt.hsla(Theme.darkGray.hslHue, Theme.darkGray.hslSaturation, Theme.darkGray.hslLightness, 0.3)
         border.color: cameraItem.state == "VideoCapture" && camera.videoRecorder.recorderState != CameraRecorder.StoppedState
-                      ? "red" : "white"
+                      ? "red"
+                      : "white"
         border.width: 2
 
         QfToolButton {

--- a/src/qml/QFieldCamera.qml
+++ b/src/qml/QFieldCamera.qml
@@ -250,7 +250,7 @@ Popup {
 
           onClicked: {
             if (cameraItem.state == "PhotoCapture") {
-              camera.imageCapture.captureToLocation('/home/webmaster/Desktop/1.jpg')//qgisProject.homePath+ '/DCIM/')
+              camera.imageCapture.captureToLocation(qgisProject.homePath+ '/DCIM/')
             } else if (cameraItem.state == "VideoCapture") {
               if (camera.videoRecorder.recorderState == CameraRecorder.StoppedState) {
                 camera.videoRecorder.record()
@@ -293,8 +293,8 @@ Popup {
         id: flashButton
         visible: cameraItem.isCapturing && camera.flash.supportedModes.length > 1
 
-        x: cameraItem.portaitMode ? (parent.width / 4) * 3 - (width / 2) : (parent.width - width) / 2
-        y: cameraItem.portaitMode ? (parent.height - height) / 2 : (parent.height / 4) - (height / 2)
+        x: cameraItem.isPortraitMode ? (parent.width / 4) * 3 - (width / 2) : (parent.width - width) / 2
+        y: cameraItem.isPortraitMode ? (parent.height - height) / 2 : (parent.height / 4) - (height / 2)
 
         iconSource: {
           switch(camera.flash.mode) {

--- a/src/qml/QFieldCamera.qml
+++ b/src/qml/QFieldCamera.qml
@@ -325,7 +325,7 @@ Popup {
         visible: cameraItem.state == "VideoCapture" && camera.videoRecorder.recorderState != CameraRecorder.StoppedState
 
         x: cameraItem.isPortraitMode ? captureRing.x + captureRing.width / 2 - width / 2 : captureRing.x + captureRing.width / 2 - width / 2
-        y: cameraItem.isPortraitMode ? captureRing.y - height - 20 : captureRing.y + captureRing.height / 2 - height / 2
+        y: cameraItem.isPortraitMode ? captureRing.y - height - 20 : captureRing.y - height - 20
 
         width: durationLabelMetrics.boundingRect('00:00:00').width + 20
         height: durationLabelMetrics.boundingRect('00:00:00').height + 10

--- a/src/qml/QFieldCamera.qml
+++ b/src/qml/QFieldCamera.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.14
 import QtQuick.Controls 2.14
+import QtQuick.Window 2.14
 import QtMultimedia 5.14
 
 import Theme 1.0
@@ -7,6 +8,9 @@ import Theme 1.0
 Popup {
   id: cameraItem
   z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature forms
+
+  property bool isCapturing: state == "PhotoCapture" || state == "VideoCapture"
+  property bool isPortraitMode: mainWindow.height > mainWindow.width
 
   property string currentPath
 
@@ -46,7 +50,23 @@ Popup {
     Camera {
       id: camera
 
+      cameraState: cameraItem.visible ? Camera.ActiveState : Camera.UnloadedState
+
       position: Camera.BackFace
+
+      metaData.cameraManufacturer: 'QField'
+      metaData.gpsLatitude: positionSource.positionInformation.latitudeValid
+                            ? positionSource.positionInformation.latitude
+                            : undefined
+      metaData.gpsLongitude: positionSource.positionInformation.longitudeValid
+                             ? positionSource.positionInformation.longitude
+                             : undefined
+      metaData.gpsAltitude: positionSource.positionInformation.elevationValid
+                            ? positionSource.positionInformation.elevation
+                            : undefined
+      metaData.gpsSpeed: positionSource.positionInformation.speedValid
+                         ? positionSource.positionInformation.speed
+                         : undefined
 
       imageCapture {
         onImageSaved: {
@@ -63,6 +83,44 @@ Popup {
         audioBitRate: 128000
         mediaContainer: "mp4"
       }
+
+      function zoomIn(increase) {
+        var zoom;
+        if (camera.opticalZoom < camera.maximumOpticalZoom) {
+          zoom = camera.opticalZoom + increase
+          if (zoom < camera.maximumOpticalZoom) {
+            camera.opticalZoom = zoom
+          } else {
+            camera.opticalZoom = camera.maximumOpticalZoom
+          }
+        } else {
+          zoom = camera.digitalZoom + increase
+          if (zoom < camera.maximumDigitalZoom) {
+            camera.digitalZoom = zoom
+          } else {
+            camera.digitalZoom = camera.maximumDigitalZoom
+          }
+        }
+      }
+
+      function zoomOut(decrease) {
+        var zoom;
+        if (camera.digitalZoom > 1) {
+          zoom = camera.digitalZoom - decrease
+          if (zoom > 1) {
+            camera.digitalZoom = zoom
+          } else {
+            camera.digitalZoom = 1
+          }
+        } else {
+          zoom = camera.opticalZoom - decrease
+          if (zoom > 1) {
+            camera.opticalZoom = zoom
+          } else {
+            camera.opticalZoom = 1
+          }
+        }
+      }
     }
 
     VideoOutput {
@@ -74,60 +132,58 @@ Popup {
       source: camera
 
       autoOrientation: true
+    }
 
-      MouseArea {
-        anchors.fill: parent
+    MouseArea {
+      anchors.fill: parent
 
-        onClicked: {
-          if (camera.lockStatus == Camera.Unlocked)
-            camera.searchAndLock();
-          else
-            camera.unlock();
+      onClicked: {
+        if (camera.lockStatus == Camera.Unlocked)
+          camera.searchAndLock();
+        else
+          camera.unlock();
+      }
+    }
+
+    PinchHandler {
+      enabled: cameraItem.visible && cameraItem.isCapturing
+      target: null
+      acceptedDevices: PointerDevice.TouchScreen | PointerDevice.TouchPad
+
+      property real oldScale: 1.0
+
+      onActiveChanged: {
+        if (active) {
+          oldScale = 1.0
+        } else {
         }
       }
 
-      QfToolButton {
-        id: captureStillImageButton
-        visible: cameraItem.state == "PhotoCapture"
-
-        anchors.right: parent.right
-        anchors.rightMargin: 5
-        anchors.verticalCenter: parent.verticalCenter
-
-        round: true
-        roundborder: true
-        bgcolor: "grey"
-        borderColor: Theme.mainColor
-
-        onClicked: camera.imageCapture.captureToLocation(qgisProject.homePath+ '/DCIM/')
-      }
-
-      QfToolButton {
-        id: recordVideoButton
-        visible: cameraItem.state == "VideoCapture"
-
-        anchors.right: parent.right
-        anchors.rightMargin: 5
-        anchors.verticalCenter: parent.verticalCenter
-
-        round: true
-        roundborder: true
-        bgcolor: camera.videoRecorder.recorderState != CameraRecorder.StoppedState  ? "black" : "red"
-        borderColor: "red"//Theme.mainColor
-
-        onClicked: {
-          if (camera.videoRecorder.recorderState == CameraRecorder.StoppedState) {
-            camera.videoRecorder.record()
-          } else {
-            camera.videoRecorder.stop()
-            videoPreview.source = camera.videoRecorder.actualLocation
-            var path = camera.videoRecorder.actualLocation.toString()
-            var filePos = path.indexOf('file://')
-            currentPath = filePos === 0 ? path.substring(7) : path
-            cameraItem.state = "VideoPreview"
-          }
+      onActiveScaleChanged: {
+        if (activeScale > oldScale) {
+          camera.zoomIn(0.05)
+        } else {
+          camera.zoomOut(0.05)
         }
+        oldScale = activeScale
       }
+    }
+
+    WheelHandler {
+      enabled: cameraItem.visible && cameraItem.isCapturing
+      target: null
+      grabPermissions: PointerHandler.CanTakeOverFromHandlersOfDifferentType | PointerHandler.ApprovesTakeOverByItems
+
+      onWheel: (event) => {
+                 if (event.angleDelta.y > 0)
+                 {
+                   camera.zoomIn(0.25)
+                 }
+                 else
+                 {
+                   camera.zoomOut(0.25)
+                 }
+               }
     }
 
     Video {
@@ -156,38 +212,176 @@ Popup {
       focus: visible
     }
 
-    QfToolButton {
-      id: okButton
+    Rectangle {
+      x: cameraItem.isPortraitMode ? 0 : parent.width - 100
+      y: cameraItem.isPortraitMode ? parent.height - 100 : 0
+      width: cameraItem.isPortraitMode ? parent.width : 100
+      height: cameraItem.isPortraitMode ? 100 : parent.height
 
-      visible: cameraItem.state == "PhotoPreview" || cameraItem.state == "VideoPreview"
+      color: Qt.hsla(Theme.darkGray.hslHue, Theme.darkGray.hslSaturation, Theme.darkGray.hslLightness, 0.3)
 
-      anchors.right: parent.right
-      anchors.rightMargin: 5
-      anchors.verticalCenter: parent.verticalCenter
-      bgcolor: Theme.mainColor
-      round: true
+      Rectangle {
+        id: captureRing
+        anchors.centerIn: parent
+        width: 64
+        height: 64
+        radius: 32
+        color: Qt.hsla(Theme.darkGray.hslHue, Theme.darkGray.hslSaturation, Theme.darkGray.hslLightness, 0.3)
+        border.color: cameraItem.state == "VideoCapture" && camera.videoRecorder.recorderState != CameraRecorder.StoppedState
+                      ? "red" : "white"
+        border.width: 2
 
-      iconSource: Theme.getThemeIcon("ic_save_white_24dp")
+        QfToolButton {
+          id: captureButton
 
-      onClicked: cameraItem.finished(currentPath)
+          anchors.centerIn: parent
+          visible: camera.cameraStatus == Camera.ActiveStatus ||
+                   camera.cameraStatus == Camera.LoadedStatus ||
+                   camera.cameraStatus == Camera.StandbyStatus
+
+          round: true
+          roundborder: true
+          iconSource: cameraItem.state == "PhotoPreview" || cameraItem.state == "VideoPreview"
+                      ? Theme.getThemeIcon("ic_check_white_48dp")
+                      : ''
+          bgcolor: cameraItem.state == "PhotoPreview" || cameraItem.state == "VideoPreview"
+                   ? Theme.mainColor
+                   : cameraItem.state == "VideoCapture" ? "red" : "white"
+
+          onClicked: {
+            if (cameraItem.state == "PhotoCapture") {
+              camera.imageCapture.captureToLocation('/home/webmaster/Desktop/1.jpg')//qgisProject.homePath+ '/DCIM/')
+            } else if (cameraItem.state == "VideoCapture") {
+              if (camera.videoRecorder.recorderState == CameraRecorder.StoppedState) {
+                camera.videoRecorder.record()
+              } else {
+                camera.videoRecorder.stop()
+                videoPreview.source = camera.videoRecorder.actualLocation
+                var path = camera.videoRecorder.actualLocation.toString()
+                var filePos = path.indexOf('file://')
+                currentPath = filePos === 0 ? path.substring(7) : path
+                cameraItem.state = "VideoPreview"
+              }
+            } else if (cameraItem.state == "PhotoPreview" || cameraItem.state == "VideoPreview") {
+              cameraItem.finished(currentPath)
+            }
+          }
+        }
+      }
+
+      QfToolButton {
+        id: zoomButton
+        visible: cameraItem.isCapturing
+
+        x: cameraItem.isPortraitMode ? (parent.width / 4) - (width / 2) : (parent.width - width) / 2
+        y: cameraItem.isPortraitMode ? (parent.height - height) / 2 : (parent.height / 4) * 3 - (height / 2)
+
+        iconColor: "white"
+        bgcolor: Qt.hsla(Theme.darkGray.hslHue, Theme.darkGray.hslSaturation, Theme.darkGray.hslLightness, 0.3)
+        round: true
+
+        text: (camera.digitalZoom * camera.opticalZoom).toFixed(1) +'X'
+        font: Theme.tinyFont
+
+        onClicked: {
+          camera.opticalZoom = 1;
+          camera.digitalZoom = 1;
+        }
+      }
+
+      QfToolButton {
+        id: flashButton
+        visible: cameraItem.isCapturing && camera.flash.supportedModes.length > 1
+
+        x: cameraItem.portaitMode ? (parent.width / 4) * 3 - (width / 2) : (parent.width - width) / 2
+        y: cameraItem.portaitMode ? (parent.height - height) / 2 : (parent.height / 4) - (height / 2)
+
+        iconSource: {
+          switch(camera.flash.mode) {
+            case Camera.FlashAuto:
+              return Theme.getThemeVectorIcon('ic_flash_auto_black_24dp');
+            case Camera.FlashOn:
+              return Theme.getThemeVectorIcon('ic_flash_on_black_24dp');
+            case Camera.FlashOff:
+              return Theme.getThemeVectorIcon('ic_flash_off_black_24dp');
+            default:
+              return'';
+          }
+        }
+        iconColor: "white"
+        bgcolor: Qt.hsla(Theme.darkGray.hslHue, Theme.darkGray.hslSaturation, Theme.darkGray.hslLightness, 0.5)
+        round: true
+
+        onClicked: {
+          if (camera.flash.mode == Camera.FlashOff) {
+            camera.flash.mode = Camera.FlashOn;
+          } else {
+            camera.flash.mode = Camera.FlashOff
+          }
+        }
+      }
+
+      Rectangle {
+        visible: cameraItem.state == "VideoCapture" && camera.videoRecorder.recorderState != CameraRecorder.StoppedState
+
+        x: cameraItem.isPortraitMode ? captureRing.x + captureRing.width / 2 - width / 2 : captureRing.x + captureRing.width / 2 - width / 2
+        y: cameraItem.isPortraitMode ? captureRing.y - height - 20 : captureRing.y + captureRing.height / 2 - height / 2
+
+        width: durationLabelMetrics.boundingRect('00:00:00').width + 20
+        height: durationLabelMetrics.boundingRect('00:00:00').height + 10
+        radius: 6
+
+        color: 'red'
+
+        Text {
+          id: durationLabel
+          anchors.centerIn: parent
+          text: {
+            if (camera.videoRecorder.duration > 0) {
+              var seconds = Math.ceil(camera.videoRecorder.duration / 1000);
+              var hours = Math.floor(seconds / 60 / 60) + '';
+              seconds -= hours * 60 * 60;
+              var minutes = Math.floor(seconds / 60) + '';
+              seconds = (seconds - minutes * 60) + '';
+              return hours.padStart(2,'0') + ':' + minutes.padStart(2,'0') + ':' + seconds.padStart(2,'0');
+            } else {
+              // tiny bit of a cheat here as the first second isn't triggered
+              return '00:00:01';
+            }
+          }
+          color: 'white'
+        }
+
+        FontMetrics {
+          id: durationLabelMetrics
+          font: durationLabel.font
+        }
+      }
     }
 
     QfToolButton {
-      id: cancelButton
+      id: backButton
 
-      visible: cameraItem.state == "PhotoPreview" || cameraItem.state == "VideoPreview"
-
-      anchors.right: parent.right
-      anchors.rightMargin: 5
+      anchors.left: parent.left
+      anchors.leftMargin: 4
       anchors.top: parent.top
-      anchors.topMargin: mainWindow.sceneTopMargin + 5
-      bgcolor: Theme.mainColor
+      anchors.topMargin: mainWindow.sceneTopMargin + 4
+
+      iconSource: Theme.getThemeIcon("ic_chevron_left_white_24dp")
+      iconColor: "white"
+      bgcolor: Qt.hsla(Theme.darkGray.hslHue, Theme.darkGray.hslSaturation, Theme.darkGray.hslLightness, 0.5)
       round: true
 
-      iconSource: Theme.getThemeIcon("ic_clear_white_24dp")
       onClicked: {
-        platformUtilities.rmFile(currentPath)
-        cameraItem.canceled()
+        // Oddly enough, we can't reset a video capture
+        if (cameraItem.state == "PhotoPreview") {
+          cameraItem.state = "PhotoCapture"
+        } else {
+          if (currentPath != '') {
+            platformUtilities.rmFile(currentPath)
+          }
+          cameraItem.canceled()
+        }
       }
     }
   }

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -22,6 +22,13 @@ Page {
   property alias mouseAsTouchScreen: registry.mouseAsTouchScreen
   property alias enableInfoCollection: registry.enableInfoCollection
 
+  Component.onCompleted: {
+    if (settings.valueBool('nativeCameraLaunched', false)) {
+      // a crash occured while the native camera was launched, disable it
+      nativeCamera = false
+    }
+  }
+
   Settings {
     id: registry
     property bool showScaleBar: true

--- a/src/qml/imports/Theme/QfToolButton.qml
+++ b/src/qml/imports/Theme/QfToolButton.qml
@@ -29,6 +29,7 @@ RoundButton {
   leftInset:0
   rightInset:0
   padding:10
+
   background: Rectangle {
     id: backgroundRectangle
     implicitWidth: 100
@@ -71,6 +72,9 @@ RoundButton {
 
   icon.source: ""
   icon.color: "transparent" // setting the color to transparent tells Qt to draw the icon using the original source color(s)
+
+  Material.foreground: icon.color
+  font: Theme.tipFont
 
   Rectangle {
     id: bottomRightIndicator


### PR DESCRIPTION
Enhancements include:
- significant UI/UX improvements
- zoom controls (pinch and mouse wheel, with button to reset to 1.0x zoom)
- flash controls
- GPS metadata
- video recording duration label

Still image capture:
![image](https://user-images.githubusercontent.com/1728657/222892691-90e204fc-cfba-4ec6-b1d0-9b9457eba016.png)

Video capture:
![image](https://user-images.githubusercontent.com/1728657/222892775-76fe0288-9de0-49bf-9c2b-2a1be8f2150c.png)

The PR also fixes a longstanding issue whereas resizing photos to match the qfieldsync maximum image size setting would result in loss of metadata. 