### PR TITLE
Revert "Move from QModelIndex to QPersistentModelIndex in the layer tree proxy model class

### DIFF
--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -440,7 +440,7 @@ QVariant FlatLayerTreeModelBase::data( const QModelIndex &index, int role ) cons
     return QVariant();
 
   const QModelIndex sourceIndex = mapToSource( index );
-  if ( !sourceIndex.isValid() )
+  if ( !sourceIndex.isValid() || !sourceIndex.internalPointer() )
     return QVariant();
 
   switch ( role )

--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -198,7 +198,7 @@ void FlatLayerTreeModelBase::insertInMap( const QModelIndex &parent, int first, 
 
     QMap<int, int> treeLevelMap;
     mIndexMap.clear();
-    const QList<QPersistentModelIndex> keys = mRowMap.keys();
+    const QList<QModelIndex> keys = mRowMap.keys();
     for ( const auto &index : keys )
     {
       int row = mRowMap[index];
@@ -291,7 +291,7 @@ void FlatLayerTreeModelBase::removeFromMap( const QModelIndex &parent, int first
 
     QMap<int, int> treeLevelMap;
     mIndexMap.clear();
-    const QList<QPersistentModelIndex> keys = mRowMap.keys();
+    const QList<QModelIndex> keys = mRowMap.keys();
     for ( const auto &index : keys )
     {
       int row = mRowMap[index];

--- a/src/core/layertreemodel.h
+++ b/src/core/layertreemodel.h
@@ -89,10 +89,10 @@ class FlatLayerTreeModelBase : public QAbstractProxyModel
     void updateTemporalState();
     void adjustTemporalStateFromAddedLayers( const QList<QgsMapLayer *> &layers );
 
-    QMap<QPersistentModelIndex, int> mRowMap;
-    QMap<int, QPersistentModelIndex> mIndexMap;
+    QMap<QModelIndex, int> mRowMap;
+    QMap<int, QModelIndex> mIndexMap;
     QMap<int, int> mTreeLevelMap;
-    QList<QPersistentModelIndex> mCollapsedItems;
+    QList<QModelIndex> mCollapsedItems;
 
     QgsLayerTreeModel *mLayerTreeModel = nullptr;
     QString mMapTheme;


### PR DESCRIPTION
This reverts commit c37cef76d09b8c85874e4dbf330733416ee5e62e -- turned out to create a separate set of issues, including corruption of legend icons. Darn.