### PR TITLE
Advanced snapping configuration toggling capability

### DIFF
--- a/src/core/layertreemodel.h
+++ b/src/core/layertreemodel.h
@@ -138,6 +138,7 @@ class FlatLayerTreeModel : public QSortFilterProxyModel
       Opacity,
       FilterExpression,
       Credits,
+      SnappingEnabled,
     };
     Q_ENUM( Roles )
 

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -398,6 +398,7 @@ void QgisMobileapp::initDeclarative()
   qRegisterMetaType<Qgis::AreaUnit>( "Qgis::AreaUnit" );
   qRegisterMetaType<Qgis::AngleUnit>( "Qgis::AngleUnit" );
   qRegisterMetaType<Qgis::DeviceConnectionStatus>( "Qgis::DeviceConnectionStatus" );
+  qRegisterMetaType<Qgis::SnappingMode>( "Qgis::SnappingMode" );
   qmlRegisterUncreatableType<Qgis>( "org.qgis", 1, 0, "Qgis", "" );
 
   qmlRegisterUncreatableType<QgsProject>( "org.qgis", 1, 0, "Project", "" );

--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -248,11 +248,11 @@ ListView {
         enabled: isVisible
 
         round: true
-        bgcolor: SnappingEnabled ? Theme.mainColor : 'transparent'
+        bgcolor: SnappingEnabled ? Theme.mainColor : Theme.controlBackgroundColor
         opacity: SnappingEnabled ? 1.0 : 0.5
 
         icon.source: Theme.getThemeVectorIcon( 'ic_snapping_white_24dp' )
-        icon.color: SnappingEnabled ? "#ffffff" : Theme.mainTextColor
+        icon.color: SnappingEnabled ? 'white' : Theme.mainTextColor
 
         onClicked: {
           SnappingEnabled = !SnappingEnabled

--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -159,9 +159,10 @@ ListView {
         width: rectangle.width
                - itemPadding
                - 46
-               - (InTracking ? 29 : 0)
-               - ((ReadOnly || GeometryLocked) ? 29 : 0)
-               - (!IsValid ? 29 : 0)
+               - (trackingBadge.isVisible ? trackingBadge.width + 5 : 0)
+               - (lockedBadge.isVisible ? lockedBadge.width + 5 : 0)
+               - (invalidBadge.isVisible ? invalidBadge.width + 5 : 0)
+               - (snappingBadge.isVisible ? snappingBadge.width + 5 : 0)
         padding: 3
         leftPadding: 0
         text: Name
@@ -181,7 +182,9 @@ ListView {
       }
 
       QfToolButton {
-        visible: InTracking ? true : false
+        id: trackingBadge
+        property bool isVisible: InTracking ? true : false
+        visible: isVisible
         height: 24
         width: 24
         padding: 4
@@ -201,7 +204,9 @@ ListView {
       }
 
       QfToolButton {
-        visible: Type === 'layer' && !IsValid
+        id: invalidBadge
+        property bool isVisible: Type === 'layer' && !IsValid
+        visible: isVisible
         height: 24
         width: 24
         padding: 4
@@ -216,7 +221,9 @@ ListView {
       }
 
       QfToolButton {
-        visible: ReadOnly || GeometryLocked
+        id: lockedBadge
+        property bool isVisible: ReadOnly || GeometryLocked
+        visible: isVisible
         height: 24
         width: 24
         padding: 4
@@ -228,6 +235,28 @@ ListView {
 
         icon.source: Theme.getThemeIcon( 'ic_lock_black_24dp' )
         icon.color: Theme.mainTextColor
+      }
+
+      QfToolButton {
+        id: snappingBadge
+        property bool isVisible: stateMachine.state === "digitize" && qgisProject.snappingConfig.mode === Qgis.SnappingMode.AdvancedConfiguration && Type === 'layer' && LayerType === "vectorlayer"
+        visible: isVisible
+        height: 24
+        width: 24
+        padding: 4
+        anchors.verticalCenter: parent.verticalCenter
+        enabled: isVisible
+
+        round: true
+        bgcolor: SnappingEnabled ? Theme.mainColor : 'transparent'
+        opacity: SnappingEnabled ? 1.0 : 0.5
+
+        icon.source: Theme.getThemeVectorIcon( 'ic_snapping_white_24dp' )
+        icon.color: SnappingEnabled ? "#ffffff" : Theme.mainTextColor
+
+        onClicked: {
+          SnappingEnabled = !SnappingEnabled
+        }
       }
     }
   }

--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -189,7 +189,7 @@ ListView {
         width: 24
         padding: 4
         anchors.verticalCenter: parent.verticalCenter
-        enabled: false
+        enabled: isVisible
 
         round: true
         bgcolor: Theme.mainColor
@@ -201,6 +201,10 @@ ListView {
 
         icon.source: Theme.getThemeVectorIcon( 'directions_walk_24dp' )
         icon.color: Theme.mainTextColor
+
+        onClicked: {
+          displayToast(qsTr('This layer is is currently tracking the device position.'))
+        }
       }
 
       QfToolButton {
@@ -211,13 +215,17 @@ ListView {
         width: 24
         padding: 4
         anchors.verticalCenter: parent.verticalCenter
-        enabled: false
+        enabled: isVisible
 
         bgcolor: 'transparent'
         opacity: 0.5
 
         icon.source: Theme.getThemeVectorIcon('ic_error_outline_24dp' )
         icon.color: Theme.errorColor
+
+        onClicked: {
+          displayToast(qsTr('This layer is invalid. This might be due to a network issue, a missing file or a misconfiguration of the project.'))
+        }
       }
 
       QfToolButton {
@@ -228,13 +236,21 @@ ListView {
         width: 24
         padding: 4
         anchors.verticalCenter: parent.verticalCenter
-        enabled: false
+        enabled: isVisible
 
         bgcolor: 'transparent'
         opacity: 0.5
 
         icon.source: Theme.getThemeIcon( 'ic_lock_black_24dp' )
         icon.color: Theme.mainTextColor
+
+        onClicked: {
+          if ( ReadOnly ) {
+            displayToast(qsTr('This layer is configured as "Read-Only" which disables adding, deleting and editing features.'))
+          } else {
+            displayToast(qsTr('This layer is configured as "Lock Geometries" which disables adding and deleting features, as well as modifying the geometries of existing features.'))
+          }
+        }
       }
 
       QfToolButton {

--- a/src/qml/imports/Theme/QfToolButton.qml
+++ b/src/qml/imports/Theme/QfToolButton.qml
@@ -33,7 +33,7 @@ RoundButton {
     id: backgroundRectangle
     implicitWidth: 100
     implicitHeight: 25
-    border.width: round && roundborder ? height / 6 : !round
+    border.width: round && roundborder ? height / 6 : 1
     border.color: button.borderColor
     color: 'transparent'
     radius: round ? height / 2 : 0

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1252,8 +1252,7 @@ ApplicationWindow {
         )
       state: qgisProject && qgisProject.snappingConfig.enabled ? "On" : "Off"
       iconSource: Theme.getThemeVectorIcon( "ic_snapping_white_24dp" )
-      iconColor: "#ffffff"
-
+      iconColor: "white"
       bgcolor: Theme.darkGray
 
       states: [
@@ -1262,7 +1261,7 @@ ApplicationWindow {
           name: "Off"
           PropertyChanges {
             target: snappingButton
-            iconColor: "#ffffff"
+            iconColor: "white"
             bgcolor: Qt.hsla(Theme.darkGray.hslHue, Theme.darkGray.hslSaturation, Theme.darkGray.hslLightness, 0.3)
           }
         },
@@ -1298,8 +1297,7 @@ ApplicationWindow {
         )
       state: qgisProject && qgisProject.topologicalEditing ? "On" : "Off"
       iconSource: Theme.getThemeVectorIcon( "ic_topology_white_24dp" )
-      iconColor: "#ffffff"
-
+      iconColor: "white"
       bgcolor: Theme.darkGray
 
       states: [
@@ -1308,7 +1306,7 @@ ApplicationWindow {
           name: "Off"
           PropertyChanges {
             target: topologyButton
-            iconColor: "#ffffff"
+            iconColor: "white"
             bgcolor: Qt.hsla(Theme.darkGray.hslHue, Theme.darkGray.hslSaturation, Theme.darkGray.hslLightness, 0.3)
           }
         },
@@ -1340,7 +1338,7 @@ ApplicationWindow {
                    (dashBoard.activeLayer.geometryType() === Qgis.GeometryType.Polygon
                     || dashBoard.activeLayer.geometryType() === Qgis.GeometryType.Line)))
       iconSource: Theme.getThemeVectorIcon( "ic_freehand_white_24dp" )
-      iconColor: "#ffffff"
+      iconColor: "white"
       bgcolor: Theme.darkGray
 
       property bool freehandDigitizing: false
@@ -1351,7 +1349,7 @@ ApplicationWindow {
           name: "Off"
           PropertyChanges {
             target: freehandButton
-            iconColor: "#ffffff"
+            iconColor: "white"
             bgcolor: Qt.hsla(Theme.darkGray.hslHue, Theme.darkGray.hslSaturation, Theme.darkGray.hslLightness, 0.3)
           }
         },


### PR DESCRIPTION
This PR implements a functionality to toggle individual vector layer's snapping enabled state for projects' snapping configuration mode set to advanced. A quick showcase first:

[Screencast from 2023-07-26 16-43-19.webm](https://github.com/opengisch/QField/assets/1728657/fe3064b1-2bdc-455b-80e3-fc3fd1cee943)

As with everything else we do in QField, the implementation tries to avoid adding UI elements until it is relevant and useful. As such, the snapping badges are only visible when QField is set to digitizing mode. When in browse mode, the badges disappear.

Alongside the previous PR that added a global snapping on/off switch, this gives us really nice snapping flexibility straight within QField.