### PR TITLE
Improve and harmonize menu item's left padding throughout QField

### DIFF
--- a/src/qml/About.qml
+++ b/src/qml/About.qml
@@ -187,7 +187,7 @@ Item {
 
             font: Theme.defaultFont
             height: 48
-            leftPadding: 10
+            leftPadding: Theme.menuItemLeftPadding
             icon.source: Theme.getThemeVectorIcon( 'ic_speaker_white_24dp' )
 
             onTriggered: {

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -393,7 +393,7 @@ Popup {
 
       font: Theme.defaultFont
       height: 48
-      leftPadding: 10
+      leftPadding: Theme.menuItemLeftPadding
 
       onTriggered: {
         if ( parseInt(layerTree.data(index, FlatLayerTreeModel.FeatureCount)) === 0 ) {

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -512,7 +512,7 @@ Rectangle {
 
       font: Theme.defaultFont
       height: 48
-      leftPadding: 15
+      leftPadding: Theme.menuItemCheckLeftPadding
 
       onTriggered: {
           toggleMultiSelection();
@@ -528,7 +528,7 @@ Rectangle {
 
       font: Theme.defaultFont
       height: 48
-      leftPadding: 10
+      leftPadding: Theme.menuItemLeftPadding
 
       onTriggered: {
           featureListMenu.close();
@@ -550,7 +550,7 @@ Rectangle {
       enabled: toolBar.model && toolBar.model.canMergeSelection && toolBar.model.selectedCount > 1 && projectInfo.editRights
 
       font: Theme.defaultFont
-      leftPadding: 10
+      leftPadding: Theme.menuItemLeftPadding
 
       onTriggered: multiMergeClicked();
     }
@@ -562,7 +562,7 @@ Rectangle {
       enabled: toolBar.model && toolBar.model.canMoveSelection && projectInfo.editRights
 
       font: Theme.defaultFont
-      leftPadding: 10
+      leftPadding: Theme.menuItemLeftPadding
 
       onTriggered: multiMoveClicked();
     }
@@ -574,7 +574,7 @@ Rectangle {
       enabled: toolBar.model && toolBar.model.canDuplicateSelection && projectInfo.insertRights
 
       font: Theme.defaultFont
-      leftPadding: 10
+      leftPadding: Theme.menuItemLeftPadding
 
       onTriggered: multiDuplicateClicked();
     }
@@ -588,7 +588,7 @@ Rectangle {
       height: enabled ? undefined : 0
 
       font: Theme.defaultFont
-      leftPadding: 10
+      leftPadding: Theme.menuItemLeftPadding
 
       onTriggered: multiDeleteClicked();
     }
@@ -619,7 +619,7 @@ Rectangle {
 
       font: Theme.defaultFont
       height: 48
-      leftPadding: 10
+      leftPadding: Theme.menuItemLeftPadding
 
       onTriggered: {
           featureListMenu.close();
@@ -635,7 +635,7 @@ Rectangle {
 
       font: Theme.defaultFont
       height: 48
-      leftPadding: 10
+      leftPadding: Theme.menuItemLeftPadding
 
       onTriggered: extentController.zoomToSelected();
     }
@@ -645,7 +645,7 @@ Rectangle {
 
       font: Theme.defaultFont
       height: 48
-      leftPadding: 15
+      leftPadding: Theme.menuItemCheckLeftPadding
 
       checkable: true
       checked: extentController.autoZoom
@@ -659,7 +659,7 @@ Rectangle {
 
       font: Theme.defaultFont
       height: 48
-      leftPadding: 10
+      leftPadding: Theme.menuItemLeftPadding
 
       onTriggered: destinationClicked();
     }
@@ -681,7 +681,7 @@ Rectangle {
 
       font: Theme.defaultFont
       height: visible ? 48 : 0
-      leftPadding: 10
+      leftPadding: Theme.menuItemLeftPadding
 
       onTriggered: moveClicked();
     }
@@ -698,7 +698,7 @@ Rectangle {
 
       font: Theme.defaultFont
       height: visible ? 48 : 0
-      leftPadding: 10
+      leftPadding: Theme.menuItemLeftPadding
 
       onTriggered: duplicateClicked();
     }
@@ -715,7 +715,7 @@ Rectangle {
 
       font: Theme.defaultFont
       height: visible ? 48 : 0
-      leftPadding: 10
+      leftPadding: Theme.menuItemLeftPadding
 
       onTriggered: deleteClicked();
     }
@@ -750,7 +750,7 @@ Rectangle {
 
       font: Theme.defaultFont
       height: 48
-      leftPadding: 10
+      leftPadding: Theme.menuItemLeftPadding
 
       enabled: false
     }
@@ -767,7 +767,8 @@ Rectangle {
         text: Title
 
         font: Theme.defaultFont
-        leftPadding: 10
+        height: 48
+        leftPadding: Theme.menuItemLeftPadding
 
         onTriggered: {
             displayToast( qsTr( 'Printing...') )

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -516,7 +516,7 @@ Page {
           font: Theme.defaultFont
           width: parent.width
           height: visible ? 48 : 0
-          leftPadding: 10
+          leftPadding: Theme.menuItemLeftPadding
 
           text: qsTr( "Download Project" )
           onTriggered: {
@@ -530,7 +530,7 @@ Page {
           font: Theme.defaultFont
           width: parent.width
           height: visible ? 48 : 0
-          leftPadding: 10
+          leftPadding: Theme.menuItemLeftPadding
 
           text: qsTr( "Open Project" )
           onTriggered: {
@@ -547,7 +547,7 @@ Page {
           font: Theme.defaultFont
           width: parent.width
           height: visible ? 48 : 0
-          leftPadding: 10
+          leftPadding: Theme.menuItemLeftPadding
 
           text: qsTr( "Remove Stored Project" )
           onTriggered: {
@@ -563,7 +563,7 @@ Page {
           font: Theme.defaultFont
           width: parent.width
           height: visible ? 48 : 0
-          leftPadding: 10
+          leftPadding: Theme.menuItemLeftPadding
 
           text: qsTr( "Cancel Project Download" )
           onTriggered: {

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -386,7 +386,7 @@ Page {
         font: Theme.defaultFont
         width: parent.width
         height: enabled ? undefined : 0
-        leftPadding: 10
+        leftPadding: Theme.menuItemLeftPadding
 
         text: qsTr( "Send to..." )
         onTriggered: { platformUtilities.sendDatasetTo(itemMenu.itemPath); }
@@ -401,7 +401,7 @@ Page {
         font: Theme.defaultFont
         width: parent.width
         height: enabled ? undefined : 0
-        leftPadding: 10
+        leftPadding: Theme.menuItemLeftPadding
 
         text: qsTr( "Export to folder..." )
         onTriggered: { platformUtilities.exportDatasetTo(itemMenu.itemPath); }
@@ -417,7 +417,7 @@ Page {
         font: Theme.defaultFont
         width: parent.width
         height: enabled? undefined : 0
-        leftPadding: 10
+        leftPadding: Theme.menuItemLeftPadding
 
         text: qsTr( "Remove dataset" )
         onTriggered: { platformUtilities.removeDataset(itemMenu.itemPath); }
@@ -432,7 +432,7 @@ Page {
         font: Theme.defaultFont
         width: parent.width
         height: enabled ? undefined : 0
-        leftPadding: 10
+        leftPadding: Theme.menuItemLeftPadding
 
         text: qsTr( "Export to folder..." )
         onTriggered: { platformUtilities.exportFolderTo(itemMenu.itemPath); }
@@ -447,7 +447,7 @@ Page {
         font: Theme.defaultFont
         width: parent.width
         height: enabled ? undefined : 0
-        leftPadding: 10
+        leftPadding: Theme.menuItemLeftPadding
 
         text: qsTr( "Send compressed folder to..." )
         onTriggered: { platformUtilities.sendCompressedFolderTo(itemMenu.itemPath); }
@@ -463,7 +463,7 @@ Page {
         font: Theme.defaultFont
         width: parent.width
         height: enabled ? undefined : 0
-        leftPadding: 10
+        leftPadding: Theme.menuItemLeftPadding
 
         text: qsTr( "Remove project folder" )
         onTriggered: { platformUtilities.removeFolder(itemMenu.itemPath); }
@@ -497,7 +497,7 @@ Page {
         font: Theme.defaultFont
         width: parent.width
         height: enabled ? undefined : 0
-        leftPadding: 10
+        leftPadding: Theme.menuItemLeftPadding
 
         text: qsTr( "Import project from folder" )
         onTriggered: { platformUtilities.importProjectFolder(); }
@@ -511,7 +511,7 @@ Page {
         font: Theme.defaultFont
         width: parent.width
         height: enabled ? undefined : 0
-        leftPadding: 10
+        leftPadding: Theme.menuItemLeftPadding
 
         text: qsTr( "Import project from ZIP" )
         onTriggered: { platformUtilities.importProjectArchive(); }
@@ -525,8 +525,7 @@ Page {
         font: Theme.defaultFont
         width: parent.width
         height: enabled ? undefined : 0
-
-        leftPadding: 10
+        leftPadding: Theme.menuItemLeftPadding
 
         text: qsTr( "Import dataset(s)" )
         onTriggered: { platformUtilities.importDatasets(); }
@@ -544,7 +543,7 @@ Page {
 
         font: Theme.defaultFont
         width: parent.width
-        leftPadding: 10
+        leftPadding: Theme.menuItemLeftPadding
 
         text: qsTr( "Import URL" )
         onTriggered: {
@@ -562,7 +561,7 @@ Page {
 
         font: Theme.defaultFont
         width: parent.width
-        leftPadding: 10
+        leftPadding: Theme.menuItemLeftPadding
 
         text: qsTr( "Storage management help" )
         onTriggered: { Qt.openUrlExternally("https://docs.qfield.org/get-started/storage/") }
@@ -596,7 +595,7 @@ Page {
         font: Theme.defaultFont
         width: parent.width
         height: enabled ? undefined : 0
-        leftPadding: 10
+        leftPadding: Theme.menuItemLeftPadding
 
         text: qsTr( "Update project from ZIP" )
         onTriggered: { platformUtilities.updateProjectFromArchive(projectInfo.filePath); }

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -657,6 +657,7 @@ Page {
                   font: Theme.defaultFont
                   width: parent.width
                   height: visible ? 48: 0
+                  leftPadding: Theme.menuItemCheckLeftPadding
                   checkable: true
                   checked: recentProjectActions.recentProjectPath === registry.defaultProject
 
@@ -673,6 +674,7 @@ Page {
                   font: Theme.defaultFont
                   width: parent.width
                   height: visible ? 48: 0
+                  leftPadding: Theme.menuItemCheckLeftPadding
                   checkable: true
                   checked: recentProjectActions.recentProjectPath === registry.baseMapProject
 
@@ -694,7 +696,7 @@ Page {
                   font: Theme.defaultFont
                   width: parent.width
                   height: visible ? 48: 0
-                  leftPadding: 50
+                  leftPadding: Theme.menuItemIconlessLeftPadding
 
                   text: qsTr( "Remove from Recent Projects" )
                   onTriggered: {

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -154,7 +154,7 @@ EditorWidgetBase {
     font: Theme.defaultFont
     icon.source: Theme.getThemeVectorIcon( "ic_copy_black_24dp" )
     height: 48
-    leftPadding: 10
+    leftPadding: Theme.menuItemLeftPadding
 
     onTriggered: {
       platformUtilities.copyTextToClipboard(value)
@@ -167,7 +167,7 @@ EditorWidgetBase {
     font: Theme.defaultFont
     icon.source: Theme.getThemeVectorIcon( "ic_paste_black_24dp" )
     height: 48
-    leftPadding: 10
+    leftPadding: Theme.menuItemLeftPadding
 
     onTriggered: {
       var text = platformUtilities.getTextFromClipboard();
@@ -185,7 +185,7 @@ EditorWidgetBase {
     font: Theme.defaultFont
     icon.source: withNfc ? Theme.getThemeVectorIcon("ic_qr_nfc_code_black_24dp") : Theme.getThemeVectorIcon("ic_qr_code_black_24dp")
     height: 48
-    leftPadding: 10
+    leftPadding: Theme.menuItemLeftPadding
 
     onTriggered: {
       requestBarcode(topItem)

--- a/src/qml/imports/Theme/Theme.qml
+++ b/src/qml/imports/Theme/Theme.qml
@@ -75,6 +75,10 @@ QtObject {
 
     readonly property int popupScreenEdgeMargin: 40
 
+    readonly property int menuItemIconlessLeftPadding: 54
+    readonly property int menuItemLeftPadding: 14
+    readonly property int menuItemCheckLeftPadding: 20
+
     function getThemeIcon(name) {
       var ppiName
       if ( ppi >= 360 )

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1480,7 +1480,7 @@ ApplicationWindow {
             text: qsTr( "Relative angle" )
             font: Theme.defaultFont
             height: 48
-            leftPadding: 10
+            leftPadding: Theme.menuItemCheckLeftPadding
 
             checkable: true
             checked: snapToCommonAngleButton.isSnapToCommonAngleRelative
@@ -1503,7 +1503,7 @@ ApplicationWindow {
 
               font: Theme.defaultFont
               height: 48
-              leftPadding: 10
+              leftPadding: Theme.menuItemCheckLeftPadding
 
               checkable: true
               checked: modelData === snapToCommonAngleButton.snapToCommonAngleDegrees
@@ -2118,7 +2118,7 @@ ApplicationWindow {
     bottomMargin: sceneBottomMargin
 
     width: {
-        var actionRowResult = actionsRow.childrenRect.width
+        var actionRowResult = actionsRow.childrenRect.width + 4
         var result = 0;
         var padding = 0;
         // Skip first Row item
@@ -2132,6 +2132,8 @@ ApplicationWindow {
 
     Row {
       id: actionsRow
+      leftPadding: 2
+      rightPadding: 2
       spacing: 2
       height: printItem.height
       clip: true
@@ -2140,9 +2142,8 @@ ApplicationWindow {
 
       QfToolButton {
         anchors.verticalCenter: parent.verticalCenter
-        height: 44
-        width: 44
-        padding: 6
+        height: 48
+        width: 48
         round: true
         iconSource: Theme.getThemeVectorIcon( "ic_home_black_24dp" )
         iconColor: Theme.mainTextColor
@@ -2159,9 +2160,8 @@ ApplicationWindow {
 
       QfToolButton {
         anchors.verticalCenter: parent.verticalCenter
-        height: 44
-        width: 44
-        padding: 6
+        height: 48
+        width: 48
         round: true
         iconSource: Theme.getThemeVectorIcon( "ic_measurement_black_24dp" )
         iconColor: Theme.mainTextColor
@@ -2177,9 +2177,8 @@ ApplicationWindow {
 
       QfToolButton {
         anchors.verticalCenter: parent.verticalCenter
-        height: 44
-        width: 44
-        padding: 6
+        height: 48
+        width: 48
         round: true
         iconSource: Theme.getThemeVectorIcon( "ic_lock_black_24dp" )
         iconColor: Theme.mainTextColor
@@ -2196,9 +2195,8 @@ ApplicationWindow {
         id: undoButton
         property bool isEnabled: featureHistory && featureHistory.isUndoAvailable
         anchors.verticalCenter: parent.verticalCenter
-        height: 44
-        width: 44
-        padding: 6
+        height: 48
+        width: 48
         round: true
         iconSource: Theme.getThemeVectorIcon( "ic_undo_black_24dp" )
         iconColor: isEnabled ? Theme.mainTextColor : Theme.mainTextDisabledColor
@@ -2222,9 +2220,8 @@ ApplicationWindow {
         id: redoButton
         property bool isEnabled: featureHistory && featureHistory.isRedoAvailable
         anchors.verticalCenter: parent.verticalCenter
-        height: 44
-        width: 44
-        padding: 6
+        height: 48
+        width: 48
         round: true
         iconSource: Theme.getThemeVectorIcon( "ic_redo_black_24dp" )
         iconColor: isEnabled ? Theme.mainTextColor : Theme.mainTextDisabledColor
@@ -2254,7 +2251,7 @@ ApplicationWindow {
       font: Theme.defaultFont
       icon.source: Theme.getThemeVectorIcon( "ic_print_black_24dp" )
       height: 48
-      leftPadding: 10
+      leftPadding: Theme.menuItemLeftPadding
       rightPadding: 40
 
       arrow: Canvas {
@@ -2302,7 +2299,7 @@ ApplicationWindow {
       font: Theme.defaultFont
       icon.source: Theme.getThemeVectorIcon( "ic_sensor_on_black_24dp" )
       height: 48
-      leftPadding: 10
+      leftPadding: Theme.menuItemLeftPadding
       rightPadding: 40
 
       arrow: Canvas {
@@ -2339,7 +2336,7 @@ ApplicationWindow {
       font: Theme.defaultFont
       icon.source: Theme.getThemeVectorIcon( "ic_project_folder_black_24dp" )
       height: 48
-      leftPadding: 10
+      leftPadding: Theme.menuItemLeftPadding
       rightPadding: 40
 
       onTriggered: {
@@ -2357,7 +2354,7 @@ ApplicationWindow {
 
       font: Theme.defaultFont
       height: 48
-      leftPadding: 50
+      leftPadding: Theme.menuItemIconlessLeftPadding
 
       onTriggered: {
         dashBoard.close()
@@ -2371,7 +2368,7 @@ ApplicationWindow {
 
       font: Theme.defaultFont
       height: 48
-      leftPadding: 50
+      leftPadding: Theme.menuItemIconlessLeftPadding
 
       onTriggered: {
         dashBoard.close()
@@ -2385,7 +2382,7 @@ ApplicationWindow {
 
       font: Theme.defaultFont
       height: 48
-      leftPadding: 50
+      leftPadding: Theme.menuItemIconlessLeftPadding
 
       onTriggered: {
         dashBoard.close()
@@ -2422,7 +2419,7 @@ ApplicationWindow {
 
       font: Theme.defaultFont
       height: 48
-      leftPadding: 10
+      leftPadding: Theme.menuItemLeftPadding
 
       enabled: false
     }
@@ -2445,7 +2442,7 @@ ApplicationWindow {
                      : Theme.getThemeVectorIcon( "ic_sensor_off_black_24dp" )
 
         font: Theme.defaultFont
-        leftPadding: 10
+        leftPadding: Theme.menuItemLeftPadding
 
         onTriggered: {
           if (SensorStatus == Qgis.DeviceConnectionStatus.Connected) {
@@ -2492,7 +2489,7 @@ ApplicationWindow {
 
       font: Theme.defaultFont
       height: 48
-      leftPadding: 10
+      leftPadding: Theme.menuItemLeftPadding
 
       enabled: false
     }
@@ -2508,7 +2505,7 @@ ApplicationWindow {
         text: Title
 
         font: Theme.defaultFont
-        leftPadding: 10
+        leftPadding: Theme.menuItemLeftPadding
 
         onTriggered: {
             highlighted = false
@@ -2605,7 +2602,7 @@ ApplicationWindow {
       text: qsTr( "Add Bookmark" )
       icon.source: Theme.getThemeIcon( "ic_bookmark_black_24dp" )
       height: 48
-      leftPadding: 10
+      leftPadding: Theme.menuItemLeftPadding
       font: Theme.defaultFont
 
       onTriggered: {
@@ -2626,7 +2623,7 @@ ApplicationWindow {
       text: qsTr( "Set as Destination" )
       icon.source: Theme.getThemeIcon( "ic_navigation_flag_purple_24dp" )
       height: 48
-      leftPadding: 10
+      leftPadding: Theme.menuItemLeftPadding
       font: Theme.defaultFont
 
       onTriggered: {
@@ -2638,7 +2635,7 @@ ApplicationWindow {
       id: copyCoordinatesItem
       text: qsTr( "Copy Coordinates" )
       height: 48
-      leftPadding: 10
+      leftPadding: Theme.menuItemLeftPadding
       font: Theme.defaultFont
       icon.source: Theme.getThemeVectorIcon( "ic_copy_black_24dp" )
 
@@ -2657,7 +2654,7 @@ ApplicationWindow {
       font: Theme.defaultFont
       icon.source: Theme.getThemeVectorIcon( "ic_lock_black_24dp" )
       height: 48
-      leftPadding: 10
+      leftPadding: Theme.menuItemLeftPadding
 
       onTriggered: {
         screenLocker.enabled = true
@@ -2721,7 +2718,7 @@ ApplicationWindow {
           text: qsTr('Open Feature Form')
           font: Theme.defaultFont
           icon.source: Theme.getThemeIcon( "ic_baseline-list_alt-24px" )
-          leftPadding: 10
+          leftPadding: Theme.menuItemLeftPadding
 
           onTriggered: {
             featureForm.model.setFeatures(menu.featureLayer, '$id = ' + menu.fid)
@@ -2735,7 +2732,7 @@ ApplicationWindow {
           font: Theme.defaultFont
           enabled: projectInfo.insertRights
           icon.source: Theme.getThemeVectorIcon( "ic_duplicate_black_24dp" )
-          leftPadding: 10
+          leftPadding: Theme.menuItemLeftPadding
 
           onTriggered: {
             featureForm.model.setFeatures(menu.featureLayer, '$id = ' + menu.fid)
@@ -2787,7 +2784,7 @@ ApplicationWindow {
 
       font: Theme.defaultFont
       height: 48
-      leftPadding: 10
+      leftPadding: Theme.menuItemLeftPadding
       rightPadding: 40
 
       arrow: Canvas {
@@ -2819,7 +2816,7 @@ ApplicationWindow {
       id: cancelNavigationItem
       text: qsTr( "Clear Destination" )
       height: 48
-      leftPadding: 10
+      leftPadding: Theme.menuItemLeftPadding
       font: Theme.defaultFont
 
       onTriggered: {
@@ -2850,7 +2847,7 @@ ApplicationWindow {
     MenuItem {
       text: qsTr( "%1 Precision" ).arg(UnitTypes.formatDistance(0.10, 2, navigation.distanceUnits))
       height: 48
-      leftPadding: 15
+      leftPadding: Theme.menuItemCheckLeftPadding
       font: Theme.defaultFont
 
       enabled: !checked
@@ -2866,7 +2863,7 @@ ApplicationWindow {
     MenuItem {
       text: qsTr( "%1 Precision" ).arg(UnitTypes.formatDistance(0.25, 2, navigation.distanceUnits))
       height: 48
-      leftPadding: 15
+      leftPadding: Theme.menuItemCheckLeftPadding
       font: Theme.defaultFont
 
       enabled: !checked
@@ -2882,7 +2879,7 @@ ApplicationWindow {
     MenuItem {
       text: qsTr( "%1 Precision" ).arg(UnitTypes.formatDistance(0.5, 2, navigation.distanceUnits))
       height: 48
-      leftPadding: 15
+      leftPadding: Theme.menuItemCheckLeftPadding
       font: Theme.defaultFont
 
       enabled: !checked
@@ -2898,7 +2895,7 @@ ApplicationWindow {
     MenuItem {
       text: qsTr( "%1 Precision" ).arg(UnitTypes.formatDistance(1, 2, navigation.distanceUnits))
       height: 48
-      leftPadding: 15
+      leftPadding: Theme.menuItemCheckLeftPadding
       font: Theme.defaultFont
 
       enabled: !checked
@@ -2914,7 +2911,7 @@ ApplicationWindow {
     MenuItem {
       text: qsTr( "%1 Precision" ).arg(UnitTypes.formatDistance(2.5, 2, navigation.distanceUnits))
       height: 48
-      leftPadding: 15
+      leftPadding: Theme.menuItemCheckLeftPadding
       font: Theme.defaultFont
 
       enabled: !checked
@@ -2930,7 +2927,7 @@ ApplicationWindow {
     MenuItem {
       text: qsTr( "%1 Precision" ).arg(UnitTypes.formatDistance(5, 2, navigation.distanceUnits))
       height: 48
-      leftPadding: 15
+      leftPadding: Theme.menuItemCheckLeftPadding
       font: Theme.defaultFont
 
       enabled: !checked
@@ -2946,7 +2943,7 @@ ApplicationWindow {
     MenuItem {
       text: qsTr( "%1 Precision" ).arg(UnitTypes.formatDistance(10, 2, navigation.distanceUnits))
       height: 48
-      leftPadding: 15
+      leftPadding: Theme.menuItemCheckLeftPadding
       font: Theme.defaultFont
 
       enabled: !checked
@@ -2964,7 +2961,7 @@ ApplicationWindow {
     MenuItem {
       text: qsTr( "Always Show Precise View" )
       height: 48
-      leftPadding: 15
+      leftPadding: Theme.menuItemCheckLeftPadding
       font: Theme.defaultFont
 
       checkable: true
@@ -2979,7 +2976,7 @@ ApplicationWindow {
     MenuItem {
       text: qsTr( "Enable Audio Proximity Feedback" )
       height: 48
-      leftPadding: 15
+      leftPadding: Theme.menuItemCheckLeftPadding
       font: Theme.defaultFont
 
       checkable: true
@@ -3025,7 +3022,7 @@ ApplicationWindow {
       id: positioningItem
       text: qsTr( "Enable Positioning" )
       height: 48
-      leftPadding: 15
+      leftPadding: Theme.menuItemCheckLeftPadding
       font: Theme.defaultFont
 
       checkable: true
@@ -3040,7 +3037,7 @@ ApplicationWindow {
     MenuItem {
       text: qsTr( "Show Position Information" )
       height: 48
-      leftPadding: 15
+      leftPadding: Theme.menuItemCheckLeftPadding
       font: Theme.defaultFont
 
       checkable: true
@@ -3055,7 +3052,7 @@ ApplicationWindow {
     MenuItem {
       text: qsTr( "Positioning Settings" )
       height: 48
-      leftPadding: 50
+      leftPadding: Theme.menuItemIconlessLeftPadding
       font: Theme.defaultFont
 
       onTriggered: {
@@ -3069,7 +3066,7 @@ ApplicationWindow {
     MenuItem {
       text: qsTr( "Center to Location" )
       height: 48
-      leftPadding: 50
+      leftPadding: Theme.menuItemIconlessLeftPadding
       font: Theme.defaultFont
 
       onTriggered: {
@@ -3081,7 +3078,7 @@ ApplicationWindow {
       text: qsTr( "Add Bookmark at Location" )
       icon.source: Theme.getThemeIcon( "ic_bookmark_black_24dp" )
       height: 48
-      leftPadding: 10
+      leftPadding: Theme.menuItemLeftPadding
       font: Theme.defaultFont
 
       onTriggered: {
@@ -3105,7 +3102,7 @@ ApplicationWindow {
     MenuItem {
       text: qsTr( "Copy Location Coordinates" )
       height: 48
-      leftPadding: 10
+      leftPadding: Theme.menuItemLeftPadding
       font: Theme.defaultFont
       icon.source: Theme.getThemeVectorIcon( "ic_copy_black_24dp" )
 


### PR DESCRIPTION
This results in a much nicer main menu button (following our re-work of it to include a top row of icons). It also slightly increases the hit area, which feels better.

Before (left) vs. PR (right):
![image](https://github.com/opengisch/QField/assets/1728657/d178e692-596c-4ed1-880b-9448e7df344d)
