### PR TITLE
Implement digitizing throuhg volume keys on Android devices

### DIFF
--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -66,6 +66,7 @@ import android.text.Html;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.DisplayCutout;
+import android.view.KeyEvent;
 import android.view.View;
 import android.view.Window;
 import android.view.WindowInsets;
@@ -105,8 +106,11 @@ public class QFieldActivity extends QtActivity {
 
     public static native void openProject(String url);
     public static native void openPath(String path);
+    public static native void volumeKeyDown(int volumeKeyCode);
+    public static native void volumeKeyUp(int volumeKeyCode);
 
     private float originalBrightness;
+    private boolean handleVolumeKeys = false;
     private String pathsToExport;
     private double sceneTopMargin = 0;
     private double sceneBottomMargin = 0;
@@ -171,6 +175,28 @@ public class QFieldActivity extends QtActivity {
             intent.getAction() == Intent.ACTION_SEND) {
             openProject(getPathFromIntent(intent));
         }
+    }
+
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        if (handleVolumeKeys && (keyCode == KeyEvent.KEYCODE_VOLUME_UP ||
+                                 keyCode == KeyEvent.KEYCODE_VOLUME_DOWN ||
+                                 keyCode == KeyEvent.KEYCODE_MUTE)) {
+            volumeKeyDown(keyCode);
+            return true;
+        }
+        return super.onKeyDown(keyCode, event);
+    }
+
+    @Override
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        if (handleVolumeKeys && (keyCode == KeyEvent.KEYCODE_VOLUME_UP ||
+                                 keyCode == KeyEvent.KEYCODE_VOLUME_DOWN ||
+                                 keyCode == KeyEvent.KEYCODE_MUTE)) {
+            volumeKeyUp(keyCode);
+            return true;
+        }
+        return super.onKeyUp(keyCode, event);
     }
 
     private boolean isDarkTheme() {
@@ -341,6 +367,14 @@ public class QFieldActivity extends QtActivity {
         WindowManager.LayoutParams lp = getWindow().getAttributes();
         lp.screenBrightness = originalBrightness;
         getWindow().setAttributes(lp);
+    }
+
+    private void takeVolumeKeys() {
+        handleVolumeKeys = true;
+    }
+
+    private void releaseVolumeKeys() {
+        handleVolumeKeys = false;
     }
 
     private void showBlockingProgressDialog(String message) {

--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -182,6 +182,7 @@ public class QFieldActivity extends QtActivity {
         if (handleVolumeKeys && (keyCode == KeyEvent.KEYCODE_VOLUME_UP ||
                                  keyCode == KeyEvent.KEYCODE_VOLUME_DOWN ||
                                  keyCode == KeyEvent.KEYCODE_MUTE)) {
+            // Forward volume keys' presses to QField
             volumeKeyDown(keyCode);
             return true;
         }
@@ -193,6 +194,7 @@ public class QFieldActivity extends QtActivity {
         if (handleVolumeKeys && (keyCode == KeyEvent.KEYCODE_VOLUME_UP ||
                                  keyCode == KeyEvent.KEYCODE_VOLUME_DOWN ||
                                  keyCode == KeyEvent.KEYCODE_MUTE)) {
+            // Forward volume keys's releases to QField
             volumeKeyUp(keyCode);
             return true;
         }

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -134,6 +134,12 @@ class AppInterface : public QObject
     //! Requests QField to open its local data picker screen to show the \a path content.
     void openPath( const QString &path );
 
+    //! Emitted when a volume key is pressed while QField is set to handle those keys.
+    void volumeKeyDown( int volumeKeyCode );
+
+    //! Emitted when a volume key is pressed while QField is set to handle those keys.
+    void volumeKeyUp( int volumeKeyCode );
+
   private:
     static AppInterface *sAppInterface;
 

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -875,7 +875,7 @@ void AndroidPlatformUtilities::setHandleVolumeKeys( const bool handle )
 {
   if ( mActivity.isValid() )
   {
-    runOnAndroidMainThread( [&handle] {
+    runOnAndroidMainThread( [handle] {
       auto activity = qtAndroidContext();
       if ( activity.isValid() )
       {

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -98,7 +98,7 @@ AndroidPlatformUtilities::AndroidPlatformUtilities()
 
 PlatformUtilities::Capabilities AndroidPlatformUtilities::capabilities() const
 {
-  PlatformUtilities::Capabilities capabilities = Capabilities() | NativeCamera | AdjustBrightness | CustomLocalDataPicker | CustomImport | CustomExport | CustomSend | FilePicker;
+  PlatformUtilities::Capabilities capabilities = Capabilities() | NativeCamera | AdjustBrightness | CustomLocalDataPicker | CustomImport | CustomExport | CustomSend | FilePicker | VolumeKeys;
 #ifdef WITH_SENTRY
   capabilities |= SentryFramework;
 #endif
@@ -871,6 +871,20 @@ void AndroidPlatformUtilities::restoreBrightness()
   }
 }
 
+void AndroidPlatformUtilities::setHandleVolumeKeys( const bool handle )
+{
+  if ( mActivity.isValid() )
+  {
+    runOnAndroidMainThread( [&handle] {
+      auto activity = qtAndroidContext();
+      if ( activity.isValid() )
+      {
+        activity.callMethod<void>( handle ? "takeVolumeKeys" : "releaseVolumeKeys" );
+      }
+    } );
+  }
+}
+
 QVariantMap AndroidPlatformUtilities::sceneMargins( QQuickWindow *window ) const
 {
   Q_UNUSED( window )
@@ -943,6 +957,27 @@ JNIEXPORT void JNICALL JNI_FUNCTION_NAME( APP_PACKAGE_JNI_NAME, QFieldActivity, 
     const char *pathStr = env->GetStringUTFChars( path, NULL );
     emit AppInterface::instance()->openPath( QString( pathStr ) );
     env->ReleaseStringUTFChars( path, pathStr );
+  }
+  return;
+}
+
+#define ANDROID_VOLUME_DOWN 25
+#define ANDROID_VOLUME_UP 24
+
+JNIEXPORT void JNICALL JNI_FUNCTION_NAME( APP_PACKAGE_JNI_NAME, QFieldActivity, volumeKeyDown )( JNIEnv *env, jobject obj, int volumeKeyCode )
+{
+  if ( AppInterface::instance() )
+  {
+    emit AppInterface::instance()->volumeKeyDown( volumeKeyCode == ANDROID_VOLUME_DOWN ? Qt::Key_VolumeDown : Qt::Key_VolumeUp );
+  }
+  return;
+}
+
+JNIEXPORT void JNICALL JNI_FUNCTION_NAME( APP_PACKAGE_JNI_NAME, QFieldActivity, volumeKeyUp )( JNIEnv *env, jobject obj, int volumeKeyCode )
+{
+  if ( AppInterface::instance() )
+  {
+    emit AppInterface::instance()->volumeKeyUp( volumeKeyCode == ANDROID_VOLUME_DOWN ? Qt::Key_VolumeDown : Qt::Key_VolumeUp );
   }
   return;
 }

--- a/src/core/platforms/android/androidplatformutilities.h
+++ b/src/core/platforms/android/androidplatformutilities.h
@@ -75,6 +75,8 @@ class AndroidPlatformUtilities : public PlatformUtilities
     void dimBrightness() override;
     void restoreBrightness() override;
 
+    void setHandleVolumeKeys( const bool handle ) override;
+
     QVariantMap sceneMargins( QQuickWindow *window ) const override;
 
     double systemFontPointSize() const override { return 16.0; }

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -43,13 +43,14 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
     {
       NoCapabilities = 0,             //!< No capabilities
       NativeCamera = 1,               //!< Native camera handling support
-      AdjustBrightness = 1 << 1,      //!< Capable of adjusting screen brightness
+      AdjustBrightness = 1 << 1,      //!< Screen brightness adjustment support
       SentryFramework = 1 << 2,       //!< Sentry framework support
       CustomLocalDataPicker = 1 << 3, //!< Custom QML local data picker support
       CustomImport = 1 << 4,          //!< Import project and dataset support
       CustomExport = 1 << 5,          //!< Export project and dataset support
       CustomSend = 1 << 6,            //!< Send/share files support
       FilePicker = 1 << 7,            //!< File picker support
+      VolumeKeys = 1 << 8,            //!< Volume keys handling support
     };
     Q_DECLARE_FLAGS( Capabilities, Capability )
     Q_FLAGS( Capabilities )
@@ -248,6 +249,11 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
      * Restores the brightness of the screen to its original value on supported devices.
      */
     Q_INVOKABLE virtual void restoreBrightness() { return; };
+
+    /**
+     * Sets whether the device volume keys are handled by QField.
+     */
+    Q_INVOKABLE virtual void setHandleVolumeKeys( const bool handle ) { Q_UNUSED( handle ); }
 
     /**
      * Copies a text \a string to the system clipboard.

--- a/src/qml/DigitizingToolbar.qml
+++ b/src/qml/DigitizingToolbar.qml
@@ -319,6 +319,10 @@ VisibilityFadingRow {
     return true;
   }
 
+  function triggerAddVertex() {
+    addVertexButton.clicked()
+  }
+
   function addVertex() {
     digitizingLogger.addCoordinate( coordinateLocator.currentCoordinate )
     coordinateLocator.flash()

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -18,6 +18,7 @@ Page {
   property alias numericalDigitizingInformation: registry.numericalDigitizingInformation
   property alias showBookmarks: registry.showBookmarks
   property alias nativeCamera: registry.nativeCamera
+  property alias digitizingVolumeKeys: registry.digitizingVolumeKeys
   property alias autoSave: registry.autoSave
   property alias mouseAsTouchScreen: registry.mouseAsTouchScreen
   property alias enableInfoCollection: registry.enableInfoCollection
@@ -38,6 +39,7 @@ Page {
     property bool numericalDigitizingInformation: false
     property bool showBookmarks: true
     property bool nativeCamera: platformUtilities.capabilities & PlatformUtilities.NativeCamera
+    property bool digitizingVolumeKeys: platformUtilities.capabilities & PlatformUtilities.VolumeKeys
     property bool autoSave: false
     property bool mouseAsTouchScreen: false
     property bool enableInfoCollection: true
@@ -45,10 +47,14 @@ Page {
 
     onEnableInfoCollectionChanged: {
       if (enableInfoCollection) {
-        iface.initiateSentry();
+        iface.initiateSentry()
       } else {
-        iface.closeSentry();
+        iface.closeSentry()
       }
+    }
+
+    onDigitizingVolumeKeysChanged: {
+      platformUtilities.setHandleVolumeKeys(digitizingVolumeKeys && stateMachine.state != 'browse')
     }
   }
 
@@ -97,6 +103,12 @@ Page {
           isVisible: true
       }
       ListElement {
+          title: qsTr( "Use volume keys to digitize" )
+          description: qsTr( "If enabled, pressing the device's volume up key will add a vertex while pressing volume down key will remove the last entered vertex during digitizing sessions." )
+          settingAlias: "digitizingVolumeKeys"
+          isVisible: true
+      }
+      ListElement {
           title: qsTr( "Consider mouse as a touchscreen device" )
           description: qsTr( "If disabled, the mouse will act as a stylus pen." )
           settingAlias: "mouseAsTouchScreen"
@@ -110,7 +122,9 @@ Page {
       }
       Component.onCompleted: {
           for (var i = 0; i < settingsModel.count; i++) {
-              if (settingsModel.get(i).settingAlias === 'nativeCamera') {
+              if (settingsModel.get(i).settingAlias === 'digitizingVolumeKeys') {
+                  settingsModel.setProperty(i, 'isVisible', platformUtilities.capabilities & PlatformUtilities.VolumeKeys ? true : false)
+              } else if (settingsModel.get(i).settingAlias === 'nativeCamera') {
                   settingsModel.setProperty(i, 'isVisible', platformUtilities.capabilities & PlatformUtilities.NativeCamera ? true : false)
               } else if (settingsModel.get(i).settingAlias === 'enableInfoCollection') {
                   settingsModel.setProperty(i, 'isVisible', platformUtilities.capabilities & PlatformUtilities.SentryFramework ? true : false)

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -449,7 +449,8 @@ ApplicationWindow {
     /* The map canvas */
     MapCanvas {
       id: mapCanvasMap
-      interactive: !dashBoard.opened && !screenLocker.enabled && !welcomeScreen.visible && !qfieldSettings.visible && !cloudPopup.visible && !codeReader.visible
+      property bool isEnabled: !dashBoard.opened && !welcomeScreen.visible && !qfieldSettings.visible && !cloudPopup.visible && !codeReader.visible
+      interactive: isEnabled && !screenLocker.enabled
       incrementalRendering: true
       quality: qfieldSettings.quality
       forceDeferredLayersRepaint: trackings.count > 0
@@ -3019,17 +3020,19 @@ ApplicationWindow {
     target: iface
 
     function onVolumeKeyUp(volumeKeyCode) {
-      if (stateMachine.state === 'browse' || !mapCanvasMap.interactive) {
+      if (stateMachine.state === 'browse' || !mapCanvasMap.isEnabled) {
         return;
       }
 
       switch (volumeKeyCode) {
         case  Qt.Key_VolumeDown:
-          digitizingToolbar.removeVertex();
+          if (mapCanvasMap.interactive) {
+            digitizingToolbar.removeVertex();
+          }
           break;
         case Qt.Key_VolumeUp:
           if (!geometryEditorsToolbar.canvasClicked(coordinateLocator.currentCoordinate)) {
-            digitizingToolbar.addVertex();
+            digitizingToolbar.triggerAddVertex();
           }
           break;
         default:

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3019,7 +3019,7 @@ ApplicationWindow {
     target: iface
 
     function onVolumeKeyUp(volumeKeyCode) {
-      if (!mapCanvasMap.interactive) {
+      if (stateMachine.state === 'browse' || !mapCanvasMap.interactive) {
         return;
       }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -166,10 +166,12 @@ ApplicationWindow {
     {
       case 'browse':
         projectInfo.stateMode = mode
+        platformUtilities.setHandleVolumeKeys(false)
         displayToast( qsTr( 'You are now in browse mode' ) );
         break;
       case 'digitize':
         projectInfo.stateMode = mode
+        platformUtilities.setHandleVolumeKeys(qfieldSettings.digitizingVolumeKeys)
         dashBoard.ensureEditableLayerSelected();
         if (dashBoard.activeLayer)
         {
@@ -181,6 +183,7 @@ ApplicationWindow {
         }
         break;
       case 'measure':
+        platformUtilities.setHandleVolumeKeys(qfieldSettings.digitizingVolumeKeys)
         elevationProfile.populateLayersFromProject();
         displayToast( qsTr( 'You are now in measure mode' ) );
         break;
@@ -3015,6 +3018,25 @@ ApplicationWindow {
   Connections {
     target: iface
 
+    function onVolumeKeyUp(volumeKeyCode) {
+      if (!mapCanvasMap.interactive) {
+        return;
+      }
+
+      switch (volumeKeyCode) {
+        case  Qt.Key_VolumeDown:
+          digitizingToolbar.removeVertex();
+          break;
+        case Qt.Key_VolumeUp:
+          if (!geometryEditorsToolbar.canvasClicked(coordinateLocator.currentCoordinate)) {
+            digitizingToolbar.addVertex();
+          }
+          break;
+        default:
+          break;
+      }
+    }
+
     function onImportTriggered(name) {
       busyOverlay.text = qsTr("Importing %1").arg(name)
       busyOverlay.state = "visible"
@@ -3062,6 +3084,7 @@ ApplicationWindow {
 
       projectInfo.filePath = path
       stateMachine.state = projectInfo.stateMode
+      platformUtilities.setHandleVolumeKeys(qfieldSettings.digitizingVolumeKeys && stateMachine.state != 'browse')
       dashBoard.activeLayer = projectInfo.activeLayer
 
       mapCanvasBackground.color = mapCanvas.mapSettings.backgroundColor


### PR DESCRIPTION
This PR implements a mechanism through which volume keys on Android devices can be used to add or remove vertices while in digitizing mode. A new toggle in the Settings panel allows for users to disable the behavior.

![image](https://github.com/opengisch/QField/assets/1728657/f0e0023e-5348-44e5-8c1e-260d62356b02)

This can be useful for people who walk around with the coordinate cursor locked to the current GNSS position and want to add vertices without the need to precisely hit the add vertex button on the screen.