### PR TITLE
Move Orthometric from device settings into Vertical grid shift correction combobox

### DIFF
--- a/src/core/positioning/nmeagnssreceiver.cpp
+++ b/src/core/positioning/nmeagnssreceiver.cpp
@@ -48,7 +48,8 @@ void NmeaGnssReceiver::stateChanged( const QgsGpsInformation &info )
   double antennaHeight = 0.0;
   if ( Positioning *positioning = qobject_cast<Positioning *>( parent() ) )
   {
-    ellipsoidalElevation = positioning->ellipsoidalElevation();
+    if ( positioning->elevationCorrectionMode() != Positioning::ElevationCorrectionMode::OrthometricFromDevice )
+      ellipsoidalElevation = true;
     antennaHeight = positioning->antennaHeight();
   }
 

--- a/src/core/positioning/nmeagnssreceiver.cpp
+++ b/src/core/positioning/nmeagnssreceiver.cpp
@@ -48,20 +48,19 @@ void NmeaGnssReceiver::stateChanged( const QgsGpsInformation &info )
   double antennaHeight = 0.0;
   if ( Positioning *positioning = qobject_cast<Positioning *>( parent() ) )
   {
-    if ( positioning->elevationCorrectionMode() != Positioning::ElevationCorrectionMode::OrthometricFromDevice )
-      ellipsoidalElevation = true;
+    ellipsoidalElevation = positioning->elevationCorrectionMode() != Positioning::ElevationCorrectionMode::OrthometricFromDevice;
     antennaHeight = positioning->antennaHeight();
   }
 
   if ( info.utcTime != mLastGnssPositionUtcTime )
   {
     mLastGnssPositionUtcTime = info.utcTime;
-
     if ( mImuPosition.valid )
     {
       mLastGnssPositionInformation = GnssPositionInformation( mImuPosition.latitude, mImuPosition.longitude,
                                                               ellipsoidalElevation ? mImuPosition.altitude : mImuPosition.altitude - info.elevation_diff,
-                                                              mImuPosition.speed * 1000 / 60 / 60, mImuPosition.direction,
+                                                              mImuPosition.speed * 1000 / 60 / 60, // QgsGpsInformation's speed is served in km/h, translate to m/s
+                                                              mImuPosition.direction,
                                                               info.satellitesInView, info.pdop, info.hdop, info.vdop,
                                                               info.hacc, info.vacc, info.utcDateTime, info.fixMode, info.fixType,
                                                               info.quality,
@@ -71,19 +70,18 @@ void NmeaGnssReceiver::stateChanged( const QgsGpsInformation &info )
                                                               mImuPosition.valid );
     }
     else
+    {
       mLastGnssPositionInformation = mCurrentNmeaGnssPositionInformation;
+    }
 
     emit lastGnssPositionInformationChanged( mLastGnssPositionInformation );
   }
 
-  double elevation = info.elevation - antennaHeight;
-  if ( ellipsoidalElevation )
-    elevation += info.elevation_diff;
-
-  // QgsGpsInformation's speed is served in km/h, translate to m/s
   mCurrentNmeaGnssPositionInformation = GnssPositionInformation( info.latitude, info.longitude,
-                                                                 elevation,
-                                                                 info.speed * 1000 / 60 / 60, info.direction, info.satellitesInView, info.pdop, info.hdop, info.vdop,
+                                                                 info.elevation - antennaHeight + ( ellipsoidalElevation ? info.elevation_diff : 0 ),
+                                                                 info.speed * 1000 / 60 / 60, // QgsGpsInformation's speed is served in km/h, translate to m/s
+                                                                 info.direction,
+                                                                 info.satellitesInView, info.pdop, info.hdop, info.vdop,
                                                                  info.hacc, info.vacc, info.utcDateTime, info.fixMode, info.fixType, info.quality, info.satellitesUsed, info.status,
                                                                  info.satPrn, info.satInfoComplete, std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN(),
                                                                  0, QStringLiteral( "nmea" ) );

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -123,14 +123,14 @@ void Positioning::setLogging( bool logging )
   emit loggingChanged();
 }
 
-void Positioning::setEllipsoidalElevation( bool ellipsoidal )
+void Positioning::setElevationCorrectionMode( ElevationCorrectionMode elevationCorrectionMode )
 {
-  if ( mEllipsoidalElevation == ellipsoidal )
+  if ( mElevationCorrectionMode == elevationCorrectionMode )
     return;
 
-  mEllipsoidalElevation = ellipsoidal;
+  mElevationCorrectionMode = elevationCorrectionMode;
 
-  emit ellipsoidalElevationChanged();
+  emit elevationCorrectionModeChanged();
 }
 
 void Positioning::setAntennaHeight( double antennaHeight )

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -55,8 +55,6 @@ class Positioning : public QObject
 
     Q_PROPERTY( bool logging READ logging WRITE setLogging NOTIFY loggingChanged )
 
-    Q_ENUMS( ElevationCorrectionMode )
-
   public:
     /**
      * Elevation correction modes
@@ -67,6 +65,7 @@ class Positioning : public QObject
       OrthometricFromDevice,   //! Apply the geoid correction provided by the device. Available only for external devices.
       OrthometricFromGeoidFile //! Apply the geoid correction from a geoid file.
     };
+    Q_ENUM( ElevationCorrectionMode )
 
     explicit Positioning( QObject *parent = nullptr );
 
@@ -242,5 +241,7 @@ class Positioning : public QObject
 
     AbstractGnssReceiver *mReceiver = nullptr;
 };
+
+Q_DECLARE_METATYPE( Positioning::ElevationCorrectionMode )
 
 #endif // POSITIONING_H

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -63,9 +63,9 @@ class Positioning : public QObject
      */
     enum class ElevationCorrectionMode
     {
-      None,
-      OrthometricFromDevice,
-      FromGeoidFile
+      None,                    //! Elevation is used as it comes from the device. For most devices including Android internal this is ellipsoidic.
+      OrthometricFromDevice,   //! Apply the geoid correction provided by the device. Available only for external devices.
+      OrthometricFromGeoidFile //! Apply the geoid correction from a geoid file.
     };
 
     explicit Positioning( QObject *parent = nullptr );

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -50,12 +50,24 @@ class Positioning : public QObject
     Q_PROPERTY( bool averagedPosition READ averagedPosition WRITE setAveragedPosition NOTIFY averagedPositionChanged )
     Q_PROPERTY( int averagedPositionCount READ averagedPositionCount NOTIFY averagedPositionCountChanged )
 
-    Q_PROPERTY( bool ellipsoidalElevation READ ellipsoidalElevation WRITE setEllipsoidalElevation NOTIFY ellipsoidalElevationChanged )
+    Q_PROPERTY( ElevationCorrectionMode elevationCorrectionMode READ elevationCorrectionMode WRITE setElevationCorrectionMode NOTIFY elevationCorrectionModeChanged )
     Q_PROPERTY( double antennaHeight READ antennaHeight WRITE setAntennaHeight NOTIFY antennaHeightChanged )
 
     Q_PROPERTY( bool logging READ logging WRITE setLogging NOTIFY loggingChanged )
 
+    Q_ENUMS( ElevationCorrectionMode )
+
   public:
+    /**
+     * Elevation correction modes
+     */
+    enum class ElevationCorrectionMode
+    {
+      None,
+      OrthometricFromDevice,
+      FromGeoidFile
+    };
+
     explicit Positioning( QObject *parent = nullptr );
 
     virtual ~Positioning() = default;
@@ -145,16 +157,16 @@ class Positioning : public QObject
     int averagedPositionCount() const { return mCollectedPositionInformations.size(); }
 
     /**
-     * Returns whether GNSS devices will be asked to report ellipsoidal height.
-     * \note Requires a device type with ellipsoidal capability
+     * Returns the current elevation correction mode.
+     * \note Some modes depends on device capabilities.
      */
-    bool ellipsoidalElevation() const { return mEllipsoidalElevation; }
+    ElevationCorrectionMode elevationCorrectionMode() const { return mElevationCorrectionMode; }
 
     /**
-     * Sets whether GNSS devices will be asked to report ellipsoidal height.
-     * \note Requires a device type with ellipsoidal capability
+     * Sets the current elevation correction mode.
+     * \note Some modes depends on device capabilities.
      */
-    void setEllipsoidalElevation( bool ellipsoidal );
+    void setElevationCorrectionMode( ElevationCorrectionMode elevationCorrectionMode );
 
     /**
      * Sets the GNSS device antenna height. This should be the pole height + sensore phase height.
@@ -192,7 +204,7 @@ class Positioning : public QObject
     void averagedPositionChanged();
     void averagedPositionCountChanged();
     void projectedPositionChanged();
-    void ellipsoidalElevationChanged();
+    void elevationCorrectionModeChanged();
     void antennaHeightChanged();
     void loggingChanged();
 
@@ -223,7 +235,7 @@ class Positioning : public QObject
 
     bool mAveragedPosition = false;
 
-    bool mEllipsoidalElevation = false;
+    ElevationCorrectionMode mElevationCorrectionMode = ElevationCorrectionMode::None;
     double mAntennaHeight = 0.0;
 
     bool mLogging = false;

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -391,6 +391,7 @@ void QgisMobileapp::initDeclarative()
   qRegisterMetaType<QFieldCloudProjectsModel::ProjectCheckout>( "QFieldCloudProjectsModel::ProjectCheckout" );
   qRegisterMetaType<QFieldCloudProjectsModel::ProjectModification>( "QFieldCloudProjectsModel::ProjectModification" );
   qRegisterMetaType<Tracker::MeasureType>( "Tracker::MeasureType" );
+  qRegisterMetaType<Positioning::ElevationCorrectionMode>( "Positioning::ElevationCorrectionMode" );
 
   qRegisterMetaType<Qgis::GeometryType>( "Qgis::GeometryType" );
   qRegisterMetaType<Qgis::WkbType>( "Qgis::WkbType" );

--- a/src/qml/PositioningInformationView.qml
+++ b/src/qml/PositioningInformationView.qml
@@ -92,18 +92,27 @@ Rectangle {
         font: Theme.tipFont
         color: textColor
         text: {
-            var altitude = qsTr( "Altitude" ) + ': ';
-            if ( positionSource.positionInformation && positionSource.positionInformation.elevationValid ) {
-                altitude += Number( positionSource.projectedPosition.z ).toLocaleString( Qt.locale(), 'f', 3 ) + ' m'
-                if ( !isNaN( parseFloat( antennaHeight ) ) ) {
-                    altitude += ' <font color="#2f2f2f"><i>(%1)</i></font>'.arg( ( antennaHeight > 0 ? "+" : "-" ) + Math.abs( antennaHeight ).toLocaleString(Qt.locale(), 'f', 3 ) );
-                }
+          var altitude = qsTr( "Altitude" ) + ': '
+          if ( positionSource.positionInformation && positionSource.positionInformation.elevationValid ) {
+            altitude += Number( positionSource.projectedPosition.z ).toLocaleString( Qt.locale(), 'f', 3 ) + ' m '
+            var details = []
+            if (positionSource.elevationCorrectionMode === Positioning.ElevationCorrectionMode.OrthometricFromGeoidFile) {
+              details.push('grid')
+            } else if (positionSource.elevationCorrectionMode === Positioning.ElevationCorrectionMode.OrthometricFromDevice) {
+              details.push('ortho.')
             }
-            else
-            {
-                altitude += qsTr('N/A');
+            if ( !isNaN( parseFloat( antennaHeight ) ) ) {
+              details.push('ant.')
             }
-            return altitude
+            if (details.length > 0) {
+              altitude += ' (%1)'.arg( details.join(', '))
+            }
+          }
+          else
+          {
+            altitude += qsTr('N/A');
+          }
+          return altitude
         }
       }
     }

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -7,7 +7,7 @@ LabSettings.Settings {
 
     property string positioningDevice: ""
     property string positioningDeviceName: qsTr( "Internal device" );
-    property bool ellipsoidalElevation: true
+    property int elevationCorrectionMode: Positioning.ElevationCorrectionMode.None
     property bool logging: false
 
     property bool showPositionInformation: false

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -1,6 +1,8 @@
 import QtQuick 2.14
 import Qt.labs.settings 1.0 as LabSettings
 
+import org.qfield 1.0
+
 LabSettings.Settings {
     property bool positioningActivated: false
     property bool positioningCoordinateLock: false

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -680,6 +680,8 @@ Page {
                               var modelIndex = positioningDeviceModel.index(currentIndex, 0);
                               positioningSettings.positioningDevice = positioningDeviceModel.data(modelIndex, PositioningDeviceModel.DeviceId)
                               positioningSettings.positioningDeviceName = positioningDeviceModel.data(modelIndex, PositioningDeviceModel.DeviceName);
+
+                              verticalGridShiftComboBox.reload()
                           }
 
                           Component.onCompleted: {
@@ -1213,31 +1215,6 @@ Page {
                   }
 
                   Label {
-                    text: qsTr("Use orthometric altitude from device")
-                    font: Theme.defaultFont
-                    color: Theme.mainTextColor
-                    wrapMode: Text.WordWrap
-                    Layout.fillWidth: true
-                    visible: positionSource.device.capabilities() & AbstractGnssReceiver.OrthometricAltitude
-
-                    MouseArea {
-                      anchors.fill: parent
-                      onClicked: reportOrthometricAltitude.toggle()
-                    }
-                  }
-
-                  QfSwitch {
-                    id: reportOrthometricAltitude
-                    Layout.preferredWidth: implicitContentWidth
-                    Layout.alignment: Qt.AlignTop
-                    visible: positionSource.device.capabilities() & AbstractGnssReceiver.OrthometricAltitude
-                    checked: !positioningSettings.ellipsoidalElevation
-                    onCheckedChanged: {
-                      positioningSettings.ellipsoidalElevation = !checked
-                    }
-                  }
-
-                  Label {
                       text: qsTr( "Vertical grid shift in use:" )
                       font: Theme.defaultFont
                       color: Theme.mainTextColor
@@ -1248,21 +1225,79 @@ Page {
                   }
 
                   ComboBox {
+                      id: verticalGridShiftComboBox
                       Layout.fillWidth: true
                       Layout.columnSpan: 2
-                      model: [ qsTr( "None" ) ].concat( platformUtilities.availableGrids() );
                       font: Theme.defaultFont
 
                       popup.font: Theme.defaultFont
                       popup.topMargin: mainWindow.sceneTopMargin
                       popup.bottomMargin: mainWindow.sceneTopMargin
 
-                      onCurrentIndexChanged: {
-                          positioningSettings.verticalGrid = currentIndex > 0 ? platformUtilities.availableGrids()[currentIndex - 1] : '';
+                      textRole: "text"
+                      valueRole: "value"
+
+                      model: ListModel {
+                          id: model
                       }
 
-                      Component.onCompleted: {
-                          currentIndex = positioningSettings.verticalGrid != '' ? find(positioningSettings.verticalGrid) : 0;
+                      onCurrentValueChanged: {
+                          if(!currentValue)
+                              return
+
+                          positioningSettings.elevationCorrectionMode = currentValue;
+
+                          if(positioningSettings.elevationCorrectionMode === Positioning.ElevationCorrectionMode.FromGeoidFile)
+                              positioningSettings.verticalGrid = currentText
+                          else
+                              positioningSettings.verticalGrid = ""
+                      }
+
+                      Component.onCompleted: reload()
+
+                      function reload()
+                      {
+                          verticalGridShiftComboBox.model.clear()
+                          verticalGridShiftComboBox.model.append({text: qsTr( "None" ), value: Positioning.ElevationCorrectionMode.None});
+
+                          if(positionSource.device.capabilities() & AbstractGnssReceiver.OrthometricAltitude)
+                              verticalGridShiftComboBox.model.append({text: qsTr( "Orthometric from device" ), value: Positioning.ElevationCorrectionMode.OrthometricFromDevice});
+
+                          // Add geoid files to combobox
+                          var geoidFiles = platformUtilities.availableGrids()
+                          for(var i = 0; i < geoidFiles.length; i++)
+                              verticalGridShiftComboBox.model.append( { text: geoidFiles[i], value: Positioning.ElevationCorrectionMode.FromGeoidFile } );
+
+                          if(positioningSettings.elevationCorrectionMode === Positioning.ElevationCorrectionMode.None)
+                          {
+                              verticalGridShiftComboBox.currentIndex = indexOfValue(positioningSettings.elevationCorrectionMode)
+                              positioningSettings.verticalGrid = "";
+                          }
+                          else if(positioningSettings.elevationCorrectionMode === Positioning.ElevationCorrectionMode.OrthometricFromDevice)
+                          {
+                              if(positionSource.device.capabilities() & AbstractGnssReceiver.OrthometricAltitude)
+                                  verticalGridShiftComboBox.currentIndex = verticalGridShiftComboBox.indexOfValue(positioningSettings.elevationCorrectionMode)
+                              else
+                                  // Orthometric not available -> fallback to None
+                                  verticalGridShiftComboBox.currentIndex = verticalGridShiftComboBox.indexOfValue(Positioning.ElevationCorrectionMode.None)
+                              positioningSettings.verticalGrid = "";
+                          }
+                          else if(positioningSettings.elevationCorrectionMode === Positioning.ElevationCorrectionMode.FromGeoidFile)
+                          {
+                              var currentVerticalGridFileIndex = verticalGridShiftComboBox.find(positioningSettings.verticalGrid);
+                              if(currentVerticalGridFileIndex < 1)
+                                  // Vertical index file not found -> fallback to None
+                                  verticalGridShiftComboBox.currentIndex = verticalGridShiftComboBox.indexOfValue(Positioning.ElevationCorrectionMode.None)
+                              else
+                                  verticalGridShiftComboBox.currentIndex = currentVerticalGridFileIndex;
+                          }
+                          else
+                          {
+                              console.log("Alarm unknown elevationCorrectionMode: '%1'".arg(positioningSettings.elevationCorrectionMode))
+
+                              // Unknown mode -> fallback to None
+                              verticalGridShiftComboBox.currentIndex = verticalGridShiftComboBox.indexOfValue(Positioning.ElevationCorrectionMode.None)
+                          }
                       }
                   }
 

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -1241,31 +1241,35 @@ Page {
                       }
 
                       onCurrentValueChanged: {
-                          if (!currentValue)
+                          if (reloading || currentValue == undefined) {
                               return
+                          }
 
                           positioningSettings.elevationCorrectionMode = currentValue;
 
-                          if (positioningSettings.elevationCorrectionMode === Positioning.ElevationCorrectionMode.OrthometricFromGeoidFile)
+                          if (positioningSettings.elevationCorrectionMode === Positioning.ElevationCorrectionMode.OrthometricFromGeoidFile) {
                               positioningSettings.verticalGrid = currentText
-                          else
+                          } else {
                               positioningSettings.verticalGrid = ""
+                          }
                       }
 
                       Component.onCompleted: reload()
 
-                      function reload()
-                      {
+                      property bool reloading: false
+                      function reload() {
+                          reloading = true
+
                           verticalGridShiftComboBox.model.clear()
-                          verticalGridShiftComboBox.model.append({text: qsTr( "None" ), value: Positioning.ElevationCorrectionMode.None});
+                          verticalGridShiftComboBox.model.append({text: qsTr("None"), value: Positioning.ElevationCorrectionMode.None});
 
                           if (positionSource.device.capabilities() & AbstractGnssReceiver.OrthometricAltitude)
-                              verticalGridShiftComboBox.model.append({text: qsTr( "Orthometric from device" ), value: Positioning.ElevationCorrectionMode.OrthometricFromDevice});
+                              verticalGridShiftComboBox.model.append({text: qsTr("Orthometric from device"), value: Positioning.ElevationCorrectionMode.OrthometricFromDevice});
 
                           // Add geoid files to combobox
                           var geoidFiles = platformUtilities.availableGrids()
                           for (var i = 0; i < geoidFiles.length; i++)
-                              verticalGridShiftComboBox.model.append( { text: geoidFiles[i], value: Positioning.ElevationCorrectionMode.OrthometricFromGeoidFile } );
+                              verticalGridShiftComboBox.model.append({text: geoidFiles[i], value: Positioning.ElevationCorrectionMode.OrthometricFromGeoidFile});
 
                           if (positioningSettings.elevationCorrectionMode === Positioning.ElevationCorrectionMode.None)
                           {
@@ -1297,6 +1301,8 @@ Page {
                               // Unknown mode -> fallback to None
                               verticalGridShiftComboBox.currentIndex = verticalGridShiftComboBox.indexOfValue(Positioning.ElevationCorrectionMode.None)
                           }
+
+                          reloading = false
                       }
                   }
 

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -1242,12 +1242,12 @@ Page {
                       }
 
                       onCurrentValueChanged: {
-                          if(!currentValue)
+                          if (!currentValue)
                               return
 
                           positioningSettings.elevationCorrectionMode = currentValue;
 
-                          if(positioningSettings.elevationCorrectionMode === Positioning.ElevationCorrectionMode.FromGeoidFile)
+                          if (positioningSettings.elevationCorrectionMode === Positioning.ElevationCorrectionMode.OrthometricFromGeoidFile)
                               positioningSettings.verticalGrid = currentText
                           else
                               positioningSettings.verticalGrid = ""
@@ -1260,32 +1260,32 @@ Page {
                           verticalGridShiftComboBox.model.clear()
                           verticalGridShiftComboBox.model.append({text: qsTr( "None" ), value: Positioning.ElevationCorrectionMode.None});
 
-                          if(positionSource.device.capabilities() & AbstractGnssReceiver.OrthometricAltitude)
+                          if (positionSource.device.capabilities() & AbstractGnssReceiver.OrthometricAltitude)
                               verticalGridShiftComboBox.model.append({text: qsTr( "Orthometric from device" ), value: Positioning.ElevationCorrectionMode.OrthometricFromDevice});
 
                           // Add geoid files to combobox
                           var geoidFiles = platformUtilities.availableGrids()
-                          for(var i = 0; i < geoidFiles.length; i++)
-                              verticalGridShiftComboBox.model.append( { text: geoidFiles[i], value: Positioning.ElevationCorrectionMode.FromGeoidFile } );
+                          for (var i = 0; i < geoidFiles.length; i++)
+                              verticalGridShiftComboBox.model.append( { text: geoidFiles[i], value: Positioning.ElevationCorrectionMode.OrthometricFromGeoidFile } );
 
-                          if(positioningSettings.elevationCorrectionMode === Positioning.ElevationCorrectionMode.None)
+                          if (positioningSettings.elevationCorrectionMode === Positioning.ElevationCorrectionMode.None)
                           {
                               verticalGridShiftComboBox.currentIndex = indexOfValue(positioningSettings.elevationCorrectionMode)
                               positioningSettings.verticalGrid = "";
                           }
-                          else if(positioningSettings.elevationCorrectionMode === Positioning.ElevationCorrectionMode.OrthometricFromDevice)
+                          else if (positioningSettings.elevationCorrectionMode === Positioning.ElevationCorrectionMode.OrthometricFromDevice)
                           {
-                              if(positionSource.device.capabilities() & AbstractGnssReceiver.OrthometricAltitude)
+                              if (positionSource.device.capabilities() & AbstractGnssReceiver.OrthometricAltitude)
                                   verticalGridShiftComboBox.currentIndex = verticalGridShiftComboBox.indexOfValue(positioningSettings.elevationCorrectionMode)
                               else
                                   // Orthometric not available -> fallback to None
                                   verticalGridShiftComboBox.currentIndex = verticalGridShiftComboBox.indexOfValue(Positioning.ElevationCorrectionMode.None)
                               positioningSettings.verticalGrid = "";
                           }
-                          else if(positioningSettings.elevationCorrectionMode === Positioning.ElevationCorrectionMode.FromGeoidFile)
+                          else if (positioningSettings.elevationCorrectionMode === Positioning.ElevationCorrectionMode.OrthometricFromGeoidFile)
                           {
                               var currentVerticalGridFileIndex = verticalGridShiftComboBox.find(positioningSettings.verticalGrid);
-                              if(currentVerticalGridFileIndex < 1)
+                              if (currentVerticalGridFileIndex < 1)
                                   // Vertical index file not found -> fallback to None
                                   verticalGridShiftComboBox.currentIndex = verticalGridShiftComboBox.indexOfValue(Positioning.ElevationCorrectionMode.None)
                               else
@@ -1293,7 +1293,7 @@ Page {
                           }
                           else
                           {
-                              console.log("Alarm unknown elevationCorrectionMode: '%1'".arg(positioningSettings.elevationCorrectionMode))
+                              console.log("Warning unknown elevationCorrectionMode: '%1'".arg(positioningSettings.elevationCorrectionMode))
 
                               // Unknown mode -> fallback to None
                               verticalGridShiftComboBox.currentIndex = verticalGridShiftComboBox.indexOfValue(Positioning.ElevationCorrectionMode.None)

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -484,9 +484,8 @@ Page {
                               var systemLanguage = qsTr( "system" );
                               var systemLanguageSuffix = systemLanguage !== 'system' ? ' (system)' : ''
                               var items = [systemLanguage + systemLanguageSuffix]
-                              model = items.concat(Object.values(languages));
-
-                              currentIndex = languageCodes.indexOf(customLanguageCode);
+                              languageComboBox.model = items.concat(Object.values(languages));
+                              languageComboBox.currentIndex = languageCodes.indexOf(customLanguageCode);
                               currentLanguageCode = customLanguageCode || ''
                               languageTip.visible = false
                           }
@@ -838,8 +837,8 @@ Page {
                             qsTr("VDOP")
                           ];
 
-                          model = measurements;
-                          currentIndex = positioningSettings.digitizingMeasureType - 1;
+                          measureComboBox.model = measurements;
+                          measureComboBox.currentIndex = positioningSettings.digitizingMeasureType - 1;
                           loaded = true;
                       }
 
@@ -1238,7 +1237,7 @@ Page {
                       valueRole: "value"
 
                       model: ListModel {
-                          id: model
+                          id: verticalGridShiftModel
                       }
 
                       onCurrentValueChanged: {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -211,7 +211,7 @@ ApplicationWindow {
       verticalGrid: positioningSettings.verticalGrid
     }
 
-    ellipsoidalElevation: positioningSettings.ellipsoidalElevation
+    elevationCorrectionMode: positioningSettings.elevationCorrectionMode
     antennaHeight: positioningSettings.antennaHeightActivated ? positioningSettings.antennaHeight : 0
     logging: positioningSettings.logging
 

--- a/test/qml/tst_positioning.qml
+++ b/test/qml/tst_positioning.qml
@@ -12,7 +12,7 @@ TestCase {
         id: positioning
         deviceId: 'udp:localhost:1958'
         active: true
-        ellipsoidalElevation: true
+        elevationCorrectionMode: Positioning.ElevationCorrectionMode.None
 
         coordinateTransformer: CoordinateTransformer {
           id: coordinateTransformer

--- a/test/qml/tst_positioning.qml
+++ b/test/qml/tst_positioning.qml
@@ -25,10 +25,12 @@ TestCase {
     }
 
     function test_01_ellipsoidalElevation() {
+        positioning.elevationCorrectionMode = Positioning.ElevationCorrectionMode.None
         coordinateTransformer.deltaZ = 0
         coordinateTransformer.verticalGrid = ''
         // wait a few seconds so positioning can catch some NMEA strings
         wait(2500)
+
 
         // the elevation in the NMEA stream goes between 320 to 322, and the ellispodal adjustment is -26.0 meters
         // we therefore simply check whether we are int the 200s value range, which indicates ellispodal elevation is
@@ -36,7 +38,21 @@ TestCase {
         compare(Math.floor(positioning.positionInformation.elevation / 100), 2)
     }
 
-    function test_02_deltaZ() {
+    function test_02_orthometricElevation() {
+        positioning.elevationCorrectionMode = Positioning.ElevationCorrectionMode.OrthometricFromDevice
+        coordinateTransformer.deltaZ = 0
+        coordinateTransformer.verticalGrid = ''
+        // wait a few seconds so positioning can catch some NMEA strings
+        wait(2500)
+
+        // the orthmoetric elevation in the NMEA stream goes between 320 to 322,
+        // we therefore simply check whether we are int the 300s value range, which indicates orthographic elevation is
+        // being returned
+        compare(Math.floor(positioning.positionInformation.elevation / 100), 3)
+    }
+
+    function test_03_deltaZ() {
+        positioning.elevationCorrectionMode = Positioning.ElevationCorrectionMode.None
         coordinateTransformer.deltaZ = -100
         coordinateTransformer.verticalGrid = ''
         // wait a few seconds so positioning can catch some NMEA strings
@@ -48,7 +64,8 @@ TestCase {
         compare(Math.floor(positioning.projectedPosition.z / 100), 1)
     }
 
-    function test_03_verticalGrid() {
+    function test_04_verticalGrid() {
+        positioning.elevationCorrectionMode = Positioning.ElevationCorrectionMode.OrthometricFromGeoidFile
         coordinateTransformer.deltaZ = 0
         coordinateTransformer.verticalGrid = dataDir + '/testgrid.tif'
         // wait a few seconds so positioning can catch some NMEA strings
@@ -60,8 +77,9 @@ TestCase {
         compare(Math.floor(positioning.projectedPosition.z / 100), -1)
     }
 
-    function test_04_tcpReceiver() {
+    function test_05_tcpReceiver() {
         positioning.deviceId = 'tcp:localhost:11111'
+        positioning.elevationCorrectionMode = Positioning.ElevationCorrectionMode.None
         coordinateTransformer.deltaZ = 0
         coordinateTransformer.verticalGrid = ''
         // wait a few seconds so positioning can catch some NMEA strings
@@ -74,9 +92,9 @@ TestCase {
         compare(Math.floor(positioning.positionInformation.vacc), 4)
     }
 
-    function test_05_happyIMU() {
+    function test_06_happyIMU() {
         positioning.deviceId = 'udp:localhost:1959'
-
+        positioning.elevationCorrectionMode = Positioning.ElevationCorrectionMode.None
         coordinateTransformer.deltaZ = 0
         coordinateTransformer.verticalGrid = ''
 
@@ -87,9 +105,9 @@ TestCase {
         compare(positioning.positionInformation.imuCorrection, true)
     }
 
-    function test_06_happyMonch2IMU() {
+    function test_07_happyMonch2IMU() {
         positioning.deviceId = 'udp:localhost:1960'
-
+        positioning.elevationCorrectionMode = Positioning.ElevationCorrectionMode.None
         coordinateTransformer.deltaZ = 0
         coordinateTransformer.verticalGrid = ''
 


### PR DESCRIPTION
This also avoid the possibility to make a double geoid correction (from device + from file)

- Orthometric is visible only for devices supporting it
- Geoid files are visibles only if available

![Peek 2023-09-07 16-27](https://github.com/opengisch/QField/assets/9881900/b012a567-f71e-4e58-96e1-e3c581203b41)
