### PR TITLE
Add new image and video media reading permission on Android >= 13 (API >= 33)

### DIFF
--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -22,6 +22,8 @@
   <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
   <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+  <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
       android:maxSdkVersion="28"
       />

--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -956,6 +956,20 @@ public class QFieldActivity extends QtActivity {
             PackageManager.PERMISSION_DENIED) {
             permissionsList.add(Manifest.permission.WRITE_EXTERNAL_STORAGE);
         }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(
+                    QFieldActivity.this,
+                    Manifest.permission.READ_MEDIA_IMAGES) ==
+                PackageManager.PERMISSION_DENIED) {
+                permissionsList.add(Manifest.permission.READ_MEDIA_IMAGES);
+            }
+            if (ContextCompat.checkSelfPermission(
+                    QFieldActivity.this,
+                    Manifest.permission.READ_MEDIA_VIDEO) ==
+                PackageManager.PERMISSION_DENIED) {
+                permissionsList.add(Manifest.permission.READ_MEDIA_VIDEO);
+            }
+        }
         if (ContextCompat.checkSelfPermission(
                 QFieldActivity.this,
                 Manifest.permission.ACCESS_FINE_LOCATION) ==


### PR DESCRIPTION
Starting with Android 13, a new pair of permissions is required to access to photos/images stored in the device's gallery. Without it, we hit a security error wall. 

This restores photo editing under these devices for the foreseeable future.