### PR TITLE
Avoid at times tremendous cost of snapping when cursor is not visible

### DIFF
--- a/src/core/utils/snappingutils.cpp
+++ b/src/core/utils/snappingutils.cpp
@@ -74,6 +74,13 @@ QgsPoint SnappingUtils::newPoint( const QgsPoint &snappedPoint, const Qgis::WkbT
 
 void SnappingUtils::snap()
 {
+  if ( !mEnabled )
+  {
+    mSnappingResult = SnappingResult();
+    emit snappingResultChanged();
+    return;
+  }
+
   QgsPointXY point = mapSettings()->screenToCoordinate( mInputCoordinate );
   QgsPointLocator::Match match = snapToMap( point );
   mSnappingResult = SnappingResult( match );
@@ -198,4 +205,21 @@ void SnappingUtils::setMapSettings( QgsQuickMapSettings *settings )
 
   mSettings = settings;
   emit mapSettingsChanged();
+}
+
+bool SnappingUtils::enabled() const
+{
+  return mEnabled;
+}
+
+void SnappingUtils::setEnabled( bool enabled )
+{
+  if ( mEnabled == enabled )
+    return;
+
+  mEnabled = enabled;
+
+  snap();
+
+  emit enabledChanged();
 }

--- a/src/core/utils/snappingutils.h
+++ b/src/core/utils/snappingutils.h
@@ -27,6 +27,7 @@ class SnappingUtils : public QgsSnappingUtils
 {
     Q_OBJECT
 
+    Q_PROPERTY( bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged )
     Q_PROPERTY( QgsQuickMapSettings *mapSettings READ mapSettings WRITE setMapSettings NOTIFY mapSettingsChanged )
     Q_PROPERTY( QgsVectorLayer *currentLayer READ currentLayer WRITE setCurrentLayer NOTIFY currentLayerChanged )
     Q_PROPERTY( SnappingResult snappingResult READ snappingResult NOTIFY snappingResultChanged )
@@ -34,6 +35,9 @@ class SnappingUtils : public QgsSnappingUtils
 
   public:
     explicit SnappingUtils( QObject *parent = nullptr );
+
+    bool enabled() const;
+    void setEnabled( bool enabled );
 
     QgsQuickMapSettings *mapSettings() const;
     void setMapSettings( QgsQuickMapSettings *settings );
@@ -55,6 +59,7 @@ class SnappingUtils : public QgsSnappingUtils
     static Q_INVOKABLE QgsSnappingConfig emptySnappingConfig() { return QgsSnappingConfig(); }
 
   signals:
+    void enabledChanged();
     void mapSettingsChanged();
     void currentLayerChanged();
     void snappingResultChanged();
@@ -75,6 +80,7 @@ class SnappingUtils : public QgsSnappingUtils
   private:
     void snap();
 
+    bool mEnabled = false;
     QgsQuickMapSettings *mSettings = nullptr;
     QgsVectorLayer *mCurrentLayer = nullptr;
 

--- a/src/qml/CoordinateLocator.qml
+++ b/src/qml/CoordinateLocator.qml
@@ -52,6 +52,7 @@ Item {
   SnappingUtils {
     id: snappingUtils
 
+    enabled: locator.visible
     mapSettings: locator.mapSettings
     inputCoordinate: sourceLocation === undefined ? Qt.point( locator.width / 2, locator.height / 2 ) : sourceLocation // In screen coordinates
     config: qgisProject ? qgisProject.snappingConfig : snappingUtils.emptySnappingConfig()

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -31,7 +31,9 @@ EditorWidgetBase {
     wrapMode: Text.Wrap
     textFormat: config['IsMultiline'] === true && config['UseHtml'] ? TextEdit.RichText : TextEdit.AutoText
 
-    text: value == null ? '' : config['IsMultiline'] === true ? stringUtilities.insertLinks(value) : stringUtilities.insertLinks(value).replace('\n','')
+    text: value == null ? '' : config['IsMultiline'] === true
+                               ? config['UseHtml'] === true ? value : stringUtilities.insertLinks(value)
+                               : stringUtilities.insertLinks(value).replace('\n','')
 
     onLinkActivated: Qt.openUrlExternally(link)
   }


### PR DESCRIPTION
@mbernasocchi , you sir stumbled on a pretty nasty situation, this PR so fix it.

Long story short, until this PR, when loading a project, QField would *always* try to snap the coordinate cursor once, even when we are non in digitizing or measurement mode. This meant that as soon as a project had snapping turned out, we'd run a snap whether we need it or not.

Now, a snap can cost virtually nothing, or it can be hugely costly. In your case Marco, the project was set to snap on all layers, with two layers being two big WFS layers. This resulted in QField doing a background fetch of all feature for both layers during project load. :scream: 

This PR improves the situation by insure that we will only snap when the coordinate cursor is on. At the very least that'll get people to see their project load super fast.  