### PR TITLE
Revert increased identify search radius now that Qt6 DPI issue is resolved

### DIFF
--- a/src/core/identifytool.cpp
+++ b/src/core/identifytool.cpp
@@ -26,7 +26,7 @@
 IdentifyTool::IdentifyTool( QObject *parent )
   : QObject( parent )
   , mMapSettings( nullptr )
-  , mSearchRadiusMm( 8 )
+  , mSearchRadiusMm( 5 )
 {
 }
 
@@ -117,7 +117,7 @@ QList<IdentifyTool::IdentifyResult> IdentifyTool::identifyVectorLayer( QgsVector
     req.setFilterRect( r );
     if ( !temporalFilter.isEmpty() )
       req.setFilterExpression( temporalFilter );
-    req.setLimit( QSettings().value( "/QField/identify/limit", 100 ).toInt() );
+    req.setLimit( QSettings().value( "/QField/identify/limit", 200 ).toInt() );
     req.setFlags( QgsFeatureRequest::ExactIntersect );
 
     QgsAttributeTableConfig config = layer->attributeTableConfig();

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -593,7 +593,7 @@ ApplicationWindow {
 
       mapSettings: mapCanvas.mapSettings
       model:  isMenuRequest ? canvasMenuFeatureListModel : featureForm.model
-      searchRadiusMm: 5
+      searchRadiusMm: 3
     }
 
     /** A rubberband for measuring **/


### PR DESCRIPTION
Early in the post-Qt6 migration era, we had to increase the identify search radius as the DPI wasn't reflecting screen pixel density. It's been fixed now (thanks to Qt 6.5.3), we can go back to a slightly smaller search radius.

One reason why that's important is that we cap our feature request to 200 (it was 100 for years until today), but that doesn't yet filter out the features that are *not* rendered (due to out-of-scale or out-of-rule situations). If the search radius is too high, we end up with an oddly small number of features shown as identified, which could have felt like a regression on QField 3.