### PR TITLE
Avoid coordinate cursor label stealing hovering state, fix map canvas menu height

### DIFF
--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -518,7 +518,7 @@ Rectangle {
     MenuSeparator { width: parent.width }
 
     MenuItem {
-      text: Qt.platform.os === "ios" ? qsTr( "Print Atlas Feature(s) to Image" ) : qsTr( 'Print Atlas Feature(s) to PDF' )
+      text: qsTr( 'Print Atlas Feature(s) to PDF' )
       icon.source: Theme.getThemeIcon( "ic_print_white_24dp" )
       enabled: toolBar.model && toolBar.model.selectedCount > 0 && LayerUtils.isAtlasCoverageLayer( toolBar.model.selectedLayer )
 
@@ -533,8 +533,10 @@ Rectangle {
     }
 
     MenuSeparator {
-      visible: mergeSelectedFeaturesBtn.visible || moveSelectedFeaturesBtn.visible || duplicateSelectedFeaturesBtn.visible || deleteSelectedFeaturesBtn.visible
+      enabled: mergeSelectedFeaturesBtn.visible || moveSelectedFeaturesBtn.visible || duplicateSelectedFeaturesBtn.visible || deleteSelectedFeaturesBtn.visible
+      visible: enabled
       width: parent.width
+      height: enabled ? undefined : 0
     }
 
     MenuItem {
@@ -542,10 +544,8 @@ Rectangle {
       text: qsTr( 'Merge Selected Features' )
       icon.source: Theme.getThemeIcon( "ic_merge_features_white_24dp" )
       enabled: toolBar.model && toolBar.model.canMergeSelection && toolBar.model.selectedCount > 1 && projectInfo.editRights
-      visible: enabled
 
       font: Theme.defaultFont
-      height: visible ? 48 : 0
       leftPadding: 10
 
       onTriggered: multiMergeClicked();
@@ -556,10 +556,8 @@ Rectangle {
       text: qsTr( 'Move Selected Feature(s)' )
       icon.source: Theme.getThemeVectorIcon( "ic_move_white_24dp" )
       enabled: toolBar.model && toolBar.model.canMoveSelection && projectInfo.editRights
-      visible: enabled
 
       font: Theme.defaultFont
-      height: visible ? 48 : 0
       leftPadding: 10
 
       onTriggered: multiMoveClicked();
@@ -570,10 +568,8 @@ Rectangle {
       text: qsTr( 'Duplicate Selected Feature(s)' )
       icon.source: Theme.getThemeVectorIcon( "ic_duplicate_black_24dp" )
       enabled: toolBar.model && toolBar.model.canDuplicateSelection && projectInfo.insertRights
-      visible: enabled
 
       font: Theme.defaultFont
-      height: visible ? 48 : 0
       leftPadding: 10
 
       onTriggered: multiDuplicateClicked();
@@ -585,9 +581,9 @@ Rectangle {
       icon.source: Theme.getThemeIcon( "ic_delete_forever_white_24dp" )
       enabled: toolBar.model && toolBar.model.canDeleteSelection && projectInfo.editRights
       visible: enabled
+      height: enabled ? undefined : 0
 
       font: Theme.defaultFont
-      height: visible ? 48 : 0
       leftPadding: 10
 
       onTriggered: multiDeleteClicked();

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -369,12 +369,13 @@ Page {
 
       MenuItem {
         id: sendDatasetTo
-        visible: platformUtilities.capabilities & PlatformUtilities.CustomSend
+        enabled: platformUtilities.capabilities & PlatformUtilities.CustomSend
                  && itemMenu.itemMetaType == LocalFilesModel.Dataset
+        visible: enabled
 
         font: Theme.defaultFont
         width: parent.width
-        height: visible ? 48 : 0
+        height: enabled ? undefined : 0
         leftPadding: 10
 
         text: qsTr( "Send to..." )
@@ -383,12 +384,13 @@ Page {
 
       MenuItem {
         id: exportDatasetTo
-        visible: platformUtilities.capabilities & PlatformUtilities.CustomExport
+        enabled: platformUtilities.capabilities & PlatformUtilities.CustomExport
                  && itemMenu.itemMetaType == LocalFilesModel.Dataset
+        visible: enabled
 
         font: Theme.defaultFont
         width: parent.width
-        height: visible ? 48 : 0
+        height: enabled ? undefined : 0
         leftPadding: 10
 
         text: qsTr( "Export to folder..." )
@@ -397,13 +399,14 @@ Page {
 
       MenuItem {
         id: removeDataset
-        visible: itemMenu.itemMetaType == LocalFilesModel.Dataset
+        enabled: itemMenu.itemMetaType == LocalFilesModel.Dataset
                  && !qfieldLocalDataPickerScreen.projectFolderView
                  && table.model.isDeletedAllowedInCurrentPath
+        visible: enabled
 
         font: Theme.defaultFont
         width: parent.width
-        height: visible ? 48 : 0
+        height: enabled? undefined : 0
         leftPadding: 10
 
         text: qsTr( "Remove dataset" )
@@ -412,12 +415,13 @@ Page {
 
       MenuItem {
         id: exportFolderTo
-        visible: platformUtilities.capabilities & PlatformUtilities.CustomExport &&
+        enabled: platformUtilities.capabilities & PlatformUtilities.CustomExport &&
                  itemMenu.itemMetaType == LocalFilesModel.Folder
+        visible: enabled
 
         font: Theme.defaultFont
         width: parent.width
-        height: visible ? 48 : 0
+        height: enabled ? undefined : 0
         leftPadding: 10
 
         text: qsTr( "Export to folder..." )
@@ -426,12 +430,13 @@ Page {
 
       MenuItem {
         id: sendCompressedFolderTo
-        visible: platformUtilities.capabilities & PlatformUtilities.CustomSend
+        enabled: platformUtilities.capabilities & PlatformUtilities.CustomSend
                  && itemMenu.itemMetaType == LocalFilesModel.Folder
+        visible: enabled
 
         font: Theme.defaultFont
         width: parent.width
-        height: visible ? 48 : 0
+        height: enabled ? undefined : 0
         leftPadding: 10
 
         text: qsTr( "Send compressed folder to..." )
@@ -440,13 +445,14 @@ Page {
 
       MenuItem {
         id: removeProjectFolder
-        visible: itemMenu.itemMetaType == LocalFilesModel.Folder
+        enabled: itemMenu.itemMetaType == LocalFilesModel.Folder
                  && !qfieldLocalDataPickerScreen.projectFolderView
                  && table.model.isDeletedAllowedInCurrentPath
+        visible: enabled
 
         font: Theme.defaultFont
         width: parent.width
-        height: visible ? 48 : 0
+        height: enabled ? undefined : 0
         leftPadding: 10
 
         text: qsTr( "Remove project folder" )
@@ -477,9 +483,10 @@ Page {
         id: importProjectFromFolder
 
         enabled: platformUtilities.capabilities & PlatformUtilities.CustomImport
+        visible: enabled
         font: Theme.defaultFont
         width: parent.width
-        height: enabled ? 48 : 0
+        height: enabled ? undefined : 0
         leftPadding: 10
 
         text: qsTr( "Import project from folder" )
@@ -490,9 +497,10 @@ Page {
         id: importProjectFromZIP
 
         enabled: platformUtilities.capabilities & PlatformUtilities.CustomImport
+        visible: enabled
         font: Theme.defaultFont
         width: parent.width
-        height: enabled ? 48 : 0
+        height: enabled ? undefined : 0
         leftPadding: 10
 
         text: qsTr( "Import project from ZIP" )
@@ -503,9 +511,10 @@ Page {
         id: importDataset
 
         enabled: platformUtilities.capabilities & PlatformUtilities.CustomImport
+        visible: enabled
         font: Theme.defaultFont
         width: parent.width
-        height: enabled ? 48 : 0
+        height: enabled ? undefined : 0
 
         leftPadding: 10
 
@@ -513,7 +522,12 @@ Page {
         onTriggered: { platformUtilities.importDatasets(); }
       }
 
-      MenuSeparator { visible: platformUtilities.capabilities & PlatformUtilities.CustomImport; width: parent.width }
+      MenuSeparator {
+        enabled: platformUtilities.capabilities & PlatformUtilities.CustomImport
+        visible: enabled
+        width: parent.width
+        height: enabled ? undefined : 0
+      }
 
       MenuItem {
         id: importUrl
@@ -529,7 +543,9 @@ Page {
         }
       }
 
-      MenuSeparator { width: parent.width }
+      MenuSeparator {
+        width: parent.width
+      }
 
       MenuItem {
         id: storageHelp

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2435,8 +2435,10 @@ ApplicationWindow {
     }
 
     MenuSeparator {
+      enabled: canvasMenuFeatureListInstantiator.count > 0
       width: parent.width
-      visible: canvasMenuFeatureListInstantiator.count > 0
+      visible: enabled
+      height: enabled ? undefined : 0
     }
 
     Instantiator {
@@ -2457,7 +2459,6 @@ ApplicationWindow {
 
         title: layerName + ': ' + featureName
         font: Theme.defaultFont
-        leftPadding: 10
 
         width: {
             var result = 0;

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -907,18 +907,19 @@ ApplicationWindow {
         return newY;
     }
 
+    textFormat: Text.PlainText
     text: {
       if ((qfieldSettings.numericalDigitizingInformation && stateMachine.state === "digitize" ) || stateMachine.state === 'measure') {
         var point = GeometryUtils.reprojectPoint(coordinateLocator.currentCoordinate, coordinateLocator.mapSettings.destinationCrs, projectInfo.coordinateDisplayCrs)
         var coordinates;
         if (coordinatesIsXY) {
-          coordinates = '<p>%1: %2<br>%3: %4</p>'
+          coordinates = '%1: %2\n%3: %4\n'
                         .arg(coordinatesIsGeographic ? qsTr( 'Lon' ) : 'X')
                         .arg(point.x.toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 5 : 2 ))
                         .arg(coordinatesIsGeographic ? qsTr( 'Lat' ) : 'Y')
                         .arg(point.y.toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 5 : 2 ));
         } else {
-          coordinates = '<p>%1: %2<br>%3: %4</p>'
+          coordinates = '%1: %2\n%3: %4\n'
                         .arg(coordinatesIsGeographic ? qsTr( 'Lat' ) : 'Y')
                         .arg(point.y.toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 5 : 2 ))
                         .arg(coordinatesIsGeographic ? qsTr( 'Lon' ) : 'X')
@@ -931,31 +932,31 @@ ApplicationWindow {
                      : '')
 
                 .arg(digitizingGeometryMeasure.lengthValid && digitizingGeometryMeasure.segmentLength != 0.0
-                     ? '<p>%1: %2</p>'
+                     ? '%1: %2\n'
                        .arg( digitizingGeometryMeasure.segmentLength != digitizingGeometryMeasure.length ? qsTr( 'Segment') : qsTr( 'Length' ) )
                        .arg(UnitTypes.formatDistance( digitizingGeometryMeasure.convertLengthMeansurement( digitizingGeometryMeasure.segmentLength, projectInfo.distanceUnits ) , 3, projectInfo.distanceUnits ) )
                      : '')
 
                 .arg(digitizingGeometryMeasure.lengthValid && digitizingGeometryMeasure.segmentLength != 0.0
-                     ? '<p>%1: %2</p>'
+                     ? '%1: %2\n'
                        .arg( qsTr( 'Azimuth') )
                        .arg( UnitTypes.formatAngle( digitizingGeometryMeasure.azimuth < 0 ? digitizingGeometryMeasure.azimuth + 360 : digitizingGeometryMeasure.azimuth, 2, Qgis.AngleUnit.Degrees ) )
                      : '')
 
                 .arg(currentRubberband.model && currentRubberband.model.geometryType === Qgis.GeometryType.Polygon
                      ? digitizingGeometryMeasure.perimeterValid
-                       ? '<p>%1: %2</p>'
+                       ? '%1: %2\n'
                          .arg( qsTr( 'Perimeter') )
                          .arg(UnitTypes.formatDistance( digitizingGeometryMeasure.convertLengthMeansurement( digitizingGeometryMeasure.perimeter, projectInfo.distanceUnits ), 3, projectInfo.distanceUnits ) )
                        : ''
                      : digitizingGeometryMeasure.lengthValid && digitizingGeometryMeasure.segmentLength != digitizingGeometryMeasure.length
-                     ? '<p>%1: %2</p>'
+                     ? '%1: %2\n'
                        .arg( qsTr( 'Length') )
                        .arg(UnitTypes.formatDistance( digitizingGeometryMeasure.convertLengthMeansurement( digitizingGeometryMeasure.length, projectInfo.distanceUnits ),3, projectInfo.distanceUnits ) )
                      : '')
 
                 .arg(digitizingGeometryMeasure.areaValid
-                     ? '<p>%1: %2</p>'
+                     ? '%1: %2\n'
                      .arg( qsTr( 'Area') )
                      .arg(UnitTypes.formatArea( digitizingGeometryMeasure.convertAreaMeansurement( digitizingGeometryMeasure.area, projectInfo.areaUnits), 3, projectInfo.areaUnits ) )
                      : '')


### PR DESCRIPTION
Good lesson learned here: when a Text item's textFormat is set to anything but Text.PlainText, it'll enable a hover state (for hyperlinks) which interferes with HoverHandler items.

