### PR TITLE
Improve error message on value not compatible with attribute type

### DIFF
--- a/vcpkg/overlay/qgis-qt6/portfile.cmake
+++ b/vcpkg/overlay/qgis-qt6/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_from_github(
         bigobj.patch
         poly2tri.patch
         mesh.patch
+	wrongattributeerrormessage.patch
 )
 
 file(REMOVE ${SOURCE_PATH}/cmake/FindQtKeychain.cmake)

--- a/vcpkg/overlay/qgis-qt6/wrongattributeerrormessage.patch
+++ b/vcpkg/overlay/qgis-qt6/wrongattributeerrormessage.patch
@@ -7,7 +7,7 @@ index 8b0ac5a4cc9..c8890ebd36d 100644
        if ( !ok )
        {
 -        pushError( tr( "wrong data type for attribute %1 of feature %2: %3" ).arg( qgisAttributeId ) .arg( f.id() ).arg( qType ) );
-+        pushError( tr( "wrong data type for attribute %1 (%2) of feature %3" ).arg( mAttributeFields.at( qgisAttributeId ).name(), OGR_GetFieldTypeName( type ), QString::number( f.id() ) ) );
++        pushError( tr( "Could not convert value for attribute \"%1\" to type %2" ).arg( mAttributeFields.at( qgisAttributeId ).name(), OGR_GetFieldTypeName( type ) ) );
          returnValue = false;
        }
      }

--- a/vcpkg/overlay/qgis-qt6/wrongattributeerrormessage.patch
+++ b/vcpkg/overlay/qgis-qt6/wrongattributeerrormessage.patch
@@ -1,0 +1,13 @@
+diff --git a/src/core/providers/ogr/qgsogrprovider.cpp b/src/core/providers/ogr/qgsogrprovider.cpp
+index 8b0ac5a4cc9..c8890ebd36d 100644
+--- a/src/core/providers/ogr/qgsogrprovider.cpp
++++ b/src/core/providers/ogr/qgsogrprovider.cpp
+@@ -1738,7 +1738,7 @@ bool QgsOgrProvider::addFeaturePrivate( QgsFeature &f, Flags flags, QgsFeatureId
+ 
+       if ( !ok )
+       {
+-        pushError( tr( "wrong data type for attribute %1 of feature %2: %3" ).arg( qgisAttributeId ) .arg( f.id() ).arg( qType ) );
++        pushError( tr( "wrong data type for attribute %1 (%2) of feature %3" ).arg( mAttributeFields.at( qgisAttributeId ).name(), OGR_GetFieldTypeName( type ), QString::number( f.id() ) ) );
+         returnValue = false;
+       }
+     }


### PR DESCRIPTION
Because this is really uncomfortable to decipher and debug

![image](https://github.com/opengisch/QField/assets/588407/f83437dd-f888-455e-8154-517d4fbeda42)