### PR TITLE
QField needs OpenGL linking no more

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ if (ANDROID)
   endif()
 endif()
 
-find_package(${QT_PKG} COMPONENTS Concurrent Core Qml Gui Xml Positioning Widgets Network Quick Svg OpenGL Sql Sensors WebView Multimedia REQUIRED)
+find_package(${QT_PKG} COMPONENTS Concurrent Core Qml Gui Xml Positioning Widgets Network Quick Svg Sql Sensors WebView Multimedia REQUIRED)
 
 # PrintSupport isn't required, because it doesn't exist for ios
 # qgis will deal with it an define a public 'QT_NO_PRINTER'

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -310,9 +310,6 @@ if(ANDROID)
                  ${CMAKE_CURRENT_BINARY_DIR}/qfield_android.h @ONLY)
   target_include_directories(
     qfield_core PUBLIC ${CMAKE_SOURCE_DIR}/src/core/platforms/android)
-
-  # GLESv3 needed by barcode reader's use of OpenGL functions
-  target_link_libraries(qfield_core PUBLIC GLESv3)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "iOS")
   target_include_directories(qfield_core
                              PUBLIC ${CMAKE_SOURCE_DIR}/src/core/platforms/ios)
@@ -331,7 +328,6 @@ target_link_libraries(
          ${QT_PKG}::Network
          ${QT_PKG}::Quick
          ${QT_PKG}::Svg
-         ${QT_PKG}::OpenGL
          ${QT_PKG}::Sensors
          ${QT_PKG}::Sql
          ${QT_PKG}::Concurrent

--- a/src/core/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloudconnection.cpp
@@ -40,9 +40,7 @@ QFieldCloudConnection::QFieldCloudConnection()
   , mToken( QSettings().value( QStringLiteral( "/QFieldCloud/token" ) ).toByteArray() )
 {
   QgsNetworkAccessManager::instance()->setTimeout( 60 * 60 * 1000 );
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
   QgsNetworkAccessManager::instance()->setTransferTimeout( 5 * 60 * 1000 );
-#endif
   // we cannot use "/" as separator, since QGIS puts a suffix QGIS/31700 anyway
   const QString userAgent = QStringLiteral( "qfield|%1|%2|%3|" ).arg( qfield::appVersion, qfield::appVersionStr, qfield::gitRev );
   QgsSettings().setValue( QStringLiteral( "/qgis/networkAndProxy/userAgent" ), userAgent );


### PR DESCRIPTION
Since we're not glued to Qt 5.14 anymore, we can make the Qt minimum version 5.15, and in doing so we get rid of the need to link against OpenGL for barcode decoding.