### PR TITLE
Align apk naming

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -20,27 +20,35 @@ jobs:
           - triplet: 'arm64-android'
             qt_arch: 'android_arm64_v8a'
             all_files_access: 'OFF'
+            artifact_name: 'android-arm64'
           - triplet: 'arm64-android'
             qt_arch: 'android_arm64_v8a'
             all_files_access: 'ON'
+            artifact_name: 'android-arm64'
           - triplet: 'arm-neon-android'
             qt_arch: 'android_armv7'
             all_files_access: 'OFF'
+            artifact_name: 'android-arm-neon'
           - triplet: 'arm-neon-android'
             qt_arch: 'android_armv7'
             all_files_access: 'ON'
+            artifact_name: 'android-arm-neon'
           - triplet: 'x64-android'
             qt_arch: 'android_x86_64'
             all_files_access: 'OFF'
+            artifact_name: 'android-x64'
           - triplet: 'x64-android'
             qt_arch: 'android_x86_64'
             all_files_access: 'ON'
+            artifact_name: 'android-x64'
           - triplet: 'x86-android'
             qt_arch: 'android_x86'
             all_files_access: 'OFF'
+            artifact_name: 'android-x86'
           - triplet: 'x86-android'
             qt_arch: 'android_x86'
             all_files_access: 'ON'
+            artifact_name: 'android-x86'
 
     steps:
       - name: 🐣 Checkout
@@ -175,7 +183,8 @@ jobs:
       - name: 🍺 Deploy
         run: |
           sudo apt install -y s3cmd
-          TRIPLET=${{ matrix.triplet }} ALL_FILES_ACCESS=${{ matrix.all_files_access }} ./scripts/ci/upload_artifacts.sh
+          # This script will rename the artifact and move it to /tmp
+          NAME=${{ matrix.artifact_name }} ALL_FILES_ACCESS=${{ matrix.all_files_access }} ./scripts/ci/upload_artifacts.sh
         env:
           S3CFG: ${{ secrets.S3CFG }}
 
@@ -214,10 +223,10 @@ jobs:
 
       - name: Download apks
         run: |
-          wget https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-arm64-android.apk
-          wget https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-arm-neon-android.apk
-          wget https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-x64-android.apk
-          wget https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-x86-android.apk
+          wget https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-arm64.apk
+          wget https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-arm-neon.apk
+          wget https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-x64.apk
+          wget https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-x86.apk
 
       - name: Upload to Google Play Store
         run: |
@@ -231,10 +240,10 @@ jobs:
           fi
 
           ./scripts/basic_upload_apks_service_account.py ch.opengis.${{ env.APP_PACKAGE_NAME }} beta "${RELEASE_MESSAGE}" \
-              qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-arm64-android.apk \
-              qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-arm-neon-android.apk \
-              qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-x64-android.apk \
-              qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-x86-android.apk
+              qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-arm64.apk \
+              qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-arm-neon.apk \
+              qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-x64.apk \
+              qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-x86.apk
         env:
           GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
 
@@ -257,17 +266,17 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.FAIRY_TOKEN }}
           message: |
-            🎉 Ta-daaa, freshly created APKs are available for ${{ github.event.pull_request.head.sha }}: [**arm64-android**](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-arm64-android.apk)
+            🎉 Ta-daaa, freshly created APKs are available for ${{ github.event.pull_request.head.sha }}: [**arm64-android**](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-arm64.apk)
             <details>
             <summary>Other architectures</summary>
 
-            - [arm-neon-android](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-arm-neon-android.apk)
-            - [x64-android](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-x64-android.apk)
-            - [x86-android](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-x86-android.apk)
-            - [**all access arm64-android**](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield_all_access-${{ env.CI_PACKAGE_FILE_SUFFIX }}-arm64-android.apk)
-            - [all access arm-neon-android](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield_all_access-${{ env.CI_PACKAGE_FILE_SUFFIX }}-arm-neon-android.apk)
-            - [all access x64-android](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield_all_access-${{ env.CI_PACKAGE_FILE_SUFFIX }}-x64-android.apk)
-            - [all access x86-android](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield_all_access-${{ env.CI_PACKAGE_FILE_SUFFIX }}-x86-android.apk)
+            - [arm-neon-android](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-arm-neon.apk)
+            - [x64-android](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-x64.apk)
+            - [x86-android](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-x86.apk)
+            - [**all access arm64-android**](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield_all_access-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-arm64.apk)
+            - [all access arm-neon-android](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield_all_access-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-arm-neon.apk)
+            - [all access x64-android](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield_all_access-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-x64.apk)
+            - [all access x86-android](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield_all_access-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-x86.apk)
             </details>
 
   comment_commit:
@@ -287,16 +296,16 @@ jobs:
         with:
           token: ${{ secrets.FAIRY_TOKEN }}
           body: |
-            🎉 Ta-daaa, freshly created APKs are available: [**arm64-android**](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-arm64-android.apk)
+            🎉 Ta-daaa, freshly created APKs are available: [**arm64-android**](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-arm64.apk)
             <details>
             <summary>Other architectures</summary>
 
-            - [arm-neon-android](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-arm-neon-android.apk)
-            - [x64-android](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-x64-android.apk)
-            - [x86-android](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-x86-android.apk)
-            - [**all access arm64-android**](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield_all_access-${{ env.CI_PACKAGE_FILE_SUFFIX }}-arm64-android.apk)
-            - [all access arm-neon-android](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield_all_access-${{ env.CI_PACKAGE_FILE_SUFFIX }}-arm-neon-android.apk)
-            - [all access x64-android](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield_all_access-${{ env.CI_PACKAGE_FILE_SUFFIX }}-x64-android.apk)
-            - [all access x86-android](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield_all_access-${{ env.CI_PACKAGE_FILE_SUFFIX }}-x86-android.apk)
+            - [arm-neon-android](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-arm-neon.apk)
+            - [x64-android](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-x64.apk)
+            - [x86-android](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-x86.apk)
+            - [**all access arm64-android**](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield_all_access-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-arm64.apk)
+            - [all access arm-neon-android](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield_all_access-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-arm-neon.apk)
+            - [all access x64-android](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield_all_access-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-x64.apk)
+            - [all access x86-android](https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/qfield_all_access-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-x86.apk)
             </details>
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -140,17 +140,6 @@ jobs:
         run: |
           bundle exec fastlane ios upload_testflight ipa:/Users/runner/builddir/qfieldIpa/QField.ipa
 
-      - name: 🚀 Upload Release Asset
-        if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v')
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: /Users/runner/builddir/qfieldIpa/QField.ipa
-          asset_name: qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-${{ env.TRIPLET }}-${{ env.DEPLOYMENT_TARGET }}.ipa
-          asset_content_type: application/zip
-
       - name: 📮 Upload debug symbols
         # if: release or labeled PR
         env:

--- a/scripts/ci/upload_artifacts.sh
+++ b/scripts/ci/upload_artifacts.sh
@@ -6,8 +6,8 @@ set -e
 if [[ "${S3CFG}" ]]; then
 	echo -e "\e[31mAbout to upload build artifacts\e[0m"
 
-	#FILENAME_AAB="${CI_PACKAGE_NAME}-${CI_PACKAGE_FILE_SUFFIX}-${TRIPLET}.aab"
-	FILENAME_APK="${CI_PACKAGE_NAME}-${CI_PACKAGE_FILE_SUFFIX}-${TRIPLET}.apk"
+	#FILENAME_AAB="${CI_PACKAGE_NAME}-${CI_PACKAGE_FILE_SUFFIX}-${NAME}.aab"
+	FILENAME_APK="${CI_PACKAGE_NAME}-${CI_PACKAGE_FILE_SUFFIX}-${NAME}.apk"
 
 	# skip AAB upload until we need it
 	#mv ${CMAKE_BUILD_DIR}/android-build/build/outputs/bundle/release/android-build-release.aab /tmp/${FILENAME_AAB}


### PR DESCRIPTION
Currently apks are named like `qfield-v3.1.7-arm64-android.apk`, whereas other platforms do `qfield-v3.1.7-windows-x64.exe`

This changes the scheme and it's now `qfield-v3.1.7-android-arm64.apk` which also makes the android artifacts appear next to each other on the release page