### PR TITLE
Guard against null object when checking permissions

### DIFF
--- a/src/core/positioning/bluetoothreceiver.cpp
+++ b/src/core/positioning/bluetoothreceiver.cpp
@@ -97,20 +97,31 @@ void BluetoothReceiver::handleConnectDevice()
   {
     QBluetoothPermission bluetoothPermission;
     bluetoothPermission.setCommunicationModes( QBluetoothPermission::Access );
-    qApp->requestPermission( bluetoothPermission, [=]( const QPermission &permission ) {
-      if ( permission.status() == Qt::PermissionStatus::Granted )
-      {
-        mPermissionChecked = true;
-        handleConnectDevice();
-      }
-      else
-      {
-        setValid( false );
-        mLastError = tr( "Bluetooth permission denied" );
-        emit lastErrorChanged( mLastError );
-      }
-    } );
-    return;
+    Qt::PermissionStatus permissionStatus = qApp->checkPermission( bluetoothPermission );
+    if ( permissionStatus == Qt::PermissionStatus::Undetermined )
+    {
+      qApp->requestPermission( bluetoothPermission, this, [=]( const QPermission &permission ) {
+        if ( permission.status() == Qt::PermissionStatus::Granted )
+        {
+          mPermissionChecked = true;
+          handleConnectDevice();
+        }
+        else
+        {
+          setValid( false );
+          mLastError = tr( "Bluetooth permission denied" );
+          emit lastErrorChanged( mLastError );
+        }
+      } );
+      return;
+    }
+    else if ( permissionStatus == Qt::PermissionStatus::Denied )
+    {
+      setValid( false );
+      mLastError = tr( "Bluetooth permission denied" );
+      emit lastErrorChanged( mLastError );
+      return;
+    }
   }
 #endif
   if ( mAddress.isEmpty() )


### PR DESCRIPTION
This fixes a crash on QField 3.1 whereas setting the GNSS receiver to an external device would crash.

The reason behind this crash is caused by the following chain of events:
1/ QField launches and activates positioning (per last session's setting);
2/ At this stage, the positioning is activating the internal gnss receiver, which calls handleConnect and request permission;
3/ After the permission is requested, but _before_ its signal is responded to, we restore the external positioning (per saved positioning ID), which means we kill the internal gnss receiver object
4/ the permission request triggers the signal, we answer to it, and we end up calling a function to a deleted object

To guard from this, this PR does two things:
1/ use the QCoreApplication::checkPermission function, avoiding the signal connection when the permission is already granted
2/ use a QPointer<...> device object and check whether the device object has _not_ been deleted