### PR TITLE
Fix confusing 'snap to 45 degree' toast when opening QField

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1474,7 +1474,8 @@ ApplicationWindow {
 
             checkable: true
             checked: snapToCommonAngleButton.isSnapToCommonAngleRelative
-            onCheckedChanged: {
+
+            onTriggered: {
               snapToCommonAngleButton.isSnapToCommonAngleRelative = checked;
               settings.setValue( "/QField/Digitizing/SnapToCommonAngleIsRelative", snapToCommonAngleButton.isSnapToCommonAngleRelative );
             }
@@ -1495,9 +1496,10 @@ ApplicationWindow {
               leftPadding: 10
 
               checkable: true
-              enabled: !checked
               checked: modelData === snapToCommonAngleButton.snapToCommonAngleDegrees
-              onCheckedChanged: {
+              enabled: modelData !== snapToCommonAngleButton.snapToCommonAngleDegrees
+
+              onTriggered: {
                 if ( !checked ) {
                   return;
                 }


### PR DESCRIPTION
By triggering the toast on a onCheckedChanged signal, we end up pushing a toast message every time QField is launched. Reason why we didn't spot this earlier is because when the welcome screen is visible, toast messages aren't shown. But for users that launch QField through file association or having re-open last project toggled on, this message is super confusing for users.