### PR TITLE
Allow QField to draw under Android's bottom navigation bar

### DIFF
--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -109,6 +109,7 @@ public class QFieldActivity extends QtActivity {
     private float originalBrightness;
     private String pathsToExport;
     private double sceneTopMargin = 0;
+    private double sceneBottomMargin = 0;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -137,6 +138,29 @@ public class QFieldActivity extends QtActivity {
             View decor = window.getDecorView();
             decor.setSystemUiVisibility(decor.getSystemUiVisibility() |
                                         View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+
+            resourceId = getResources().getIdentifier(
+                "config_navBarInteractionMode", "integer", "android");
+            if (resourceId > 0) {
+                // if the navigation bar is in gesture mode, draw under it
+                if (getResources().getInteger(resourceId) == 2) {
+                    resourceId = getResources().getIdentifier(
+                        "navigation_bar_height", "dimen", "android");
+                    if (resourceId > 0) {
+                        sceneBottomMargin =
+                            getResources().getDimension(resourceId);
+
+                        window.addFlags(WindowManager.LayoutParams
+                                            .FLAG_TRANSLUCENT_NAVIGATION);
+                        window.setNavigationBarColor(Color.TRANSPARENT);
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                            decor.setSystemUiVisibility(
+                                decor.getSystemUiVisibility() |
+                                View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR);
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -300,6 +324,10 @@ public class QFieldActivity extends QtActivity {
             }
         }
         return margin;
+    }
+
+    private double navigationBarMargin() {
+        return sceneBottomMargin;
     }
 
     private void dimBrightness() {

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -672,13 +672,15 @@ QVariantMap AndroidPlatformUtilities::sceneMargins( QQuickWindow *window ) const
 
   const QAndroidJniObject activity = QtAndroid::androidActivity();
   double statusBarMargin = std::abs( static_cast<double>( activity.callMethod<jdouble>( "statusBarMargin" ) ) );
+  double navigationBarMargin = std::abs( static_cast<double>( activity.callMethod<jdouble>( "navigationBarMargin" ) ) );
 
   statusBarMargin /= QGuiApplication::primaryScreen()->devicePixelRatio();
+  navigationBarMargin /= QGuiApplication::primaryScreen()->devicePixelRatio();
 
   QVariantMap margins;
   margins[QLatin1String( "top" )] = statusBarMargin;
   margins[QLatin1String( "right" )] = 0.0;
-  margins[QLatin1String( "bottom" )] = 0.0;
+  margins[QLatin1String( "bottom" )] = navigationBarMargin;
   margins[QLatin1String( "left" )] = 0.0;
   return margins;
 }


### PR DESCRIPTION
Look at all that extra map canvas visibility:

![image](https://user-images.githubusercontent.com/1728657/233260828-e9e30020-9735-46f1-bc2f-ba0d6b221296.png)

Equally importantly, I came to realize we need this to insure the UI is sound on iOS (which is less frequently tested by main devs.). Case in point: https://github.com/opengisch/QField/pull/4199