### PR TITLE
Import from URL action 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,7 @@ find_package(QGIS COMPONENTS Core Analysis REQUIRED)
 find_package(PROJ REQUIRED)
 find_package(GDAL REQUIRED)
 find_package(Qca REQUIRED)
+find_package(LibZip REQUIRED)
 find_package(QtKeychain REQUIRED)
 
 set(ENABLE_TESTS CACHE BOOL "Build unit tests")

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -267,7 +267,6 @@ configure_file(qfield.h.in ${CMAKE_CURRENT_BINARY_DIR}/qfield.h @ONLY)
 target_include_directories(qfield_core SYSTEM
                            PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
-target_include_directories(qfield_core SYSTEM PRIVATE ${GDAL_INCLUDE_DIR})
 # to include <qpa/qplatformnativeinterface.h>
 target_include_directories(qfield_core SYSTEM
                            PRIVATE ${${QT_PKG}Gui_PRIVATE_INCLUDE_DIRS})
@@ -301,6 +300,8 @@ endif()
 target_compile_features(qfield_core PUBLIC cxx_std_17)
 set_target_properties(qfield_core PROPERTIES AUTOMOC TRUE)
 
+target_include_directories(qfield_core SYSTEM PRIVATE ${GDAL_INCLUDE_DIR})
+
 target_link_libraries(
   qfield_core
   PUBLIC ${QT_PKG}::Core
@@ -323,7 +324,6 @@ target_link_libraries(
          PROJ::proj
          SQLite::SQLite3
          Qca::qca
-         ZXing::ZXing
          QtKeychain::QtKeychain
          ${GDAL_LIBRARIES})
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -11,6 +11,7 @@ set(QFIELD_CORE_SRCS
     utils/snappingutils.cpp
     utils/stringutils.cpp
     utils/urlutils.cpp
+    utils/ziputils.cpp
     qgsquick/qgsquickcoordinatetransformer.cpp
     qgsquick/qgsquickmapcanvasmap.cpp
     qgsquick/qgsquickelevationprofilecanvas.cpp
@@ -111,6 +112,7 @@ set(QFIELD_CORE_HDRS
     utils/snappingutils.h
     utils/stringutils.h
     utils/urlutils.h
+    utils/ziputils.h
     qgsquick/qgsquickcoordinatetransformer.h
     qgsquick/qgsquickmapcanvasmap.h
     qgsquick/qgsquickelevationprofilecanvas.h
@@ -325,7 +327,8 @@ target_link_libraries(
          SQLite::SQLite3
          Qca::qca
          QtKeychain::QtKeychain
-         ${GDAL_LIBRARIES})
+         ${GDAL_LIBRARIES}
+         libzip::zip)
 
 if(WITH_BLUETOOTH)
   find_package(

--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -21,6 +21,7 @@
 #if WITH_SENTRY
 #include "sentry_wrapper.h"
 #endif
+#include "ziputils.h"
 
 #include <QDirIterator>
 #include <QFileInfo>
@@ -245,7 +246,7 @@ void AppInterface::importUrl( const QString &url )
           QDir( zipDirectory ).mkpath( "." );
 
           QStringList files;
-          QgsZipUtils::unzip( filePath, zipDirectory, files, false );
+          ZipUtils::unzip( filePath, zipDirectory, files, false );
           QString projectFilePath;
           for ( const QString &file : std::as_const( files ) )
           {

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -38,6 +38,8 @@ class AppInterface : public QObject
       Q_ASSERT( false );
     }
 
+    Q_INVOKABLE void importUrl( const QString &url );
+
     Q_INVOKABLE void loadLastProject();
     Q_INVOKABLE void loadFile( const QString &path, const QString &name = QString() );
     Q_INVOKABLE void reloadProject();
@@ -89,6 +91,10 @@ class AppInterface : public QObject
 
   signals:
     void openFeatureFormRequested();
+
+    void importUrlTriggered( const QString &url, const QString &name );
+
+    void importUrlEnded( const QString &path = QString() );
 
     void loadProjectTriggered( const QString &path, const QString &name );
 

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -92,17 +92,39 @@ class AppInterface : public QObject
   signals:
     void openFeatureFormRequested();
 
-    void importUrlTriggered( const QString &url, const QString &name );
+    /**
+     * Emitted when a dataset or project import has been triggered.
+     * \param name a indentifier-friendly string (e.g. a file being imported)
+     */
+    void importTriggered( const QString &name );
 
-    void importUrlEnded( const QString &path = QString() );
+    /**
+     * Emitted when an ongoing import reports its \a progress.
+     * \note when an import is started, its progress will be indefinite by default
+     */
+    void importProgress( double progress );
 
+    /**
+     * Emitted when an import has ended.
+     * \param path the path within which the imported dataset or project has been copied into
+     * \note if the import was not successful, the path value will be an empty string
+     */
+    void importEnded( const QString &path = QString() );
+
+    /**
+     * Emitted when a project has begin loading.
+     */
     void loadProjectTriggered( const QString &path, const QString &name );
 
+    /**
+     * Emitted when a project loading has ended.
+     */
     void loadProjectEnded( const QString &path, const QString &name );
 
+    //! Requests QField to set its map to the provided \a extent.
     void setMapExtent( const QgsRectangle &extent );
 
-    //! Signal emitted requesting QField to open its local data picker screen to show the \a path content
+    //! Requests QField to open its local data picker screen to show the \a path content.
     void openPath( const QString &path );
 
   private:

--- a/src/core/platforms/platformutilities.cpp
+++ b/src/core/platforms/platformutilities.cpp
@@ -182,7 +182,7 @@ bool PlatformUtilities::renameFile( const QString &filename, const QString &newn
 
 QString PlatformUtilities::applicationDirectory() const
 {
-  return QString();
+  return QStandardPaths::standardLocations( QStandardPaths::DocumentsLocation ).first() + QStringLiteral( "/QField/" );
 }
 
 QStringList PlatformUtilities::additionalApplicationDirectories() const

--- a/src/core/utils/ziputils.cpp
+++ b/src/core/utils/ziputils.cpp
@@ -1,0 +1,163 @@
+/***************************************************************************
+                        ziputils.h
+                        ---------------
+  begin                : March 2023
+  copyright            : (C) 2023 by Mathieu Pellerin
+  email                : mathieu@opengis.ch
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   Original QgsZipUtils code by Paul Blottiere                           *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "ziputils.h"
+
+#include <QDir>
+#include <QFileInfo>
+#include <qgsmessagelog.h>
+
+#include <fstream>
+#include <iostream>
+#include <zip.h>
+#include <zlib.h>
+
+const QStringList ZipUtils::files( const QString &zip )
+{
+  if ( zip.isEmpty() && !QFileInfo::exists( zip ) )
+  {
+    return QStringList();
+  }
+  QStringList files;
+
+  int rc = 0;
+  const QByteArray fileNamePtr = zip.toUtf8();
+  struct zip *z = zip_open( fileNamePtr.constData(), 0, &rc );
+
+  if ( rc == ZIP_ER_OK && z )
+  {
+    const int count = zip_get_num_files( z );
+    if ( count != -1 )
+    {
+      struct zip_stat stat;
+
+      for ( int i = 0; i < count; i++ )
+      {
+        zip_stat_index( z, i, 0, &stat );
+        files << QString( stat.name );
+      }
+    }
+
+    zip_close( z );
+  }
+
+  return files;
+}
+
+bool ZipUtils::unzip( const QString &zipFilename, const QString &dir, QStringList &files, bool checkConsistency )
+{
+  files.clear();
+
+  if ( !QFileInfo::exists( zipFilename ) )
+  {
+    QgsMessageLog::logMessage( QObject::tr( "Error zip file does not exist: '%1'" ).arg( zipFilename ) );
+    return false;
+  }
+  else if ( zipFilename.isEmpty() )
+  {
+    QgsMessageLog::logMessage( QObject::tr( "Error zip filename is empty" ) );
+    return false;
+  }
+  else if ( !QDir( dir ).exists( dir ) )
+  {
+    QgsMessageLog::logMessage( QObject::tr( "Error output dir does not exist: '%1'" ).arg( dir ) );
+    return false;
+  }
+  else if ( !QFileInfo( dir ).isDir() )
+  {
+    QgsMessageLog::logMessage( QObject::tr( "Error output dir is not a directory: '%1'" ).arg( dir ) );
+    return false;
+  }
+  else if ( !QFileInfo( dir ).isWritable() )
+  {
+    QgsMessageLog::logMessage( QObject::tr( "Error output dir is not writable: '%1'" ).arg( dir ) );
+    return false;
+  }
+
+  int rc = 0;
+  const QByteArray fileNamePtr = zipFilename.toUtf8();
+  struct zip *z = zip_open( fileNamePtr.constData(), checkConsistency ? ZIP_CHECKCONS : 0, &rc );
+
+  if ( rc == ZIP_ER_OK && z )
+  {
+    const int count = zip_get_num_files( z );
+    if ( count != -1 )
+    {
+      struct zip_stat stat;
+
+      for ( int i = 0; i < count; i++ )
+      {
+        zip_stat_index( z, i, 0, &stat );
+        const size_t len = stat.size;
+
+        struct zip_file *file = zip_fopen_index( z, i, 0 );
+        const std::unique_ptr<char[]> buf( new char[len] );
+        if ( zip_fread( file, buf.get(), len ) != -1 )
+        {
+          const QString fileName( stat.name );
+          const QFileInfo newFile( QDir( dir ), fileName );
+
+          // Create path for a new file if it does not exist.
+          if ( !newFile.absoluteDir().exists() )
+          {
+            if ( !QDir( dir ).mkpath( newFile.absolutePath() ) )
+              QgsMessageLog::logMessage( QObject::tr( "Failed to create a subdirectory %1/%2" ).arg( dir ).arg( fileName ) );
+          }
+
+          QFile outFile( newFile.absoluteFilePath() );
+          if ( !outFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
+          {
+            QgsMessageLog::logMessage( QObject::tr( "Could not write to %1" ).arg( newFile.absoluteFilePath() ) );
+          }
+          else
+          {
+            outFile.write( buf.get(), len );
+          }
+          zip_fclose( file );
+          files.append( newFile.absoluteFilePath() );
+        }
+        else
+        {
+          zip_fclose( file );
+          QgsMessageLog::logMessage( QObject::tr( "Error reading file: '%1'" ).arg( zip_strerror( z ) ) );
+          return false;
+        }
+      }
+    }
+    else
+    {
+      zip_close( z );
+      QgsMessageLog::logMessage( QObject::tr( "Error getting files: '%1'" ).arg( zip_strerror( z ) ) );
+      return false;
+    }
+
+    zip_close( z );
+  }
+  else
+  {
+    QgsMessageLog::logMessage( QObject::tr( "Error opening zip archive: '%1' (Error code: %2)" ).arg( z ? zip_strerror( z ) : zipFilename ).arg( rc ) );
+    return false;
+  }
+
+  return true;
+}

--- a/src/core/utils/ziputils.h
+++ b/src/core/utils/ziputils.h
@@ -36,7 +36,7 @@ namespace ZipUtils
    * \param zip The zip filename
    * \param dir The output directory
    * \param files The absolute path of unzipped files
-   * \param consistencyCheck Perform additional stricter consistency checks on the archive, and error if they fail
+   * \param checkConsistency Perform additional stricter consistency checks on the archive, and error if they fail
    * \returns FALSE if the zip filename does not exist, the output directory
    * does not exist or is not writable.
    */

--- a/src/core/utils/ziputils.h
+++ b/src/core/utils/ziputils.h
@@ -1,0 +1,51 @@
+/***************************************************************************
+                        ziputils.h
+                        ---------------
+  begin                : March 2023
+  copyright            : (C) 2023 by Mathieu Pellerin
+  email                : mathieu@opengis.ch
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   Original QgsZipUtils code by Paul Blottiere                           *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef ZIPUTILS_H
+#define ZIPUTILS_H
+
+#include "qfield_core_export.h"
+
+#include <QStringList>
+
+namespace ZipUtils
+{
+
+  /**
+   * Unzip a zip file in an output directory.
+   * \param zip The zip filename
+   * \param dir The output directory
+   * \param files The absolute path of unzipped files
+   * \param consistencyCheck Perform additional stricter consistency checks on the archive, and error if they fail
+   * \returns FALSE if the zip filename does not exist, the output directory
+   * does not exist or is not writable.
+   */
+  QFIELD_CORE_EXPORT bool unzip( const QString &zipFilename, const QString &dir, QStringList &files, bool checkConsistency = true );
+
+  /**
+   * Returns the list of files within a \a zip file
+   */
+  QFIELD_CORE_EXPORT const QStringList files( const QString &zip );
+}; // namespace ZipUtils
+
+#endif //ZIPUTILS_H

--- a/src/qml/BusyOverlay.qml
+++ b/src/qml/BusyOverlay.qml
@@ -1,0 +1,67 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import Theme 1.0
+import org.qfield 1.0
+
+Rectangle {
+  id: busyOverlay
+
+  property alias text: busyMessage.text
+
+  anchors.fill: parent
+  color: Theme.darkGray
+  opacity: 0
+  visible: false
+
+  state: "hidden"
+  states: [
+      State {
+          name: "hidden"
+          PropertyChanges { target: busyOverlay; opacity: 0 }
+          PropertyChanges { target: busyOverlay; visible: false }
+      },
+
+      State {
+          name: "visible"
+          PropertyChanges { target: busyOverlay; visible: true }
+          PropertyChanges { target: busyOverlay; opacity: 0.75 }
+      }]
+  transitions: [
+      Transition {
+          from: "hidden"
+          to: "visible"
+          SequentialAnimation {
+              PropertyAnimation { target: busyOverlay; property: "visible"; duration: 0 }
+              NumberAnimation { target: busyOverlay; easing.type: Easing.InOutQuad; properties: "opacity"; duration: 250 }
+          }
+      },
+      Transition {
+          from: "visible"
+          to: "hidden"
+          SequentialAnimation {
+              PropertyAnimation { target: busyOverlay; easing.type: Easing.InOutQuad; property: "opacity"; duration: 250 }
+              PropertyAnimation { target: busyOverlay; property: "visible"; duration: 0 }
+          }
+      }
+  ]
+
+  BusyIndicator {
+    id: busyIndicator
+    anchors.centerIn: parent
+    running: busyOverlay.visible
+    width: 100
+    height: 100
+  }
+
+  Text {
+    id: busyMessage
+    anchors.top: busyIndicator.bottom
+    anchors.horizontalCenter: parent.horizontalCenter
+    horizontalAlignment: Text.AlignHCenter
+    font: Theme.tipFont
+    color: Theme.mainColor
+    text: ''
+  }
+}

--- a/src/qml/BusyOverlay.qml
+++ b/src/qml/BusyOverlay.qml
@@ -9,9 +9,10 @@ Rectangle {
   id: busyOverlay
 
   property alias text: busyMessage.text
+  property alias progress: busyProgress.value
 
   anchors.fill: parent
-  color: Theme.darkGray
+  color: Theme.darkGraySemiOpaque
   opacity: 0
   visible: false
 
@@ -26,7 +27,7 @@ Rectangle {
       State {
           name: "visible"
           PropertyChanges { target: busyOverlay; visible: true }
-          PropertyChanges { target: busyOverlay; opacity: 0.75 }
+          PropertyChanges { target: busyOverlay; opacity: 1 }
       }]
   transitions: [
       Transition {
@@ -34,6 +35,7 @@ Rectangle {
           to: "visible"
           SequentialAnimation {
               PropertyAnimation { target: busyOverlay; property: "visible"; duration: 0 }
+              ScriptAction { script: busyProgress.value = 0.0; }
               NumberAnimation { target: busyOverlay; easing.type: Easing.InOutQuad; properties: "opacity"; duration: 250 }
           }
       },
@@ -50,9 +52,21 @@ Rectangle {
   BusyIndicator {
     id: busyIndicator
     anchors.centerIn: parent
+    visible: !busyProgress.visible
     running: busyOverlay.visible
     width: 100
     height: 100
+  }
+
+  ProgressBar {
+    id: busyProgress
+    anchors.centerIn: busyIndicator
+    visible: value != 0.0
+    width: 160
+    height: 14
+    indeterminate: false
+    value: 0.0
+    to: 1.0
   }
 
   Text {

--- a/src/qml/Changelog.qml
+++ b/src/qml/Changelog.qml
@@ -5,8 +5,6 @@ import QtQuick.Layouts 1.14
 import Theme 1.0
 import org.qfield 1.0
 
-
-
 Popup {
     id: changelogPopup
 

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -328,8 +328,7 @@ Page {
       QfToolButton {
         id: importButton
         round: true
-        visible: platformUtilities.capabilities & PlatformUtilities.CustomImport
-                 && table.model.currentPath === 'root'
+        visible: table.model.currentPath === 'root'
 
         anchors.bottom: parent.bottom
         anchors.right: parent.right
@@ -470,6 +469,7 @@ Page {
       MenuItem {
         id: importProjectFromFolder
 
+        visible: platformUtilities.capabilities & PlatformUtilities.CustomImport
         font: Theme.defaultFont
         width: parent.width
         height: visible ? 48 : 0
@@ -482,6 +482,7 @@ Page {
       MenuItem {
         id: importProjectFromZIP
 
+        visible: platformUtilities.capabilities & PlatformUtilities.CustomImport
         font: Theme.defaultFont
         width: parent.width
         height: visible ? 48 : 0
@@ -494,6 +495,7 @@ Page {
       MenuItem {
         id: importDataset
 
+        visible: platformUtilities.capabilities & PlatformUtilities.CustomImport
         font: Theme.defaultFont
         width: parent.width
         height: visible ? 48 : 0
@@ -501,6 +503,23 @@ Page {
 
         text: qsTr( "Import dataset(s)" )
         onTriggered: { platformUtilities.importDatasets(); }
+      }
+
+      MenuSeparator { visible: platformUtilities.capabilities & PlatformUtilities.CustomImport; width: parent.width }
+
+      MenuItem {
+        id: importUrl
+
+        font: Theme.defaultFont
+        width: parent.width
+        height: visible ? 48 : 0
+        leftPadding: 10
+
+        text: qsTr( "Import URL" )
+        onTriggered: {
+          importUrlDialog.open()
+          importUrlInput.focus = true
+        }
       }
 
       MenuSeparator { width: parent.width }
@@ -516,6 +535,44 @@ Page {
         text: qsTr( "Storage management help" )
         onTriggered: { Qt.openUrlExternally("https://docs.qfield.org/get-started/storage/") }
       }
+    }
+  }
+
+  Dialog {
+    id: importUrlDialog
+    title: "Import URL"
+    focus: true
+
+    x: ( mainWindow.width - width ) / 2
+    y: ( mainWindow.height - height ) / 2
+
+    Column {
+      width: childrenRect.width
+      height: childrenRect.height
+
+      TextMetrics {
+        id: importUrlLabelMetrics
+        font: importUrlLabel.font
+        text: importUrlLabel.text
+      }
+
+      Label {
+        id: importUrlLabel
+        width: mainWindow.width - 60 < importUrlLabelMetrics.width ? mainWindow.width - 60 : importUrlLabelMetrics.width
+        text: "Type a URL below to import a project or dataset:"
+        wrapMode: Text.WordWrap
+        font: Theme.defaultFont
+      }
+      QfTextField {
+        id: importUrlInput
+        width: importUrlLabel.width
+        focus: true
+      }
+    }
+
+    standardButtons: Dialog.Ok | Dialog.Cancel
+    onAccepted: {
+      form.cancel()
     }
   }
 

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -574,7 +574,7 @@ Page {
 
     standardButtons: Dialog.Ok | Dialog.Cancel
     onAccepted: {
-      iface.importUrl(importUrlLabel.text)
+      iface.importUrl(importUrlInput.text)
     }
   }
 

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -549,6 +549,7 @@ Page {
     Column {
       width: childrenRect.width
       height: childrenRect.height
+      spacing: 10
 
       TextMetrics {
         id: importUrlLabelMetrics
@@ -562,6 +563,7 @@ Page {
         text: qsTr("Type a URL below to download and import the project or dataset:")
         wrapMode: Text.WordWrap
         font: Theme.defaultFont
+        color: Theme.mainTextColor
       }
       QfTextField {
         id: importUrlInput
@@ -572,7 +574,7 @@ Page {
 
     standardButtons: Dialog.Ok | Dialog.Cancel
     onAccepted: {
-      form.cancel()
+      iface.importUrl(importUrlLabel.text)
     }
   }
 

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -559,7 +559,7 @@ Page {
       Label {
         id: importUrlLabel
         width: mainWindow.width - 60 < importUrlLabelMetrics.width ? mainWindow.width - 60 : importUrlLabelMetrics.width
-        text: "Type a URL below to import a project or dataset:"
+        text: qsTr("Type a URL below to download and import the project or dataset:")
         wrapMode: Text.WordWrap
         font: Theme.defaultFont
       }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2735,7 +2735,7 @@ ApplicationWindow {
         qfieldLocalDataPickerScreen.visible = true
         welcomeScreen.visible = false
       } else {
-        displayToast(qsTr('Import from URL failed'))
+        displayToast(qsTr('Import URL failed'))
       }
     }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2723,12 +2723,16 @@ ApplicationWindow {
   Connections {
     target: iface
 
-    function onImportUrlTriggered(url,name) {
-      busyOverlay.text = qsTr( "Importing %1" ).arg( name !== '' ? name : path )
+    function onImportTriggered(name) {
+      busyOverlay.text = qsTr("Importing %1").arg(name)
       busyOverlay.state = "visible"
     }
 
-    function onImportUrlEnded(path) {
+    function onImportProgress(progress) {
+      busyOverlay.progress = progress;
+    }
+
+    function onImportEnded(path) {
       busyOverlay.state = "hidden"
       if (path !== '') {
         qfieldLocalDataPickerScreen.model.currentPath = path

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2712,168 +2712,110 @@ ApplicationWindow {
       toast.show(message, type)
   }
 
-  Rectangle {
-    id: busyMessage
-    anchors.fill: parent
-    color: Theme.darkGray
-    opacity: 0
-    visible: false
+  Timer {
+    id: readProjectTimer
 
-    state: "hidden"
-    states: [
-        State {
-            name: "hidden"
-            PropertyChanges { target: busyMessage; opacity: 0 }
-            PropertyChanges { target: busyMessage; visible: false }
-        },
+    interval: 250
+    repeat: false
+    onTriggered: iface.readProject()
+  }
 
-        State {
-            name: "visible"
-            PropertyChanges { target: busyMessage; visible: true }
-            PropertyChanges { target: busyMessage; opacity: 0.75 }
-        }]
-    transitions: [
-        Transition {
-            from: "hidden"
-            to: "visible"
-            SequentialAnimation {
-                PropertyAnimation { target: busyMessage; property: "visible"; duration: 0 }
-                NumberAnimation { target: busyMessage; easing.type: Easing.InOutQuad; properties: "opacity"; duration: 250 }
-            }
-        },
-        Transition {
-            from: "visible"
-            to: "hidden"
-            SequentialAnimation {
-                PropertyAnimation { target: busyMessage; easing.type: Easing.InOutQuad; property: "opacity"; duration: 250 }
-                PropertyAnimation { target: busyMessage; property: "visible"; duration: 0 }
-            }
-        }
-    ]
+  Connections {
+    target: iface
 
-    BusyIndicator {
-      id: busyMessageIndicator
-      anchors.centerIn: parent
-      running: true
-      width: 100
-      height: 100
+    function onLoadProjectTriggered(path,name) {
+      qfieldLocalDataPickerScreen.visible = false
+      qfieldLocalDataPickerScreen.focus = false
+      welcomeScreen.visible = false
+      welcomeScreen.focus = false
+
+      if (changelogPopup.visible)
+        changelogPopup.close()
+
+      dashBoard.layerTree.freeze()
+      mapCanvasMap.freeze('projectload')
+
+      busyOverlay.text = qsTr( "Loading %1" ).arg( name !== '' ? name : path )
+      busyOverlay.state = "visible"
+
+      navigation.clearDestinationFeature();
+
+      projectInfo.filePath = '';
+      readProjectTimer.start()
     }
 
-    Text {
-      id: busyMessageText
-      anchors.top: busyMessageIndicator.bottom
-      anchors.horizontalCenter: parent.horizontalCenter
-      horizontalAlignment: Text.AlignHCenter
-      font: Theme.tipFont
-      color: Theme.mainColor
-      text: ''
+    function onLoadProjectEnded(path,name) {
+      mapCanvasMap.unfreeze('projectload')
+      busyOverlay.state = "hidden"
+
+      projectInfo.filePath = path;
+
+      mapCanvasBackground.color = mapCanvas.mapSettings.backgroundColor
+
+      recentProjectListModel.reloadModel()
+
+      var cloudProjectId = QFieldCloudUtils.getProjectId(qgisProject.fileName)
+      cloudProjectsModel.currentProjectId = cloudProjectId
+      cloudProjectsModel.refreshProjectModification(cloudProjectId)
+      if (cloudProjectId !== '') {
+        var cloudProjectData = cloudProjectsModel.getProjectData(cloudProjectId)
+        switch(cloudProjectData.UserRole) {
+          case 'reader':
+            stateMachine.state = "browse"
+            projectInfo.hasInsertRights = false
+            projectInfo.hasEditRights = false
+            break;
+          case 'reporter':
+            projectInfo.hasInsertRights = true
+            projectInfo.hasEditRights = false
+            break;
+          case 'editor':
+          case 'manager':
+          case 'admin':
+            projectInfo.hasInsertRights = true
+            projectInfo.hasEditRights = true
+            break;
+          default:
+            projectInfo.hasInsertRights = true
+            projectInfo.hasEditRights = true
+            break;
+        }
+
+        if (cloudProjectsModel.layerObserver.deltaFileWrapper.hasError()) {
+          cloudPopup.show()
+        }
+      } else {
+        projectInfo.hasInsertRights = true
+        projectInfo.hasEditRights = true
+      }
+
+      if (stateMachine.state === "digitize") {
+          dashBoard.ensureEditableLayerSelected();
+      }
+
+      var distanceString = iface.readProjectEntry("Measurement" ,"/DistanceUnits", "")
+      projectInfo.distanceUnits = distanceString !== "" ? UnitTypes.decodeDistanceUnit(distanceString) : Qgis.DistanceUnit.Meters
+      var areaString = iface.readProjectEntry("Measurement" ,"/AreaeUnits", "")
+      projectInfo.areaUnits = areaString !== "" ? UnitTypes.decodeAreaUnit(areaString) : Qgis.AreaUnit.SquareMeters
+
+      if (qgisProject.displaySettings) {
+        projectInfo.coordinateDisplayCrs = qgisProject.displaySettings.coordinateCrs
+      } else {
+        projectInfo.coordinateDisplayCrs = !mapCanvas.mapSettings.destinationCrs.isGeographic
+                                           && iface.readProjectEntry("PositionPrecision", "/DegreeFormat", "MU") !== "MU"
+                                           ? CoordinateReferenceSystemUtils.wgs84Crs()
+                                           : mapCanvas.mapSettings.destinationCrs
+      }
+
+      layoutListInstantiator.model.project = qgisProject
+      layoutListInstantiator.model.reloadModel()
+      printMenu.enablePrintItem(layoutListInstantiator.model.rowCount())
+
+      settings.setValue( "/QField/FirstRunFlag", false )
     }
 
-    Timer {
-      id: readProjectTimer
-
-      interval: 250
-      repeat: false
-      onTriggered: iface.readProject()
-    }
-
-    Connections {
-      target: iface
-
-      function onLoadProjectTriggered(path,name) {
-        qfieldLocalDataPickerScreen.visible = false
-        qfieldLocalDataPickerScreen.focus = false
-        welcomeScreen.visible = false
-        welcomeScreen.focus = false
-
-        if (changelogPopup.visible)
-          changelogPopup.close()
-
-        dashBoard.layerTree.freeze()
-        mapCanvasMap.freeze('projectload')
-
-        busyMessageText.text = qsTr( "Loading %1" ).arg( name !== '' ? name : path )
-        busyMessage.state = "visible"
-
-        navigation.clearDestinationFeature();
-
-        projectInfo.filePath = '';
-        readProjectTimer.start()
-      }
-
-      function onLoadProjectEnded(path,name) {
-        mapCanvasMap.unfreeze('projectload')
-        busyMessage.state = "hidden"
-
-        projectInfo.filePath = path;
-
-        mapCanvasBackground.color = mapCanvas.mapSettings.backgroundColor
-
-        recentProjectListModel.reloadModel()
-
-        var cloudProjectId = QFieldCloudUtils.getProjectId(qgisProject.fileName)
-        cloudProjectsModel.currentProjectId = cloudProjectId
-        cloudProjectsModel.refreshProjectModification(cloudProjectId)
-        if (cloudProjectId != '') {
-          var cloudProjectData = cloudProjectsModel.getProjectData(cloudProjectId)
-          switch(cloudProjectData.UserRole) {
-            case 'reader':
-              stateMachine.state = "browse"
-              projectInfo.hasInsertRights = false
-              projectInfo.hasEditRights = false
-              break;
-            case 'reporter':
-              projectInfo.hasInsertRights = true
-              projectInfo.hasEditRights = false
-              break;
-            case 'editor':
-            case 'manager':
-            case 'admin':
-              projectInfo.hasInsertRights = true
-              projectInfo.hasEditRights = true
-              break;
-            default:
-              projectInfo.hasInsertRights = true
-              projectInfo.hasEditRights = true
-              break;
-          }
-
-          if (cloudProjectsModel.layerObserver.deltaFileWrapper.hasError()) {
-            cloudPopup.show()
-          }
-        } else {
-          projectInfo.hasInsertRights = true
-          projectInfo.hasEditRights = true
-        }
-
-        if (stateMachine.state === "digitize") {
-            dashBoard.ensureEditableLayerSelected();
-        }
-
-        var distanceString = iface.readProjectEntry("Measurement" ,"/DistanceUnits", "")
-        projectInfo.distanceUnits = distanceString !== "" ? UnitTypes.decodeDistanceUnit(distanceString) : Qgis.DistanceUnit.Meters
-        var areaString = iface.readProjectEntry("Measurement" ,"/AreaeUnits", "")
-        projectInfo.areaUnits = areaString !== "" ? UnitTypes.decodeAreaUnit(areaString) : Qgis.AreaUnit.SquareMeters
-
-        if (qgisProject.displaySettings) {
-          projectInfo.coordinateDisplayCrs = qgisProject.displaySettings.coordinateCrs
-        } else {
-          projectInfo.coordinateDisplayCrs = !mapCanvas.mapSettings.destinationCrs.isGeographic
-                                             && iface.readProjectEntry("PositionPrecision", "/DegreeFormat", "MU") !== "MU"
-                                             ? CoordinateReferenceSystemUtils.wgs84Crs()
-                                             : mapCanvas.mapSettings.destinationCrs
-        }
-
-        layoutListInstantiator.model.project = qgisProject
-        layoutListInstantiator.model.reloadModel()
-        printMenu.enablePrintItem(layoutListInstantiator.model.rowCount())
-
-        settings.setValue( "/QField/FirstRunFlag", false )
-      }
-
-      function onSetMapExtent(extent) {
-          mapCanvas.mapSettings.extent = extent;
-      }
+    function onSetMapExtent(extent) {
+        mapCanvas.mapSettings.extent = extent;
     }
   }
 
@@ -3413,6 +3355,10 @@ ApplicationWindow {
     onDropped: (drop) => {
       iface.loadFile( drop.urls[0] )
     }
+  }
+
+  BusyOverlay {
+    id: busyOverlay
   }
 
   property bool alreadyCloseRequested: false

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2723,6 +2723,22 @@ ApplicationWindow {
   Connections {
     target: iface
 
+    function onImportUrlTriggered(url,name) {
+      busyOverlay.text = qsTr( "Importing %1" ).arg( name !== '' ? name : path )
+      busyOverlay.state = "visible"
+    }
+
+    function onImportUrlEnded(path) {
+      busyOverlay.state = "hidden"
+      if (path !== '') {
+        qfieldLocalDataPickerScreen.model.currentPath = path
+        qfieldLocalDataPickerScreen.visible = true
+        welcomeScreen.visible = false
+      } else {
+        displayToast(qsTr('Import from URL failed'))
+      }
+    }
+
     function onLoadProjectTriggered(path,name) {
       qfieldLocalDataPickerScreen.visible = false
       qfieldLocalDataPickerScreen.focus = false

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -7,6 +7,7 @@
         <file>BookmarkProperties.qml</file>
         <file>BookmarkRenderer.qml</file>
         <file>BrowserPanel.qml</file>
+        <file>BusyOverlay.qml</file>
         <file>ConfirmationToolbar.qml</file>
         <file>CoordinateLocator.qml</file>
         <file>DashBoard.qml</file>


### PR DESCRIPTION
*A picture*
![image](https://user-images.githubusercontent.com/1728657/224479976-899eb0f4-f2e9-4087-9c86-482af134b591.png)

*An explanation*
This PR add a new 'import URL' action in the local data picker screen, which allows for users to paste a URL (say a dropbox link) and have QField automatically download and import the dataset or zipped project.

This is useful across Android and iOS, but comes in especially handy for iOS as it has currently no other mean to import datasets and projects nor file association. Without this, users have to do a fair amount of acrobatics when trying to import within the phone directly.

*Why ZipUtils?*
It's there until the ZipUtils::files() and the new parameter in ZipUtils::unzip() is upstreamed.