### PR TITLE
Revert geometry/rubberband item's buffer parameter change

### DIFF
--- a/src/core/qgssggeometry.cpp
+++ b/src/core/qgssggeometry.cpp
@@ -164,7 +164,7 @@ QSGGeometry *QgsSGGeometry::qgsPolygonToQSGGeometry( const QgsPolygon *polygon, 
   Q_ASSERT( polygon );
 
   QgsGeometry geom( polygon->clone() );
-  geom = geom.buffer( 0.0000001, 1, Qgis::EndCapStyle::Flat, Qgis::JoinStyle::Miter, 5 );
+  geom = geom.buffer( 0.0000001, 5 );
   QgsPolygon *bufferedPolygon = qgsgeometry_cast<QgsPolygon *>( geom.constGet() );
   QgsTessellator t( visibleExtent.xMinimum(), visibleExtent.yMaximum(), false, false, false, true );
   if ( bufferedPolygon )

--- a/src/core/sgrubberband.cpp
+++ b/src/core/sgrubberband.cpp
@@ -109,7 +109,7 @@ QSGGeometryNode *SGRubberband::createLineGeometry( const QVector<QgsPoint> &poin
 QSGGeometryNode *SGRubberband::createPolygonGeometry( const QVector<QgsPoint> &points )
 {
   QgsGeometry geom( new QgsPolygon( new QgsLineString( points ) ) );
-  geom = geom.buffer( 0.0000001, 1, Qgis::EndCapStyle::Flat, Qgis::JoinStyle::Miter, 5 );
+  geom = geom.buffer( 0.0000001, 5 );
   // QgsTesselator doesn't allow for coordinates distance smaller than 0.001
   geom.removeDuplicateNodes( 0.001 );
   QgsPolygon *polygon = qgsgeometry_cast<QgsPolygon *>( geom.constGet() );


### PR DESCRIPTION
This PR aims at fixing a crasher that emerged in QField 3.0.3:

![image](https://github.com/opengisch/QField/assets/1728657/5fe052a6-57bc-430b-bb49-b7f1d7e2677f)

Stacktrace:

![image](https://github.com/opengisch/QField/assets/1728657/d3ad26f3-75c2-47bf-9222-39b32b8dc79d)

Looking at the list of commits (https://github.com/opengisch/QField/compare/v3.0.2...v3.0.3) I can only see one culprit: the buffer parameter change here (https://github.com/opengisch/QField/commit/869c1977182b25ef989c27bd3dfbcc7a7a7e7e55#diff-6ec0f90b884446f8c30d9dd753160c7e100e8929ae79edd44679d1df523bee57R167)

The logic behind that change was to reduce the number of vertices produced by the buffering operation as a tiny optimization. That appears to have had negative consequences. Let's revert.

(Note that the other change, the removeDuplicateNodes call in the rubber band, is important and not tied to the crash, hence keeping it in.