### PR TITLE
Scene bottom margin improvements (i.e. avoid overlap with iOS navigation bar)

### DIFF
--- a/src/qml/About.qml
+++ b/src/qml/About.qml
@@ -18,6 +18,7 @@ Item {
         id: aboutContainer
         anchors.fill: parent
         anchors.margins: 20
+        anchors.bottomMargin: mainWindow.sceneBottomMargin
 
         ScrollView {
             Layout.fillWidth: true

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -38,6 +38,7 @@ Page {
   property bool featureCreated: false
 
   property double topMargin: 0.0
+  property double bottomMargin: 0.0
 
   function reset() {
     master.reset()
@@ -204,6 +205,7 @@ Page {
               anchors.fill: parent
               contentWidth: content.width
               contentHeight: content.height
+              bottomMargin: form.bottomMargin
               clip: true
 
               ScrollBar.vertical: ScrollBar {

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -189,6 +189,7 @@ Rectangle {
     anchors.left: parent.left
     anchors.right: parent.right
     anchors.bottom: parent.bottom
+    bottomMargin: mainWindow.sceneBottomMargin
 
     property bool shown: false
 
@@ -350,6 +351,7 @@ Rectangle {
     anchors.left: parent.left
     anchors.right: parent.right
     anchors.bottom: parent.bottom
+    bottomMargin: mainWindow.sceneBottomMargin
     height: parent.height - globalFeaturesList.height
 
     digitizingToolbar: featureForm.digitizingToolbar

--- a/src/qml/MessageLog.qml
+++ b/src/qml/MessageLog.qml
@@ -27,6 +27,7 @@ Page {
 
   ColumnLayout {
     anchors.margins: 8
+    anchors.bottomMargin: mainWindow.sceneBottomMargin
     anchors.fill: parent
     Layout.margins: 0
     spacing: 10

--- a/src/qml/OverlayFeatureFormDrawer.qml
+++ b/src/qml/OverlayFeatureFormDrawer.qml
@@ -75,6 +75,7 @@ Drawer {
     visible: true
 
     topMargin: overlayFeatureFormDrawer.y == 0 ? mainWindow.sceneTopMargin : 0.0
+    bottomMargin: mainWindow.sceneBottomMargin
 
     property alias featureModel: attributeFormModel.featureModel
     property bool isSaved: false

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -575,6 +575,7 @@ Page {
       QfButton {
           id: refreshProjectsListBtn
           Layout.fillWidth: true
+          Layout.bottomMargin: mainWindow.sceneBottomMargin
           text: qsTr( "Refresh projects list" )
           enabled: cloudConnection.status === QFieldCloudConnection.LoggedIn
                    && cloudConnection.state === QFieldCloudConnection.Idle

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -332,15 +332,15 @@ Page {
 
         anchors.bottom: parent.bottom
         anchors.right: parent.right
-        anchors.bottomMargin: 10
+        anchors.bottomMargin: mainWindow.sceneBottomMargin + 10
         anchors.rightMargin: 10
 
         bgcolor: Theme.mainColor
         iconSource: Theme.getThemeIcon( "ic_add_white_24dp" )
 
         onClicked: {
-          importMenu.popup(mainWindow.width - importMenu.width - 10,
-                           mainWindow.height - importMenu.height - 58)
+          importMenu.popup(importButton.x + importButton.width - importMenu.width + 10,
+                           importButton.y - importMenu.height)
         }
       }
     }

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -37,8 +37,6 @@ Page {
   ColumnLayout {
     id: files
     anchors.fill: parent
-    Layout.fillWidth: true
-    Layout.fillHeight: true
     spacing: 2
 
     RowLayout {
@@ -79,6 +77,7 @@ Page {
       Layout.fillHeight: true
       Layout.margins: 10
       Layout.topMargin: 0
+      Layout.bottomMargin: mainWindow.sceneBottomMargin
       color: Theme.controlBackgroundColor
       border.color: Theme.controlBorderColor
       border.width: 1
@@ -332,7 +331,7 @@ Page {
 
         anchors.bottom: parent.bottom
         anchors.right: parent.right
-        anchors.bottomMargin: mainWindow.sceneBottomMargin + 10
+        anchors.bottomMargin: 10
         anchors.rightMargin: 10
 
         bgcolor: Theme.mainColor

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -477,6 +477,13 @@ Page {
                           onLinkActivated: Qt.openUrlExternally(link)
                       }
                   }
+
+                  Item {
+                      // spacer item
+                      Layout.fillWidth: true
+                      Layout.fillHeight: true
+                      Layout.minimumHeight: mainWindow.sceneBottomMargin + 20
+                  }
               }
           }
       }
@@ -1239,18 +1246,19 @@ Page {
                   // spacer item
                   Layout.fillWidth: true
                   Layout.fillHeight: true
-                  Layout.minimumHeight: 20
+                  Layout.minimumHeight: mainWindow.sceneBottomMargin + 20
               }
             }
           }
         }
 
       Item {
-          VariableEditor {
-              id: variableEditor
-              anchors.fill: parent
-              anchors.margins: 4
-          }
+        VariableEditor {
+            id: variableEditor
+            anchors.fill: parent
+            anchors.margins: 4
+            anchors.bottomMargin: mainWindow.sceneBottomMargin
+        }
       }
     }
   }

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -697,6 +697,7 @@ Page {
       topMargin: mainWindow.sceneTopMargin
     }
     iconSource: Theme.getThemeIcon( 'ic_chevron_left_black_24dp' )
+    iconColor: Theme.mainTextColor
     bgcolor: "transparent"
 
     onClicked: {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -769,6 +769,7 @@ ApplicationWindow {
     anchors.bottom: parent.bottom
     anchors.left: parent.left
     anchors.right: parent.right
+    anchors.bottomMargin: mainWindow.sceneBottomMargin
     visible: navigation.isActive ||
              positioningSettings.showPositionInformation ||
              positioningPreciseView.visible ||
@@ -831,10 +832,10 @@ ApplicationWindow {
     }
 
     Rectangle {
-      visible: positioningInformationView.visible && sensorInformationView
+      visible: positioningInformationView.visible && sensorInformationView.visible
       width: parent.width
       height: 1
-      color: Theme.navigationBackgroundColor
+      color: Theme.sensorBackgroundColor
     }
 
     SensorInformationView {
@@ -961,7 +962,9 @@ ApplicationWindow {
     anchors.left: mapCanvas.left
     anchors.bottom: mapCanvas.bottom
     anchors.leftMargin: 4
-    anchors.bottomMargin: mainWindow.sceneBottomMargin + 56
+    anchors.bottomMargin: informationView.visible
+                          ? 54
+                          : mainWindow.sceneBottomMargin + 54
 
     round: true
     bgcolor: Theme.darkGraySemiOpaque
@@ -977,7 +980,9 @@ ApplicationWindow {
     anchors.left: mapCanvas.left
     anchors.bottom: mapCanvas.bottom
     anchors.leftMargin: 4
-    anchors.bottomMargin: mainWindow.sceneBottomMargin + 10
+    anchors.bottomMargin: informationView.visible
+                          ? 10
+                          : mainWindow.sceneBottomMargin + 10
   }
 
   QfDropShadow {
@@ -1372,7 +1377,9 @@ ApplicationWindow {
     anchors.right: mapCanvas.right
     anchors.rightMargin: 4
     anchors.bottom: mapCanvas.bottom
-    anchors.bottomMargin: mainWindow.sceneBottomMargin + 4
+    anchors.bottomMargin: informationView.visible
+                          ? 4
+                          : mainWindow.sceneBottomMargin + 4
     spacing: 4
 
     QfToolButton {


### PR DESCRIPTION
Had the opportunity to test QField's latest enhancements on an iOS device yesterday and saw a bunch of UI shortcoming with regards to handling of scene's bottom margin (i.e. the iOS navigation bar). This PR fixes all issues I've spotted yesterday.

The biggest one being the iOS bar overlapping the positioning information panel at the bottom of the main screen, preventing users from reading numbers there :scream: 