### PR TITLE
Implement expressed driven feature-level locked geometry

### DIFF
--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -43,11 +43,12 @@ class FeatureModel : public QAbstractListModel
     //! the vertex model is used to highlight vertices on the map
     Q_PROPERTY( VertexModel *vertexModel READ vertexModel WRITE setVertexModel NOTIFY vertexModelChanged )
     Q_PROPERTY( Geometry *geometry MEMBER mGeometry NOTIFY geometryChanged )
+    Q_PROPERTY( bool geometryLocked READ geometryLocked NOTIFY geometryLockedChanged )
     Q_PROPERTY( QgsVectorLayer *currentLayer READ layer WRITE setCurrentLayer NOTIFY currentLayerChanged )
     Q_PROPERTY( GnssPositionInformation positionInformation READ positionInformation WRITE setPositionInformation NOTIFY positionInformationChanged )
     Q_PROPERTY( SnappingResult topSnappingResult READ topSnappingResult WRITE setTopSnappingResult NOTIFY topSnappingResultChanged )
     Q_PROPERTY( bool positionLocked READ positionLocked WRITE setPositionLocked NOTIFY positionLockedChanged )
-    Q_PROPERTY( CloudUserInformation cloudUserInformation READ cloudUserInformation WRITE setCloudUserInformation NOTIFY cloudUserInformationChanged );
+    Q_PROPERTY( CloudUserInformation cloudUserInformation READ cloudUserInformation WRITE setCloudUserInformation NOTIFY cloudUserInformationChanged )
     Q_PROPERTY( QgsProject *project READ project WRITE setProject NOTIFY projectChanged )
 
   public:
@@ -144,6 +145,8 @@ class FeatureModel : public QAbstractListModel
     VertexModel *vertexModel();
     //! \copydoc vertexModel
     void setVertexModel( VertexModel *model );
+
+    bool geometryLocked() const { return mGeometryLocked; }
 
     QHash<int, QByteArray> roleNames() const override;
     int rowCount( const QModelIndex &parent ) const override;
@@ -275,6 +278,7 @@ class FeatureModel : public QAbstractListModel
     void linkedRelationOrderingFieldChanged();
     void vertexModelChanged();
     void geometryChanged();
+    void geometryLockedChanged();
     void currentLayerChanged();
     void positionInformationChanged();
     void topSnappingResultChanged();
@@ -289,6 +293,14 @@ class FeatureModel : public QAbstractListModel
     bool startEditing();
     void setLinkedFeatureValues();
     void updateDefaultValues();
+    void updateGeometryLocked();
+
+    // The current feature geometry locked state
+    bool mGeometryLocked = false;
+    // The vector layer locked geometry setting
+    bool mGeometryLockedByDefault = false;
+    // The vector layer locked geometry expression
+    QString mGeometryLockedExpression;
 
     ModelModes mModelMode = SingleFeatureModel;
     QPointer<QgsVectorLayer> mLayer;

--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -731,7 +731,9 @@ QVariant FlatLayerTreeModelBase::data( const QModelIndex &index, int role ) cons
         QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( nodeLayer->layer() );
 
         if ( layer )
-          return layer->customProperty( QStringLiteral( "QFieldSync/is_geometry_locked" ), false ).toBool();
+        {
+          return ( layer->customProperty( QStringLiteral( "QFieldSync/is_geometry_locked" ), false ).toBool() && !layer->customProperty( QStringLiteral( "QFieldSync/is_geometry_locked_expression_active" ), false ).toBool() );
+        }
       }
 
       return false;

--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -360,7 +360,30 @@ bool MultiFeatureListModelBase::canMoveSelection()
     return false;
 
   QgsVectorLayer *vlayer = mSelectedFeatures[0].first;
-  return !vlayer->readOnly() && ( vlayer->dataProvider()->capabilities() & QgsVectorDataProvider::ChangeGeometries ) && !vlayer->customProperty( QStringLiteral( "QFieldSync/is_geometry_locked" ), false ).toBool();
+  if ( !vlayer || vlayer->readOnly() || !( vlayer->dataProvider()->capabilities() & QgsVectorDataProvider::ChangeGeometries ) || vlayer->customProperty( QStringLiteral( "QFieldSync/is_geometry_locked" ), false ).toBool() )
+    return false;
+
+  const bool geometryLockedExpressionActive = vlayer->customProperty( QStringLiteral( "QFieldSync/is_geometry_locked_expression_active" ), false ).toBool();
+  if ( geometryLockedExpressionActive )
+  {
+    const QString geometryLockedExpression = vlayer->customProperty( QStringLiteral( "QFieldSync/geometry_locked_expression" ), QString() ).toString().trimmed();
+    if ( !geometryLockedExpression.isEmpty() )
+    {
+      QgsExpressionContext expressionContext = vlayer->createExpressionContext();
+      for ( const QPair<QgsVectorLayer *, QgsFeature> &selectedFeature : std::as_const( mSelectedFeatures ) )
+      {
+        expressionContext.setFeature( selectedFeature.second );
+        QgsExpression expression( geometryLockedExpression );
+        expression.prepare( &expressionContext );
+        if ( !expression.evaluate( &expressionContext ).toBool() )
+        {
+          return false;
+        }
+      }
+    }
+  }
+
+  return true;
 }
 
 bool MultiFeatureListModelBase::mergeSelection()

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -303,7 +303,7 @@ Rectangle {
 
     visible: stateMachine.state === "digitize"
              && ! selection.focusedGeometry.isNull
-             && ! selection.focusedLayer.customProperty( "QFieldSync/is_geometry_locked", false )
+             && ! featureFormList.model.featureModel.geometryLocked
              && ( projectInfo.editRights || editButton.isCreatedCloudFeature )
              && parent.state == "Navigation" && !readOnly && projectInfo.editRights
 
@@ -675,7 +675,7 @@ Rectangle {
       icon.source: Theme.getThemeVectorIcon( "ic_move_white_24dp" )
       enabled: (
                  (projectInfo.editRights || editButton.isCreatedCloudFeature)
-                 && (!selection.focusedLayer || !selection.focusedLayer.customProperty( "QFieldSync/is_geometry_locked", false ))
+                 && (!selection.focusedLayer || !featureFormList.model.featureModel.geometryLocked)
       )
       visible: enabled
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1415,7 +1415,7 @@ ApplicationWindow {
         bgcolor: Theme.darkGray
 
         property bool isSnapToCommonAngleEnabled: false
-        property bool isSnapToCommonAngleRelative: false
+        property bool isSnapToCommonAngleRelative: true
         property int snapToCommonAngleDegrees: 45
 
         state: isSnapToCommonAngleEnabled ? "On" : "Off"
@@ -1442,6 +1442,7 @@ ApplicationWindow {
 
         onClicked: {
           isSnapToCommonAngleEnabled = !isSnapToCommonAngleEnabled;
+          settings.setValue( "/QField/Digitizing/SnapToCommonAngleIsEnabled", isSnapToCommonAngleEnabled );
 
           displayToast(
             isSnapToCommonAngleEnabled
@@ -1454,21 +1455,9 @@ ApplicationWindow {
           snapToCommonAngleMenu.popup( parent.x, parent.y );
         }
 
-        onIsSnapToCommonAngleEnabledChanged: {
-          settings.setValue( "/QField/Digitizing/SnapToCommonAngleIsEnabled", isSnapToCommonAngleEnabled );
-        }
-
-        onIsSnapToCommonAngleRelativeChanged: {
-          settings.setValue( "/QField/Digitizing/SnapToCommonAngleIsRelative", isSnapToCommonAngleRelative );
-        }
-
-        onSnapToCommonAngleDegreesChanged: {
-          settings.setValue( "/QField/Digitizing/SnapToCommonAngleDegrees", snapToCommonAngleDegrees );
-        }
-
         Component.onCompleted: {
           isSnapToCommonAngleEnabled = settings.valueBool( "/QField/Digitizing/SnapToCommonAngleIsEnabled", false );
-          isSnapToCommonAngleRelative = settings.valueBool( "/QField/Digitizing/SnapToCommonAngleIsRelative", false );
+          isSnapToCommonAngleRelative = settings.valueBool( "/QField/Digitizing/SnapToCommonAngleIsRelative", true );
           snapToCommonAngleDegrees = settings.valueInt( "/QField/Digitizing/SnapToCommonAngleDegrees", snapToCommonAngleDegrees );
         }
 
@@ -1486,6 +1475,7 @@ ApplicationWindow {
             checked: snapToCommonAngleButton.isSnapToCommonAngleRelative
             onCheckedChanged: {
               snapToCommonAngleButton.isSnapToCommonAngleRelative = checked;
+              settings.setValue( "/QField/Digitizing/SnapToCommonAngleIsRelative", snapToCommonAngleButton.isSnapToCommonAngleRelative );
             }
           }
 
@@ -1513,6 +1503,7 @@ ApplicationWindow {
 
                 snapToCommonAngleButton.isSnapToCommonAngleEnabled = true;
                 snapToCommonAngleButton.snapToCommonAngleDegrees = modelData;
+                settings.setValue( "/QField/Digitizing/SnapToCommonAngleDegrees", snapToCommonAngleButton.snapToCommonAngleDegrees );
 
                 displayToast( qsTr( "Snap to %1° angle turned on" ).arg( modelData ) );
 


### PR DESCRIPTION
This PR implements a new expression driven locked geometry state for individual features within vector layers. This allows for a same layer to hold both features that have their geometry locked while others can still be edited. 

The code also covers moving of a group of selected features. If the group of selected features contains one or more locked features, it will not be possible to move the group. However, if all features are defined by the expression as not locked, group move will be allowed.

It's a really nice addition, makes it possible for administrators of project to define within a single layer features deemed as having a finalized geometry state vs. not.

Within a QFieldCloud environment, it gets even sweeter as cloud variables can drive locked state.

_(Requires this QFieldSync improvement when configuring the project in QGIS: https://github.com/opengisch/qfieldsync/pull/548)_