### PR TITLE
Add a rendering quality property to the map canvas

### DIFF
--- a/src/core/qgsquick/qgsquickmapcanvasmap.h
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.h
@@ -84,6 +84,15 @@ class QgsQuickMapCanvasMap : public QQuickItem
      */
     Q_PROPERTY( bool incrementalRendering READ incrementalRendering WRITE setIncrementalRendering NOTIFY incrementalRenderingChanged )
 
+    /**
+     * The quality property allows for an increase in rendering speed and memory usage reduction at the
+     * cost of rendering quality.
+     *
+     * By default, the value is set to 1.0, providing for the best rendering. The lowest quality
+     * value is 0.5.
+     */
+    Q_PROPERTY( double quality READ quality WRITE setQuality NOTIFY qualityChanged )
+
   public:
     //! Create map canvas map
     explicit QgsQuickMapCanvasMap( QQuickItem *parent = nullptr );
@@ -115,6 +124,12 @@ class QgsQuickMapCanvasMap : public QQuickItem
     //! \copydoc QgsQuickMapCanvasMap::incrementalRendering
     void setIncrementalRendering( bool incrementalRendering );
 
+    //! \copydoc QgsQuickMapCanvasMap::quality
+    double quality() const;
+
+    //! \copydoc QgsQuickMapCanvasMap::incrementalRendering
+    void setQuality( double quality );
+
     /**
      * Returns an image of the last successful map canvas rendering
      */
@@ -143,6 +158,9 @@ class QgsQuickMapCanvasMap : public QQuickItem
 
     //!\copydoc QgsQuickMapCanvasMap::incrementalRendering
     void incrementalRenderingChanged();
+
+    //!\copydoc QgsQuickMapCanvasMap::quality
+    void qualityChanged();
 
   protected:
 #if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
@@ -214,6 +232,7 @@ class QgsQuickMapCanvasMap : public QQuickItem
     bool mIncrementalRendering = false;
     bool mSilentRefresh = false;
     bool mDeferredRefreshPending = false;
+    double mQuality = 1.0;
 
     QQuickWindow *mWindow = nullptr;
 };

--- a/src/qml/MapCanvas.qml
+++ b/src/qml/MapCanvas.qml
@@ -26,6 +26,7 @@ Item {
   property alias mapSettings: mapCanvasWrapper.mapSettings
   property alias isRendering: mapCanvasWrapper.isRendering
   property alias incrementalRendering: mapCanvasWrapper.incrementalRendering
+  property alias quality: mapCanvasWrapper.quality
 
   property bool interactive: true
   property bool hovered: false

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -546,6 +546,17 @@ Page {
                               initialized = true
                           }
                       }
+
+                      Label {
+                          text: qsTr( "A lower quality trades rendering precision in favor of lower memory usage and rendering time." )
+                          font: Theme.tipFont
+                          color: Theme.secondaryTextColor
+                          textFormat: Qt.RichText
+                          wrapMode: Text.WordWrap
+                          Layout.fillWidth: true
+
+                          onLinkActivated: Qt.openUrlExternally(link)
+                      }
                   }
 
                   Item {

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -21,6 +21,7 @@ Page {
   property alias autoSave: registry.autoSave
   property alias mouseAsTouchScreen: registry.mouseAsTouchScreen
   property alias enableInfoCollection: registry.enableInfoCollection
+  property alias quality: registry.quality
 
   Component.onCompleted: {
     if (settings.valueBool('nativeCameraLaunched', false)) {
@@ -40,6 +41,7 @@ Page {
     property bool autoSave: false
     property bool mouseAsTouchScreen: false
     property bool enableInfoCollection: true
+    property double quality: 1.0
 
     onEnableInfoCollectionChanged: {
       if (enableInfoCollection) {
@@ -501,6 +503,48 @@ Page {
                           Layout.fillWidth: true
 
                           onLinkActivated: Qt.openUrlExternally(link)
+                      }
+
+                      Label {
+                          Layout.fillWidth: true
+                          text: qsTr( "Map canvas rendering quality:" )
+                          font: Theme.defaultFont
+                          color: Theme.mainTextColor
+
+                          wrapMode: Text.WordWrap
+                      }
+
+                      ComboBox {
+                          id: renderingQualityComboBox
+                          enabled: true
+                          Layout.fillWidth: true
+                          Layout.alignment: Qt.AlignVCenter
+                          font: Theme.defaultFont
+
+                          popup.font: Theme.defaultFont
+                          popup.topMargin: mainWindow.sceneTopMargin
+                          popup.bottomMargin: mainWindow.sceneTopMargin
+
+                          model: ListModel {
+                            ListElement { name: qsTr('Best quality'); value: 1.0 }
+                            ListElement { name: qsTr('Lower quality'); value: 0.75 }
+                            ListElement { name: qsTr('Lowest quality'); value: 0.5 }
+                          }
+                          textRole: "name"
+                          valueRole: "value"
+
+                          property bool initialized: false
+
+                          onCurrentValueChanged: {
+                              if (initialized) {
+                                quality = currentValue
+                              }
+                          }
+
+                          Component.onCompleted: {
+                              currentIndex = indexOfValue(quality)
+                              initialized = true
+                          }
                       }
                   }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -455,6 +455,7 @@ ApplicationWindow {
       id: mapCanvasMap
       interactive: !screenLocker.enabled
       incrementalRendering: true
+      quality: qfieldSettings.quality
       freehandDigitizing: freehandButton.freehandDigitizing && freehandHandler.active
 
       anchors.fill: parent


### PR DESCRIPTION
This PR implements a map canvas quality property which allows users to trade rendering sharpness in favor of lower memory usage and rendering time. The UI is found in the settings panel below the language combobox:

![image](https://github.com/opengisch/QField/assets/1728657/8e83bd49-be40-4054-a47f-2f4b711aa18e)

Three quality settings are available: Best quality (current rendering), lower quality, and lowest quality.

Behind the scene, what we are doing is lowering the rendered output size to create smaller images resulting in smaller memory footprint (very useful for devices with low RAM) and less CPU cycles spent rendering (i.e., lowering battery drain).

Fixes #1447