### PR TITLE
Properly reset the attachment editor widget to avoid previous image showing

### DIFF
--- a/src/qml/editorwidgets/+Qt5/ExternalResource.qml
+++ b/src/qml/editorwidgets/+Qt5/ExternalResource.qml
@@ -79,6 +79,7 @@ EditorWidgetBase {
     if (currentValue != undefined && currentValue !== '')
     {
       image.visible = isImage
+      geoTagBadge.visible = isImage
       player.visible = isVideo
       playerControls.visible = isVideo || isAudio
       if (isImage) {
@@ -90,14 +91,15 @@ EditorWidgetBase {
         image.anchors.topMargin = 0
         image.source = 'file://' + prefixToRelativePath + value
         geoTagBadge.hasGeoTag = ExifTools.hasGeoTag(prefixToRelativePath + value)
-        geoTagBadge.visible = true
       } else if (isAudio || isVideo) {
         mediaFrame.height = 48
         player.source = 'file://' + prefixToRelativePath + value
       }
     } else {
+      image.source = ''
       image.visible = documentViewer == document_IMAGE
       image.opacity = 0.15
+      geoTagBadge.visible = false
       player.visible = false
       playerControls.visible = false
       mediaFrame.height = 48

--- a/src/qml/editorwidgets/+Qt6/ExternalResource.qml
+++ b/src/qml/editorwidgets/+Qt6/ExternalResource.qml
@@ -83,6 +83,7 @@ EditorWidgetBase {
     if (currentValue != undefined && currentValue !== '')
     {
       image.visible = isImage
+      geoTagBadge.visible = isImage
       player.visible = isVideo
       playerControls.visible = isVideo || isAudio
       if (isImage) {
@@ -94,14 +95,15 @@ EditorWidgetBase {
         image.anchors.topMargin = 0
         image.source = 'file://' + prefixToRelativePath + value
         geoTagBadge.hasGeoTag = ExifTools.hasGeoTag(prefixToRelativePath + value)
-        geoTagBadge.visible = true
       } else if (isAudio || isVideo) {
         mediaFrame.height = 48
         player.source = 'file://' + prefixToRelativePath + value
       }
     } else {
+      image.source = ''
       image.visible = documentViewer == document_IMAGE
       image.opacity = 0.15
+      geoTagBadge.visible = false
       player.visible = false
       playerControls.visible = false
       mediaFrame.height = 48


### PR DESCRIPTION
This is an issue only present on the dev branch.