### PR TITLE
Add a shift modifier to rotate via hold middle-click, and go back to pan with no modifier

### DIFF
--- a/src/qml/MapCanvas.qml
+++ b/src/qml/MapCanvas.qml
@@ -304,6 +304,35 @@ Item {
     target: null
     enabled: interactive && !pinchArea.isDragging
     acceptedDevices: PointerDevice.Stylus | PointerDevice.Mouse
+    acceptedModifiers: Qt.NoModifier
+    grabPermissions: PointerHandler.TakeOverForbidden
+    acceptedButtons: Qt.MiddleButton
+
+    property var oldPos
+
+    onActiveChanged: {
+      if (active) {
+        freeze('pan')
+        oldPos = centroid.position
+      } else {
+        unfreeze('pan')
+      }
+    }
+
+    onCentroidChanged: {
+      if (active) {
+        var oldPos1 = oldPos
+        oldPos = centroid.position
+        mapCanvasWrapper.pan(centroid.position, oldPos1)
+      }
+    }
+  }
+
+  DragHandler {
+    target: null
+    enabled: interactive && !pinchArea.isDragging
+    acceptedDevices: PointerDevice.Stylus | PointerDevice.Mouse
+    acceptedModifiers: Qt.ShiftModifier
     grabPermissions: PointerHandler.TakeOverForbidden
     acceptedButtons: Qt.MiddleButton
 


### PR DESCRIPTION
The muscle memory expecting panning when middle-click dragging on the canvas is really high, and ATM QField rotates when doing that. 

To harmonize with QGIS while still allowing for rotation, let's use shift+middle-click to rotate, and pan when no modifier is present. It also aligns with what GIMP does.

@suricactus , as discussed.

