### PR TITLE
[Backport release-2_7] Revert "Update default values when editing a new feature to match QGIS behavior"

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -515,8 +515,7 @@ void AttributeFormModelBase::updateDefaultValues( int fieldIndex, QVector<int> u
   {
     QStandardItem *item = constraintIterator.key();
     int fidx = item->data( AttributeFormModel::FieldIndex ).toInt();
-    const bool isNewFeature = mFeatureModel->feature().id() == FID_NULL;
-    if ( fidx == fieldIndex || !fields.at( fidx ).defaultValueDefinition().isValid() || ( !isNewFeature && !fields.at( fidx ).defaultValueDefinition().applyOnUpdate() ) )
+    if ( fidx == fieldIndex || !fields.at( fidx ).defaultValueDefinition().isValid() || !fields.at( fidx ).defaultValueDefinition().applyOnUpdate() )
       continue;
 
     QgsExpression exp( fields.at( fidx ).defaultValueDefinition().expression() );


### PR DESCRIPTION
Backport #4189
 **Authored by:** @nirvn