### PR TITLE
Force deferred repaint for all layer requests when tracking is on

### DIFF
--- a/src/core/qgsquick/qgsquickmapcanvasmap.cpp
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.cpp
@@ -236,9 +236,9 @@ void QgsQuickMapCanvasMap::layerRepaintRequested( bool deferred )
 
   if ( !mFreeze )
   {
-    if ( deferred )
+    if ( deferred || mForceDeferredLayersRepaint )
     {
-      if ( !mJob )
+      if ( !mJob && !mRefreshTimer.isActive() )
       {
         mSilentRefresh = true;
         refresh();
@@ -368,6 +368,20 @@ void QgsQuickMapCanvasMap::setQuality( double quality )
 
   // And trigger a new rendering job
   refresh();
+}
+
+bool QgsQuickMapCanvasMap::forceDeferredLayersRepaint() const
+{
+  return mForceDeferredLayersRepaint;
+}
+
+void QgsQuickMapCanvasMap::setForceDeferredLayersRepaint( bool deferred )
+{
+  if ( mForceDeferredLayersRepaint == deferred )
+    return;
+
+  mForceDeferredLayersRepaint = deferred;
+  emit forceDeferredLayersRepaintChanged();
 }
 
 bool QgsQuickMapCanvasMap::freeze() const

--- a/src/core/qgsquick/qgsquickmapcanvasmap.h
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.h
@@ -93,6 +93,11 @@ class QgsQuickMapCanvasMap : public QQuickItem
      */
     Q_PROPERTY( double quality READ quality WRITE setQuality NOTIFY qualityChanged )
 
+    /**
+     * When the forceDeferredLayersRepaint property is set to true, all layer repaint signals will be deferred.
+     */
+    Q_PROPERTY( double forceDeferredLayersRepaint READ forceDeferredLayersRepaint WRITE setForceDeferredLayersRepaint NOTIFY forceDeferredLayersRepaintChanged )
+
   public:
     //! Create map canvas map
     explicit QgsQuickMapCanvasMap( QQuickItem *parent = nullptr );
@@ -130,6 +135,12 @@ class QgsQuickMapCanvasMap : public QQuickItem
     //! \copydoc QgsQuickMapCanvasMap::incrementalRendering
     void setQuality( double quality );
 
+    //!\copydoc QgsQuickMapCanvasMap::forceDeferredLayersRepaint
+    bool forceDeferredLayersRepaint() const;
+
+    //!\copydoc QgsQuickMapCanvasMap::forceDeferredLayersRepaint
+    void setForceDeferredLayersRepaint( bool deferred );
+
     /**
      * Returns an image of the last successful map canvas rendering
      */
@@ -161,6 +172,9 @@ class QgsQuickMapCanvasMap : public QQuickItem
 
     //!\copydoc QgsQuickMapCanvasMap::quality
     void qualityChanged();
+
+    //!\copydoc QgsQuickMapCanvasMap::forceDeferredLayersRepaint
+    void forceDeferredLayersRepaintChanged();
 
   protected:
 #if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
@@ -233,6 +247,7 @@ class QgsQuickMapCanvasMap : public QQuickItem
     bool mSilentRefresh = false;
     bool mDeferredRefreshPending = false;
     double mQuality = 1.0;
+    bool mForceDeferredLayersRepaint = false;
 
     QQuickWindow *mWindow = nullptr;
 };

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -117,7 +117,7 @@ void Tracker::start()
   {
     mTimeIntervalFulfilled = true;
   }
-  if ( mMinimumDistance > 0 || qgsDoubleNear( mTimeInterval, 0.0 ) )
+  if ( mMinimumDistance > 0 || ( qgsDoubleNear( mTimeInterval, 0.0 ) && !mSensorCapture ) )
   {
     connect( mRubberbandModel, &RubberbandModel::currentCoordinateChanged, this, &Tracker::positionReceived );
   }
@@ -161,7 +161,7 @@ void Tracker::stop()
     mTimer.stop();
     disconnect( &mTimer, &QTimer::timeout, this, &Tracker::trackPosition );
   }
-  if ( mMinimumDistance > 0 )
+  if ( mMinimumDistance > 0 || ( qgsDoubleNear( mTimeInterval, 0.0 ) && !mSensorCapture ) )
   {
     disconnect( mRubberbandModel, &RubberbandModel::currentCoordinateChanged, this, &Tracker::positionReceived );
   }

--- a/src/qml/MapCanvas.qml
+++ b/src/qml/MapCanvas.qml
@@ -27,6 +27,7 @@ Item {
   property alias isRendering: mapCanvasWrapper.isRendering
   property alias incrementalRendering: mapCanvasWrapper.incrementalRendering
   property alias quality: mapCanvasWrapper.quality
+  property alias forceDeferredLayersRepaint: mapCanvasWrapper.forceDeferredLayersRepaint
 
   property bool interactive: true
   property bool hovered: false

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -453,6 +453,7 @@ ApplicationWindow {
       interactive: !screenLocker.enabled
       incrementalRendering: true
       quality: qfieldSettings.quality
+      forceDeferredLayersRepaint: trackings.count > 0
       freehandDigitizing: freehandButton.freehandDigitizing && freehandHandler.active
 
       anchors.fill: parent


### PR DESCRIPTION
This PR implements a mean to force deferred repaints for all layer repaint requests _when one or more tracking sessions are ongoing_ to avoid a "frozen" map canvas state when tracked feature addition/change's repaint trigger interval is smaller than the time it takes to draw the canvas.