### PR TITLE
Fix QfTextField regression in Qt 6.5.2 and use the widget in more places

### DIFF
--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -841,7 +841,7 @@ Page {
                       Layout.leftMargin: 8
                   }
 
-                  TextField {
+                  QfTextField {
                       id: accuracyBadInput
                       width: antennaHeightActivated.width
                       font: Theme.defaultFont
@@ -853,13 +853,6 @@ Page {
 
                       inputMethodHints: Qt.ImhFormattedNumbersOnly
                       validator: DoubleValidator { locale: 'C' }
-
-                      background: Rectangle {
-                        y: parent.height - height - parent.bottomPadding / 2
-                        implicitWidth: 120
-                        height: parent.activeFocus ? 2: 1
-                        color: parent.activeFocus ? Theme.accentColor : Theme.accentLightColor
-                      }
 
                       Component.onCompleted: {
                           text = isNaN( positioningSettings.accuracyBad ) ? '' : positioningSettings.accuracyBad
@@ -883,7 +876,7 @@ Page {
                       Layout.leftMargin: 8
                   }
 
-                  TextField {
+                  QfTextField {
                       id: accuracyExcellentInput
                       width: antennaHeightActivated.width
                       font: Theme.defaultFont
@@ -895,13 +888,6 @@ Page {
 
                       inputMethodHints: Qt.ImhFormattedNumbersOnly
                       validator: DoubleValidator { locale: 'C' }
-
-                      background: Rectangle {
-                        y: parent.height - height - parent.bottomPadding / 2
-                        implicitWidth: 120
-                        height: parent.activeFocus ? 2: 1
-                        color: parent.activeFocus ? Theme.accentColor : Theme.accentLightColor
-                      }
 
                       Component.onCompleted: {
                           text = isNaN( positioningSettings.accuracyExcellent ) ? '' : positioningSettings.accuracyExcellent
@@ -993,7 +979,7 @@ Page {
                       Layout.leftMargin: 8
                   }
 
-                  TextField {
+                  QfTextField {
                       id: averagedPositioningMinimumCount
                       width: averagedPositioning.width
                       font: Theme.defaultFont
@@ -1005,13 +991,6 @@ Page {
 
                       inputMethodHints: Qt.ImhFormattedNumbersOnly
                       validator: IntValidator { locale: 'C' }
-
-                      background: Rectangle {
-                        y: parent.height - height - parent.bottomPadding / 2
-                        implicitWidth: 120
-                        height: parent.activeFocus ? 2: 1
-                        color: parent.activeFocus ? Theme.accentColor : Theme.accentLightColor
-                      }
 
                       Component.onCompleted: {
                           text = isNaN( positioningSettings.averagedPositioningMinimumCount ) ? '' : positioningSettings.averagedPositioningMinimumCount
@@ -1100,7 +1079,7 @@ Page {
                       Layout.leftMargin: 8
                   }
 
-                  TextField {
+                  QfTextField {
                       id: antennaHeightInput
                       enabled: antennaHeightActivated.checked
                       visible: antennaHeightActivated.checked
@@ -1112,13 +1091,6 @@ Page {
 
                       inputMethodHints: Qt.ImhFormattedNumbersOnly
                       validator: DoubleValidator { locale: 'C' }
-
-                      background: Rectangle {
-                        y: parent.height - height - parent.bottomPadding / 2
-                        implicitWidth: 120
-                        height: parent.activeFocus ? 2: 1
-                        color: parent.activeFocus ? Theme.accentColor : Theme.accentLightColor
-                      }
 
                       Component.onCompleted: {
                           text = isNaN( positioningSettings.antennaHeight ) ? '' : positioningSettings.antennaHeight

--- a/src/qml/Tracking.qml
+++ b/src/qml/Tracking.qml
@@ -276,7 +276,7 @@ Item {
               Layout.fillWidth: true
             }
 
-            TextField {
+            QfTextField {
               id: timeIntervalValue
               width: timeInterval.width
               font: Theme.defaultFont
@@ -288,13 +288,6 @@ Item {
 
               inputMethodHints: Qt.ImhFormattedNumbersOnly
               validator: DoubleValidator { locale: 'C' }
-
-              background: Rectangle {
-                y: parent.height - height - parent.bottomPadding / 2
-                implicitWidth: 120
-                height: parent.activeFocus ? 2: 1
-                color: parent.activeFocus ? Theme.accentColor : Theme.accentLightColor
-              }
 
               Component.onCompleted: {
                 text = isNaN(positioningSettings.trackerTimeInterval) ? '' : positioningSettings.trackerTimeInterval
@@ -348,7 +341,7 @@ Item {
               Layout.fillWidth: true
             }
 
-            TextField {
+            QfTextField {
               id: minimumDistanceValue
               width: minimumDistance.width
               font: Theme.defaultFont
@@ -360,13 +353,6 @@ Item {
 
               inputMethodHints: Qt.ImhFormattedNumbersOnly
               validator: DoubleValidator { locale: 'C' }
-
-              background: Rectangle {
-                y: parent.height - height - parent.bottomPadding / 2
-                implicitWidth: 120
-                height: parent.activeFocus ? 2: 1
-                color: parent.activeFocus ? Theme.accentColor : Theme.accentLightColor
-              }
 
               Component.onCompleted: {
                 text = isNaN(positioningSettings.trackerMinimumDistance) ? '' : positioningSettings.trackerMinimumDistance

--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -91,7 +91,7 @@ EditorWidgetBase {
       anchors.right: parent.right
       y: checkValue.height - height - checkValue.bottomPadding / 2
       implicitWidth: 120
-      height: checkBox.activeFocus || checkBox.pressed || checkArea.containsPress ? 2: 1
+      height: checkBox.activeFocus || checkBox.pressed || checkArea.containsPress ? 2 : 1
       color: checkBox.activeFocus || checkBox.pressed || checkArea.containsPress ? Theme.accentColor : Theme.accentLightColor
   }
 

--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -53,10 +53,15 @@ EditorWidgetBase {
           inputMethodHints: Qt.ImhFormattedNumbersOnly
 
           background: Rectangle {
+            implicitWidth: 120
+            color: "transparent"
+
+            Rectangle {
               y: textField.height - height - textField.bottomPadding / 2
-              implicitWidth: 120
-              height: textField.activeFocus ? 2: 1
+              width: textField.width
+              height: textField.activeFocus ? 2 : 1
               color: textField.activeFocus ? Theme.accentColor : Theme.accentLightColor
+            }
           }
 
           onTextChanged: {
@@ -222,7 +227,7 @@ EditorWidgetBase {
     visible: widgetStyle === "Slider"
     width: sliderRow.width
     implicitWidth: 120
-    height: slider.activeFocus ? 2: 1
+    height: slider.activeFocus ? 2 : 1
     color: slider.activeFocus ? Theme.accentColor : Theme.accentLightColor
   }
 

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -122,7 +122,7 @@ EditorWidgetBase {
       anchors.right: parent.right
       y: Math.max( textField.height, textArea.height ) - height - textField.bottomPadding / 2
       implicitWidth: 120
-      height: textField.activeFocus || textArea.activeFocus ? 2: 1
+      height: textField.activeFocus || textArea.activeFocus ? 2 : 1
       color: textField.activeFocus || textArea.activeFocus ? Theme.accentColor : Theme.accentLightColor
   }
 

--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -87,7 +87,7 @@ EditorWidgetBase {
         visible: !enabled
         y: comboBox.height - 12
         width: comboBox.width
-        height: comboBox.activeFocus ? 2: 1
+        height: comboBox.activeFocus ? 2 : 1
         color: comboBox.activeFocus ? Theme.accentColor : Theme.accentLightColor
       }
 

--- a/src/qml/imports/Theme/QfTextField.qml
+++ b/src/qml/imports/Theme/QfTextField.qml
@@ -11,8 +11,9 @@ Item {
   property alias horizontalAlignment: textField.horizontalAlignment
   property alias inputMethodHints: textField.inputMethodHints
   property alias inputMask: textField.inputMask
+  property alias validator: textField.validator
 
-  property var echoMode: TextInput.Normal
+  property int echoMode: TextInput.Normal
 
   signal textEdited
   signal editingFinished
@@ -37,10 +38,15 @@ Item {
     inputMethodHints: Qt.ImhNone
 
     background: Rectangle {
-      y: textField.height - height - textField.bottomPadding / 2
       implicitWidth: 120
-      height: textField.activeFocus ? 2: 1
-      color: textField.activeFocus ? Theme.accentColor : Theme.accentLightColor
+      color: "transparent"
+
+      Rectangle {
+        y: textField.height - height - textField.bottomPadding / 2
+        width: textField.width
+        height: textField.activeFocus ? 2 : 1
+        color: textField.activeFocus ? Theme.accentColor : Theme.accentLightColor
+      }
     }
 
     onActiveFocusChanged: {


### PR DESCRIPTION
Qt 6.5.2 doesn't like a 1-pixel Rectangle TextEdit background item. 