### PR TITLE
Fix handling of ripple effect on tool buttons in dark mode

### DIFF
--- a/src/qml/imports/Theme/QfToolButton.qml
+++ b/src/qml/imports/Theme/QfToolButton.qml
@@ -55,7 +55,7 @@ RoundButton {
       anchor: parent
       active: button.down
       color: Theme.darkTheme
-             ? bgcolor == "#ffffff" || bgcolor == "#00000000" ? "#10ffffff" : "#22aaaaaa"
+             ? bgcolor == "#ffffff" ? "#10000000" : "#10ffffff"
              : bgcolor == "#ffffff" || bgcolor == "#00000000" ? "#10000000" : "#22ffffff"
     }
   }


### PR DESCRIPTION
Just noticed that the QML camera's "capture" button is missing a ripple effect, making it hard to figure out whether an action was taken. Cause was a bad logic for ripple effect's color pick on dark theme.