### PR TITLE
Brand new search bar active layer feature matching functionality + UI/UX improvements

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -18,6 +18,7 @@ set(QFIELD_CORE_SRCS
     qgsquick/qgsquickelevationprofilecanvas.cpp
     qgsquick/qgsquickmapsettings.cpp
     qgsquick/qgsquickmaptransform.cpp
+    locator/activelayerfeatureslocatorfilter.cpp
     locator/bookmarklocatorfilter.cpp
     locator/expressioncalculatorlocatorfilter.cpp
     locator/featureslocatorfilter.cpp
@@ -124,6 +125,7 @@ set(QFIELD_CORE_HDRS
     qgsquick/qgsquickelevationprofilecanvas.h
     qgsquick/qgsquickmapsettings.h
     qgsquick/qgsquickmaptransform.h
+    locator/activelayerfeatureslocatorfilter.h
     locator/bookmarklocatorfilter.h
     locator/expressioncalculatorlocatorfilter.h
     locator/featureslocatorfilter.h

--- a/src/core/locator/activelayerfeatureslocatorfilter.cpp
+++ b/src/core/locator/activelayerfeatureslocatorfilter.cpp
@@ -154,6 +154,7 @@ QStringList ActiveLayerFeaturesLocatorFilter::prepare( const QString &string, co
   mFieldIterator = layer->getFeatures( req );
 
   mLayerId = layer->id();
+  mLayerName = layer->name();
   mAttributeAliases.clear();
   for ( int idx = 0; idx < layer->fields().size(); ++idx )
   {
@@ -177,6 +178,7 @@ void ActiveLayerFeaturesLocatorFilter::fetchResults( const QString &string, cons
     {
       QgsLocatorResult result;
       result.displayString = QStringLiteral( "@%1" ).arg( field );
+      result.group = mLayerName;
       result.description = tr( "Limit the search to the field '%1'" ).arg( field );
       result.userData = QVariantMap( { { QStringLiteral( "type" ), QVariant::fromValue( ResultType::FieldRestriction ) },
                                        { QStringLiteral( "search_text" ), QStringLiteral( "%1 @%2 " ).arg( prefix(), field ) } } );
@@ -198,6 +200,7 @@ void ActiveLayerFeaturesLocatorFilter::fetchResults( const QString &string, cons
 
       QgsLocatorResult result;
       result.displayString = mDispExpression.evaluate( &mContext ).toString();
+      result.group = mLayerName;
 
       result.userData = QVariantList() << f.id() << mLayerId;
       result.score = static_cast<double>( searchString.length() ) / result.displayString.size();
@@ -247,7 +250,7 @@ void ActiveLayerFeaturesLocatorFilter::fetchResults( const QString &string, cons
     }
     if ( result.displayString.isEmpty() )
       continue; //not sure how this result slipped through...
-
+    result.group = mLayerName;
     result.description = mDispExpression.evaluate( &mContext ).toString();
     result.userData = QVariantList() << f.id() << mLayerId;
     result.score = static_cast<double>( searchString.length() ) / result.displayString.size();

--- a/src/core/locator/activelayerfeatureslocatorfilter.cpp
+++ b/src/core/locator/activelayerfeatureslocatorfilter.cpp
@@ -47,7 +47,9 @@ QString ActiveLayerFeaturesLocatorFilter::fieldRestriction( QString &searchStrin
   QString _fieldRestriction;
   searchString = searchString.trimmed();
   if ( isRestricting )
+  {
     *isRestricting = searchString.startsWith( '@' );
+  }
   if ( searchString.startsWith( '@' ) )
   {
     _fieldRestriction = searchString.left( std::min( searchString.indexOf( ' ' ), searchString.length() ) ).remove( 0, 1 );
@@ -84,7 +86,9 @@ QStringList ActiveLayerFeaturesLocatorFilter::prepare( const QString &string, co
     QgsFeatureRequest req;
     req.setSubsetOfAttributes( qgis::setToList( mDispExpression.referencedAttributeIndexes( layer->fields() ) ) );
     if ( !mDispExpression.needsGeometry() )
+    {
       req.setFlags( QgsFeatureRequest::NoGeometry );
+    }
     QString enhancedSearch = searchString;
     enhancedSearch.replace( ' ', '%' );
     req.setFilterExpression( QStringLiteral( "%1 ILIKE '%%2%'" )
@@ -105,7 +109,9 @@ QStringList ActiveLayerFeaturesLocatorFilter::prepare( const QString &string, co
   for ( const QgsField &field : fields )
   {
     if ( field.configurationFlags().testFlag( QgsField::ConfigurationFlag::NotSearchable ) )
+    {
       continue;
+    }
 
     if ( isRestricting )
     {
@@ -145,10 +151,14 @@ QStringList ActiveLayerFeaturesLocatorFilter::prepare( const QString &string, co
 
   QgsFeatureRequest req;
   if ( !mDispExpression.needsGeometry() )
+  {
     req.setFlags( QgsFeatureRequest::NoGeometry );
+  }
   req.setFilterExpression( expression );
   if ( isRestricting )
+  {
     req.setSubsetOfAttributes( subsetOfAttributes );
+  }
 
   req.setLimit( mMaxTotalResults );
   mFieldIterator = layer->getFeatures( req );
@@ -241,9 +251,13 @@ void ActiveLayerFeaturesLocatorFilter::fetchResults( const QString &string, cons
       if ( attrString.contains( searchString, Qt::CaseInsensitive ) )
       {
         if ( idx < mAttributeAliases.count() )
+        {
           result.displayString = QStringLiteral( "%1 (%2)" ).arg( attrString, mAttributeAliases[idx] );
+        }
         else
+        {
           result.displayString = attrString;
+        }
         break;
       }
       idx++;
@@ -378,9 +392,13 @@ void ActiveLayerFeaturesLocatorFilter::triggerResultFromAction( const QgsLocator
           }
 
           if ( r.isEmpty() || mLocatorBridge->keepScale() )
+          {
             mLocatorBridge->mapSettings()->setCenter( QgsPoint( r.center() ) );
+          }
           else
+          {
             mLocatorBridge->mapSettings()->setExtent( r );
+          }
 
           mLocatorBridge->locatorHighlightGeometry()->setProperty( "qgsGeometry", geom );
           mLocatorBridge->locatorHighlightGeometry()->setProperty( "crs", layer->crs() );

--- a/src/core/locator/activelayerfeatureslocatorfilter.cpp
+++ b/src/core/locator/activelayerfeatureslocatorfilter.cpp
@@ -1,0 +1,390 @@
+/***************************************************************************
+  activelayerfeatureslocatorfilter.cpp
+
+ ---------------------
+ begin                : 30.08.2023
+ copyright            : (C) 2023 by Mathieu Pellerin
+ email                : mathieu@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "activelayerfeatureslocatorfilter.h"
+#include "featurelistextentcontroller.h"
+#include "locatormodelsuperbridge.h"
+#include "qgsgeometrywrapper.h"
+#include "qgsquickmapsettings.h"
+
+#include <QAction>
+#include <qgsexpressioncontextutils.h>
+#include <qgsfeedback.h>
+#include <qgsmaplayermodel.h>
+#include <qgsproject.h>
+#include <qgsvectorlayer.h>
+
+#include <math.h>
+
+
+ActiveLayerFeaturesLocatorFilter::ActiveLayerFeaturesLocatorFilter( LocatorModelSuperBridge *locatorBridge, QObject *parent )
+  : QgsLocatorFilter( parent )
+  , mLocatorBridge( locatorBridge )
+{
+  setUseWithoutPrefix( false );
+}
+
+ActiveLayerFeaturesLocatorFilter *ActiveLayerFeaturesLocatorFilter::clone() const
+{
+  return new ActiveLayerFeaturesLocatorFilter( mLocatorBridge );
+}
+
+QString ActiveLayerFeaturesLocatorFilter::fieldRestriction( QString &searchString, bool *isRestricting )
+{
+  QString _fieldRestriction;
+  searchString = searchString.trimmed();
+  if ( isRestricting )
+    *isRestricting = searchString.startsWith( '@' );
+  if ( searchString.startsWith( '@' ) )
+  {
+    _fieldRestriction = searchString.left( std::min( searchString.indexOf( ' ' ), searchString.length() ) ).remove( 0, 1 );
+    searchString = searchString.mid( _fieldRestriction.length() + 2 );
+  }
+  return _fieldRestriction;
+}
+
+QStringList ActiveLayerFeaturesLocatorFilter::prepare( const QString &string, const QgsLocatorContext &locatorContext )
+{
+  // Normally skip very short search strings, unless when specifically searching using this filter or try to match fields
+  if ( string.length() < 3 && !locatorContext.usingPrefix && !string.startsWith( '@' ) )
+    return QStringList();
+
+  QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( mLocatorBridge->activeLayer() );
+  if ( !layer )
+    return QStringList();
+
+  mLayerIsSpatial = layer->isSpatial();
+  mDispExpression = QgsExpression( layer->displayExpression() );
+  mContext.appendScopes( QgsExpressionContextUtils::globalProjectLayerScopes( layer ) );
+  mDispExpression.prepare( &mContext );
+
+  // determine if search is restricted to a specific field
+  QString searchString = string;
+  bool isRestricting = false;
+  QString _fieldRestriction = fieldRestriction( searchString, &isRestricting );
+  bool allowNumeric = false;
+  double numericalValue = searchString.toDouble( &allowNumeric );
+
+  // search in display expression if no field restriction
+  if ( !isRestricting )
+  {
+    QgsFeatureRequest req;
+    req.setSubsetOfAttributes( qgis::setToList( mDispExpression.referencedAttributeIndexes( layer->fields() ) ) );
+    if ( !mDispExpression.needsGeometry() )
+      req.setFlags( QgsFeatureRequest::NoGeometry );
+    QString enhancedSearch = searchString;
+    enhancedSearch.replace( ' ', '%' );
+    req.setFilterExpression( QStringLiteral( "%1 ILIKE '%%2%'" )
+                               .arg( layer->displayExpression(), enhancedSearch ) );
+    req.setLimit( mMaxTotalResults );
+    mDisplayTitleIterator = layer->getFeatures( req );
+  }
+  else
+  {
+    mDisplayTitleIterator = QgsFeatureIterator();
+  }
+
+  // build up request expression
+  QStringList expressionParts;
+  QStringList completionList;
+  const QgsFields fields = layer->fields();
+  QgsAttributeList subsetOfAttributes = qgis::setToList( mDispExpression.referencedAttributeIndexes( layer->fields() ) );
+  for ( const QgsField &field : fields )
+  {
+    if ( field.configurationFlags().testFlag( QgsField::ConfigurationFlag::NotSearchable ) )
+      continue;
+
+    if ( isRestricting )
+    {
+      if ( !field.name().startsWith( _fieldRestriction ) )
+      {
+        continue;
+      }
+
+      int index = layer->fields().indexFromName( field.name() );
+      if ( !subsetOfAttributes.contains( index ) )
+      {
+        subsetOfAttributes << index;
+      }
+
+      // if we are trying to find a field (and not searching anything yet)
+      // keep the list of matching fields to display them as results
+      if ( searchString.isEmpty() && _fieldRestriction != field.name() )
+      {
+        mFieldsCompletion << field.name();
+      }
+    }
+
+    // the completion list (returned by the current method) is used by the locator line edit directly
+    completionList.append( QStringLiteral( "@%1 " ).arg( field.name() ) );
+
+    if ( field.type() == QVariant::String )
+    {
+      expressionParts << QStringLiteral( "%1 ILIKE '%%2%'" ).arg( QgsExpression::quotedColumnRef( field.name() ), searchString );
+    }
+    else if ( allowNumeric && field.isNumeric() )
+    {
+      expressionParts << QStringLiteral( "%1 = %2" ).arg( QgsExpression::quotedColumnRef( field.name() ), QString::number( numericalValue, 'g', 17 ) );
+    }
+  }
+
+  QString expression = QStringLiteral( "(%1)" ).arg( expressionParts.join( QLatin1String( " ) OR ( " ) ) );
+
+  QgsFeatureRequest req;
+  if ( !mDispExpression.needsGeometry() )
+    req.setFlags( QgsFeatureRequest::NoGeometry );
+  req.setFilterExpression( expression );
+  if ( isRestricting )
+    req.setSubsetOfAttributes( subsetOfAttributes );
+
+  req.setLimit( mMaxTotalResults );
+  mFieldIterator = layer->getFeatures( req );
+
+  mLayerId = layer->id();
+  mAttributeAliases.clear();
+  for ( int idx = 0; idx < layer->fields().size(); ++idx )
+  {
+    mAttributeAliases.append( layer->attributeDisplayName( idx ) );
+  }
+
+  return completionList;
+}
+
+void ActiveLayerFeaturesLocatorFilter::fetchResults( const QString &string, const QgsLocatorContext &, QgsFeedback *feedback )
+{
+  QgsFeatureIds featuresFound;
+  QgsFeature f;
+  QString searchString = string;
+  fieldRestriction( searchString );
+
+  if ( searchString.trimmed().isEmpty() )
+  {
+    // propose available fields for restriction
+    for ( const QString &field : std::as_const( mFieldsCompletion ) )
+    {
+      QgsLocatorResult result;
+      result.displayString = QStringLiteral( "@%1" ).arg( field );
+      result.description = tr( "Limit the search to the field '%1'" ).arg( field );
+      result.userData = QVariantMap( { { QStringLiteral( "type" ), QVariant::fromValue( ResultType::FieldRestriction ) },
+                                       { QStringLiteral( "search_text" ), QStringLiteral( "%1 @%2 " ).arg( prefix(), field ) } } );
+      result.score = 1;
+      emit resultFetched( result );
+    }
+    return;
+  }
+
+  // search in display title
+  if ( mDisplayTitleIterator.isValid() )
+  {
+    while ( mDisplayTitleIterator.nextFeature( f ) )
+    {
+      if ( feedback->isCanceled() )
+        return;
+
+      mContext.setFeature( f );
+
+      QgsLocatorResult result;
+      result.displayString = mDispExpression.evaluate( &mContext ).toString();
+
+      result.userData = QVariantList() << f.id() << mLayerId;
+      result.score = static_cast<double>( searchString.length() ) / result.displayString.size();
+      result.actions << QgsLocatorResult::ResultAction( OpenForm, tr( "Open form" ), QStringLiteral( "ic_baseline-list_alt-24px" ) );
+      if ( mLayerIsSpatial )
+      {
+        result.actions << QgsLocatorResult::ResultAction( Navigation, tr( "Set feature as destination" ), QStringLiteral( "ic_navigation_flag_purple_24dp" ) );
+      }
+
+      emit resultFetched( result );
+
+      featuresFound << f.id();
+      if ( featuresFound.count() >= mMaxTotalResults )
+        break;
+    }
+  }
+
+  // search in fields
+  while ( mFieldIterator.nextFeature( f ) )
+  {
+    if ( feedback->isCanceled() )
+      return;
+
+    // do not display twice the same feature
+    if ( featuresFound.contains( f.id() ) )
+      continue;
+
+    QgsLocatorResult result;
+
+    mContext.setFeature( f );
+
+    // find matching field content
+    int idx = 0;
+    const QgsAttributes attributes = f.attributes();
+    for ( const QVariant &var : attributes )
+    {
+      QString attrString = var.toString();
+      if ( attrString.contains( searchString, Qt::CaseInsensitive ) )
+      {
+        if ( idx < mAttributeAliases.count() )
+          result.displayString = QStringLiteral( "%1 (%2)" ).arg( attrString, mAttributeAliases[idx] );
+        else
+          result.displayString = attrString;
+        break;
+      }
+      idx++;
+    }
+    if ( result.displayString.isEmpty() )
+      continue; //not sure how this result slipped through...
+
+    result.description = mDispExpression.evaluate( &mContext ).toString();
+    result.userData = QVariantList() << f.id() << mLayerId;
+    result.score = static_cast<double>( searchString.length() ) / result.displayString.size();
+    result.actions << QgsLocatorResult::ResultAction( OpenForm, tr( "Open form" ), QStringLiteral( "ic_baseline-list_alt-24px" ) );
+    if ( mLayerIsSpatial )
+    {
+      result.actions << QgsLocatorResult::ResultAction( Navigation, tr( "Set feature as destination" ), QStringLiteral( "ic_navigation_flag_purple_24dp" ) );
+    }
+
+    emit resultFetched( result );
+
+    featuresFound << f.id();
+    if ( featuresFound.count() >= mMaxTotalResults )
+      break;
+  }
+}
+
+void ActiveLayerFeaturesLocatorFilter::triggerResult( const QgsLocatorResult &result )
+{
+  triggerResultFromAction( result, Normal );
+}
+
+void ActiveLayerFeaturesLocatorFilter::triggerResultFromAction( const QgsLocatorResult &result, const int actionId )
+{
+  QVariantMap data = result.userData.toMap();
+  switch ( data.value( QStringLiteral( "type" ) ).value<ResultType>() )
+  {
+    case ResultType::FieldRestriction:
+    {
+      QTimer::singleShot( 100, [=] { emit mLocatorBridge->requestSearchTextChange( data.value( "search_text" ).toString() ); } );
+      break;
+    }
+
+    case ResultType::Feature:
+    {
+      QVariantList dataList = result.userData.toList();
+      QgsFeatureId fid = dataList.at( 0 ).toLongLong();
+      QString layerId = dataList.at( 1 ).toString();
+      QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( layerId ) );
+      if ( !layer )
+        return;
+
+      QgsFeature feature;
+      QgsFeatureRequest featureRequest = QgsFeatureRequest().setFilterFid( fid );
+
+      switch ( actionId )
+      {
+        case OpenForm:
+        {
+          QMap<QgsVectorLayer *, QgsFeatureRequest> requests;
+          requests.insert( layer, featureRequest );
+          mLocatorBridge->featureListController()->model()->setFeatures( requests );
+          mLocatorBridge->featureListController()->selection()->setFocusedItem( 0 );
+          mLocatorBridge->featureListController()->requestFeatureFormState();
+          break;
+        }
+
+        case Navigation:
+        {
+          if ( !mLocatorBridge->navigation() )
+            return;
+
+          QgsFeatureIterator it = layer->getFeatures( featureRequest );
+          it.nextFeature( feature );
+          if ( feature.hasGeometry() )
+          {
+            mLocatorBridge->navigation()->setDestinationFeature( feature, layer );
+          }
+          else
+          {
+            mLocatorBridge->emitMessage( tr( "Feature has no geometry" ) );
+          }
+          break;
+        }
+
+        case Normal:
+        {
+          QgsFeatureIterator it = layer->getFeatures( featureRequest.setNoAttributes() );
+          it.nextFeature( feature );
+          const QgsGeometry geom = feature.geometry();
+          if ( geom.isNull() || geom.constGet()->isEmpty() )
+          {
+            mLocatorBridge->emitMessage( tr( "Feature has no geometry" ) );
+            return;
+          }
+          QgsRectangle r = mLocatorBridge->mapSettings()->mapSettings().layerExtentToOutputExtent( layer, geom.boundingBox() );
+
+          // zoom in if point cannot be distinguished from others
+          // code taken from QgsMapCanvas::zoomToSelected
+          if ( !mLocatorBridge->keepScale() )
+          {
+            if ( layer->geometryType() == Qgis::GeometryType::Point && r.isEmpty() )
+            {
+              int scaleFactor = 5;
+              const QgsPointXY center = mLocatorBridge->mapSettings()->mapSettings().mapToLayerCoordinates( layer, r.center() );
+              const QgsRectangle extentRect = mLocatorBridge->mapSettings()->mapSettings().mapToLayerCoordinates( layer, mLocatorBridge->mapSettings()->visibleExtent() ).scaled( 1.0 / scaleFactor, &center );
+              const QgsFeatureRequest pointRequest = QgsFeatureRequest().setFilterRect( extentRect ).setLimit( 1000 ).setNoAttributes();
+              QgsFeatureIterator fit = layer->getFeatures( pointRequest );
+              QgsFeature pointFeature;
+              QgsPointXY closestPoint;
+              double closestSquaredDistance = pow( extentRect.width() + extentRect.height(), 2.0 );
+              bool pointFound = false;
+              while ( fit.nextFeature( pointFeature ) )
+              {
+                QgsPointXY point = pointFeature.geometry().asPoint();
+                double sqrDist = point.sqrDist( center );
+                if ( sqrDist > closestSquaredDistance || sqrDist < 4 * std::numeric_limits<double>::epsilon() )
+                  continue;
+                pointFound = true;
+                closestPoint = point;
+                closestSquaredDistance = sqrDist;
+              }
+              if ( pointFound )
+              {
+                // combine selected point with closest point and scale this rect
+                r.combineExtentWith( mLocatorBridge->mapSettings()->mapSettings().layerToMapCoordinates( layer, closestPoint ) );
+                const QgsPointXY rCenter = r.center();
+                r.scale( scaleFactor, &rCenter );
+              }
+            }
+            else if ( !r.isEmpty() )
+            {
+              r.scale( 5 );
+            }
+          }
+
+          if ( r.isEmpty() || mLocatorBridge->keepScale() )
+            mLocatorBridge->mapSettings()->setCenter( QgsPoint( r.center() ) );
+          else
+            mLocatorBridge->mapSettings()->setExtent( r );
+
+          mLocatorBridge->locatorHighlightGeometry()->setProperty( "qgsGeometry", geom );
+          mLocatorBridge->locatorHighlightGeometry()->setProperty( "crs", layer->crs() );
+          break;
+        }
+      }
+      break;
+    }
+  }
+}

--- a/src/core/locator/activelayerfeatureslocatorfilter.h
+++ b/src/core/locator/activelayerfeatureslocatorfilter.h
@@ -1,0 +1,83 @@
+/***************************************************************************
+  activelayerfeatureslocatorfilter.h
+
+ ---------------------
+ begin                : 30.08.2023
+ copyright            : (C) 2023 by Mathieu Pellerin
+ email                : mathieu@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef ACTIVELAYERFEATURESLOCATORFILTER_H
+#define ACTIVELAYERFEATURESLOCATORFILTER_H
+
+#include <QObject>
+#include <qgsexpressioncontext.h>
+#include <qgslocatorfilter.h>
+#include <qgsvectorlayerfeatureiterator.h>
+
+
+class LocatorModelSuperBridge;
+
+/**
+ * FeaturesLocatorFilter is a locator filter to search
+ * for features across layers in the project.
+ * Reimplemented from QGIS code (app).
+ */
+class ActiveLayerFeaturesLocatorFilter : public QgsLocatorFilter
+{
+    Q_OBJECT
+
+  public:
+    //! Origin of the action which triggers the result
+    enum ActionOrigin
+    {
+      Normal,
+      OpenForm,
+      Navigation,
+    };
+
+    enum class ResultType
+    {
+      Feature,
+      FieldRestriction,
+    };
+    Q_ENUM( ResultType )
+
+    explicit ActiveLayerFeaturesLocatorFilter( LocatorModelSuperBridge *locatorBridge, QObject *parent = nullptr );
+    ActiveLayerFeaturesLocatorFilter *clone() const override;
+    // Note that the name is important here, has to match the QgsLocator::CORE_FILTERS one to give us a 1-letter prefix
+    QString name() const override { return QStringLiteral( "features" ); }
+    QString displayName() const override { return tr( "Features from active layer" ); }
+    Priority priority() const override { return Medium; }
+    QString prefix() const override { return QStringLiteral( "f" ); }
+
+    QStringList prepare( const QString &string, const QgsLocatorContext &locatorContext ) override;
+    void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) override;
+    void triggerResult( const QgsLocatorResult &result ) override;
+    void triggerResultFromAction( const QgsLocatorResult &result, const int actionId ) override;
+
+  private:
+    QString fieldRestriction( QString &searchString, bool *isRestricting = nullptr );
+
+    QgsExpression mDispExpression;
+    QgsExpressionContext mContext;
+    QgsFeatureIterator mDisplayTitleIterator;
+    QgsFeatureIterator mFieldIterator;
+    QString mLayerId;
+    bool mLayerIsSpatial = false;
+    QStringList mAttributeAliases;
+    QStringList mFieldsCompletion;
+
+    int mMaxTotalResults = 16;
+    LocatorModelSuperBridge *mLocatorBridge = nullptr;
+};
+
+#endif // ACTIVELAYERFEATURESLOCATORFILTER_H

--- a/src/core/locator/activelayerfeatureslocatorfilter.h
+++ b/src/core/locator/activelayerfeatureslocatorfilter.h
@@ -72,6 +72,7 @@ class ActiveLayerFeaturesLocatorFilter : public QgsLocatorFilter
     QgsFeatureIterator mDisplayTitleIterator;
     QgsFeatureIterator mFieldIterator;
     QString mLayerId;
+    QString mLayerName;
     bool mLayerIsSpatial = false;
     QStringList mAttributeAliases;
     QStringList mFieldsCompletion;

--- a/src/core/locator/locatormodelsuperbridge.cpp
+++ b/src/core/locator/locatormodelsuperbridge.cpp
@@ -189,6 +189,21 @@ QString LocatorModelSuperBridge::getLocatorModelDescrition( const int row )
   return proxyModel()->data( index, Qt::DisplayRole ).toString();
 }
 
+QString LocatorModelSuperBridge::getPrefixFromSreachString( const QString &string )
+{
+  QRegularExpression separatorRx( QStringLiteral( "^([^\\s]+)(?:\\s|$)" ) );
+  QRegularExpressionMatch match = separatorRx.match( string.trimmed() );
+  if ( match.hasMatch() )
+  {
+    if ( !locator()->filters( match.captured( 1 ) ).isEmpty() )
+    {
+      return match.captured( 1 );
+    }
+  }
+
+  return QString();
+}
+
 void LocatorModelSuperBridge::emitMessage( const QString &text )
 {
   emit messageEmitted( text );

--- a/src/core/locator/locatormodelsuperbridge.cpp
+++ b/src/core/locator/locatormodelsuperbridge.cpp
@@ -180,6 +180,15 @@ LocatorActionsModel *LocatorModelSuperBridge::contextMenuActionsModel( const int
   return model;
 }
 
+QString LocatorModelSuperBridge::getLocatorModelDescrition( const int row )
+{
+  const QModelIndex index = proxyModel()->index( row, 1 );
+  if ( !index.isValid() )
+    return nullptr;
+
+  return proxyModel()->data( index, Qt::DisplayRole ).toString();
+}
+
 void LocatorModelSuperBridge::emitMessage( const QString &text )
 {
   emit messageEmitted( text );

--- a/src/core/locator/locatormodelsuperbridge.cpp
+++ b/src/core/locator/locatormodelsuperbridge.cpp
@@ -180,7 +180,7 @@ LocatorActionsModel *LocatorModelSuperBridge::contextMenuActionsModel( const int
   return model;
 }
 
-QString LocatorModelSuperBridge::getLocatorModelDescrition( const int row )
+QString LocatorModelSuperBridge::getLocatorModelDescription( const int row )
 {
   const QModelIndex index = proxyModel()->index( row, 1 );
   if ( !index.isValid() )
@@ -189,7 +189,7 @@ QString LocatorModelSuperBridge::getLocatorModelDescrition( const int row )
   return proxyModel()->data( index, Qt::DisplayRole ).toString();
 }
 
-QString LocatorModelSuperBridge::getPrefixFromSreachString( const QString &string )
+QString LocatorModelSuperBridge::getPrefixFromSearchString( const QString &string )
 {
   QRegularExpression separatorRx( QStringLiteral( "^([^\\s]+)(?:\\s|$)" ) );
   QRegularExpressionMatch match = separatorRx.match( string.trimmed() );

--- a/src/core/locator/locatormodelsuperbridge.cpp
+++ b/src/core/locator/locatormodelsuperbridge.cpp
@@ -256,7 +256,7 @@ QHash<int, QByteArray> LocatorFiltersModel::roleNames() const
 QVariant LocatorFiltersModel::data( const QModelIndex &index, int role ) const
 {
   const static QMap<QString, QString> sLocatorFilterDescriptions = {
-    { QStringLiteral( "activelayerfeatures" ), tr( "Returns a list of features from the active layer with matching attributes" ) },
+    { QStringLiteral( "features" ), tr( "Returns a list of features from the active layer with matching attributes" ) },
     { QStringLiteral( "allfeatures" ), tr( "Returns a list of features accross all searchable layers with matching attributes" ) },
     { QStringLiteral( "goto" ), tr( "Returns a point from a pair of X and Y coordinates typed in the search bar" ) },
     { QStringLiteral( "bookmarks" ), tr( "Returns a list of bookmark with matching names" ) },

--- a/src/core/locator/locatormodelsuperbridge.cpp
+++ b/src/core/locator/locatormodelsuperbridge.cpp
@@ -36,11 +36,11 @@
 LocatorModelSuperBridge::LocatorModelSuperBridge( QObject *parent )
   : QgsLocatorModelBridge( parent )
 {
+  locator()->registerFilter( new ActiveLayerFeaturesLocatorFilter( this ) );
   locator()->registerFilter( new FeaturesLocatorFilter( this ) );
   locator()->registerFilter( new GotoLocatorFilter( this ) );
   locator()->registerFilter( new BookmarkLocatorFilter( this ) );
   locator()->registerFilter( new ExpressionCalculatorLocatorFilter( this ) );
-  locator()->registerFilter( new ActiveLayerFeaturesLocatorFilter( this ) );
 
   // Finnish's Digitransit geocoder
   mFinlandGeocoder = new PeliasGeocoder( QStringLiteral( "https://api.digitransit.fi/geocoding/v1/search" ) );
@@ -256,12 +256,12 @@ QHash<int, QByteArray> LocatorFiltersModel::roleNames() const
 QVariant LocatorFiltersModel::data( const QModelIndex &index, int role ) const
 {
   const static QMap<QString, QString> sLocatorFilterDescriptions = {
-    { QStringLiteral( "features" ), tr( "Returns a list of features from the active layer with matching attributes" ) },
-    { QStringLiteral( "allfeatures" ), tr( "Returns a list of features accross all searchable layers with matching attributes" ) },
-    { QStringLiteral( "goto" ), tr( "Returns a point from a pair of X and Y coordinates typed in the search bar" ) },
-    { QStringLiteral( "bookmarks" ), tr( "Returns a list of bookmark with matching names" ) },
-    { QStringLiteral( "calculator" ), tr( "Returns the value of the expression typed in the search bar" ) },
-    { QStringLiteral( "pelias-finland" ), tr( "Returns a list of locations and addresses within Finland with matching terms" ) } };
+    { QStringLiteral( "features" ), tr( "Returns a list of features from the active layer with matching attributes. Restricting matching to a single attribute is done by identifying its name prefixed with an '@'." ) },
+    { QStringLiteral( "allfeatures" ), tr( "Returns a list of features accross all searchable layers with matching display name." ) },
+    { QStringLiteral( "goto" ), tr( "Returns a point from a pair of X and Y coordinates - or WGS84 latitude and longitude - typed in the search bar." ) },
+    { QStringLiteral( "bookmarks" ), tr( "Returns a list of user and currently open project bookmarks with matching names." ) },
+    { QStringLiteral( "calculator" ), tr( "Returns the value of an expression typed in the search bar." ) },
+    { QStringLiteral( "pelias-finland" ), tr( "Returns a list of locations and addresses within Finland with matching terms." ) } };
 
   if ( !mLocatorModelSuperBridge->locator() || !index.isValid() || index.parent().isValid() || index.row() < 0 || index.row() >= rowCount( QModelIndex() ) )
     return QVariant();

--- a/src/core/locator/locatormodelsuperbridge.cpp
+++ b/src/core/locator/locatormodelsuperbridge.cpp
@@ -15,6 +15,7 @@
  ***************************************************************************/
 
 
+#include "activelayerfeatureslocatorfilter.h"
 #include "bookmarklocatorfilter.h"
 #include "expressioncalculatorlocatorfilter.h"
 #include "featurelistextentcontroller.h"
@@ -39,6 +40,7 @@ LocatorModelSuperBridge::LocatorModelSuperBridge( QObject *parent )
   locator()->registerFilter( new GotoLocatorFilter( this ) );
   locator()->registerFilter( new BookmarkLocatorFilter( this ) );
   locator()->registerFilter( new ExpressionCalculatorLocatorFilter( this ) );
+  locator()->registerFilter( new ActiveLayerFeaturesLocatorFilter( this ) );
 
   // Finnish's Digitransit geocoder
   mFinlandGeocoder = new PeliasGeocoder( QStringLiteral( "https://api.digitransit.fi/geocoding/v1/search" ) );
@@ -152,6 +154,11 @@ void LocatorModelSuperBridge::setKeepScale( bool keepScale )
   emit keepScaleChanged();
 }
 
+void LocatorModelSuperBridge::requestSearchTextChange( const QString &text )
+{
+  emit searchTextChangeRequested( text );
+}
+
 LocatorActionsModel *LocatorModelSuperBridge::contextMenuActionsModel( const int row )
 {
   const QModelIndex index = proxyModel()->index( row, 0 );
@@ -240,6 +247,7 @@ QHash<int, QByteArray> LocatorFiltersModel::roleNames() const
 QVariant LocatorFiltersModel::data( const QModelIndex &index, int role ) const
 {
   const static QMap<QString, QString> sLocatorFilterDescriptions = {
+    { QStringLiteral( "activelayerfeatures" ), tr( "Returns a list of features from the active layer with matching attributes" ) },
     { QStringLiteral( "allfeatures" ), tr( "Returns a list of features accross all searchable layers with matching attributes" ) },
     { QStringLiteral( "goto" ), tr( "Returns a point from a pair of X and Y coordinates typed in the search bar" ) },
     { QStringLiteral( "bookmarks" ), tr( "Returns a list of bookmark with matching names" ) },

--- a/src/core/locator/locatormodelsuperbridge.cpp
+++ b/src/core/locator/locatormodelsuperbridge.cpp
@@ -124,6 +124,20 @@ void LocatorModelSuperBridge::setFeatureListController( FeatureListExtentControl
   emit featureListControllerChanged();
 }
 
+QgsMapLayer *LocatorModelSuperBridge::activeLayer() const
+{
+  return mActiveLayer.data();
+}
+
+void LocatorModelSuperBridge::setActiveLayer( QgsMapLayer *layer )
+{
+  if ( mActiveLayer == layer )
+    return;
+
+  mActiveLayer = layer;
+  emit activeLayerChanged();
+}
+
 bool LocatorModelSuperBridge::keepScale() const
 {
   return mKeepScale;

--- a/src/core/locator/locatormodelsuperbridge.cpp
+++ b/src/core/locator/locatormodelsuperbridge.cpp
@@ -233,8 +233,8 @@ LocatorActionsModel::LocatorActionsModel( int rows, int columns, QObject *parent
 QHash<int, QByteArray> LocatorActionsModel::roleNames() const
 {
   QHash<int, QByteArray> roles;
-  roles[IconPathRole] = "iconPath";
-  roles[IdRole] = "id";
+  roles[IconPathRole] = "IconPath";
+  roles[IdRole] = "Id";
   return roles;
 }
 

--- a/src/core/locator/locatormodelsuperbridge.h
+++ b/src/core/locator/locatormodelsuperbridge.h
@@ -61,6 +61,7 @@ class LocatorModelSuperBridge : public QgsLocatorModelBridge
     Q_PROPERTY( QgsQuickMapSettings *mapSettings READ mapSettings WRITE setMapSettings NOTIFY mapSettingsChanged )
     Q_PROPERTY( QObject *locatorHighlightGeometry READ locatorHighlightGeometry WRITE setLocatorHighlightGeometry NOTIFY locatorHighlightGeometryChanged )
     Q_PROPERTY( FeatureListExtentController *featureListController READ featureListController WRITE setFeatureListController NOTIFY featureListControllerChanged )
+    Q_PROPERTY( QgsMapLayer *activeLayer READ activeLayer WRITE setActiveLayer NOTIFY activeLayerChanged )
     Q_PROPERTY( BookmarkModel *bookmarks READ bookmarks WRITE setBookmarks NOTIFY bookmarksChanged )
     Q_PROPERTY( Navigation *navigation READ navigation WRITE setNavigation NOTIFY navigationChanged )
     Q_PROPERTY( bool keepScale READ keepScale WRITE setKeepScale NOTIFY keepScaleChanged )
@@ -84,6 +85,9 @@ class LocatorModelSuperBridge : public QgsLocatorModelBridge
     FeatureListExtentController *featureListController() const;
     void setFeatureListController( FeatureListExtentController *featureListController );
 
+    QgsMapLayer *activeLayer() const;
+    void setActiveLayer( QgsMapLayer *layer );
+
     bool keepScale() const;
     void setKeepScale( bool keepScale );
 
@@ -97,6 +101,7 @@ class LocatorModelSuperBridge : public QgsLocatorModelBridge
     void navigationChanged();
     void locatorHighlightGeometryChanged();
     void featureListControllerChanged();
+    void activeLayerChanged();
     void messageEmitted( const QString &text );
     void keepScaleChanged();
 
@@ -107,6 +112,7 @@ class LocatorModelSuperBridge : public QgsLocatorModelBridge
     QgsQuickMapSettings *mMapSettings = nullptr;
     QObject *mLocatorHighlightGeometry = nullptr;
     FeatureListExtentController *mFeatureListController = nullptr;
+    QPointer<QgsMapLayer> mActiveLayer;
     bool mKeepScale = false;
 
     PeliasGeocoder *mFinlandGeocoder = nullptr;

--- a/src/core/locator/locatormodelsuperbridge.h
+++ b/src/core/locator/locatormodelsuperbridge.h
@@ -91,6 +91,8 @@ class LocatorModelSuperBridge : public QgsLocatorModelBridge
     bool keepScale() const;
     void setKeepScale( bool keepScale );
 
+    void requestSearchTextChange( const QString &text );
+
     Q_INVOKABLE LocatorActionsModel *contextMenuActionsModel( const int row );
 
     void emitMessage( const QString &text );
@@ -104,6 +106,7 @@ class LocatorModelSuperBridge : public QgsLocatorModelBridge
     void activeLayerChanged();
     void messageEmitted( const QString &text );
     void keepScaleChanged();
+    void searchTextChangeRequested( const QString text );
 
   public slots:
     Q_INVOKABLE void triggerResultAtRow( const int row, const int id = -1 );

--- a/src/core/locator/locatormodelsuperbridge.h
+++ b/src/core/locator/locatormodelsuperbridge.h
@@ -97,6 +97,8 @@ class LocatorModelSuperBridge : public QgsLocatorModelBridge
 
     Q_INVOKABLE QString getLocatorModelDescrition( const int row );
 
+    Q_INVOKABLE QString getPrefixFromSreachString( const QString &string );
+
     void emitMessage( const QString &text );
 
   signals:

--- a/src/core/locator/locatormodelsuperbridge.h
+++ b/src/core/locator/locatormodelsuperbridge.h
@@ -95,6 +95,8 @@ class LocatorModelSuperBridge : public QgsLocatorModelBridge
 
     Q_INVOKABLE LocatorActionsModel *contextMenuActionsModel( const int row );
 
+    Q_INVOKABLE QString getLocatorModelDescrition( const int row );
+
     void emitMessage( const QString &text );
 
   signals:

--- a/src/core/locator/locatormodelsuperbridge.h
+++ b/src/core/locator/locatormodelsuperbridge.h
@@ -108,7 +108,7 @@ class LocatorModelSuperBridge : public QgsLocatorModelBridge
     void activeLayerChanged();
     void messageEmitted( const QString &text );
     void keepScaleChanged();
-    void searchTextChangeRequested( const QString text );
+    void searchTextChangeRequested( const QString &text );
 
   public slots:
     Q_INVOKABLE void triggerResultAtRow( const int row, const int id = -1 );

--- a/src/core/locator/locatormodelsuperbridge.h
+++ b/src/core/locator/locatormodelsuperbridge.h
@@ -53,51 +53,88 @@ class LocatorActionsModel : public QStandardItemModel
 
 /**
  * LocatorModelSuperBridge reimplements QgsLocatorModelBridge
- *  for specific needs of QField / QML implementation.
+ * for specific needs of QField / QML implementation.
  */
 class LocatorModelSuperBridge : public QgsLocatorModelBridge
 {
     Q_OBJECT
+
+    //! The current project's map settings
     Q_PROPERTY( QgsQuickMapSettings *mapSettings READ mapSettings WRITE setMapSettings NOTIFY mapSettingsChanged )
+    //! The locator highlight geometry object through which locator actions can highhlight features
     Q_PROPERTY( QObject *locatorHighlightGeometry READ locatorHighlightGeometry WRITE setLocatorHighlightGeometry NOTIFY locatorHighlightGeometryChanged )
+    //! The feature list extent controller
     Q_PROPERTY( FeatureListExtentController *featureListController READ featureListController WRITE setFeatureListController NOTIFY featureListControllerChanged )
+    //! The current project's active layer
     Q_PROPERTY( QgsMapLayer *activeLayer READ activeLayer WRITE setActiveLayer NOTIFY activeLayerChanged )
+    //! The bookmark manager containing user and current project bookmarks
     Q_PROPERTY( BookmarkModel *bookmarks READ bookmarks WRITE setBookmarks NOTIFY bookmarksChanged )
+    //! The navigation object from which destination can be set or modified
     Q_PROPERTY( Navigation *navigation READ navigation WRITE setNavigation NOTIFY navigationChanged )
+    //! The keep scale flag. When turned on, locator actions should not result in changed scale
     Q_PROPERTY( bool keepScale READ keepScale WRITE setKeepScale NOTIFY keepScaleChanged )
 
   public:
     explicit LocatorModelSuperBridge( QObject *parent = nullptr );
     ~LocatorModelSuperBridge() = default;
 
+    //! \copydoc LocatorModelSuperBridge::mapSettings
     QgsQuickMapSettings *mapSettings() const;
+    //! \copydoc LocatorModelSuperBridge::mapSettings
     void setMapSettings( QgsQuickMapSettings *mapSettings );
 
+    //! \copydoc LocatorModelSuperBridge::bookmarks
     BookmarkModel *bookmarks() const;
+    //! \copydoc LocatorModelSuperBridge::bookmarks
     void setBookmarks( BookmarkModel *bookmarks );
 
+    //! \copydoc LocatorModelSuperBridge::navigation
     Navigation *navigation() const;
+    //! \copydoc LocatorModelSuperBridge::navigation
     void setNavigation( Navigation *navigation );
 
+    //! \copydoc LocatorModelSuperBridge::locatorHighlightGeometry
     QObject *locatorHighlightGeometry() const;
+    //! \copydoc LocatorModelSuperBridge::locatorHighlightGeometry
     void setLocatorHighlightGeometry( QObject *locatorHighlightGeometry );
 
+    //! \copydoc LocatorModelSuperBridge::featureListController
     FeatureListExtentController *featureListController() const;
+    //! \copydoc LocatorModelSuperBridge::featureListController
     void setFeatureListController( FeatureListExtentController *featureListController );
 
+    //! \copydoc LocatorModelSuperBridge::activeLayer
     QgsMapLayer *activeLayer() const;
+    //! \copydoc LocatorModelSuperBridge::activeLayer
     void setActiveLayer( QgsMapLayer *layer );
 
+    //! \copydoc LocatorModelSuperBridge::keepScale
     bool keepScale() const;
+    //! \copydoc LocatorModelSuperBridge::keepScale
     void setKeepScale( bool keepScale );
 
+    /**
+     * Requests for the current text in the search bar to be changed to the
+     * provided \a text string.
+     */
     void requestSearchTextChange( const QString &text );
 
+    /**
+     * Returns the actions model for a given locator search result list item.
+     */
     Q_INVOKABLE LocatorActionsModel *contextMenuActionsModel( const int row );
 
-    Q_INVOKABLE QString getLocatorModelDescrition( const int row );
+    /**
+     * Returns the description for a given locator search result list item.
+     */
+    Q_INVOKABLE QString getLocatorModelDescription( const int row );
 
-    Q_INVOKABLE QString getPrefixFromSreachString( const QString &string );
+    /**
+     * Looks for and if present returns the locator filter prefix from
+     * a given search string. If not prefix is detected, an empty
+     * string will be returned.
+     */
+    Q_INVOKABLE QString getPrefixFromSearchString( const QString &string );
 
     void emitMessage( const QString &text );
 

--- a/src/qml/LocatorItem.qml
+++ b/src/qml/LocatorItem.qml
@@ -274,7 +274,7 @@ Item {
         property int resultIndex: index
 
         anchors.margins: 10
-        height: isFilterName || isGroup ? 30 : 40
+        height: isFilterName || isGroup ? 30 : Math.max(actionsRow.childrenRect.height, textArea.childrenRect.height + textArea.topPadding + textArea.bottomPadding)
         width: resultsList.width
         color: isFilterName ? Theme.mainColor : isGroup ? Theme.controlBorderColor : "transparent"
         opacity: 0.95
@@ -289,18 +289,41 @@ Item {
           color: Material.rippleColor
         }
 
-        Text {
-          id: textCell
-          text: isFilterName ? model.ResultFilterName : model.Text.trim()
+        Column {
+          id: textArea
           anchors.verticalCenter: parent.verticalCenter
           anchors.left: parent.left
           anchors.right: actionsRow.left
-          leftPadding: 5
-          font.bold: false
-          font.pointSize: Theme.resultFont.pointSize
-          color: isFilterName ? "white" : Theme.mainTextColor
-          elide: Text.ElideRight
-          horizontalAlignment: isGroup ? Text.AlignHCenter : Text.AlignLeft
+          topPadding: 8
+          bottomPadding: 8
+          spacing: 2
+
+          Text {
+            id: nameCell
+            anchors.left: parent.left
+            anchors.right: parent.right
+            text: isFilterName ? model.ResultFilterName : model.Text.trim()
+            leftPadding: 5
+            font.bold: false
+            font.pointSize: Theme.resultFont.pointSize
+            color: isFilterName ? "white" : Theme.mainTextColor
+            elide: Text.ElideRight
+            horizontalAlignment: isGroup ? Text.AlignHCenter : Text.AlignLeft
+          }
+
+          Text {
+            id: descriptionCell
+            visible: !isFilterName && !isGroup && text !== ''
+            anchors.left: parent.left
+            anchors.right: parent.right
+            text: locator.getLocatorModelDescrition(index)
+            leftPadding: 5
+            font.bold: false
+            font.pointSize: Theme.resultFont.pointSize
+            color: Theme.secondaryTextColor
+            elide: Text.ElideRight
+            horizontalAlignment: Text.AlignLeft
+          }
         }
 
         Row {
@@ -346,8 +369,10 @@ Item {
           anchors.right: actionsRow.left
 
           onClicked: {
-            locator.triggerResultAtRow(index)
-            locatorItem.state = "off"
+            if (!isFilterName && !isGroup && nameCell.text !== '') {
+              locator.triggerResultAtRow(index)
+              locatorItem.state = "off"
+            }
           }
         }
       }

--- a/src/qml/LocatorItem.qml
+++ b/src/qml/LocatorItem.qml
@@ -113,7 +113,7 @@ Item {
     enabled: false
 
     function onDecoded(string) {
-      var prefix = locator.getPrefixFromSreachString(searchField.text)
+      var prefix = locator.getPrefixFromSearchString(searchField.text)
       searchField.text = prefix !== '' ? prefix + ' ' + string : string;
     }
 
@@ -415,7 +415,7 @@ Item {
             visible: !isFilterName && !isGroup && text !== ''
             anchors.left: parent.left
             anchors.right: parent.right
-            text: locator.getLocatorModelDescrition(index)
+            text: locator.getLocatorModelDescription(index)
             leftPadding: 5
             font.bold: false
             font.pointSize: Theme.resultFont.pointSize

--- a/src/qml/LocatorItem.qml
+++ b/src/qml/LocatorItem.qml
@@ -329,7 +329,7 @@ Item {
             id: descriptionCell
             anchors.left: parent.left
             anchors.right: parent.right
-            text: Description
+            text: Description || ''
             leftPadding: 5
             font.bold: false
             font.pointSize: Theme.resultFont.pointSize
@@ -364,8 +364,8 @@ Item {
       Rectangle {
         id: delegateRect
 
-        property bool isGroup: model.ResultFilterGroupSorting === 0
-        property bool isFilterName: model.ResultType === 0
+        property bool isGroup: ResultFilterGroupSorting === 0
+        property bool isFilterName: ResultType === 0
         property int resultIndex: index
 
         anchors.margins: 10
@@ -397,7 +397,11 @@ Item {
             id: nameCell
             anchors.left: parent.left
             anchors.right: parent.right
-            text: isFilterName ? model.ResultFilterName : model.Text.trim()
+            text: isFilterName
+                  ? ResultFilterName
+                  : typeof(model.Text) == 'string'
+                    ? model.Text.trim()
+                    : ''
             leftPadding: 5
             font.bold: false
             font.pointSize: Theme.resultFont.pointSize
@@ -438,11 +442,11 @@ Item {
               padding: 0
               bgcolor: "transparent"
 
-              iconSource: Theme.getThemeIcon(model.iconPath)
+              iconSource: Theme.getThemeIcon(IconPath)
 
               onClicked: {
                 locatorItem.state = "off"
-                locator.triggerResultAtRow(delegateRect.resultIndex, model.id)
+                locator.triggerResultAtRow(delegateRect.resultIndex, Id)
               }
             }
           }

--- a/src/qml/LocatorItem.qml
+++ b/src/qml/LocatorItem.qml
@@ -83,6 +83,10 @@ Item {
     onMessageEmitted: {
       displayToast(text)
     }
+
+    onSearchTextChangeRequested: (text) => {
+      searchField.text = text
+    }
   }
 
   Connections {
@@ -147,6 +151,7 @@ Item {
       }
       inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
       onDisplayTextChanged: {
+        locatorItem.state = "on"
         searchTermHandled = false
         searchTermChanged(searchField.displayText)
         if (!searchTermHandled) {
@@ -318,8 +323,8 @@ Item {
               iconSource: Theme.getThemeIcon(model.iconPath)
 
               onClicked: {
-                locator.triggerResultAtRow(delegateRect.resultIndex, model.id)
                 locatorItem.state = "off"
+                locator.triggerResultAtRow(delegateRect.resultIndex, model.id)
               }
             }
           }

--- a/src/qml/LocatorItem.qml
+++ b/src/qml/LocatorItem.qml
@@ -158,10 +158,15 @@ Item {
       inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
       onDisplayTextChanged: {
         locatorItem.state = "on"
+
         searchTermHandled = false
         searchTermChanged(searchField.displayText)
         if (!searchTermHandled) {
           locator.performSearch(searchField.displayText)
+        }
+
+        if (searchField.displayText == 'f ' && dashBoard.activeLayer == undefined) {
+          displayToast(qsTr('To search features within the active layer, select a vector layer through the legend.'))
         }
       }
     }

--- a/src/qml/LocatorItem.qml
+++ b/src/qml/LocatorItem.qml
@@ -113,7 +113,8 @@ Item {
     enabled: false
 
     function onDecoded(string) {
-      searchField.text = string;
+      var prefix = locator.getPrefixFromSreachString(searchField.text)
+      searchField.text = prefix !== '' ? prefix + ' ' + string : string;
     }
 
     function onVisibleChanged() {

--- a/src/qml/LocatorItem.qml
+++ b/src/qml/LocatorItem.qml
@@ -13,6 +13,7 @@ Item {
 
   property bool searchFieldVisible: searchField.visible
   property alias locatorModelSuperBridge: locator
+  property alias locatorFiltersModel: locatorFilters
 
   /* Emitted when the search term typed into the locator bar has changed. If
    * the searchTermHandled boolean property is set to true while the signal
@@ -87,6 +88,11 @@ Item {
     onSearchTextChangeRequested: (text) => {
       searchField.text = text
     }
+  }
+
+  LocatorFiltersModel {
+    id: locatorFilters
+    locatorModelSuperBridge: locator
   }
 
   Connections {
@@ -261,12 +267,95 @@ Item {
       z: 2
       anchors.top: resultsBox.top
       anchors.topMargin: 24
-      model: locator.proxyModel()
+      model: searchField.displayText !== '' ? locator.proxyModel() : locatorFilters
       width: parent.width
       height: resultsList.count > 0 ? Math.min( childrenRect.height, mainWindow.height / 2 - searchFieldRect.height - 10 ) : 0
       clip: true
 
-      delegate: Rectangle {
+      delegate: searchField.displayText !== '' ? resultsComponent : filtersComponent
+    }
+
+    Component {
+      id: filtersComponent
+
+      Rectangle {
+        id: delegateRect
+
+        anchors.margins: 10
+        height: textArea.childrenRect.height + textArea.topPadding + textArea.bottomPadding
+        width: resultsList.width
+        color: "transparent"
+        opacity: 0.95
+
+        Ripple {
+          clip: true
+          width: parent.width
+          height: parent.height
+          pressed: mouseArea.pressed
+          anchor: delegateRect
+          active: mouseArea.pressed
+          color: Material.rippleColor
+        }
+
+        Column {
+          id: textArea
+          anchors.verticalCenter: parent.verticalCenter
+          anchors.left: parent.left
+          anchors.right: parent.right
+          topPadding: 8
+          bottomPadding: 8
+          spacing: 2
+
+          Text {
+            id: nameCell
+            anchors.left: parent.left
+            anchors.right: parent.right
+            text: Name + ' (' + Prefix + ')'
+            leftPadding: 5
+            font.bold: false
+            font.pointSize: Theme.resultFont.pointSize
+            color: Theme.mainTextColor
+            elide: Text.ElideRight
+            horizontalAlignment: Text.AlignLeft
+          }
+
+          Text {
+            id: descriptionCell
+            anchors.left: parent.left
+            anchors.right: parent.right
+            text: Description
+            leftPadding: 5
+            font.bold: false
+            font.pointSize: Theme.resultFont.pointSize
+            color: Theme.secondaryTextColor
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignLeft
+          }
+        }
+
+        /* bottom border */
+        Rectangle {
+          anchors.bottom: parent.bottom
+          height: 1
+          color: Theme.controlBorderColor
+          width: parent.width
+        }
+
+        MouseArea {
+          id: mouseArea
+          anchors.fill: parent
+
+          onClicked: {
+            searchField.text = Prefix + ' ';
+          }
+        }
+      }
+    }
+
+    Component {
+      id: resultsComponent
+
+      Rectangle {
         id: delegateRect
 
         property bool isGroup: model.ResultFilterGroupSorting === 0

--- a/src/qml/LocatorSettings.qml
+++ b/src/qml/LocatorSettings.qml
@@ -10,8 +10,7 @@ import Theme 1.0
 Popup {
     id: popup
 
-    property alias locatorModelSuperBridge: locatorFiltersModel.locatorModelSuperBridge
-    property alias model: locatorFiltersModel
+    property alias locatorFiltersModel: locatorfiltersList.model
 
     width: Math.min(400, mainWindow.width - Theme.popupScreenEdgeMargin)
     x: (parent.width - width) / 2
@@ -68,10 +67,6 @@ Popup {
                 width: parent.width
                 height: Math.min( childrenRect.height, mainWindow.height - 160 );
                 clip: true
-
-                model: LocatorFiltersModel {
-                    id: locatorFiltersModel
-                }
 
                 delegate: Rectangle {
                     id: rectangle

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1076,6 +1076,7 @@ ApplicationWindow {
 
     locatorModelSuperBridge.navigation: navigation
     locatorModelSuperBridge.bookmarks: bookmarkModel
+    locatorModelSuperBridge.activeLayer: dashBoard.activeLayer
 
     anchors.right: parent.right
     anchors.top: parent.top

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -307,7 +307,7 @@ ApplicationWindow {
       if ( positionSource.positionInformation ) {
         positionSource.currentness = ((Date.now() - positionSource.positionInformation.utcDateTime.getTime()) / 1000) < 30;
         if (!geocoderLocatorFiltersChecked && positionSource.valid) {
-          locatorSettings.model.setGeocoderLocatorFiltersDefaulByPosition(positionSource.positionInformation);
+          locatorItem.locatorFiltersModel.setGeocoderLocatorFiltersDefaulByPosition(positionSource.positionInformation);
           geocoderLocatorFiltersChecked = true;
         }
       }
@@ -1106,7 +1106,7 @@ ApplicationWindow {
 
   LocatorSettings {
       id: locatorSettings
-      locatorModelSuperBridge: locatorItem.locatorModelSuperBridge
+      locatorFiltersModel: locatorItem.locatorFiltersModel
 
       modal: true
       closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside


### PR DESCRIPTION
This PR adds a new functionality to the search bar: an active layer feature matching. To begin with, here's a screencast showcasing the UI/UX:

[Screencast from 2023-09-01 11-07-04.webm](https://github.com/opengisch/QField/assets/1728657/71fd9a70-7e97-4691-96ac-03dc190a0754)

Few notes:
- The search functionality _must be activated via its *f* prefix_ as the search can be quite costly;
- Contrary to the all features (within all layers) search, this search functionality allows for single character searches (thanks to it being prefixed), and will not only try to match against a feature's display name but also _all text and numerical fields_;
- When an attribute match occurs, the attribute value and attribute name are highlighted, while the feature display name is appended as a second text row (seen in screencast above);
- It is possible to restrict to search to one specific field by using the following syntax: '`f @ATTRIBUTE_NAME search term`'). This matches the behavior found in QGIS and can be super useful in narrowing searches on the spot.

The screencast also shows a nice UX improvements added here. Since we are now having quite a few search functionalities, with a few activated only via prefix, it has become slightly harder for QField users to be made aware of all of the cool stuff the search bar those. To remedy to that, the search bar now shows a list of functionalities when users activate the search bar prior to entering text. 

Part of the code logic was taken from @nyalldawson 's equivalent locator filter in QGIS (https://github.com/qgis/QGIS/blob/master/src/app/locator/qgsactivelayerfeatureslocatorfilter.cpp). Insuring that QField and QGIS have matching behaviors was important. I'm pretty sure we'll get a few QField users aware of the `@ATTRIBUTE` restriction in QGIS now ;-P