### PR TITLE
Improve scalebar rendering by moving to shapes

### DIFF
--- a/src/qml/ScaleBar.qml
+++ b/src/qml/ScaleBar.qml
@@ -1,12 +1,17 @@
 import QtQuick 2.14
+import QtQuick.Shapes 1.14
 
 import org.qfield 1.0
 import org.qgis 1.0
 import Theme 1.0
 
 Item {
+  id: scaleBar
+
   property alias mapSettings: measurement.mapSettings
   property double lineWidth: 2
+
+  height: childrenRect.height
 
   ScaleBarMeasurement {
       id: measurement
@@ -14,77 +19,67 @@ Item {
       referenceScreenLength: 300
   }
 
-  Rectangle {
-    id: mainLineBackground
-    width: measurement.screenLength + 2
-    height: lineWidth + 2
-    color: "#AAFFFFFF"
-  }
-
-  Rectangle {
-    width: lineWidth + 2
-    height: ( 3 * lineWidth ) + 1
-    color: "#AAFFFFFF"
-    anchors.left: mainLineBackground.left
-    anchors.bottom: mainLineBackground.top
-  }
-
-  Rectangle {
-    width: lineWidth + 2
-    height: ( 3 * lineWidth ) + 1
-    color: "#AAFFFFFF"
-    anchors.right: mainLineBackground.right
-    anchors.bottom: mainLineBackground.top
-  }
-
-  Rectangle {
-    id: mainLine
-    width: measurement.screenLength
-    height: lineWidth
-    color: Theme.darkGray
-    anchors {
-        horizontalCenter: mainLineBackground.horizontalCenter
-        verticalCenter: mainLineBackground.verticalCenter
-    }
-  }
-
-  Rectangle {
-    width: lineWidth
-    height: 3 * lineWidth
-    color: Theme.darkGray
-    anchors.left: mainLine.left
-    anchors.bottom: mainLine.top
-  }
-
-  Rectangle {
-    width: lineWidth
-    height: 3 * lineWidth
-    color: Theme.darkGray
-    anchors.right: mainLine.right
-    anchors.bottom: mainLine.top
-  }
-
   Text {
     id: label
-    anchors.bottomMargin: 7
-    anchors.bottom: mainLine.top
-    anchors.horizontalCenter: mainLine.horizontalCenter
-    anchors.left: undefined // The value will be set to mainLine.left is the label is wider than the mainLine
+    anchors.horizontalCenter: bar.horizontalCenter
+    anchors.left: undefined
     font: Theme.defaultFont
     color: Theme.darkGray
-
     style: Text.Outline
-    styleColor: "#AAFFFFFF"
+    styleColor: "#CCFFFFFF"
 
     states: State {
-        name: "narrow"; when: label.width > mainLine.width
+        name: "narrow"; when: label.width > bar.width
         AnchorChanges {
             target: label
             anchors.horizontalCenter: undefined
-            anchors.left: mainLine.left
+            anchors.left: bar.left
         }
     }
 
     text: measurement.label
+  }
+
+  Shape {
+    id: bar
+    anchors.top: label.bottom
+    anchors.topMargin: 2
+    width: measurement.screenLength
+    height: 8
+
+    ShapePath {
+      strokeWidth: barLine.strokeWidth + 1.5
+      strokeColor: "#CCFFFFFF"
+      fillColor: "transparent"
+      startX: 0; startY: 0
+
+      PathLine {
+        x: 0; y: bar.height
+      }
+      PathLine {
+        x: measurement.screenLength; y: bar.height
+      }
+      PathLine {
+        x: measurement.screenLength; y: 0
+      }
+    }
+
+    ShapePath {
+      id: barLine
+      strokeWidth: scaleBar.lineWidth
+      strokeColor: "#000000"
+      fillColor: "transparent"
+      startX: 0; startY: 0
+
+      PathLine {
+        x: 0; y: bar.height
+      }
+      PathLine {
+        x: measurement.screenLength; y: bar.height
+      }
+      PathLine {
+        x: measurement.screenLength; y: 0
+      }
+    }
   }
 }


### PR DESCRIPTION
Let's put an end of rectangle abuse and move to proper shape-based rendering.

One of the things it fixes is a small visual imperfection our scale bar had for as long as I can remember:

![image](https://github.com/opengisch/QField/assets/1728657/c0b8791b-fc34-4373-affa-698235324ed5)

The inconsistent top of the tick's outline width is gone:

![image](https://github.com/opengisch/QField/assets/1728657/ad936767-22e9-4fb4-a9a9-eef1a09f1109)
