### PR TITLE
Search bar's filters list improvement

### DIFF
--- a/src/core/locator/activelayerfeatureslocatorfilter.cpp
+++ b/src/core/locator/activelayerfeatureslocatorfilter.cpp
@@ -416,7 +416,7 @@ void ActiveLayerFeaturesLocatorFilter::triggerResultFromAction( const QgsLocator
             }
             else if ( !r.isEmpty() )
             {
-              r.scale( 5 );
+              r.scale( 1.25 );
             }
           }
 

--- a/src/core/locator/featureslocatorfilter.cpp
+++ b/src/core/locator/featureslocatorfilter.cpp
@@ -228,7 +228,7 @@ void FeaturesLocatorFilter::triggerResultFromAction( const QgsLocatorResult &res
       }
       else if ( !r.isEmpty() )
       {
-        r.scale( 5 );
+        r.scale( 1.25 );
       }
     }
 

--- a/src/core/projectinfo.cpp
+++ b/src/core/projectinfo.cpp
@@ -310,6 +310,8 @@ void ProjectInfo::setActiveLayer( QgsMapLayer *layer )
   mSettings.beginGroup( QStringLiteral( "/qgis/projectInfo/%1" ).arg( mFilePath ) );
   mSettings.setValue( QStringLiteral( "activeLayer" ), layer->id() );
   mSettings.endGroup();
+
+  emit activeLayerChanged();
 }
 
 QgsMapLayer *ProjectInfo::activeLayer() const

--- a/src/qml/LocatorItem.qml
+++ b/src/qml/LocatorItem.qml
@@ -275,7 +275,7 @@ Item {
       anchors.topMargin: 24
       model: searchField.displayText !== '' ? locator.proxyModel() : locatorFilters
       width: parent.width
-      height: resultsList.count > 0 ? Math.min( childrenRect.height, mainWindow.height / 2 - searchFieldRect.height - 10 ) : 0
+      height: resultsList.count > 0 ? Math.min( contentHeight, mainWindow.height / 2 - searchFieldRect.height - 10 ) : 0
       clip: true
 
       delegate: searchField.displayText !== '' ? resultsComponent : filtersComponent
@@ -288,10 +288,10 @@ Item {
         id: delegateRect
 
         anchors.margins: 10
-        height: textArea.childrenRect.height + textArea.topPadding + textArea.bottomPadding
         width: resultsList.width
+        height: textArea.childrenRect.height + textArea.topPadding + textArea.bottomPadding
         color: "transparent"
-        opacity: 0.95
+        opacity: (Prefix === 'f' && dashBoard.activeLayer == undefined) ? 0.35 : 0.95
 
         Ripple {
           clip: true
@@ -316,7 +316,7 @@ Item {
             id: nameCell
             anchors.left: parent.left
             anchors.right: parent.right
-            text: Name + ' (' + Prefix + ')'
+            text: Name + ' (' + Prefix + ')' + (Prefix === 'f' && dashBoard.activeLayer ? ' — ' + dashBoard.activeLayer.name : '')
             leftPadding: 5
             font.bold: false
             font.pointSize: Theme.resultFont.pointSize
@@ -352,7 +352,11 @@ Item {
           anchors.fill: parent
 
           onClicked: {
-            searchField.text = Prefix + ' ';
+            if (Prefix === 'f' && dashBoard.activeLayer == undefined) {
+              displayToast(qsTr('Activate a vector layer in the legend first to use this functionality'), 'warning')
+            } else {
+              searchField.text = Prefix + ' '
+            }
           }
         }
       }


### PR DESCRIPTION
This PR improves the handling of the search bar's filters list (i.e. when no search term is entered) by _disabling_ the active layer search item when no vector layer is active/selected in the dashboard's legend. The user will also be thrown a toast message if they click on the filter informing them of what is required to use the filter.

@mbernasocchi , as requested.