### PR TITLE
Fix rubber band display 'glitchy' following optimization

### DIFF
--- a/src/core/linepolygonhighlight.cpp
+++ b/src/core/linepolygonhighlight.cpp
@@ -55,7 +55,6 @@ QSGNode *LinePolygonHighlight::updatePaintNode( QSGNode *n, QQuickItem::UpdatePa
     n->appendChildNode( gn );
 
     mDirty = false;
-    updateTransform();
 
     emit updated();
   }
@@ -133,10 +132,10 @@ void LinePolygonHighlight::updateTransform()
 
   const QgsPointXY pixelCorner = mMapSettings->coordinateToScreen( mGeometryCorner );
 
-  setX( pixelCorner.x() );
-  setY( pixelCorner.y() );
+  setX( mDirty ? 0 : pixelCorner.x() );
+  setY( mDirty ? 0 : pixelCorner.y() );
+  setScale( mDirty ? 1.0 : mGeometryMUPP / mMapSettings->mapUnitsPerPoint() );
   setRotation( mMapSettings->rotation() );
-  setScale( mGeometryMUPP / mMapSettings->mapUnitsPerPoint() );
 
   update();
 }

--- a/src/core/rubberband.cpp
+++ b/src/core/rubberband.cpp
@@ -131,9 +131,9 @@ void Rubberband::updateTransform()
 
   const QgsPointXY pixelCorner = mMapSettings->coordinateToScreen( mGeometryCorner );
 
-  setX( pixelCorner.x() );
-  setY( pixelCorner.y() );
-  setScale( mGeometryMUPP / mMapSettings->mapUnitsPerPoint() );
+  setX( mDirty ? 0 : pixelCorner.x() );
+  setY( mDirty ? 0 : pixelCorner.y() );
+  setScale( mDirty ? 1.0 : mGeometryMUPP / mMapSettings->mapUnitsPerPoint() );
   setRotation( mMapSettings->rotation() );
 
   update();
@@ -147,7 +147,7 @@ void Rubberband::rotationChanged()
 void Rubberband::visibleExtentChanged()
 {
   const double scaleChange = mGeometryMUPP / mMapSettings->mapUnitsPerPoint();
-  mDirty = mGeometryMUPP == 0.0 || scaleChange > 1.75 || scaleChange < 0.25;
+  mDirty = mDirty || mGeometryMUPP == 0.0 || scaleChange > 1.75 || scaleChange < 0.25;
   updateTransform();
 }
 
@@ -221,7 +221,6 @@ QSGNode *Rubberband::updatePaintNode( QSGNode *n, QQuickItem::UpdatePaintNodeDat
     mGeometryMUPP = mMapSettings->mapUnitsPerPoint();
 
     mDirty = false;
-    updateTransform();
   }
 
   return n;


### PR DESCRIPTION
Title says it all.  We need to reset X,Y, and scale values when dirtying the rubber band (or line geometry) item to avoid glitches. Without this fix, moving around while digitizing features has the rubber band doing micro jumps.