### PR TITLE
Add NSLocalNetworkUsageDescription permission for iOS

### DIFF
--- a/platform/ios/Info.plist.in
+++ b/platform/ios/Info.plist.in
@@ -83,6 +83,9 @@
     <key>NFCReaderUsageDescription</key>
     <string>NFC access needed to read text from tags.</string>
 
+    <key>NSLocalNetworkUsageDescription</key>
+    <string>Local network access needed to connect to external GNSS device via TCP or UDP NMEA streams.</string>
+
     <key>CSResourcesFileMapped</key>
     <true/>
 


### PR DESCRIPTION
See https://developer.apple.com/documentation/bundleresources/information_property_list/nslocalnetworkusagedescription?language=objc

