### PR TITLE
Fix handling of non-HTML text values having had links inserted (fixes #4615)

### DIFF
--- a/src/core/utils/stringutils.cpp
+++ b/src/core/utils/stringutils.cpp
@@ -28,10 +28,18 @@ StringUtils::StringUtils( QObject *parent )
 {
 }
 
-
 QString StringUtils::insertLinks( const QString &string )
 {
   return QgsStringUtils::insertLinks( string );
+}
+
+bool StringUtils::hasLinks( const QString &string )
+{
+  // These expressions are taken from QgsStringUtils::insertLinks
+  const thread_local QRegularExpression urlRegEx( QStringLiteral( "(\\b(([\\w-]+://?|www[.])[^\\s()<>]+(?:\\([\\w\\d]+\\)|([^!\"#$%&'()*+,\\-./:;<=>?@[\\\\\\]^_`{|}~\\s]|/))))" ) );
+  const thread_local QRegularExpression emailRegEx( QStringLiteral( "([\\w._%+-]+@[\\w.-]+\\.[A-Za-z]+)" ) );
+
+  return string.contains( urlRegEx ) || string.contains( emailRegEx );
 }
 
 QString StringUtils::createUuid()

--- a/src/core/utils/stringutils.h
+++ b/src/core/utils/stringutils.h
@@ -34,6 +34,9 @@ class QFIELD_CORE_EXPORT StringUtils : public QObject
     //! Returns a string with any URL (e.g., http(s)/ftp) and mailto: text converted to valid HTML <a …> links
     static Q_INVOKABLE QString insertLinks( const QString &string );
 
+    //! Returns whether a string contains one or more URLs
+    static Q_INVOKABLE bool hasLinks( const QString &string );
+
     //! Returns a new UUID string
     static Q_INVOKABLE QString createUuid();
 

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -29,7 +29,9 @@ EditorWidgetBase {
     color: Theme.mainTextColor
     opacity: 0.45
     wrapMode: Text.Wrap
-    textFormat: config['IsMultiline'] === true && config['UseHtml'] ? TextEdit.RichText : TextEdit.AutoText
+    textFormat: (config['IsMultiline'] === true && config['UseHtml']) || stringUtilities.hasLinks(value)
+                ? TextEdit.RichText
+                : TextEdit.AutoText
 
     text: value == null ? '' : config['IsMultiline'] === true
                                ? config['UseHtml'] === true ? value : stringUtilities.insertLinks(value)


### PR DESCRIPTION
QField now handles insertion of hyperlinks in non-HTML text edit widget the same way QGIS does, which in turn fixes automatically inserted links (e.g. https://github.com/opengisch/QField/issues/4615)