### PR TITLE
Add qimageformats plugin to allow for tiff WMS layers

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -71,7 +71,7 @@ jobs:
         uses: jurplel/install-qt-action@v3
         with:
           version: 6.5.3
-          modules: 'qt5compat qtcharts qtpositioning qtserialport qtconnectivity qtmultimedia qtwebview qtsensors'
+          modules: 'qt5compat qtcharts qtpositioning qtserialport qtconnectivity qtimageformats qtmultimedia qtwebview qtsensors'
           target: android
           arch: ${{ matrix.qt_arch }}
           cache: false
@@ -80,7 +80,7 @@ jobs:
         uses: jurplel/install-qt-action@v3
         with:
           version: 6.5.3
-          modules: 'qt5compat qtcharts qtpositioning qtserialport qtconnectivity qtmultimedia qtwebview qtsensors'
+          modules: 'qt5compat qtcharts qtpositioning qtserialport qtconnectivity qtimageformats qtmultimedia qtwebview qtsensors'
           target: desktop
           cache: false
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -47,7 +47,7 @@ jobs:
         uses: jurplel/install-qt-action@v3
         with:
           version: 6.5.3
-          modules: 'qt5compat qtcharts qtpositioning qtconnectivity qtmultimedia qtwebview qtsensors'
+          modules: 'qt5compat qtcharts qtpositioning qtconnectivity qtimageformats qtmultimedia qtwebview qtsensors'
           target: ios
           cache: true
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -45,7 +45,7 @@ jobs:
         uses: jurplel/install-qt-action@v3
         with:
           version: 6.5.3
-          modules: 'qt5compat qtcharts qtpositioning qtserialport qtconnectivity qtmultimedia qtwebview qtsensors'
+          modules: 'qt5compat qtcharts qtpositioning qtserialport qtconnectivity qtimageformats qtmultimedia qtwebview qtsensors'
           target: desktop
 
       - name: Install linuxdeploy


### PR DESCRIPTION
Without the extra module, Qt fails to load tiffs, which is required for the WMS provider to behave.

It also unlocks image/webp WMS layers.