### PR TITLE
Improve the looks and  behavior of the coordinate locator item

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -904,9 +904,9 @@ ApplicationWindow {
         return newX;
     }
     y: {
-        var newY = coordinateLocator.displayPosition.y + 10
+        var newY = coordinateLocator.displayPosition.y + 14
         if (newY + height > mapCanvas.y + mapCanvas.height)
-            newY -= height - 20;
+            newY -= height - 28;
         return newY;
     }
 


### PR DESCRIPTION
This is a sister PR to https://github.com/opengisch/QField/pull/4789 -- now that we moved our rubber band rendering to rely on Shape, we benefit from revamping the coordinate locator to also rely on shape so we can aim at rendering the exact same visual buffer outlines.

I've taken the opportunity to clean up the item a bit and make it more QML-esque by relying for a property to style the snapped state.

But above all, the usage of a shape item gives us a lot more flexibility in the way we style the cursor, which allowed me to refine or cursor.

Video first:

[Screencast from 2023-11-21 20-15-18.webm](https://github.com/opengisch/QField/assets/1728657/3d94ffbd-a31c-4ad9-a11d-dbc81afa1de9)

Notice that when the cursor isn't snapped to a feature geometry, it now has an "open" look, whereas the circle is more of a dash that a solid circle line. When snapped, we scale down the cursor a bit like before but we now also _draw the circle fully closed_ This has two big advantages:
- it gives us more visibility on the map canvas (OK, it's a few more pixels in space, but it matters :) )
- it allows us to give a visual queue of the "locked/snapped" state that goes beyond the scale, which IMHO is a lot easier for users to quickly understand

Finally, when the cursor is locked to current position, it now adopts the blue color we defined as being tied to positioning elements:

![Screenshot from 2023-11-21 20-22-28](https://github.com/opengisch/QField/assets/1728657/863310bf-9c17-48e5-a70d-cbf89e3e5590)
 