### PR TITLE
Enable automatic fetching of missing fonts through QGIS' font manager

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -134,6 +134,7 @@
 #include <qgsfeature.h>
 #include <qgsfield.h>
 #include <qgsfieldconstraints.h>
+#include <qgsfontmanager.h>
 #include <qgsgeopackageprojectstorage.h>
 #include <qgslayertree.h>
 #include <qgslayertreemodel.h>
@@ -248,6 +249,8 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   QFontDatabase::addApplicationFont( ":/fonts/Cadastra-Semibolditalic.ttf" );
   QFontDatabase::addApplicationFont( ":/fonts/CadastraSymbol-Mask.ttf" );
   QFontDatabase::addApplicationFont( ":/fonts/CadastraSymbol-Regular.ttf" );
+
+  QgsApplication::fontManager()->enableFontDownloadsForSession();
 
   mProject = QgsProject::instance();
   mGpkgFlusher = std::make_unique<QgsGpkgFlusher>( mProject );


### PR DESCRIPTION
And with this 3-line change, we do much, much better with vector tile fonts out of the box:

![image](https://github.com/opengisch/QField/assets/1728657/3565122f-45e9-499e-9ee7-2e7775816484)
