### PR TITLE
Add attribution/credits details in the layer properties popup

### DIFF
--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -900,6 +900,30 @@ QVariant FlatLayerTreeModelBase::data( const QModelIndex &index, int role ) cons
       return QString();
     }
 
+    case FlatLayerTreeModel::Credits:
+    {
+      QgsLayerTreeNode *node = mLayerTreeModel->index2node( sourceIndex );
+      QgsMapLayer *layer = nullptr;
+      if ( QgsLayerTree::isLayer( node ) )
+      {
+        QgsLayerTreeLayer *nodeLayer = QgsLayerTree::toLayer( node );
+        layer = nodeLayer->layer();
+      }
+      else if ( QgsLayerTreeModelLegendNode *sym = mLayerTreeModel->index2legendNode( sourceIndex ) )
+      {
+        layer = sym->layerNode()->layer();
+      }
+
+      if ( layer )
+      {
+        QStringList credits = !layer->metadata().rights().isEmpty() ? layer->metadata().rights() : QStringList() << layer->attribution();
+        std::for_each( credits.begin(), credits.end(), []( QString &credit ) { credit = credit.trimmed(); } );
+        credits.removeAll( QStringLiteral( "" ) ); // skip-keyword-check
+        return credits.join( QStringLiteral( "; " ) );
+      }
+      return QVariant();
+    }
+
     default:
       return QAbstractProxyModel::data( index, role );
   }
@@ -1040,6 +1064,7 @@ QHash<int, QByteArray> FlatLayerTreeModelBase::roleNames() const
   roleNames[FlatLayerTreeModel::LabelsVisible] = "LabelsVisible";
   roleNames[FlatLayerTreeModel::Opacity] = "Opacity";
   roleNames[FlatLayerTreeModel::FilterExpression] = "FilterExpression";
+  roleNames[FlatLayerTreeModel::Credits] = "Credits";
   return roleNames;
 }
 

--- a/src/core/layertreemodel.h
+++ b/src/core/layertreemodel.h
@@ -137,6 +137,7 @@ class FlatLayerTreeModel : public QSortFilterProxyModel
       LabelsVisible,
       Opacity,
       FilterExpression,
+      Credits,
     };
     Q_ENUM( Roles )
 

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -35,23 +35,24 @@ Popup {
 
   onIndexChanged: {
     if (index === undefined)
-      return;
+      return
 
-    updateTitle();
+    updateTitle()
+    updateCredits()
 
-    itemVisibleCheckBox.checked = layerTree.data(index, FlatLayerTreeModel.Visible);
-    itemLabelsVisibleCheckBox.checked = layerTree.data(index, FlatLayerTreeModel.LabelsVisible);
+    itemVisibleCheckBox.checked = layerTree.data(index, FlatLayerTreeModel.Visible)
+    itemLabelsVisibleCheckBox.checked = layerTree.data(index, FlatLayerTreeModel.LabelsVisible)
 
     expandCheckBox.text = layerTree.data( index, FlatLayerTreeModel.Type ) === 'group' ? qsTr('Expand group') : qsTr('Expand legend item')
     expandCheckBox.checked = !layerTree.data(index, FlatLayerTreeModel.IsCollapsed)
 
     reloadDataButtonVisible = layerTree.data(index, FlatLayerTreeModel.CanReloadData)
     zoomToButtonVisible = layerTree.data(index, FlatLayerTreeModel.HasSpatialExtent)
-    showFeaturesListButtonVisible = isShowFeaturesListButtonVisible();
-    showVisibleFeaturesListDropdownVisible = isShowVisibleFeaturesListDropdownVisible();
+    showFeaturesListButtonVisible = isShowFeaturesListButtonVisible()
+    showVisibleFeaturesListDropdownVisible = isShowVisibleFeaturesListDropdownVisible()
 
     trackingButtonVisible = isTrackingButtonVisible()
-    trackingButtonText = trackingModel.layerInTracking( layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer) )
+    trackingButtonText = trackingModel.layerInTracking(layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer))
         ? qsTr('Stop tracking')
         : qsTr('Setup tracking')
 
@@ -60,8 +61,9 @@ Popup {
   }
 
   Page {
+    id: popupContent
     width: parent.width
-    padding: 10
+    padding: 0
     header: RowLayout {
       spacing: 2
       Label {
@@ -95,234 +97,261 @@ Popup {
       }
     }
 
-    ColumnLayout {
-      spacing: 4
-      width: parent.width
+    ScrollView {
+      padding: 10
+      ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+      ScrollBar.vertical.policy: ScrollBar.AsNeeded
+      contentWidth: popupLayout.childrenRect.width
+      contentHeight: popupLayout.childrenRect.height
+      height: Math.min(popupLayout.childrenRect.height + 20, mainWindow.height - mainWindow.sceneTopMargin - mainWindow.sceneBottomMargin)
+      clip: true
 
-      FontMetrics {
-        id: fontMetrics
-        font: lockText.font
-      }
-
-      Text {
-        id: invalidText
-        property var invalidIcon: Theme.getThemeVectorIcon('ic_error_outline_24dp')
-        property var invalidSize: fontMetrics.height - 5
-
-        visible: index !== undefined && !layerTree.data(index, FlatLayerTreeModel.IsValid)
-        Layout.fillWidth: true
-
-        wrapMode: Text.WordWrap
-        textFormat: Text.RichText
-        text: '<img src="' + invalidIcon + '" width="' + invalidSize + '" height="' + invalidSize + '"> '
-              + qsTr('This layer is invalid. This might be due to a network issue, a missing file or a misconfiguration of the project.')
-        font: Theme.tipFont
-      }
-
-      CheckBox {
-        id: expandCheckBox
-        Layout.fillWidth: true
-        topPadding: 5
-        bottomPadding: 5
-        text: qsTr('Expand legend item')
-        font: Theme.defaultFont
-        visible: index && layerTree.data(index, FlatLayerTreeModel.HasChildren) ? true : false
-
-        onClicked: {
-          layerTree.setData(index, checkState === Qt.Unchecked, FlatLayerTreeModel.IsCollapsed);
-          close()
-        }
-      }
-
-      CheckBox {
-        id: itemVisibleCheckBox
-        Layout.fillWidth: true
-        topPadding: 5
-        bottomPadding: 5
-        text: qsTr('Show on map')
-        font: Theme.defaultFont
-        // visible for all layer tree items but nonspatial layers
-        visible: index && layerTree.data(index, FlatLayerTreeModel.HasSpatialExtent) ? true : false
-        indicator.height: 16
-        indicator.width: 16
-        indicator.implicitHeight: 24
-        indicator.implicitWidth: 24
-
-        onClicked: {
-          layerTree.setData(index, checkState === Qt.Checked, FlatLayerTreeModel.Visible);
-          flatLayerTree.mapTheme = '';
-          projectInfo.saveLayerTreeState();
-          close();
-        }
-      }
-
-      CheckBox {
-        id: itemLabelsVisibleCheckBox
-        Layout.fillWidth: true
-        topPadding: 5
-        bottomPadding: 5
-        text: qsTr('Show labels')
-        font: Theme.defaultFont
-        visible: index && layerTree.data(index, FlatLayerTreeModel.HasLabels) ? true : false
-        indicator.height: 16
-        indicator.width: 16
-        indicator.implicitHeight: 24
-        indicator.implicitWidth: 24
-
-        onClicked: {
-          layerTree.setData(index, checkState === Qt.Checked, FlatLayerTreeModel.LabelsVisible);
-          projectInfo.saveLayerStyle(layerTree.data(index, FlatLayerTreeModel.MapLayerPointer))
-          close();
-        }
-      }
-
-      RowLayout {
-        id: opacitySlider
-
-        Layout.fillWidth: true
-        Layout.topMargin: 4
-        Layout.bottomMargin:4
+      ColumnLayout {
+        id: popupLayout
+        width: popupContent.width - 20
         spacing: 4
-        visible: opacitySliderVisible
 
-        QfToolButton {
-          Layout.alignment: Qt.AlignVCenter | Qt.alignHCenter
-          Layout.leftMargin: 3
-          Layout.rightMargin: 1
-          width: 24
-          height: 24
-          padding: 0
-          enabled: false
-
-          icon.source: Theme.getThemeVectorIcon("ic_opacity_black_24dp")
-          icon.color: Theme.mainTextColor
+        FontMetrics {
+          id: fontMetrics
+          font: lockText.font
         }
 
-        ColumnLayout {
-          Layout.alignment: Layout.Center
-          Layout.rightMargin: 6
-          spacing: 0
+        Text {
+          id: invalidText
+          property var invalidIcon: Theme.getThemeVectorIcon('ic_error_outline_24dp')
+          property var invalidSize: fontMetrics.height - 5
 
-          Text {
-            Layout.fillWidth: true
-            text: qsTr("Opacity")
-            font: Theme.defaultFont
-            color: Theme.mainTextColor
+          visible: index !== undefined && !layerTree.data(index, FlatLayerTreeModel.IsValid)
+          Layout.fillWidth: true
+
+          wrapMode: Text.WordWrap
+          textFormat: Text.RichText
+          text: '<img src="' + invalidIcon + '" width="' + invalidSize + '" height="' + invalidSize + '"> '
+                + qsTr('This layer is invalid. This might be due to a network issue, a missing file or a misconfiguration of the project.')
+          font: Theme.tipFont
+        }
+
+        CheckBox {
+          id: expandCheckBox
+          Layout.fillWidth: true
+          topPadding: 5
+          bottomPadding: 5
+          text: qsTr('Expand legend item')
+          font: Theme.defaultFont
+          visible: index && layerTree.data(index, FlatLayerTreeModel.HasChildren) ? true : false
+
+          onClicked: {
+            layerTree.setData(index, checkState === Qt.Unchecked, FlatLayerTreeModel.IsCollapsed);
+            close()
+          }
+        }
+
+        CheckBox {
+          id: itemVisibleCheckBox
+          Layout.fillWidth: true
+          topPadding: 5
+          bottomPadding: 5
+          text: qsTr('Show on map')
+          font: Theme.defaultFont
+          // visible for all layer tree items but nonspatial layers
+          visible: index && layerTree.data(index, FlatLayerTreeModel.HasSpatialExtent) ? true : false
+          indicator.height: 16
+          indicator.width: 16
+          indicator.implicitHeight: 24
+          indicator.implicitWidth: 24
+
+          onClicked: {
+            layerTree.setData(index, checkState === Qt.Checked, FlatLayerTreeModel.Visible);
+            flatLayerTree.mapTheme = '';
+            projectInfo.saveLayerTreeState();
+            close();
+          }
+        }
+
+        CheckBox {
+          id: itemLabelsVisibleCheckBox
+          Layout.fillWidth: true
+          topPadding: 5
+          bottomPadding: 5
+          text: qsTr('Show labels')
+          font: Theme.defaultFont
+          visible: index && layerTree.data(index, FlatLayerTreeModel.HasLabels) ? true : false
+          indicator.height: 16
+          indicator.width: 16
+          indicator.implicitHeight: 24
+          indicator.implicitWidth: 24
+
+          onClicked: {
+            layerTree.setData(index, checkState === Qt.Checked, FlatLayerTreeModel.LabelsVisible);
+            projectInfo.saveLayerStyle(layerTree.data(index, FlatLayerTreeModel.MapLayerPointer))
+            close();
+          }
+        }
+
+        RowLayout {
+          id: opacitySlider
+
+          Layout.fillWidth: true
+          Layout.topMargin: 4
+          Layout.bottomMargin:4
+          spacing: 4
+          visible: opacitySliderVisible
+
+          QfToolButton {
+            Layout.alignment: Qt.AlignVCenter | Qt.alignHCenter
+            Layout.leftMargin: 3
+            Layout.rightMargin: 1
+            width: 24
+            height: 24
+            padding: 0
+            enabled: false
+
+            icon.source: Theme.getThemeVectorIcon("ic_opacity_black_24dp")
+            icon.color: Theme.mainTextColor
           }
 
-          QfSlider {
-            Layout.fillWidth: true
+          ColumnLayout {
+            Layout.alignment: Layout.Center
+            Layout.rightMargin: 6
+            spacing: 0
 
-            id: slider
-            value: index !== undefined ? layerTree.data(index, FlatLayerTreeModel.Opacity) * 100 : 0
-            from: 0
-            to: 100
-            stepSize: 1
-            suffixText: " %"
-            height: 40
+            Text {
+              Layout.fillWidth: true
+              text: qsTr("Opacity")
+              font: Theme.defaultFont
+              color: Theme.mainTextColor
+            }
 
-            onMoved: function () {
-              layerTree.setData(index, value / 100, FlatLayerTreeModel.Opacity)
-              projectInfo.saveLayerStyle(layerTree.data(index, FlatLayerTreeModel.MapLayerPointer))
+            QfSlider {
+              Layout.fillWidth: true
+
+              id: slider
+              value: index !== undefined ? layerTree.data(index, FlatLayerTreeModel.Opacity) * 100 : 0
+              from: 0
+              to: 100
+              stepSize: 1
+              suffixText: " %"
+              height: 40
+
+              onMoved: function () {
+                layerTree.setData(index, value / 100, FlatLayerTreeModel.Opacity)
+                projectInfo.saveLayerStyle(layerTree.data(index, FlatLayerTreeModel.MapLayerPointer))
+              }
             }
           }
         }
-      }
 
-      QfButton {
-        id: zoomToButton
-        Layout.fillWidth: true
-        Layout.topMargin: 5
-        text: index ? layerTree.data( index, FlatLayerTreeModel.Type ) === 'group'
-                      ? qsTr('Zoom to group')
-                      : layerTree.data( index, FlatLayerTreeModel.Type ) === 'legend'
-                        ? qsTr('Zoom to parent layer')
-                        : qsTr('Zoom to layer') : ''
-        visible: zoomToButtonVisible
-        icon.source: Theme.getThemeVectorIcon( 'zoom_out_map_24dp' )
+        QfButton {
+          id: zoomToButton
+          Layout.fillWidth: true
+          Layout.topMargin: 5
+          text: index ? layerTree.data( index, FlatLayerTreeModel.Type ) === 'group'
+                        ? qsTr('Zoom to group')
+                        : layerTree.data( index, FlatLayerTreeModel.Type ) === 'legend'
+                          ? qsTr('Zoom to parent layer')
+                          : qsTr('Zoom to layer') : ''
+          visible: zoomToButtonVisible
+          icon.source: Theme.getThemeVectorIcon( 'zoom_out_map_24dp' )
 
-        onClicked: {
-          mapCanvas.mapSettings.extent = layerTree.nodeExtent(index, mapCanvas.mapSettings);
-          close()
-          dashBoard.visible = false
+          onClicked: {
+            mapCanvas.mapSettings.extent = layerTree.nodeExtent(index, mapCanvas.mapSettings);
+            close()
+            dashBoard.visible = false
+          }
         }
-      }
 
-      QfButton {
-        id: showFeaturesList
-        Layout.fillWidth: true
-        Layout.topMargin: 5
-        dropdown: showVisibleFeaturesListDropdownVisible
-        text: qsTr('Show features list')
-        visible: showFeaturesListButtonVisible
-        icon.source: Theme.getThemeVectorIcon( 'ic_list_black_24dp' )
+        QfButton {
+          id: showFeaturesList
+          Layout.fillWidth: true
+          Layout.topMargin: 5
+          dropdown: showVisibleFeaturesListDropdownVisible
+          text: qsTr('Show features list')
+          visible: showFeaturesListButtonVisible
+          icon.source: Theme.getThemeVectorIcon( 'ic_list_black_24dp' )
 
-        onClicked: {
-          if ( parseInt(layerTree.data(index, FlatLayerTreeModel.FeatureCount)) === 0 ) {
-            displayToast( qsTr( "The layer has no features" ) )
-          } else {
-            var vl = layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer)
-            var filter = layerTree.data(index, FlatLayerTreeModel.FilterExpression)
-            featureForm.model.setFeatures(vl, filter)
-            if (layerTree.data(index, FlatLayerTreeModel.HasSpatialExtent)) {
-              mapCanvas.mapSettings.extent = layerTree.nodeExtent(index, mapCanvas.mapSettings)
+          onClicked: {
+            if ( parseInt(layerTree.data(index, FlatLayerTreeModel.FeatureCount)) === 0 ) {
+              displayToast( qsTr( "The layer has no features" ) )
+            } else {
+              var vl = layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer)
+              var filter = layerTree.data(index, FlatLayerTreeModel.FilterExpression)
+              featureForm.model.setFeatures(vl, filter)
+              if (layerTree.data(index, FlatLayerTreeModel.HasSpatialExtent)) {
+                mapCanvas.mapSettings.extent = layerTree.nodeExtent(index, mapCanvas.mapSettings)
+              }
             }
+
+            close()
+            dashBoard.visible = false
           }
 
-          close()
-          dashBoard.visible = false
+          onDropdownClicked: {
+            showFeaturesMenu.popup(showFeaturesList.width - showFeaturesMenu.width + 10, showFeaturesList.y + 10)
+          }
         }
 
-        onDropdownClicked: {
-          showFeaturesMenu.popup(showFeaturesList.width - showFeaturesMenu.width + 10, showFeaturesList.y + 10)
-        }
-      }
+        QfButton {
+          id: trackingButton
+          Layout.fillWidth: true
+          Layout.topMargin: 5
+          text: trackingButtonText
+          visible: trackingButtonVisible
+          icon.source: Theme.getThemeVectorIcon( 'directions_walk_24dp' )
 
-      QfButton {
-        id: trackingButton
-        Layout.fillWidth: true
-        Layout.topMargin: 5
-        text: trackingButtonText
-        visible: trackingButtonVisible
-        icon.source: Theme.getThemeVectorIcon( 'directions_walk_24dp' )
-
-        onClicked: {
+          onClicked: {
             //start track
             if ( trackingModel.layerInTracking( layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer) ) ) {
-                 trackingModel.stopTracker(layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer));
-                 displayToast( qsTr( 'Track on layer %1 stopped' ).arg( layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer).name  ) )
+              trackingModel.stopTracker(layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer));
+              displayToast( qsTr( 'Track on layer %1 stopped' ).arg( layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer).name  ) )
             } else {
-                trackingModel.createTracker(layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer), itemVisibleCheckBox.checked );
+              trackingModel.createTracker(layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer), itemVisibleCheckBox.checked );
             }
             close()
+          }
         }
-      }
 
-      Text {
-        id: lockText
-        property var padlockIcon: Theme.getThemeIcon('ic_lock_black_24dp')
-        property var padlockSize: fontMetrics.height - 5
+        Text {
+          id: lockText
 
-        property bool isReadOnly: index !== undefined && layerTree.data(index, FlatLayerTreeModel.ReadOnly)
-        property bool isGeometryLocked: index !== undefined && layerTree.data(index, FlatLayerTreeModel.GeometryLocked)
+          property var padlockIcon: Theme.getThemeIcon('ic_lock_black_24dp')
+          property var padlockSize: fontMetrics.height - 5
 
-        visible: isReadOnly || isGeometryLocked
-        Layout.fillWidth: true
+          property bool isReadOnly: index !== undefined && layerTree.data(index, FlatLayerTreeModel.ReadOnly)
+          property bool isGeometryLocked: index !== undefined && layerTree.data(index, FlatLayerTreeModel.GeometryLocked)
 
-        wrapMode: Text.WordWrap
-        textFormat: Text.RichText
-        text: '<img src="' + padlockIcon + '" width="' + padlockSize + '" height="' + padlockSize + '"> '
-              + (isReadOnly ? qsTr('Read-Only Layer') : qsTr('Geometry Locked Layer'))
-        font: Theme.tipFont
+          visible: isReadOnly || isGeometryLocked
+          Layout.fillWidth: true
 
-        MouseArea {
+          wrapMode: Text.WordWrap
+          textFormat: Text.RichText
+          text: '<img src="' + padlockIcon + '" width="' + padlockSize + '" height="' + padlockSize + '"> '
+                + (isReadOnly ? qsTr('Read-Only Layer') : qsTr('Geometry Locked Layer'))
+          font: Theme.tipFont
+          color: Theme.secondaryTextColor
+
+          MouseArea {
             anchors.fill: parent
             onClicked: {
-                if ( lockText.isReadOnly )
-                    displayToast(qsTr('This layer is configured as "Read-Only" which disables adding, deleting and editing features.'))
-                else
-                    displayToast(qsTr('This layer is configured as "Lock Geometries" which disables adding and deleting features, as well as modifying the geometries of existing features.'))
+              if ( lockText.isReadOnly )
+                displayToast(qsTr('This layer is configured as "Read-Only" which disables adding, deleting and editing features.'))
+              else
+                displayToast(qsTr('This layer is configured as "Lock Geometries" which disables adding and deleting features, as well as modifying the geometries of existing features.'))
             }
+          }
+        }
+
+        Text {
+          id: creditsText
+          Layout.fillWidth: true
+          Layout.topMargin: 5
+          wrapMode: Text.WordWrap
+          textFormat: Text.RichText
+          text: ''
+          font.pointSize: Theme.tipFont.pointSize
+          font.italic: true
+          color: Theme.secondaryTextColor
+
+          onLinkActivated: (link) => { Qt.openUrlExternally(link) }
         }
       }
     }
@@ -366,39 +395,51 @@ Popup {
   }
 
   Connections {
-      target: layerTree
+    target: layerTree
 
-      function onDataChanged(topleft, bottomright, roles) {
-          if (index === undefined)
-            return;
+    function onDataChanged(topleft, bottomright, roles) {
+      if (index === undefined)
+        return;
 
-          if (roles.includes(FlatLayerTreeModel.FeatureCount)) {
-            updateTitle();
-          }
+      if (roles.includes(FlatLayerTreeModel.FeatureCount)) {
+        updateTitle();
       }
+    }
   }
 
   function updateTitle() {
-      if (index === undefined)
-        return
+    if (index === undefined)
+      return
 
-      var title = layerTree.data(index, Qt.Name)
-      var type = layerTree.data(index, FlatLayerTreeModel.Type)
-      var vl = layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer)
-      if (vl) {
-        if (type === 'legend') {
-          title += ' (' + vl.name + ')'
-        } else if (type === 'layer' && layerTree.data(index, FlatLayerTreeModel.IsValid)) {
-          var count = layerTree.data(index, FlatLayerTreeModel.FeatureCount)
-          if (count !== undefined && count >= 0) {
-              var countSuffix = ' [' + count + ']'
+    var title = layerTree.data(index, Qt.Name)
+    var type = layerTree.data(index, FlatLayerTreeModel.Type)
+    var vl = layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer)
+    if (vl) {
+      if (type === 'legend') {
+        title += ' (' + vl.name + ')'
+      } else if (type === 'layer' && layerTree.data(index, FlatLayerTreeModel.IsValid)) {
+        var count = layerTree.data(index, FlatLayerTreeModel.FeatureCount)
+        if (count !== undefined && count >= 0) {
+            var countSuffix = ' [' + count + ']'
 
-              if (!title.endsWith(countSuffix))
-                  title += countSuffix
-          }
+            if (!title.endsWith(countSuffix))
+                title += countSuffix
         }
       }
-      titleLabel.text = title
+    }
+    titleLabel.text = title
+  }
+
+  function updateCredits() {
+    var credits = ''
+    if (index !== undefined) {
+      credits = StringUtils.insertLinks(layerTree.data(index, FlatLayerTreeModel.Credits))
+    } else {
+      credits = ''
+    }
+
+    creditsText.text = credits
+    creditsText.visible = credits !== ''
   }
 
   function isTrackingButtonVisible() {


### PR DESCRIPTION
This PR adds a credits label in the layer properties popup. In action:
![image](https://github.com/opengisch/QField/assets/1728657/827e493d-cfc1-453e-aeed-86b0502e8c4f)

This can be quite useful when packaging projects to be released to the public and are under legal obligation or providing attribution (or you know, just because you're good person :wink:).