### PR TITLE
Safeguard from triggering needless feature gathering when referincing feature list model gets passed the same feature

### DIFF
--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -78,6 +78,9 @@ QVariant ReferencingFeatureListModel::data( const QModelIndex &index, int role )
 
 void ReferencingFeatureListModel::setFeature( const QgsFeature &feature )
 {
+  if ( mFeature == feature )
+    return;
+
   mFeature = feature;
   reload();
 }


### PR DESCRIPTION
Our referencing feature list model was needlessly triggering (possibly costly) features fetches when the  referencing feature property was set with the exact same feature (which does happen when QML builds our feature form item). This offers yet another nice optimization for our feature form.

This PR also fixes https://github.com/opengisch/QField/issues/3031 . It doesn't fix the root cause of it (it freezes in the OGR connection pool, stuck in a loop evaluating expressions et al), but by axing the number of feature fetches by half, the connection pool never gets saturated.