### PR TITLE
Insert individual dataset layer(s) optimally within base map projects

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -137,6 +137,7 @@
 #include <qgsgeopackageprojectstorage.h>
 #include <qgslayertree.h>
 #include <qgslayertreemodel.h>
+#include <qgslayertreeregistrybridge.h>
 #include <qgslayoutatlas.h>
 #include <qgslayoutexporter.h>
 #include <qgslayoutitemmap.h>
@@ -692,6 +693,7 @@ void QgisMobileapp::readProjectFile()
 
   mProject->removeAllMapLayers();
   mProject->setTitle( QString() );
+  mProject->layerTreeRegistryBridge()->setLayerInsertionMethod( Qgis::LayerTreeInsertionMethod::OptimalInInsertionGroup );
 
   mTrackingModel->reset();
 


### PR DESCRIPTION
This change relies on QGIS' optimal insertion method when opening individual datasets and insert the layers within a base map project.

For e.g, say your base map project layer tree looks like this:

- audio notes (point layer)
- satellite image (XYZ tile layer)

Until now, if you open a geotiff against that basemap project, it'd be added _at the very top_ of the layer tree, hiding the audio notes point layer. With this change, the geotiff would be inserted below all vector layers and above XYZ {raster,vector} layers. This is a much friendlier behavior that expands the uses for base map projects