### PR TITLE
Bump ubuntu 18.04 to latest

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   backport:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     name: Backport
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Since the backport is not a critical CI element with a lot of dependencies, I just made it to point to latest, so in 4 years I don't have to make the same PR.