### PR TITLE
Fix checkbox editor widget value comparison

### DIFF
--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -75,7 +75,7 @@ EditorWidgetBase {
         editedValue = !isNull ? !value : true
       } else {
         if (!isNull) {
-          editedValue = value === config['CheckedState'] ? config['UncheckedState'] : config['CheckedState']
+          editedValue = value == config['CheckedState'] ? config['UncheckedState'] : config['CheckedState']
         } else {
           editedValue = config['CheckedState']
         }


### PR DESCRIPTION
Fixes https://github.com/opengisch/QField/issues/4380 .

Long story short, 1 is not equal to '1' :)