### PR TITLE
Add QField camera UI to toggle geotagging

### DIFF
--- a/src/qml/imports/QFieldControls/+Qt5/QFieldCamera.qml
+++ b/src/qml/imports/QFieldControls/+Qt5/QFieldCamera.qml
@@ -2,6 +2,7 @@ import QtQuick 2.14
 import QtQuick.Controls 2.14
 import QtQuick.Window 2.14
 import QtMultimedia 5.14
+import Qt.labs.settings 1.0
 
 import org.qfield 1.0
 
@@ -38,6 +39,11 @@ Popup {
       camera.captureMode = Camera.CaptureVideo
       videoPreview.source = '';
     }
+  }
+
+  Settings {
+    id: settings
+    property bool geoTagging: true
   }
 
   Page {
@@ -253,7 +259,9 @@ Popup {
               }
             } else if (cameraItem.state == "PhotoPreview" || cameraItem.state == "VideoPreview") {
               if (cameraItem.state == "PhotoPreview") {
-                FileUtils.addImageMetadata(currentPath, positionSource.positionInformation)
+                if (settings.geoTagging && positionSource.active) {
+                  FileUtils.addImageMetadata(currentPath, positionSource.positionInformation)
+                }
               }
               cameraItem.finished(currentPath)
             }
@@ -361,7 +369,7 @@ Popup {
 
       iconSource: Theme.getThemeIcon("ic_chevron_left_white_24dp")
       iconColor: "white"
-      bgcolor: Qt.hsla(Theme.darkGray.hslHue, Theme.darkGray.hslSaturation, Theme.darkGray.hslLightness, 0.5)
+      bgcolor: Theme.darkGraySemiOpaque
       round: true
 
       onClicked: {
@@ -373,6 +381,27 @@ Popup {
             platformUtilities.rmFile(currentPath)
           }
           cameraItem.canceled()
+        }
+      }
+    }
+
+    QfToolButton {
+      id: geotagButton
+
+      anchors.left: parent.left
+      anchors.leftMargin: 4
+      anchors.top: backButton.bottom
+      anchors.topMargin: 4
+
+      iconSource: positionSource.active ? Theme.getThemeIcon("ic_geotag_24dp") : Theme.getThemeIcon("ic_geotag_missing_24dp")
+      iconColor: positionSource.active && settings.geoTagging ? Theme.mainColor : "white"
+      bgcolor: Theme.darkGraySemiOpaque
+      round: true
+
+      onClicked: {
+        if (positionSource.active) {
+          settings.geoTagging = !settings.geoTagging
+          displayToast(settings.geoTagging ? qsTr("Geotagging enabled") : qsTr("Geotagging disabled"))
         }
       }
     }

--- a/src/qml/imports/QFieldControls/+Qt6/QFieldCamera.qml
+++ b/src/qml/imports/QFieldControls/+Qt6/QFieldCamera.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Window
 import QtMultimedia
+import Qt.labs.settings
 
 import Theme 1.0
 
@@ -36,6 +37,11 @@ Popup {
       photoPreview.source = ''
       videoPreview.source = ''
     }
+  }
+
+  Settings {
+    id: settings
+    property bool geoTagging: true
   }
 
   Page {
@@ -217,7 +223,9 @@ Popup {
               }
             } else if (cameraItem.state == "PhotoPreview" || cameraItem.state == "VideoPreview") {
               if (cameraItem.state == "PhotoPreview") {
-                FileUtils.addImageMetadata(currentPath, positionSource.positionInformation)
+                if (settings.geoTagging && positionSource.active) {
+                  FileUtils.addImageMetadata(currentPath, positionSource.positionInformation)
+                }
               }
               cameraItem.finished(currentPath)
             }
@@ -336,6 +344,27 @@ Popup {
             platformUtilities.rmFile(currentPath)
           }
           cameraItem.canceled()
+        }
+      }
+    }
+
+    QfToolButton {
+      id: geotagButton
+
+      anchors.left: parent.left
+      anchors.leftMargin: 4
+      anchors.top: backButton.bottom
+      anchors.topMargin: 4
+
+      iconSource: positionSource.active ? Theme.getThemeIcon("ic_geotag_24dp") : Theme.getThemeIcon("ic_geotag_missing_24dp")
+      iconColor: positionSource.active && settings.geoTagging ? Theme.mainColor : "white"
+      bgcolor: Theme.darkGraySemiOpaque
+      round: true
+
+      onClicked: {
+        if (positionSource.active) {
+          settings.geoTagging = !settings.geoTagging
+          displayToast(settings.geoTagging ? qsTr("Geotagging enabled") : qsTr("Geotagging disabled"))
         }
       }
     }


### PR DESCRIPTION
This PR adds a UI  to the QField camera to toggle geotagging:

![image](https://github.com/opengisch/QField/assets/1728657/47b201dc-1e86-452b-b812-80e3b5b1985c)

When enabled, the following tags are added:
- latitude, longitude, and altitude (provided they are valid values)
- ground speed
- compass orientation
