### PR TITLE
Fix screen lock not blocking back button presses

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3583,17 +3583,20 @@ ApplicationWindow {
   property bool alreadyCloseRequested: false
 
   onClosing: (close) => {
-      if( !alreadyCloseRequested )
-      {
-        close.accepted = false
-        alreadyCloseRequested = true
-        displayToast( qsTr( "Press back again to close project and app" ) )
-        closingTimer.start()
-      }
-      else
-      {
-        close.accepted = true
-      }
+    if (screenLocker.enabled) {
+       close.accepted = false
+       displayToast(qsTr("Unlock the screen to to close project and app"))
+       return
+    }
+
+    if (!alreadyCloseRequested) {
+      close.accepted = false
+      alreadyCloseRequested = true
+      displayToast(qsTr("Press back again to close project and app"))
+      closingTimer.start()
+    } else {
+      close.accepted = true
+    }
   }
 
   Timer {


### PR DESCRIPTION
This PR fixes the bug aspect of what was raised here (https://github.com/opengisch/QField/issues/4770). The screen lock mode definitively needs to prevent back button action. That was an implementation gap.
