### PR TITLE
Fix significant issues with saving/restoring customized project settings

### DIFF
--- a/src/core/projectinfo.cpp
+++ b/src/core/projectinfo.cpp
@@ -293,7 +293,7 @@ void ProjectInfo::setSnappingEnabled( bool enabled )
 
 void ProjectInfo::saveLayerSnappingConfiguration( QgsMapLayer *layer )
 {
-  if ( mFilePath.isEmpty() || !layer )
+  if ( mFilePath.isEmpty() )
     return;
 
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
@@ -397,7 +397,7 @@ void ProjectInfo::restoreSettings( QString &projectFilePath, QgsProject *project
     const bool isDataset = project->readBoolEntry( QStringLiteral( "QField" ), QStringLiteral( "isDataset" ), false );
     const QList<QgsMapLayer *> mapLayers = isDataset ? project->layerStore()->mapLayers().values() : QList<QgsMapLayer *>();
 
-    for ( QString &id : ids )
+    for ( QString id : std::as_const( ids ) )
     {
       const double opacity = settings.value( QStringLiteral( "%1/opacity" ).arg( id ), 1.0 ).toDouble();
       const bool labelsEnabled = settings.value( QStringLiteral( "%1/labelsEnabled" ).arg( id ), false ).toBool();
@@ -469,7 +469,7 @@ void ProjectInfo::restoreSettings( QString &projectFilePath, QgsProject *project
       const bool isDataset = project->readBoolEntry( QStringLiteral( "QField" ), QStringLiteral( "isDataset" ), false );
       const QList<QgsMapLayer *> mapLayers = isDataset ? project->layerStore()->mapLayers().values() : QList<QgsMapLayer *>();
 
-      for ( QString id : ids )
+      for ( QString id : std::as_const( ids ) )
       {
         const double enabled = settings.value( QStringLiteral( "%1/enabled" ).arg( id ), false ).toBool();
 

--- a/src/core/projectinfo.h
+++ b/src/core/projectinfo.h
@@ -59,7 +59,7 @@ class ProjectInfo : public QObject
     Q_PROPERTY( QString stateMode READ stateMode WRITE setStateMode NOTIFY stateModeChanged )
 
     /**
-     * The active layer for the currently oepened project.
+     * The active layer for the currently opened project.
      */
     Q_PROPERTY( QgsMapLayer *activeLayer READ activeLayer WRITE setActiveLayer NOTIFY activeLayerChanged )
 
@@ -67,6 +67,11 @@ class ProjectInfo : public QObject
      * The tracking model object, used to save and restore tracking session for individual vector layers.
      */
     Q_PROPERTY( TrackingModel *trackingModel READ trackingModel WRITE setTrackingModel NOTIFY trackingModelChanged )
+
+    /**
+     * The snapping enabled state for the currently opened project.
+     */
+    Q_PROPERTY( bool snappingEnabled READ snappingEnabled WRITE setSnappingEnabled NOTIFY snappingEnabledChanged )
 
   public:
     explicit ProjectInfo( QObject *parent = nullptr );
@@ -110,7 +115,7 @@ class ProjectInfo : public QObject
     /**
      * Saves the current snapping configuration settings
      */
-    Q_INVOKABLE void saveSnappingConfiguration();
+    Q_INVOKABLE void saveLayerSnappingConfiguration( QgsMapLayer *layer );
 
     /**
      * Saves the state \a mode for the current project
@@ -133,6 +138,16 @@ class ProjectInfo : public QObject
      */
     QgsMapLayer *activeLayer() const;
 
+    /**
+     * Returns the saved snapping enabed state for the current project
+     */
+    bool snappingEnabled() const;
+
+    /**
+     * Saves the snapping \a enabled state for the current project
+     */
+    void setSnappingEnabled( bool enabled );
+
     //! Save an ongoing vector \a layer tracking session details
     Q_INVOKABLE void saveTracker( QgsVectorLayer *layer );
 
@@ -150,6 +165,7 @@ class ProjectInfo : public QObject
     void stateModeChanged();
     void activeLayerChanged();
     void trackingModelChanged();
+    void snappingEnabledChanged();
 
   private slots:
 

--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -273,7 +273,7 @@ ListView {
 
         onClicked: {
           SnappingEnabled = !SnappingEnabled
-          projectInfo.saveSnappingConfiguration()
+          projectInfo.saveLayerSnappingConfiguration(VectorLayerPointer)
         }
       }
     }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1301,7 +1301,7 @@ ApplicationWindow {
           var snappingConfig = qgisProject.snappingConfig
           snappingConfig.enabled = !snappingConfig.enabled
           qgisProject.snappingConfig = snappingConfig
-          projectInfo.saveSnappingConfiguration()
+          projectInfo.snappingEnabled = snappingConfig.enabled
           displayToast( snappingConfig.enabled ? qsTr( "Snapping turned on" ) : qsTr( "Snapping turned off" ) )
         }
       }


### PR DESCRIPTION
This PR reworks the way we save and restore user-customized layer styling (label visibility and layer opacity) as well as layer/project snapping enabled state. The previous way was saving and restoring whole layer XML style and snapping configuration, which resulted in subsequent changes to project configuration not respected by QField.

This meant that until now, symbology / labeling changes to a given layer or tweaking to advanced snapping configuration (e.g. snapping to vertex + segment instead of vertex alone) would not be loaded properly.

I'm shocked it took us so long to realize this was an issue, esp. considering it "freezes" symbologies. 

Fixes https://github.com/opengisch/QField/issues/4866.