### PR TITLE
Hide project file's preview images from the local file picker/project folder

### DIFF
--- a/src/core/localfilesmodel.cpp
+++ b/src/core/localfilesmodel.cpp
@@ -231,6 +231,12 @@ void LocalFilesModel::reloadModel()
         else
         {
           const QString suffix = fi.suffix().toLower();
+          if ( suffix == QStringLiteral( "jpg" ) && items.contains( fi.completeBaseName() ) )
+          {
+            // Skip project preview images
+            continue;
+          }
+
           if ( SUPPORTED_PROJECT_EXTENSIONS.contains( suffix ) )
           {
             projects << Item( ItemMetaType::Project, ItemType::ProjectFile, fi.completeBaseName(), suffix, fi.absoluteFilePath(), fi.size() );


### PR DESCRIPTION
Before (left) vs PR (right):
![image](https://github.com/opengisch/QField/assets/1728657/25d2dd12-7b34-4546-941c-d1acfe1bd51d)

Makes for a much cleaner view.