### PR TITLE
Fix Qt >= 6.5.1 crasher, re-enable disk cache

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -89,11 +89,6 @@ int main( int argc, char **argv )
     return 0;
   }
 
-#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 1 )
-  // Avoids systematic crash after first launch, a regression in Qt >= 6.5.1
-  qputenv( "QML_DISABLE_DISK_CACHE", "1" );
-#endif
-
   initGraphics();
 
   // Read settings, use a dummy app to get access to QSettings

--- a/src/core/projectinfo.cpp
+++ b/src/core/projectinfo.cpp
@@ -28,6 +28,8 @@ ProjectInfo::ProjectInfo( QObject *parent )
   : QObject( parent )
 {
   mSaveExtentTimer.setSingleShot( true );
+  mSaveRotationTimer.setSingleShot( true );
+  mSaveTemporalStateTimer.setSingleShot( true );
   connect( &mSaveExtentTimer, &QTimer::timeout, this, &ProjectInfo::saveExtent );
   connect( &mSaveRotationTimer, &QTimer::timeout, this, &ProjectInfo::saveRotation );
   connect( &mSaveTemporalStateTimer, &QTimer::timeout, this, &ProjectInfo::saveTemporalState );

--- a/src/qml/OverlayFeatureFormDrawer.qml
+++ b/src/qml/OverlayFeatureFormDrawer.qml
@@ -7,7 +7,7 @@ import org.qfield 1.0
 Drawer {
   id: overlayFeatureFormDrawer
 
-  property alias featureModel: overlayFeatureForm.featureModel
+  property alias featureModel: attributeFormModel.featureModel
   property alias state: overlayFeatureForm.state
   property alias featureForm: overlayFeatureForm
   property alias digitizingToolbar: overlayFeatureForm.digitizingToolbar
@@ -77,7 +77,6 @@ Drawer {
     topMargin: overlayFeatureFormDrawer.y == 0 ? mainWindow.sceneTopMargin : 0.0
     bottomMargin: mainWindow.sceneBottomMargin
 
-    property alias featureModel: attributeFormModel.featureModel
     property bool isSaved: false
 
     digitizingToolbar: overlayFeatureFormDrawer.digitizingToolbar


### PR DESCRIPTION
TIL: aliasing an alias isn't something Qt6 likes (and really, isn't something we should do anyways). 