### PR TITLE
Fix rubber band polygon highlight going missing due to coordinate distance fail

### DIFF
--- a/src/core/qgssggeometry.cpp
+++ b/src/core/qgssggeometry.cpp
@@ -164,7 +164,7 @@ QSGGeometry *QgsSGGeometry::qgsPolygonToQSGGeometry( const QgsPolygon *polygon, 
   Q_ASSERT( polygon );
 
   QgsGeometry geom( polygon->clone() );
-  geom = geom.buffer( 0.0000001, 5 );
+  geom = geom.buffer( 0.0000001, 1, Qgis::EndCapStyle::Flat, Qgis::JoinStyle::Miter, 5 );
   QgsPolygon *bufferedPolygon = qgsgeometry_cast<QgsPolygon *>( geom.constGet() );
   QgsTessellator t( visibleExtent.xMinimum(), visibleExtent.yMaximum(), false, false, false, true );
   if ( bufferedPolygon )

--- a/src/core/sgrubberband.cpp
+++ b/src/core/sgrubberband.cpp
@@ -109,7 +109,9 @@ QSGGeometryNode *SGRubberband::createLineGeometry( const QVector<QgsPoint> &poin
 QSGGeometryNode *SGRubberband::createPolygonGeometry( const QVector<QgsPoint> &points )
 {
   QgsGeometry geom( new QgsPolygon( new QgsLineString( points ) ) );
-  geom = geom.buffer( 0.0000001, 5 );
+  geom = geom.buffer( 0.0000001, 1, Qgis::EndCapStyle::Flat, Qgis::JoinStyle::Miter, 5 );
+  // QgsTesselator doesn't allow for coordinates distance smaller than 0.001
+  geom.removeDuplicateNodes( 0.001 );
   QgsPolygon *polygon = qgsgeometry_cast<QgsPolygon *>( geom.constGet() );
   QgsTessellator t( 0, 0, false, false, false, true );
   if ( points.size() > 2 && polygon )


### PR DESCRIPTION
The rubber band uses scene coordinates, and when buffering it often creates vertices that are closer than what the QGIS tesselator likes, this PR fixes that (which means we don't suffer from highlights going missing when digitizing)

I've also taken the time to change the buffer style to reduce the number of additional vertices, we don't need round microscopic buffers :)