### PR TITLE
When opening or reloading a project, clear the previous one to empty the layer tree

### DIFF
--- a/src/core/layertreemodel.h
+++ b/src/core/layertreemodel.h
@@ -34,6 +34,7 @@ class FlatLayerTreeModelBase : public QAbstractProxyModel
 
     void updateMap( const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles );
     int buildMap( QgsLayerTreeModel *model, const QModelIndex &parent = QModelIndex(), int row = 0, int treeLevel = 0 );
+    void clearMap();
 
     void removeFromMap( const QModelIndex &parent, int first, int last );
     void insertInMap( const QModelIndex &parent, int first, int last );
@@ -101,7 +102,7 @@ class FlatLayerTreeModelBase : public QAbstractProxyModel
 
     bool mIsTemporal = false;
 
-    bool mFrozen = false;
+    int mFrozen = 0;
 };
 
 class FlatLayerTreeModel : public QSortFilterProxyModel

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -690,6 +690,8 @@ bool QgisMobileapp::loadProjectFile( const QString &path, const QString &name )
 
     mAuthRequestHandler->clearStoredRealms();
 
+    // Clear project to empty the layer tree prior to freezing during project load
+    mProject->clear();
     mProjectFilePath = path;
     mProjectFileName = !name.isEmpty() ? name : fi.completeBaseName();
 
@@ -705,6 +707,9 @@ void QgisMobileapp::reloadProjectFile()
   if ( mProjectFilePath.isEmpty() )
     QgsMessageLog::logMessage( tr( "No project file currently opened" ), QStringLiteral( "QField" ), Qgis::Warning );
 
+  // Clear project to empty the layer tree prior to freezing during project load
+  mProject->clear();
+
   emit loadProjectTriggered( mProjectFilePath, mProjectFileName );
 }
 
@@ -718,8 +723,6 @@ void QgisMobileapp::readProjectFile()
 
   const QString suffix = fi.suffix().toLower();
 
-  mProject->removeAllMapLayers();
-  mProject->setTitle( QString() );
   mProject->layerTreeRegistryBridge()->setLayerInsertionMethod( Qgis::LayerTreeInsertionMethod::OptimalInInsertionGroup );
 
   mTrackingModel->reset();

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3274,9 +3274,9 @@ ApplicationWindow {
       busyOverlay.text = qsTr( "Loading %1" ).arg( name !== '' ? name : path )
       busyOverlay.state = "visible"
 
-      navigation.clearDestinationFeature();
+      navigation.clearDestinationFeature()
 
-      projectInfo.filePath = '';
+      projectInfo.filePath = ''
       readProjectTimer.start()
     }
 


### PR DESCRIPTION
When opening or reloading a project, clear the previous one to empty the layer tree, which should avoid pointer to removed source layer tree items. 

Furthermore, we're doing a better handling of project clearing by removing the source mapping _at the beginning_ of the clearing.