### PR TITLE
[Backport release-3_0] Move from QModelIndex to QPersistentModelIndex in the layer tree proxy model class

### DIFF
--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -198,7 +198,7 @@ void FlatLayerTreeModelBase::insertInMap( const QModelIndex &parent, int first, 
 
     QMap<int, int> treeLevelMap;
     mIndexMap.clear();
-    const QList<QModelIndex> keys = mRowMap.keys();
+    const QList<QPersistentModelIndex> keys = mRowMap.keys();
     for ( const auto &index : keys )
     {
       int row = mRowMap[index];
@@ -291,7 +291,7 @@ void FlatLayerTreeModelBase::removeFromMap( const QModelIndex &parent, int first
 
     QMap<int, int> treeLevelMap;
     mIndexMap.clear();
-    const QList<QModelIndex> keys = mRowMap.keys();
+    const QList<QPersistentModelIndex> keys = mRowMap.keys();
     for ( const auto &index : keys )
     {
       int row = mRowMap[index];

--- a/src/core/layertreemodel.h
+++ b/src/core/layertreemodel.h
@@ -89,10 +89,10 @@ class FlatLayerTreeModelBase : public QAbstractProxyModel
     void updateTemporalState();
     void adjustTemporalStateFromAddedLayers( const QList<QgsMapLayer *> &layers );
 
-    QMap<QModelIndex, int> mRowMap;
-    QMap<int, QModelIndex> mIndexMap;
+    QMap<QPersistentModelIndex, int> mRowMap;
+    QMap<int, QPersistentModelIndex> mIndexMap;
     QMap<int, int> mTreeLevelMap;
-    QList<QModelIndex> mCollapsedItems;
+    QList<QPersistentModelIndex> mCollapsedItems;
 
     QgsLayerTreeModel *mLayerTreeModel = nullptr;
     QString mMapTheme;


### PR DESCRIPTION
Backport #4705
 **Authored by:** @nirvn