### PR TITLE
Fix rubber band model wrongly added M dimension when we want Z

### DIFF
--- a/src/core/rubberbandmodel.cpp
+++ b/src/core/rubberbandmodel.cpp
@@ -78,7 +78,7 @@ QgsPointSequence RubberbandModel::pointSequence( const QgsCoordinateReferenceSys
 
     if ( QgsWkbTypes::hasZ( wkbType ) )
     {
-      p2.addMValue( QgsWkbTypes::hasZ( pt.wkbType() ) ? pt.z() : 0 );
+      p2.addZValue( QgsWkbTypes::hasZ( pt.wkbType() ) ? pt.z() : 0 );
     }
 
     sequence.append( p2 );


### PR DESCRIPTION
This fixes a pretty serious typo leading to the issue filed here (https://github.com/opengisch/QField/issues/4163).