### PR TITLE
[Backport master] Fix crash when QField exits with an open feature form containing relationships

### DIFF
--- a/src/core/utils/relationutils.cpp
+++ b/src/core/utils/relationutils.cpp
@@ -27,6 +27,9 @@ RelationUtils::RelationUtils( QObject *parent )
 
 QgsRelation RelationUtils::resolveReferencingRelation( QgsProject *project, QgsVectorLayer *layer, const QString &fieldName, const QString &relationId )
 {
+  if ( !project )
+    return QgsRelation();
+
   QgsRelationManager *relationManager = project->relationManager();
   QgsRelation relation = relationManager->relation( relationId );
   if ( relation.isValid() )


### PR DESCRIPTION
Backport #4326
 **Authored by:** @nirvn