### PR TITLE
NMEA sentence logging functionality

### DIFF
--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -422,6 +422,7 @@ public class QFieldActivity extends QtActivity {
                 new File(dataDir + "fonts/").mkdirs();
                 new File(dataDir + "proj/").mkdirs();
                 new File(dataDir + "auth/").mkdirs();
+                new File(dataDir + "logs/").mkdirs();
 
                 dataDirs.add(dataDir);
             }

--- a/src/core/platforms/ios/iosplatformutilities.mm
+++ b/src/core/platforms/ios/iosplatformutilities.mm
@@ -81,6 +81,7 @@ void IosPlatformUtilities::afterUpdate() {
   appDir.mkpath(QStringLiteral("QField/auth"));
   appDir.mkpath(QStringLiteral("QField/fonts"));
   appDir.mkpath(QStringLiteral("QField/basemaps"));
+  appDir.mkpath(QStringLiteral("QField/logs"));
 }
 
 QString IosPlatformUtilities::systemSharedDataLocation() const {

--- a/src/core/platforms/platformutilities.cpp
+++ b/src/core/platforms/platformutilities.cpp
@@ -100,6 +100,7 @@ void PlatformUtilities::afterUpdate()
     appDir.mkpath( QStringLiteral( "auth" ) );
     appDir.mkpath( QStringLiteral( "fonts" ) );
     appDir.mkpath( QStringLiteral( "basemaps" ) );
+    appDir.mkpath( QStringLiteral( "logs" ) );
   }
 }
 

--- a/src/core/positioning/abstractgnssreceiver.h
+++ b/src/core/positioning/abstractgnssreceiver.h
@@ -50,6 +50,9 @@ class AbstractGnssReceiver : public QObject
     Q_INVOKABLE void connectDevice() { handleConnectDevice(); }
     Q_INVOKABLE void disconnectDevice() { handleDisconnectDevice(); }
 
+    Q_INVOKABLE void startLogging() { handleStartLogging(); }
+    Q_INVOKABLE void stopLogging() { handleStopLogging(); }
+
     GnssPositionInformation lastGnssPositionInformation() const { return mLastGnssPositionInformation; }
 
     QAbstractSocket::SocketState socketState() const { return mSocketState; }
@@ -75,6 +78,9 @@ class AbstractGnssReceiver : public QObject
 
     virtual void handleConnectDevice() {}
     virtual void handleDisconnectDevice() {}
+
+    virtual void handleStartLogging() {}
+    virtual void handleStopLogging() {}
 
     bool mValid = false;
     GnssPositionInformation mLastGnssPositionInformation;

--- a/src/core/positioning/abstractgnssreceiver.h
+++ b/src/core/positioning/abstractgnssreceiver.h
@@ -31,6 +31,15 @@ class AbstractGnssReceiver : public QObject
     Q_PROPERTY( QString lastError READ lastError NOTIFY lastErrorChanged )
 
   public:
+    enum Capability
+    {
+      NoCapabilities = 0,      //!< No capabilities
+      OrthometricAltitude = 1, //!< Orthometric altitude support
+      Logging = 1 << 1,        //!< Logging support
+    };
+    Q_DECLARE_FLAGS( Capabilities, Capability )
+    Q_FLAGS( Capabilities )
+
     explicit AbstractGnssReceiver( QObject *parent = nullptr )
       : QObject( parent ) {}
     virtual ~AbstractGnssReceiver() = default;
@@ -46,6 +55,8 @@ class AbstractGnssReceiver : public QObject
     QAbstractSocket::SocketState socketState() const { return mSocketState; }
     QString socketStateString() const { return mSocketStateString; }
     QString lastError() const { return mLastError; }
+
+    Q_INVOKABLE virtual AbstractGnssReceiver::Capabilities capabilities() const { return NoCapabilities; }
 
   signals:
     void validChanged();

--- a/src/core/positioning/nmeagnssreceiver.cpp
+++ b/src/core/positioning/nmeagnssreceiver.cpp
@@ -75,7 +75,7 @@ void NmeaGnssReceiver::handleStartLogging()
   const QStringList appDataDirs = PlatformUtilities::instance()->appDataDirs();
   if ( !appDataDirs.isEmpty() )
   {
-    mLogFile.setFileName( QStringLiteral( "%1/nmea-%2.log" ).arg( appDataDirs.at( 0 ), QDateTime::currentDateTime().toString( QStringLiteral( "yyyy-MM-ddThh:mm:ss" ) ) ) );
+    mLogFile.setFileName( QStringLiteral( "%1/logs/nmea-%2.log" ).arg( appDataDirs.at( 0 ), QDateTime::currentDateTime().toString( QStringLiteral( "yyyy-MM-ddThh:mm:ss" ) ) ) );
     mLogFile.open( QIODevice::WriteOnly );
     mLogStream.setDevice( &mLogFile );
   }

--- a/src/core/positioning/nmeagnssreceiver.h
+++ b/src/core/positioning/nmeagnssreceiver.h
@@ -35,6 +35,8 @@ class NmeaGnssReceiver : public AbstractGnssReceiver
 
     void initNmeaConnection( QIODevice *ioDevice );
 
+    AbstractGnssReceiver::Capabilities capabilities() const override { return AbstractGnssReceiver::OrthometricAltitude; }
+
   protected:
     std::unique_ptr<QgsNmeaConnection> mNmeaConnection;
 

--- a/src/core/positioning/nmeagnssreceiver.h
+++ b/src/core/positioning/nmeagnssreceiver.h
@@ -19,6 +19,7 @@
 #include "abstractgnssreceiver.h"
 #include "qgsnmeaconnection.h"
 
+#include <QFile>
 #include <QObject>
 
 /**
@@ -44,9 +45,16 @@ class NmeaGnssReceiver : public AbstractGnssReceiver
 
   private slots:
     void stateChanged( const QgsGpsInformation &info );
+    void nmeaSentenceReceived( const QString &substring );
 
   private:
+    void handleStartLogging() override;
+    void handleStopLogging() override;
+
     QTime mLastGnssPositionUtcTime;
+
+    QFile mLogFile;
+    QTextStream mLogStream;
 };
 
 #endif // NMEAGNSSRECEIVER_H

--- a/src/core/positioning/nmeagnssreceiver.h
+++ b/src/core/positioning/nmeagnssreceiver.h
@@ -36,7 +36,7 @@ class NmeaGnssReceiver : public AbstractGnssReceiver
 
     void initNmeaConnection( QIODevice *ioDevice );
 
-    AbstractGnssReceiver::Capabilities capabilities() const override { return AbstractGnssReceiver::OrthometricAltitude; }
+    AbstractGnssReceiver::Capabilities capabilities() const override { return Capabilities() | AbstractGnssReceiver::OrthometricAltitude | AbstractGnssReceiver::Logging; }
 
   protected:
     std::unique_ptr<QgsNmeaConnection> mNmeaConnection;

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -101,6 +101,28 @@ void Positioning::setAveragedPosition( bool averaged )
   emit averagedPositionChanged();
 }
 
+void Positioning::setLogging( bool logging )
+{
+  if ( mLogging == logging )
+    return;
+
+  mLogging = logging;
+
+  if ( mReceiver )
+  {
+    if ( mLogging )
+    {
+      mReceiver->startLogging();
+    }
+    else
+    {
+      mReceiver->stopLogging();
+    }
+  }
+
+  emit loggingChanged();
+}
+
 void Positioning::setEllipsoidalElevation( bool ellipsoidal )
 {
   if ( mEllipsoidalElevation == ellipsoidal )
@@ -132,6 +154,7 @@ void Positioning::setupDevice()
   if ( mReceiver )
   {
     mReceiver->disconnectDevice();
+    mReceiver->stopLogging();
     disconnect( mReceiver, &AbstractGnssReceiver::lastGnssPositionInformationChanged, this, &Positioning::lastGnssPositionInformationChanged );
     mReceiver->deleteLater();
     mReceiver = nullptr;
@@ -178,6 +201,11 @@ void Positioning::setupDevice()
   setValid( mReceiver->valid() );
 
   emit deviceChanged();
+
+  if ( mLogging )
+  {
+    mReceiver->startLogging();
+  }
 
   if ( mActive )
   {

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -52,6 +52,8 @@ class Positioning : public QObject
 
     Q_PROPERTY( bool ellipsoidalElevation READ ellipsoidalElevation WRITE setEllipsoidalElevation NOTIFY ellipsoidalElevationChanged )
 
+    Q_PROPERTY( bool logging READ logging WRITE setLogging NOTIFY loggingChanged )
+
   public:
     explicit Positioning( QObject *parent = nullptr );
 
@@ -141,9 +143,29 @@ class Positioning : public QObject
      */
     int averagedPositionCount() const { return mCollectedPositionInformations.size(); }
 
+    /**
+     * Returns whether GNSS devices will be asked to report ellipsoidal height.
+     * \note Requires a device type with ellipsoidal capability
+     */
     bool ellipsoidalElevation() const { return mEllipsoidalElevation; }
 
+    /**
+     * Sets whether GNSS devices will be asked to report ellipsoidal height.
+     * \note Requires a device type with ellipsoidal capability
+     */
     void setEllipsoidalElevation( bool ellipsoidal );
+
+    /**
+     * Returns whether GNSS devices will log their incoming position stream into a logfile.
+     * \note Requires a device type with logging capability
+     */
+    bool logging() const { return mLogging; }
+
+    /**
+     * Sets whether GNSS devices will log their incoming position stream into a logfile.
+     * \note Requires a device type with logging capability
+     */
+    void setLogging( bool logging );
 
   signals:
 
@@ -157,6 +179,7 @@ class Positioning : public QObject
     void averagedPositionCountChanged();
     void projectedPositionChanged();
     void ellipsoidalElevationChanged();
+    void loggingChanged();
 
   private slots:
 
@@ -186,6 +209,8 @@ class Positioning : public QObject
     bool mAveragedPosition = false;
 
     bool mEllipsoidalElevation = false;
+
+    bool mLogging = false;
 
     AbstractGnssReceiver *mReceiver = nullptr;
 };

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -8,6 +8,7 @@ LabSettings.Settings {
     property string positioningDevice: ""
     property string positioningDeviceName: qsTr( "Internal device" );
     property bool ellipsoidalElevation: true
+    property bool logging: false
 
     property bool showPositionInformation: false
 

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -649,31 +649,6 @@ Page {
                       }
                   }
 
-                  Label {
-                    text: qsTr("Use orthometric altitude from device")
-                    font: Theme.defaultFont
-                    color: Theme.mainTextColor
-                    wrapMode: Text.WordWrap
-                    Layout.fillWidth: true
-                    visible: positionSource.device.capabilities() & AbstractGnssReceiver.OrthometricAltitude
-
-                    MouseArea {
-                      anchors.fill: parent
-                      onClicked: reportOrthometricAltitude.toggle()
-                    }
-                  }
-
-                  QfSwitch {
-                    id: reportOrthometricAltitude
-                    Layout.preferredWidth: implicitContentWidth
-                    Layout.alignment: Qt.AlignTop
-                    visible: positionSource.device.capabilities() & AbstractGnssReceiver.OrthometricAltitude
-                    checked: !positioningSettings.ellipsoidalElevation
-                    onCheckedChanged: {
-                      positioningSettings.ellipsoidalElevation = !checked
-                    }
-                  }
-
                   QfButton {
                     id: connectButton
                     Layout.fillWidth: true
@@ -1164,6 +1139,36 @@ Page {
 
                       wrapMode: Text.WordWrap
                       Layout.fillWidth: true
+                  }
+
+                  Item {
+                      // empty cell in grid layout
+                      width: 1
+                  }
+
+                  Label {
+                    text: qsTr("Use orthometric altitude from device")
+                    font: Theme.defaultFont
+                    color: Theme.mainTextColor
+                    wrapMode: Text.WordWrap
+                    Layout.fillWidth: true
+                    visible: positionSource.device.capabilities() & AbstractGnssReceiver.OrthometricAltitude
+
+                    MouseArea {
+                      anchors.fill: parent
+                      onClicked: reportOrthometricAltitude.toggle()
+                    }
+                  }
+
+                  QfSwitch {
+                    id: reportOrthometricAltitude
+                    Layout.preferredWidth: implicitContentWidth
+                    Layout.alignment: Qt.AlignTop
+                    visible: positionSource.device.capabilities() & AbstractGnssReceiver.OrthometricAltitude
+                    checked: !positioningSettings.ellipsoidalElevation
+                    onCheckedChanged: {
+                      positioningSettings.ellipsoidalElevation = !checked
+                    }
                   }
               }
 

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -655,7 +655,7 @@ Page {
                     color: Theme.mainTextColor
                     wrapMode: Text.WordWrap
                     Layout.fillWidth: true
-                    visible: positioningSettings.positioningDevice !== ''
+                    visible: positionSource.device.capabilities() & AbstractGnssReceiver.OrthometricAltitude
 
                     MouseArea {
                       anchors.fill: parent
@@ -667,7 +667,7 @@ Page {
                     id: reportOrthometricAltitude
                     Layout.preferredWidth: implicitContentWidth
                     Layout.alignment: Qt.AlignTop
-                    visible: positioningSettings.positioningDevice !== ''
+                    visible: positionSource.device.capabilities() & AbstractGnssReceiver.OrthometricAltitude
                     checked: !positioningSettings.ellipsoidalElevation
                     onCheckedChanged: {
                       positioningSettings.ellipsoidalElevation = !checked

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -1210,7 +1210,7 @@ Page {
                   }
 
                   Label {
-                    text: qsTr("Log NMEA setences from device to file")
+                    text: qsTr("Log NMEA sentences from device to file")
                     font: Theme.defaultFont
                     color: Theme.mainTextColor
                     wrapMode: Text.WordWrap

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -1170,11 +1170,6 @@ Page {
                       positioningSettings.ellipsoidalElevation = !checked
                     }
                   }
-              }
-
-              ColumnLayout {
-                  Layout.fillWidth: true
-                  Layout.bottomMargin: 40
 
                   Label {
                       text: qsTr( "Vertical grid shift in use:" )
@@ -1183,10 +1178,12 @@ Page {
 
                       wrapMode: Text.WordWrap
                       Layout.fillWidth: true
+                      Layout.columnSpan: 2
                   }
 
                   ComboBox {
                       Layout.fillWidth: true
+                      Layout.columnSpan: 2
                       model: [ qsTr( "None" ) ].concat( platformUtilities.availableGrids() );
                       font: Theme.defaultFont
                       popup.font: Theme.defaultFont
@@ -1209,6 +1206,32 @@ Page {
 
                       wrapMode: Text.WordWrap
                       Layout.fillWidth: true
+                      Layout.columnSpan: 2
+                  }
+
+                  Label {
+                    text: qsTr("Log NMEA setences from device to file")
+                    font: Theme.defaultFont
+                    color: Theme.mainTextColor
+                    wrapMode: Text.WordWrap
+                    Layout.fillWidth: true
+                    visible: positionSource.device.capabilities() & AbstractGnssReceiver.Logging
+
+                    MouseArea {
+                      anchors.fill: parent
+                      onClicked: positionLogging.toggle()
+                    }
+                  }
+
+                  QfSwitch {
+                    id: positionLogging
+                    Layout.preferredWidth: implicitContentWidth
+                    Layout.alignment: Qt.AlignTop
+                    visible: positionSource.device.capabilities() & AbstractGnssReceiver.Logging
+                    checked: positioningSettings.logging
+                    onCheckedChanged: {
+                      positioningSettings.logging = checked
+                    }
                   }
               }
 
@@ -1216,6 +1239,7 @@ Page {
                   // spacer item
                   Layout.fillWidth: true
                   Layout.fillHeight: true
+                  Layout.minimumHeight: 20
               }
             }
           }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -210,6 +210,7 @@ ApplicationWindow {
     }
 
     ellipsoidalElevation: positioningSettings.ellipsoidalElevation
+    logging: positioningSettings.logging
 
     onProjectedPositionChanged: {
       if (active && gnssButton.followActive) {


### PR DESCRIPTION
This PR implements a new NMEA setence logging [to file] functionality. It can be activated when a bluetooth/tcp/udp postioning receiver is selected:

![image](https://user-images.githubusercontent.com/1728657/232473378-bdd0e67d-d6d0-4c13-b097-f288d404e5ca.png)

One file per session is created, with the following filename template (nmea-year-month-dayThours:minutes:secondes):
![image](https://user-images.githubusercontent.com/1728657/232473517-be51a6f3-110f-485f-b770-b07d0ba1d678.png)

As per usual, I did a bit of cleanup here and there, and added a capabilities flag to our positioning receivers (future-proofing us some more).