### PR TITLE
Move from QModelIndex to QPersistentModelIndex in the layer tree proxy model class

### DIFF
--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -198,7 +198,7 @@ void FlatLayerTreeModelBase::insertInMap( const QModelIndex &parent, int first, 
 
     QMap<int, int> treeLevelMap;
     mIndexMap.clear();
-    const QList<QModelIndex> keys = mRowMap.keys();
+    const QList<QPersistentModelIndex> keys = mRowMap.keys();
     for ( const auto &index : keys )
     {
       int row = mRowMap[index];
@@ -291,7 +291,7 @@ void FlatLayerTreeModelBase::removeFromMap( const QModelIndex &parent, int first
 
     QMap<int, int> treeLevelMap;
     mIndexMap.clear();
-    const QList<QModelIndex> keys = mRowMap.keys();
+    const QList<QPersistentModelIndex> keys = mRowMap.keys();
     for ( const auto &index : keys )
     {
       int row = mRowMap[index];

--- a/src/core/layertreemodel.h
+++ b/src/core/layertreemodel.h
@@ -89,10 +89,10 @@ class FlatLayerTreeModelBase : public QAbstractProxyModel
     void updateTemporalState();
     void adjustTemporalStateFromAddedLayers( const QList<QgsMapLayer *> &layers );
 
-    QMap<QModelIndex, int> mRowMap;
-    QMap<int, QModelIndex> mIndexMap;
+    QMap<QPersistentModelIndex, int> mRowMap;
+    QMap<int, QPersistentModelIndex> mIndexMap;
     QMap<int, int> mTreeLevelMap;
-    QList<QModelIndex> mCollapsedItems;
+    QList<QPersistentModelIndex> mCollapsedItems;
 
     QgsLayerTreeModel *mLayerTreeModel = nullptr;
     QString mMapTheme;


### PR DESCRIPTION
Trying to fix this (https://opengisch.sentry.io/issues/4569883968/?project=6119013&query=is%3Aunresolved&referrer=issue-stream&sort=user&statsPeriod=7d&stream_index=10) which has been a longstanding crasher, but appears to be more frequent in Qt6.

The stacktrace is really unhelpful, but it does tell us that FlatLayerTreeModelBase::data's check for a valid source model QModelIndex doesn't appear to be enough.

I think moving from a `QList<QModelIndex>` to a `QList<QPersistentModelIndex>` could improve things here. 