### PR TITLE
Add `FlatLayerTreeModel::Visible` to be refreshed in QML on data change

### DIFF
--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -141,7 +141,7 @@ void FlatLayerTreeModelBase::updateMap( const QModelIndex &topLeft, const QModel
   QModelIndex modifiedIndex = mapFromSource( topLeft );
   if ( modifiedIndex.isValid() )
   {
-    emit dataChanged( modifiedIndex, modifiedIndex, QVector<int>() << Qt::DisplayRole << FlatLayerTreeModel::Name << FlatLayerTreeModel::FeatureCount );
+    emit dataChanged( modifiedIndex, modifiedIndex, QVector<int>() << Qt::DisplayRole << FlatLayerTreeModel::Name << FlatLayerTreeModel::FeatureCount << FlatLayerTreeModel::Visible );
   }
 }
 


### PR DESCRIPTION
Prevent multiple layers to appear selected in mutually exclusive groups.

![image](https://github.com/opengisch/QField/assets/2820439/9d104e2b-832b-490d-9ca8-eaaabe89df04)
