### PR TITLE
Remove unused property that creates tons of Qt warnings, which in turn breaks the smoke/spix test

### DIFF
--- a/src/core/vertexmodel.h
+++ b/src/core/vertexmodel.h
@@ -58,8 +58,6 @@ class QFIELD_CORE_EXPORT VertexModel : public QAbstractListModel
     Q_PROPERTY( bool canPreviousVertex READ canPreviousVertex NOTIFY canPreviousVertexChanged )
     //! determines if one can go to next vertex
     Q_PROPERTY( bool canNextVertex READ canNextVertex NOTIFY canNextVertexChanged )
-    //! geometry type
-    Q_PROPERTY( Qgis::GeometryType geometryType READ geometryType NOTIFY geometryTypeChanged )
     //! determines if the map is currently being hovered (then when moving the map, it will not move directly a vertex if the mode is AddVertex)
     Q_PROPERTY( bool isHovering MEMBER mIsHovering )
 


### PR DESCRIPTION
The recent vertex editor addition exposed an issue with the registration VertexModel metatype interfering with Qgis enums.

In turn, that causes the smoke test to die (app launch doesn't like the Qt errors thrown). Luckily, the offending Q_PROPERTY in VertexModel isn't used so we can remove it.

I had seen this issue before, but the errors were triggered only when activating the vertex model (vs. now on app launch). We have other classes that have a Qgis::GeometryType Q_PROPERTY (e.g. rubberband), it's a mystery to me why VertexModel clashes here. I suspect it has to do with the Q_DECLARE_METATYPE( VertexModel::Vertex ); at the end of the header file as it is not present in other classes with the same property.