### PR TITLE
[Backport release-3_1] Disable map canvas interaction when the QFieldCloud projects panel and the local data picker panel are visible too

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -419,7 +419,7 @@ ApplicationWindow {
     /* The map canvas */
     MapCanvas {
       id: mapCanvasMap
-      property bool isEnabled: !dashBoard.opened && !welcomeScreen.visible && !qfieldSettings.visible && !cloudPopup.visible && !codeReader.visible
+      property bool isEnabled: !dashBoard.opened && !welcomeScreen.visible && !qfieldSettings.visible && !qfieldLocalDataPickerScreen.visible && !qfieldCloudScreen.visible && !cloudPopup.visible && !codeReader.visible
       interactive: isEnabled && !screenLocker.enabled
       incrementalRendering: true
       quality: qfieldSettings.quality


### PR DESCRIPTION
Backport #4878
 **Authored by:** @nirvn