### PR TITLE
Fix setting an int property to a string value breaks children deletion

### DIFF
--- a/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
@@ -335,7 +335,7 @@ EditorWidgetBase {
             onClicked: {
               deleteDialog.referencingFeatureId = model.referencingFeature.id
               deleteDialog.referencingFeatureDisplayMessage = model.displayString
-              deleteDialog.nmReferencedFeatureId = nmRelationId ? model.model.nmReferencedFeature.id : ''
+              deleteDialog.nmReferencedFeatureId = nmRelationId ? model.model.nmReferencedFeature.id : 0
               deleteDialog.nmReferencedFeatureDisplayMessage = nmRelationId ? model.nmDisplayString : ''
               deleteDialog.visible = true
             }

--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -243,7 +243,7 @@ EditorWidgetBase {
               onClicked: {
                 deleteDialog.referencingFeatureId = model.referencingFeature.id
                 deleteDialog.referencingFeatureDisplayMessage = model.displayString
-                deleteDialog.nmReferencedFeatureId = nmRelationId ? model.model.nmReferencedFeature.id : ''
+                deleteDialog.nmReferencedFeatureId = nmRelationId ? model.model.nmReferencedFeature.id : 0
                 deleteDialog.nmReferencedFeatureDisplayMessage = nmRelationId ? model.nmDisplayString : ''
                 deleteDialog.visible = true
               }


### PR DESCRIPTION
This fixes https://github.com/opengisch/QField/issues/4631

Qt6 doesn't allow a property int to be set to a string. Why Qt5 was allowing this to begin with is a mystery :)