### PR TITLE
Fix move feature(s) action

### DIFF
--- a/src/core/utils/geometryutils.h
+++ b/src/core/utils/geometryutils.h
@@ -67,10 +67,13 @@ class QFIELD_CORE_EXPORT GeometryUtils : public QObject
     //! Reshape a polyon with given \a fid using the ring in the rubberband model.
     static Q_INVOKABLE GeometryOperationResult reshapeFromRubberband( QgsVectorLayer *layer, QgsFeatureId fid, RubberbandModel *rubberBandModel );
 
-    //! Add a ring to a polyon with given \a fid using the ring in the rubberband model.
+    //! Adds a ring to a polyon with given \a fid using the ring in the rubberband model.
     static Q_INVOKABLE GeometryOperationResult addRingFromRubberband( QgsVectorLayer *layer, QgsFeatureId fid, RubberbandModel *rubberBandModel );
 
-    //! This will perform a split using the line in the rubberband model. It works with the layer selection if some features are selected.
+    /**
+     * Performs a split using the line in the rubberband model.
+     * \note Requires a given vector layer to have selected feature(s).
+     */
     static Q_INVOKABLE GeometryOperationResult splitFeatureFromRubberband( QgsVectorLayer *layer, RubberbandModel *rubberBandModel );
 
     //! Converts QGeoCoordinate to QgsPoint.
@@ -82,11 +85,14 @@ class QFIELD_CORE_EXPORT GeometryUtils : public QObject
     //! Returns a reprojected \a point from the stated \a crs to WGS84.
     static Q_INVOKABLE QgsPoint reprojectPointToWgs84( const QgsPoint &point, const QgsCoordinateReferenceSystem &crs );
 
-    //! Returns a reprojected \a point from the stated \a sourceCrs to a \a destinationCrs
+    //! Returns a reprojected \a point from the stated \a sourceCrs to a \a destinationCrs.
     static Q_INVOKABLE QgsPoint reprojectPoint( const QgsPoint &point, const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs );
 
-    //! Returns an empty (i.e. null) point
+    //! Returns an empty (i.e. null) point.
     static Q_INVOKABLE QgsPoint emptyPoint() { return QgsPoint(); }
+
+    //! Creates a point from \a x and \a y.
+    static Q_INVOKABLE QgsPoint point( double x, double y ) { return QgsPoint( x, y ); }
 };
 
 #endif // GEOMETRYUTILS_H

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1858,15 +1858,15 @@ ApplicationWindow {
         id: moveFeaturesToolbar
 
         property bool moveFeaturesRequested: false
-        property variant startPoint: undefined // QgsPoint or undefined
-        property variant endPoint: undefined // QgsPoint or undefined
+        property var startPoint: undefined // QgsPoint or undefined
+        property var endPoint: undefined // QgsPoint or undefined
         signal moveConfirmed
         signal moveCanceled
 
         stateVisible: moveFeaturesRequested
 
         onConfirm: {
-            endPoint = mapCanvas.mapSettings.center
+            endPoint = GeometryUtils.point(mapCanvas.mapSettings.center.x, mapCanvas.mapSettings.center.y)
             moveFeaturesRequested = false
             moveConfirmed()
         }
@@ -1882,7 +1882,7 @@ ApplicationWindow {
               featureForm.extentController.zoomToSelected()
             }
 
-            startPoint = mapCanvas.mapSettings.center
+            startPoint = GeometryUtils.point(mapCanvas.mapSettings.center.x, mapCanvas.mapSettings.center.y)
             moveFeaturesRequested = true
         }
     }


### PR DESCRIPTION
This fixes https://github.com/opengisch/QField/issues/4414

TIL: in Qt5 QML, assigned an object property to a variant property would copy the value; in Qt6, it binds the variant to the object property. That's a pretty significant change.

E.g.:

property variant startPoint: undefined
startPoint = mapSettings.extent.center

In Qt5, startPoint would have a copied QgsPoint. In Qt6, it binds the value to mapSettings.extent.center and updates. Ouf.