### PR TITLE
Simplify the wording for locator search

### DIFF
--- a/src/qml/LocatorSettings.qml
+++ b/src/qml/LocatorSettings.qml
@@ -36,7 +36,7 @@ Popup {
             leftPadding: 48
             rightPadding: 48
             width: parent.width - 20
-            text: qsTr( "Search Settings" )
+            text: qsTr( "Search Bar Settings" )
             font: Theme.strongFont
             color: Theme.mainColor
             horizontalAlignment: Text.AlignHCenter
@@ -92,11 +92,20 @@ Popup {
                             color: Theme.mainTextColor
                             wrapMode: Text.WordWrap
                         }
+                        Text {
+                            Layout.fillWidth: true
+                            leftPadding: 5
+                            bottomPadding: 5
+                            text: Description
+                            font: Theme.tipFont
+                            color: Theme.secondaryTextColor
+                            wrapMode: Text.WordWrap
+                        }
                         CheckBox {
                               Layout.fillWidth: true
                               topPadding: 5
                               bottomPadding: 5
-                              text: qsTr('Enable %1 locator by default').arg('<em>'+Name+'</em>')
+                              text: qsTr('Enable %1 locator by default').arg('<b>'+Name+'</b>')
                               font: Theme.tipFont
                               indicator.height: 16
                               indicator.width: 16
@@ -106,19 +115,11 @@ Popup {
                               onCheckedChanged: Default = checked
                         }
                         Text {
+                            visible: Default ? false : true
                             Layout.fillWidth: true
                             leftPadding: 5
                             bottomPadding: 5
-                            text: qsTr('By typing the %1 prefix in the locator, this can still be triggered when disabled').arg('<em>'+Prefix+'</em>')
-                            font: Theme.tipFont
-                            color: Theme.secondaryTextColor
-                            wrapMode: Text.WordWrap
-                        }
-                        Text {
-                            Layout.fillWidth: true
-                            leftPadding: 5
-                            bottomPadding: 5
-                            text: Description
+                            text: qsTr('By typing the %1 prefix in the search bar, this locator filter can even be used when disabled').arg('<b>'+Prefix+'</b>')
                             font: Theme.tipFont
                             color: Theme.secondaryTextColor
                             wrapMode: Text.WordWrap

--- a/src/qml/LocatorSettings.qml
+++ b/src/qml/LocatorSettings.qml
@@ -96,7 +96,7 @@ Popup {
                               Layout.fillWidth: true
                               topPadding: 5
                               bottomPadding: 5
-                              text: qsTr('Trigger without its prefix')  + ' (' + Prefix + ')'
+                              text: qsTr('Enable %1 locator by default').arg(Name)
                               font: Theme.tipFont
                               indicator.height: 16
                               indicator.width: 16
@@ -104,6 +104,15 @@ Popup {
                               indicator.implicitWidth: 24
                               checked: Default? true : false
                               onCheckedChanged: Default = checked
+                        }
+                        Text {
+                            Layout.fillWidth: true
+                            leftPadding: 5
+                            bottomPadding: 5
+                            text: tr('With the <em>%1</em> prefix this can also be triggered when disabled').arg(Prefix)
+                            font: Theme.tipFont
+                            color: Theme.secondaryTextColor
+                            wrapMode: Text.WordWrap
                         }
                         Text {
                             Layout.fillWidth: true

--- a/src/qml/LocatorSettings.qml
+++ b/src/qml/LocatorSettings.qml
@@ -101,6 +101,16 @@ Popup {
                             color: Theme.secondaryTextColor
                             wrapMode: Text.WordWrap
                         }
+                        Text {
+                            visible: Default ? false : true
+                            Layout.fillWidth: true
+                            leftPadding: 5
+                            bottomPadding: 5
+                            text: qsTr('When disabled, this locator filter can still be used by typing the prefix %1 in the search bar.').arg('<b>'+Prefix+'</b>')
+                            font: Theme.tipFont
+                            color: Theme.secondaryTextColor
+                            wrapMode: Text.WordWrap
+                        }
                         CheckBox {
                               Layout.fillWidth: true
                               topPadding: 5
@@ -113,16 +123,6 @@ Popup {
                               indicator.implicitWidth: 24
                               checked: Default? true : false
                               onCheckedChanged: Default = checked
-                        }
-                        Text {
-                            visible: Default ? false : true
-                            Layout.fillWidth: true
-                            leftPadding: 5
-                            bottomPadding: 5
-                            text: qsTr('By typing the %1 prefix in the search bar, this locator filter can even be used when disabled').arg('<b>'+Prefix+'</b>')
-                            font: Theme.tipFont
-                            color: Theme.secondaryTextColor
-                            wrapMode: Text.WordWrap
                         }
                     }
                 }

--- a/src/qml/LocatorSettings.qml
+++ b/src/qml/LocatorSettings.qml
@@ -96,7 +96,7 @@ Popup {
                               Layout.fillWidth: true
                               topPadding: 5
                               bottomPadding: 5
-                              text: qsTr('Enable %1 locator by default').arg(Name)
+                              text: qsTr('Enable %1 locator by default').arg('<em>'+Name+'</em>')
                               font: Theme.tipFont
                               indicator.height: 16
                               indicator.width: 16
@@ -109,7 +109,7 @@ Popup {
                             Layout.fillWidth: true
                             leftPadding: 5
                             bottomPadding: 5
-                            text: tr('With the <em>%1</em> prefix this can also be triggered when disabled').arg(Prefix)
+                            text: qsTr('By typing the %1 prefix in the locator, this can still be triggered when disabled').arg('<em>'+Prefix+'</em>')
                             font: Theme.tipFont
                             color: Theme.secondaryTextColor
                             wrapMode: Text.WordWrap


### PR DESCRIPTION
"Trigger without its prefix" tends to be quite obscure to casual users.
I couldn't test (cannot build currently).