### PR TITLE
[Backport release-3_0] Safeguard from triggering needless feature gathering when referincing feature list model gets passed the same feature

### DIFF
--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -78,6 +78,9 @@ QVariant ReferencingFeatureListModel::data( const QModelIndex &index, int role )
 
 void ReferencingFeatureListModel::setFeature( const QgsFeature &feature )
 {
+  if ( mFeature == feature )
+    return;
+
   mFeature = feature;
   reload();
 }


### PR DESCRIPTION
Backport #4645
 **Authored by:** @nirvn