### PR TITLE
Catch missing android activity and inform users instead of crashing

### DIFF
--- a/platform/android/res/values/strings.xml
+++ b/platform/android/res/values/strings.xml
@@ -71,4 +71,7 @@
     <string name="import_project_wait">Please wait while QField is importing the project</string>
     <string name="import_dataset_wait">Please wait while QField is importing the dataset(s)</string>
     <string name="upload_pending_attachments">Currently uploading attachments to QFieldCloud</string>
+    <string name="operation_unsupported">Operation Unsupported</string>
+    <string name="import_operation_unsupported">Your device does not support this import operation.</string>
+    <string name="export_operation_unsupported">Your device does not support this export operation.</string>
 </resources>

--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -571,7 +571,14 @@ public class QFieldActivity extends QtActivity {
         intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
         intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
         intent.setType("*/*");
-        startActivityForResult(intent, R.id.import_dataset);
+        try {
+            startActivityForResult(intent, R.id.import_dataset);
+        } catch (ActivityNotFoundException e) {
+            displayAlertDialog(
+                getString(R.string.operation_unsupported),
+                getString(R.string.import_operation_unsupported));
+            Log.w("QField", "No activity found for ACTION_OPEN_DOCUMENT.");
+        }
         return;
     }
 
@@ -584,6 +591,9 @@ public class QFieldActivity extends QtActivity {
         try {
             startActivityForResult(intent, R.id.import_project_folder);
         } catch (ActivityNotFoundException e) {
+            displayAlertDialog(
+                getString(R.string.operation_unsupported),
+                getString(R.string.import_operation_unsupported));
             Log.w("QField", "No activity found for ACTION_OPEN_DOCUMENT_TREE.");
         }
         return;
@@ -596,7 +606,14 @@ public class QFieldActivity extends QtActivity {
         intent.addFlags(Intent.FLAG_GRANT_PREFIX_URI_PERMISSION);
         intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
         intent.setType("application/zip");
-        startActivityForResult(intent, R.id.import_project_archive);
+        try {
+            startActivityForResult(intent, R.id.import_project_archive);
+        } catch (ActivityNotFoundException e) {
+            displayAlertDialog(
+                getString(R.string.operation_unsupported),
+                getString(R.string.import_operation_unsupported));
+            Log.w("QField", "No activity found for ACTION_OPEN_DOCUMENT.");
+        }
         return;
     }
 
@@ -644,6 +661,9 @@ public class QFieldActivity extends QtActivity {
         try {
             startActivityForResult(intent, R.id.export_to_folder);
         } catch (ActivityNotFoundException e) {
+            displayAlertDialog(
+                getString(R.string.operation_unsupported),
+                getString(R.string.export_operation_unsupported));
             Log.w("QField", "No activity found for ACTION_OPEN_DOCUMENT_TREE.");
         }
         return;


### PR DESCRIPTION
@m-kuhn , @ZsanettMed , fixes a crash reported on sentry-db-fwd (https://opengisch.sentry.io/issues/4041139270/?project=4504830515085312&query=is%3Aunresolved&referrer=issue-stream&stream_index=3)