### PR TITLE
Fix follow orientation math to avoid a refresh on every minor compass value change

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1611,7 +1611,7 @@ ApplicationWindow {
         }
       }
       function followOrientation() {
-        if (magnetometer.hasValue && Math.abs(magnetometer.orientation - mapCanvas.mapSettings.rotation) > 10) {
+        if (magnetometer.hasValue && Math.abs(-magnetometer.orientation - mapCanvas.mapSettings.rotation) >= 10) {
           gnssButton.followActiveSkipRotationChanged = true
           mapCanvas.mapSettings.rotation = -magnetometer.orientation
         }


### PR DESCRIPTION
This PR fixes the follow compass orientation threshold math to avoid a rotation for every tiny angle change.

Should fix https://github.com/opengisch/QField/issues/4127 

