### PR TITLE
Fix QgsApplication::exitQgis() never called

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -310,8 +310,6 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
 
   load( QUrl( "qrc:/qml/qgismobileapp.qml" ) );
 
-  connect( this, &QQmlApplicationEngine::quit, this, &QgisMobileapp::requestQuit );
-
   mMapCanvas = rootObjects().first()->findChild<QgsQuickMapCanvasMap *>();
   Q_ASSERT_X( mMapCanvas, "QML Init", "QgsQuickMapCanvasMap not found. It is likely that we failed to load the QML files. Check debug output for related messages." );
 
@@ -1340,7 +1338,9 @@ void QgisMobileapp::setScreenDimmerTimeout( int timeoutSeconds )
 bool QgisMobileapp::event( QEvent *event )
 {
   if ( event->type() == QEvent::Close )
-    requestQuit();
+  {
+    quit();
+  }
 
   return QQmlApplicationEngine::event( event );
 }
@@ -1357,17 +1357,15 @@ void QgisMobileapp::saveProjectPreviewImage()
   }
 }
 
-void QgisMobileapp::requestQuit()
-{
-  mApp->exitQgis();
-  QMetaObject::invokeMethod( mApp, &QgsApplication::quit, Qt::QueuedConnection );
-}
-
 QgisMobileapp::~QgisMobileapp()
 {
   saveProjectPreviewImage();
+
   delete mOfflineEditing;
   mProject->removeAllMapLayers();
   delete mProject;
   delete mAppMissingGridHandler;
+
+  mApp->exitQgis();
+  QMetaObject::invokeMethod( mApp, &QgsApplication::quit, Qt::QueuedConnection );
 }

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -187,7 +187,6 @@ class QFIELD_CORE_EXPORT QgisMobileapp : public QQmlApplicationEngine
 
     void onAfterFirstRendering();
     void onMapCanvasRefreshed();
-    void requestQuit();
 
   private:
     void initDeclarative();


### PR DESCRIPTION
ATM, QField never actually gets to call mApp->exitQgis() when it shuts down, which has a number of consequences. One important one: authentication methods never get to unload properly, which can leave behind crucial data. E.g., for oauth2 authentication method, this meant that the cached token was never cleared on exit, resulting in authentication being made permanent (irrespective of the oauth2 setting dedicated to that).

I assume this could have caused a few more issues, glad we could spot this now. From a starting point being "oauth2 won't log out", that was an interesting one to dissect.

