### PR TITLE
Event queue optimizations

### DIFF
--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -194,6 +194,7 @@ ListView {
         round: true
         bgcolor: Theme.mainColor
         SequentialAnimation on bgcolor  {
+            running: isVisible && legend.isVisible
             loops: Animation.Infinite
             ColorAnimation  { from: Theme.mainColor; to: "#5a8725"; duration: 2000; easing.type: Easing.InOutQuad }
             ColorAnimation  { from: "#5a8725"; to: Theme.mainColor; duration: 1000; easing.type: Easing.InOutQuad }

--- a/src/qml/LocationMarker.qml
+++ b/src/qml/LocationMarker.qml
@@ -96,12 +96,6 @@ Item {
       PathLine { x: 13; y: 16 }
       PathLine { x: 5; y: 22 }
       PathLine { x: 13; y: 2 }
-
-      SequentialAnimation on fillColor  {
-        loops: Animation.Infinite
-        ColorAnimation  { from: locationMarker.color; to: locationMarker.darkerColor; duration: 2000; easing.type: Easing.InOutQuad }
-        ColorAnimation  { from: locationMarker.darkerColor; to: locationMarker.color; duration: 1000; easing.type: Easing.InOutQuad }
-      }
     }
 
     layer.enabled: true
@@ -129,12 +123,6 @@ Item {
     color: locationMarker.color
     border.color: "white"
     border.width: 3
-
-    SequentialAnimation on color  {
-      loops: Animation.Infinite
-      ColorAnimation  { from: locationMarker.color; to: locationMarker.darkerColor; duration: 2000; easing.type: Easing.InOutQuad }
-      ColorAnimation  { from: locationMarker.darkerColor; to: locationMarker.color; duration: 1000; easing.type: Easing.InOutQuad }
-    }
 
     layer.enabled: true
     layer.effect: QfDropShadow {
@@ -172,12 +160,6 @@ Item {
       PathLine { x: 18; y: 20 }
       PathLine { x: 2; y: 20 }
       PathLine { x: 10; y: 0 }
-
-      SequentialAnimation on fillColor  {
-        loops: Animation.Infinite
-        ColorAnimation  { from: locationMarker.color; to: locationMarker.darkerColor; duration: 2000; easing.type: Easing.InOutQuad }
-        ColorAnimation  { from: locationMarker.darkerColor; to: locationMarker.color; duration: 1000; easing.type: Easing.InOutQuad }
-      }
     }
 
     layer.enabled: true


### PR DESCRIPTION
Alright, this turned out to be quite an instructive investigation.

Animated QML items are great looking, but turns out they end up *flooding* the main app event queue, which in turn has some significant consequence when trying to invoke methods on the main app thread (e.g. rendering maps with data-defined expression that require a main thread method invocation).

The biggest issue here turned out to be the legend. _Even if_ an animated item is not visible, the animation does run and does trigger a lot of event. In our case, we had an animated tracker badge _for each legend item_ triggering events, which meant that a large project would create loads and loads of events.

Solution: if an animation isn't providing that much more visual feedback, kill it. If it's important or can be confined, insure it's only running when needed.