### PR TITLE
Runtime profiler logging capability

### DIFF
--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -163,7 +163,7 @@ void AppInterface::logMessage( const QString &message )
 
 void AppInterface::logRuntimeProfiler()
 {
-#if _QGIS_VERSION_INT >= 33300
+#if _QGIS_VERSION_INT >= 33299
   QgsMessageLog::logMessage( QgsApplication::profiler()->asText(), QStringLiteral( "QField" ) );
 #else
   QgsMessageLog::logMessage( QStringLiteral( "QField must be compiled against QGIS >= 3.34 to support logging of the runtime profiler" ), QStringLiteral( "QField" ) );

--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -26,8 +26,10 @@
 #include <QDirIterator>
 #include <QFileInfo>
 #include <QImageReader>
+#include <qgsapplication.h>
 #include <qgsexiftools.h>
 #include <qgsmessagelog.h>
+#include <qgsruntimeprofiler.h>
 #include <qgsziputils.h>
 
 AppInterface *AppInterface::sAppInterface = nullptr;
@@ -157,6 +159,15 @@ bool AppInterface::isFileExtensionSupported( const QString &filename ) const
 void AppInterface::logMessage( const QString &message )
 {
   QgsMessageLog::logMessage( message, QStringLiteral( "QField" ) );
+}
+
+void AppInterface::logRuntimeProfiler()
+{
+#if _QGIS_VERSION_INT >= 33300
+  QgsMessageLog::logMessage( QgsApplication::profiler()->asText(), QStringLiteral( "QField" ) );
+#else
+  QgsMessageLog::logMessage( QStringLiteral( "QField must be compiled against QGIS >= 3.34 to support logging of the runtime profiler" ), QStringLiteral( "QField" ) );
+#endif
 }
 
 void AppInterface::sendLog( const QString &message )

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -67,6 +67,13 @@ class AppInterface : public QObject
     Q_INVOKABLE void logMessage( const QString &message );
 
     /**
+     * Outputs the current runtime profiler model content into the message log
+     * panel, as well as added into the device's system logs
+     * which will be captured by the sentry's reporting framework when enabled.
+     */
+    Q_INVOKABLE void logRuntimeProfiler();
+
+    /**
      * Sends a logs reporting through to sentry when enabled.
      */
     Q_INVOKABLE void sendLog( const QString &message );

--- a/src/qml/MessageLog.qml
+++ b/src/qml/MessageLog.qml
@@ -44,6 +44,15 @@ Page {
         objectName: 'messagesList'
         flickableDirection: Flickable.VerticalFlick
         boundsBehavior: Flickable.StopAtBounds
+        ScrollBar.vertical: ScrollBar {
+          policy: ScrollBar.AsNeeded
+          width: 6
+          contentItem: Rectangle {
+            implicitWidth: 6
+            implicitHeight: 25
+            color: Theme.mainColor
+          }
+        }
         clip: true
         anchors.fill: parent
         spacing: 2

--- a/src/qml/MessageLog.qml
+++ b/src/qml/MessageLog.qml
@@ -121,7 +121,7 @@ Page {
     }
 
     QfButton {
-        text: qsTr("Log current runtime profiler")
+        text: qsTr("Log runtime profiler")
         Layout.fillWidth: true
 
         onClicked: {

--- a/src/qml/MessageLog.qml
+++ b/src/qml/MessageLog.qml
@@ -84,7 +84,7 @@ Page {
               objectName: 'messageText'
               padding: 5
               width: rectangle.width - datetext.width - tagtext.width - separator.width - 3 * line.spacing
-              text: Message
+              text: Message.replace(new RegExp('\n', "gi"), '<br>')
               font: Theme.tipFont
               color: Theme.mainTextColor
               wrapMode: Text.WordWrap
@@ -109,6 +109,15 @@ Page {
     TextEdit{
         id: copyHelper
         visible: false
+    }
+
+    QfButton {
+        text: qsTr("Log current runtime profiler")
+        Layout.fillWidth: true
+
+        onClicked: {
+            iface.logRuntimeProfiler()
+        }
     }
 
     QfButton {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2777,7 +2777,7 @@ ApplicationWindow {
             result = Math.max(item.contentItem.implicitWidth, result);
             padding = Math.max(item.padding, padding);
         }
-        return Math.min( result + padding * 2,mainWindow.width - 20);
+        return Math.max(10, Math.min(result + padding * 2,mainWindow.width - 20));
     }
 
     MenuItem {

--- a/vcpkg/overlay/qgis-qt6/portfile.cmake
+++ b/vcpkg/overlay/qgis-qt6/portfile.cmake
@@ -21,6 +21,7 @@ vcpkg_from_github(
         vectortilelabels.patch # Remove when updating to QGIS 3.34
         version.patch # Remove when updating to QGIS 3.34
         snapping_properties.patch # Remove when updating to QGIS 3.34
+        profiler.patch # Remove when updating to QGIS 3.34
 )
 
 file(REMOVE ${SOURCE_PATH}/cmake/FindQtKeychain.cmake)

--- a/vcpkg/overlay/qgis-qt6/profiler.patch
+++ b/vcpkg/overlay/qgis-qt6/profiler.patch
@@ -1,0 +1,115 @@
+diff --git a/python/core/auto_generated/qgsruntimeprofiler.sip.in b/python/core/auto_generated/qgsruntimeprofiler.sip.in
+index a9bfe71e003..fa3bbce1de4 100644
+--- a/python/core/auto_generated/qgsruntimeprofiler.sip.in
++++ b/python/core/auto_generated/qgsruntimeprofiler.sip.in
+@@ -127,6 +127,15 @@ Returns the translated name of a standard profile ``group``.
+     virtual QVariant headerData( int section, Qt::Orientation orientation, int role = Qt::DisplayRole ) const;
+ 
+ 
++    QString asText( const QString &group = QString() );
++%Docstring
++Returns the model as a multi-line text string.
++
++:param group: A group name to filter the model against.
++
++.. versionadded:: 3.34
++%End
++
+ 
+     void groupAdded( const QString &group );
+ %Docstring
+diff --git a/src/core/qgsruntimeprofiler.cpp b/src/core/qgsruntimeprofiler.cpp
+index e97e29c4d7e..f3ad7c854dc 100644
+--- a/src/core/qgsruntimeprofiler.cpp
++++ b/src/core/qgsruntimeprofiler.cpp
+@@ -575,6 +575,42 @@ QgsRuntimeProfilerNode *QgsRuntimeProfiler::index2node( const QModelIndex &index
+   return reinterpret_cast<QgsRuntimeProfilerNode *>( index.internalPointer() );
+ }
+ 
++void QgsRuntimeProfiler::extractModelAsText( QStringList &lines, const QString &group, const QModelIndex &parent, int level )
++{
++  const int rc = rowCount( parent );
++  const int cc = columnCount( parent );
++  for ( int r = 0; r < rc; r++ )
++  {
++    QModelIndex rowIndex = index( r, 0, parent );
++    if ( data( rowIndex, QgsRuntimeProfilerNode::Group ).toString() != group )
++      continue;
++
++    QStringList cells;
++    for ( int c = 0; c < cc; c++ )
++    {
++      QModelIndex cellIndex = index( r, c, parent );
++      cells << data( cellIndex ).toString();
++    }
++    lines << QStringLiteral( "%1 %2" ).arg( QStringLiteral( "-" ).repeated( level + 1 ), cells.join( QStringLiteral( ": " ) ) );
++    extractModelAsText( lines, group, rowIndex, level + 1 );
++  }
++}
++
++QString QgsRuntimeProfiler::asText( const QString &group )
++{
++  QStringList lines;
++  for ( const QString &g : std::as_const( mGroups ) )
++  {
++    if ( !group.isEmpty() && g != group )
++      continue;
++
++    const QString groupName = translateGroupName( g );
++    lines << ( !groupName.isEmpty() ? groupName : g );
++    extractModelAsText( lines, g );
++  }
++  return lines.join( QStringLiteral( "\r\n" ) );
++}
++
+ 
+ //
+ // QgsScopedRuntimeProfile
+diff --git a/src/core/qgsruntimeprofiler.h b/src/core/qgsruntimeprofiler.h
+index 7d615610354..5de0a45dc11 100644
+--- a/src/core/qgsruntimeprofiler.h
++++ b/src/core/qgsruntimeprofiler.h
+@@ -263,6 +263,13 @@ class CORE_EXPORT QgsRuntimeProfiler : public QAbstractItemModel
+     QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
+     QVariant headerData( int section, Qt::Orientation orientation, int role = Qt::DisplayRole ) const override;
+ 
++    /**
++     * Returns the model as a multi-line text string.
++     * \param group A group name to filter the model against.
++     * \since QGIS 3.34
++     */
++    QString asText( const QString &group = QString() );
++
+ #ifndef SIP_RUN
+     ///@cond PRIVATE
+   signals:
+@@ -293,6 +300,7 @@ class CORE_EXPORT QgsRuntimeProfiler : public QAbstractItemModel
+     QgsRuntimeProfilerNode *pathToNode( const QString &group, const QStringList &path ) const;
+     QModelIndex node2index( QgsRuntimeProfilerNode *node ) const;
+     QModelIndex indexOfParentNode( QgsRuntimeProfilerNode *parentNode ) const;
++    void extractModelAsText( QStringList &lines, const QString &group, const QModelIndex &parent = QModelIndex(), int level = 0 );
+ 
+     /**
+      * Returns node for given index. Returns root node for invalid index.
+diff --git a/tests/src/core/testqgsruntimeprofiler.cpp b/tests/src/core/testqgsruntimeprofiler.cpp
+index 0a170644da3..d2d9f8de624 100644
+--- a/tests/src/core/testqgsruntimeprofiler.cpp
++++ b/tests/src/core/testqgsruntimeprofiler.cpp
+@@ -87,6 +87,17 @@ void TestQgsRuntimeProfiler::testGroups()
+   QCOMPARE( profiler.childGroups( QString(), QStringLiteral( "group 1" ) ), QStringList() << QStringLiteral( "task 1" ) );
+   QCOMPARE( profiler.childGroups( QStringLiteral( "task 1" ), QStringLiteral( "group 1" ) ), QStringList() << QStringLiteral( "task 1a" ) );
+   QCOMPARE( profiler.childGroups( QString(), QStringLiteral( "group 2" ) ), QStringList() << QStringLiteral( "task 2" ) );
++
++  QString profilerAsText = profiler.asText();
++  // verify individual chunks as the ordering of individual model items can vary
++  QVERIFY( profilerAsText.contains( QStringLiteral( "group 2\r\n- task 2: 0" ) ) );
++  QVERIFY( profilerAsText.contains( QStringLiteral( "group 1\r\n" ) ) );
++  QVERIFY( profilerAsText.contains( QStringLiteral( "\r\n- task 1: 0" ) ) );
++  QVERIFY( profilerAsText.contains( QStringLiteral( "\r\n-- task 1a: 0" ) ) );
++
++  profilerAsText = profiler.asText( QStringLiteral( "group 2" ) );
++  // verify individual chunks as the ordering of individual model items can vary
++  QCOMPARE( profilerAsText, QStringLiteral( "group 2\r\n- task 2: 0" ) );
+ }
+ 
+ 

--- a/vcpkg/overlay/qgis/portfile.cmake
+++ b/vcpkg/overlay/qgis/portfile.cmake
@@ -23,6 +23,7 @@ vcpkg_from_github(
         vectortilelabels.patch # Remove when updating to QGIS 3.34
         version.patch # Remove when updating to QGIS 3.34
         snapping_properties.patch # Remove when updating to QGIS 3.34
+        profiler.patch # Remove when updating to QGIS 3.34
 )
 
 file(REMOVE ${SOURCE_PATH}/cmake/FindQtKeychain.cmake)

--- a/vcpkg/overlay/qgis/profiler.patch
+++ b/vcpkg/overlay/qgis/profiler.patch
@@ -1,0 +1,115 @@
+diff --git a/python/core/auto_generated/qgsruntimeprofiler.sip.in b/python/core/auto_generated/qgsruntimeprofiler.sip.in
+index a9bfe71e003..fa3bbce1de4 100644
+--- a/python/core/auto_generated/qgsruntimeprofiler.sip.in
++++ b/python/core/auto_generated/qgsruntimeprofiler.sip.in
+@@ -127,6 +127,15 @@ Returns the translated name of a standard profile ``group``.
+     virtual QVariant headerData( int section, Qt::Orientation orientation, int role = Qt::DisplayRole ) const;
+ 
+ 
++    QString asText( const QString &group = QString() );
++%Docstring
++Returns the model as a multi-line text string.
++
++:param group: A group name to filter the model against.
++
++.. versionadded:: 3.34
++%End
++
+ 
+     void groupAdded( const QString &group );
+ %Docstring
+diff --git a/src/core/qgsruntimeprofiler.cpp b/src/core/qgsruntimeprofiler.cpp
+index e97e29c4d7e..f3ad7c854dc 100644
+--- a/src/core/qgsruntimeprofiler.cpp
++++ b/src/core/qgsruntimeprofiler.cpp
+@@ -575,6 +575,42 @@ QgsRuntimeProfilerNode *QgsRuntimeProfiler::index2node( const QModelIndex &index
+   return reinterpret_cast<QgsRuntimeProfilerNode *>( index.internalPointer() );
+ }
+ 
++void QgsRuntimeProfiler::extractModelAsText( QStringList &lines, const QString &group, const QModelIndex &parent, int level )
++{
++  const int rc = rowCount( parent );
++  const int cc = columnCount( parent );
++  for ( int r = 0; r < rc; r++ )
++  {
++    QModelIndex rowIndex = index( r, 0, parent );
++    if ( data( rowIndex, QgsRuntimeProfilerNode::Group ).toString() != group )
++      continue;
++
++    QStringList cells;
++    for ( int c = 0; c < cc; c++ )
++    {
++      QModelIndex cellIndex = index( r, c, parent );
++      cells << data( cellIndex ).toString();
++    }
++    lines << QStringLiteral( "%1 %2" ).arg( QStringLiteral( "-" ).repeated( level + 1 ), cells.join( QStringLiteral( ": " ) ) );
++    extractModelAsText( lines, group, rowIndex, level + 1 );
++  }
++}
++
++QString QgsRuntimeProfiler::asText( const QString &group )
++{
++  QStringList lines;
++  for ( const QString &g : std::as_const( mGroups ) )
++  {
++    if ( !group.isEmpty() && g != group )
++      continue;
++
++    const QString groupName = translateGroupName( g );
++    lines << ( !groupName.isEmpty() ? groupName : g );
++    extractModelAsText( lines, g );
++  }
++  return lines.join( QStringLiteral( "\r\n" ) );
++}
++
+ 
+ //
+ // QgsScopedRuntimeProfile
+diff --git a/src/core/qgsruntimeprofiler.h b/src/core/qgsruntimeprofiler.h
+index 7d615610354..5de0a45dc11 100644
+--- a/src/core/qgsruntimeprofiler.h
++++ b/src/core/qgsruntimeprofiler.h
+@@ -263,6 +263,13 @@ class CORE_EXPORT QgsRuntimeProfiler : public QAbstractItemModel
+     QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
+     QVariant headerData( int section, Qt::Orientation orientation, int role = Qt::DisplayRole ) const override;
+ 
++    /**
++     * Returns the model as a multi-line text string.
++     * \param group A group name to filter the model against.
++     * \since QGIS 3.34
++     */
++    QString asText( const QString &group = QString() );
++
+ #ifndef SIP_RUN
+     ///@cond PRIVATE
+   signals:
+@@ -293,6 +300,7 @@ class CORE_EXPORT QgsRuntimeProfiler : public QAbstractItemModel
+     QgsRuntimeProfilerNode *pathToNode( const QString &group, const QStringList &path ) const;
+     QModelIndex node2index( QgsRuntimeProfilerNode *node ) const;
+     QModelIndex indexOfParentNode( QgsRuntimeProfilerNode *parentNode ) const;
++    void extractModelAsText( QStringList &lines, const QString &group, const QModelIndex &parent = QModelIndex(), int level = 0 );
+ 
+     /**
+      * Returns node for given index. Returns root node for invalid index.
+diff --git a/tests/src/core/testqgsruntimeprofiler.cpp b/tests/src/core/testqgsruntimeprofiler.cpp
+index 0a170644da3..d2d9f8de624 100644
+--- a/tests/src/core/testqgsruntimeprofiler.cpp
++++ b/tests/src/core/testqgsruntimeprofiler.cpp
+@@ -87,6 +87,17 @@ void TestQgsRuntimeProfiler::testGroups()
+   QCOMPARE( profiler.childGroups( QString(), QStringLiteral( "group 1" ) ), QStringList() << QStringLiteral( "task 1" ) );
+   QCOMPARE( profiler.childGroups( QStringLiteral( "task 1" ), QStringLiteral( "group 1" ) ), QStringList() << QStringLiteral( "task 1a" ) );
+   QCOMPARE( profiler.childGroups( QString(), QStringLiteral( "group 2" ) ), QStringList() << QStringLiteral( "task 2" ) );
++
++  QString profilerAsText = profiler.asText();
++  // verify individual chunks as the ordering of individual model items can vary
++  QVERIFY( profilerAsText.contains( QStringLiteral( "group 2\r\n- task 2: 0" ) ) );
++  QVERIFY( profilerAsText.contains( QStringLiteral( "group 1\r\n" ) ) );
++  QVERIFY( profilerAsText.contains( QStringLiteral( "\r\n- task 1: 0" ) ) );
++  QVERIFY( profilerAsText.contains( QStringLiteral( "\r\n-- task 1a: 0" ) ) );
++
++  profilerAsText = profiler.asText( QStringLiteral( "group 2" ) );
++  // verify individual chunks as the ordering of individual model items can vary
++  QCOMPARE( profilerAsText, QStringLiteral( "group 2\r\n- task 2: 0" ) );
+ }
+ 
+ 


### PR DESCRIPTION
We've got the runtime profiler to thanks for the massive optimization found here (https://github.com/opengisch/QField/pull/4571), we might as well expose it :wink: 

It'll help advanced users getting a clear sense of rendering and project load bottlenecks.

Photo time:
![image](https://github.com/opengisch/QField/assets/1728657/53475c72-ba36-4dec-b006-b75be0eda633)

Outputting the data through the message log also means users can send that over sentry, which I'm sure will come in handy.

Note: it requires upcoming 3.34 to work, so APKs won't show anything for now.