### PR TITLE
Fix missing font declaration for import ULR dialog leading to tiny buttons

### DIFF
--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -542,9 +542,10 @@ Page {
     id: importUrlDialog
     title: "Import URL"
     focus: true
+    font: Theme.defaultFont
 
     x: ( mainWindow.width - width ) / 2
-    y: ( mainWindow.height - height ) / 2
+    y: ( mainWindow.height - height - 80 ) / 2
 
     Column {
       width: childrenRect.width


### PR DESCRIPTION
When writing documentation shows you that font declaration you'd missed...