### PR TITLE
[Backport release-3_0] Fix initiation of fill ring geometry editor, Qt6 isn't tolerant

### DIFF
--- a/src/qml/geometryeditors/FillRing.qml
+++ b/src/qml/geometryeditors/FillRing.qml
@@ -109,7 +109,7 @@ VisibilityFadingRow {
   function init(featureModel, mapSettings, editorRubberbandModel, editorRenderer)
   {
     fillRingToolbar.featureModel = featureModel
-    digitizingLogger.digitizingLayer = featureModel.currentLayer
+    drawPolygonToolbar.digitizingLogger.digitizingLayer = featureModel.currentLayer
     drawPolygonToolbar.rubberbandModel = editorRubberbandModel
     drawPolygonToolbar.rubberbandModel.geometryType = Qgis.GeometryType.Polygon
     drawPolygonToolbar.mapSettings = mapSettings


### PR DESCRIPTION
Backport #4664
 **Authored by:** @nirvn