### PR TITLE
Add an additional safeguard when the barcode decoder attempts to process a video frame

### DIFF
--- a/src/core/barcodedecoder.cpp
+++ b/src/core/barcodedecoder.cpp
@@ -133,7 +133,7 @@ void BarcodeDecoder::setVideoSink( QVideoSink *sink )
 
 void BarcodeDecoder::decodeVideoFrame( const QVideoFrame &frame )
 {
-  if ( mDecodingThread )
+  if ( mDecodingThread || !frame.isValid() )
     return;
 
   QImage image = frame.toImage();


### PR DESCRIPTION
From google play store: 

```
  #00  pc 0x00000000005274d8  /data/app/~~NvLQJeNXuJ1MIvzR2SZqNA==/ch.opengis.qfield-OYiB52lJAdLR_0PRU7Huow==/lib/arm64/libQt6Gui_arm64-v8a.so (BuildId: 0dec58bd9c200cd94edc46d18eee12fee52ae8dc)
  #01  pc 0x00000000005280b0  /data/app/~~NvLQJeNXuJ1MIvzR2SZqNA==/ch.opengis.qfield-OYiB52lJAdLR_0PRU7Huow==/lib/arm64/libQt6Gui_arm64-v8a.so (BuildId: 0dec58bd9c200cd94edc46d18eee12fee52ae8dc)
  #02  pc 0x000000000044d134  /data/app/~~NvLQJeNXuJ1MIvzR2SZqNA==/ch.opengis.qfield-OYiB52lJAdLR_0PRU7Huow==/lib/arm64/libQt6Gui_arm64-v8a.so (QRhi::endOffscreenFrame(QFlags<QRhi::EndFrameFlag>)+64) (BuildId: 0dec58bd9c200cd94edc46d18eee12fee52ae8dc)
  #03  pc 0x00000000000c7978  /data/app/~~NvLQJeNXuJ1MIvzR2SZqNA==/ch.opengis.qfield-OYiB52lJAdLR_0PRU7Huow==/lib/arm64/libQt6Multimedia_arm64-v8a.so (qImageFromVideoFrame(QVideoFrame const&, QVideoFrame::RotationAngle, bool, bool)+2736) (BuildId: c0765931d079263b66cf06c483feb9bfe27443dd)
  #04  pc 0x00000000000c29b8  /data/app/~~NvLQJeNXuJ1MIvzR2SZqNA==/ch.opengis.qfield-OYiB52lJAdLR_0PRU7Huow==/lib/arm64/libQt6Multimedia_arm64-v8a.so (BuildId: c0765931d079263b66cf06c483feb9bfe27443dd)
  #05  pc 0x00000000000c64b8  /data/app/~~NvLQJeNXuJ1MIvzR2SZqNA==/ch.opengis.qfield-OYiB52lJAdLR_0PRU7Huow==/lib/arm64/libc++_shared.so (std::__ndk1::__call_once(unsigned long volatile&, void*, void (*)(void*))+164) (BuildId: a59088f9640cd272bc9542d94dc84a0c88afd558)
  #06  pc 0x00000000000c1c54  /data/app/~~NvLQJeNXuJ1MIvzR2SZqNA==/ch.opengis.qfield-OYiB52lJAdLR_0PRU7Huow==/lib/arm64/libQt6Multimedia_arm64-v8a.so (QVideoFrame::toImage() const+96) (BuildId: c0765931d079263b66cf06c483feb9bfe27443dd)
  #07  pc 0x0000000001eeeab4  /data/app/~~NvLQJeNXuJ1MIvzR2SZqNA==/ch.opengis.qfield-OYiB52lJAdLR_0PRU7Huow==/lib/arm64/libqfield_arm64-v8a.so (BarcodeDecoder::decodeVideoFrame(QVideoFrame const&)+52) (BuildId: a75578015316ac7d9753d901e88698581a3e774f)
```

Not sure there's much we can do, but not processing invalid QVideoFrame is probably not a bad idea :)

(If that doesn't help, I think we'll just need to keep track of this upstream issue: https://bugreports.qt.io/browse/QTBUG-115716)