### PR TITLE
Allow for children to be added to a parent feature being added but not yet created

### DIFF
--- a/src/core/attributeformmodel.cpp
+++ b/src/core/attributeformmodel.cpp
@@ -85,6 +85,11 @@ void AttributeFormModel::applyFeatureModel()
   return mSourceModel->applyFeatureModel();
 }
 
+void AttributeFormModel::applyParentDefaultValues()
+{
+  return mSourceModel->applyParentDefaultValues();
+}
+
 bool AttributeFormModel::filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const
 {
   return mSourceModel->data( mSourceModel->index( source_row, 0, source_parent ), CurrentlyVisible ).toBool();

--- a/src/core/attributeformmodel.h
+++ b/src/core/attributeformmodel.h
@@ -103,6 +103,9 @@ class AttributeFormModel : public QSortFilterProxyModel
     //! Forces the form to update the fields visibility and constraints
     Q_INVOKABLE void applyFeatureModel();
 
+    //! Applies default values linked to a parent feature
+    Q_INVOKABLE void applyParentDefaultValues();
+
   signals:
     void featureModelChanged();
     void hasTabsChanged();

--- a/src/core/attributeformmodelbase.h
+++ b/src/core/attributeformmodelbase.h
@@ -61,6 +61,9 @@ class AttributeFormModelBase : public QStandardItemModel
     //! Applies feature model data such as attribute values, constraints, visibility to the attribute form model
     void applyFeatureModel();
 
+    //! Applies default values linked to a parent feature
+    void applyParentDefaultValues();
+
   signals:
     void featureModelChanged();
     void hasTabsChanged();

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -244,6 +244,7 @@ void FeatureModel::setLinkedParentFeature( const QgsFeature &feature )
     return;
 
   mLinkedParentFeature = feature;
+  emit linkedParentFeatureChanged();
 
   if ( mLinkedRelation.isValid() )
     setLinkedFeatureValues();

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -194,10 +194,21 @@ void FeatureModel::setLinkedFeatureValues()
 {
   beginResetModel();
   mLinkedAttributeIndexes.clear();
+  const bool parentFeatureIsNew = std::numeric_limits<QgsFeatureId>::min() == mLinkedParentFeature.id();
   const auto fieldPairs = mLinkedRelation.fieldPairs();
   for ( QgsRelation::FieldPair fieldPair : fieldPairs )
   {
-    mFeature.setAttribute( mFeature.fieldNameIndex( fieldPair.first ), linkedParentFeature().attribute( fieldPair.second ) );
+    mFeature.setAttribute( fieldPair.first, linkedParentFeature().attribute( fieldPair.second ) );
+    if ( parentFeatureIsNew && mLinkedRelation.referencedLayer() )
+    {
+      if ( mLinkedRelation.referencedLayer()->dataProvider() )
+      {
+        if ( mFeature.attribute( fieldPair.first ).toString() == mLinkedRelation.referencedLayer()->dataProvider()->defaultValueClause( mLinkedParentFeature.fieldNameIndex( fieldPair.second ) ) )
+        {
+          mFeature.setAttribute( fieldPair.first, QVariant() );
+        }
+      }
+    }
     mLinkedAttributeIndexes.append( mFeature.fieldNameIndex( fieldPair.first ) );
   }
   endResetModel();
@@ -731,6 +742,28 @@ bool FeatureModel::create()
     return false;
   }
 
+  // Gather any relationship children which would have relied on an auto-generated field value
+  const QList<QgsRelation> relations = mProject->relationManager()->referencedRelations( mLayer );
+  QList<QPair<QgsRelation, QgsFeatureRequest>> revisitRelations;
+  QgsFeature temporaryFeature = mFeature;
+  for ( const QgsRelation &relation : relations )
+  {
+    const QgsAttributeList rereferencedFields = relation.referencedFields();
+    bool needsRevisit = false;
+    for ( const int fieldIndex : rereferencedFields )
+    {
+      if ( mLayer->dataProvider() && !mLayer->dataProvider()->defaultValueClause( fieldIndex ).isEmpty() )
+      {
+        temporaryFeature.setAttribute( fieldIndex, QVariant() );
+        needsRevisit = true;
+      }
+    }
+    if ( needsRevisit )
+    {
+      revisitRelations << qMakePair( relation, relation.getRelatedFeaturesRequest( temporaryFeature ) );
+    }
+  }
+
   // The connection below will be triggered when the new feature is committed and will provide
   // the saved feature ID needed to fetch the saved feature back from the data provider
   QgsFeatureId createdFeatureId;
@@ -747,6 +780,24 @@ bool FeatureModel::create()
       QgsFeature feat;
       if ( mLayer->getFeatures( QgsFeatureRequest().setFilterFid( createdFeatureId ) ).nextFeature( feat ) )
       {
+        // Revisit relations in need of attribute updates
+        for ( auto revisitRelation : revisitRelations )
+        {
+          const QList<QgsRelation::FieldPair> fieldPairs = revisitRelation.first.fieldPairs();
+          revisitRelation.first.referencingLayer()->startEditing();
+          QgsFeatureIterator it = revisitRelation.first.referencingLayer()->getFeatures( revisitRelation.second );
+          QgsFeature childFeature;
+          while ( it.nextFeature( childFeature ) )
+          {
+            for ( const QgsRelation::FieldPair fieldPair : fieldPairs )
+            {
+              childFeature.setAttribute( fieldPair.referencingField(), feat.attribute( fieldPair.referencedField() ) );
+            }
+            revisitRelation.first.referencingLayer()->updateFeature( childFeature );
+          }
+          revisitRelation.first.referencingLayer()->commitChanges();
+        }
+
         setFeature( feat );
       }
       else

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -218,6 +218,24 @@ class FeatureGatherer : public QThread
     {
       mWasCanceled = false;
 
+      const bool featureIsNew = std::numeric_limits<QgsFeatureId>::min() == mFeature.id();
+      if ( featureIsNew )
+      {
+        const auto fieldPairs = mRelation.fieldPairs();
+        for ( QgsRelation::FieldPair fieldPair : fieldPairs )
+        {
+          {
+            if ( mRelation.referencedLayer() && mRelation.referencedLayer()->dataProvider() )
+            {
+              if ( !mRelation.referencedLayer()->dataProvider()->defaultValueClause( mFeature.fieldNameIndex( fieldPair.second ) ).isEmpty() )
+              {
+                mFeature.setAttribute( fieldPair.second, QVariant() );
+              }
+            }
+          }
+        }
+      }
+
       QgsFeatureIterator relatedFeaturesIt = mRelation.getRelatedFeatures( mFeature );
       QgsExpressionContext context = mRelation.referencingLayer()->createExpressionContext();
       QgsExpression expression( mRelation.referencingLayer()->displayExpression() );

--- a/src/qml/editorwidgets/RelationReference.qml
+++ b/src/qml/editorwidgets/RelationReference.qml
@@ -21,8 +21,8 @@ EditorWidgetBase {
 
     currentLayer: _rel.referencedLayer
     keyField: _rel.resolveReferencedField(field.name)
-    addNull: config['AllowNULL'] // no, it is not a misspelled version of config['AllowNull']
-    orderByValue: config['OrderByValue']
+    addNull: !!config['AllowNULL'] // no, it is not a misspelled version of config['AllowNull']
+    orderByValue: !!config['OrderByValue']
     attributeField: field
     currentFormFeature: currentFeature
     filterExpression: ""

--- a/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
@@ -116,18 +116,16 @@ EditorWidgetBase {
       MouseArea {
         anchors.fill: parent
         onClicked: {
-          if( save() ) {
-            //this has to be checked after buffering because the primary could be a value that has been created on creating featurer (e.g. fid)
-            if( orderedRelationModel.parentPrimariesAvailable ) {
-              displayToast( qsTr( 'Adding child feature in layer %1' ).arg( orderedRelationModel.relation.referencingLayer.name ) )
-              if ( orderedRelationModel.relation.referencingLayer.geometryType() !== Qgis.GeometryType.Null ) {
-                requestGeometry( relationEditor, orderedRelationModel.relation.referencingLayer );
-                return;
-              }
-              showAddFeaturePopup()
-            } else {
-              displayToast (qsTr( 'Cannot add child feature: parent primary keys are not available' ), 'warning' )
+          //this has to be checked after buffering because the primary could be a value that has been created on creating featurer (e.g. fid)
+          if( orderedRelationModel.parentPrimariesAvailable ) {
+            displayToast( qsTr( 'Adding child feature in layer %1' ).arg( orderedRelationModel.relation.referencingLayer.name ) )
+            if ( orderedRelationModel.relation.referencingLayer.geometryType() !== Qgis.GeometryType.Null ) {
+              requestGeometry( relationEditor, orderedRelationModel.relation.referencingLayer );
+              return;
             }
+            showAddFeaturePopup()
+          } else {
+            displayToast (qsTr( 'Cannot add child feature: attribute value linking parent and children is not set' ), 'warning' )
           }
         }
       }

--- a/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
@@ -467,5 +467,6 @@ EditorWidgetBase {
       embeddedPopup.applyGeometry(geometry)
     }
     embeddedPopup.open()
+    embeddedPopup.attributeFormModel.applyParentDefaultValues()
   }
 }

--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -372,5 +372,6 @@ EditorWidgetBase {
             embeddedPopup.applyGeometry(geometry)
         }
         embeddedPopup.open()
+        embeddedPopup.attributeFormModel.applyParentDefaultValues()
     }
 }

--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -131,21 +131,19 @@ EditorWidgetBase {
             MouseArea {
               anchors.fill: parent
               onClicked: {
-                if( save() ) {
-                  //this has to be checked after buffering because the primary could be a value that has been created on creating featurer (e.g. fid)
-                  if( relationEditorModel.parentPrimariesAvailable ) {
-                    displayToast( qsTr( 'Adding child feature in layer %1' ).arg( relationEditorModel.relation.referencingLayer.name ) )
-                    if ( relationEditorModel.relation.referencingLayer.geometryType() !== Qgis.GeometryType.Null )
-                    {
-                      requestGeometry( relationEditor, relationEditorModel.relation.referencingLayer );
-                      return;
-                    }
-                    showAddFeaturePopup()
-                  }
-                  else
+                //this has to be checked after buffering because the primary could be a value that has been created on creating featurer (e.g. fid)
+                if( relationEditorModel.parentPrimariesAvailable ) {
+                  displayToast( qsTr( 'Adding child feature in layer %1' ).arg( relationEditorModel.relation.referencingLayer.name ) )
+                  if ( relationEditorModel.relation.referencingLayer.geometryType() !== Qgis.GeometryType.Null )
                   {
-                    displayToast (qsTr( 'Cannot add child feature: parent primary keys are not available' ), 'warning' )
+                    requestGeometry( relationEditor, relationEditorModel.relation.referencingLayer );
+                    return;
                   }
+                  showAddFeaturePopup()
+                }
+                else
+                {
+                  displayToast (qsTr( 'Cannot add child feature: attribute value linking parent and children is not set' ), 'warning' )
                 }
               }
             }


### PR DESCRIPTION
This PR unlocks addition of children features to a parent feature that is being added _but not yet created_ . There is logic in there to recognize attribute values that are provided by the data provider upon feature creation (e.g. "fid") and propagate that to children features to guarantee the parent<->children relationship is maintained.

In addition, the PR adds a currently missing parent form scope (i.e. @current_parent_{value,feature,geometry}). This allows for default value expressions to capture the parent feature's values without the need to rely on the get_feature(). The latter wouldn't work when adding a new feature which hasn't been committed yet.

I.e., getting a parent feature's attribute would be `attribute(@current_parent_feature,'my_attribute_name')` instead of `attribute(get_feature('parent_layer','referenced_field',"referencing_field"),'my_attribute_name')`. It's also much faster to execute.