### PR TITLE
Update Android NDK (r25) to match what is used in pre-built Qt libraries

### DIFF
--- a/.docker/android_dev/Dockerfile
+++ b/.docker/android_dev/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:22.04
-ARG NDK_VERSION=23.1.7779620
+ARG NDK_VERSION=25.1.8937393
 
 ENV ANDROID_SDK_HOME /opt/android-sdk-linux
 ENV ANDROID_SDK_ROOT /opt/android-sdk-linux

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -52,9 +52,9 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "ANDROID_NDK_VERSION=23.1.7779620" >> $GITHUB_ENV
-          echo "ANDROID_BUILD_TOOLS_VERSION=30.0.3" >> $GITHUB_ENV
-          echo "ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk/23.1.7779620" >> $GITHUB_ENV
+          echo "ANDROID_NDK_VERSION=25.1.8937393" >> $GITHUB_ENV
+          echo "ANDROID_BUILD_TOOLS_VERSION=33.0.0" >> $GITHUB_ENV
+          echo "ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk/25.1.8937393" >> $GITHUB_ENV
           echo "ndk.dir=$ANDROID_NDK_HOME" >> local.properties
           ALL_FILES_ACCESS=${{ matrix.all_files_access }} ./scripts/ci/env_gh.sh
 
@@ -121,6 +121,9 @@ jobs:
           TRIPLET=${{ matrix.triplet }} ALL_FILES_ACCESS=${{ matrix.all_files_access }} source ./scripts/version_number.sh
           TRIPLET=${{ matrix.triplet }} ALL_FILES_ACCESS=${{ matrix.all_files_access }} source ./scripts/ci/generate-version-details.sh
 
+          sudo apt remove libgles2
+          sudo apt remove libegl1
+
           cmake -S "${{ github.workspace }}" \
                 -B "${CMAKE_BUILD_DIR}" \
                 -G Ninja \
@@ -136,7 +139,7 @@ jobs:
                 -D WITH_SPIX=OFF \
                 -D CMAKE_PREFIX_PATH=${Qt6_DIR} \
                 -D QT_HOST_PATH=/home/runner/work/QField/Qt/${{ env.INSTALL_QT_VERSION }}/gcc_64 \
-                -D QT_HOST_PATH_CMAKE_DIR:PATH=/home/runner/work/QField/Qt/${{ env.INSTALL_QT_VERSION }}/gcc_64 \
+                -D QT_HOST_PATH_CMAKE_DIR:PATH=/home/runner/work/QField/Qt/${{ env.INSTALL_QT_VERSION }}/gcc_64/lib/cmake \
                 -D APP_VERSION="${APP_VERSION}" \
                 -D APK_VERSION_CODE="${APK_VERSION_CODE}" \
                 -D APP_VERSION_STR="${APP_VERSION_STR}" \

--- a/cmake/Platform.cmake
+++ b/cmake/Platform.cmake
@@ -20,8 +20,9 @@ elseif(VCPKG_TARGET_TRIPLET STREQUAL "x86-android")
 endif()
 
 if(ANDROID_ABI)
-  set(ANDROID_NDK_VERSION "$ENV{ANDROID_NDK_HOME}" CACHE STRING "Android NDK version")
-  set(ANDROID_BUILD_TOOLS_VERSION "30.0.3" CACHE STRING "Android build-tools version")
+  set(ANDROID_NDK_VERSION "$ENV{ANDROID_NDK_VERSION}" CACHE STRING "Android NDK version")
+  set(ANDROID_NDK_HOME "$ENV{ANDROID_NDK_HOME}" CACHE STRING "Android NDK home path")
+  set(ANDROID_BUILD_TOOLS_VERSION "33.0.0" CACHE STRING "Android build-tools version")
   set(ANDROID_TARGET_PLATFORM 33 CACHE INT "Target Android platform SDK version")
   set(ANDROID_PLATFORM 21 CACHE INT "Minimum Android platform SDK version")
   set(ANDROID_PLATFORM_INT 21 CACHE INT "Minimum Android platform SDK version") # Used in build.gradle.in

--- a/scripts/build-vcpkg.sh
+++ b/scripts/build-vcpkg.sh
@@ -18,7 +18,6 @@ echo "Package name ${APP_PACKAGE_NAME}"
 cmake -S "${SOURCE_DIR}" \
 	-B "${CMAKE_BUILD_DIR}" \
 	-G Ninja \
-	-D BUILD_WITH_QT6=ON \
 	-D CMAKE_PREFIX_PATH=${Qt6_DIR} \
 	-D QT_HOST_PATH=/home/devel/${install_qt_version}/gcc_64 \
 	-D QT_HOST_PATH_CMAKE_DIR=/home/devel/${install_qt_version}/gcc_64/lib/cmake \


### PR DESCRIPTION
Hoping this can resolve an obscure armv7-only crash that appeared when we updated to Qt 6.6 (e.g. https://opengisch.sentry.io/issues/4561431917/?project=6119013&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=5)