### PR TITLE
Fix coordinate cursor locked to position not sticking to position

### DIFF
--- a/src/qml/CoordinateLocator.qml
+++ b/src/qml/CoordinateLocator.qml
@@ -49,7 +49,7 @@ Item {
         ? overrideLocation
         : snappingUtils.snappedCoordinate;
 
-    return coordinate !== undefined ? mapSettings.coordinateToScreen(coordinate) : Qt.point();
+    return !!mapSettings.visibleExtent && coordinate !== undefined ? mapSettings.coordinateToScreen(coordinate) : Qt.point();
   }
 
   property variant rubberbandModel: undefined


### PR DESCRIPTION
@suricactus , the removed `!!mapSettings.visibleExtent` check in the displayCoordinate property was actually important, without it, the coordinate isn't refreshed when panning/zooming around, which results in the cursor not sticking to position.