### PR TITLE
Open exported atlas PDF in non-single file mode when only one feature is being escorted

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -1293,8 +1293,20 @@ bool QgisMobileapp::printAtlasFeatures( const QString &layoutName, const QList<l
 
   layoutToPrint->atlas()->setFilterExpression( QStringLiteral( "$id IN (%1)" ).arg( ids.join( ',' ) ), error );
   layoutToPrint->atlas()->setFilterFeatures( true );
+  layoutToPrint->atlas()->updateFeatures();
 
   const QString destination = mProject->homePath() + '/' + layoutToPrint->name() + '-' + QDateTime::currentDateTime().toString( QStringLiteral( "yyyyMMdd_hhmmss" ) ) + QStringLiteral( ".pdf" );
+  QString finalDestination;
+  const bool destinationSingleFile = layoutToPrint->customProperty( QStringLiteral( "singleFile" ), true ).toBool();
+  if ( !destinationSingleFile && ids.size() == 1 )
+  {
+    layoutToPrint->atlas()->first();
+    finalDestination = mProject->homePath() + '/' + layoutToPrint->atlas()->currentFilename() + QStringLiteral( ".pdf" );
+  }
+  else
+  {
+    finalDestination = destination;
+  }
   const bool success = printAtlas( layoutToPrint, destination );
 
   layoutToPrint->atlas()->setFilterExpression( priorFilterExpression, error );
@@ -1302,9 +1314,9 @@ bool QgisMobileapp::printAtlasFeatures( const QString &layoutName, const QList<l
 
   if ( success )
   {
-    if ( layoutToPrint->customProperty( QStringLiteral( "singleFile" ), true ).toBool() )
+    if ( destinationSingleFile || ids.size() == 1 )
     {
-      PlatformUtilities::instance()->open( destination );
+      PlatformUtilities::instance()->open( finalDestination );
     }
     else
     {


### PR DESCRIPTION
This PR makes QField a tiny bit more intelligent in the way it handled non single file export of atlas. If we're exporting a single atlas feature, QField will now open the resulting singular pdf. 