### PR TITLE
Implement a mean to filter out platform-specific parts of release changelogs

### DIFF
--- a/src/core/changelogcontents.cpp
+++ b/src/core/changelogcontents.cpp
@@ -111,6 +111,22 @@ void ChangelogContents::request()
     changelog = changelog.replace( regexpAllTitles, QStringLiteral( "\n###\n##\\1\n\n\n" ) );
     changelog = "Up to release **" + versionNumbersOnly + "**" + changelog;
 
+#if defined( Q_OS_ANDROID )
+    const QString platformName = QLatin1String( "android" );
+#elif defined( Q_OS_IOS )
+    const QString platformName = QLatin1String( "ios" );
+#elif defined( Q_OS_WIN )
+    const QString platformName = QLatin1String( "windows" );
+#elif defined( Q_OS_MACOS )
+    const QString platformName = QLatin1String( "macos" );
+#elif defined( Q_OS_LINUX )
+    const QString platformName = QLatin1String( "ios" );
+#else
+    const QString platformName = QString();
+#endif
+    QRegularExpression regexpPlatform( QStringLiteral( "<!--\\s*platformbegin:\\s*((?!%1).)*-->(.|\r|\n)*?<!--\\s*platformend\\s*-->" ).arg( platformName ) );
+    changelog = changelog.replace( regexpPlatform, QString() );
+
     mStatus = SuccessStatus;
     mMarkdown = changelog;
 


### PR DESCRIPTION
This PR gives us the possibility to filter out chunks of our release changelogs based on the platform QField is being executed from. The functionality relies on markdown <!-- comment --> to mark boundaries of platform-specific blocks. It also has the benefit of showing *everything* when viewing the release changelogs on a browser.

E.g., this would tell our changelog code that the block is Android-specific, which we would only show for QField instances run on Android:

```
<!-- platformbegin: android -->
## Android-specific changes
- Camera won't crash anymore!
<!-- platformend -->
```

The logic also allows for multiple platforms, e.g. this would be shown on all desktop platforms:

```
<!-- platformbegin: windows linux macos -->
## Desktop-specific changes
- Fullscreen mode implemented, just hit f11!
<!-- platformend -->
```