### PR TITLE
[Backport release-3_1] Properly cancel geometry editor's fill ring and split feature tools

### DIFF
--- a/src/qml/geometryeditors/FillRing.qml
+++ b/src/qml/geometryeditors/FillRing.qml
@@ -77,6 +77,10 @@ VisibilityFadingRow {
         addPolygonDialog.show();
       }
     }
+
+    onCancel: {
+      rubberbandModel.reset()
+    }
   }
 
   Dialog {

--- a/src/qml/geometryeditors/SplitFeature.qml
+++ b/src/qml/geometryeditors/SplitFeature.qml
@@ -71,6 +71,10 @@ VisibilityFadingRow {
 
       featureModel.currentLayer.removeSelection()
     }
+
+    onCancel: {
+      rubberbandModel.reset()
+    }
   }
 
   function init(featureModel, mapSettings, editorRubberbandModel, editorRenderer)


### PR DESCRIPTION
Backport #4877
 **Authored by:** @nirvn