### PR TITLE
Tweak search radius value to take into account Qt6's change from physical to logical DPI

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -562,7 +562,7 @@ ApplicationWindow {
 
       mapSettings: mapCanvas.mapSettings
       model:  isMenuRequest ? canvasMenuFeatureListModel : featureForm.model
-      searchRadiusMm: 3
+      searchRadiusMm: 5
     }
 
     /** A rubberband for measuring **/


### PR DESCRIPTION
When we migrated to Qt6, we had to change our map canvas DPI from physical to logical DPI here (https://github.com/opengisch/QField/blob/master/src/core/qgsquick/qgsquickmapcanvasmap.cpp#L283). It resulted in a smaller search area on Android, which makes it quite hard to hit points.

The PR adjusts the value to be friendlier on highdpi screens using Qt6.