### PR TITLE
Fix the delete selected feature(s) action

### DIFF
--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -573,7 +573,7 @@ Rectangle {
     }
 
     onMultiDeleteClicked: {
-        if( trackingModel.featureInTracking(featureForm.selection.focusedLayer, featureForm.selection.model.selectedFeatures) )
+        if( trackingModel.featuresInTracking(featureForm.selection.focusedLayer, featureForm.selection.model.selectedFeatures) )
         {
           displayToast( qsTr( "A number of features are being tracked, stop tracking to delete those" ) )
         }


### PR DESCRIPTION
Fascinating. This was _always_ broken, since day one. But, Qt5 QML was much more tolerant (read: way too tolerant) and would just allow for a list object to be passed as an int value. Good grief.

Fixes https://github.com/opengisch/QField/issues/4430