### PR TITLE
Fix wrong color of undo icon in the cloud popup panel

### DIFF
--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -413,7 +413,6 @@ Popup {
                   : qsTr('Reset project')
             enabled: cloudProjectsModel.layerObserver.deltaFileWrapper.count > 0 || cloudProjectsModel.layerObserver.deltaFileWrapper.hasError()
             icon.source: Theme.getThemeVectorIcon('ic_undo_black_24dp')
-            icon.color: "white"
 
             onClicked: {
               if (!cloudProjectsModel.layerObserver.deltaFileWrapper.hasError()) {


### PR DESCRIPTION
Fixes this:
![Screenshot from 2023-12-23 13-31-23](https://github.com/opengisch/QField/assets/1728657/9f039cde-e43a-4c20-8652-29434036cb1c)

It's a master-only regression, no need for backport.