### PR TITLE
Fix visibility toggling of sensors information panel

### DIFF
--- a/src/qml/SensorInformationView.qml
+++ b/src/qml/SensorInformationView.qml
@@ -9,6 +9,8 @@ import Theme 1.0
 Rectangle {
   id: sensorInformationView
 
+  property alias activeSensors: grid.count
+
   property int ceilsCount: 4
   property double rowHeight: 30
   property color backgroundColor: Theme.mainBackgroundColor
@@ -20,7 +22,6 @@ Rectangle {
           ? rowHeight * Math.ceil(grid.count / 3)
           : rowHeight * Math.ceil(grid.count / 2)
   anchors.margins: 20
-  visible: grid.count > 0
 
   color: Theme.mainBackgroundColor
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2004,7 +2004,7 @@ ApplicationWindow {
           sensorMenu.popup( mainMenu.x, mainMenu.y + sensorItem.y )
         } else {
           mainMenu.close();
-          toast.show(qsTr('No sensor available'), 'info', qsTr('Learn more'), function() { Qt.openUrlExternally('https://docs.qfield.org/how-to/') })
+          toast.show(qsTr('No sensor available'), 'info', qsTr('Learn more'), function() { Qt.openUrlExternally('https://docs.qfield.org/how-to/sensors/') })
         }
         highlighted = false
       }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -775,7 +775,7 @@ ApplicationWindow {
     visible: navigation.isActive ||
              positioningSettings.showPositionInformation ||
              positioningPreciseView.visible ||
-             sensorInformationView.visible ||
+             sensorInformationView.activeSensors > 0 ||
              (stateMachine.state === 'measure' && elevationProfileButton.elevationProfileActive)
 
     width: parent.width


### PR DESCRIPTION
Once again the creation of documentation led to the discovery of a glitch :)

PSA: the visible property shouldn't be use to drive a parent visibility state as the visibility state of children is *always* false when the parent is hidden. I keep forgetting this lesson. 