### PR TITLE
Play it safe, use a QPointer to the map canvas item to reduce risks of crash

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -1363,10 +1363,13 @@ void QgisMobileapp::saveProjectPreviewImage()
   if ( !mProjectFilePath.isEmpty() && mMapCanvas && !mMapCanvas->isRendering() )
   {
     const QImage grab = mMapCanvas->image();
-    const int pixels = std::min( grab.width(), grab.height() );
-    const QRect rect( ( grab.width() - pixels ) / 2, ( grab.height() - pixels ) / 2, pixels, pixels );
-    const QImage img = grab.copy( rect );
-    img.save( QStringLiteral( "%1.jpg" ).arg( mProjectFilePath ) );
+    if ( !grab.isNull() )
+    {
+      const int pixels = std::min( grab.width(), grab.height() );
+      const QRect rect( ( grab.width() - pixels ) / 2, ( grab.height() - pixels ) / 2, pixels, pixels );
+      const QImage img = grab.copy( rect );
+      img.save( QStringLiteral( "%1.jpg" ).arg( mProjectFilePath ) );
+    }
   }
 }
 

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -196,7 +196,7 @@ class QFIELD_CORE_EXPORT QgisMobileapp : public QQmlApplicationEngine
     QgsMapLayerProxyModel *mLayerList = nullptr;
     AppInterface *mIface = nullptr;
     Settings mSettings;
-    QgsQuickMapCanvasMap *mMapCanvas = nullptr;
+    QPointer<QgsQuickMapCanvasMap> mMapCanvas;
     bool mFirstRenderingFlag;
     LegendImageProvider *mLegendImageProvider = nullptr;
     LocalFilesImageProvider *mLocalFilesImageProvider = nullptr;


### PR DESCRIPTION
Crash seen on google play store's crash reporting (which is becoming quite good):

```
backtrace:
  #00  pc 0x0000000001eb0264  /data/app/~~AidkTkmVejfLrdD_MYFiCA==/ch.opengis.qfield-thT7LfUTg_MgkCMOzMjSww==/lib/arm64/libqfield_arm64-v8a.so (QgsQuickMapCanvasMap::isRendering() const) (BuildId: a75578015316ac7d9753d901e88698581a3e774f)
  #01  pc 0x0000000001f8979c  /data/app/~~AidkTkmVejfLrdD_MYFiCA==/ch.opengis.qfield-thT7LfUTg_MgkCMOzMjSww==/lib/arm64/libqfield_arm64-v8a.so (QgisMobileapp::saveProjectPreviewImage()+52) (BuildId: a75578015316ac7d9753d901e88698581a3e774f)
  #02  pc 0x0000000001f89430  /data/app/~~AidkTkmVejfLrdD_MYFiCA==/ch.opengis.qfield-thT7LfUTg_MgkCMOzMjSww==/lib/arm64/libqfield_arm64-v8a.so (QgisMobileapp::loadProjectFile(QString const&, QString const&)+2420) (BuildId: a75578015316ac7d9753d901e88698581a3e774f)
  #03  pc 0x0000000001edd8ec  /data/app/~~AidkTkmVejfLrdD_MYFiCA==/ch.opengis.qfield-thT7LfUTg_MgkCMOzMjSww==/lib/arm64/libqfield_arm64-v8a.so (AppInterface::loadFile(QString const&, QString const&)+112) (BuildId: a75578015316ac7d9753d901e88698581a3e774f)
  #04  pc 0x0000000001fd0b80  /data/app/~~AidkTkmVejfLrdD_MYFiCA==/ch.opengis.qfield-thT7LfUTg_MgkCMOzMjSww==/lib/arm64/libqfield_arm64-v8a.so (Java_ch_opengis_qfield_QFieldActivity_openProject+148) (BuildId: a75578015316ac7d9753d901e88698581a3e774f)
```

