### PR TITLE
Add GPS metadata to image reflecting the time the photo was snapped

### DIFF
--- a/src/qml/imports/QFieldControls/+Qt5/QFieldCamera.qml
+++ b/src/qml/imports/QFieldControls/+Qt5/QFieldCamera.qml
@@ -16,6 +16,7 @@ Popup {
   property bool isPortraitMode: mainWindow.height > mainWindow.width
 
   property string currentPath
+  property var currentPosition
 
   signal finished(string path)
   signal canceled()
@@ -246,6 +247,7 @@ Popup {
           onClicked: {
             if (cameraItem.state == "PhotoCapture") {
               camera.imageCapture.captureToLocation(qgisProject.homePath+ '/DCIM/')
+              currentPosition = positionSource.positionInformation
             } else if (cameraItem.state == "VideoCapture") {
               if (camera.videoRecorder.recorderState == CameraRecorder.StoppedState) {
                 camera.videoRecorder.record()
@@ -260,7 +262,7 @@ Popup {
             } else if (cameraItem.state == "PhotoPreview" || cameraItem.state == "VideoPreview") {
               if (cameraItem.state == "PhotoPreview") {
                 if (settings.geoTagging && positionSource.active) {
-                  FileUtils.addImageMetadata(currentPath, positionSource.positionInformation)
+                  FileUtils.addImageMetadata(currentPath, currentPosition)
                 }
               }
               cameraItem.finished(currentPath)

--- a/src/qml/imports/QFieldControls/+Qt6/QFieldCamera.qml
+++ b/src/qml/imports/QFieldControls/+Qt6/QFieldCamera.qml
@@ -14,6 +14,7 @@ Popup {
   property bool isPortraitMode: mainWindow.height > mainWindow.width
 
   property string currentPath
+  property var currentPosition
 
   signal finished(string path)
   signal canceled()
@@ -210,6 +211,7 @@ Popup {
           onClicked: {
             if (cameraItem.state == "PhotoCapture") {
               captureSession.imageCapture.captureToFile(qgisProject.homePath+ '/DCIM/')
+              currentPosition = positionSource.positionInformation
             } else if (cameraItem.state == "VideoCapture") {
               if (captureSession.recorder.recorderState === MediaRecorder.StoppedState) {
                 captureSession.recorder.record()
@@ -224,7 +226,7 @@ Popup {
             } else if (cameraItem.state == "PhotoPreview" || cameraItem.state == "VideoPreview") {
               if (cameraItem.state == "PhotoPreview") {
                 if (settings.geoTagging && positionSource.active) {
-                  FileUtils.addImageMetadata(currentPath, positionSource.positionInformation)
+                  FileUtils.addImageMetadata(currentPath, currentPosition)
                 }
               }
               cameraItem.finished(currentPath)


### PR DESCRIPTION
This is actually quite important as someone might turn (or even walk) away from their position/orientation at the time they snapped the photo prior to accepting the snapped photo.