### PR TITLE
Re-introduce a timer to avoid finger hover / stylus interference

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -342,8 +342,8 @@ ApplicationWindow {
         }
 
         onHoveredChanged: {
-            if (skipHover) {
-              skipHover = hovered
+            if ( skipHover ) {
+              dummyHoverTimer.restart()
               return
             }
 
@@ -359,7 +359,17 @@ ApplicationWindow {
     /* The second hover handler is a workaround what appears to be an issue with
      * Qt whereas synthesized mouse event would trigger the first HoverHandler even though
      * PointerDevice.TouchScreen was explicitly taken out of the accepted devices.
+     * The timer is needed as adding additional fingers onto a device re-triggers hovered
+     * changes in unpredictable order.
      */
+    Timer {
+      id: dummyHoverTimer
+      interval: 100
+      repeat: false
+
+      onTriggered: hoverHandler.skipHover = hoverHandler.hovered
+    }
+
     HoverHandler {
         id: dummyHoverHandler
         enabled: !qfieldSettings.mouseAsTouchScreen


### PR DESCRIPTION
After some more debugging, turns out adding a second finger onto the screen retriggers the whole hovering chain of event, however depending on how fast the second finger is added, the ordering is inconsistent. 

The solution here is to (re-)introduce a timer that gives us a threshold to have events go in any order Qt sees fit.