### PR TITLE
Value relation editor widget search improvements & cleanups

### DIFF
--- a/src/core/featurelistmodel.cpp
+++ b/src/core/featurelistmodel.cpp
@@ -336,14 +336,25 @@ void FeatureListModel::processFeatureList()
     entries.append( entry );
   }
 
-  if ( mOrderByValue )
+  if ( mOrderByValue || !mSearchTerm.isEmpty() )
   {
-    std::sort( entries.begin(), entries.end(), []( const Entry &entry1, const Entry &entry2 ) {
+    std::sort( entries.begin(), entries.end(), [=]( const Entry &entry1, const Entry &entry2 ) {
       if ( entry1.key.isNull() )
         return true;
 
       if ( entry2.key.isNull() )
         return false;
+
+      if ( !mSearchTerm.isEmpty() )
+      {
+        const bool entry1StartsWithSearchTerm = entry1.displayString.toLower().startsWith( mSearchTerm.toLower() );
+        const bool entry2StartsWithSearchTerm = entry2.displayString.toLower().startsWith( mSearchTerm.toLower() );
+        if ( entry1StartsWithSearchTerm && !entry2StartsWithSearchTerm )
+          return true;
+
+        if ( !entry1StartsWithSearchTerm && entry2StartsWithSearchTerm )
+          return false;
+      }
 
       return entry1.displayString.toLower() < entry2.displayString.toLower();
     } );

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -54,225 +54,219 @@ Item {
     }
 
     Popup {
-        id: searchFeaturePopup
+      id: searchFeaturePopup
 
-        parent: ApplicationWindow.overlay
-        x: Theme.popupScreenEdgeMargin
-        y: Theme.popupScreenEdgeMargin
-        z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes
-        width: parent.width - Theme.popupScreenEdgeMargin * 2
-        height: parent.height - Theme.popupScreenEdgeMargin * 2
-        padding: 0
-        modal: true
-        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
-        focus: visible
+      parent: ApplicationWindow.overlay
+      x: Theme.popupScreenEdgeMargin
+      y: Theme.popupScreenEdgeMargin
+      z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes
+      width: parent.width - Theme.popupScreenEdgeMargin * 2
+      height: parent.height - Theme.popupScreenEdgeMargin * 2
+      padding: 0
+      modal: true
+      closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+      focus: visible
 
-        onOpened: {
-            if (searchableText.typedFilter != '') {
-                searchField.text = searchableText.typedFilter
-            }
-
-            if (resultsList.contentHeight > resultsList.height) {
-                searchField.forceActiveFocus()
-            }
+      onOpened: {
+        if (searchableText.typedFilter != '') {
+          searchField.text = searchableText.typedFilter
         }
 
-        onClosed: {
-            searchField.text = ''
+        if (resultsList.contentHeight > resultsList.height) {
+          searchField.forceActiveFocus()
+        }
+      }
+
+      onClosed: {
+        searchField.text = ''
+      }
+
+      Page {
+        anchors.fill: parent
+
+        header: PageHeader {
+          title: fieldLabel
+          showBackButton: false
+          showApplyButton: false
+          showCancelButton: true
+          onCancel: searchFeaturePopup.close()
         }
 
-        Page {
+        TextField {
+          z: 1
+          id: searchField
+          anchors.left: parent.left
+          anchors.right: parent.right
+
+          placeholderText: qsTr("Search…")
+          placeholderTextColor: Theme.mainColor
+
+          height: fontMetrics.height * 2.5
+          padding: 24
+          bottomPadding: 9
+          font: Theme.defaultFont
+          selectByMouse: true
+          verticalAlignment: TextInput.AlignVCenter
+
+          inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhSensitiveData
+
+          onDisplayTextChanged: {
+            featureListModel.searchTerm = searchField.displayText
+          }
+
+          Keys.onPressed: {
+            if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+              if (featureListModel.rowCount() === 1) {
+                resultsList.itemAtIndex(0).performClick()
+                searchFeaturePopup.close()
+              }
+            }
+          }
+        }
+
+        QfToolButton {
+          id: clearButton
+          z: 1
+          width: fontMetrics.height
+          height: fontMetrics.height
+          anchors { top: searchField.top; right: searchField.right; topMargin: height - 7; rightMargin: height - 7 }
+
+          padding: 0
+          iconSource: Theme.getThemeIcon("ic_clear_black_18dp")
+          iconColor: Theme.mainTextColor
+          bgcolor: "transparent"
+
+          opacity: searchField.displayText.length > 0 ? 1 : 0.25
+
+          onClicked: {
+            searchField.text = '';
+          }
+        }
+
+        ListView {
+          id: resultsList
+          anchors.left: parent.left
+          anchors.right: parent.right
+          anchors.top: searchField.bottom
+          model: featureListModel
+          width: parent.width
+          height: searchFeaturePopup.height - searchField.height - 50
+          clip: true
+
+          ScrollBar.vertical: ScrollBar {
+            policy: ScrollBar.AsNeeded
+            width: 6
+            contentItem: Rectangle {
+              implicitWidth: 6
+              implicitHeight: 25
+              color: Theme.mainColor
+            }
+          }
+
+          delegate: Rectangle {
+            id: delegateRect
+
+            property int idx: index
+            property string itemText: featureListModel.searchTerm != ''
+                                      ? displayString.replace(featureListModel.searchTerm, '<u>'+featureListModel.searchTerm+'</u>')
+                                      : displayString
+
+            anchors.margins: 10
+            height: radioButton.visible ? radioButton.height : checkBoxButton.height
+            width: parent ? parent.width : undefined
+            color: model.checked ? Theme.mainColor : Theme.controlBackgroundAlternateColor
+
+            Row {
+              RadioButton {
+                id: radioButton
+
+                visible: !featureListModel.allowMulti
+                anchors.verticalCenter: parent.verticalCenter
+                width: resultsList.width - padding * 2
+                padding: 12
+
+                font.pointSize: Theme.defaultFont.pointSize
+                font.weight: model.checked ? Font.DemiBold : Font.Normal
+
+                checked: model.checked
+                indicator: Rectangle {}
+
+                text: itemText
+                contentItem: Text {
+                  text: parent.text
+                  font: parent.font
+                  width: parent.width
+                  verticalAlignment: Text.AlignVCenter
+                  leftPadding: parent.indicator.width + parent.spacing
+                  elide: Text.ElideRight
+                  color: Theme.mainTextColor
+                  textFormat: Text.RichText
+                }
+              }
+
+              CheckBox {
+                id: checkBoxButton
+
+                visible: !!featureListModel.allowMulti
+                anchors.verticalCenter: parent.verticalCenter
+                width: resultsList.width - padding * 2
+                padding: 12
+
+                font.pointSize: Theme.defaultFont.pointSize
+                font.weight: model.checked ? Font.DemiBold : Font.Normal
+
+                text: itemText
+                contentItem: Text {
+                  text: parent.text
+                  font: parent.font
+                  width: parent.width
+                  verticalAlignment: Text.AlignVCenter
+                  leftPadding: parent.indicator.width + parent.spacing
+                  elide: Text.ElideRight
+                  color: Theme.mainTextColor
+                  textFormat: Text.RichText
+                }
+              }
+            }
+
+
+            /* bottom border */
+            Rectangle {
+              anchors.bottom: parent.bottom
+              height: 1
+              color: Theme.controlBorderColor
+              width: resultsList.width
+            }
+
+            function performClick() {
+              model.checked = true;
+            }
+          }
+
+          MouseArea {
             anchors.fill: parent
+            propagateComposedEvents: true
 
-            header: PageHeader {
-                title: fieldLabel
-                showBackButton: false
-                showApplyButton: false
-                showCancelButton: true
-                onCancel: searchFeaturePopup.close()
+            onClicked: {
+              var item = resultsList.itemAt(resultsList.contentX + mouse.x, resultsList.contentY + mouse.y)
+              if (!item)
+                return;
+
+              item.performClick()
+              model.checked = !model.checked
+
+              if (!resultsList.model.allowMulti) {
+                searchFeaturePopup.close()
+              }
             }
+          }
 
-            TextField {
-                z: 1
-                id: searchField
-                anchors.left: parent.left
-                anchors.right: parent.right
-
-                placeholderText: qsTr("Search…")
-                placeholderTextColor: Theme.mainColor
-
-                height: fontMetrics.height * 2.5
-                padding: 24
-                bottomPadding: 9
-                font: Theme.defaultFont
-                selectByMouse: true
-                verticalAlignment: TextInput.AlignVCenter
-
-                inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhSensitiveData
-
-                onDisplayTextChanged: {
-                    featureListModel.searchTerm = searchField.displayText
-                }
-
-                Keys.onPressed: {
-                    if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
-                        if (featureListModel.rowCount() === 1) {
-                            resultsList.itemAtIndex(0).performClick()
-                            searchFeaturePopup.close()
-                        }
-                    }
-                }
-            }
-
-            QfToolButton {
-                id: clearButton
-                z: 1
-                width: fontMetrics.height
-                height: fontMetrics.height
-                anchors { top: searchField.top; right: searchField.right; topMargin: height - 7; rightMargin: height - 7 }
-
-                padding: 0
-                iconSource: Theme.getThemeIcon("ic_clear_black_18dp")
-                iconColor: Theme.mainTextColor
-                bgcolor: "transparent"
-
-                opacity: searchField.displayText.length > 0 ? 1 : 0.25
-
-                onClicked: {
-                    searchField.text = '';
-                }
-            }
-
-            ScrollView {
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.top: searchField.bottom
-
-                padding: 0
-                ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
-                ScrollBar.vertical.policy: ScrollBar.AsNeeded
-                contentItem: resultsList
-                contentWidth: resultsList.width
-                contentHeight: resultsList.height
-                clip: true
-
-                ListView {
-                    id: resultsList
-                    anchors.top: parent.top
-                    model: featureListModel
-                    width: parent.width
-                    height: searchFeaturePopup.height - searchField.height - 50
-                    clip: true
-
-                    delegate: Rectangle {
-                        id: delegateRect
-
-                        property int idx: index
-                        property string itemText: featureListModel.searchTerm != ''
-                                                  ? displayString.replace(featureListModel.searchTerm, '<u>'+featureListModel.searchTerm+'</u>')
-                                                  : displayString
-
-                        anchors.margins: 10
-                        height: radioButton.visible ? radioButton.height : checkBoxButton.height
-                        width: parent ? parent.width : undefined
-                        color: model.checked ? Theme.mainColor : Theme.controlBackgroundAlternateColor
-
-                        Row {
-                            RadioButton {
-                                id: radioButton
-
-                                visible: !featureListModel.allowMulti
-                                anchors.verticalCenter: parent.verticalCenter
-                                width: resultsList.width - padding * 2
-                                padding: 12
-
-                                font.pointSize: Theme.defaultFont.pointSize
-                                font.weight: model.checked ? Font.DemiBold : Font.Normal
-
-                                checked: model.checked
-                                indicator: Rectangle {}
-
-                                text: itemText
-                                contentItem: Text {
-                                    text: parent.text
-                                    font: parent.font
-                                    width: parent.width
-                                    verticalAlignment: Text.AlignVCenter
-                                    leftPadding: parent.indicator.width + parent.spacing
-                                    elide: Text.ElideRight
-                                    color: Theme.mainTextColor
-                                    textFormat: Text.RichText
-                                }
-
-                                ButtonGroup.group: buttonGroup
-                            }
-
-                            CheckBox {
-                                id: checkBoxButton
-
-                                visible: !!featureListModel.allowMulti
-                                anchors.verticalCenter: parent.verticalCenter
-                                width: resultsList.width - padding * 2
-                                padding: 12
-
-                                font.pointSize: Theme.defaultFont.pointSize
-                                font.weight: model.checked ? Font.DemiBold : Font.Normal
-
-                                text: itemText
-                                contentItem: Text {
-                                    text: parent.text
-                                    font: parent.font
-                                    width: parent.width
-                                    verticalAlignment: Text.AlignVCenter
-                                    leftPadding: parent.indicator.width + parent.spacing
-                                    elide: Text.ElideRight
-                                    color: Theme.mainTextColor
-                                    textFormat: Text.RichText
-                                }
-                            }
-                        }
-
-
-                        /* bottom border */
-                        Rectangle {
-                            anchors.bottom: parent.bottom
-                            height: 1
-                            color: Theme.controlBorderColor
-                            width: resultsList.width
-                        }
-
-                        function performClick() {
-                            model.checked = true;
-                        }
-                    }
-
-                    MouseArea {
-                        anchors.fill: parent
-                        propagateComposedEvents: true
-
-                        onClicked: {
-                            var item = resultsList.itemAt(resultsList.contentX + mouse.x, resultsList.contentY + mouse.y)
-                            if (!item)
-                                return;
-
-                            item.performClick()
-                            model.checked = !model.checked
-
-                            if (!resultsList.model.allowMulti) {
-                                searchFeaturePopup.close()
-                            }
-                        }
-                    }
-
-                    onMovementStarted: {
-                        Qt.inputMethod.hide()
-                    }
-                }
-            }
+          onMovementStarted: {
+            Qt.inputMethod.hide()
+          }
         }
+      }
     }
-
-    ButtonGroup { id: buttonGroup }
 
     RowLayout {
         anchors { left: parent.left; right: parent.right }

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -168,6 +168,9 @@ Item {
                         id: delegateRect
 
                         property int idx: index
+                        property string itemText: featureListModel.searchTerm != ''
+                                                  ? displayString.replace(featureListModel.searchTerm, '<u>'+featureListModel.searchTerm+'</u>')
+                                                  : displayString
 
                         anchors.margins: 10
                         height: radioButton.visible ? radioButton.height : checkBoxButton.height
@@ -179,15 +182,17 @@ Item {
                                 id: radioButton
 
                                 visible: !featureListModel.allowMulti
-                                checked: model.checked
                                 anchors.verticalCenter: parent.verticalCenter
-                                text: displayString
                                 width: resultsList.width - padding * 2
                                 padding: 12
-                                ButtonGroup.group: buttonGroup
+
+                                font.pointSize: Theme.defaultFont.pointSize
                                 font.weight: model.checked ? Font.DemiBold : Font.Normal
 
+                                checked: model.checked
                                 indicator: Rectangle {}
+
+                                text: itemText
                                 contentItem: Text {
                                     text: parent.text
                                     font: parent.font
@@ -195,8 +200,11 @@ Item {
                                     verticalAlignment: Text.AlignVCenter
                                     leftPadding: parent.indicator.width + parent.spacing
                                     elide: Text.ElideRight
-                                    color: model.checked ? Theme.light : Theme.mainTextColor
+                                    color: Theme.mainTextColor
+                                    textFormat: Text.RichText
                                 }
+
+                                ButtonGroup.group: buttonGroup
                             }
 
                             CheckBox {
@@ -204,8 +212,23 @@ Item {
 
                                 visible: !!featureListModel.allowMulti
                                 anchors.verticalCenter: parent.verticalCenter
-                                text: displayString
+                                width: resultsList.width - padding * 2
                                 padding: 12
+
+                                font.pointSize: Theme.defaultFont.pointSize
+                                font.weight: model.checked ? Font.DemiBold : Font.Normal
+
+                                text: itemText
+                                contentItem: Text {
+                                    text: parent.text
+                                    font: parent.font
+                                    width: parent.width
+                                    verticalAlignment: Text.AlignVCenter
+                                    leftPadding: parent.indicator.width + parent.spacing
+                                    elide: Text.ElideRight
+                                    color: Theme.mainTextColor
+                                    textFormat: Text.RichText
+                                }
                             }
                         }
 

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -279,6 +279,8 @@ Item {
             property var _cachedCurrentValue
 
             model: featureListModel
+            textRole: 'display'
+            valueRole: 'keyFieldValue'
 
             onCurrentIndexChanged: {
                 var newValue = featureListModel.dataFromRowIndex(currentIndex, FeatureListModel.KeyFieldRole)
@@ -314,13 +316,14 @@ Item {
                 comboBox.popup.z = 10000 // 1000s are embedded feature forms, use a higher value to insure popups always show above embedded feature formes
             }
 
-            textRole: 'display'
             font: Theme.defaultFont
             popup.font: Theme.defaultFont
             contentItem: Text {
                 leftPadding: enabled ? 5 : 0
                 height: fontMetrics.height + 20
-                text: comboBox.displayText
+                text: comboBox.currentIndex == -1 && value !== undefined
+                      ? '(' + value +')'
+                      : comboBox.currentText
                 font: comboBox.font
                 color: value === undefined || !enabled ? Theme.mainTextDisabledColor : Theme.mainTextColor
                 horizontalAlignment: Text.AlignLeft

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -168,7 +168,7 @@ Item {
 
             property int idx: index
             property string itemText: featureListModel.searchTerm != ''
-                                      ? displayString.replace(featureListModel.searchTerm, '<u>'+featureListModel.searchTerm+'</u>')
+                                      ? displayString.replace(new RegExp('('+featureListModel.searchTerm+')', "i"), '<u>$1</u>')
                                       : displayString
 
             anchors.margins: 10

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -168,7 +168,8 @@ Item {
 
             property int idx: index
             property string itemText: featureListModel.searchTerm != ''
-                                      ? displayString.replace(new RegExp('('+featureListModel.searchTerm+')', "i"), '<u>$1</u>')
+                                      ? displayString.replace(new RegExp('('+featureListModel.searchTerm+')', "i"),
+                                                              '<span style="text-decoration:underline;' + Theme.toInlineStyles({color:Theme.mainTextColor}) + '">$1</span>')
                                       : displayString
 
             anchors.margins: 10
@@ -199,7 +200,7 @@ Item {
                   verticalAlignment: Text.AlignVCenter
                   leftPadding: parent.indicator.width + parent.spacing
                   elide: Text.ElideRight
-                  color: Theme.mainTextColor
+                  color: featureListModel.searchTerm != '' ? Theme.secondaryTextColor : Theme.mainTextColor
                   textFormat: Text.RichText
                 }
               }


### PR DESCRIPTION
This PR improves the value relation editor widget's search popup by placing matching features that *begins with* the searched term at the top of the list. In addition, the list will highlight in underscore the matching part.

In action:
![image](https://user-images.githubusercontent.com/1728657/232413226-a11a3945-d639-4f86-8fe2-39b3161a9216.png)

A bunch of cleanups and optimization (e.g. avoiding double scrollview situation) also made their way into the widget.

Finally, the widget now behaves like QGIS when a preexisting attribute value is not found in the list. Instead of showing a blank, it now shows the value within brackets:
![image](https://user-images.githubusercontent.com/1728657/232375429-bf4b1ba0-dda9-4b43-b865-3b3516a405ef.png)
