### PR TITLE
Locking compass update rate to 0.5sec was maybe a too extreme, change to 0.2sec

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -266,7 +266,7 @@ ApplicationWindow {
 
     onReadingChanged: {
       var timestamp = Date.now();
-      if (timestamp - lastAcceptedReading > 500) {
+      if (timestamp - lastAcceptedReading > 200) {
         lastAcceptedReading = timestamp;
         orientation = userOrientation + (-(Math.atan2(reading.x, reading.y) / Math.PI) * 180)
         hasValue = true


### PR DESCRIPTION
0.5s feels too sluggish, and we can _easily_ afford 0.25s.