### PR TITLE
Buffer polygons prior to passing them to QgsTessellator to fix crashes

### DIFF
--- a/src/core/qgssggeometry.cpp
+++ b/src/core/qgssggeometry.cpp
@@ -160,8 +160,13 @@ QSGGeometry *QgsSGGeometry::qgsPolylineToQSGGeometry( const QgsPolylineXY &line,
 QSGGeometry *QgsSGGeometry::qgsPolygonToQSGGeometry( const QgsPolygon *polygon, const QgsRectangle visibleExtent, double scaleFactor )
 {
   Q_ASSERT( polygon );
+
+  QgsGeometry geom( polygon->clone() );
+  geom = geom.buffer( 0.0000001, 5 );
+  QgsPolygon *bufferedPolygon = qgsgeometry_cast<QgsPolygon *>( geom.constGet() );
+
   QgsTessellator t( visibleExtent.xMinimum(), visibleExtent.yMaximum(), false, false, false, true );
-  t.addPolygon( *polygon, 0 );
+  t.addPolygon( *bufferedPolygon, 0 );
 
   QSGGeometry *sgGeom = new QSGGeometry( QSGGeometry::defaultAttributes_Point2D(), t.dataVerticesCount() );
 

--- a/src/core/sgrubberband.cpp
+++ b/src/core/sgrubberband.cpp
@@ -108,11 +108,13 @@ QSGGeometryNode *SGRubberband::createLineGeometry( const QVector<QgsPoint> &poin
 
 QSGGeometryNode *SGRubberband::createPolygonGeometry( const QVector<QgsPoint> &points )
 {
-  QgsPolygon polygon = QgsPolygon( new QgsLineString( points ) );
+  QgsGeometry geom( new QgsPolygon( new QgsLineString( points ) ) );
+  geom = geom.buffer( 0.0000001, 5 );
+  QgsPolygon *polygon = qgsgeometry_cast<QgsPolygon *>( geom.constGet() );
   QgsTessellator t( 0, 0, false, false, false, true );
   if ( points.size() > 2 )
   {
-    t.addPolygon( polygon, 0 );
+    t.addPolygon( *polygon, 0 );
   }
 
   QSGGeometryNode *node = new QSGGeometryNode;


### PR DESCRIPTION
The tiny buffering operation works wonders in taking care of overlapping vertices, and in doing so fix QgsTessellator crashes when creating a polygon highlight/rubberband.