### PR TITLE
Further strenghten finger hovering protection

### DIFF
--- a/src/qml/MapCanvas.qml
+++ b/src/qml/MapCanvas.qml
@@ -29,6 +29,9 @@ Item {
   property alias quality: mapCanvasWrapper.quality
   property alias forceDeferredLayersRepaint: mapCanvasWrapper.forceDeferredLayersRepaint
 
+  property alias pinch: pinchArea
+  property alias mouse: mouseArea
+
   property bool interactive: true
   property bool hovered: false
   property bool freehandDigitizing: false

--- a/src/qml/MapCanvas.qml
+++ b/src/qml/MapCanvas.qml
@@ -34,6 +34,7 @@ Item {
 
   property bool interactive: true
   property bool hovered: false
+  property bool pinched: pinchArea.isDragging
   property bool freehandDigitizing: false
 
   // for signals, type can be "stylus" for any device click or "touch"

--- a/src/qml/MapCanvas.qml
+++ b/src/qml/MapCanvas.qml
@@ -29,9 +29,6 @@ Item {
   property alias quality: mapCanvasWrapper.quality
   property alias forceDeferredLayersRepaint: mapCanvasWrapper.forceDeferredLayersRepaint
 
-  property alias pinch: pinchArea
-  property alias mouse: mouseArea
-
   property bool interactive: true
   property bool hovered: false
   property bool pinched: pinchArea.isDragging

--- a/src/qml/imports/QFieldControls/+Qt6/QFieldCamera.qml
+++ b/src/qml/imports/QFieldControls/+Qt6/QFieldCamera.qml
@@ -201,28 +201,18 @@ Popup {
       focus: visible
     }
 
-    PinchHandler {
+    PinchArea {
+      id: pinchArea
       enabled: cameraItem.visible && cameraItem.isCapturing
-      target: null
-      grabPermissions: PointerHandler.CanTakeOverFromAnything | PointerHandler.TakeOverForbidden
-      acceptedDevices: PointerDevice.TouchScreen | PointerDevice.TouchPad
+      anchors.fill: parent
 
-      property real oldScale: 1.0
-
-      onActiveChanged: {
-        if (active) {
-          oldScale = 1.0
-        }
-      }
-
-      onActiveScaleChanged: {
-        if (activeScale > oldScale) {
-          camera.zoomIn(0.05)
-        } else {
-          camera.zoomOut(0.05)
-        }
-        oldScale = activeScale
-      }
+      onPinchUpdated: (pinch) => {
+                        if (pinch.scale > pinch.previousScale) {
+                          camera.zoomIn(0.05)
+                        } else {
+                          camera.zoomOut(0.05)
+                        }
+                      }
     }
 
     WheelHandler {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -345,6 +345,7 @@ ApplicationWindow {
         onHoveredChanged: {
             if ( skipHover ) {
               if ( !hovered ) {
+                mapCanvasMap.hovered = false
                 dummyHoverTimer.restart()
               }
               return

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -343,6 +343,10 @@ ApplicationWindow {
         }
 
         onHoveredChanged: {
+            if ( mapCanvasMap.pinched ) {
+              return
+            }
+
             if ( skipHover ) {
               if ( !hovered ) {
                 mapCanvasMap.hovered = false

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -319,7 +319,7 @@ ApplicationWindow {
         }
 
         onPointChanged: {
-            if (skipHover) {
+            if (skipHover || !hovered) {
               return
             }
 
@@ -344,7 +344,9 @@ ApplicationWindow {
 
         onHoveredChanged: {
             if ( skipHover ) {
-              dummyHoverTimer.restart()
+              if ( !hovered ) {
+                dummyHoverTimer.restart()
+              }
               return
             }
 
@@ -365,10 +367,12 @@ ApplicationWindow {
      */
     Timer {
       id: dummyHoverTimer
-      interval: 100
+      interval: 750
       repeat: false
 
-      onTriggered: hoverHandler.skipHover = hoverHandler.hovered
+      onTriggered: {
+        hoverHandler.skipHover = false
+      }
     }
 
     HoverHandler {
@@ -380,6 +384,7 @@ ApplicationWindow {
 
         onHoveredChanged: {
             if ( hovered ) {
+                dummyHoverTimer.stop()
                 hoverHandler.skipHover = true
             }
         }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -319,7 +319,7 @@ ApplicationWindow {
         }
 
         onPointChanged: {
-            if (skipHover || !hovered) {
+            if (skipHover || !mapCanvasMap.hovered) {
               return
             }
 
@@ -1217,30 +1217,63 @@ ApplicationWindow {
     }
 
     Rectangle {
+      id: debug0
+      anchors.verticalCenter: parent.verticalCenter
+      width: 48
+      height: 48
+
+      color: hoverHandler.hovered ? "red" : "green"
+
+      Text {
+        anchors.centerIn: parent
+        font: Theme.tipFont
+        text: 'h.h'
+      }
+    }
+
+    Rectangle {
       id: debug1
       anchors.verticalCenter: parent.verticalCenter
-      width: 20
-      height: 20
+      width: 48
+      height: 48
 
       color: mapCanvasMap.hovered ? "red" : "green"
+
+      Text {
+        anchors.centerIn: parent
+        font: Theme.tipFont
+        text: 'm.h'
+      }
     }
 
     Rectangle {
       id: debug2
       anchors.verticalCenter: parent.verticalCenter
-      width: 20
-      height: 20
+      width: 48
+      height: 48
 
       color: mapCanvasMap.pinch.isDragging ? "red" : "green"
+
+      Text {
+        anchors.centerIn: parent
+        font: Theme.tipFont
+        text: 'm.p'
+      }
     }
 
     Rectangle {
       id: debug3
       anchors.verticalCenter: parent.verticalCenter
-      width: 20
-      height: 20
+      width: 48
+      height: 48
 
       color: mapCanvasMap.mouse.pressed ? "red" : "green"
+
+      Text {
+        anchors.centerIn: parent
+        font: Theme.tipFont
+        text: 'm.m'
+      }
     }
 
     QfCloseButton {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1216,6 +1216,33 @@ ApplicationWindow {
       }
     }
 
+    Rectangle {
+      id: debug1
+      anchors.verticalCenter: parent.verticalCenter
+      width: 20
+      height: 20
+
+      color: mapCanvasMap.hovered ? "red" : "green"
+    }
+
+    Rectangle {
+      id: debug2
+      anchors.verticalCenter: parent.verticalCenter
+      width: 20
+      height: 20
+
+      color: mapCanvasMap.pinch.isDragging ? "red" : "green"
+    }
+
+    Rectangle {
+      id: debug3
+      anchors.verticalCenter: parent.verticalCenter
+      width: 20
+      height: 20
+
+      color: mapCanvasMap.mouse.pressed ? "red" : "green"
+    }
+
     QfCloseButton {
       id: closeMeasureTool
       visible: stateMachine.state === 'measure'

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1221,66 +1221,6 @@ ApplicationWindow {
       }
     }
 
-    Rectangle {
-      id: debug0
-      anchors.verticalCenter: parent.verticalCenter
-      width: 48
-      height: 48
-
-      color: hoverHandler.hovered ? "red" : "green"
-
-      Text {
-        anchors.centerIn: parent
-        font: Theme.tipFont
-        text: 'h.h'
-      }
-    }
-
-    Rectangle {
-      id: debug1
-      anchors.verticalCenter: parent.verticalCenter
-      width: 48
-      height: 48
-
-      color: mapCanvasMap.hovered ? "red" : "green"
-
-      Text {
-        anchors.centerIn: parent
-        font: Theme.tipFont
-        text: 'm.h'
-      }
-    }
-
-    Rectangle {
-      id: debug2
-      anchors.verticalCenter: parent.verticalCenter
-      width: 48
-      height: 48
-
-      color: mapCanvasMap.pinch.isDragging ? "red" : "green"
-
-      Text {
-        anchors.centerIn: parent
-        font: Theme.tipFont
-        text: 'm.p'
-      }
-    }
-
-    Rectangle {
-      id: debug3
-      anchors.verticalCenter: parent.verticalCenter
-      width: 48
-      height: 48
-
-      color: mapCanvasMap.mouse.pressed ? "red" : "green"
-
-      Text {
-        anchors.centerIn: parent
-        font: Theme.tipFont
-        text: 'm.m'
-      }
-    }
-
     QfCloseButton {
       id: closeMeasureTool
       visible: stateMachine.state === 'measure'


### PR DESCRIPTION
The PR fixes one corner scenario identified whereas the timer resetting the skipHover boolean could happen at the same time as a second tap on the screen, resulting in the stylus hover being wrongly triggered as skipHover was then set to false.

Other code changes are made to strengthen the handling of the dummy hover.

With these changes in, things appear to be in good shape.

----

![image](https://github.com/opengisch/QField/assets/1728657/9585f0ee-50c3-4a15-843a-fc68a203d3f8)

----

After more debugging, another crucial finding: once the PinchArea is active, the dummy hover handler that is safeguarding taps from being registered as stylus is not working because the PinchArea prevents the latter from stealing focus. 

We must therefore also keep track of the pinch state. One more corner scenario fixed.

----

Also turns out that an hoverhandler on Android won't "de-hover" when using edge gestures on Android. See the video below and pay attention to the debug squares next to the main menu button, the first one being the HoverHandler's hovered property:


https://github.com/opengisch/QField/assets/1728657/fb56a0d8-7670-4c06-a68e-4bbaa748f0a3


Changes in this PR takes care of handling this unfortunate scenario too.