### PR TITLE
Improve android docker build process

### DIFF
--- a/.docker/android_dev/Dockerfile
+++ b/.docker/android_dev/Dockerfile
@@ -68,7 +68,9 @@ RUN yes | /opt/android-sdk-linux/cmdline-tools/latest/bin/sdkmanager --licenses 
 
 RUN mkdir /home/devel
 WORKDIR /home/devel
+ARG INSTALL_QT_ARCH
+ARG INSTALL_QT_VERSION
 RUN pip3 install aqtinstall cmake && \
-    /usr/local/bin/aqt install-qt linux android 6.5.3 android_arm64_v8a -m qtcharts qt5compat qtpositioning qtserialport qtconnectivity qtmultimedia qtwebview qtsensors --autodesktop
+    /usr/local/bin/aqt install-qt linux android "${INSTALL_QT_VERSION}" "${INSTALL_QT_ARCH}" -m qt5compat qtcharts qtpositioning qtserialport qtconnectivity qtimageformats qtmultimedia qtwebview qtsensors --autodesktop
 ENV ANDROID_NDK_HOME=/opt/android-sdk-linux/ndk/${NDK_VERSION}
 ENV ANDROID_NDK_VERSION=${NDK_VERSION}

--- a/cmake/Package.cmake
+++ b/cmake/Package.cmake
@@ -83,6 +83,7 @@ if(ANDROID AND ANDROIDDEPLOYQT_EXECUTABLE)
     set(ANDROID_TEMPLATE_FOLDER "${CMAKE_BINARY_DIR}/android-template")
     file(COPY ${CMAKE_SOURCE_DIR}/platform/android/ DESTINATION ${ANDROID_TEMPLATE_FOLDER}/)
     set(SRC_FOLDER "${ANDROID_TEMPLATE_FOLDER}/src/ch/opengis/${APP_PACKAGE_NAME}")
+    file(REMOVE_RECURSE ${SRC_FOLDER}) # remove any pre-existing content
     file(RENAME "${ANDROID_TEMPLATE_FOLDER}/src/ch/opengis/qfield" ${SRC_FOLDER})
     file(GLOB JAVA_FILES "${SRC_FOLDER}/*.java")
     foreach(JAVA_FILE ${JAVA_FILES})

--- a/scripts/build-vcpkg.sh
+++ b/scripts/build-vcpkg.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-echo "building for ${triplet}"
+echo "building for ${triplet} on Qt ${install_qt_version} (${install_qt_arch})"
 
 export SOURCE_DIR=/usr/src/qfield
 
 CMAKE_BUILD_DIR=/usr/src/qfield/build-${triplet}
 
-export Qt6_DIR=/home/devel/6.6.0/android_arm64_v8a
+export Qt6_DIR=/home/devel/${install_qt_version}/${install_qt_arch}
 
 [[ -z ${APP_NAME} ]] && APP_NAME="QField"
 [[ -z ${APP_PACKAGE_NAME} ]] && APP_PACKAGE_NAME="qfield"
@@ -20,8 +20,8 @@ cmake -S "${SOURCE_DIR}" \
 	-G Ninja \
 	-D BUILD_WITH_QT6=ON \
 	-D CMAKE_PREFIX_PATH=${Qt6_DIR} \
-	-D QT_HOST_PATH=/home/devel/6.6.0/gcc_64 \
-	-D QT_HOST_PATH_CMAKE_DIR=/home/devel/6.6.0/gcc_64/lib/cmake \
+	-D QT_HOST_PATH=/home/devel/${install_qt_version}/gcc_64 \
+	-D QT_HOST_PATH_CMAKE_DIR=/home/devel/${install_qt_version}/gcc_64/lib/cmake \
 	-D VCPKG_TARGET_TRIPLET="${triplet}" \
 	-D SYSTEM_QT=ON \
 	-D ANDROID_NDK_VERSION="${ANDROID_NDK_VERSION}" \

--- a/scripts/build-vcpkg.sh
+++ b/scripts/build-vcpkg.sh
@@ -8,9 +8,9 @@ CMAKE_BUILD_DIR=/usr/src/qfield/build-${triplet}
 
 export Qt6_DIR=/home/devel/${install_qt_version}/${install_qt_arch}
 
-[[ -z ${APP_NAME} ]] && APP_NAME="QField"
-[[ -z ${APP_PACKAGE_NAME} ]] && APP_PACKAGE_NAME="qfield"
-[[ -z ${APP_ICON} ]] && APP_ICON="qfield_logo"
+[[ -z ${APP_NAME} ]] && APP_NAME="QField Home"
+[[ -z ${APP_PACKAGE_NAME} ]] && APP_PACKAGE_NAME="qfield_home"
+[[ -z ${APP_ICON} ]] && APP_ICON="qfield_logo_beta"
 
 echo "Package name ${APP_PACKAGE_NAME}"
 
@@ -29,9 +29,9 @@ cmake -S "${SOURCE_DIR}" \
 	-D ANDROID_SDK_ROOT=/opt/android-sdk-linux \
 	-D ANDROID_BUILD_TOOLS_VERSION="${ANDROID_BUILD_TOOLS_VERSION}" \
 	-D WITH_SPIX=OFF \
-	-D APP_VERSION="v1.0.0" \
-	-D APK_VERSION_CODE="${APK_VERSION_CODE}" \
-	-D APP_VERSION_STR="${APP_VERSION_STR}" \
+	-D APK_VERSION_CODE="1" \
+	-D APP_VERSION="" \
+	-D APP_VERSION_STR="Home" \
 	-D APP_PACKAGE_NAME="${APP_PACKAGE_NAME}" \
 	-D APP_ICON="${APP_ICON}" \
 	-D APP_NAME="${APP_NAME}" \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,14 +8,31 @@ export APK_VERSION_CODE=${APK_VERSION_CODE:-1}
 export APP_VERSION_STR=${APP_VERSION_STR:-dev}
 
 triplet=${triplet:-arm64-android}
+install_qt_version="6.6.0"
 
-docker build ${SRC_DIR}/.docker/android_dev -t qfield_and_dev
+if [[ ${triplet} == arm-android ]]; then
+	install_qt_arch="android_armv7"
+elif [[ ${triplet} == arm-neon-android ]]; then
+	install_qt_arch="android_armv7"
+elif [[ ${triplet} == arm64-android ]]; then
+	install_qt_arch="android_arm64_v8a"
+elif [[ ${triplet} == x86-android ]]; then
+	install_qt_arch="android_x86"
+elif [[ ${triplet} == x64-android ]]; then
+	install_qt_arch="android_x86_64"
+else
+	install_qt_arch="android_arm64_v8a"
+fi
+
+docker build ${SRC_DIR}/.docker/android_dev -t qfield_and_dev --build-arg INSTALL_QT_ARCH=${install_qt_arch} --build-arg INSTALL_QT_VERSION=${install_qt_version}
 
 docker run -it --rm qfield_and_dev env
 docker run -it --rm \
 	-v "$SRC_DIR":/usr/src/qfield:Z \
 	$(if [ -n "$CACHE_DIR" ]; then echo "-v $CACHE_DIR:/io/.cache:Z"; fi) \
 	-e triplet=${triplet} \
+	-e install_qt_version=${install_qt_version} \
+	-e install_qt_arch=${install_qt_arch} \
 	-e STOREPASS \
 	-e KEYNAME \
 	-e KEYPASS \


### PR DESCRIPTION
Improvements:
- Fix building for arch other than arm64 (!)
- Use a single variable to drive Qt version number
- Avoid using "qfield" as app name so development doesn't come at the cost of removing the official QField installed through the play store :)
