### PR TITLE
Sentry update

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Download sentry libs
         run: |
           mkdir /tmp/sentry-android-ndk
-          wget https://repo1.maven.org/maven2/io/sentry/sentry-android-ndk/6.13.1/sentry-android-ndk-6.13.1.aar -O /tmp/sentry.zip
+          wget https://repo1.maven.org/maven2/io/sentry/sentry-android-ndk/6.34.0/sentry-android-ndk-6.34.0.aar -O /tmp/sentry.zip
           unzip /tmp/sentry.zip -d /tmp/sentry-android-ndk
 
       - name: 🌱 Update ndk

--- a/platform/android/build.gradle.in
+++ b/platform/android/build.gradle.in
@@ -103,5 +103,5 @@ android {
 
 // Add Sentry's SDK as a dependency.
 dependencies {
-    implementation 'io.sentry:sentry-android:6.13.1'
+    implementation 'io.sentry:sentry-android:6.34.0'
 }


### PR DESCRIPTION
Seen references of sentry SDK 0.6.X fixing some crashes on Android r25b (what we use now).

Objective: the QField 3.1.1 release has been 20% deployed (earlier today) and I've spotted an immediate spike in sentry-related crashes. Doing some research on sentry SDK github's page indicates that our old sentry android version shipped with an SDK (0.5.4) that was prone to crashing.

I've asked @lindacamathias to test QField 3.1.1 on her old device, it crashes.

She then tried this PR, it doesn't crash anymore. 