### PR TITLE
Date field does not update value when modified in QField

### DIFF
--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -37,13 +37,15 @@ EditorWidgetBase {
   property bool isDateTimeType: field.isDateOrTime
   property bool fieldIsDate: LayerUtils.fieldType( field ) === 'QDate'
   property var currentValue: {
-    label.text = formatDateTime( value );
+    const formattedDate = formatDateTime( value );
+    label.text = formattedDate;
+    return formattedDate;
   }
 
   function formatDateTime(value) {
     // Will handle both null and undefined as date values
     if ( value == null || value === '' ) {
-      return qsTr('(no date)')
+      return qsTr('(no date)');
     } else {
       const displayFormat = config['display_format'] == null
           ? 'yyyy-MM-dd'


### PR DESCRIPTION
I am not sure why was that `label.text` was not updating when `main.value` was updated, but this seems to solve the issue. Also note that in my understanding the `main.currentValue` was no longer used in the code, so I took use of it.

Finally, I also changed the `if` on line 45, so when the value is set to `null` it does not become automatically 1970-01-01 .

Steps to reproduce (before this patch is applied): 1) Open a feature form with date field
2) Click on set to now button
3) Delete the contents
4) Click on set to now button
5) Nothing happens

Inspured by #4803 report.