### PR TITLE
Better github checks naming

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -205,6 +205,7 @@ jobs:
 
 
   deploy_to_playstore:
+    name: deploy to play store
     runs-on: ubuntu-20.04
     needs: build
     if: ${{ github.event_name == 'release' || ( github.event_name == 'push' && github.ref == 'refs/heads/master' ) }}
@@ -245,6 +246,7 @@ jobs:
 
 
   comment_pr:
+    name: comment (pr)
     runs-on: ubuntu-20.04
     needs: build
     if: ${{ github.event_name == 'pull_request' }}
@@ -275,6 +277,7 @@ jobs:
             </details>
 
   comment_commit:
+    name: comment (commit)
     runs-on: ubuntu-20.04
     needs: build
     if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/code_layout.yml
+++ b/.github/workflows/code_layout.yml
@@ -26,6 +26,7 @@ jobs:
   #        run: ./scripts/test_licenses.sh
 
   banned_keywords_check:
+    name: banned keywords check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -34,6 +35,7 @@ jobs:
         run: ./scripts/test_banned_keywords.sh
 
   cppcheck-1_9:
+    name: cpp check
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   build:
+    name: build (ios)
     runs-on: macos-12
     env:
       DEPLOYMENT_TARGET: '13.0'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   build:
+    name: build (linux)
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   build:
+    name: build (macos)
     runs-on: macos-11
 
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   build:
+    name: build (windows)
     runs-on: windows-2022
 
     steps:


### PR DESCRIPTION
Trying to avoid having half a dozen "build" checks, which makes it hard to figure out which is which:
![image](https://github.com/opengisch/QField/assets/1728657/589798a3-854a-4e4e-a0c4-cf24af072a31)

The change also helps add critical contexts to the action page. See how easy it is to identify this action page as a linux build now that we have a proper label (instead of generic "build"):
![image](https://github.com/opengisch/QField/assets/1728657/c9bb41d3-72f4-4a17-ac78-d3a37a042ef8)

