### PR TITLE
Add a nifty expression calculator in the search bar

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -19,6 +19,7 @@ set(QFIELD_CORE_SRCS
     qgsquick/qgsquickmapsettings.cpp
     qgsquick/qgsquickmaptransform.cpp
     locator/bookmarklocatorfilter.cpp
+    locator/expressioncalculatorlocatorfilter.cpp
     locator/featureslocatorfilter.cpp
     locator/finlandlocatorfilter.cpp
     locator/gotolocatorfilter.cpp
@@ -122,6 +123,7 @@ set(QFIELD_CORE_HDRS
     qgsquick/qgsquickmapsettings.h
     qgsquick/qgsquickmaptransform.h
     locator/bookmarklocatorfilter.h
+    locator/expressioncalculatorlocatorfilter.h
     locator/featureslocatorfilter.h
     locator/finlandlocatorfilter.h
     locator/gotolocatorfilter.h

--- a/src/core/locator/expressioncalculatorlocatorfilter.cpp
+++ b/src/core/locator/expressioncalculatorlocatorfilter.cpp
@@ -1,0 +1,86 @@
+/***************************************************************************
+  expressioncalculatorlocatorfilter.cpp
+
+ ---------------------
+ begin                : 11.04.2023
+ copyright            : (C) 2023 by Mathieu Pellerin
+ email                : mathieu at opengis dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "expressioncalculatorlocatorfilter.h"
+#include "locatormodelsuperbridge.h"
+#include "platformutilities.h"
+
+#include <QAction>
+#include <QRegularExpression>
+#include <qgscoordinatereferencesystemutils.h>
+#include <qgscoordinateutils.h>
+#include <qgsexpressioncontextutils.h>
+#include <qgsfeedback.h>
+#include <qgspoint.h>
+#include <qgsproject.h>
+
+
+ExpressionCalculatorLocatorFilter::ExpressionCalculatorLocatorFilter( LocatorModelSuperBridge *locatorBridge, QObject *parent )
+  : QgsLocatorFilter( parent )
+  , mLocatorBridge( locatorBridge )
+{
+  setUseWithoutPrefix( false );
+}
+
+ExpressionCalculatorLocatorFilter *ExpressionCalculatorLocatorFilter::clone() const
+{
+  return new ExpressionCalculatorLocatorFilter( mLocatorBridge );
+}
+
+void ExpressionCalculatorLocatorFilter::fetchResults( const QString &string, const QgsLocatorContext &, QgsFeedback * )
+{
+  QgsExpressionContext context;
+  context << QgsExpressionContextUtils::globalScope()
+          << QgsExpressionContextUtils::projectScope( QgsProject::instance() );
+
+  QString error;
+  if ( QgsExpression::checkExpression( string, &context, error ) )
+  {
+    QgsExpression exp( string );
+    const QString resultString = exp.evaluate( &context ).toString();
+    if ( !resultString.isEmpty() )
+    {
+      QgsLocatorResult result;
+      result.filter = this;
+      result.displayString = tr( "Copy “%1” to clipboard" ).arg( resultString );
+      result.userData = resultString;
+      result.score = 1;
+      emit resultFetched( result );
+    }
+  }
+
+  return;
+}
+
+void ExpressionCalculatorLocatorFilter::triggerResult( const QgsLocatorResult &result )
+{
+  triggerResultFromAction( result, Normal );
+}
+
+void ExpressionCalculatorLocatorFilter::triggerResultFromAction( const QgsLocatorResult &result, const int actionId )
+{
+  QString resultString = result.userData.toString();
+
+  switch ( actionId )
+  {
+    case Normal:
+    {
+      PlatformUtilities::instance()->copyTextToClipboard( resultString );
+    }
+  }
+
+  return;
+}

--- a/src/core/locator/expressioncalculatorlocatorfilter.h
+++ b/src/core/locator/expressioncalculatorlocatorfilter.h
@@ -1,0 +1,59 @@
+/***************************************************************************
+  expressioncalculatorlocatorfilter.h
+
+ ---------------------
+ begin                : 11.04.2023
+ copyright            : (C) 2023 by Mathieu Pellerin
+ email                : mathieu at opengis dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef EXPRESSIONCALCULATORLOCATORFILTER_H
+#define EXPRESSIONCALCULATORLOCATORFILTER_H
+
+#include <QObject>
+#include <qgsexpressioncontext.h>
+#include <qgslocatorfilter.h>
+
+
+class LocatorModelSuperBridge;
+
+/**
+ * ExpressionCalculatorLocatorFilter is a locator filter to type in expressions
+ * and copy their returned value.
+ */
+class ExpressionCalculatorLocatorFilter : public QgsLocatorFilter
+{
+    Q_OBJECT
+
+  public:
+    //! Origin of the action which triggers the result
+    enum ActionOrigin
+    {
+      Normal,
+    };
+
+    explicit ExpressionCalculatorLocatorFilter( LocatorModelSuperBridge *locatorBridge, QObject *parent = nullptr );
+    ExpressionCalculatorLocatorFilter *clone() const override;
+    QString name() const override { return QStringLiteral( "calculator" ); }
+    QString displayName() const override { return tr( "Calculator" ); }
+    Priority priority() const override { return Highest; }
+    QString prefix() const override { return QStringLiteral( "=" ); }
+    QgsLocatorFilter::Flags flags() const override { return QgsLocatorFilter::FlagFast; }
+
+    void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) override;
+    void triggerResult( const QgsLocatorResult &result ) override;
+    void triggerResultFromAction( const QgsLocatorResult &result, const int actionId ) override;
+
+  private:
+    LocatorModelSuperBridge *mLocatorBridge = nullptr;
+};
+
+#endif // EXPRESSIONCALCULATORLOCATORFILTER_H

--- a/src/core/locator/locatormodelsuperbridge.cpp
+++ b/src/core/locator/locatormodelsuperbridge.cpp
@@ -16,6 +16,7 @@
 
 
 #include "bookmarklocatorfilter.h"
+#include "expressioncalculatorlocatorfilter.h"
 #include "featurelistextentcontroller.h"
 #include "featureslocatorfilter.h"
 #include "finlandlocatorfilter.h"
@@ -37,6 +38,7 @@ LocatorModelSuperBridge::LocatorModelSuperBridge( QObject *parent )
   locator()->registerFilter( new FeaturesLocatorFilter( this ) );
   locator()->registerFilter( new GotoLocatorFilter( this ) );
   locator()->registerFilter( new BookmarkLocatorFilter( this ) );
+  locator()->registerFilter( new ExpressionCalculatorLocatorFilter( this ) );
 
   // Finnish's Digitransit geocoder
   mFinlandGeocoder = new PeliasGeocoder( QStringLiteral( "https://api.digitransit.fi/geocoding/v1/search" ) );
@@ -227,6 +229,7 @@ QVariant LocatorFiltersModel::data( const QModelIndex &index, int role ) const
     { QStringLiteral( "allfeatures" ), tr( "Returns a list of features accross all searchable layers with matching attributes" ) },
     { QStringLiteral( "goto" ), tr( "Returns a point from a pair of X and Y coordinates typed in the search bar" ) },
     { QStringLiteral( "bookmarks" ), tr( "Returns a list of bookmark with matching names" ) },
+    { QStringLiteral( "calculator" ), tr( "Returns the value of the expression typed in the search bar" ) },
     { QStringLiteral( "pelias-finland" ), tr( "Returns a list of locations and addresses within Finland with matching terms" ) } };
 
   if ( !mLocatorModelSuperBridge->locator() || !index.isValid() || index.parent().isValid() || index.row() < 0 || index.row() >= rowCount( QModelIndex() ) )


### PR DESCRIPTION
In May, 2017, @nyalldawson , had a great locator filter idea in the form of an expression calculator. I've been using this every other week in QGIS, and it's time QField equips itself with the same nifty tool :)

In action, a simple math expression:
![image](https://user-images.githubusercontent.com/1728657/231046379-3fd5f1d4-38b9-46bc-863b-9bb320483177.png)
