### PR TITLE
Revert "Absence of data is not 0, use NaN"

### DIFF
--- a/src/core/rubberbandmodel.cpp
+++ b/src/core/rubberbandmodel.cpp
@@ -71,13 +71,14 @@ QgsPointSequence RubberbandModel::pointSequence( const QgsCoordinateReferenceSys
     p2.setY( p1.y() );
 
     //overwrite z and m values if already existent in the point
-    if ( QgsWkbTypes::hasZ( wkbType ) )
-    {
-      p2.addMValue( QgsWkbTypes::hasZ( pt.wkbType() ) ? pt.z() : std::numeric_limits<double>::quiet_NaN() );
-    }
     if ( QgsWkbTypes::hasM( wkbType ) )
     {
-      p2.addMValue( QgsWkbTypes::hasM( pt.wkbType() ) ? pt.m() : std::numeric_limits<double>::quiet_NaN() );
+      p2.addMValue( QgsWkbTypes::hasM( pt.wkbType() ) ? pt.m() : 0 );
+    }
+
+    if ( QgsWkbTypes::hasZ( wkbType ) )
+    {
+      p2.addMValue( QgsWkbTypes::hasZ( pt.wkbType() ) ? pt.z() : 0 );
     }
 
     sequence.append( p2 );
@@ -166,6 +167,7 @@ QgsPoint RubberbandModel::currentPoint( const QgsCoordinateReferenceSystem &crs,
   double x = currentPt.x();
   double y = currentPt.y();
   double z = QgsWkbTypes::hasZ( currentPt.wkbType() ) ? currentPt.z() : 0;
+  double m = QgsWkbTypes::hasM( currentPt.wkbType() ) ? currentPt.m() : 0;
 
   try
   {
@@ -184,13 +186,9 @@ QgsPoint RubberbandModel::currentPoint( const QgsCoordinateReferenceSystem &crs,
 
   QgsPoint resultPt( x, y );
   if ( QgsWkbTypes::hasZ( wkbType ) )
-  {
-    resultPt.addZValue( QgsWkbTypes::hasZ( currentPt.wkbType() ) ? z : std::numeric_limits<double>::quiet_NaN() );
-  }
+    resultPt.addZValue( z );
   if ( QgsWkbTypes::hasM( wkbType ) )
-  {
-    resultPt.addMValue( QgsWkbTypes::hasM( currentPt.wkbType() ) ? currentPt.m() : std::numeric_limits<double>::quiet_NaN() );
-  }
+    resultPt.addMValue( m );
 
   return resultPt;
 }


### PR DESCRIPTION
This reverts commit adfdc1475eb87c46d357cf6c67f570983b438d92 , which turned out to break digitizing on (at least) shapefile layers with Z or ZM dimension geometries.

Fixes https://github.com/opengisch/qfieldsync/issues/504
Fixes #4035 