### PR TITLE
Fix relation combobox add button's icon dark theme color

### DIFF
--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -532,6 +532,7 @@ Item {
             bgcolor: "transparent"
             opacity: enabled ? 1 : 0.3
             iconSource: Theme.getThemeIcon("ic_add_black_48dp")
+            iconColor: Theme.mainTextColor
 
             visible: enabled && allowAddFeature && _relation !== undefined && _relation.isValid
 


### PR DESCRIPTION
This fixes the black + button on dark theme:
![image](https://user-images.githubusercontent.com/1728657/230262479-2f92964d-c685-4c19-9a10-a4731e809fef.png)

