### PR TITLE
Brand new tracker functionality: maximum distance tolerance

### DIFF
--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -21,6 +21,8 @@
 #include <qgsproject.h>
 #include <qgssensormanager.h>
 
+#define MAXIMUM_DISTANCE_FAILURES 20
+
 Tracker::Tracker( QgsVectorLayer *layer, bool visible )
   : mLayer( layer ), mVisible( visible )
 {
@@ -48,7 +50,7 @@ void Tracker::trackPosition()
   if ( !qgsDoubleNear( mMaximumDistance, 0.0 ) && mCurrentDistance > mMaximumDistance )
   {
     // Simple logic to avoid getting stuck in an infinite erroneous distance having somehow actually moved beyond the safeguard threshold
-    if ( ++mMaximumDistanceFailures < 20 )
+    if ( ++mMaximumDistanceFailuresCount < MAXIMUM_DISTANCE_FAILURES )
     {
       return;
     }
@@ -57,7 +59,7 @@ void Tracker::trackPosition()
   mSkipPositionReceived = true;
   model()->addVertex();
 
-  mMaximumDistanceFailures = 0;
+  mMaximumDistanceFailuresCount = 0;
   mCurrentDistance = 0.0;
   mTimeIntervalFulfilled = false;
   mMinimumDistanceFulfilled = false;
@@ -171,7 +173,7 @@ void Tracker::start()
   }
 
   mSkipPositionReceived = false;
-  mMaximumDistanceFailures = 0;
+  mMaximumDistanceFailuresCount = 0;
   mCurrentDistance = mMaximumDistance;
 
   //track first position

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -117,7 +117,7 @@ class Tracker : public QObject
     double mTimeInterval = 0.0;
     double mMinimumDistance = 0.0;
     double mMaximumDistance = 0.0;
-    int mMaximumDistanceFailures = 0;
+    int mMaximumDistanceFailuresCount = 0;
     double mCurrentDistance = 0.0;
     bool mSensorCapture = false;
     bool mConjunction = true;

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -49,42 +49,49 @@ class Tracker : public QObject
     RubberbandModel *model() const;
     void setModel( RubberbandModel *model );
 
-    //! the (minimum) time interval between setting trackpoints
+    //! Returns the minimum time interval constraint between each tracked point
     double timeInterval() const { return mTimeInterval; }
-    //! the (minimum) time interval between setting trackpoints
+    //! Sets the minimum time interval constraint between each tracked point
     void setTimeInterval( const double timeInterval ) { mTimeInterval = timeInterval; }
 
-    //! the minimum distance between setting trackpoints
+    //! Returns the minimum distance constraint between each tracked point
     double minimumDistance() const { return mMinimumDistance; }
-    //! the minimum distance between setting trackpoints
+    //! Sets the minimum distance constraint between each tracked point
     void setMinimumDistance( const double minimumDistance ) { mMinimumDistance = minimumDistance; };
 
-    //! Returns if TRUE, newly captured sensor data is needed before setting trackpoints
+    //! Returns the maximum distance tolerated beyond which a position will be considered errenous
+    double maximumDistance() const { return mMaximumDistance; }
+    //! Sets the maximum distance tolerated beyond which a position will be considered errenous
+    void setMaximumDistance( const double maximumDistance ) { mMaximumDistance = maximumDistance; };
+
+    //! Returns if TRUE, newly captured sensor data is needed between each tracked point
     bool sensorCapture() const { return mSensorCapture; }
-    //! Sets whether newly captured sensor data is needed before setting trackpoints
+    //! Sets whether newly captured sensor data is needed between each tracked point
     void setSensorCapture( const bool capture ) { mSensorCapture = capture; }
 
-    //! if both, the minimum distance and the time interval, needs to be fulfilled before setting trackpoints
+    //! Returns TRUE if all constraints need to be fulfilled between each tracked point
     bool conjunction() const { return mConjunction; }
-    //! if both, the minimum distance and the time interval, needs to be fulfilled before setting trackpoints
+    //! Sets where all constraints need to be fulfilled between each tracked point
     void setConjunction( const bool conjunction ) { mConjunction = conjunction; }
 
-    //! the timestamp of the first recorded position
+    //! Returns the timestamp of the first recorded point
     QDateTime startPositionTimestamp() const { return mStartPositionTimestamp; }
-    //! the timestamp of the first recorded position
+    //! Sets the timestamp of the first recorded point
     void setStartPositionTimestamp( const QDateTime &startPositionTimestamp ) { mStartPositionTimestamp = startPositionTimestamp; }
 
-    //! the current layer
+    //! Returns the current layer
     QgsVectorLayer *layer() const { return mLayer.data(); }
-    //! the current layer
+    //! Sets the current layer
     void setLayer( QgsVectorLayer *layer ) { mLayer = layer; }
-    //! the created feature
+
+    //! Returns the created feature
     QgsFeature feature() const { return mFeature; }
-    //! the created feature
+    //! Sets the created feature
     void setFeature( const QgsFeature &feature ) { mFeature = feature; }
-    //! if the layer (and the rubberband ) is visible
+
+    //! Returns TRUE if the layer and the rubberband are visible
     bool visible() const { return mVisible; }
-    //! if the layer (and the rubberband ) is visible
+    //! Sets whether the layer and the rubberband are visible
     void setVisible( const bool visible ) { mVisible = visible; }
 
     MeasureType measureType() const { return mMeasureType; }
@@ -105,8 +112,11 @@ class Tracker : public QObject
     RubberbandModel *mRubberbandModel = nullptr;
 
     QTimer mTimer;
-    double mTimeInterval = 0;
-    double mMinimumDistance = 0;
+    double mTimeInterval = 0.0;
+    double mMinimumDistance = 0.0;
+    double mMaximumDistance = 0.0;
+    int mMaximumDistanceFailures = 0;
+    double mCurrentDistance = 0.0;
     bool mSensorCapture = false;
     bool mConjunction = true;
     bool mTimeIntervalFulfilled = false;

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -109,6 +109,8 @@ class Tracker : public QObject
     void sensorDataReceived();
 
   private:
+    void trackPosition();
+
     RubberbandModel *mRubberbandModel = nullptr;
 
     QTimer mTimer;
@@ -122,6 +124,7 @@ class Tracker : public QObject
     bool mTimeIntervalFulfilled = false;
     bool mMinimumDistanceFulfilled = false;
     bool mSensorCaptureFulfilled = false;
+    bool mSkipPositionReceived = false;
 
     QPointer<QgsVectorLayer> mLayer;
     QgsFeature mFeature;
@@ -131,8 +134,6 @@ class Tracker : public QObject
     QDateTime mStartPositionTimestamp;
 
     MeasureType mMeasureType = Tracker::SecondsSinceStart;
-
-    void trackPosition();
 };
 
 #endif // TRACKER_H

--- a/src/core/trackingmodel.cpp
+++ b/src/core/trackingmodel.cpp
@@ -34,6 +34,7 @@ QHash<int, QByteArray> TrackingModel::roleNames() const
   roles[VectorLayer] = "vectorLayer";
   roles[TimeInterval] = "timeInterval";
   roles[MinimumDistance] = "minimumDistance";
+  roles[MaximumDistance] = "maximumDistance";
   roles[Conjunction] = "conjunction";
   roles[Feature] = "feature";
   roles[RubberModel] = "rubberModel";
@@ -119,6 +120,9 @@ bool TrackingModel::setData( const QModelIndex &index, const QVariant &value, in
       break;
     case SensorCapture:
       currentTracker->setSensorCapture( value.toBool() );
+      break;
+    case MaximumDistance:
+      currentTracker->setMaximumDistance( value.toDouble() );
       break;
     default:
       return false;

--- a/src/core/trackingmodel.cpp
+++ b/src/core/trackingmodel.cpp
@@ -14,6 +14,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "rubberbandmodel.h"
 #include "trackingmodel.h"
 
 TrackingModel::TrackingModel( QObject *parent )

--- a/src/core/trackingmodel.h
+++ b/src/core/trackingmodel.h
@@ -16,7 +16,6 @@
 #ifndef TRACKINGMODEL_H
 #define TRACKINGMODEL_H
 
-#include "rubberbandmodel.h"
 #include "tracker.h"
 
 #include <QAbstractItemModel>

--- a/src/core/trackingmodel.h
+++ b/src/core/trackingmodel.h
@@ -35,16 +35,17 @@ class TrackingModel : public QAbstractItemModel
     enum TrackingRoles
     {
       DisplayString = Qt::UserRole,
-      VectorLayer,            //! the layer in the current tracking session
-      RubberModel,            //! the rubberbandmodel used in the current tracking session
-      TimeInterval,           //! the (minimum) time interval constraint between setting trackpoints
-      MinimumDistance,        //! the minimum distance constraint between setting trackpoints
-      Conjunction,            //! if TRUE, all constraints needs to be fulfilled before setting trackpoints
+      VectorLayer,            //! layer in the current tracking session
+      RubberModel,            //! rubberbandmodel used in the current tracking session
+      TimeInterval,           //! minimum time interval constraint between each tracked point
+      MinimumDistance,        //! minimum distance constraint between each tracked point
+      Conjunction,            //! if TRUE, all constraints needs to be fulfilled before tracking a point
       Visible,                //! if the layer and so the tracking components like rubberband is visible
-      Feature,                //! the feature in the current tracking session
-      StartPositionTimestamp, //! the timestamp when the current tracking session started
-      MeasureType,            //! the measurement type used to set the measure value
-      SensorCapture,          //! if TRUE, newly captured sensor data constraint required between setting trackpoints
+      Feature,                //! feature in the current tracking session
+      StartPositionTimestamp, //! timestamp when the current tracking session started
+      MeasureType,            //! measurement type used to set the measure value
+      SensorCapture,          //! if TRUE, newly captured sensor data constraint will be required between each tracked point
+      MaximumDistance,        //! maximum distance tolerated beyond which a position will be considered errenous
     };
 
     QHash<int, QByteArray> roleNames() const override;

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -38,6 +38,9 @@ LabSettings.Settings {
     property bool trackerSensorCaptureConstraint: false
     property bool trackerMeetAllConstraints: false
 
+    property bool trackerErroneousDistanceSafeguard: false
+    property double trackerErroneousDistance: 100
+
     property int trackerMeasureType: 0
     property int digitizingMeasureType: 1
 }

--- a/src/qml/Tracking.qml
+++ b/src/qml/Tracking.qml
@@ -444,6 +444,76 @@ Item {
               Layout.columnSpan: 2
             }
 
+
+
+            Label {
+              text: qsTr("Erroneous distance safeguard")
+              font: Theme.defaultFont
+              wrapMode: Text.WordWrap
+              Layout.fillWidth: true
+
+              MouseArea {
+                anchors.fill: parent
+                onClicked: maximumDistance.toggle()
+              }
+            }
+
+            QfSwitch {
+              id: erroneousDistanceSafeguard
+              Layout.preferredWidth: implicitContentWidth
+              Layout.alignment: Qt.AlignTop
+              checked: positioningSettings.trackerErroneousDistanceSafeguard
+              onCheckedChanged: {
+                positioningSettings.trackerErroneousDistanceSafeguard = checked
+              }
+            }
+
+            Label {
+              text: qsTr("Maximum tolerated distance [%1]").arg( UnitTypes.toAbbreviatedString( infoDistanceArea.lengthUnits ) )
+              font: Theme.defaultFont
+              wrapMode: Text.WordWrap
+              enabled: erroneousDistanceSafeguard.checked
+              visible: erroneousDistanceSafeguard.checked
+              Layout.leftMargin: 8
+              Layout.fillWidth: true
+            }
+
+            QfTextField {
+              id: erroneousDistanceValue
+              width: erroneousDistanceSafeguard.width
+              font: Theme.defaultFont
+              enabled: erroneousDistanceSafeguard.checked
+              visible: erroneousDistanceSafeguard.checked
+              horizontalAlignment: TextInput.AlignHCenter
+              Layout.preferredWidth: 60
+              Layout.preferredHeight: font.height + 20
+
+              inputMethodHints: Qt.ImhFormattedNumbersOnly
+              validator: DoubleValidator { locale: 'C' }
+
+              Component.onCompleted: {
+                text = isNaN(positioningSettings.trackerErroneousDistance) ? '' : positioningSettings.trackerErroneousDistance
+              }
+
+              onTextChanged: {
+                if( text.length === 0 || isNaN(text) ) {
+                  positioningSettings.trackerErroneousDistance = NaN
+                } else {
+                  positioningSettings.trackerErroneousDistance = parseFloat( text )
+                }
+              }
+            }
+
+            Label {
+                text: qsTr( "When erroneous distance safeguard is enabled, position readings that have a distance beyond the specified tolerance value will be discarded." )
+                font: Theme.tipFont
+                color: Theme.secondaryTextColor
+
+                wrapMode: Text.WordWrap
+                Layout.fillWidth: true
+                Layout.columnSpan: 2
+            }
+
             Label {
                 id: measureLabel
                 Layout.fillWidth: true
@@ -519,8 +589,9 @@ Item {
               icon.source: Theme.getThemeVectorIcon( 'directions_walk_24dp' )
 
               onClicked: {
-                track.timeInterval = timeIntervalValue.text.length == 0 || !timeInterval.checked ? 0 : timeIntervalValue.text
-                track.minimumDistance = minimumDistanceValue.text.length == 0 || !minimumDistance.checked ? 0 : minimumDistanceValue.text
+                track.timeInterval = timeIntervalValue.text.length == 0 || !timeInterval.checked ? 0.0 : timeIntervalValue.text
+                track.minimumDistance = minimumDistanceValue.text.length == 0 || !minimumDistance.checked ? 0.0 : minimumDistanceValue.text
+                track.maximumDistance = erroneousDistanceValue.text.length == 0 || !erroneousDistanceSafeguard.checked ? 0.0 : erroneousDistanceValue.text
                 track.sensorCapture = sensorCapture.checked
                 track.conjunction = (timeInterval.checked + minimumDistance.checked + sensorCapture.checked) > 1 && allConstraints.checked
                 track.rubberModel = rubberbandModel

--- a/src/qml/TrackingSession.qml
+++ b/src/qml/TrackingSession.qml
@@ -9,9 +9,9 @@ import Theme 1.0
 import '.'
 
 Item {
-  id: tracking
+  id: trackingSession
 
-  property var track: model
+  property var tracker: model
 
   Component.onCompleted: {
     featureModel.resetAttributes()
@@ -22,14 +22,14 @@ Item {
   RubberbandModel {
     id: rubberbandModel
     frozen: false
-    vectorLayer: track.vectorLayer
+    vectorLayer: tracker.vectorLayer
     currentCoordinate: positionSource.projectedPosition
 
-    property int measureType: track.measureType
+    property int measureType: tracker.measureType
     measureValue: {
       switch(measureType) {
         case Tracker.SecondsSinceStart:
-          return ( positionSource.positionInformation.utcDateTime - track.startPositionTimestamp ) / 1000
+          return ( positionSource.positionInformation.utcDateTime - tracker.startPositionTimestamp ) / 1000
         case Tracker.Timestamp:
           return positionSource.positionInformation.utcDateTime.getTime()
         case Tracker.GroundSpeed:
@@ -74,7 +74,7 @@ Item {
           {
             // indirect action, no need to check for success and display a toast, the log is enough
             featureModel.create()
-            track.feature = featureModel.feature
+            tracker.feature = featureModel.feature
           }
           else
           {
@@ -88,7 +88,7 @@ Item {
 
   Rubberband {
     id: rubberband
-    visible: track.visible
+    visible: tracker.visible
 
     lineWidth: 4
     color: Qt.rgba(Math.min(0.75, Math.random()),
@@ -104,12 +104,12 @@ Item {
   FeatureModel {
     id: featureModel
     project: qgisProject
-    currentLayer: track.vectorLayer
+    currentLayer: tracker.vectorLayer
 
     geometry: Geometry {
       id: featureModelGeometry
       rubberbandModel: rubberbandModel
-      vectorLayer: track.vectorLayer
+      vectorLayer: tracker.vectorLayer
     }
 
     positionInformation: coordinateLocator.positionInformation
@@ -164,14 +164,14 @@ Item {
 
         onTemporaryStored: {
           embeddedFeatureForm.active = false
-          trackingModel.startTracker(track.vectorLayer)
-          displayToast(qsTr('Track on layer %1 started').arg(track.vectorLayer.name))
+          trackingModel.startTracker(tracker.vectorLayer)
+          displayToast(qsTr('Track on layer %1 started').arg(tracker.vectorLayer.name))
         }
 
         onCancelled: {
           embeddedFeatureForm.active = false
           embeddedFeatureForm.focus = false
-          trackingModel.stopTracker(track.vectorLayer)
+          trackingModel.stopTracker(tracker.vectorLayer)
         }
       }
 
@@ -221,7 +221,7 @@ Item {
 
           onBack: {
             trackInformationDialog.active = false
-            trackingModel.stopTracker(track.vectorLayer)
+            trackingModel.stopTracker(tracker.vectorLayer)
           }
         }
 
@@ -326,7 +326,7 @@ Item {
 
             DistanceArea {
               id: infoDistanceArea
-              property VectorLayer currentLayer: track.vectorLayer
+              property VectorLayer currentLayer: tracker.vectorLayer
               project: qgisProject
               crs: qgisProject.crs
             }
@@ -526,7 +526,7 @@ Item {
 
             ComboBox {
                 id: measureComboBox
-                enabled: LayerUtils.hasMValue(track.vectorLayer)
+                enabled: LayerUtils.hasMValue(tracker.vectorLayer)
                 Layout.fillWidth: true
                 Layout.columnSpan: 2
                 Layout.alignment: Qt.AlignVCenter
@@ -565,7 +565,7 @@ Item {
 
             Label {
                 id: measureTipLabel
-                visible: !LayerUtils.hasMValue(track.vectorLayer)
+                visible: !LayerUtils.hasMValue(tracker.vectorLayer)
                 Layout.fillWidth: true
                 text: qsTr( "To active the measurement functionality, make sure the vector layer's geometry type used for the tracking session has an M dimension." )
                 font: Theme.tipFont
@@ -589,21 +589,21 @@ Item {
               icon.source: Theme.getThemeVectorIcon( 'directions_walk_24dp' )
 
               onClicked: {
-                track.timeInterval = timeIntervalValue.text.length == 0 || !timeInterval.checked ? 0.0 : timeIntervalValue.text
-                track.minimumDistance = minimumDistanceValue.text.length == 0 || !minimumDistance.checked ? 0.0 : minimumDistanceValue.text
-                track.maximumDistance = erroneousDistanceValue.text.length == 0 || !erroneousDistanceSafeguard.checked ? 0.0 : erroneousDistanceValue.text
-                track.sensorCapture = sensorCapture.checked
-                track.conjunction = (timeInterval.checked + minimumDistance.checked + sensorCapture.checked) > 1 && allConstraints.checked
-                track.rubberModel = rubberbandModel
-                track.measureType = measureComboBox.currentIndex
-                rubberbandModel.measureType = track.measureType
+                tracker.timeInterval = timeIntervalValue.text.length == 0 || !timeInterval.checked ? 0.0 : timeIntervalValue.text
+                tracker.minimumDistance = minimumDistanceValue.text.length == 0 || !minimumDistance.checked ? 0.0 : minimumDistanceValue.text
+                tracker.maximumDistance = erroneousDistanceValue.text.length == 0 || !erroneousDistanceSafeguard.checked ? 0.0 : erroneousDistanceValue.text
+                tracker.sensorCapture = sensorCapture.checked
+                tracker.conjunction = (timeInterval.checked + minimumDistance.checked + sensorCapture.checked) > 1 && allConstraints.checked
+                tracker.rubberModel = rubberbandModel
+                tracker.measureType = measureComboBox.currentIndex
+                rubberbandModel.measureType = tracker.measureType
 
                 trackInformationDialog.active = false
                 if (embeddedAttributeFormModel.rowCount() > 0 && !featureModel.suppressFeatureForm()) {
                   embeddedFeatureForm.active = true
                 } else {
-                  trackingModel.startTracker(track.vectorLayer)
-                  displayToast(qsTr('Track on layer %1 started').arg(track.vectorLayer.name))
+                  trackingModel.startTracker(tracker.vectorLayer)
+                  displayToast(qsTr('Track on layer %1 started').arg(tracker.vectorLayer.name))
                 }
               }
             }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -578,7 +578,7 @@ ApplicationWindow {
         id: trackings
         model: trackingModel
 
-        Tracking {}
+        TrackingSession {}
     }
 
     /** A rubberband for ditizing **/

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -79,7 +79,7 @@
         <file>imports/Theme/qmldir</file>
         <file>imports/QFieldControls/qmldir</file>
         <file>PageHeader.qml</file>
-        <file>Tracking.qml</file>
+        <file>TrackingSession.qml</file>
         <file>EmbeddedFeatureForm.qml</file>
         <file>ImageDial.qml</file>
         <file>ScreenLocker.qml</file>


### PR DESCRIPTION
This PR implements a new functionality to QField's tracker, allowing users to set a maximum distance tolerance in-between tracked points/vertices beyond which a received position will be flagged as erroneous.

UI-wise, it looks like this:
![image](https://github.com/opengisch/QField/assets/1728657/cadef382-7418-4120-ba36-dabe12e1a10a)

I've taken the opportunity to clean up the documentation a bit, as well as renaming a source file and some variables to (hopefully) increase readability of code. 