### PR TITLE
Make the accept audio recording button valid state much more visible

### DIFF
--- a/src/qml/imports/QFieldControls/+Qt5/QFieldAudioRecorder.qml
+++ b/src/qml/imports/QFieldControls/+Qt5/QFieldAudioRecorder.qml
@@ -266,13 +266,13 @@ Popup {
 
         QfToolButton {
           id: acceptButton
-          Layout.alignment: Qt.AlignVCenter
-          round: true
-          iconSource: Theme.getThemeIcon( 'ic_check_black_48dp' )
-          iconColor: Theme.mainTextColor
-          bgcolor: "transparent"
           enabled: audioRecorder.hasRecordedClip
-          opacity: enabled ? 1 : 0.25
+          opacity: enabled ? 1 : 0.2
+          Layout.alignment: Qt.AlignVCenter
+          iconSource: Theme.getThemeIcon( 'ic_check_black_48dp' )
+          iconColor: enabled ? "white" : Theme.mainTextColor
+          bgcolor: enabled ? Theme.mainColor : "transparent"
+          round: true
 
           onClicked: {
             var path = recorder.actualLocation.toString()

--- a/src/qml/imports/QFieldControls/+Qt6/QFieldAudioRecorder.qml
+++ b/src/qml/imports/QFieldControls/+Qt6/QFieldAudioRecorder.qml
@@ -269,13 +269,13 @@ Popup {
 
         QfToolButton {
           id: acceptButton
-          Layout.alignment: Qt.AlignVCenter
-          round: true
-          iconSource: Theme.getThemeIcon( 'ic_check_black_48dp' )
-          iconColor: Theme.mainTextColor
-          bgcolor: "transparent"
           enabled: audioRecorder.hasRecordedClip
-          opacity: enabled ? 1 : 0.25
+          opacity: enabled ? 1 : 0.2
+          Layout.alignment: Qt.AlignVCenter
+          iconSource: Theme.getThemeIcon( 'ic_check_black_48dp' )
+          iconColor: enabled ? "white" : Theme.mainTextColor
+          bgcolor: enabled ? Theme.mainColor : "transparent"
+          round: true
 
           onClicked: {
             var path = recorder.actualLocation.toString()


### PR DESCRIPTION
A UI/UX shortcoming identified when working on the code reader. Equivalent commit for the code reader UI here (https://github.com/opengisch/QField/pull/4539/commits/49502b5574f7ec05d4951dc232fd20a54b79fc81)