### PR TITLE
Skip antenna height correction when IMU is active

### DIFF
--- a/src/core/positioning/internalgnssreceiver.cpp
+++ b/src/core/positioning/internalgnssreceiver.cpp
@@ -15,6 +15,7 @@
  ***************************************************************************/
 
 #include "internalgnssreceiver.h"
+#include "positioning.h"
 
 #include <QGuiApplication>
 #include <qgsapplication.h>
@@ -132,10 +133,15 @@ void InternalGnssReceiver::handlePositionUpdated( const QGeoPositionInfo &positi
     longitude = positionInfo.coordinate().longitude();
     updatePositionInformation = true;
   }
+
+  double antennaHeight = 0.0;
+  if ( Positioning *positioning = qobject_cast<Positioning *>( parent() ) )
+    antennaHeight = positioning->antennaHeight();
+
   double elevation = mLastGnssPositionInformation.elevation();
   if ( !qgsDoubleNear( positionInfo.coordinate().altitude(), elevation ) )
   {
-    elevation = positionInfo.coordinate().altitude();
+    elevation = positionInfo.coordinate().altitude() - antennaHeight;
     updatePositionInformation = true;
   }
 

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -250,10 +250,6 @@ void Positioning::lastGnssPositionInformationChanged( const GnssPositionInformat
     mSourcePosition.clear();
   }
 
-  // With IMU active the antenna height is corrected by the device
-  if ( mAntennaHeight && !mPositionInformation.imuCorrection() )
-    mSourcePosition.setZ( mSourcePosition.z() - mAntennaHeight );
-
   if ( mCoordinateTransformer )
   {
     mCoordinateTransformer->setSourcePosition( mSourcePosition );

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -133,6 +133,16 @@ void Positioning::setEllipsoidalElevation( bool ellipsoidal )
   emit ellipsoidalElevationChanged();
 }
 
+void Positioning::setAntennaHeight( double antennaHeight )
+{
+  if ( mAntennaHeight == antennaHeight )
+    return;
+
+  mAntennaHeight = antennaHeight;
+
+  emit antennaHeightChanged();
+}
+
 void Positioning::setCoordinateTransformer( QgsQuickCoordinateTransformer *coordinateTransformer )
 {
   if ( mCoordinateTransformer == coordinateTransformer )
@@ -239,6 +249,10 @@ void Positioning::lastGnssPositionInformationChanged( const GnssPositionInformat
   {
     mSourcePosition.clear();
   }
+
+  // With IMU active the antenna height is corrected by the device
+  if ( mAntennaHeight && !mPositionInformation.imuCorrection() )
+    mSourcePosition.setZ( mSourcePosition.z() - mAntennaHeight );
 
   if ( mCoordinateTransformer )
   {

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -51,6 +51,7 @@ class Positioning : public QObject
     Q_PROPERTY( int averagedPositionCount READ averagedPositionCount NOTIFY averagedPositionCountChanged )
 
     Q_PROPERTY( bool ellipsoidalElevation READ ellipsoidalElevation WRITE setEllipsoidalElevation NOTIFY ellipsoidalElevationChanged )
+    Q_PROPERTY( double antennaHeight READ antennaHeight WRITE setAntennaHeight NOTIFY antennaHeightChanged )
 
     Q_PROPERTY( bool logging READ logging WRITE setLogging NOTIFY loggingChanged )
 
@@ -156,6 +157,19 @@ class Positioning : public QObject
     void setEllipsoidalElevation( bool ellipsoidal );
 
     /**
+     * Sets the GNSS device antenna height. This should be the pole height + sensore phase height.
+     * \note When IMU is active this value is ignored as the device does the correction internally.
+    **/
+    double antennaHeight() const { return mAntennaHeight; }
+
+    /**
+     * Returns the GNSS device antenna height. This should be the pole height + sensore phase height.
+     * \note When IMU is active this value is ignored as the device does the correction internally.
+    **/
+    void setAntennaHeight( double antennaHeight );
+
+
+    /**
      * Returns whether GNSS devices will log their incoming position stream into a logfile.
      * \note Requires a device type with logging capability
      */
@@ -179,6 +193,7 @@ class Positioning : public QObject
     void averagedPositionCountChanged();
     void projectedPositionChanged();
     void ellipsoidalElevationChanged();
+    void antennaHeightChanged();
     void loggingChanged();
 
   private slots:
@@ -209,6 +224,7 @@ class Positioning : public QObject
     bool mAveragedPosition = false;
 
     bool mEllipsoidalElevation = false;
+    double mAntennaHeight = 0.0;
 
     bool mLogging = false;
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -209,12 +209,13 @@ ApplicationWindow {
     coordinateTransformer: CoordinateTransformer {
       destinationCrs: mapCanvas.mapSettings.destinationCrs
       transformContext: qgisProject ? qgisProject.transformContext : CoordinateReferenceSystemUtils.emptyTransformContext()
-      deltaZ: positioningSettings.antennaHeightActivated ? positioningSettings.antennaHeight * -1 : 0
+      deltaZ: 0
       skipAltitudeTransformation: positioningSettings.skipAltitudeCorrection
       verticalGrid: positioningSettings.verticalGrid
     }
 
     ellipsoidalElevation: positioningSettings.ellipsoidalElevation
+    antennaHeight: positioningSettings.antennaHeightActivated ? positioningSettings.antennaHeight : 0
     logging: positioningSettings.logging
 
     onProjectedPositionChanged: {


### PR DESCRIPTION
When IMU is active, the GNSS device provides the position at the end of the pole.
The antenna height must not be subtracted again from the Z value.