### PR TITLE
Insure that all QField popup menus don't overlap with scene margins

### DIFF
--- a/src/qml/BluetoothDeviceChooser.qml
+++ b/src/qml/BluetoothDeviceChooser.qml
@@ -79,7 +79,10 @@ Item {
       Layout.fillWidth: true
       visible: bluetoothDeviceComboBox.count
       font: Theme.defaultFont
+
       popup.font: Theme.defaultFont
+      popup.topMargin: mainWindow.sceneTopMargin
+      popup.bottomMargin: mainWindow.sceneTopMargin
 
       enabled: bluetoothDeviceModel.scanningStatus !== BluetoothDeviceModel.Scanning
 

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -243,6 +243,11 @@ Drawer {
           ComboBox {
               id: mapThemeComboBox
               Layout.fillWidth: true
+              font: Theme.defaultFont
+
+              popup.font: Theme.defaultFont
+              popup.topMargin: mainWindow.sceneTopMargin
+              popup.bottomMargin: mainWindow.sceneTopMargin
 
               Connections {
                   target: iface

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -500,7 +500,8 @@ Rectangle {
         return result + padding * 2 + 10;
     }
 
-    topMargin: Math.min(sceneTopMargin, Math.max(0, (contentHeight + topPadding + bottomPadding) - mainWindow.height + sceneTopMargin));
+    topMargin: mainWindow.sceneTopMargin
+    bottomMargin: mainWindow.sceneBottomMargin
 
     MenuItem {
       text: qsTr( 'Toggle Feature Selection' )
@@ -611,7 +612,8 @@ Rectangle {
         return result + padding * 2;
     }
 
-    topMargin: Math.min(sceneTopMargin, Math.max(0, (contentHeight + topPadding + bottomPadding) - mainWindow.height + sceneTopMargin));
+    topMargin: mainWindow.sceneTopMargin
+    bottomMargin: mainWindow.sceneBottomMargin
 
     MenuItem {
       text: Qt.platform.os === "ios" ? qsTr( "Print Atlas Feature to Image" ) : qsTr( 'Print Atlas Feature to PDF' )
@@ -742,6 +744,9 @@ Rectangle {
         }
         return Math.min( result + padding * 2,mainWindow.width - 20);
     }
+
+    topMargin: mainWindow.sceneTopMargin
+    bottomMargin: mainWindow.sceneBottomMargin
 
     MenuItem {
       text: qsTr( 'Select template below' )

--- a/src/qml/PositioningDeviceSettings.qml
+++ b/src/qml/PositioningDeviceSettings.qml
@@ -105,7 +105,10 @@ Popup {
               id: positioningDeviceType
               Layout.fillWidth: true
               font: Theme.defaultFont
+
               popup.font: Theme.defaultFont
+              popup.topMargin: mainWindow.sceneTopMargin
+              popup.bottomMargin: mainWindow.sceneTopMargin
 
               textRole: "name"
               valueRole: "value"

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -486,7 +486,8 @@ Page {
         property string projectName: ''
         property string projectLocalPath: ''
 
-        title: 'Project Actions'
+        title: qsTr('Project Actions')
+
         width: {
             var result = 0;
             var padding = 0;
@@ -497,6 +498,9 @@ Page {
             }
             return Math.min( result + padding * 2,mainWindow.width - 20);
         }
+
+        topMargin: mainWindow.sceneTopMargin
+        bottomMargin: mainWindow.sceneBottomMargin
 
         MenuItem {
           id: downloadProject

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -339,7 +339,7 @@ Page {
 
         onClicked: {
           importMenu.popup(importButton.x + importButton.width - importMenu.width + 10,
-                           importButton.y - importMenu.height)
+                           importButton.y - importButton.height)
         }
       }
     }
@@ -351,7 +351,8 @@ Page {
       property int itemType: 0
       property string itemPath: ''
 
-      title: 'Item Actions'
+      title: qsTr('Item Actions')
+
       width: {
         var result = 0;
         var padding = 0;
@@ -362,6 +363,9 @@ Page {
         }
         return Math.min( result + padding * 2,mainWindow.width - 20);
       }
+
+      topMargin: sceneTopMargin
+      bottomMargin: sceneBottomMargin
 
       MenuItem {
         id: sendDatasetTo
@@ -453,7 +457,8 @@ Page {
     Menu {
       id: importMenu
 
-      title: 'Import Actions'
+      title: qsTr('Import Actions')
+
       width: {
         var result = 0;
         var padding = 0;
@@ -465,13 +470,16 @@ Page {
         return Math.min( result + padding * 2,mainWindow.width - 20);
       }
 
+      topMargin: sceneTopMargin
+      bottomMargin: sceneBottomMargin
+
       MenuItem {
         id: importProjectFromFolder
 
-        visible: platformUtilities.capabilities & PlatformUtilities.CustomImport
+        enabled: platformUtilities.capabilities & PlatformUtilities.CustomImport
         font: Theme.defaultFont
         width: parent.width
-        height: visible ? 48 : 0
+        height: enabled ? 48 : 0
         leftPadding: 10
 
         text: qsTr( "Import project from folder" )
@@ -481,10 +489,10 @@ Page {
       MenuItem {
         id: importProjectFromZIP
 
-        visible: platformUtilities.capabilities & PlatformUtilities.CustomImport
+        enabled: platformUtilities.capabilities & PlatformUtilities.CustomImport
         font: Theme.defaultFont
         width: parent.width
-        height: visible ? 48 : 0
+        height: enabled ? 48 : 0
         leftPadding: 10
 
         text: qsTr( "Import project from ZIP" )
@@ -494,10 +502,11 @@ Page {
       MenuItem {
         id: importDataset
 
-        visible: platformUtilities.capabilities & PlatformUtilities.CustomImport
+        enabled: platformUtilities.capabilities & PlatformUtilities.CustomImport
         font: Theme.defaultFont
         width: parent.width
-        height: visible ? 48 : 0
+        height: enabled ? 48 : 0
+
         leftPadding: 10
 
         text: qsTr( "Import dataset(s)" )
@@ -511,7 +520,6 @@ Page {
 
         font: Theme.defaultFont
         width: parent.width
-        height: visible ? 48 : 0
         leftPadding: 10
 
         text: qsTr( "Import URL" )
@@ -528,7 +536,6 @@ Page {
 
         font: Theme.defaultFont
         width: parent.width
-        height: visible ? 48 : 0
         leftPadding: 10
 
         text: qsTr( "Storage management help" )

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -340,7 +340,10 @@ Page {
                           Layout.fillWidth: true
                           Layout.alignment: Qt.AlignVCenter
                           font: Theme.defaultFont
+
                           popup.font: Theme.defaultFont
+                          popup.topMargin: mainWindow.sceneTopMargin
+                          popup.bottomMargin: mainWindow.sceneTopMargin
 
                           model: ListModel {
                             ListElement { name: qsTr('Follow system appearance'); value: 'system' }
@@ -381,7 +384,10 @@ Page {
                           Layout.fillWidth: true
                           Layout.alignment: Qt.AlignVCenter
                           font: Theme.defaultFont
+
                           popup.font: Theme.defaultFont
+                          popup.topMargin: mainWindow.sceneTopMargin
+                          popup.bottomMargin: mainWindow.sceneTopMargin
 
                           model: ListModel {
                             ListElement { name: qsTr('Tiny'); value: 0.75 }
@@ -435,7 +441,10 @@ Page {
                           Layout.fillWidth: true
                           Layout.alignment: Qt.AlignVCenter
                           font: Theme.defaultFont
+
                           popup.font: Theme.defaultFont
+                          popup.topMargin: mainWindow.sceneTopMargin
+                          popup.bottomMargin: mainWindow.sceneBottomMargin
 
                           property variant languageCodes: undefined
                           property string currentLanguageCode: undefined
@@ -531,7 +540,10 @@ Page {
                           Layout.fillWidth: true
                           Layout.alignment: Qt.AlignVCenter
                           font: Theme.defaultFont
+
                           popup.font: Theme.defaultFont
+                          popup.topMargin: mainWindow.sceneTopMargin
+                          popup.bottomMargin: mainWindow.sceneTopMargin
 
                           textRole: 'DeviceName'
                           valueRole: 'DeviceType'
@@ -733,7 +745,10 @@ Page {
                       Layout.columnSpan: 2
                       Layout.alignment: Qt.AlignVCenter
                       font: Theme.defaultFont
+
                       popup.font: Theme.defaultFont
+                      popup.topMargin: mainWindow.sceneTopMargin
+                      popup.bottomMargin: mainWindow.sceneTopMargin
 
                       property bool loaded: false
                       Component.onCompleted: {
@@ -1193,7 +1208,10 @@ Page {
                       Layout.columnSpan: 2
                       model: [ qsTr( "None" ) ].concat( platformUtilities.availableGrids() );
                       font: Theme.defaultFont
+
                       popup.font: Theme.defaultFont
+                      popup.topMargin: mainWindow.sceneTopMargin
+                      popup.bottomMargin: mainWindow.sceneTopMargin
 
                       onCurrentIndexChanged: {
                           positioningSettings.verticalGrid = currentIndex > 0 ? platformUtilities.availableGrids()[currentIndex - 1] : '';

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -319,6 +319,9 @@ Item {
 
             font: Theme.defaultFont
             popup.font: Theme.defaultFont
+            popup.topMargin: mainWindow.sceneTopMargin
+            popup.bottomMargin: mainWindow.sceneTopMargin
+
             contentItem: Text {
                 leftPadding: enabled ? 5 : 0
                 height: fontMetrics.height + 20

--- a/src/qml/SerialPortDeviceChooser.qml
+++ b/src/qml/SerialPortDeviceChooser.qml
@@ -51,7 +51,10 @@ Item {
       Layout.fillWidth: true
       visible: serialPortComboBox.count
       font: Theme.defaultFont
+
       popup.font: Theme.defaultFont
+      popup.topMargin: mainWindow.sceneTopMargin
+      popup.bottomMargin: mainWindow.sceneTopMargin
 
       textRole: 'display'
       model: SerialPortModel {

--- a/src/qml/Tracking.qml
+++ b/src/qml/Tracking.qml
@@ -475,7 +475,10 @@ Item {
                 Layout.columnSpan: 2
                 Layout.alignment: Qt.AlignVCenter
                 font: Theme.defaultFont
+
                 popup.font: Theme.defaultFont
+                popup.topMargin: mainWindow.sceneTopMargin
+                popup.bottomMargin: mainWindow.sceneTopMargin
 
                 property bool loaded: false
                 Component.onCompleted: {

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -579,7 +579,7 @@ Page {
                 property string recentProjectPath: ''
                 property int recentProjectType: 0
 
-                title: 'Recent Project Actions'
+                title: qsTr('Recent Project Actions')
 
                 width: {
                   var result = 0;
@@ -591,6 +591,9 @@ Page {
                   }
                   return Math.min( result + padding, mainWindow.width - 20);
                 }
+
+                topMargin: mainWindow.sceneTopMargin
+                bottomMargin: mainWindow.sceneBottomMargin
 
                 MenuItem {
                   id: defaultProject

--- a/src/qml/editorwidgets/EditorWidgetBase.qml
+++ b/src/qml/editorwidgets/EditorWidgetBase.qml
@@ -23,6 +23,9 @@ Item {
           }
           return result + padding * 2;
       }
+
+      topMargin: mainWindow.sceneTopMargin
+      bottomMargin: mainWindow.sceneBottomMargin
     }
 
     /* This signal is emmited when an editor widget has changed the value.

--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -28,7 +28,10 @@ EditorWidgetBase {
     id: comboBox
     anchors { left: parent.left; right: parent.right }
     font: Theme.defaultFont
+
     popup.font: Theme.defaultFont
+    popup.topMargin: mainWindow.sceneTopMargin
+    popup.bottomMargin: mainWindow.sceneTopMargin
 
     currentIndex: model.keyToIndex(value)
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1895,6 +1895,9 @@ ApplicationWindow {
     id: mainMenu
     title: qsTr( "Main Menu" )
 
+    topMargin: sceneTopMargin
+    bottomMargin: sceneBottomMargin
+
     width: {
         var result = 0;
         var padding = 0;
@@ -1905,8 +1908,6 @@ ApplicationWindow {
         }
         return result + padding * 2;
     }
-
-    topMargin: Math.min(sceneTopMargin, Math.max(0, (contentHeight + topPadding + bottomPadding) - mainWindow.height + sceneTopMargin));
 
     MenuItem {
       text: qsTr( 'Measure Tool' )
@@ -2000,7 +2001,7 @@ ApplicationWindow {
 
       onTriggered: {
         if (sensorListInstantiator.count > 0) {
-          sensorMenu.popup( mainMenu.x, mainMenu.y + printItem.y )
+          sensorMenu.popup( mainMenu.x, mainMenu.y + sensorItem.y )
         } else {
           mainMenu.close();
           toast.show(qsTr('No sensor available'), 'info', qsTr('Learn more'), function() { Qt.openUrlExternally('https://docs.qfield.org/how-to/') })
@@ -2112,6 +2113,9 @@ ApplicationWindow {
 
     title: qsTr( "Sensors" )
 
+    topMargin: sceneTopMargin
+    bottomMargin: sceneBottomMargin
+
     width: {
         var result = 0;
         var padding = 0;
@@ -2122,8 +2126,6 @@ ApplicationWindow {
         }
         return Math.min( result + padding * 2,mainWindow.width - 20);
     }
-
-    topMargin: Math.min(sceneTopMargin, Math.max(0, (contentHeight + topPadding + bottomPadding) - mainWindow.height + sceneTopMargin));
 
     MenuItem {
       text: qsTr( 'Select sensor below' )
@@ -2181,6 +2183,9 @@ ApplicationWindow {
 
     title: qsTr( "Print" )
 
+    topMargin: sceneTopMargin
+    bottomMargin: sceneBottomMargin
+
     width: {
         var result = 0;
         var padding = 0;
@@ -2191,8 +2196,6 @@ ApplicationWindow {
         }
         return Math.min( result + padding * 2,mainWindow.width - 20);
     }
-
-    topMargin: Math.min(sceneTopMargin, Math.max(0, (contentHeight + topPadding + bottomPadding) - mainWindow.height + sceneTopMargin));
 
     MenuItem {
       text: qsTr( 'Select layout below' )
@@ -2280,6 +2283,9 @@ ApplicationWindow {
                    : xLabel + ': ' + xValue
     }
 
+    topMargin: sceneTopMargin
+    bottomMargin: sceneBottomMargin
+
     width: {
         var result = 0;
         var padding = 0;
@@ -2290,8 +2296,6 @@ ApplicationWindow {
         }
         return Math.min( result + padding * 2,mainWindow.width - 20);
     }
-
-    topMargin: Math.min(sceneTopMargin, Math.max(0, (contentHeight + topPadding + bottomPadding) - mainWindow.height + sceneTopMargin));
 
     MenuItem {
         id: xItem
@@ -2381,6 +2385,9 @@ ApplicationWindow {
     title: qsTr( "Navigation Options" )
     font: Theme.defaultFont
 
+    topMargin: sceneTopMargin
+    bottomMargin: sceneBottomMargin
+
     width: {
         var result = 0;
         var padding = 0;
@@ -2391,8 +2398,6 @@ ApplicationWindow {
         }
         return Math.min(result + padding, mainWindow.width - 20);
     }
-
-    topMargin: Math.min(sceneTopMargin, Math.max(0, (contentHeight + topPadding + bottomPadding) - mainWindow.height + sceneTopMargin));
 
     MenuItem {
       id: preciseViewItem
@@ -2446,6 +2451,9 @@ ApplicationWindow {
     title: qsTr( "Precise View Settings" )
     font: Theme.defaultFont
 
+    topMargin: sceneTopMargin
+    bottomMargin: sceneBottomMargin
+
     width: {
         var result = 0;
         var padding = 0;
@@ -2456,8 +2464,6 @@ ApplicationWindow {
         }
         return Math.min( result + padding * 2,mainWindow.width - 20);
     }
-
-    topMargin: Math.min(sceneTopMargin, Math.max(0, (contentHeight + topPadding + bottomPadding) - mainWindow.height + sceneTopMargin));
 
     MenuItem {
       text: qsTr( "%1 Precision" ).arg(UnitTypes.formatDistance(0.10, 2, navigation.distanceUnits))
@@ -2609,6 +2615,9 @@ ApplicationWindow {
     title: qsTr( "Positioning Options" )
     font: Theme.defaultFont
 
+    topMargin: sceneTopMargin
+    bottomMargin: sceneBottomMargin
+
     width: {
         var result = 0;
         var padding = 0;
@@ -2619,8 +2628,6 @@ ApplicationWindow {
         }
         return Math.min( result + padding * 2,mainWindow.width - 20);
     }
-
-    topMargin: Math.min(sceneTopMargin, Math.max(0, (contentHeight + topPadding + bottomPadding) - mainWindow.height + sceneTopMargin));
 
     MenuItem {
         id: positioningDeviceName


### PR DESCRIPTION
Without this fix, combobox (and some non-combobox) popup menus can overlap the top and bottom margins, making it impossible for users to select the item(s) falling within those regions.

Fixes stuff like this: 
![image](https://user-images.githubusercontent.com/1728657/236096070-b63c3bae-ac03-4f02-bbc0-d03a4c6f74af.png)
