### PR TITLE
Fallback when relation id is not set

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -8,6 +8,7 @@ set(QFIELD_CORE_SRCS
     utils/layerutils.cpp
     utils/positioningutils.cpp
     utils/qfieldcloudutils.cpp
+    utils/relationutils.cpp
     utils/snappingutils.cpp
     utils/stringutils.cpp
     utils/urlutils.cpp
@@ -109,6 +110,7 @@ set(QFIELD_CORE_HDRS
     utils/layerutils.h
     utils/positioningutils.h
     utils/qfieldcloudutils.h
+    utils/relationutils.h
     utils/snappingutils.h
     utils/stringutils.h
     utils/urlutils.h

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -101,6 +101,7 @@
 #include "qgsquickmaptransform.h"
 #include "recentprojectlistmodel.h"
 #include "referencingfeaturelistmodel.h"
+#include "relationutils.h"
 #include "resourcesource.h"
 #include "rubberband.h"
 #include "rubberbandmodel.h"
@@ -490,6 +491,7 @@ void QgisMobileapp::initDeclarative()
   REGISTER_SINGLETON( "org.qfield", FeatureUtils, "FeatureUtils" );
   REGISTER_SINGLETON( "org.qfield", FileUtils, "FileUtils" );
   REGISTER_SINGLETON( "org.qfield", LayerUtils, "LayerUtils" );
+  REGISTER_SINGLETON( "org.qfield", RelationUtils, "RelationUtils" );
   REGISTER_SINGLETON( "org.qfield", StringUtils, "StringUtils" );
   REGISTER_SINGLETON( "org.qfield", UrlUtils, "UrlUtils" );
   REGISTER_SINGLETON( "org.qfield", QFieldCloudUtils, "QFieldCloudUtils" );

--- a/src/core/utils/relationutils.cpp
+++ b/src/core/utils/relationutils.cpp
@@ -25,7 +25,7 @@ RelationUtils::RelationUtils( QObject *parent )
 {
 }
 
-QgsRelation RelationUtils::resolveReferencingRelation( QgsProject *qgisProject, QgsVectorLayer *layer, const QString &fieldName, const QString &relationId )
+QgsRelation RelationUtils::resolveReferencingRelation( QgsProject *project, QgsVectorLayer *layer, const QString &fieldName, const QString &relationId )
 {
   QgsRelationManager *relationManager = qgisProject->relationManager();
   QgsRelation relation = relationManager->relation( relationId );

--- a/src/core/utils/relationutils.cpp
+++ b/src/core/utils/relationutils.cpp
@@ -27,7 +27,7 @@ RelationUtils::RelationUtils( QObject *parent )
 
 QgsRelation RelationUtils::resolveReferencingRelation( QgsProject *project, QgsVectorLayer *layer, const QString &fieldName, const QString &relationId )
 {
-  QgsRelationManager *relationManager = qgisProject->relationManager();
+  QgsRelationManager *relationManager = project->relationManager();
   QgsRelation relation = relationManager->relation( relationId );
   if ( relation.isValid() )
     return relation;

--- a/src/core/utils/relationutils.cpp
+++ b/src/core/utils/relationutils.cpp
@@ -1,0 +1,41 @@
+/***************************************************************************
+  relationutils.cpp - RelationUtils
+
+ ---------------------
+ begin                : 19.03.2023
+ copyright            : (C) 2023 by Matthias Kuhn
+ email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "relationutils.h"
+
+#include <qgsproject.h>
+#include <qgsrelationmanager.h>
+#include <qgsvectorlayer.h>
+
+RelationUtils::RelationUtils( QObject *parent )
+  : QObject( parent )
+{
+}
+
+QgsRelation RelationUtils::resolveReferencingRelation( QgsProject *qgisProject, QgsVectorLayer *layer, const QString &fieldName, const QString &relationId )
+{
+  QgsRelationManager *relationManager = qgisProject->relationManager();
+  QgsRelation relation = relationManager->relation( relationId );
+  if ( relation.isValid() )
+    return relation;
+
+  // In case we don't find the relation by id, fall back to any suitable relation, that's how QGIS does it too
+  int index = layer->fields().indexFromName( fieldName );
+  QList<QgsRelation> relations = relationManager->referencingRelations( layer, index );
+  if ( !relations.empty() )
+    return relations.first();
+  return QgsRelation();
+}

--- a/src/core/utils/relationutils.h
+++ b/src/core/utils/relationutils.h
@@ -1,0 +1,33 @@
+/***************************************************************************
+  relationutils.h - RelationUtils
+
+ ---------------------
+ begin                : 19.03.2021
+ copyright            : (C) 2023 by Matthias Kuhn
+ email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef RELATIONUTILS_H
+#define RELATIONUTILS_H
+
+#include <QObject>
+#include <qgsrelation.h>
+
+class RelationUtils : public QObject
+{
+    Q_OBJECT
+
+  public:
+    explicit RelationUtils( QObject *parent = nullptr );
+
+    Q_INVOKABLE QgsRelation resolveReferencingRelation( QgsProject *qgisProject, QgsVectorLayer *layer, const QString &fieldName, const QString &relationId );
+};
+
+#endif // RELATIONUTILS_H

--- a/src/core/utils/relationutils.h
+++ b/src/core/utils/relationutils.h
@@ -27,7 +27,7 @@ class RelationUtils : public QObject
   public:
     explicit RelationUtils( QObject *parent = nullptr );
 
-    Q_INVOKABLE QgsRelation resolveReferencingRelation( QgsProject *qgisProject, QgsVectorLayer *layer, const QString &fieldName, const QString &relationId );
+    Q_INVOKABLE QgsRelation resolveReferencingRelation( QgsProject *project, QgsVectorLayer *layer, const QString &fieldName, const QString &relationId );
 };
 
 #endif // RELATIONUTILS_H

--- a/src/qml/editorwidgets/RelationReference.qml
+++ b/src/qml/editorwidgets/RelationReference.qml
@@ -14,12 +14,13 @@ EditorWidgetBase {
   anchors { left: parent.left; right: parent.right; }
 
   property bool showOpenFormButton: config['ShowOpenFormButton'] === undefined || config['ShowOpenFormButton'] === true
+  property var _rel: RelationUtils.resolveReferencingRelation(qgisProject, currentLayer, field.name, config['Relation'])
 
   FeatureCheckListModel {
     id: listModel
 
-    currentLayer: qgisProject.relationManager.relation(config['Relation']).referencedLayer
-    keyField: qgisProject.relationManager.relation(config['Relation']).resolveReferencedField(field.name)
+    currentLayer: _rel.referencedLayer
+    keyField: _rel.resolveReferencedField(field.name)
     addNull: config['AllowNULL'] // no, it is not a misspelled version of config['AllowNull']
     orderByValue: config['OrderByValue']
     attributeField: field
@@ -44,7 +45,7 @@ EditorWidgetBase {
     useSearch: true
     allowAddFeature: config['AllowAddFeatures'] !== undefined && config['AllowAddFeatures'] === true
 
-    property var _relation: qgisProject.relationManager.relation(config['Relation'])
+    property var _relation: _rel
   }
 
   QfToolButton  {


### PR DESCRIPTION
When the relation reference widget does not have a relation id set, in QField it will show "invalid relation". On QGIS it will fallback to any relation available for this field.
If no configuration is ever done on the attribute form (and only the relation is added in QGIS project properties) this situation occurs.

Fixes https://github.com/opengisch/QField/issues/4049