### PR TITLE
Fix copying bookmark details into clipboard

### DIFF
--- a/src/core/bookmarkmodel.cpp
+++ b/src/core/bookmarkmodel.cpp
@@ -154,10 +154,10 @@ void BookmarkModel::removeBookmark( const QString &id )
   mManager->removeBookmark( id );
 }
 
-QgsPointXY BookmarkModel::getBookmarkPoint( const QString &id )
+QgsPoint BookmarkModel::getBookmarkPoint( const QString &id )
 {
   const QgsBookmark bookmark = mManager->bookmarkById( id );
-  return bookmark.extent().center();
+  return QgsPoint( bookmark.extent().center() );
 }
 
 QgsCoordinateReferenceSystem BookmarkModel::getBookmarkCrs( const QString &id )

--- a/src/core/bookmarkmodel.h
+++ b/src/core/bookmarkmodel.h
@@ -56,7 +56,7 @@ class BookmarkModel : public QSortFilterProxyModel
 
     Q_INVOKABLE void removeBookmark( const QString &id );
 
-    Q_INVOKABLE QgsPointXY getBookmarkPoint( const QString &id );
+    Q_INVOKABLE QgsPoint getBookmarkPoint( const QString &id );
 
     Q_INVOKABLE QgsCoordinateReferenceSystem getBookmarkCrs( const QString &id );
 

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -339,7 +339,7 @@ Page {
 
         onClicked: {
           importMenu.popup(importButton.x + importButton.width - importMenu.width + 10,
-                           importButton.y - importButton.height)
+                           importButton.y - importButton.height - header.height - 10)
         }
       }
     }


### PR DESCRIPTION
Here's our 2.8.3 justification :) the copy bookmark details [text into clipboard] function broke in 2.7 or 2.6, this fixes the situation.

A tiny UI polishing commit also included to avoid triggering two PRs x 2 (master and backport).