### PR TITLE
Feature form's text widget implementation

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -208,7 +208,7 @@ void AttributeFormModelBase::resetModel()
           item->setData( element->name(), AttributeFormModel::Name );
           item->setData( "container", AttributeFormModel::ElementType );
           item->setData( QString(), AttributeFormModel::GroupName );
-          item->setData( QVariant(), AttributeFormModel::GroupIndex );
+          item->setData( QModelIndex(), AttributeFormModel::GroupIndex );
           item->setData( true, AttributeFormModel::CurrentlyVisible );
           item->setData( true, AttributeFormModel::ConstraintHardValid );
           item->setData( true, AttributeFormModel::ConstraintSoftValid );
@@ -353,7 +353,7 @@ void AttributeFormModelBase::buildForm( QgsAttributeEditorContainer *container, 
     item->setData( columnCount, AttributeFormModel::ColumnCount );
     item->setData( currentTabIndex, AttributeFormModel::TabIndex );
     item->setData( QString(), AttributeFormModel::GroupName );
-    item->setData( QVariant(), AttributeFormModel::GroupIndex );
+    item->setData( QModelIndex(), AttributeFormModel::GroupIndex );
     item->setData( true, AttributeFormModel::ConstraintHardValid );
     item->setData( true, AttributeFormModel::ConstraintSoftValid );
 

--- a/src/core/attributeformmodelbase.h
+++ b/src/core/attributeformmodelbase.h
@@ -93,6 +93,9 @@ class AttributeFormModelBase : public QStandardItemModel
     //! Update default values refering to the \a fieldIndex.
     void updateDefaultValues( int fieldIndex = -1, QVector<int> updatedFields = QVector<int>() );
 
+    //! Update QML, HTML, and text widget code.
+    void updateEditorWidgetCodes( const QString &fieldName );
+
     //! Udate the visibility state of groups as well as constraints of field items
     void updateVisibilityAndConstraints( int fieldIndex = -1 );
 

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -246,6 +246,8 @@ Page {
         }
         opacity: textLabel.opacity
         color: Theme.mainTextColor
+        linkColor: Theme.mainColor
+        onLinkActivated: Qt.openUrlExternally(link)
       }
     }
   }

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -344,6 +344,45 @@ Page {
     }
   }
 
+  Component {
+    id: innerContainer
+
+    Item {
+      height: childrenRect.height
+      anchors {
+        left: parent.left
+        right: parent.right
+      }
+
+      Flow {
+        id: innerContainerContent
+        anchors {
+          left: parent.left
+          right: parent.right
+        }
+
+        Repeater {
+          model: SubModel {
+            id: innerSubModel
+            model: form.model
+            rootIndex: form.model.mapFromSource(containerGroupIndex)
+          }
+          delegate: fieldItem
+        }
+
+        Connections {
+          target: form.model
+
+          function onModelReset() {
+            if (containerGroupIndex !== undefined && innerContainer.visible) {
+              innerSubModel.rootIndex = form.model.mapFromSource(containerGroupIndex)
+            }
+          }
+        }
+      }
+    }
+  }
+
   /**
    * A field editor
    */
@@ -398,65 +437,23 @@ Page {
       Item {
         id: field
 
-        height: childrenRect.height
         anchors {
           top: fieldGroupTitle.bottom
           left: parent.left
           right: parent.right
         }
 
-        Item {
-          id: innerContainer
+        Loader {
+          property var containerGroupIndex: GroupIndex
 
-          property bool isVisible: GroupIndex != undefined && Type === 'container' && GroupIndex.valid
-
-          visible: isVisible
-          height: childrenRect.height
+          active: GroupIndex != undefined && Type === 'container' && GroupIndex.valid
+          height: active ? item.childrenRect.height : 0
           anchors {
             left: parent.left
             right: parent.right
           }
 
-          Loader {
-            id: innerContainerLoader
-            anchors {
-              left: parent.left
-              right: parent.right
-            }
-            sourceComponent: innerContainerComponent
-            active: innerContainer.isVisible
-          }
-
-          Component {
-            id: innerContainerComponent
-
-            Flow {
-              id: innerContainerContent
-              anchors {
-                left: parent.left
-                right: parent.right
-              }
-
-              Repeater {
-                model: SubModel {
-                  id: innerSubModel
-                  model: form.model
-                  rootIndex: form.model.mapFromSource(GroupIndex)
-                }
-                delegate: fieldItem
-              }
-
-              Connections {
-                target: form.model
-
-                function onModelReset() {
-                  if (innerContainerContent !== undefined && GroupIndex !== undefined && innerContainer.isVisible) {
-                    innerContainerContent.innerSubModel.rootIndex = form.model.mapFromSource(GroupIndex)
-                  }
-                }
-              }
-            }
-          }
+          sourceComponent: innerContainer
         }
 
         Loader {

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -385,6 +385,12 @@ Page {
     }
   }
 
+  Component {
+    id: dummyContainer
+
+    Item {}
+  }
+
   /**
    * A field editor
    */
@@ -446,36 +452,29 @@ Page {
         }
 
         Loader {
-          property var containerGroupIndex: GroupIndex
-
-          active: GroupIndex != undefined && Type === 'container' && GroupIndex.valid
-          height: active ? item.childrenRect.height : 0
-          anchors {
-            left: parent.left
-            right: parent.right
-          }
-
-          sourceComponent: innerContainer
-        }
-
-        Loader {
           property string containerName: Name || ''
           property string containerCode: EditorWidgetCode || ''
+          property var containerGroupIndex: GroupIndex
           property var labelOverrideColor: LabelOverrideColor
           property var labelColor: LabelColor
 
-          active: (Type === 'text' || Type === 'html' || Type === 'qml') && form.model.featureModel.modelMode != FeatureModel.MultiFeatureModel
+          active: (Type === 'container' && GroupIndex !== undefined && GroupIndex.valid) ||
+                  ((Type === 'text' || Type === 'html' || Type === 'qml') && form.model.featureModel.modelMode != FeatureModel.MultiFeatureModel)
           height: active ? item.childrenRect.height : 0
           anchors {
             left: parent.left
             right: parent.right
           }
 
-          sourceComponent: Type === 'qml'
-                           ? qmlContainer
-                           : Type === 'text'
-                             ? textContainer
-                             : htmlContainer
+          sourceComponent: Type === 'container' && GroupIndex !== undefined && GroupIndex.valid
+                           ? innerContainer
+                           : Type === 'qml'
+                             ? qmlContainer
+                             : Type === 'html'
+                               ? htmlContainer
+                               : Type === 'text'
+                                 ? textContainer
+                                 : dummyContainer
         }
 
         Item {

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -342,7 +342,7 @@ Page {
 
         onLoadingChanged: {
           if ( !loading ) {
-            runJavaScript("document.body.offsetHeight", function(result) { htmlItem.height = (result + 20) } );
+            runJavaScript("document.body.offsetHeight", function(result) { htmlItem.height = (result + 18) } );
           }
         }
       }

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -207,6 +207,49 @@ Page {
     }
   }
 
+  Component {
+    id: textContainer
+
+    Item {
+      height: childrenRect.height
+      anchors {
+        left: parent.left
+        right: parent.right
+        leftMargin: 12
+      }
+
+      Label {
+        id: textLabel
+        width: parent.width
+        text: containerName
+        wrapMode: Text.WordWrap
+        font.pointSize: Theme.tinyFont.pointSize
+        font.bold: true
+        topPadding: 10
+        bottomPadding: 5
+        opacity: form.state === 'ReadOnly' || embedded && EditorWidget === 'RelationEditor'
+                 ? 0.45
+                 : 1
+        color: labelOverrideColor !== undefined && labelOverrideColor ? labelColor : Theme.mainTextColor
+      }
+
+      Text {
+        id: textContent
+        width: parent.width
+        text: containerCode
+        wrapMode: Text.WordWrap
+        font: Theme.defaultFont
+        anchors {
+          left: parent.left
+          right: parent.right
+          top: textLabel.bottom
+        }
+        opacity: textLabel.opacity
+        color: Theme.mainTextColor
+      }
+    }
+  }
+
   /**
    * A field editor
    */
@@ -320,6 +363,23 @@ Page {
               }
             }
           }
+        }
+
+        Loader {
+          property string containerName: Name || ''
+          property string containerCode: EditorWidgetCode || ''
+          property var labelOverrideColor: LabelOverrideColor
+          property var labelColor: LabelColor
+
+          active: Type === 'text' && form.model.featureModel.modelMode != FeatureModel.MultiFeatureModel
+
+          height: active ? item.childrenRect.height : 0
+          anchors {
+            left: parent.left
+            right: parent.right
+          }
+
+          sourceComponent: textContainer
         }
 
         Item {

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -325,6 +325,7 @@ Page {
 
       WebView {
         id: htmlItem
+        height: 0
         anchors {
           left: parent.left
           right: parent.right
@@ -334,13 +335,21 @@ Page {
 
         property string code: containerCode
         onCodeChanged: {
-          loadHtml(code);
+          if (parent.visible) {
+            loadHtml(code);
+          }
         }
 
         onLoadingChanged: {
           if ( !loading ) {
-            runJavaScript("document.body.offsetHeight", function(result) { htmlItem.height = ( result + 30 ) } );
+            runJavaScript("document.body.offsetHeight", function(result) { htmlItem.height = (result + 20) } );
           }
+        }
+      }
+
+      onVisibleChanged: {
+        if (visible) {
+          htmlItem.loadHtml(htmlItem.code);
         }
       }
     }


### PR DESCRIPTION
This PR implements support for the {attribute,feature} form's text widget. The implementation takes a slightly different path from that of the QML and HTML container and apply the new path to the latter two; I'm hoping will result in faster feature form loading as it kills a few unnecessary QML item creations.

The PR also makes the text editor widget (as well as its QML and HTML siblings) dynamic and responsive to feature attribute value change as the feature is being edited.

Simple example: notice how the text editor's "parent feature details" text value changes as I'm picking a different parent feature in a parent<->child relationship:

[Screencast from 2023-08-23 18-22-42.webm](https://github.com/opengisch/QField/assets/1728657/5326beac-3aa3-4491-bcbe-73db155cdf7d)
