### PR TITLE
[Backport release-2_8] Add `FlatLayerTreeModel::Visible` to be refreshed in QML on data change

### DIFF
--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -141,7 +141,7 @@ void FlatLayerTreeModelBase::updateMap( const QModelIndex &topLeft, const QModel
   QModelIndex modifiedIndex = mapFromSource( topLeft );
   if ( modifiedIndex.isValid() )
   {
-    emit dataChanged( modifiedIndex, modifiedIndex, QVector<int>() << Qt::DisplayRole << FlatLayerTreeModel::Name << FlatLayerTreeModel::FeatureCount );
+    emit dataChanged( modifiedIndex, modifiedIndex, QVector<int>() << Qt::DisplayRole << FlatLayerTreeModel::Name << FlatLayerTreeModel::FeatureCount << FlatLayerTreeModel::Visible );
   }
 }
 


### PR DESCRIPTION
Backport #4289
 **Authored by:** @suricactus