### PR TITLE
Fix a couple of children geometry addition issues

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -768,7 +768,7 @@ Page {
   }
 
   function cancel() {
-    if( form.state === 'Add' && featureCreated && qfieldSettings.autoSave ) {
+    if( form.state === 'Add' && featureCreated ) {
       // indirect action, no need to check for success and display a toast, the log is enough
       model.deleteFeature()
     }

--- a/src/qml/MapCanvas.qml
+++ b/src/qml/MapCanvas.qml
@@ -195,6 +195,7 @@ Item {
   // stylus clicks
   TapHandler {
     enabled: interactive && hovered && !pinchArea.isDragging
+    grabPermissions: PointerHandler.CanTakeOverFromHandlersOfDifferentType | PointerHandler.ApprovesTakeOverByAnything | PointerHandler.ApprovesCancellation
     acceptedDevices: PointerDevice.Stylus | PointerDevice.Mouse
     acceptedButtons: Qt.LeftButton | Qt.RightButton
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -373,9 +373,9 @@ ApplicationWindow {
             }
             // when hovering various toolbars, reset coordinate locator position for nicer UX
             if ( !freehandHandler.active && ( pointInItem( point, digitizingToolbar ) || pointInItem( point, elevationProfileButton ) ) ) {
-                coordinateLocator.sourceLocation = mapCanvas.mapSettings.coordinateToScreen( digitizingToolbar.rubberbandModel.lastCoordinate );
+                coordinateLocator.sourceLocation = mapCanvas.mapSettings.coordinateToScreen( digitizingToolbar.rubberbandModel.lastCoordinate )
             } else if ( !freehandHandler.active && pointInItem( point, geometryEditorsToolbar ) ) {
-                coordinateLocator.sourceLocation = mapCanvas.mapSettings.coordinateToScreen( geometryEditorsToolbar.editorRubberbandModel.lastCoordinate );
+                coordinateLocator.sourceLocation = mapCanvas.mapSettings.coordinateToScreen( geometryEditorsToolbar.editorRubberbandModel.lastCoordinate )
             } else if ( !freehandHandler.active ) {
                 // after a click, it seems that the position is sent once at 0,0 => weird)
                 if (point.position !== Qt.point(0, 0))
@@ -446,7 +446,7 @@ ApplicationWindow {
     /* The map canvas */
     MapCanvas {
       id: mapCanvasMap
-      interactive: !screenLocker.enabled
+      interactive: !dashBoard.opened && !screenLocker.enabled && !welcomeScreen.visible && !qfieldSettings.visible && !cloudPopup.visible && !codeReader.visible
       incrementalRendering: true
       quality: qfieldSettings.quality
       forceDeferredLayersRepaint: trackings.count > 0
@@ -455,6 +455,10 @@ ApplicationWindow {
       anchors.fill: parent
 
       onClicked: (point, type) => {
+          if (type === "stylus" && (featureForm.visible || overlayFeatureFormDrawer.opened)) {
+              return;
+          }
+
           if (!digitizingToolbar.geometryRequested && featureForm.state == "FeatureFormEdit") {
               featureForm.requestCancel();
               return;
@@ -466,6 +470,23 @@ ApplicationWindow {
           }
 
           if ( type === "stylus" ) {
+
+              function pointInItem(point, item) {
+                  var itemCoordinates = item.mapToItem(mainWindow.contentItem, 0, 0);
+                  return point.x >= itemCoordinates.x && point.x <= itemCoordinates.x + item.width &&
+                         point.y >= itemCoordinates.y && point.y <= itemCoordinates.y + item.height;
+              }
+
+              if ( pointInItem( point, digitizingToolbar ) ||
+                   pointInItem( point, zoomToolbar ) ||
+                   pointInItem( point, mainToolbar ) ||
+                   pointInItem( point, mainMenuBar ) ||
+                   pointInItem( point, geometryEditorsToolbar ) ||
+                   pointInItem( point, locationToolbar ) ||
+                   pointInItem( point, locatorItem ) ) {
+                  return;
+              }
+
               // Check if geometry editor is taking over
               if ( !(positionSource.active && positioningSettings.positioningCoordinateLock) && geometryEditorsToolbar.canvasClicked(point) )
                   return;

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -455,7 +455,7 @@ ApplicationWindow {
       anchors.fill: parent
 
       onClicked: (point, type) => {
-          if (featureForm.state == "FeatureFormEdit") {
+          if (!digitizingToolbar.geometryRequested && featureForm.state == "FeatureFormEdit") {
               featureForm.requestCancel();
               return;
           }
@@ -1832,10 +1832,14 @@ ApplicationWindow {
 
       onCancel: {
           if ( stateMachine.state === 'measure' && elevationProfileButton.elevationProfileActive ) {
-              elevationProfile.clear();
-              elevationProfile.refresh();
+              elevationProfile.clear()
+              elevationProfile.refresh()
           } else {
               if ( geometryRequested ) {
+                  if ( overlayFeatureFormDrawer.isAdding )
+                  {
+                      overlayFeatureFormDrawer.open()
+                  }
                   geometryRequested = false
               }
           }
@@ -1845,7 +1849,9 @@ ApplicationWindow {
         if ( geometryRequested )
         {
             if ( overlayFeatureFormDrawer.isAdding )
+            {
                 overlayFeatureFormDrawer.open()
+            }
 
             coordinateLocator.flash()
             digitizingFeature.geometry.applyRubberband()

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1857,8 +1857,7 @@ ApplicationWindow {
               elevationProfile.refresh()
           } else {
               if ( geometryRequested ) {
-                  if ( overlayFeatureFormDrawer.isAdding )
-                  {
+                  if ( overlayFeatureFormDrawer.isAdding ) {
                       overlayFeatureFormDrawer.open()
                   }
                   geometryRequested = false
@@ -1869,8 +1868,7 @@ ApplicationWindow {
       onConfirmed: {
         if ( geometryRequested )
         {
-            if ( overlayFeatureFormDrawer.isAdding )
-            {
+            if ( overlayFeatureFormDrawer.isAdding ) {
                 overlayFeatureFormDrawer.open()
             }
 


### PR DESCRIPTION
This fixes:
- deleting a parent feature being added following the addition of a child is not working
- stylus usage while adding a child geometry
- parent feature form being added not re-appearing after cancelling a child addition

In addition, some changes were committed to improve the stylus experience by attempting to work around Qt limitation / poor handling of the stylus. Massive UX improvement there.