### PR TITLE
Add a fallback to old photo_naming key when fetching attachment file path expression

### DIFF
--- a/src/core/expressionevaluator.cpp
+++ b/src/core/expressionevaluator.cpp
@@ -54,6 +54,7 @@ QVariant ExpressionEvaluator::evaluate()
                     << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
                     << QgsExpressionContextUtils::layerScope( mLayer );
 
+  exp.prepare( &expressionContext );
   QVariant value = exp.evaluate( &expressionContext );
   return value.toString();
 }

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -108,12 +108,16 @@ EditorWidgetBase {
     feature: currentFeature
     layer: currentLayer
     expressionText: {
-      if ( currentLayer && currentLayer.customProperty('QFieldSync/attachment_naming') !== undefined ) {
-        var value =JSON.parse(currentLayer.customProperty('QFieldSync/attachment_naming'))[field.name];
+      var value;
+      if (currentLayer && currentLayer.customProperty('QFieldSync/attachment_naming') !== undefined) {
+        value = JSON.parse(currentLayer.customProperty('QFieldSync/attachment_naming'))[field.name];
         return value !== undefined ? value : ''
-      } else {
-        return ''
+      } else if (currentLayer && currentLayer.customProperty('QFieldSync/photo_naming') !== undefined) {
+        // Fallback to old configuration key
+        value = JSON.parse(currentLayer.customProperty('QFieldSync/photo_naming'))[field.name];
+        return value !== undefined ? value : ''
       }
+      return ''
     }
   }
 


### PR DESCRIPTION
Because a bunch of people out there are still using projects that were prepared with old qfieldsync versions.