### PR TITLE
Significant optimization in handling of rubber band and line/polygon items

### DIFF
--- a/src/core/linepolygonhighlight.h
+++ b/src/core/linepolygonhighlight.h
@@ -76,6 +76,8 @@ class LinePolygonHighlight : public QQuickItem
     bool mDirty = false;
     QgsQuickMapSettings *mMapSettings = nullptr;
     QgsGeometryWrapper *mGeometry = nullptr;
+    QgsPoint mGeometryCorner;
+    double mGeometryMUPP = 0.0;
 };
 
 #endif // LOCATORHIGHLIGHT_H

--- a/src/core/rubberband.h
+++ b/src/core/rubberband.h
@@ -17,6 +17,7 @@
 #define RUBBERBAND_H
 
 #include <QQuickItem>
+#include <qgspoint.h>
 #include <qgswkbtypes.h>
 
 class RubberbandModel;
@@ -120,6 +121,8 @@ class Rubberband : public QQuickItem
     QColor mColorCurrentPoint = QColor( 192, 57, 43, 150 );
     float mWidthCurrentPoint = 1.2;
     Qgis::GeometryType mGeometryType = Qgis::GeometryType::Null;
+    QgsPoint mGeometryCorner;
+    double mGeometryMUPP = 0.0;
 };
 
 


### PR DESCRIPTION
Until now, we have been wasting quite a lot of CPU cycles re-building the OpenGL nodes of rubber band and line/polygon quick items every time the map extent changed. 

For simple panning operations, there are _no reason whatsoever_ we'd want to re-build the nodes, a simple setX() setY() transform will do.

When we zoom in or out, we eventually want to rebuild to make sure we're super accurate when zooming into _centimeter_ accuracy. 

This PR achieves that by triggering a rebuild when the map unit per point changes significantly/enough to justify the cost. 

On complex geometries, this makes panning around _blazingly fast_ when it used to be real sluggish until now.