### PR TITLE
Fix cloud project synchronization on Windows

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -318,20 +318,6 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   mMapCanvas->mapSettings()->setProject( mProject );
   mBookmarkModel->setMapSettings( mMapCanvas->mapSettings() );
 
-  QFieldCloudProjectsModel *qFieldCloudProjectsModel = rootObjects().first()->findChild<QFieldCloudProjectsModel *>();
-
-  connect( qFieldCloudProjectsModel, &QFieldCloudProjectsModel::projectDownloaded, this, [=]( const QString &projectId, const QString &projectName, const bool hasError, const QString &errorString ) {
-    Q_UNUSED( projectName )
-    Q_UNUSED( errorString )
-    if ( !hasError )
-    {
-      if ( projectId == QFieldCloudUtils::getProjectId( mProjectFilePath ) )
-      {
-        reloadProjectFile();
-      }
-    }
-  } );
-
   mFlatLayerTree->layerTreeModel()->setLegendMapViewData( mMapCanvas->mapSettings()->mapSettings().mapUnitsPerPixel(),
                                                           static_cast<int>( std::round( mMapCanvas->mapSettings()->outputDpi() ) ), mMapCanvas->mapSettings()->mapSettings().scale() );
 


### PR DESCRIPTION
@suricactus , a few notes on this:

- calling mProject->setFileName(QString()) does *not* clear the project, it merely changes the project file path string, which is used for e.g. in expressions when calling @project_folder. I've changed this to mProject->clear().
- I've removed the old way we were reloading the project when a synchronization (i.e. setting a signal connection in qgismobileapp.cpp via finding a child of the QML scene), it felt a bit shaky. Instead, we reload the project via appinterface which feels more straightforward. It took me way too long to find out where the connection was to begin with :)
- The PR also fixes an issue whereas downloading a cloud project would _always_ set the current project file name to '', which if you had a different project opened meant that expressions could get real messy real quick. Also would have messed up with attachment upload as the project file path would have been null, therefore failing to find relative path location.
