### PR TITLE
Feature list sorting capability 

### DIFF
--- a/src/core/identifytool.cpp
+++ b/src/core/identifytool.cpp
@@ -125,6 +125,10 @@ QList<IdentifyTool::IdentifyResult> IdentifyTool::identifyVectorLayer( QgsVector
     {
       req.addOrderBy( config.sortExpression(), config.sortOrder() == Qt::AscendingOrder );
     }
+    else if ( !layer->displayExpression().isEmpty() )
+    {
+      req.addOrderBy( layer->displayExpression() );
+    }
 
     QgsFeatureIterator fit = layer->getFeatures( req );
     QgsFeature f;

--- a/src/core/identifytool.cpp
+++ b/src/core/identifytool.cpp
@@ -120,6 +120,12 @@ QList<IdentifyTool::IdentifyResult> IdentifyTool::identifyVectorLayer( QgsVector
     req.setLimit( QSettings().value( "/QField/identify/limit", 100 ).toInt() );
     req.setFlags( QgsFeatureRequest::ExactIntersect );
 
+    QgsAttributeTableConfig config = layer->attributeTableConfig();
+    if ( !config.sortExpression().isEmpty() )
+    {
+      req.addOrderBy( config.sortExpression(), config.sortOrder() == Qt::AscendingOrder );
+    }
+
     QgsFeatureIterator fit = layer->getFeatures( req );
     QgsFeature f;
     while ( fit.nextFeature( f ) )

--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -54,6 +54,10 @@ void MultiFeatureListModelBase::setFeatures( const QMap<QgsVectorLayer *, QgsFea
     {
       request.addOrderBy( config.sortExpression(), config.sortOrder() == Qt::AscendingOrder );
     }
+    else if ( !vl->displayExpression().isEmpty() )
+    {
+      request.addOrderBy( vl->displayExpression() );
+    }
 
     QgsFeature feat;
     QgsFeatureIterator fit = vl->getFeatures( request );

--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -44,12 +44,19 @@ void MultiFeatureListModelBase::setFeatures( const QMap<QgsVectorLayer *, QgsFea
   for ( it = requests.constBegin(); it != requests.constEnd(); it++ )
   {
     QgsVectorLayer *vl = it.key();
+    QgsFeatureRequest request = it.value();
 
     if ( !vl || !vl->isValid() )
       continue;
 
+    QgsAttributeTableConfig config = vl->attributeTableConfig();
+    if ( !config.sortExpression().isEmpty() )
+    {
+      request.addOrderBy( config.sortExpression(), config.sortOrder() == Qt::AscendingOrder );
+    }
+
     QgsFeature feat;
-    QgsFeatureIterator fit = vl->getFeatures( it.value() );
+    QgsFeatureIterator fit = vl->getFeatures( request );
     while ( fit.nextFeature( feat ) )
     {
       mFeatures.append( QPair<QgsVectorLayer *, QgsFeature>( vl, feat ) );


### PR DESCRIPTION
This PR improves feature list sorting by respecting the sorting expression defined in a given vector layer's attribute table configuration. If the sorting expression is empty, QField will fallback to sorting features by display expression. This enhancement results in a much friendlier display of features when identifying through map canvas taps or by through the show feature list button in the layer properties popup.

For documentation purposes, the way to configure an attribute table sorting is by:

a/ in table view, clicking on a column header (easy enough)

b/ also in table view, right clicking on any part of the column header and selecting the 'Sort...' menu item, giving users the possibility to enter complex expressions to sort features.

![image](https://user-images.githubusercontent.com/1728657/232998754-7261419a-0632-4216-9fcb-4ce7454f1519.png)

c/ in form view, clicking on the expression button on top of the features list provides sorting functionality

![image](https://user-images.githubusercontent.com/1728657/232999540-c63cbba9-7ff9-4490-98a3-9b5e87040b66.png)


