### PR TITLE
Move the magnetometer reading into the c++ positioning class, add @{position,gnss}_orientation variable

### DIFF
--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -27,7 +27,6 @@
 #include <QFileInfo>
 #include <QImageReader>
 #include <qgsapplication.h>
-#include <qgsexiftools.h>
 #include <qgsmessagelog.h>
 #include <qgsruntimeprofiler.h>
 #include <qgsziputils.h>
@@ -189,24 +188,6 @@ void AppInterface::closeSentry() const
 #if WITH_SENTRY
   sentry_wrapper::close();
 #endif
-}
-
-void AppInterface::restrictImageSize( const QString &imagePath, int maximumWidthHeight )
-{
-  QVariantMap metadata = QgsExifTools::readTags( imagePath );
-  QImage img( imagePath );
-  if ( !img.isNull() && ( img.width() > maximumWidthHeight || img.height() > maximumWidthHeight ) )
-  {
-    QImage scaledImage = img.width() > img.height()
-                           ? img.scaledToWidth( maximumWidthHeight, Qt::SmoothTransformation )
-                           : img.scaledToHeight( maximumWidthHeight, Qt::SmoothTransformation );
-    scaledImage.save( imagePath );
-
-    for ( const QString key : metadata.keys() )
-    {
-      QgsExifTools::tagImage( imagePath, key, metadata[key] );
-    }
-  }
 }
 
 void AppInterface::importUrl( const QString &url )

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -88,8 +88,6 @@ class AppInterface : public QObject
      */
     Q_INVOKABLE void closeSentry() const;
 
-    Q_INVOKABLE void restrictImageSize( const QString &imagePath, int maximumWidthHeight );
-
     static void setInstance( AppInterface *instance ) { sAppInterface = instance; }
     static AppInterface *instance() { return sAppInterface; }
 

--- a/src/core/positioning/gnsspositioninformation.cpp
+++ b/src/core/positioning/gnsspositioninformation.cpp
@@ -14,8 +14,6 @@
  ***************************************************************************/
 
 #include "gnsspositioninformation.h"
-#include "qgslogger.h"
-#include "qgsnmeaconnection.h"
 
 #include <QCoreApplication>
 #include <QFileInfo>
@@ -28,7 +26,7 @@ GnssPositionInformation::GnssPositionInformation( double latitude, double longit
                                                   const QList<QgsSatelliteInfo> &satellitesInView, double pdop, double hdop, double vdop, double hacc, double vacc,
                                                   QDateTime utcDateTime, QChar fixMode, int fixType, int quality, int satellitesUsed, QChar status, const QList<int> &satPrn,
                                                   bool satInfoComplete, double verticalSpeed, double magneticVariation, int averagedCount, const QString &sourceName,
-                                                  bool imuCorrection )
+                                                  bool imuCorrection, double orientation )
   : mLatitude( latitude )
   , mLongitude( longitude )
   , mElevation( elevation )
@@ -54,6 +52,7 @@ GnssPositionInformation::GnssPositionInformation( double latitude, double longit
   , mAveragedCount( averagedCount )
   , mSourceName( sourceName )
   , mImuCorrection( imuCorrection )
+  , mOrientation( orientation )
 {
 }
 
@@ -78,7 +77,9 @@ bool GnssPositionInformation::operator==( const GnssPositionInformation &other )
          mSatInfoComplete == other.mSatInfoComplete &&
          mVerticalSpeed == other.mVerticalSpeed &&
          mMagneticVariation == other.mMagneticVariation &&
-         mSourceName == other.mSourceName;
+         mSourceName == other.mSourceName &&
+         mImuCorrection== other.mImuCorrection &&
+         mOrientation == other.mOrientation;
   // clang-format on
 }
 

--- a/src/core/positioning/gnsspositioninformation.h
+++ b/src/core/positioning/gnsspositioninformation.h
@@ -82,6 +82,8 @@ class GnssPositionInformation
     Q_PROPERTY( int averagedCount READ averagedCount )
     Q_PROPERTY( QString sourceName READ sourceName )
     Q_PROPERTY( bool imuCorrection READ imuCorrection )
+    Q_PROPERTY( double orientation READ orientation )
+    Q_PROPERTY( double orientationValid READ orientationValid )
 
   public:
     /**
@@ -103,7 +105,7 @@ class GnssPositionInformation
                              double hacc = std::numeric_limits<double>::quiet_NaN(), double vacc = std::numeric_limits<double>::quiet_NaN(), QDateTime utcDateTime = QDateTime(),
                              QChar fixMode = QChar(), int fixType = 0, int quality = -1, int satellitesUsed = 0, QChar status = QChar(), const QList<int> &satPrn = QList<int>(), bool satInfoComplete = false,
                              double verticalSpeed = std::numeric_limits<double>::quiet_NaN(), double magneticVariation = std::numeric_limits<double>::quiet_NaN(), int averagedCount = 0, const QString &sourceName = QString(),
-                             bool imuCorrection = false );
+                             bool imuCorrection = false, double orientation = std::numeric_limits<double>::quiet_NaN() );
 
     bool operator==( const GnssPositionInformation &other ) const;
     bool operator!=( const GnssPositionInformation &other ) const { return !operator==( other ); }
@@ -268,6 +270,12 @@ class GnssPositionInformation
      */
     bool imuCorrection() const { return mImuCorrection; }
 
+    /**
+     * Orientation (in degrees).
+     */
+    double orientation() const { return mOrientation; }
+    bool orientationValid() const { return !std::isnan( mOrientation ); }
+
   private:
     double mLatitude = std::numeric_limits<double>::quiet_NaN();
     double mLongitude = std::numeric_limits<double>::quiet_NaN();
@@ -294,6 +302,7 @@ class GnssPositionInformation
     int mAveragedCount = 0;
     QString mSourceName;
     bool mImuCorrection;
+    double mOrientation = std::numeric_limits<double>::quiet_NaN();
 };
 
 Q_DECLARE_METATYPE( GnssPositionInformation )

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -55,7 +55,11 @@ void Positioning::setActive( bool active )
       setupDevice();
     }
     mReceiver->connectDevice();
-    if ( !QSensor::sensorsForType( "QCompass" ).isEmpty() )
+#if QT_VERSION > QT_VERSION_CHECK( 6, 0, 0 )
+    if ( !QSensor::sensorsForType( QCompass::sensorType ).isEmpty() )
+#else
+    if ( !QSensor::sensorsForType( QCompass::type ).isEmpty() )
+#endif
     {
       mCompass.setActive( true );
       mCompassTimer.start();

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -240,15 +240,41 @@ void Positioning::lastGnssPositionInformationChanged( const GnssPositionInformat
   if ( mPositionInformation == lastGnssPositionInformation )
     return;
 
+  const GnssPositionInformation positionInformation( lastGnssPositionInformation.latitude(),
+                                                     lastGnssPositionInformation.longitude(),
+                                                     lastGnssPositionInformation.elevation(),
+                                                     lastGnssPositionInformation.speed(),
+                                                     lastGnssPositionInformation.direction(),
+                                                     lastGnssPositionInformation.satellitesInView(),
+                                                     lastGnssPositionInformation.pdop(),
+                                                     lastGnssPositionInformation.hdop(),
+                                                     lastGnssPositionInformation.vdop(),
+                                                     lastGnssPositionInformation.hacc(),
+                                                     lastGnssPositionInformation.vacc(),
+                                                     lastGnssPositionInformation.utcDateTime(),
+                                                     lastGnssPositionInformation.fixMode(),
+                                                     lastGnssPositionInformation.fixType(),
+                                                     lastGnssPositionInformation.quality(),
+                                                     lastGnssPositionInformation.satellitesUsed(),
+                                                     lastGnssPositionInformation.status(),
+                                                     lastGnssPositionInformation.satPrn(),
+                                                     lastGnssPositionInformation.satInfoComplete(),
+                                                     lastGnssPositionInformation.verticalSpeed(),
+                                                     lastGnssPositionInformation.magneticVariation(),
+                                                     lastGnssPositionInformation.averagedCount(),
+                                                     lastGnssPositionInformation.sourceName(),
+                                                     lastGnssPositionInformation.imuCorrection(),
+                                                     mOrientation );
+
   if ( mAveragedPosition )
   {
-    mCollectedPositionInformations << lastGnssPositionInformation;
+    mCollectedPositionInformations << positionInformation;
     mPositionInformation = PositioningUtils::averagedPositionInformation( mCollectedPositionInformations );
     emit averagedPositionCountChanged();
   }
   else
   {
-    mPositionInformation = lastGnssPositionInformation;
+    mPositionInformation = positionInformation;
   }
 
   if ( mPositionInformation.isValid() )

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -21,6 +21,7 @@
 #include "gnsspositioninformation.h"
 #include "qgsquickcoordinatetransformer.h"
 
+#include <QMagnetometer>
 #include <QObject>
 #include <qgscoordinatereferencesystem.h>
 #include <qgscoordinatetransformcontext.h>
@@ -52,6 +53,8 @@ class Positioning : public QObject
 
     Q_PROPERTY( ElevationCorrectionMode elevationCorrectionMode READ elevationCorrectionMode WRITE setElevationCorrectionMode NOTIFY elevationCorrectionModeChanged )
     Q_PROPERTY( double antennaHeight READ antennaHeight WRITE setAntennaHeight NOTIFY antennaHeightChanged )
+
+    Q_PROPERTY( double orientation READ orientation NOTIFY orientationChanged );
 
     Q_PROPERTY( bool logging READ logging WRITE setLogging NOTIFY loggingChanged )
 
@@ -179,6 +182,10 @@ class Positioning : public QObject
     **/
     void setAntennaHeight( double antennaHeight );
 
+    /**
+     * Returns the current device orientation
+     */
+    double orientation() const { return mOrientation; }
 
     /**
      * Returns whether GNSS devices will log their incoming position stream into a logfile.
@@ -205,11 +212,13 @@ class Positioning : public QObject
     void projectedPositionChanged();
     void elevationCorrectionModeChanged();
     void antennaHeightChanged();
+    void orientationChanged();
     void loggingChanged();
 
   private slots:
 
     void lastGnssPositionInformationChanged( const GnssPositionInformation &lastGnssPositionInformation );
+    void magnetometerReadingChanged();
     void projectedPositionTransformed();
 
   private:
@@ -240,6 +249,10 @@ class Positioning : public QObject
     bool mLogging = false;
 
     AbstractGnssReceiver *mReceiver = nullptr;
+
+    QMagnetometer mMagnetometer;
+    double mOrientation = std::numeric_limits<double>::quiet_NaN();
+    quint64 mLastOrientationTimestamp = 0;
 };
 
 Q_DECLARE_METATYPE( Positioning::ElevationCorrectionMode )

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -21,7 +21,7 @@
 #include "gnsspositioninformation.h"
 #include "qgsquickcoordinatetransformer.h"
 
-#include <QMagnetometer>
+#include <QCompass>
 #include <QObject>
 #include <qgscoordinatereferencesystem.h>
 #include <qgscoordinatetransformcontext.h>
@@ -218,7 +218,7 @@ class Positioning : public QObject
   private slots:
 
     void lastGnssPositionInformationChanged( const GnssPositionInformation &lastGnssPositionInformation );
-    void magnetometerReadingChanged();
+    void compassReadingChanged();
     void projectedPositionTransformed();
 
   private:
@@ -250,7 +250,7 @@ class Positioning : public QObject
 
     AbstractGnssReceiver *mReceiver = nullptr;
 
-    QMagnetometer mMagnetometer;
+    QCompass mCompass;
     double mOrientation = std::numeric_limits<double>::quiet_NaN();
     quint64 mLastOrientationTimestamp = 0;
 };

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -23,6 +23,7 @@
 
 #include <QCompass>
 #include <QObject>
+#include <QTimer>
 #include <qgscoordinatereferencesystem.h>
 #include <qgscoordinatetransformcontext.h>
 #include <qgspoint.h>
@@ -218,7 +219,7 @@ class Positioning : public QObject
   private slots:
 
     void lastGnssPositionInformationChanged( const GnssPositionInformation &lastGnssPositionInformation );
-    void compassReadingChanged();
+    void processCompassReading();
     void projectedPositionTransformed();
 
   private:
@@ -251,8 +252,8 @@ class Positioning : public QObject
     AbstractGnssReceiver *mReceiver = nullptr;
 
     QCompass mCompass;
+    QTimer mCompassTimer;
     double mOrientation = std::numeric_limits<double>::quiet_NaN();
-    quint64 mLastOrientationTimestamp = 0;
 };
 
 Q_DECLARE_METATYPE( Positioning::ElevationCorrectionMode )

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -125,6 +125,7 @@
 #include <QQmlFileSelector>
 #include <QResource>
 #include <QScreen>
+#include <QSensor>
 #include <QStyleHints>
 #include <QtQml/QQmlApplicationEngine>
 #include <QtQml/QQmlContext>

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -125,7 +125,6 @@
 #include <QQmlFileSelector>
 #include <QResource>
 #include <QScreen>
-#include <QSensor>
 #include <QStyleHints>
 #include <QtQml/QQmlApplicationEngine>
 #include <QtQml/QQmlContext>

--- a/src/core/utils/expressioncontextutils.cpp
+++ b/src/core/utils/expressioncontextutils.cpp
@@ -40,6 +40,7 @@ QgsExpressionContextScope *ExpressionContextUtils::positionScope( const GnssPosi
   const QDateTime timestamp = positionInformation.utcDateTime();
   const qreal direction = positionInformation.direction();
   const qreal groundSpeed = positionInformation.speed();
+  const qreal orientation = positionInformation.orientation();
   const qreal magneticVariation = positionInformation.magneticVariation();
   const qreal horizontalAccuracy = positionInformation.hacc();
   const qreal verticalAccuracy = positionInformation.vacc();
@@ -60,6 +61,7 @@ QgsExpressionContextScope *ExpressionContextUtils::positionScope( const GnssPosi
   addPositionVariable( scope, QStringLiteral( "timestamp" ), timestamp, positionLocked );
   addPositionVariable( scope, QStringLiteral( "direction" ), direction, positionLocked );
   addPositionVariable( scope, QStringLiteral( "ground_speed" ), groundSpeed, positionLocked );
+  addPositionVariable( scope, QStringLiteral( "orientation" ), orientation, positionLocked );
   addPositionVariable( scope, QStringLiteral( "magnetic_variation" ), magneticVariation, positionLocked );
   addPositionVariable( scope, QStringLiteral( "horizontal_accuracy" ), horizontalAccuracy, positionLocked );
   addPositionVariable( scope, QStringLiteral( "vertical_accuracy" ), verticalAccuracy, positionLocked );

--- a/src/core/utils/fileutils.cpp
+++ b/src/core/utils/fileutils.cpp
@@ -193,28 +193,40 @@ void FileUtils::addImageMetadata( const QString &imagePath, const GnssPositionIn
     return;
   }
 
-  QVariantMap exifTags;
+  QVariantMap metadata;
   if ( positionInformation.latitudeValid() && positionInformation.longitudeValid() )
   {
-    exifTags["Exif.GPSInfo.GPSLatitude"] = std::abs( positionInformation.latitude() );
-    exifTags["Exif.GPSInfo.GPSLatitudeRef"] = positionInformation.latitude() >= 0 ? "N" : "S";
-    exifTags["Exif.GPSInfo.GPSLongitude"] = std::abs( positionInformation.longitude() );
-    exifTags["Exif.GPSInfo.GPSLongitudeRef"] = positionInformation.latitude() >= 0 ? "E" : "W";
+    metadata["Exif.GPSInfo.GPSLatitude"] = std::abs( positionInformation.latitude() );
+    metadata["Exif.GPSInfo.GPSLatitudeRef"] = positionInformation.latitude() >= 0 ? "N" : "S";
+    metadata["Exif.GPSInfo.GPSLongitude"] = std::abs( positionInformation.longitude() );
+    metadata["Exif.GPSInfo.GPSLongitudeRef"] = positionInformation.latitude() >= 0 ? "E" : "W";
     if ( positionInformation.elevationValid() )
     {
-      exifTags["Exif.GPSInfo.GPSAltitude"] = std::abs( positionInformation.elevation() );
-      exifTags["Exif.GPSInfo.GPSAltitudeRef"] = positionInformation.elevation() >= 0 ? "1" : "0";
+      metadata["Exif.GPSInfo.GPSAltitude"] = std::abs( positionInformation.elevation() );
+      metadata["Exif.GPSInfo.GPSAltitudeRef"] = positionInformation.elevation() >= 0 ? "1" : "0";
     }
   }
-
   if ( positionInformation.orientationValid() )
   {
-    exifTags["Exif.GPSInfo.GPSImgDirectionRef"] = "M";
-    exifTags["Exif.GPSInfo.GPSImgDirection"] = positionInformation.orientation();
+    metadata["Exif.GPSInfo.GPSImgDirection"] = positionInformation.orientation();
+    metadata["Exif.GPSInfo.GPSImgDirectionRef"] = "M";
+  }
+  if ( positionInformation.speedValid() )
+  {
+    metadata["Exif.GPSInfo.GPSSpeed"] = positionInformation.speed();
+    metadata["Exif.GPSInfo.GPSSpeedRef"] = "K";
   }
 
-  exifTags["Exif.GPSInfo.GPSDateStamp"] = positionInformation.utcDateTime().date();
-  exifTags["Exif.GPSInfo.GPSTimeStamp"] = positionInformation.utcDateTime().time();
+  metadata["Exif.GPSInfo.GPSDateStamp"] = positionInformation.utcDateTime().date();
+  metadata["Exif.GPSInfo.GPSTimeStamp"] = positionInformation.utcDateTime().time();
 
-  exifTags["Exif.GPSInfo.GPSSatellites"] = QString::number( positionInformation.satellitesUsed() ).rightJustified( 2, '0' );
+  metadata["Exif.GPSInfo.GPSSatellites"] = QString::number( positionInformation.satellitesUsed() ).rightJustified( 2, '0' );
+
+  metadata["Exif.Image.Make"] = QStringLiteral( "QField" );
+  metadata["Xmp.tiff.Make"] = QStringLiteral( "QField" );
+
+  for ( const QString key : metadata.keys() )
+  {
+    QgsExifTools::tagImage( imagePath, key, metadata[key] );
+  }
 }

--- a/src/core/utils/fileutils.h
+++ b/src/core/utils/fileutils.h
@@ -42,6 +42,13 @@ class QFIELD_CORE_EXPORT FileUtils : public QObject
     //! Returns a human-friendly size from bytes
     Q_INVOKABLE static QString representFileSize( qint64 bytes );
 
+    /**
+     * Insures that a given image's width and height are restricted to a maximum size.
+     * \param imagePath the image file path
+     * \param maximumWidthHeight the maximum width and height size
+     */
+    Q_INVOKABLE void restrictImageSize( const QString &imagePath, int maximumWidthHeight );
+
     static bool copyRecursively( const QString &sourceFolder, const QString &destFolder, QgsFeedback *feedback = nullptr, bool wipeDestFolder = true );
     /**
      * Creates checksum of a file. Returns null QByteArray if cannot be calculated.

--- a/src/core/utils/fileutils.h
+++ b/src/core/utils/fileutils.h
@@ -23,6 +23,8 @@
 #include <QObject>
 #include <qgsfeedback.h>
 
+class GnssPositionInformation;
+
 class QFIELD_CORE_EXPORT FileUtils : public QObject
 {
     Q_OBJECT
@@ -48,6 +50,8 @@ class QFIELD_CORE_EXPORT FileUtils : public QObject
      * \param maximumWidthHeight the maximum width and height size
      */
     Q_INVOKABLE void restrictImageSize( const QString &imagePath, int maximumWidthHeight );
+
+    Q_INVOKABLE void addImageMetadata( const QString &imagePath, const GnssPositionInformation &positionInformation );
 
     static bool copyRecursively( const QString &sourceFolder, const QString &destFolder, QgsFeedback *feedback = nullptr, bool wipeDestFolder = true );
     /**

--- a/src/qml/PositioningPreciseView.qml
+++ b/src/qml/PositioningPreciseView.qml
@@ -17,8 +17,8 @@ Item {
   property bool hasReachedTarget: hasAcceptableAccuracy && navigation.distance - positionSource.positionInformation.hacc - (precision / 10) <= 0
   property bool hasAlarmSnoozed: false
 
-  property double positionX: Math.min(precision, navigation.distance) * Math.cos((navigation.bearing - magnetometer.orientation - 90) * Math.PI / 180) * (preciseTarget.width / 2) / precision
-  property double positionY: Math.min(precision, navigation.distance) * Math.sin((navigation.bearing - magnetometer.orientation - 90) * Math.PI / 180) * (preciseTarget.width / 2) / precision
+  property double positionX: Math.min(precision, navigation.distance) * Math.cos((navigation.bearing - positionSource.orientation - 90) * Math.PI / 180) * (preciseTarget.width / 2) / precision
+  property double positionY: Math.min(precision, navigation.distance) * Math.sin((navigation.bearing - positionSource.orientation - 90) * Math.PI / 180) * (preciseTarget.width / 2) / precision
   property double positionZ: hasZ ? Math.min(precision, Math.max(-precision, -navigation.verticalDistance)) * ((preciseElevation.height - 15) / 2) / precision : 0.0
   property point positionCenter: Qt.point(preciseTarget.width / 2 + preciseTarget.x + preciseTarget.parent.x,
                                           preciseTarget.height / 2 + preciseTarget.y + preciseTarget.parent.y)
@@ -54,7 +54,7 @@ Item {
       width: Math.min(positioningPreciseView.height - 10,
                       positioningPreciseView.width - preciseElevation.width - labelTarget.contentWidth - labelElevation.width - 20)
       height: width
-      rotation: magnetometer.hasValue ? -magnetometer.orientation + positionSource.bearingTrueNorth : 0
+      rotation: !isNaN(positionSource.orientation) ? -positionSource.orientation + positionSource.bearingTrueNorth : 0
 
       ShapePath {
         strokeWidth: 1
@@ -323,7 +323,7 @@ Item {
     y: positionCenter.y + positionY - width / 2
     width: 28
     height: width
-    rotation: navigation.bearing - magnetometer.orientation
+    rotation: navigation.bearing - positionSource.orientation
 
     ShapePath {
       strokeWidth: 1
@@ -388,7 +388,7 @@ Item {
   Text {
     id: preciseHorizontalPositionInfo
 
-    property bool leftOfPoint: magnetometer.hasValue && positionX >= 0
+    property bool leftOfPoint: !isNaN(positionSource.orientation) && positionX >= 0
     x: positionCenter.x + positionX + (positionX >= 0 ? -contentWidth - 10 : preciseHorizontalPosition.width / 2)
     y: positionCenter.y + positionY + (positionY >= 0 ? -preciseHorizontalPosition.height : preciseHorizontalPosition.height / 2)
 

--- a/src/qml/editorwidgets/+Qt5/ExternalResource.qml
+++ b/src/qml/editorwidgets/+Qt5/ExternalResource.qml
@@ -598,7 +598,7 @@ EditorWidgetBase {
         if (!cameraLoader.isVideo) {
           var maximumWidhtHeight = iface.readProjectNumEntry("qfieldsync", "maximumImageWidthHeight", 0)
           if(maximumWidhtHeight > 0) {
-            iface.restrictImageSize(prefixToRelativePath + filepath, maximumWidhtHeight)
+            FileUtils.restrictImageSize(prefixToRelativePath + filepath, maximumWidhtHeight)
           }
         }
 
@@ -623,7 +623,7 @@ EditorWidgetBase {
       {
         var maximumWidhtHeight = iface.readProjectNumEntry("qfieldsync", "maximumImageWidthHeight", 0)
         if(maximumWidhtHeight > 0) {
-          iface.restrictImageSize(prefixToRelativePath + path, maximumWidhtHeight)
+          FileUtils.restrictImageSize(prefixToRelativePath + path, maximumWidhtHeight)
         }
 
         valueChangeRequested(path, false)

--- a/src/qml/editorwidgets/+Qt6/ExternalResource.qml
+++ b/src/qml/editorwidgets/+Qt6/ExternalResource.qml
@@ -607,7 +607,7 @@ EditorWidgetBase {
         if (!cameraLoader.isVideo) {
           var maximumWidhtHeight = iface.readProjectNumEntry("qfieldsync", "maximumImageWidthHeight", 0)
           if(maximumWidhtHeight > 0) {
-            iface.restrictImageSize(prefixToRelativePath + filepath, maximumWidhtHeight)
+            FileUtils.restrictImageSize(prefixToRelativePath + filepath, maximumWidhtHeight)
           }
         }
 
@@ -632,7 +632,7 @@ EditorWidgetBase {
       {
         var maximumWidhtHeight = iface.readProjectNumEntry("qfieldsync", "maximumImageWidthHeight", 0)
         if(maximumWidhtHeight > 0) {
-          iface.restrictImageSize(prefixToRelativePath + path, maximumWidhtHeight)
+          FileUtils.restrictImageSize(prefixToRelativePath + path, maximumWidhtHeight)
         }
 
         valueChangeRequested(path, false)

--- a/src/qml/imports/QFieldControls/+Qt5/QFieldCamera.qml
+++ b/src/qml/imports/QFieldControls/+Qt5/QFieldCamera.qml
@@ -3,6 +3,8 @@ import QtQuick.Controls 2.14
 import QtQuick.Window 2.14
 import QtMultimedia 5.14
 
+import org.qfield 1.0
+
 import Theme 1.0
 
 Popup {
@@ -54,20 +56,6 @@ Popup {
       cameraState: cameraItem.visible ? Camera.ActiveState : Camera.UnloadedState
 
       position: Camera.BackFace
-
-      metaData.cameraManufacturer: 'QField'
-      metaData.gpsLatitude: positionSource.positionInformation.latitudeValid
-                            ? positionSource.positionInformation.latitude
-                            : undefined
-      metaData.gpsLongitude: positionSource.positionInformation.longitudeValid
-                             ? positionSource.positionInformation.longitude
-                             : undefined
-      metaData.gpsAltitude: positionSource.positionInformation.elevationValid
-                            ? positionSource.positionInformation.elevation
-                            : undefined
-      metaData.gpsSpeed: positionSource.positionInformation.speedValid
-                         ? positionSource.positionInformation.speed
-                         : undefined
 
       imageCapture {
         onImageSaved: {
@@ -264,6 +252,9 @@ Popup {
                 cameraItem.state = "VideoPreview"
               }
             } else if (cameraItem.state == "PhotoPreview" || cameraItem.state == "VideoPreview") {
+              if (cameraItem.state == "PhotoPreview") {
+                FileUtils.addImageMetadata(currentPath, positionSource.positionInformation)
+              }
               cameraItem.finished(currentPath)
             }
           }

--- a/src/qml/imports/QFieldControls/+Qt6/QFieldCamera.qml
+++ b/src/qml/imports/QFieldControls/+Qt6/QFieldCamera.qml
@@ -216,6 +216,9 @@ Popup {
                 cameraItem.state = "VideoPreview"
               }
             } else if (cameraItem.state == "PhotoPreview" || cameraItem.state == "VideoPreview") {
+              if (cameraItem.state == "PhotoPreview") {
+                FileUtils.addImageMetadata(currentPath, positionSource.positionInformation)
+              }
               cameraItem.finished(currentPath)
             }
           }


### PR DESCRIPTION
This is some restructuring to prepare for interesting functionality. 

To begin with, this permits us to easily add a @{position,gnss}_orientation variable, which gives users the possibility of capturing in a feature attribute the orientation of the device during a point being captured.

This will also allow us (in a different PR) to write the orientation into an image file via exif tag writing.
