### PR TITLE
Fix QFieldCloud layer packaging feedback dialog text color with dark theme

### DIFF
--- a/src/qml/QFieldCloudPackageLayersFeedback.qml
+++ b/src/qml/QFieldCloudPackageLayersFeedback.qml
@@ -46,6 +46,7 @@ Dialog {
         width: parent.width
         text: modelData
         font: Theme.resultFont
+        color: Theme.secondaryTextColor
         wrapMode: Text.WordWrap
       }
     }


### PR DESCRIPTION
Fix black text on dark background seen here:
![image](https://user-images.githubusercontent.com/1728657/230715042-bb23423b-6bc6-4596-bef9-fd10d59dee75.png)

