### PR TITLE
Tiny fixes/tweaks as we are marching towards release

### DIFF
--- a/src/qml/EmbeddedFeatureForm.qml
+++ b/src/qml/EmbeddedFeatureForm.qml
@@ -47,13 +47,13 @@ Popup {
     parent: mainWindow.contentItem
     closePolicy: Popup.NoAutoClose // prevent accidental feature addition and editing
 
-    x: Math.max(mainWindow.sceneTopMargin, Theme.popupScreenEdgeMargin)
-    y: x
+    x: Theme.popupScreenEdgeMargin / 2
+    y: Theme.popupScreenEdgeMargin
     z: 1000 + embeddedLevel
 
     padding: 0
-    width: parent.width - x * 2
-    height: parent.height - y * 2
+    width: parent.width - Theme.popupScreenEdgeMargin
+    height: parent.height - Theme.popupScreenEdgeMargin * 2
     modal: true
 
     FeatureForm {

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -297,7 +297,8 @@ Popup {
           icon.source: Theme.getThemeVectorIcon( 'directions_walk_24dp' )
 
           onClicked: {
-            //start track
+            close()
+
             if ( trackingModel.layerInTracking( layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer) ) ) {
               trackingModel.stopTracker(layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer));
               displayToast( qsTr( 'Track on layer %1 stopped' ).arg( layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer).name  ) )
@@ -319,8 +320,8 @@ Popup {
               }
               trackerSettings.tracker = tracker
               trackerSettings.open()
+              trackerSettings.focus = true
             }
-            close()
           }
         }
 

--- a/src/qml/TrackerSettings.qml
+++ b/src/qml/TrackerSettings.qml
@@ -559,6 +559,7 @@ Popup {
 
         onTemporaryStored: {
           tracker.feature = featureModel.feature
+          embeddedFeatureFormPopup.close()
           embeddedFeatureForm.active = false
           trackingModel.startTracker(tracker.vectorLayer)
           displayToast(qsTr('Track on layer %1 started').arg(tracker.vectorLayer.name))
@@ -569,15 +570,12 @@ Popup {
         }
 
         onCancelled: {
+          embeddedFeatureFormPopup.close()
           embeddedFeatureForm.active = false
           embeddedFeatureForm.focus = false
           trackingModel.stopTracker(tracker.vectorLayer)
           trackerSettings.close()
         }
-      }
-
-      onClosed: {
-        form.confirm()
       }
     }
   }

--- a/src/qml/TrackerSettings.qml
+++ b/src/qml/TrackerSettings.qml
@@ -536,10 +536,10 @@ Popup {
       id: embeddedFeatureFormPopup
       parent: mainWindow.contentItem
 
-      x: Theme.popupScreenEdgeMargin
+      x: Theme.popupScreenEdgeMargin / 2
       y: Theme.popupScreenEdgeMargin
       padding: 0
-      width: parent.width - Theme.popupScreenEdgeMargin * 2
+      width: parent.width - Theme.popupScreenEdgeMargin
       height: parent.height - Theme.popupScreenEdgeMargin * 2
       modal: true
       closePolicy: Popup.CloseOnEscape


### PR DESCRIPTION
TIL: interestingly, Qt 6.5.3 doesn't like closing popup via deactivating a parent Loader item.  If the popup isn't closed when the Loaded is deactivated, the popup disappears but the shading overlay stays. 