### PR TITLE
Fix undo/redo history TypeError warning when closing QField

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2136,7 +2136,7 @@ ApplicationWindow {
         iconColor: Theme.mainTextColor
         height: 48
         width: 48
-        enabled: featureHistory.isUndoAvailable
+        enabled: featureHistory && featureHistory.isUndoAvailable
         opacity: enabled ? 1 : 0.5
 
         onClicked: {
@@ -2156,7 +2156,7 @@ ApplicationWindow {
         iconColor: Theme.mainTextColor
         height: 48
         width: 48
-        enabled: featureHistory.isRedoAvailable
+        enabled: featureHistory && featureHistory.isRedoAvailable
         opacity: enabled ? 1 : 0.5
 
         onClicked: {


### PR DESCRIPTION
@suricactus , the context property gets reset before the scene is fully unloaded, we need to do these checks to avoid (harmless) errors on shutdown.