### PR TITLE
Use screen's physical DPI value again, android regression fixed in Qt 6.5.3

### DIFF
--- a/src/core/qgsquick/qgsquickelevationprofilecanvas.cpp
+++ b/src/core/qgsquick/qgsquickelevationprofilecanvas.cpp
@@ -104,7 +104,7 @@ class QgsElevationProfilePlotItem : public Qgs2DPlot
 
       // force immediate recalculation of plot area
       QgsRenderContext context;
-      context.setScaleFactor( ( mCanvas->window()->screen()->logicalDotsPerInch() * mCanvas->window()->screen()->devicePixelRatio() ) / 25.4 );
+      context.setScaleFactor( ( mCanvas->window()->screen()->physicalDotsPerInch() * mCanvas->window()->screen()->devicePixelRatio() ) / 25.4 );
 
       calculateOptimisedIntervals( context );
       mPlotArea = interiorPlotArea( context );
@@ -290,7 +290,7 @@ void QgsQuickElevationProfileCanvas::refresh()
   connect( mCurrentJob, &QgsProfilePlotRenderer::generationFinished, this, &QgsQuickElevationProfileCanvas::generationFinished );
 
   QgsProfileGenerationContext generationContext;
-  generationContext.setDpi( window()->screen()->logicalDotsPerInch() * window()->screen()->devicePixelRatio() );
+  generationContext.setDpi( window()->screen()->physicalDotsPerInch() * window()->screen()->devicePixelRatio() );
   generationContext.setMaximumErrorMapUnits( MAX_ERROR_PIXELS * ( mProfileCurve.get()->length() ) / mPlotItem->plotArea().width() );
   generationContext.setMapUnitsPerDistancePixel( mProfileCurve.get()->length() / mPlotItem->plotArea().width() );
   mCurrentJob->setContext( generationContext );
@@ -449,7 +449,7 @@ void QgsQuickElevationProfileCanvas::refineResults()
   if ( mCurrentJob )
   {
     QgsProfileGenerationContext context;
-    context.setDpi( window()->screen()->logicalDotsPerInch() * window()->screen()->devicePixelRatio() );
+    context.setDpi( window()->screen()->physicalDotsPerInch() * window()->screen()->devicePixelRatio() );
     const double plotDistanceRange = mPlotItem->xMaximum() - mPlotItem->xMinimum();
     const double plotElevationRange = mPlotItem->yMaximum() - mPlotItem->yMinimum();
     const double plotDistanceUnitsPerPixel = plotDistanceRange / mPlotItem->plotArea().width();

--- a/src/core/qgsquick/qgsquickmapcanvasmap.cpp
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.cpp
@@ -280,7 +280,7 @@ void QgsQuickMapCanvasMap::onScreenChanged( QScreen *screen )
     {
       mMapSettings->setDevicePixelRatio( screen->devicePixelRatio() );
     }
-    mMapSettings->setOutputDpi( screen->logicalDotsPerInch() );
+    mMapSettings->setOutputDpi( screen->physicalDotsPerInch() );
   }
 }
 


### PR DESCRIPTION
Fixes a 3.0 visual regression reported here (https://github.com/opengisch/QField/issues/4625). We're lucky, Qt 6.5.0 through to 6.5.2 had a regression which was fixed in 6.5.3, woupidou. 

Thanks to the user for reminding me to test this again.