### PR TITLE
[Backport release-2_7] Store snapped vector layer as a QPointer<QgsVectorLayer>

### DIFF
--- a/src/core/snappingresult.cpp
+++ b/src/core/snappingresult.cpp
@@ -106,7 +106,7 @@ int SnappingResult::vertexIndex() const
 
 QgsVectorLayer *SnappingResult::layer() const
 {
-  return mLayer;
+  return mLayer.data();
 }
 
 QgsFeatureId SnappingResult::featureId() const

--- a/src/core/snappingresult.h
+++ b/src/core/snappingresult.h
@@ -90,7 +90,7 @@ class SnappingResult
     Type mType;
     double mDist;
     QgsPoint mPoint;
-    QgsVectorLayer *mLayer = nullptr;
+    QPointer<QgsVectorLayer> mLayer;
     QgsFeatureId mFid;
     int mVertexIndex; // e.g. vertex index
     QgsPoint mEdgePoints[2];


### PR DESCRIPTION
Backport #4186
 **Authored by:** @nirvn