### PR TITLE
[Backport release-2_7] Fix QFieldCloud layer packaging feedback dialog text color with dark theme

### DIFF
--- a/src/qml/QFieldCloudPackageLayersFeedback.qml
+++ b/src/qml/QFieldCloudPackageLayersFeedback.qml
@@ -46,6 +46,7 @@ Dialog {
         width: parent.width
         text: modelData
         font: Theme.resultFont
+        color: Theme.secondaryTextColor
         wrapMode: Text.WordWrap
       }
     }


### PR DESCRIPTION
Backport #4136
 **Authored by:** @nirvn