### PR TITLE
Value relation editor widget autocomplete fixes and improvements

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -48,6 +48,7 @@ Page {
     }
   }
 
+  clip: true
   states: [
     State {
       name: 'ReadOnly'

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -420,14 +420,16 @@ Item {
                 onDisplayTextChanged: {
                     if (activeFocus) {
                         if (text != comboBox.displayText) {
-                            var trimmedText = text.trim();
+                            var trimmedText = text.trim()
                             var matches = featureListModel.findDisplayValueMatches(trimmedText)
                             if (matches.length > 0) {
                                 var remainder = featureListModel.dataFromRowIndex(matches[0], featureListModel.DisplayStringRole).substring(trimmedText.length)
                                 searchableLabel.completer = '<span style="color:rgba(0,0,0,0);">' + trimmedText + '</span><span style="font-weight:'
                                         + (matches.length === 1 ? 'bold' : 'normal' ) + ';">'  + remainder + '</span>'
+                                color = Theme.mainTextColor
                             } else {
                                 searchableLabel.completer = ''
+                                color = Theme.warningColor
                             }
                         } else {
                             searchableLabel.completer = ''
@@ -441,24 +443,31 @@ Item {
                         if (text === '') {
                             if (!featureListModel.addNull || comboBox.currentIndex != 0) {
                                 text = comboBox.displayText
-                                searchableLabel.completer = ''
-                            } else {
-                                searchableLabel.completer = ''
+                                color = Theme.mainTextColor
                             }
+                            searchableLabel.completer = ''
                         }
                     } else {
-                        if (text === '' && featureListModel.addNull) {
-                            comboBox.currentIndex = 0;
-                            searchableLabel.completer = comboBox.displayText
-                        } else {
-                            applyAutoCompletion(true)
+                        if (!isLastKeyPressedReturn) {
+                            if (text === '' && featureListModel.addNull) {
+                                comboBox.currentIndex = 0;
+                                searchableLabel.completer = comboBox.displayText
+                            } else {
+                                applyAutoCompletion(true)
+                            }
                         }
                     }
                 }
 
+                property bool isLastKeyPressedReturn: false
                 Keys.onPressed: {
                     if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
-                        applyAutoCompletion()
+                        if (!isLastKeyPressedReturn) {
+                          applyAutoCompletion()
+                        }
+                        isLastKeyPressedReturn = true
+                    } else {
+                      isLastKeyPressedReturn = false
                     }
                 }
 

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -377,8 +377,11 @@ Item {
                 property bool useCompleter: false
                 property string completer: ''
 
+                anchors.verticalCenter: parent.verticalCenter
+                topPadding: 0
                 leftPadding: 5
                 rightPadding: 5
+                bottomPadding: 0
                 width: parent.width - dropDownArrowCanvas.width - dropDownArrowCanvas.anchors.rightMargin * 2
                 height: fontMetrics.height + 12
                 text: useCompleter ? completer : comboBox.displayText
@@ -398,10 +401,10 @@ Item {
                 property string typedFilter: ''
 
                 anchors.verticalCenter: parent.verticalCenter
-                topPadding: fontMetrics.ascent - 1
+                topPadding: 0
                 rightPadding: 5
                 leftPadding: 5
-                bottomPadding: 5
+                bottomPadding: 0
                 topInset: 0
                 bottomInset: 0
                 width: parent.width - dropDownArrowCanvas.width - dropDownArrowCanvas.anchors.rightMargin * 2

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -398,8 +398,10 @@ Item {
                 property string typedFilter: ''
 
                 anchors.verticalCenter: parent.verticalCenter
-                padding: 5
                 topPadding: fontMetrics.ascent - 1
+                rightPadding: 5
+                leftPadding: 5
+                bottomPadding: 5
                 topInset: 0
                 bottomInset: 0
                 width: parent.width - dropDownArrowCanvas.width - dropDownArrowCanvas.anchors.rightMargin * 2


### PR DESCRIPTION
The big UX improvement is the addition of a visual feedback that tells the user that an entered auto-complete value is *not* within the value relation list:

[Screencast from 2023-06-25 16-57-20.webm](https://github.com/opengisch/QField/assets/1728657/16fac1ce-4619-464d-8239-69a565a55850)

The handling of the Enter/Return action has also been fixed to avoid a reset to NULL value when the user tries to submit an auto-completion via that key press.