### PR TITLE
Fix translation files after updating to lupdate 5.15

### DIFF
--- a/i18n/qfield_ar.ts
+++ b/i18n/qfield_ar.ts
@@ -666,6 +666,29 @@ Cancel to make a minimal device scan instead.</source>
     </message>
 </context>
 <context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
     <name>FeatureListForm</name>
     <message>
         <source>Stop tracking this feature to edit attributes</source>
@@ -2105,6 +2128,14 @@ While you can still view and use the project, it is strongly recommended to rese
         <source>No changes to revert</source>
         <translation>لا يوجد تغيرات لاسترجاعها</translation>
     </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>QFieldCloudProjectsModel</name>
@@ -2341,6 +2372,10 @@ While you can still view and use the project, it is strongly recommended to rese
     </message>
     <message>
         <source>Project Actions</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>, updated data available on the cloud</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -3719,7 +3754,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>لا يمكن إضافة ميزة فرعية: المفتاح الرئيسي للميزة الأساسية غير متاح.</translation>
+        <translation type="vanished">لا يمكن إضافة ميزة فرعية: المفتاح الرئيسي للميزة الأساسية غير متاح.</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -3741,100 +3776,104 @@ Cancel to make a minimal device scan instead.</source>
         <source>Failed to delete referencing feature</source>
         <translation>فشل حذف الميزة المرجعية</translation>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">أنت الآن في وضع الاستعراض</translation>
+        <translation>أنت الآن في وضع الاستعراض</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">أنت الآن في وضع الترقيم في الطبقة %1</translation>
+        <translation>أنت الآن في وضع الترقيم في الطبقة %1</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">أنت الآن في وضع الترقيم</translation>
+        <translation>أنت الآن في وضع الترقيم</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">أنت الآن في وضع القياس</translation>
+        <translation>أنت الآن في وضع القياس</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">عرض</translation>
+        <translation>عرض</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">طول</translation>
+        <translation>طول</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">القطعة</translation>
+        <translation>القطعة</translation>
     </message>
     <message>
         <source>Perimeter</source>
-        <translation type="vanished">المحيط</translation>
+        <translation>المحيط</translation>
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">الطول</translation>
+        <translation>الطول</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">المساحة</translation>
+        <translation>المساحة</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">إغلاق أداة القياس</translation>
+        <translation>إغلاق أداة القياس</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">إيقاف التحرير</translation>
+        <translation>إيقاف التحرير</translation>
     </message>
     <message>
         <source>Cancel addition</source>
-        <translation type="vanished">إلغاء الإضافة</translation>
+        <translation>إلغاء الإضافة</translation>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">تم تشغيل التحرير الطبقي</translation>
+        <translation>تم تشغيل التحرير الطبقي</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">تم إيقاف التحرير الطبقي</translation>
+        <translation>تم إيقاف التحرير الطبقي</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">تشغيل وضع التحرير باليد الحرة</translation>
+        <translation>تشغيل وضع التحرير باليد الحرة</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">إطفاء وضع التحرير باليد الحرة</translation>
+        <translation>إطفاء وضع التحرير باليد الحرة</translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
-        <translation type="vanished">تم قفل مؤشر الإحداثيات على الموقع</translation>
+        <translation>تم قفل مؤشر الإحداثيات على الموقع</translation>
     </message>
     <message>
         <source>Coordinate cursor unlocked</source>
-        <translation type="vanished">تم إلغاء قفل مؤشر الإحداثيات</translation>
+        <translation>تم إلغاء قفل مؤشر الإحداثيات</translation>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">الموقع المُستقبل</translation>
+        <translation>الموقع المُستقبل</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">البحث عن موقع</translation>
+        <translation>البحث عن موقع</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">يجري تتبع الموقع</translation>
+        <translation>يجري تتبع الموقع</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">جار انتظار تحديد الموقع</translation>
+        <translation>جار انتظار تحديد الموقع</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3846,19 +3885,19 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">تم إيقاف تتبع الموقع</translation>
+        <translation>تم إيقاف تتبع الموقع</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">فشل إنشاء الميزة</translation>
+        <translation>فشل إنشاء الميزة</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">فشل حفظ الميزة</translation>
+        <translation>فشل حفظ الميزة</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">القائمة الرئيسية</translation>
+        <translation>القائمة الرئيسية</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3866,7 +3905,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">طباعة إلى ملف PDF</translation>
+        <translation>طباعة إلى ملف PDF</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3886,15 +3925,15 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">الإعدادات</translation>
+        <translation>الإعدادات</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">ملخص الرسائل</translation>
+        <translation>ملخص الرسائل</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">حول QFeild</translation>
+        <translation>حول QFeild</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3902,7 +3941,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Activating positioning service</source>
-        <translation type="vanished">جار تفعيل خدمة التموضع</translation>
+        <translation>جار تفعيل خدمة التموضع</translation>
     </message>
     <message>
         <source>QField has no permissions to use positioning.</source>
@@ -3910,15 +3949,15 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Map Canvas Options</source>
-        <translation type="vanished">خيارات سياج الخريطة</translation>
+        <translation>خيارات سياج الخريطة</translation>
     </message>
     <message>
         <source>Add Bookmark</source>
-        <translation type="vanished">إضافة علامة مرجعية</translation>
+        <translation>إضافة علامة مرجعية</translation>
     </message>
     <message>
         <source>Set as Destination</source>
-        <translation type="vanished">ضبط كوجهة</translation>
+        <translation>ضبط كوجهة</translation>
     </message>
     <message>
         <source>Add Bookmark at Coordinates</source>
@@ -3926,7 +3965,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Untitled bookmark</source>
-        <translation type="vanished">علامة مرجعية بدون تسمية</translation>
+        <translation>علامة مرجعية بدون تسمية</translation>
     </message>
     <message>
         <source>Set Coordinates as Destination</source>
@@ -3934,7 +3973,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Copy Coordinates</source>
-        <translation type="vanished">نسخ الإحداثيات</translation>
+        <translation>نسخ الإحداثيات</translation>
     </message>
     <message>
         <source>X</source>
@@ -3946,11 +3985,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Coordinates copied to clipboard</source>
-        <translation type="vanished">تم نسخ الإحداثيات إلى الحافظة</translation>
+        <translation>تم نسخ الإحداثيات إلى الحافظة</translation>
     </message>
     <message>
         <source>Precise View Settings</source>
-        <translation type="vanished">إعدادات المظهر الدقيق</translation>
+        <translation>إعدادات المظهر الدقيق</translation>
     </message>
     <message>
         <source>0.25m Precision</source>
@@ -3978,27 +4017,27 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Always Show Precise View</source>
-        <translation type="vanished">إظهار المظهر الدقيق دائماً</translation>
+        <translation>إظهار المظهر الدقيق دائماً</translation>
     </message>
     <message>
         <source>Center to Location</source>
-        <translation type="vanished">التوسيط إلى الموقع</translation>
+        <translation>التوسيط إلى الموقع</translation>
     </message>
     <message>
         <source>Add Bookmark at Location</source>
-        <translation type="vanished">إضافة لاعمة مرجعية عند الموقع</translation>
+        <translation>إضافة لاعمة مرجعية عند الموقع</translation>
     </message>
     <message>
         <source>Copy Location Coordinates</source>
-        <translation type="vanished">نسخ إحداثيات الموقع</translation>
+        <translation>نسخ إحداثيات الموقع</translation>
     </message>
     <message>
         <source>Signed out</source>
-        <translation type="vanished">تم تسجيل الخروج</translation>
+        <translation>تم تسجيل الخروج</translation>
     </message>
     <message>
         <source>Signed in</source>
-        <translation type="vanished">تم تسجيل الدخول</translation>
+        <translation>تم تسجيل الدخول</translation>
     </message>
     <message>
         <source>Set As Destination</source>
@@ -4006,35 +4045,35 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Navigation Options</source>
-        <translation type="vanished">خيارات الملاحة</translation>
+        <translation>خيارات الملاحة</translation>
     </message>
     <message>
         <source>Clear Destination</source>
-        <translation type="vanished">تصفير المسافة</translation>
+        <translation>تصفير المسافة</translation>
     </message>
     <message>
         <source>%1 Precision</source>
-        <translation type="vanished">الدقة %1</translation>
+        <translation>الدقة %1</translation>
     </message>
     <message>
         <source>Enable Audio Proximity Feedback</source>
-        <translation type="vanished">نفعيل التصحيح الصوتي التقريبي</translation>
+        <translation>نفعيل التصحيح الصوتي التقريبي</translation>
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">خيارات التموضع</translation>
+        <translation>خيارات التموضع</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">تمكين التموضع</translation>
+        <translation>تمكين التموضع</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">إظهار معلومات التموضع</translation>
+        <translation>إظهار معلومات التموضع</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">إعدادات التموضع</translation>
+        <translation>إعدادات التموضع</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4046,11 +4085,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Current location unknown</source>
-        <translation type="vanished">الموقع الحالي غير معروف</translation>
+        <translation>الموقع الحالي غير معروف</translation>
     </message>
     <message>
         <source>My location</source>
-        <translation type="vanished">موقعي</translation>
+        <translation>موقعي</translation>
     </message>
     <message>
         <source>Copy Current Location</source>
@@ -4058,27 +4097,27 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">الدقة</translation>
+        <translation>الدقة</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">غير محدد</translation>
+        <translation>غير محدد</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
-        <translation type="vanished">تم نسخ الموقع الحالي إلى الحافظة</translation>
+        <translation>تم نسخ الموقع الحالي إلى الحافظة</translation>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
-        <translation type="vanished">تحولت الطبقة الحالية إلى الطبقة أحادية الرسم المحدد.</translation>
+        <translation>تحولت الطبقة الحالية إلى الطبقة أحادية الرسم المحدد.</translation>
     </message>
     <message>
         <source>Editing of multi geometry layer is not supported yet.</source>
-        <translation type="vanished">تحرير الطبقة متعددة الرسومات غير مدعوم حالياً.</translation>
+        <translation>تحرير الطبقة متعددة الرسومات غير مدعوم حالياً.</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">جار تحميل %1</translation>
+        <translation>جار تحميل %1</translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4086,7 +4125,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">جار الاتصال ...</translation>
+        <translation>جار الاتصال ...</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4094,23 +4133,23 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">فشل تحميل مشروع %1</translation>
+        <translation>فشل تحميل مشروع %1</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
-        <translation type="vanished">تم تحميل مشروع %1 بنجاح، وهو جاهز للفتح الآن</translation>
+        <translation>تم تحميل مشروع %1 بنجاح، وهو جاهز للفتح الآن</translation>
     </message>
     <message>
         <source>Changes failed to reach QFieldCloud: %1</source>
-        <translation type="vanished">فشل وصول التغيرات إلى  : %1QFieldCloud</translation>
+        <translation>فشل وصول التغيرات إلى  : %1QFieldCloud</translation>
     </message>
     <message>
         <source>Changes successfully pushed to QFieldCloud</source>
-        <translation type="vanished">تم نشر التغيرات بنجاح إلى QFieldCloud</translation>
+        <translation>تم نشر التغيرات بنجاح إلى QFieldCloud</translation>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">اضغط زر الرجوع مرة أخرى للخروج من التطبيق</translation>
+        <translation>اضغط زر الرجوع مرة أخرى للخروج من التطبيق</translation>
     </message>
     <message>
         <source>Positioning error: %1</source>
@@ -4142,10 +4181,106 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="unfinished"/>
+        <translation>تكرار الميزة</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
+        <translation>تم تكرار الميزة بنجاح</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation>مجلد المشروع</translation>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -4161,7 +4296,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>لا يمكن إضافة ميزة فرعية: المفتاح الرئيسي للميزة الأساسية غير متاح.</translation>
+        <translation type="vanished">لا يمكن إضافة ميزة فرعية: المفتاح الرئيسي للميزة الأساسية غير متاح.</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -4182,6 +4317,10 @@ Cancel to make a minimal device scan instead.</source>
     <message>
         <source>Failed to delete referencing feature</source>
         <translation>فشل حذف الميزة المرجعية</translation>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 </TS>

--- a/i18n/qfield_bg.ts
+++ b/i18n/qfield_bg.ts
@@ -666,6 +666,29 @@ Cancel to make a minimal device scan instead.</source>
     </message>
 </context>
 <context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
     <name>FeatureListForm</name>
     <message>
         <source>Stop tracking this feature to edit attributes</source>
@@ -2109,6 +2132,14 @@ While you can still view and use the project, it is strongly recommended to rese
         <source>No changes to revert</source>
         <translation>Няма промени за отменяне</translation>
     </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>QFieldCloudProjectsModel</name>
@@ -2347,6 +2378,10 @@ While you can still view and use the project, it is strongly recommended to rese
     </message>
     <message>
         <source>Project Actions</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>, updated data available on the cloud</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -3725,7 +3760,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Не може да се добави наследник: слоят източник няма начален ключ.</translation>
+        <translation type="vanished">Не може да се добави наследник: слоят източник няма начален ключ.</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -3747,100 +3782,104 @@ Cancel to make a minimal device scan instead.</source>
         <source>Failed to delete referencing feature</source>
         <translation>Неуспешено изтриване на обект</translation>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">Активиран е режим преглед</translation>
+        <translation>Активиран е режим преглед</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">Активиран е режим на цифроване за слоя &quot;%1&quot;</translation>
+        <translation>Активиран е режим на цифроване за слоя &quot;%1&quot;</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">Активиран е режим цифроване</translation>
+        <translation>Активиран е режим цифроване</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">Активиран е режим измерване</translation>
+        <translation>Активиран е режим измерване</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">Дълж.</translation>
+        <translation>Дълж.</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">Шир.</translation>
+        <translation>Шир.</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">Сегмент</translation>
+        <translation>Сегмент</translation>
     </message>
     <message>
         <source>Perimeter</source>
-        <translation type="vanished">Периметър</translation>
+        <translation>Периметър</translation>
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">Дължина</translation>
+        <translation>Дължина</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">Площ</translation>
+        <translation>Площ</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">Прекратяване на измерването</translation>
+        <translation>Прекратяване на измерването</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">Приключване на редакцията</translation>
+        <translation>Приключване на редакцията</translation>
     </message>
     <message>
         <source>Cancel addition</source>
-        <translation type="vanished">Откажи добавянето</translation>
+        <translation>Откажи добавянето</translation>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">Включено топологично редактиране</translation>
+        <translation>Включено топологично редактиране</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">Изключено топологично редактиране</translation>
+        <translation>Изключено топологично редактиране</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">Включено свободно изчертаване</translation>
+        <translation>Включено свободно изчертаване</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">Изключено свободно изчертаване</translation>
+        <translation>Изключено свободно изчертаване</translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
-        <translation type="vanished">Индикаторът за локация е заключен</translation>
+        <translation>Индикаторът за локация е заключен</translation>
     </message>
     <message>
         <source>Coordinate cursor unlocked</source>
-        <translation type="vanished">Индикаторът за локация е отзаключен</translation>
+        <translation>Индикаторът за локация е отзаключен</translation>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">Получена позиция</translation>
+        <translation>Получена позиция</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">Търсене на позиция</translation>
+        <translation>Търсене на позиция</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">Картата следва локацията</translation>
+        <translation>Картата следва локацията</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">Очакване на локация</translation>
+        <translation>Очакване на локация</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3852,19 +3891,19 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">Картата не следва локацията</translation>
+        <translation>Картата не следва локацията</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">Неуспешно създаване на обект!</translation>
+        <translation>Неуспешно създаване на обект!</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">Неуспешен запис на обект!</translation>
+        <translation>Неуспешен запис на обект!</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">Главно меню</translation>
+        <translation>Главно меню</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3872,7 +3911,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">Създай PDF</translation>
+        <translation>Създай PDF</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3892,15 +3931,15 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">Настройки</translation>
+        <translation>Настройки</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">Съобщение</translation>
+        <translation>Съобщение</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">Относно QField</translation>
+        <translation>Относно QField</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3908,7 +3947,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Activating positioning service</source>
-        <translation type="vanished">Активиране на услугата за позициониране</translation>
+        <translation>Активиране на услугата за позициониране</translation>
     </message>
     <message>
         <source>QField has no permissions to use positioning.</source>
@@ -3916,15 +3955,15 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Map Canvas Options</source>
-        <translation type="vanished">Настройки на картния обзор</translation>
+        <translation>Настройки на картния обзор</translation>
     </message>
     <message>
         <source>Add Bookmark</source>
-        <translation type="vanished">Добави отметка</translation>
+        <translation>Добави отметка</translation>
     </message>
     <message>
         <source>Set as Destination</source>
-        <translation type="vanished">Използвай като дестинация</translation>
+        <translation>Използвай като дестинация</translation>
     </message>
     <message>
         <source>Add Bookmark at Coordinates</source>
@@ -3932,7 +3971,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Untitled bookmark</source>
-        <translation type="vanished">Неозаглавена отметка</translation>
+        <translation>Неозаглавена отметка</translation>
     </message>
     <message>
         <source>Set Coordinates as Destination</source>
@@ -3940,7 +3979,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Copy Coordinates</source>
-        <translation type="vanished">Копирай координатите</translation>
+        <translation>Копирай координатите</translation>
     </message>
     <message>
         <source>X</source>
@@ -3952,11 +3991,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Coordinates copied to clipboard</source>
-        <translation type="vanished">Координаните са копирани</translation>
+        <translation>Координаните са копирани</translation>
     </message>
     <message>
         <source>Precise View Settings</source>
-        <translation type="vanished">Настройки на прецизен изглед</translation>
+        <translation>Настройки на прецизен изглед</translation>
     </message>
     <message>
         <source>0.25m Precision</source>
@@ -3984,27 +4023,27 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Always Show Precise View</source>
-        <translation type="vanished">Винаги показвай прецизен изглед</translation>
+        <translation>Винаги показвай прецизен изглед</translation>
     </message>
     <message>
         <source>Center to Location</source>
-        <translation type="vanished">Центрирай до локацията</translation>
+        <translation>Центрирай до локацията</translation>
     </message>
     <message>
         <source>Add Bookmark at Location</source>
-        <translation type="vanished">Добави отметка на локацията</translation>
+        <translation>Добави отметка на локацията</translation>
     </message>
     <message>
         <source>Copy Location Coordinates</source>
-        <translation type="vanished">Копирай координатите на локацията</translation>
+        <translation>Копирай координатите на локацията</translation>
     </message>
     <message>
         <source>Signed out</source>
-        <translation type="vanished">Невписан</translation>
+        <translation>Невписан</translation>
     </message>
     <message>
         <source>Signed in</source>
-        <translation type="vanished">Вписан</translation>
+        <translation>Вписан</translation>
     </message>
     <message>
         <source>Set As Destination</source>
@@ -4012,35 +4051,35 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Navigation Options</source>
-        <translation type="vanished">Настройки на навигацията</translation>
+        <translation>Настройки на навигацията</translation>
     </message>
     <message>
         <source>Clear Destination</source>
-        <translation type="vanished">Изчисти дестинацията</translation>
+        <translation>Изчисти дестинацията</translation>
     </message>
     <message>
         <source>%1 Precision</source>
-        <translation type="vanished">%1 прецизност</translation>
+        <translation>%1 прецизност</translation>
     </message>
     <message>
         <source>Enable Audio Proximity Feedback</source>
-        <translation type="vanished">Разрешаване на звуков сигнал при приближаване</translation>
+        <translation>Разрешаване на звуков сигнал при приближаване</translation>
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">Настройки на позиционирането</translation>
+        <translation>Настройки на позиционирането</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">Включи позициониране</translation>
+        <translation>Включи позициониране</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">Показвай информация за позицията</translation>
+        <translation>Показвай информация за позицията</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">Настройки на позиционирането</translation>
+        <translation>Настройки на позиционирането</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4052,11 +4091,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Current location unknown</source>
-        <translation type="vanished">Текущата локация е неизвестна</translation>
+        <translation>Текущата локация е неизвестна</translation>
     </message>
     <message>
         <source>My location</source>
-        <translation type="vanished">Моята локация</translation>
+        <translation>Моята локация</translation>
     </message>
     <message>
         <source>Copy Current Location</source>
@@ -4064,27 +4103,27 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">Точност</translation>
+        <translation>Точност</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">N/A</translation>
+        <translation>N/A</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
-        <translation type="vanished">Текущата локация е копирана</translation>
+        <translation>Текущата локация е копирана</translation>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
-        <translation type="vanished">Текущият слой е превключен към слоя, който съдържа избрания обект.</translation>
+        <translation>Текущият слой е превключен към слоя, който съдържа избрания обект.</translation>
     </message>
     <message>
         <source>Editing of multi geometry layer is not supported yet.</source>
-        <translation type="vanished">Промяна на слоеве със сложна (мулти) геометрия все още не се поддържа.</translation>
+        <translation>Промяна на слоеве със сложна (мулти) геометрия все още не се поддържа.</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">Зареждане на %1</translation>
+        <translation>Зареждане на %1</translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4092,7 +4131,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">Свързване...</translation>
+        <translation>Свързване...</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4100,23 +4139,23 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">Неуспешно изтегляне на проект %1</translation>
+        <translation>Неуспешно изтегляне на проект %1</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
-        <translation type="vanished">Проект %1 е успешно изтеглен и вече е наличен за отваряне</translation>
+        <translation>Проект %1 е успешно изтеглен и вече е наличен за отваряне</translation>
     </message>
     <message>
         <source>Changes failed to reach QFieldCloud: %1</source>
-        <translation type="vanished">Промените не са качени в QFieldCloud: %1</translation>
+        <translation>Промените не са качени в QFieldCloud: %1</translation>
     </message>
     <message>
         <source>Changes successfully pushed to QFieldCloud</source>
-        <translation type="vanished">Промениса са успешно качени в QFieldCloud</translation>
+        <translation>Промениса са успешно качени в QFieldCloud</translation>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">Натисни назад отново за затваряне на проекта и приложението</translation>
+        <translation>Натисни назад отново за затваряне на проекта и приложението</translation>
     </message>
     <message>
         <source>Positioning error: %1</source>
@@ -4124,11 +4163,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Azimuth</source>
-        <translation type="vanished">Азимут</translation>
+        <translation>Азимут</translation>
     </message>
     <message>
         <source>Lock Screen</source>
-        <translation type="vanished">Заключи екрана</translation>
+        <translation>Заключи екрана</translation>
     </message>
     <message>
         <source>Print to Image</source>
@@ -4148,10 +4187,106 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="unfinished"/>
+        <translation>Копирай обекта</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
+        <translation>Успешно копиран обект</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation>Директория на проекта</translation>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -4167,7 +4302,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Не може да се добави наследник: слоят източник няма начален ключ.</translation>
+        <translation type="vanished">Не може да се добави наследник: слоят източник няма начален ключ.</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -4188,6 +4323,10 @@ Cancel to make a minimal device scan instead.</source>
     <message>
         <source>Failed to delete referencing feature</source>
         <translation>Неуспешено изтриване на обект</translation>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 </TS>

--- a/i18n/qfield_bs.ts
+++ b/i18n/qfield_bs.ts
@@ -665,6 +665,29 @@ Cancel to make a minimal device scan instead.</source>
     </message>
 </context>
 <context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
     <name>FeatureListForm</name>
     <message>
         <source>Stop tracking this feature to edit attributes</source>
@@ -2110,6 +2133,14 @@ Iako i dalje možete pregledati i koristiti ovaj projekat, strogo je preporučiv
         <source>No changes to revert</source>
         <translation>Nema promjena za vraćanje</translation>
     </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>QFieldCloudProjectsModel</name>
@@ -2346,6 +2377,10 @@ Iako i dalje možete pregledati i koristiti ovaj projekat, strogo je preporučiv
     </message>
     <message>
         <source>Project Actions</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>, updated data available on the cloud</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -3723,7 +3758,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Nije moguće dodati objekat &quot;dijete&quot;: nije dostupan primarni ključ &quot;roditelja&quot;</translation>
+        <translation type="vanished">Nije moguće dodati objekat &quot;dijete&quot;: nije dostupan primarni ključ &quot;roditelja&quot;</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -3745,36 +3780,40 @@ Cancel to make a minimal device scan instead.</source>
         <source>Failed to delete referencing feature</source>
         <translation>Nije uspjelo brisanje referentnog objekta</translation>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">Sada ste u modu za pregledavanje</translation>
+        <translation>Sada ste u modu za pregledavanje</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">Sada ste u modu za digitalizaciju na sloju %1</translation>
+        <translation>Sada ste u modu za digitalizaciju na sloju %1</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">Sada ste u modu za digitalizaciju</translation>
+        <translation>Sada ste u modu za digitalizaciju</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">Sada ste u modu mjerenja</translation>
+        <translation>Sada ste u modu mjerenja</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">Lon</translation>
+        <translation>Lon</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">Lat</translation>
+        <translation>Lat</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">Segment</translation>
+        <translation>Segment</translation>
     </message>
     <message>
         <source>Perimeter</source>
@@ -3782,63 +3821,63 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">Dužina</translation>
+        <translation>Dužina</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">Površina</translation>
+        <translation>Površina</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">Zatvori alat za mjerenje</translation>
+        <translation>Zatvori alat za mjerenje</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">Zaustavi editovanje</translation>
+        <translation>Zaustavi editovanje</translation>
     </message>
     <message>
         <source>Cancel addition</source>
-        <translation type="vanished">Otkaži dodavanje</translation>
+        <translation>Otkaži dodavanje</translation>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">Topološko editovanje je uključeno</translation>
+        <translation>Topološko editovanje je uključeno</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">Topološko editovanje je isključeno</translation>
+        <translation>Topološko editovanje je isključeno</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">Uključena digitalizacija slobodnom rukom</translation>
+        <translation>Uključena digitalizacija slobodnom rukom</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">Isključena digitalizacija slobodnom rukom</translation>
+        <translation>Isključena digitalizacija slobodnom rukom</translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
-        <translation type="vanished">Koordinate kursora su sada zaključane za lokaciju</translation>
+        <translation>Koordinate kursora su sada zaključane za lokaciju</translation>
     </message>
     <message>
         <source>Coordinate cursor unlocked</source>
-        <translation type="vanished">Koordinate kursora otključane</translation>
+        <translation>Koordinate kursora otključane</translation>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">Primjena lokacija</translation>
+        <translation>Primjena lokacija</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">Traženje lokacije</translation>
+        <translation>Traženje lokacije</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">Kanvas prati lokaciju</translation>
+        <translation>Kanvas prati lokaciju</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">Čekanje lokacije</translation>
+        <translation>Čekanje lokacije</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3850,19 +3889,19 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">Kanvas je prestao pratiti lokaciju</translation>
+        <translation>Kanvas je prestao pratiti lokaciju</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">Nije uspjelo kreiranje objekta!</translation>
+        <translation>Nije uspjelo kreiranje objekta!</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">Nije uspjelo snimanje objekta!</translation>
+        <translation>Nije uspjelo snimanje objekta!</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">Glavni meni</translation>
+        <translation>Glavni meni</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3870,7 +3909,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">Štampa u PDF</translation>
+        <translation>Štampa u PDF</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3890,15 +3929,15 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">Postavke</translation>
+        <translation>Postavke</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">Log poruka</translation>
+        <translation>Log poruka</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">O aplikaciji QField</translation>
+        <translation>O aplikaciji QField</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3906,7 +3945,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Activating positioning service</source>
-        <translation type="vanished">Aktiviranje usluge lociranja</translation>
+        <translation>Aktiviranje usluge lociranja</translation>
     </message>
     <message>
         <source>QField has no permissions to use positioning.</source>
@@ -3914,7 +3953,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Map Canvas Options</source>
-        <translation type="vanished">Opcije okvira karte</translation>
+        <translation>Opcije okvira karte</translation>
     </message>
     <message>
         <source>Add Bookmark</source>
@@ -3930,7 +3969,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Untitled bookmark</source>
-        <translation type="vanished">Neimenovana zabilješka</translation>
+        <translation>Neimenovana zabilješka</translation>
     </message>
     <message>
         <source>Set Coordinates as Destination</source>
@@ -3938,7 +3977,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Copy Coordinates</source>
-        <translation type="vanished">Kopiraj koodinate</translation>
+        <translation>Kopiraj koodinate</translation>
     </message>
     <message>
         <source>X</source>
@@ -3950,7 +3989,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Coordinates copied to clipboard</source>
-        <translation type="vanished">Koorinate kopirane u međumemoriju</translation>
+        <translation>Koorinate kopirane u međumemoriju</translation>
     </message>
     <message>
         <source>Precise View Settings</source>
@@ -4010,11 +4049,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Navigation Options</source>
-        <translation type="vanished">Opcije navigacije</translation>
+        <translation>Opcije navigacije</translation>
     </message>
     <message>
         <source>Clear Destination</source>
-        <translation type="vanished">Očisti destinaciju</translation>
+        <translation>Očisti destinaciju</translation>
     </message>
     <message>
         <source>%1 Precision</source>
@@ -4026,19 +4065,19 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">Opcije lociranja</translation>
+        <translation>Opcije lociranja</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">Omogući lociranje</translation>
+        <translation>Omogući lociranje</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">Prikaži informacije o lokaciji</translation>
+        <translation>Prikaži informacije o lokaciji</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">Postavke lociranja</translation>
+        <translation>Postavke lociranja</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4050,11 +4089,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Current location unknown</source>
-        <translation type="vanished">Nepoznata trenutna lokacija</translation>
+        <translation>Nepoznata trenutna lokacija</translation>
     </message>
     <message>
         <source>My location</source>
-        <translation type="vanished">Moja lokacija</translation>
+        <translation>Moja lokacija</translation>
     </message>
     <message>
         <source>Copy Current Location</source>
@@ -4062,27 +4101,27 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">Tačnost</translation>
+        <translation>Tačnost</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">Nije dostupno</translation>
+        <translation>Nije dostupno</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
-        <translation type="vanished">Trenutna lokacija kopirana u međumemoriju</translation>
+        <translation>Trenutna lokacija kopirana u međumemoriju</translation>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
-        <translation type="vanished">Trenutni sloj promijenjen na onaj koji sadrži selektovanu geometriju.</translation>
+        <translation>Trenutni sloj promijenjen na onaj koji sadrži selektovanu geometriju.</translation>
     </message>
     <message>
         <source>Editing of multi geometry layer is not supported yet.</source>
-        <translation type="vanished">Editovanje sloja sa višestrukom geometrijom još nije podržano</translation>
+        <translation>Editovanje sloja sa višestrukom geometrijom još nije podržano</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">Učitavanje %1</translation>
+        <translation>Učitavanje %1</translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4090,7 +4129,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">Povezivanje...</translation>
+        <translation>Povezivanje...</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4098,23 +4137,23 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">Projekat %1 nije skinut</translation>
+        <translation>Projekat %1 nije skinut</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
-        <translation type="vanished">Projekat %1 je uspješno skinut, sada je dostupan za otvaranje</translation>
+        <translation>Projekat %1 je uspješno skinut, sada je dostupan za otvaranje</translation>
     </message>
     <message>
         <source>Changes failed to reach QFieldCloud: %1</source>
-        <translation type="vanished">Promjene nisu došle do QFieldCloud: %1</translation>
+        <translation>Promjene nisu došle do QFieldCloud: %1</translation>
     </message>
     <message>
         <source>Changes successfully pushed to QFieldCloud</source>
-        <translation type="vanished">Promjene uspješno poslane na QFieldCloud</translation>
+        <translation>Promjene uspješno poslane na QFieldCloud</translation>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">Kliknite nazad da zatvorite projekat i aplikaciju</translation>
+        <translation>Kliknite nazad da zatvorite projekat i aplikaciju</translation>
     </message>
     <message>
         <source>Positioning error: %1</source>
@@ -4146,10 +4185,106 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="unfinished"/>
+        <translation>Dupliciraj objekat</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
+        <translation>Uspješno dupliciranje objekta</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -4165,7 +4300,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Nije moguće dodati objekat &quot;dijete&quot;: nije dostupan primarni ključ &quot;roditelja&quot;</translation>
+        <translation type="vanished">Nije moguće dodati objekat &quot;dijete&quot;: nije dostupan primarni ključ &quot;roditelja&quot;</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -4186,6 +4321,10 @@ Cancel to make a minimal device scan instead.</source>
     <message>
         <source>Failed to delete referencing feature</source>
         <translation>Nije uspjelo brisanje referentnog objekta</translation>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 </TS>

--- a/i18n/qfield_cs.ts
+++ b/i18n/qfield_cs.ts
@@ -666,6 +666,29 @@ Zrušte pro jen minimální skenování zařízení. </translation>
     </message>
 </context>
 <context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
     <name>FeatureListForm</name>
     <message>
         <source>Stop tracking this feature to edit attributes</source>
@@ -2112,6 +2135,14 @@ Projekt sice můžete stále prohlížet a používat, ale důrazně doporučuje
         <source>No changes to revert</source>
         <translation>Žádné změny k vrácení</translation>
     </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation>Tento projekt má aktualizovaný projektový soubor v cloudu, doporučuje se synchronizovat.</translation>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation>Tento projekt má aktualizovaná data v cloudu, měli byste synchronizovat.</translation>
+    </message>
 </context>
 <context>
     <name>QFieldCloudProjectsModel</name>
@@ -2165,7 +2196,7 @@ Projekt sice můžete stále prohlížet a používat, ale důrazně doporučuje
     </message>
     <message>
         <source>Getting job status finished, but the project is deleted.</source>
-        <translation type="unfinished"/>
+        <translation>Dokončeno získání stavu úlohy, ale projekt byl smazán.</translation>
     </message>
     <message>
         <source>job(%1) status response does not contain all the expected keys: status(string)</source>
@@ -2177,7 +2208,7 @@ Projekt sice můžete stále prohlížet a používat, ale důrazně doporučuje
     </message>
     <message>
         <source>Project busy.</source>
-        <translation type="unfinished"/>
+        <translation>Projekt je zaneprázdněný.</translation>
     </message>
     <message>
         <source>Packaging job finished unsuccessfully for `%1`. %2</source>
@@ -2348,6 +2379,10 @@ Projekt sice můžete stále prohlížet a používat, ale důrazně doporučuje
     </message>
     <message>
         <source>Project Actions</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>, updated data available on the cloud</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -3726,7 +3761,7 @@ Zrušte pro jen minimální skenování zařízení. </translation>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Nelze přidat podřízený prvek: základní primární klíče nejsou k dispozici.</translation>
+        <translation type="vanished">Nelze přidat podřízený prvek: základní primární klíče nejsou k dispozici.</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -3748,100 +3783,104 @@ Zrušte pro jen minimální skenování zařízení. </translation>
         <source>Failed to delete referencing feature</source>
         <translation>Smazání referenčního prvku se nezdařilo</translation>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">Nyní jste v režimu procházení</translation>
+        <translation>Nyní jste v režimu procházení</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">Nyní jste v režimu digitalizace ve vrstvě %1</translation>
+        <translation>Nyní jste v režimu digitalizace ve vrstvě %1</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">Nyní jste v digitalizačním režimu</translation>
+        <translation>Nyní jste v digitalizačním režimu</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">Nyní jste v režimu měření</translation>
+        <translation>Nyní jste v režimu měření</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">Zem. dél.</translation>
+        <translation>Zem. dél.</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">Zem. šíř.</translation>
+        <translation>Zem. šíř.</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">Segment</translation>
+        <translation>Segment</translation>
     </message>
     <message>
         <source>Perimeter</source>
-        <translation type="vanished">Obvod</translation>
+        <translation>Obvod</translation>
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">Délka</translation>
+        <translation>Délka</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">Výměra</translation>
+        <translation>Výměra</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">Zavřít nástroj měření</translation>
+        <translation>Zavřít nástroj měření</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">Zastavit úpravy</translation>
+        <translation>Zastavit úpravy</translation>
     </message>
     <message>
         <source>Cancel addition</source>
-        <translation type="vanished">Zrušit přidávání</translation>
+        <translation>Zrušit přidávání</translation>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">Byla zapnuta topologická úprava</translation>
+        <translation>Byla zapnuta topologická úprava</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">Byla vypnuta topologická úprava</translation>
+        <translation>Byla vypnuta topologická úprava</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">Zapnutá ruční digitalizace</translation>
+        <translation>Zapnutá ruční digitalizace</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">Vypnutá digitalizace od ruky</translation>
+        <translation>Vypnutá digitalizace od ruky</translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
-        <translation type="vanished">Souřadnicový kurzor je nyní přichycen na polohu</translation>
+        <translation>Souřadnicový kurzor je nyní přichycen na polohu</translation>
     </message>
     <message>
         <source>Coordinate cursor unlocked</source>
-        <translation type="vanished">Souřadnicový kurzor není přichycen</translation>
+        <translation>Souřadnicový kurzor není přichycen</translation>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">Získávání polohy</translation>
+        <translation>Získávání polohy</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">Získávání polohy</translation>
+        <translation>Získávání polohy</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">Čekání na určení polohy...</translation>
+        <translation>Čekání na určení polohy...</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">Čekání na určení polohy</translation>
+        <translation>Čekání na určení polohy</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3853,19 +3892,19 @@ Zrušte pro jen minimální skenování zařízení. </translation>
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">Canvas stopped following location</translation>
+        <translation>Canvas stopped following location</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">Nepodařilo se vytvořit prvek!</translation>
+        <translation>Nepodařilo se vytvořit prvek!</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">Nepodařilo se uložit prvek!</translation>
+        <translation>Nepodařilo se uložit prvek!</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">Hlavní menu</translation>
+        <translation>Hlavní menu</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3873,7 +3912,7 @@ Zrušte pro jen minimální skenování zařízení. </translation>
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">Tisk do PDF</translation>
+        <translation>Tisk do PDF</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3893,15 +3932,15 @@ Zrušte pro jen minimální skenování zařízení. </translation>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">Nastavení</translation>
+        <translation>Nastavení</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">Výpis zpráv</translation>
+        <translation>Výpis zpráv</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">O QField</translation>
+        <translation>O QField</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3909,7 +3948,7 @@ Zrušte pro jen minimální skenování zařízení. </translation>
     </message>
     <message>
         <source>Activating positioning service</source>
-        <translation type="vanished">Aktivace služby určování polohy</translation>
+        <translation>Aktivace služby určování polohy</translation>
     </message>
     <message>
         <source>QField has no permissions to use positioning.</source>
@@ -3917,15 +3956,15 @@ Zrušte pro jen minimální skenování zařízení. </translation>
     </message>
     <message>
         <source>Map Canvas Options</source>
-        <translation type="vanished">Volby výřezu mapy</translation>
+        <translation>Volby výřezu mapy</translation>
     </message>
     <message>
         <source>Add Bookmark</source>
-        <translation type="vanished">Přidat záložku</translation>
+        <translation>Přidat záložku</translation>
     </message>
     <message>
         <source>Set as Destination</source>
-        <translation type="vanished">Nastavit jako cíl</translation>
+        <translation>Nastavit jako cíl</translation>
     </message>
     <message>
         <source>Add Bookmark at Coordinates</source>
@@ -3933,7 +3972,7 @@ Zrušte pro jen minimální skenování zařízení. </translation>
     </message>
     <message>
         <source>Untitled bookmark</source>
-        <translation type="vanished">Bezejmenná záložka</translation>
+        <translation>Bezejmenná záložka</translation>
     </message>
     <message>
         <source>Set Coordinates as Destination</source>
@@ -3941,7 +3980,7 @@ Zrušte pro jen minimální skenování zařízení. </translation>
     </message>
     <message>
         <source>Copy Coordinates</source>
-        <translation type="vanished">Kopírovat souřadnice</translation>
+        <translation>Kopírovat souřadnice</translation>
     </message>
     <message>
         <source>X</source>
@@ -3953,11 +3992,11 @@ Zrušte pro jen minimální skenování zařízení. </translation>
     </message>
     <message>
         <source>Coordinates copied to clipboard</source>
-        <translation type="vanished">Souřadnice byly zkopírovány do schránky</translation>
+        <translation>Souřadnice byly zkopírovány do schránky</translation>
     </message>
     <message>
         <source>Precise View Settings</source>
-        <translation type="vanished">Nastavení přesného pohledu</translation>
+        <translation>Nastavení přesného pohledu</translation>
     </message>
     <message>
         <source>0.25m Precision</source>
@@ -3985,27 +4024,27 @@ Zrušte pro jen minimální skenování zařízení. </translation>
     </message>
     <message>
         <source>Always Show Precise View</source>
-        <translation type="vanished">Vždy zobrazovat přesný pohled</translation>
+        <translation>Vždy zobrazovat přesný pohled</translation>
     </message>
     <message>
         <source>Center to Location</source>
-        <translation type="vanished">Vycentrovat na polohu</translation>
+        <translation>Vycentrovat na polohu</translation>
     </message>
     <message>
         <source>Add Bookmark at Location</source>
-        <translation type="vanished">Přidat záložku na polohu</translation>
+        <translation>Přidat záložku na polohu</translation>
     </message>
     <message>
         <source>Copy Location Coordinates</source>
-        <translation type="vanished">Kopírovat souřadnice polohy</translation>
+        <translation>Kopírovat souřadnice polohy</translation>
     </message>
     <message>
         <source>Signed out</source>
-        <translation type="vanished">Odhlášeno</translation>
+        <translation>Odhlášeno</translation>
     </message>
     <message>
         <source>Signed in</source>
-        <translation type="vanished">Přihlášeno</translation>
+        <translation>Přihlášeno</translation>
     </message>
     <message>
         <source>Set As Destination</source>
@@ -4013,35 +4052,35 @@ Zrušte pro jen minimální skenování zařízení. </translation>
     </message>
     <message>
         <source>Navigation Options</source>
-        <translation type="vanished">Volby pro navigaci</translation>
+        <translation>Volby pro navigaci</translation>
     </message>
     <message>
         <source>Clear Destination</source>
-        <translation type="vanished">Vymazat cíl</translation>
+        <translation>Vymazat cíl</translation>
     </message>
     <message>
         <source>%1 Precision</source>
-        <translation type="vanished">Přesnost %1</translation>
+        <translation>Přesnost %1</translation>
     </message>
     <message>
         <source>Enable Audio Proximity Feedback</source>
-        <translation type="vanished">Zapnout zvukovou zpětnou vazbu blízkosti</translation>
+        <translation>Zapnout zvukovou zpětnou vazbu blízkosti</translation>
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">Volby pro určování polohy</translation>
+        <translation>Volby pro určování polohy</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">Povolit polohu</translation>
+        <translation>Povolit polohu</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">Zobrazit informaci o poloze</translation>
+        <translation>Zobrazit informaci o poloze</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">Nastavení polohy</translation>
+        <translation>Nastavení polohy</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4053,11 +4092,11 @@ Zrušte pro jen minimální skenování zařízení. </translation>
     </message>
     <message>
         <source>Current location unknown</source>
-        <translation type="vanished">Aktuální poloha není známa</translation>
+        <translation>Aktuální poloha není známa</translation>
     </message>
     <message>
         <source>My location</source>
-        <translation type="vanished">Moje poloha</translation>
+        <translation>Moje poloha</translation>
     </message>
     <message>
         <source>Copy Current Location</source>
@@ -4065,27 +4104,27 @@ Zrušte pro jen minimální skenování zařízení. </translation>
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">Přesnost</translation>
+        <translation>Přesnost</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">N/A</translation>
+        <translation>N/A</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
-        <translation type="vanished">Aktuální poloha zkopírována do schránky</translation>
+        <translation>Aktuální poloha zkopírována do schránky</translation>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
-        <translation type="vanished">Aktuální vrstva byla přepnuta na vrstvu, která má vybranou geometrii.</translation>
+        <translation>Aktuální vrstva byla přepnuta na vrstvu, která má vybranou geometrii.</translation>
     </message>
     <message>
         <source>Editing of multi geometry layer is not supported yet.</source>
-        <translation type="vanished">Úpravy vrstvy s multi-geometrií zatím nejsou podporovány.</translation>
+        <translation>Úpravy vrstvy s multi-geometrií zatím nejsou podporovány.</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">Nahrávám %1</translation>
+        <translation>Nahrávám %1</translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4093,7 +4132,7 @@ Zrušte pro jen minimální skenování zařízení. </translation>
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">Připojuji se...</translation>
+        <translation>Připojuji se...</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4101,23 +4140,23 @@ Zrušte pro jen minimální skenování zařízení. </translation>
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">Projekt %1 se nepodařilo stáhnout</translation>
+        <translation>Projekt %1 se nepodařilo stáhnout</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
-        <translation type="vanished">Projekt %1 byl úspěšně stáhnut, nyní je možné ho otevřít</translation>
+        <translation>Projekt %1 byl úspěšně stáhnut, nyní je možné ho otevřít</translation>
     </message>
     <message>
         <source>Changes failed to reach QFieldCloud: %1</source>
-        <translation type="vanished">Nepodařilo se přenést změny na QFieldCloud: %1</translation>
+        <translation>Nepodařilo se přenést změny na QFieldCloud: %1</translation>
     </message>
     <message>
         <source>Changes successfully pushed to QFieldCloud</source>
-        <translation type="vanished">Změny byly úspěšně přeneseny na QFieldCloud</translation>
+        <translation>Změny byly úspěšně přeneseny na QFieldCloud</translation>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">Opětovným stisknutím tlačítka zavřete projekt a aplikaci</translation>
+        <translation>Opětovným stisknutím tlačítka zavřete projekt a aplikaci</translation>
     </message>
     <message>
         <source>Positioning error: %1</source>
@@ -4125,11 +4164,11 @@ Zrušte pro jen minimální skenování zařízení. </translation>
     </message>
     <message>
         <source>Azimuth</source>
-        <translation type="vanished">Azimut</translation>
+        <translation>Azimut</translation>
     </message>
     <message>
         <source>Lock Screen</source>
-        <translation type="vanished">Uzamknout obrazovku</translation>
+        <translation>Uzamknout obrazovku</translation>
     </message>
     <message>
         <source>Print to Image</source>
@@ -4137,22 +4176,118 @@ Zrušte pro jen minimální skenování zařízení. </translation>
     </message>
     <message>
         <source>Printing...</source>
-        <translation type="vanished">Tisknu...</translation>
+        <translation>Tisknu...</translation>
     </message>
     <message>
         <source>Print</source>
-        <translation type="vanished">Vytisknout</translation>
+        <translation>Vytisknout</translation>
     </message>
     <message>
         <source>Positioning device error: %1</source>
-        <translation type="vanished">Chyba polohovacího zařízení: %1</translation>
+        <translation>Chyba polohovacího zařízení: %1</translation>
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="unfinished"/>
+        <translation>Duplikovat prvek</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
+        <translation>Prvek úspěšně zduplikován</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation>Více informací</translation>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation>Složka projektu</translation>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation>Import URL selhal</translation>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -4168,7 +4303,7 @@ Zrušte pro jen minimální skenování zařízení. </translation>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Nelze přidat podřízený prvek: základní primární klíče nejsou k dispozici.</translation>
+        <translation type="vanished">Nelze přidat podřízený prvek: základní primární klíče nejsou k dispozici.</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -4189,6 +4324,10 @@ Zrušte pro jen minimální skenování zařízení. </translation>
     <message>
         <source>Failed to delete referencing feature</source>
         <translation>Smazání referenčního prvku se nezdařilo</translation>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 </TS>

--- a/i18n/qfield_de.ts
+++ b/i18n/qfield_de.ts
@@ -666,6 +666,29 @@ Abbrechen um einen minimalen Scan durchzuführen. </translation>
     </message>
 </context>
 <context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
     <name>FeatureListForm</name>
     <message>
         <source>Stop tracking this feature to edit attributes</source>
@@ -2106,6 +2129,14 @@ While you can still view and use the project, it is strongly recommended to rese
         <source>No changes to revert</source>
         <translation>Keine Änderungen zum Zurücksetzen vorhanden</translation>
     </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>QFieldCloudProjectsModel</name>
@@ -2340,6 +2371,10 @@ While you can still view and use the project, it is strongly recommended to rese
     </message>
     <message>
         <source>Project Actions</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>, updated data available on the cloud</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -3740,100 +3775,104 @@ Abbrechen um einen minimalen Scan durchzuführen. </translation>
         <source>Failed to delete referencing feature</source>
         <translation>Referenziertes Feature konnte nicht gelöscht werden</translation>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">Navigationsmodus aktiv</translation>
+        <translation>Navigationsmodus aktiv</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">Digitalisierungsmodus für Layer %1 aktiv</translation>
+        <translation>Digitalisierungsmodus für Layer %1 aktiv</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">Digitalisierungs - Modus aktiviert</translation>
+        <translation>Digitalisierungs - Modus aktiviert</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">Bemaßungs - Modus aktiviert</translation>
+        <translation>Bemaßungs - Modus aktiviert</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">Länge</translation>
+        <translation>Länge</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">Breite</translation>
+        <translation>Breite</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">Segment</translation>
+        <translation>Segment</translation>
     </message>
     <message>
         <source>Perimeter</source>
-        <translation type="vanished">Umfang</translation>
+        <translation>Umfang</translation>
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">Länge</translation>
+        <translation>Länge</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">Fläche</translation>
+        <translation>Fläche</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">Messwerkzeug schliessen</translation>
+        <translation>Messwerkzeug schliessen</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">Bearbeitung beenden</translation>
+        <translation>Bearbeitung beenden</translation>
     </message>
     <message>
         <source>Cancel addition</source>
-        <translation type="vanished">Hinzufügen abbrechen</translation>
+        <translation>Hinzufügen abbrechen</translation>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">Topologische Bearbeitung eingeschaltet</translation>
+        <translation>Topologische Bearbeitung eingeschaltet</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">Topologische Bearbeitung ausgeschaltet</translation>
+        <translation>Topologische Bearbeitung ausgeschaltet</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">Freihand-Digitalisierung angeschaltet</translation>
+        <translation>Freihand-Digitalisierung angeschaltet</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">Freihand Digitalisierung abgeschaltet</translation>
+        <translation>Freihand Digitalisierung abgeschaltet</translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
-        <translation type="vanished">Cursor an aktueller Position fixiert</translation>
+        <translation>Cursor an aktueller Position fixiert</translation>
     </message>
     <message>
         <source>Coordinate cursor unlocked</source>
-        <translation type="vanished">Cursor wieder freigegeben</translation>
+        <translation>Cursor wieder freigegeben</translation>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">Position empfangen</translation>
+        <translation>Position empfangen</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">Suche Position...</translation>
+        <translation>Suche Position...</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">Kartenausschnitt folgt dem Standort</translation>
+        <translation>Kartenausschnitt folgt dem Standort</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">Warten auf Standort</translation>
+        <translation>Warten auf Standort</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3845,19 +3884,19 @@ Abbrechen um einen minimalen Scan durchzuführen. </translation>
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">Kartenausschnitt folgt nicht mehr dem Standort</translation>
+        <translation>Kartenausschnitt folgt nicht mehr dem Standort</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">Feature konnte nicht erstellt werden!</translation>
+        <translation>Feature konnte nicht erstellt werden!</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">Feature konnte nicht gespeichert werden!</translation>
+        <translation>Feature konnte nicht gespeichert werden!</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">Hauptmenü</translation>
+        <translation>Hauptmenü</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3865,7 +3904,7 @@ Abbrechen um einen minimalen Scan durchzuführen. </translation>
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">Als PDF drucken</translation>
+        <translation>Als PDF drucken</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3885,15 +3924,15 @@ Abbrechen um einen minimalen Scan durchzuführen. </translation>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">Einstellungen</translation>
+        <translation>Einstellungen</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">Nachrichtenprotokoll</translation>
+        <translation>Nachrichtenprotokoll</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">Über QField</translation>
+        <translation>Über QField</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3901,7 +3940,7 @@ Abbrechen um einen minimalen Scan durchzuführen. </translation>
     </message>
     <message>
         <source>Activating positioning service</source>
-        <translation type="vanished">Positionierung wird gestartet...</translation>
+        <translation>Positionierung wird gestartet...</translation>
     </message>
     <message>
         <source>QField has no permissions to use positioning.</source>
@@ -3909,15 +3948,15 @@ Abbrechen um einen minimalen Scan durchzuführen. </translation>
     </message>
     <message>
         <source>Map Canvas Options</source>
-        <translation type="vanished">Kartenbildoption</translation>
+        <translation>Kartenbildoption</translation>
     </message>
     <message>
         <source>Add Bookmark</source>
-        <translation type="vanished">Lesezeichen hinzufügen</translation>
+        <translation>Lesezeichen hinzufügen</translation>
     </message>
     <message>
         <source>Set as Destination</source>
-        <translation type="vanished">Als Ziel auswählen</translation>
+        <translation>Als Ziel auswählen</translation>
     </message>
     <message>
         <source>Add Bookmark at Coordinates</source>
@@ -3925,7 +3964,7 @@ Abbrechen um einen minimalen Scan durchzuführen. </translation>
     </message>
     <message>
         <source>Untitled bookmark</source>
-        <translation type="vanished">Unbenanntes Lesezeichen</translation>
+        <translation>Unbenanntes Lesezeichen</translation>
     </message>
     <message>
         <source>Set Coordinates as Destination</source>
@@ -3933,7 +3972,7 @@ Abbrechen um einen minimalen Scan durchzuführen. </translation>
     </message>
     <message>
         <source>Copy Coordinates</source>
-        <translation type="vanished">Kopiere Koordinaten</translation>
+        <translation>Kopiere Koordinaten</translation>
     </message>
     <message>
         <source>X</source>
@@ -3945,7 +3984,7 @@ Abbrechen um einen minimalen Scan durchzuführen. </translation>
     </message>
     <message>
         <source>Coordinates copied to clipboard</source>
-        <translation type="vanished">Koordinaten in die Zwischenablage kopiert</translation>
+        <translation>Koordinaten in die Zwischenablage kopiert</translation>
     </message>
     <message>
         <source>Precise View Settings</source>
@@ -3977,27 +4016,27 @@ Abbrechen um einen minimalen Scan durchzuführen. </translation>
     </message>
     <message>
         <source>Always Show Precise View</source>
-        <translation type="vanished">Immer präzise Ansicht anzeigen</translation>
+        <translation>Immer präzise Ansicht anzeigen</translation>
     </message>
     <message>
         <source>Center to Location</source>
-        <translation type="vanished">Zentriere auf Standort</translation>
+        <translation>Zentriere auf Standort</translation>
     </message>
     <message>
         <source>Add Bookmark at Location</source>
-        <translation type="vanished">Lesezeichen an Standort hinzufügen</translation>
+        <translation>Lesezeichen an Standort hinzufügen</translation>
     </message>
     <message>
         <source>Copy Location Coordinates</source>
-        <translation type="vanished">Kopiere Ortskoordinaten</translation>
+        <translation>Kopiere Ortskoordinaten</translation>
     </message>
     <message>
         <source>Signed out</source>
-        <translation type="vanished">Abgemeldet</translation>
+        <translation>Abgemeldet</translation>
     </message>
     <message>
         <source>Signed in</source>
-        <translation type="vanished">Angemeldet</translation>
+        <translation>Angemeldet</translation>
     </message>
     <message>
         <source>Set As Destination</source>
@@ -4005,15 +4044,15 @@ Abbrechen um einen minimalen Scan durchzuführen. </translation>
     </message>
     <message>
         <source>Navigation Options</source>
-        <translation type="vanished">Navigationsmöglichkeiten</translation>
+        <translation>Navigationsmöglichkeiten</translation>
     </message>
     <message>
         <source>Clear Destination</source>
-        <translation type="vanished">Lösche Zielpunkt</translation>
+        <translation>Lösche Zielpunkt</translation>
     </message>
     <message>
         <source>%1 Precision</source>
-        <translation type="vanished">%1 Genauigkeit</translation>
+        <translation>%1 Genauigkeit</translation>
     </message>
     <message>
         <source>Enable Audio Proximity Feedback</source>
@@ -4021,19 +4060,19 @@ Abbrechen um einen minimalen Scan durchzuführen. </translation>
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">Positionierungsoptionen</translation>
+        <translation>Positionierungsoptionen</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">Positionierung einschalten</translation>
+        <translation>Positionierung einschalten</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">Postionsinformation anzeigen</translation>
+        <translation>Postionsinformation anzeigen</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">Positionierungs-Einstellungen</translation>
+        <translation>Positionierungs-Einstellungen</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4045,11 +4084,11 @@ Abbrechen um einen minimalen Scan durchzuführen. </translation>
     </message>
     <message>
         <source>Current location unknown</source>
-        <translation type="vanished">Aktuelle Position unbekannt</translation>
+        <translation>Aktuelle Position unbekannt</translation>
     </message>
     <message>
         <source>My location</source>
-        <translation type="vanished">Mein Standort</translation>
+        <translation>Mein Standort</translation>
     </message>
     <message>
         <source>Copy Current Location</source>
@@ -4057,27 +4096,27 @@ Abbrechen um einen minimalen Scan durchzuführen. </translation>
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">Genauigkeit</translation>
+        <translation>Genauigkeit</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">N. a.</translation>
+        <translation>N. a.</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
-        <translation type="vanished">Aktuelle Position in die Zwischenablage kopiert</translation>
+        <translation>Aktuelle Position in die Zwischenablage kopiert</translation>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
-        <translation type="vanished">Der aktuelle Layer wechselte zu dem Layer, der die ausgewählte Geometrie enthält.</translation>
+        <translation>Der aktuelle Layer wechselte zu dem Layer, der die ausgewählte Geometrie enthält.</translation>
     </message>
     <message>
         <source>Editing of multi geometry layer is not supported yet.</source>
-        <translation type="vanished">Das Editieren von mehrteiligen Geometrien wird noch nicht unterstützt.</translation>
+        <translation>Das Editieren von mehrteiligen Geometrien wird noch nicht unterstützt.</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">Lade %1</translation>
+        <translation>Lade %1</translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4085,7 +4124,7 @@ Abbrechen um einen minimalen Scan durchzuführen. </translation>
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">Verbinde...</translation>
+        <translation>Verbinde...</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4093,7 +4132,7 @@ Abbrechen um einen minimalen Scan durchzuführen. </translation>
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">Projektdownload %1 fehlgeschlagen</translation>
+        <translation>Projektdownload %1 fehlgeschlagen</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
@@ -4109,7 +4148,7 @@ Abbrechen um einen minimalen Scan durchzuführen. </translation>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">Zurück erneut drücken, um QField zu beenden</translation>
+        <translation>Zurück erneut drücken, um QField zu beenden</translation>
     </message>
     <message>
         <source>Positioning error: %1</source>
@@ -4117,11 +4156,11 @@ Abbrechen um einen minimalen Scan durchzuführen. </translation>
     </message>
     <message>
         <source>Azimuth</source>
-        <translation type="vanished">Azimut</translation>
+        <translation>Azimut</translation>
     </message>
     <message>
         <source>Lock Screen</source>
-        <translation type="vanished">Bildschirm sperren</translation>
+        <translation>Bildschirm sperren</translation>
     </message>
     <message>
         <source>Print to Image</source>
@@ -4129,22 +4168,118 @@ Abbrechen um einen minimalen Scan durchzuführen. </translation>
     </message>
     <message>
         <source>Printing...</source>
-        <translation type="vanished">Drucke...</translation>
+        <translation>Drucke...</translation>
     </message>
     <message>
         <source>Print</source>
-        <translation type="vanished">Drucken</translation>
+        <translation>Drucken</translation>
     </message>
     <message>
         <source>Positioning device error: %1</source>
-        <translation type="vanished">Fehler Ortungsgerät: %1</translation>
+        <translation>Fehler Ortungsgerät: %1</translation>
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="unfinished"/>
+        <translation>Dupliziere Objekt</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
+        <translation>Objekt dupliziert</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation>Projektordner</translation>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation>Import %1</translation>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -4181,6 +4316,10 @@ Abbrechen um einen minimalen Scan durchzuführen. </translation>
     <message>
         <source>Failed to delete referencing feature</source>
         <translation>Referenziertes Feature konnte nicht gelöscht werden</translation>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 </TS>

--- a/i18n/qfield_en.ts
+++ b/i18n/qfield_en.ts
@@ -671,6 +671,29 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
 </context>
 <context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FeatureListForm</name>
     <message>
         <source>Stop tracking this feature to edit attributes</source>
@@ -2138,6 +2161,14 @@ While you can still view and use the project, it is strongly recommended to rese
         <source>No changes to revert</source>
         <translation>No changes to revert</translation>
     </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QFieldCloudProjectsModel</name>
@@ -2374,6 +2405,10 @@ While you can still view and use the project, it is strongly recommended to rese
     </message>
     <message>
         <source>Project Actions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>, updated data available on the cloud</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3755,7 +3790,7 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Cannot add child feature: parent primary keys are not available</translation>
+        <translation type="vanished">Cannot add child feature: parent primary keys are not available</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -3777,100 +3812,104 @@ Cancel to make a minimal device scan instead.</translation>
         <source>Failed to delete referencing feature</source>
         <translation>Failed to delete referencing feature</translation>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">You are now in browse mode</translation>
+        <translation>You are now in browse mode</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">You are now in digitize mode on layer %1</translation>
+        <translation>You are now in digitize mode on layer %1</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">You are now in digitize mode</translation>
+        <translation>You are now in digitize mode</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">You are now in measure mode</translation>
+        <translation>You are now in measure mode</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">Lon</translation>
+        <translation>Lon</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">Lat</translation>
+        <translation>Lat</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">Segment</translation>
+        <translation>Segment</translation>
     </message>
     <message>
         <source>Perimeter</source>
-        <translation type="vanished">Perimeter</translation>
+        <translation>Perimeter</translation>
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">Length</translation>
+        <translation>Length</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">Area</translation>
+        <translation>Area</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">Close measure tool</translation>
+        <translation>Close measure tool</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">Stop editing</translation>
+        <translation>Stop editing</translation>
     </message>
     <message>
         <source>Cancel addition</source>
-        <translation type="vanished">Cancel addition</translation>
+        <translation>Cancel addition</translation>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">Topological editing turned on</translation>
+        <translation>Topological editing turned on</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">Topological editing turned off</translation>
+        <translation>Topological editing turned off</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">Freehand digitizing turned on</translation>
+        <translation>Freehand digitizing turned on</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">Freehand digitizing turned off</translation>
+        <translation>Freehand digitizing turned off</translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
-        <translation type="vanished">Coordinate cursor now locked to position</translation>
+        <translation>Coordinate cursor now locked to position</translation>
     </message>
     <message>
         <source>Coordinate cursor unlocked</source>
-        <translation type="vanished">Coordinate cursor unlocked</translation>
+        <translation>Coordinate cursor unlocked</translation>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">Received position</translation>
+        <translation>Received position</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">Searching for position</translation>
+        <translation>Searching for position</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">Canvas follows location</translation>
+        <translation>Canvas follows location</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">Waiting for location</translation>
+        <translation>Waiting for location</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3882,19 +3921,19 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">Canvas stopped following location</translation>
+        <translation>Canvas stopped following location</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">Failed to create feature!</translation>
+        <translation>Failed to create feature!</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">Failed to save feature!</translation>
+        <translation>Failed to save feature!</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">Main Menu</translation>
+        <translation>Main Menu</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3902,7 +3941,7 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">Print to PDF</translation>
+        <translation>Print to PDF</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3922,15 +3961,15 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">Settings</translation>
+        <translation>Settings</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">Message Log</translation>
+        <translation>Message Log</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">About QField</translation>
+        <translation>About QField</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3938,7 +3977,7 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Activating positioning service</source>
-        <translation type="vanished">Activating positioning service</translation>
+        <translation>Activating positioning service</translation>
     </message>
     <message>
         <source>QField has no permissions to use positioning.</source>
@@ -3946,15 +3985,15 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Map Canvas Options</source>
-        <translation type="vanished">Map Canvas Options</translation>
+        <translation>Map Canvas Options</translation>
     </message>
     <message>
         <source>Add Bookmark</source>
-        <translation type="vanished">Add Bookmark</translation>
+        <translation>Add Bookmark</translation>
     </message>
     <message>
         <source>Set as Destination</source>
-        <translation type="vanished">Set as Destination</translation>
+        <translation>Set as Destination</translation>
     </message>
     <message>
         <source>Add Bookmark at Coordinates</source>
@@ -3962,7 +4001,7 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Untitled bookmark</source>
-        <translation type="vanished">Untitled bookmark</translation>
+        <translation>Untitled bookmark</translation>
     </message>
     <message>
         <source>Set Coordinates as Destination</source>
@@ -3970,7 +4009,7 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Copy Coordinates</source>
-        <translation type="vanished">Copy Coordinates</translation>
+        <translation>Copy Coordinates</translation>
     </message>
     <message>
         <source>X</source>
@@ -3982,11 +4021,11 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Coordinates copied to clipboard</source>
-        <translation type="vanished">Coordinates copied to clipboard</translation>
+        <translation>Coordinates copied to clipboard</translation>
     </message>
     <message>
         <source>Precise View Settings</source>
-        <translation type="vanished">Precise View Settings</translation>
+        <translation>Precise View Settings</translation>
     </message>
     <message>
         <source>0.25m Precision</source>
@@ -4014,27 +4053,27 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Always Show Precise View</source>
-        <translation type="vanished">Always Show Precise View</translation>
+        <translation>Always Show Precise View</translation>
     </message>
     <message>
         <source>Center to Location</source>
-        <translation type="vanished">Center to Location</translation>
+        <translation>Center to Location</translation>
     </message>
     <message>
         <source>Add Bookmark at Location</source>
-        <translation type="vanished">Add Bookmark at Location</translation>
+        <translation>Add Bookmark at Location</translation>
     </message>
     <message>
         <source>Copy Location Coordinates</source>
-        <translation type="vanished">Copy Location Coordinates</translation>
+        <translation>Copy Location Coordinates</translation>
     </message>
     <message>
         <source>Signed out</source>
-        <translation type="vanished">Signed out</translation>
+        <translation>Signed out</translation>
     </message>
     <message>
         <source>Signed in</source>
-        <translation type="vanished">Signed in</translation>
+        <translation>Signed in</translation>
     </message>
     <message>
         <source>Set As Destination</source>
@@ -4042,35 +4081,35 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Navigation Options</source>
-        <translation type="vanished">Navigation Options</translation>
+        <translation>Navigation Options</translation>
     </message>
     <message>
         <source>Clear Destination</source>
-        <translation type="vanished">Clear Destination</translation>
+        <translation>Clear Destination</translation>
     </message>
     <message>
         <source>%1 Precision</source>
-        <translation type="vanished">%1 Precision</translation>
+        <translation>%1 Precision</translation>
     </message>
     <message>
         <source>Enable Audio Proximity Feedback</source>
-        <translation type="vanished">Enable Audio Proximity Feedback</translation>
+        <translation>Enable Audio Proximity Feedback</translation>
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">Positioning Options</translation>
+        <translation>Positioning Options</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">Enable Positioning</translation>
+        <translation>Enable Positioning</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">Show Position Information</translation>
+        <translation>Show Position Information</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">Positioning Settings</translation>
+        <translation>Positioning Settings</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4082,11 +4121,11 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Current location unknown</source>
-        <translation type="vanished">Current location unknown</translation>
+        <translation>Current location unknown</translation>
     </message>
     <message>
         <source>My location</source>
-        <translation type="vanished">My location</translation>
+        <translation>My location</translation>
     </message>
     <message>
         <source>Copy Current Location</source>
@@ -4094,27 +4133,27 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">Accuracy</translation>
+        <translation>Accuracy</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">N/A</translation>
+        <translation>N/A</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
-        <translation type="vanished">Current location copied to clipboard</translation>
+        <translation>Current location copied to clipboard</translation>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
-        <translation type="vanished">Current layer switched to the one holding the selected geometry.</translation>
+        <translation>Current layer switched to the one holding the selected geometry.</translation>
     </message>
     <message>
         <source>Editing of multi geometry layer is not supported yet.</source>
-        <translation type="vanished">Editing of multi geometry layer is not supported yet.</translation>
+        <translation>Editing of multi geometry layer is not supported yet.</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">Loading %1</translation>
+        <translation>Loading %1</translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4122,7 +4161,7 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">Connecting...</translation>
+        <translation>Connecting...</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4130,23 +4169,23 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">Project %1 failed to download</translation>
+        <translation>Project %1 failed to download</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
-        <translation type="vanished">Project %1 successfully downloaded, it&apos;s now available to open</translation>
+        <translation>Project %1 successfully downloaded, it&apos;s now available to open</translation>
     </message>
     <message>
         <source>Changes failed to reach QFieldCloud: %1</source>
-        <translation type="vanished">Changes failed to reach QFieldCloud: %1</translation>
+        <translation>Changes failed to reach QFieldCloud: %1</translation>
     </message>
     <message>
         <source>Changes successfully pushed to QFieldCloud</source>
-        <translation type="vanished">Changes successfully pushed to QFieldCloud</translation>
+        <translation>Changes successfully pushed to QFieldCloud</translation>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">Press back again to close project and app</translation>
+        <translation>Press back again to close project and app</translation>
     </message>
     <message>
         <source>Positioning error: %1</source>
@@ -4154,11 +4193,11 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Azimuth</source>
-        <translation type="vanished">Azimuth</translation>
+        <translation>Azimuth</translation>
     </message>
     <message>
         <source>Lock Screen</source>
-        <translation type="vanished">Lock Screen</translation>
+        <translation>Lock Screen</translation>
     </message>
     <message>
         <source>Print to Image</source>
@@ -4166,23 +4205,119 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Printing...</source>
-        <translation type="vanished">Printing...</translation>
+        <translation>Printing...</translation>
     </message>
     <message>
         <source>Print</source>
-        <translation type="vanished">Print</translation>
+        <translation>Print</translation>
     </message>
     <message>
         <source>Positioning device error: %1</source>
-        <translation type="vanished">Positioning device error: %1</translation>
+        <translation>Positioning device error: %1</translation>
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="obsolete">Duplicate Feature</translation>
+        <translation type="unfinished">Duplicate Feature</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
-        <translation type="obsolete">Successfully duplicated feature</translation>
+        <translation type="unfinished">Successfully duplicated feature</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation type="unfinished">Project Folder</translation>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4197,7 +4332,7 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Cannot add child feature: parent primary keys are not available</translation>
+        <translation type="vanished">Cannot add child feature: parent primary keys are not available</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -4218,6 +4353,10 @@ Cancel to make a minimal device scan instead.</translation>
     <message>
         <source>Failed to delete referencing feature</source>
         <translation>Failed to delete referencing feature</translation>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/i18n/qfield_es.ts
+++ b/i18n/qfield_es.ts
@@ -34,7 +34,7 @@
     </message>
     <message>
         <source>Set feature as destination</source>
-        <translation>Establecer entidad como destino</translation>
+        <translation>Establecer objeto como destino</translation>
     </message>
     <message>
         <source>Feature has no geometry</source>
@@ -164,7 +164,7 @@
     </message>
     <message numerus="yes">
         <source>%n device(s) found</source>
-        <translation><numerusform>1 dispositivo encontrado</numerusform><numerusform>%n dispositivos encontrados</numerusform><numerusform>%n dispositivos encontrados</numerusform></translation>
+        <translation><numerusform>1 dispositivo encontrado</numerusform><numerusform>%n dispositivos encontrados</numerusform><numerusform>%n dispositivo(s) encontrado(s)</numerusform></translation>
     </message>
     <message>
         <source>Scanning canceled</source>
@@ -214,7 +214,7 @@ Cancele para hacer una búsqueda mínima de dispositivos en su lugar.</translati
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">N/A</translation>
+        <translation type="vanished">N/D</translation>
     </message>
     <message>
         <source>Bluetooth device address:</source>
@@ -230,7 +230,7 @@ Cancele para hacer una búsqueda mínima de dispositivos en su lugar.</translati
     </message>
     <message>
         <source>Scanning error: %1</source>
-        <translation type="unfinished"/>
+        <translation>Error de escaneo: %1</translation>
     </message>
 </context>
 <context>
@@ -241,7 +241,7 @@ Cancele para hacer una búsqueda mínima de dispositivos en su lugar.</translati
     </message>
     <message>
         <source>Bluetooth permission denied</source>
-        <translation type="unfinished"/>
+        <translation>Denegado el permiso de Bluetooth</translation>
     </message>
 </context>
 <context>
@@ -292,7 +292,7 @@ Cancele para hacer una búsqueda mínima de dispositivos en su lugar.</translati
     </message>
     <message>
         <source>Bluetooth permission denied</source>
-        <translation type="unfinished"/>
+        <translation>Denegado el permiso de Bluetooth</translation>
     </message>
 </context>
 <context>
@@ -666,6 +666,29 @@ Cancele para hacer una búsqueda mínima de dispositivos en su lugar.</translati
     </message>
 </context>
 <context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation>Falló al deshacer creación de objetos en la capa &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation>Falló al deshacer eliminación de objetos en la capa &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation>Falló al deshacer modificación de objetos en la capa &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation>Falló al cometer deshacer modificación de objeto en la capa &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation>Falló al revertir deshacer modificaciones de objeto en la capa &quot;%1&quot;  </translation>
+    </message>
+</context>
+<context>
     <name>FeatureListForm</name>
     <message>
         <source>Stop tracking this feature to edit attributes</source>
@@ -945,7 +968,7 @@ Las geometrías de los objetos se combinarán en el objeto &apos;%1&apos;, que c
     <name>InternalGnssReceiver</name>
     <message>
         <source>Location permission denied</source>
-        <translation type="unfinished"/>
+        <translation>Denegado el permiso de ubicación</translation>
     </message>
 </context>
 <context>
@@ -1188,7 +1211,7 @@ Las geometrías de los objetos se combinarán en el objeto &apos;%1&apos;, que c
     </message>
     <message>
         <source>Returns a list of features accross all searchable layers with matching display name.</source>
-        <translation type="unfinished"/>
+        <translation>Devuelve una lista de objetos a lo largo de todas las capas en las que se puede buscar con nombres coincidentes.</translation>
     </message>
     <message>
         <source>Returns a point from a pair of X and Y coordinates - or WGS84 latitude and longitude - typed in the search bar.</source>
@@ -1196,15 +1219,15 @@ Las geometrías de los objetos se combinarán en el objeto &apos;%1&apos;, que c
     </message>
     <message>
         <source>Returns a list of user and currently open project bookmarks with matching names.</source>
-        <translation type="unfinished"/>
+        <translation>Devuelve una lista de marcadores de usuario y proyecto actualmente abiertos con nombres coincidentes.</translation>
     </message>
     <message>
         <source>Returns the value of an expression typed in the search bar.</source>
-        <translation type="unfinished"/>
+        <translation>Devuelve el valor de una expresión escrita en la barra de búsqueda.</translation>
     </message>
     <message>
         <source>Returns a list of locations and addresses within Finland with matching terms.</source>
-        <translation type="unfinished"/>
+        <translation>Devuelve una lista de localizaciones y direcciones dentro de Finlandia en las que coinciden los términos</translation>
     </message>
 </context>
 <context>
@@ -1215,11 +1238,11 @@ Las geometrías de los objetos se combinarán en el objeto &apos;%1&apos;, que c
     </message>
     <message>
         <source>To search features within the active layer, select a vector layer through the legend.</source>
-        <translation type="unfinished"/>
+        <translation>Para buscar objetos en la capa activa seleccione una capa vectorial en la leyenda.</translation>
     </message>
     <message>
         <source>Activate a vector layer in the legend first to use this functionality</source>
-        <translation type="unfinished"/>
+        <translation>Primero debe activar una capa vectorial en la leyenda para usar esta funcionalidad</translation>
     </message>
 </context>
 <context>
@@ -1273,23 +1296,23 @@ Las geometrías de los objetos se combinarán en el objeto &apos;%1&apos;, que c
     </message>
     <message>
         <source>Log runtime profiler</source>
-        <translation type="unfinished"/>
+        <translation>Registro de perfilador en tiempo de ejecución</translation>
     </message>
     <message>
         <source>Type optional details</source>
-        <translation type="unfinished"/>
+        <translation>Escriba detalles opcionales</translation>
     </message>
     <message>
         <source>Include cloud user details</source>
-        <translation type="unfinished"/>
+        <translation>Incluya detalles del usuario de la nube</translation>
     </message>
     <message>
         <source>This will send a log of your current session to the development team. You only need to do this when you are asked for it.</source>
-        <translation type="unfinished"/>
+        <translation>Se enviará un registro de su sesión actual al equipo de desarrollo. Sólo hace falta realizarlo cuando se pida.</translation>
     </message>
     <message>
         <source>Your application log is being sent…</source>
-        <translation type="unfinished"/>
+        <translation>El registro de su aplicación se está enviando...</translation>
     </message>
 </context>
 <context>
@@ -1774,19 +1797,19 @@ Las geometrías de los objetos se combinarán en el objeto &apos;%1&apos;, que c
     <name>QFieldCamera</name>
     <message>
         <source>Geotagging enabled</source>
-        <translation type="unfinished"/>
+        <translation>Geoetiquetado habilitado</translation>
     </message>
     <message>
         <source>Geotagging disabled</source>
-        <translation type="unfinished"/>
+        <translation>Geoetiquetado deshabilitado</translation>
     </message>
     <message>
         <source>Grid enabled</source>
-        <translation type="unfinished"/>
+        <translation>Grid habilitado</translation>
     </message>
     <message>
         <source>Grid disabled</source>
-        <translation type="unfinished"/>
+        <translation>Grid deshabilitado</translation>
     </message>
 </context>
 <context>
@@ -2109,6 +2132,14 @@ While you can still view and use the project, it is strongly recommended to rese
         <source>No changes to revert</source>
         <translation>Ningún cambio que revertir</translation>
     </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation>Este proyecto tiene un archivo de proyecto actualizado en la nube, se recomienda sincronizarlo.</translation>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation>Este proyecto tiene datos actualizados en la nube, deberías sincronizarlos.</translation>
+    </message>
 </context>
 <context>
     <name>QFieldCloudProjectsModel</name>
@@ -2347,6 +2378,10 @@ While you can still view and use the project, it is strongly recommended to rese
         <source>Project Actions</source>
         <translation>Acciones del proyecto</translation>
     </message>
+    <message>
+        <source>, updated data available on the cloud</source>
+        <translation>, datos actualizados disponibles en la nube</translation>
+    </message>
 </context>
 <context>
     <name>QFieldLocalDataPickerScreen</name>
@@ -2444,7 +2479,7 @@ While you can still view and use the project, it is strongly recommended to rese
     </message>
     <message>
         <source>Update project from ZIP</source>
-        <translation type="unfinished"/>
+        <translation>Actualiza proyecto desde ZIP</translation>
     </message>
 </context>
 <context>
@@ -2809,15 +2844,15 @@ Cancelar para hacer una búsqueda mínima de dispositivos en su lugar.</translat
     </message>
     <message>
         <source>Orthometric from device</source>
-        <translation type="unfinished"/>
+        <translation>Ortométrica desde el dispositivo</translation>
     </message>
     <message>
         <source>Use volume keys to digitize</source>
-        <translation type="unfinished"/>
+        <translation>Utiliza teclas de volumen para digitalizar</translation>
     </message>
     <message>
         <source>If enabled, pressing the device&apos;s volume up key will add a vertex while pressing volume down key will remove the last entered vertex during digitizing sessions.</source>
-        <translation type="unfinished"/>
+        <translation>Si se habilita, presionar la tecla de subir volumen del dispositivo adicionará un vértice mientras que presionar la tecla de bajar el volumen eliminará el último vértice registrado durante la sesión de digitalización.</translation>
     </message>
 </context>
 <context>
@@ -3236,19 +3271,19 @@ Cancelar para hacer una búsqueda mínima de dispositivos en su lugar.</translat
     <name>TrackerSettings</name>
     <message>
         <source>Tracking: %1</source>
-        <translation type="unfinished"/>
+        <translation>Registrando: %1</translation>
     </message>
     <message>
         <source>Tracking</source>
-        <translation type="unfinished"/>
+        <translation>Registrando</translation>
     </message>
     <message>
         <source>Requirement Settings</source>
-        <translation type="unfinished"/>
+        <translation>Ajustes de Requisitos</translation>
     </message>
     <message>
         <source>Time requirement</source>
-        <translation type="unfinished"/>
+        <translation>Requisito de tiempo</translation>
     </message>
     <message>
         <source>Minimum time [sec]</source>
@@ -3256,11 +3291,11 @@ Cancelar para hacer una búsqueda mínima de dispositivos en su lugar.</translat
     </message>
     <message>
         <source>When enabled, vertex additions will occur when the time between the last and new vertex meets a configured mimimum value.</source>
-        <translation type="unfinished"/>
+        <translation>Cuando está habilitado, las adiciones de vértices se producirán cuando el tiempo entre el último y el nuevo vértice alcance un valor mínimo configurado.</translation>
     </message>
     <message>
         <source>Distance requirement</source>
-        <translation type="unfinished"/>
+        <translation>Requisito de distancia</translation>
     </message>
     <message>
         <source>Minimum distance [%1]</source>
@@ -3268,39 +3303,39 @@ Cancelar para hacer una búsqueda mínima de dispositivos en su lugar.</translat
     </message>
     <message>
         <source>When enabled, vertex additions will occur when the distance between the last and new vertex meets a configured mimimum value.</source>
-        <translation type="unfinished"/>
+        <translation>Cuando está habilitado, las adiciones de vértices se producirán cuando la distancia entre el último y el nuevo vértice alcance un valor mínimo configurado.</translation>
     </message>
     <message>
         <source>Sensor data requirement</source>
-        <translation type="unfinished"/>
+        <translation>Requisito de datos del sensor</translation>
     </message>
     <message>
         <source>When enabled, vertex additions will occur when sensors have captured new data.</source>
-        <translation type="unfinished"/>
+        <translation>Cuando está habilitado, las adiciones de vértices se producirán cuando los sensores capturen nuevos datos.</translation>
     </message>
     <message>
         <source>Wait for all active requirements</source>
-        <translation type="unfinished"/>
+        <translation>Espera por todos los requisitos activos</translation>
     </message>
     <message>
         <source>When enabled, vertices will only be recorded when all active requirements are met. When disabled, individual requirement met will trigger vertex additions.</source>
-        <translation type="unfinished"/>
+        <translation>Cuando está habilitado, los vértices solo se registrarán cuando se cumplan todas las restricciones activas. Si la configuración está deshabilitada, las restricciones individuales cumplidas activarán una adición de vértice.</translation>
     </message>
     <message>
         <source>General Settings</source>
-        <translation type="unfinished"/>
+        <translation>Ajustes Generales</translation>
     </message>
     <message>
         <source>Erroneous distance safeguard</source>
-        <translation type="unfinished"/>
+        <translation>Salvaguarda de distancia errónea</translation>
     </message>
     <message>
         <source>Maximum tolerated distance [%1]</source>
-        <translation type="unfinished"/>
+        <translation>Máxima distancia tolerada [1%]</translation>
     </message>
     <message>
         <source>When enabled, vertex addition will not occur when the distance between the last and new vertex is greater than a configured maximum value.</source>
-        <translation type="unfinished"/>
+        <translation>Cuando está habilitado, las adiciones de vértices no se producirán cuando la distancia entre el último y el nuevo vértice es mayor que un valor máximo configurado.</translation>
     </message>
     <message>
         <source>Measure (M) value attached to vertices:</source>
@@ -3356,7 +3391,7 @@ Cancelar para hacer una búsqueda mínima de dispositivos en su lugar.</translat
     </message>
     <message>
         <source>Resume tracking</source>
-        <translation type="unfinished"/>
+        <translation>Reanudar registro</translation>
     </message>
 </context>
 <context>
@@ -3723,7 +3758,7 @@ Cancelar para hacer una búsqueda mínima de dispositivos en su lugar.</translat
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>No se puede añadir el objeto hijo: la clave primaria del padre no está disponible</translation>
+        <translation type="vanished">No se puede añadir el objeto hijo: la clave primaria del padre no está disponible</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -3745,100 +3780,104 @@ Cancelar para hacer una búsqueda mínima de dispositivos en su lugar.</translat
         <source>Failed to delete referencing feature</source>
         <translation>No se pudo borrar el objeto que hace referencia</translation>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation>No se puede agregar objeto hijo: el valor del atributo relacional padre e hijo no está asignado</translation>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">Ahora está en modo exploración</translation>
+        <translation>Ahora está en modo exploración</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">Ahora está en modo digitalización en la capa %1</translation>
+        <translation>Ahora está en modo digitalización en la capa %1</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">Ahora está en modo digitalización</translation>
+        <translation>Ahora está en modo digitalización</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">Ahora está en modo medición</translation>
+        <translation>Ahora está en modo medición</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">Lon</translation>
+        <translation>Lon</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">Lat</translation>
+        <translation>Lat</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">Segmento</translation>
+        <translation>Segmento</translation>
     </message>
     <message>
         <source>Perimeter</source>
-        <translation type="vanished">Perímetro</translation>
+        <translation>Perímetro</translation>
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">Longitud</translation>
+        <translation>Longitud</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">Área</translation>
+        <translation>Área</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">Cerrar herramienta de medida</translation>
+        <translation>Cerrar herramienta de medida</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">Detener edición</translation>
+        <translation>Detener edición</translation>
     </message>
     <message>
         <source>Cancel addition</source>
-        <translation type="vanished">Cancelar adición</translation>
+        <translation>Cancelar adición</translation>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">Edición topológica activada</translation>
+        <translation>Edición topológica activada</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">Edición topológica desactivada</translation>
+        <translation>Edición topológica desactivada</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">Digitalización a mano alzada activada</translation>
+        <translation>Digitalización a mano alzada activada</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">Digitalización a mano alzada desactivada</translation>
+        <translation>Digitalización a mano alzada desactivada</translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
-        <translation type="vanished">Cursor de coordenadas ahora bloqueado a la posiciòn</translation>
+        <translation>Cursor de coordenadas ahora bloqueado a la posiciòn</translation>
     </message>
     <message>
         <source>Coordinate cursor unlocked</source>
-        <translation type="vanished">Cursor de coordenadas desbloqueado</translation>
+        <translation>Cursor de coordenadas desbloqueado</translation>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">Posición recibida</translation>
+        <translation>Posición recibida</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">Buscando posición</translation>
+        <translation>Buscando posición</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">El lienzo sigue la localización</translation>
+        <translation>El lienzo sigue la localización</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">Esperando localización</translation>
+        <translation>Esperando localización</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3850,19 +3889,19 @@ Cancelar para hacer una búsqueda mínima de dispositivos en su lugar.</translat
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">El lienzo dejó de seguir la localización</translation>
+        <translation>El lienzo dejó de seguir la localización</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">¡No se pudo crear el objeto!</translation>
+        <translation>¡No se pudo crear el objeto!</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">¡No se pudo guardar el objeto!</translation>
+        <translation>¡No se pudo guardar el objeto!</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">Menú principal</translation>
+        <translation>Menú principal</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3870,7 +3909,7 @@ Cancelar para hacer una búsqueda mínima de dispositivos en su lugar.</translat
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">Imprimir a PDF</translation>
+        <translation>Imprimir a PDF</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3890,15 +3929,15 @@ Cancelar para hacer una búsqueda mínima de dispositivos en su lugar.</translat
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">Configuración</translation>
+        <translation>Configuración</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">Registro de mensajes</translation>
+        <translation>Registro de mensajes</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">Acerca de QField</translation>
+        <translation>Acerca de QField</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3906,7 +3945,7 @@ Cancelar para hacer una búsqueda mínima de dispositivos en su lugar.</translat
     </message>
     <message>
         <source>Activating positioning service</source>
-        <translation type="vanished">Activando el servicio de posicionamiento</translation>
+        <translation>Activando el servicio de posicionamiento</translation>
     </message>
     <message>
         <source>QField has no permissions to use positioning.</source>
@@ -3914,15 +3953,15 @@ Cancelar para hacer una búsqueda mínima de dispositivos en su lugar.</translat
     </message>
     <message>
         <source>Map Canvas Options</source>
-        <translation type="vanished">Opciones de lienzo de mapa</translation>
+        <translation>Opciones de lienzo de mapa</translation>
     </message>
     <message>
         <source>Add Bookmark</source>
-        <translation type="vanished">Añadir marcador</translation>
+        <translation>Añadir marcador</translation>
     </message>
     <message>
         <source>Set as Destination</source>
-        <translation type="vanished">Establecer como destino</translation>
+        <translation>Establecer como destino</translation>
     </message>
     <message>
         <source>Add Bookmark at Coordinates</source>
@@ -3930,7 +3969,7 @@ Cancelar para hacer una búsqueda mínima de dispositivos en su lugar.</translat
     </message>
     <message>
         <source>Untitled bookmark</source>
-        <translation type="vanished">Marcador sin título</translation>
+        <translation>Marcador sin título</translation>
     </message>
     <message>
         <source>Set Coordinates as Destination</source>
@@ -3938,7 +3977,7 @@ Cancelar para hacer una búsqueda mínima de dispositivos en su lugar.</translat
     </message>
     <message>
         <source>Copy Coordinates</source>
-        <translation type="vanished">Copiar coordenadas</translation>
+        <translation>Copiar coordenadas</translation>
     </message>
     <message>
         <source>X</source>
@@ -3950,11 +3989,11 @@ Cancelar para hacer una búsqueda mínima de dispositivos en su lugar.</translat
     </message>
     <message>
         <source>Coordinates copied to clipboard</source>
-        <translation type="vanished">Coordenadas copiadas al portapapeles</translation>
+        <translation>Coordenadas copiadas al portapapeles</translation>
     </message>
     <message>
         <source>Precise View Settings</source>
-        <translation type="vanished">Configuración de vista precisa</translation>
+        <translation>Configuración de vista precisa</translation>
     </message>
     <message>
         <source>0.25m Precision</source>
@@ -3982,27 +4021,27 @@ Cancelar para hacer una búsqueda mínima de dispositivos en su lugar.</translat
     </message>
     <message>
         <source>Always Show Precise View</source>
-        <translation type="vanished">Mostrar siempre una vista precisa</translation>
+        <translation>Mostrar siempre una vista precisa</translation>
     </message>
     <message>
         <source>Center to Location</source>
-        <translation type="vanished">Centrar a localización</translation>
+        <translation>Centrar a localización</translation>
     </message>
     <message>
         <source>Add Bookmark at Location</source>
-        <translation type="vanished">Añadir marcador en la localización</translation>
+        <translation>Añadir marcador en la localización</translation>
     </message>
     <message>
         <source>Copy Location Coordinates</source>
-        <translation type="vanished">Copiar coordenadas de la localización</translation>
+        <translation>Copiar coordenadas de la localización</translation>
     </message>
     <message>
         <source>Signed out</source>
-        <translation type="vanished">Cerrar sesión</translation>
+        <translation>Cerrar sesión</translation>
     </message>
     <message>
         <source>Signed in</source>
-        <translation type="vanished">Iniciar sesión</translation>
+        <translation>Iniciar sesión</translation>
     </message>
     <message>
         <source>Set As Destination</source>
@@ -4010,35 +4049,35 @@ Cancelar para hacer una búsqueda mínima de dispositivos en su lugar.</translat
     </message>
     <message>
         <source>Navigation Options</source>
-        <translation type="vanished">Opciones de navegación</translation>
+        <translation>Opciones de navegación</translation>
     </message>
     <message>
         <source>Clear Destination</source>
-        <translation type="vanished">Borrar destino</translation>
+        <translation>Borrar destino</translation>
     </message>
     <message>
         <source>%1 Precision</source>
-        <translation type="vanished">%1 Precisión</translation>
+        <translation>%1 Precisión</translation>
     </message>
     <message>
         <source>Enable Audio Proximity Feedback</source>
-        <translation type="vanished">Habilitar el audio de proximidad</translation>
+        <translation>Habilitar el audio de proximidad</translation>
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">Opciones de posicionamiento</translation>
+        <translation>Opciones de posicionamiento</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">Habilitar posicionamiento</translation>
+        <translation>Habilitar posicionamiento</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">Mostrar información de la posición</translation>
+        <translation>Mostrar información de la posición</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">Configuración de posicionamiento</translation>
+        <translation>Configuración de posicionamiento</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4050,11 +4089,11 @@ Cancelar para hacer una búsqueda mínima de dispositivos en su lugar.</translat
     </message>
     <message>
         <source>Current location unknown</source>
-        <translation type="vanished">Ubicación actual desconocida</translation>
+        <translation>Ubicación actual desconocida</translation>
     </message>
     <message>
         <source>My location</source>
-        <translation type="vanished">Mi localización</translation>
+        <translation>Mi localización</translation>
     </message>
     <message>
         <source>Copy Current Location</source>
@@ -4062,27 +4101,27 @@ Cancelar para hacer una búsqueda mínima de dispositivos en su lugar.</translat
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">Precisión</translation>
+        <translation>Precisión</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">N/A</translation>
+        <translation>N/A</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
-        <translation type="vanished">Ubicación actual copiada al portapapeles</translation>
+        <translation>Ubicación actual copiada al portapapeles</translation>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
-        <translation type="vanished">La capa actual se cambió a la que tiene la geometría seleccionada.</translation>
+        <translation>La capa actual se cambió a la que tiene la geometría seleccionada.</translation>
     </message>
     <message>
         <source>Editing of multi geometry layer is not supported yet.</source>
-        <translation type="vanished">La edición de capas de geometría múltiples aún no está soportada.</translation>
+        <translation>La edición de capas de geometría múltiples aún no está soportada.</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">Cargando %1</translation>
+        <translation>Cargando %1</translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4090,7 +4129,7 @@ Cancelar para hacer una búsqueda mínima de dispositivos en su lugar.</translat
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">Conectando…</translation>
+        <translation>Conectando…</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4098,23 +4137,23 @@ Cancelar para hacer una búsqueda mínima de dispositivos en su lugar.</translat
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">El proyecto %1 no se pudo descargar</translation>
+        <translation>El proyecto %1 no se pudo descargar</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
-        <translation type="vanished">Proyecto %1 descargado correctamente, ahora está disponible para abrirlo</translation>
+        <translation>Proyecto %1 descargado correctamente, ahora está disponible para abrirlo</translation>
     </message>
     <message>
         <source>Changes failed to reach QFieldCloud: %1</source>
-        <translation type="vanished">Los cambios no se pudieron subir a QFieldCloud: %1</translation>
+        <translation>Los cambios no se pudieron subir a QFieldCloud: %1</translation>
     </message>
     <message>
         <source>Changes successfully pushed to QFieldCloud</source>
-        <translation type="vanished">Cambios subidos correctamente a QFieldCloud</translation>
+        <translation>Cambios subidos correctamente a QFieldCloud</translation>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">Pulsar atrás otra vez para cerrar el proyecto y la aplicación</translation>
+        <translation>Pulsar atrás otra vez para cerrar el proyecto y la aplicación</translation>
     </message>
     <message>
         <source>Positioning error: %1</source>
@@ -4122,11 +4161,11 @@ Cancelar para hacer una búsqueda mínima de dispositivos en su lugar.</translat
     </message>
     <message>
         <source>Azimuth</source>
-        <translation type="vanished">Azimut</translation>
+        <translation>Azimut</translation>
     </message>
     <message>
         <source>Lock Screen</source>
-        <translation type="vanished">Bloquear pantalla</translation>
+        <translation>Bloquear pantalla</translation>
     </message>
     <message>
         <source>Print to Image</source>
@@ -4134,22 +4173,118 @@ Cancelar para hacer una búsqueda mínima de dispositivos en su lugar.</translat
     </message>
     <message>
         <source>Printing...</source>
-        <translation type="vanished">Imprimiendo...</translation>
+        <translation>Imprimiendo...</translation>
     </message>
     <message>
         <source>Print</source>
-        <translation type="vanished">Imprimir</translation>
+        <translation>Imprimir</translation>
     </message>
     <message>
         <source>Positioning device error: %1</source>
-        <translation type="vanished">Error de dispositivo de posicionamiento: %1</translation>
+        <translation>Error de dispositivo de posicionamiento: %1</translation>
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="unfinished"/>
+        <translation>Duplicar objeto</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
+        <translation>Objeto duplicado con éxito</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation>Autoajuste activado</translation>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation>Autoajuste desactivado</translation>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation>El lienzo sigue la ubicación y la orientación de la brújula</translation>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation>No hay diseño de impresión disponible</translation>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation>Aprende más</translation>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation>Sensores</translation>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation>Ningún sensor disponible</translation>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation>Carpeta del proyecto</translation>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation>Seleccione el sensor a continuación</translation>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation>Error de sensor: %1</translation>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation>Desconectando el sensor &apos;%1&apos;...</translation>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation>Conectando el sensor &apos;%1&apos;...</translation>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation>Seleccione el diseño a continuación</translation>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation>Capa:</translation>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation>Objeto:</translation>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation>Abrir formulario de objetos</translation>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation>Duplicado de objetos no disponible</translation>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation>Importando %1</translation>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation>Falló la importación de URL</translation>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -4165,7 +4300,7 @@ Cancelar para hacer una búsqueda mínima de dispositivos en su lugar.</translat
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>No se puede añadir el objeto hijo: la clave primaria del padre no está disponible</translation>
+        <translation type="vanished">No se puede añadir el objeto hijo: la clave primaria del padre no está disponible</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -4186,6 +4321,10 @@ Cancelar para hacer una búsqueda mínima de dispositivos en su lugar.</translat
     <message>
         <source>Failed to delete referencing feature</source>
         <translation>No se pudo borrar el objeto que hace referencia</translation>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation>No se puede agregar objeto hijo: el valor del atributo relacional padre e hijo no está asignado</translation>
     </message>
 </context>
 </TS>

--- a/i18n/qfield_fi.ts
+++ b/i18n/qfield_fi.ts
@@ -230,7 +230,7 @@ Peruuta tehdäksesi suppeampi laiteskannaus.</translation>
     </message>
     <message>
         <source>Scanning error: %1</source>
-        <translation type="unfinished"/>
+        <translation>Skannnausvirhe: %1</translation>
     </message>
 </context>
 <context>
@@ -241,7 +241,7 @@ Peruuta tehdäksesi suppeampi laiteskannaus.</translation>
     </message>
     <message>
         <source>Bluetooth permission denied</source>
-        <translation type="unfinished"/>
+        <translation>Bluetoothin käyttöoikeus estetty</translation>
     </message>
 </context>
 <context>
@@ -292,7 +292,7 @@ Peruuta tehdäksesi suppeampi laiteskannaus.</translation>
     </message>
     <message>
         <source>Bluetooth permission denied</source>
-        <translation type="unfinished"/>
+        <translation>Bluetoothin käyttöoikeus estetty</translation>
     </message>
 </context>
 <context>
@@ -499,7 +499,7 @@ Peruuta tehdäksesi suppeampi laiteskannaus.</translation>
     <name>DeltaListModel</name>
     <message>
         <source>Expected the json document to be an array of delta status</source>
-        <translation>Odotettiin JSON dokumentin olevan delta-statuksen taulukko </translation>
+        <translation>Odotettiin JSON-dokumentin olevan delta-statuksen taulukko </translation>
     </message>
     <message>
         <source>Expected all array elements to be an object, but the element at #%1 is not</source>
@@ -663,6 +663,29 @@ Peruuta tehdäksesi suppeampi laiteskannaus.</translation>
     <message>
         <source>You are about to leave editing state, any changes will be lost. Proceed?</source>
         <translation>Olet poistumassa muokkaustilasta, kaikki muutokset menetetään. Jatketaanko?</translation>
+    </message>
+</context>
+<context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -863,11 +886,11 @@ Kohteen geometriat yhdistetään kohteeseen &apos;%1&apos;, johon sisällytetä�
     </message>
     <message>
         <source>The ring crosses existing rings (it is not disjoint)</source>
-        <translation type="vanished">Piiri leikkaa olemassa olevia piirejä (se ei ole erillinen)</translation>
+        <translation type="vanished">Piiri leikkaa olemassaolevia piirejä (se ei ole erillinen)</translation>
     </message>
     <message>
         <source>The ring doesn&apos;t have any existing ring to fit into</source>
-        <translation type="vanished">Piirille ei ole olemassa olevaa piiriä johon sovittautua</translation>
+        <translation type="vanished">Piirille ei ole olemassaolevaa piiriä johon sovittautua</translation>
     </message>
     <message>
         <source>Unknown error when creating the ring</source>
@@ -893,7 +916,7 @@ Kohteen geometriat yhdistetään kohteeseen &apos;%1&apos;, johon sisällytetä�
     <name>GeometryEditorsToolbar</name>
     <message>
         <source>Vertex Tool</source>
-        <translation>Taitepiste-työkalu</translation>
+        <translation>Taitepistetyökalu</translation>
     </message>
     <message>
         <source>Split Tool</source>
@@ -943,7 +966,7 @@ Kohteen geometriat yhdistetään kohteeseen &apos;%1&apos;, johon sisällytetä�
     <name>InternalGnssReceiver</name>
     <message>
         <source>Location permission denied</source>
-        <translation type="unfinished"/>
+        <translation>Kohteen käyttöoikeus estetty</translation>
     </message>
 </context>
 <context>
@@ -2110,6 +2133,14 @@ Vaikka voit edelleen tarkastella ja käyttää projektia, sen alustamista suosit
         <source>No changes to revert</source>
         <translation>Ei palautettavia muutoksia</translation>
     </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>QFieldCloudProjectsModel</name>
@@ -2348,6 +2379,10 @@ Tämä voi viedä jonkin aikaa, ole hyvä ja odota...</translation>
     <message>
         <source>Project Actions</source>
         <translation>Projektin toimet</translation>
+    </message>
+    <message>
+        <source>, updated data available on the cloud</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3725,7 +3760,7 @@ Peruuta tehdäksesi suppeampi laiteskannaus.</translation>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Ei voida lisätä alakohdetta: pääavaimia ei ole käytettävissä.</translation>
+        <translation type="vanished">Ei voida lisätä alakohdetta: pääavaimia ei ole käytettävissä.</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -3747,100 +3782,104 @@ Peruuta tehdäksesi suppeampi laiteskannaus.</translation>
         <source>Failed to delete referencing feature</source>
         <translation>Viittaavan kohteen poisto epäonnistui</translation>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">Olet selaustilassa</translation>
+        <translation>Olet selaustilassa</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">Olet nyt digitointitilassa tasolla %1</translation>
+        <translation>Olet nyt digitointitilassa tasolla %1</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">Olet digitointitilassa</translation>
+        <translation>Olet digitointitilassa</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">Olet mittaustilassa</translation>
+        <translation>Olet mittaustilassa</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">Lon</translation>
+        <translation>Lon</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">Lat</translation>
+        <translation>Lat</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">Segmentti</translation>
+        <translation>Segmentti</translation>
     </message>
     <message>
         <source>Perimeter</source>
-        <translation type="vanished">Piiri</translation>
+        <translation>Piiri</translation>
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">Pituus</translation>
+        <translation>Pituus</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">Alue</translation>
+        <translation>Alue</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">Sulje mittaustyökalu</translation>
+        <translation>Sulje mittaustyökalu</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">Keskeytä muokkaus</translation>
+        <translation>Keskeytä muokkaus</translation>
     </message>
     <message>
         <source>Cancel addition</source>
-        <translation type="vanished">Peruuta lisäys</translation>
+        <translation>Peruuta lisäys</translation>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">Topologinen muokkaus päällä</translation>
+        <translation>Topologinen muokkaus päällä</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">Topologinen muokkaus pois päältä</translation>
+        <translation>Topologinen muokkaus pois päältä</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">Vapaalla kädellä digitointi päällä</translation>
+        <translation>Vapaalla kädellä digitointi päällä</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">Vapaalla kädellä digitointi pois päältä</translation>
+        <translation>Vapaalla kädellä digitointi pois päältä</translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
-        <translation type="vanished">Koordinaattikursori lukittu sijaintiin</translation>
+        <translation>Koordinaattikursori lukittu sijaintiin</translation>
     </message>
     <message>
         <source>Coordinate cursor unlocked</source>
-        <translation type="vanished">Koordinaattikursori vapautettu</translation>
+        <translation>Koordinaattikursori vapautettu</translation>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">Saatiin sijainti</translation>
+        <translation>Saatiin sijainti</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">Haetaan sijaintia</translation>
+        <translation>Haetaan sijaintia</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">Karttapohja seuraa sijaintia</translation>
+        <translation>Karttapohja seuraa sijaintia</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">Odotetaan sijaintitietoa</translation>
+        <translation>Odotetaan sijaintitietoa</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3852,19 +3891,19 @@ Peruuta tehdäksesi suppeampi laiteskannaus.</translation>
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">Karttapohja ei seuraa sijaintia</translation>
+        <translation>Karttapohja ei seuraa sijaintia</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">Kohteen luonti epäonnistui!</translation>
+        <translation>Kohteen luonti epäonnistui!</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">Kohteen tallennus epäonnistui!</translation>
+        <translation>Kohteen tallennus epäonnistui!</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">Päävalikko</translation>
+        <translation>Päävalikko</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3872,7 +3911,7 @@ Peruuta tehdäksesi suppeampi laiteskannaus.</translation>
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">Tulosta PDF:ksi</translation>
+        <translation>Tulosta PDF:ksi</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3892,15 +3931,15 @@ Peruuta tehdäksesi suppeampi laiteskannaus.</translation>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">Asetukset</translation>
+        <translation>Asetukset</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">Viestiloki</translation>
+        <translation>Viestiloki</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">Lisätietoja QFieldistä</translation>
+        <translation>Lisätietoja QFieldistä</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3908,7 +3947,7 @@ Peruuta tehdäksesi suppeampi laiteskannaus.</translation>
     </message>
     <message>
         <source>Activating positioning service</source>
-        <translation type="vanished">Aktivoidaan paikannuspalvelu</translation>
+        <translation>Aktivoidaan paikannuspalvelu</translation>
     </message>
     <message>
         <source>QField has no permissions to use positioning.</source>
@@ -3916,15 +3955,15 @@ Peruuta tehdäksesi suppeampi laiteskannaus.</translation>
     </message>
     <message>
         <source>Map Canvas Options</source>
-        <translation type="vanished">Karttaikkunan asetukset</translation>
+        <translation>Karttaikkunan asetukset</translation>
     </message>
     <message>
         <source>Add Bookmark</source>
-        <translation type="vanished">Lisää kirjanmerkki</translation>
+        <translation>Lisää kirjanmerkki</translation>
     </message>
     <message>
         <source>Set as Destination</source>
-        <translation type="vanished">Aseta kohteeksi</translation>
+        <translation>Aseta kohteeksi</translation>
     </message>
     <message>
         <source>Add Bookmark at Coordinates</source>
@@ -3932,7 +3971,7 @@ Peruuta tehdäksesi suppeampi laiteskannaus.</translation>
     </message>
     <message>
         <source>Untitled bookmark</source>
-        <translation type="vanished">Kirjanmerkki ilman otsikkoa</translation>
+        <translation>Kirjanmerkki ilman otsikkoa</translation>
     </message>
     <message>
         <source>Set Coordinates as Destination</source>
@@ -3940,7 +3979,7 @@ Peruuta tehdäksesi suppeampi laiteskannaus.</translation>
     </message>
     <message>
         <source>Copy Coordinates</source>
-        <translation type="vanished">Kopioi koordinaatit</translation>
+        <translation>Kopioi koordinaatit</translation>
     </message>
     <message>
         <source>X</source>
@@ -3952,11 +3991,11 @@ Peruuta tehdäksesi suppeampi laiteskannaus.</translation>
     </message>
     <message>
         <source>Coordinates copied to clipboard</source>
-        <translation type="vanished">Koordinaatit kopioitu leikepöydälle</translation>
+        <translation>Koordinaatit kopioitu leikepöydälle</translation>
     </message>
     <message>
         <source>Precise View Settings</source>
-        <translation type="vanished">Tarkat näkymän asetukset</translation>
+        <translation>Tarkat näkymän asetukset</translation>
     </message>
     <message>
         <source>0.25m Precision</source>
@@ -3984,27 +4023,27 @@ Peruuta tehdäksesi suppeampi laiteskannaus.</translation>
     </message>
     <message>
         <source>Always Show Precise View</source>
-        <translation type="vanished">Näytä aina tarkka näkymä</translation>
+        <translation>Näytä aina tarkka näkymä</translation>
     </message>
     <message>
         <source>Center to Location</source>
-        <translation type="vanished">Keskitä sijaintiin</translation>
+        <translation>Keskitä sijaintiin</translation>
     </message>
     <message>
         <source>Add Bookmark at Location</source>
-        <translation type="vanished">Lisää kirjanmerkki sijaintiin</translation>
+        <translation>Lisää kirjanmerkki sijaintiin</translation>
     </message>
     <message>
         <source>Copy Location Coordinates</source>
-        <translation type="vanished">Kopioi sijainnin koordinaatit</translation>
+        <translation>Kopioi sijainnin koordinaatit</translation>
     </message>
     <message>
         <source>Signed out</source>
-        <translation type="vanished">Olet kirjautunut ulos</translation>
+        <translation>Olet kirjautunut ulos</translation>
     </message>
     <message>
         <source>Signed in</source>
-        <translation type="vanished">Olet kirjautunut sisään</translation>
+        <translation>Olet kirjautunut sisään</translation>
     </message>
     <message>
         <source>Set As Destination</source>
@@ -4012,35 +4051,35 @@ Peruuta tehdäksesi suppeampi laiteskannaus.</translation>
     </message>
     <message>
         <source>Navigation Options</source>
-        <translation type="vanished">Navigoinnin asetukset</translation>
+        <translation>Navigoinnin asetukset</translation>
     </message>
     <message>
         <source>Clear Destination</source>
-        <translation type="vanished">Tyhjennä kohde</translation>
+        <translation>Tyhjennä kohde</translation>
     </message>
     <message>
         <source>%1 Precision</source>
-        <translation type="vanished">%1 tarkkuus</translation>
+        <translation>%1 tarkkuus</translation>
     </message>
     <message>
         <source>Enable Audio Proximity Feedback</source>
-        <translation type="vanished">Ota äänen läheisyyspalaute käyttöön</translation>
+        <translation>Ota äänen läheisyyspalaute käyttöön</translation>
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">Paikannuksen asetukset</translation>
+        <translation>Paikannuksen asetukset</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">Ota paikannus käyttöön</translation>
+        <translation>Ota paikannus käyttöön</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">Näytä sijainnin tiedot</translation>
+        <translation>Näytä sijainnin tiedot</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">Paikannusasetukset</translation>
+        <translation>Paikannusasetukset</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4052,11 +4091,11 @@ Peruuta tehdäksesi suppeampi laiteskannaus.</translation>
     </message>
     <message>
         <source>Current location unknown</source>
-        <translation type="vanished">Nykyinen sijainti tuntematon</translation>
+        <translation>Nykyinen sijainti tuntematon</translation>
     </message>
     <message>
         <source>My location</source>
-        <translation type="vanished">Sijaintini</translation>
+        <translation>Sijaintini</translation>
     </message>
     <message>
         <source>Copy Current Location</source>
@@ -4064,27 +4103,27 @@ Peruuta tehdäksesi suppeampi laiteskannaus.</translation>
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">Tarkkuus</translation>
+        <translation>Tarkkuus</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">N/A</translation>
+        <translation>N/A</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
-        <translation type="vanished">Nykyinen sijainti kopioitu leikepöydälle</translation>
+        <translation>Nykyinen sijainti kopioitu leikepöydälle</translation>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
-        <translation type="vanished">Nykyinen taso vaihdettiin siihen jossa valitut geometriat.</translation>
+        <translation>Nykyinen taso vaihdettiin siihen jossa valitut geometriat.</translation>
     </message>
     <message>
         <source>Editing of multi geometry layer is not supported yet.</source>
-        <translation type="vanished">Monigeometrisen tason muokkausta ei vielä tueta.</translation>
+        <translation>Monigeometrisen tason muokkausta ei vielä tueta.</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">Ladataan %1</translation>
+        <translation>Ladataan %1</translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4092,7 +4131,7 @@ Peruuta tehdäksesi suppeampi laiteskannaus.</translation>
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">Yhdistetään...</translation>
+        <translation>Yhdistetään...</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4100,23 +4139,23 @@ Peruuta tehdäksesi suppeampi laiteskannaus.</translation>
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">Projektin %1 lataus epäonnistui</translation>
+        <translation>Projektin %1 lataus epäonnistui</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
-        <translation type="vanished">Projektin %1 lataus onnistui, sen voi nyt avata</translation>
+        <translation>Projektin %1 lataus onnistui, sen voi nyt avata</translation>
     </message>
     <message>
         <source>Changes failed to reach QFieldCloud: %1</source>
-        <translation type="vanished">Muutosten vienti QFieldCloudiin epäonnistui: %1</translation>
+        <translation>Muutosten vienti QFieldCloudiin epäonnistui: %1</translation>
     </message>
     <message>
         <source>Changes successfully pushed to QFieldCloud</source>
-        <translation type="vanished">Muutokset ajettu onnistuneesti QFieldCloudiin</translation>
+        <translation>Muutokset ajettu onnistuneesti QFieldCloudiin</translation>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">Paina uudestaan takaisin sulkeaksesi projektin ja sovelluksen</translation>
+        <translation>Paina uudestaan takaisin sulkeaksesi projektin ja sovelluksen</translation>
     </message>
     <message>
         <source>Positioning error: %1</source>
@@ -4124,11 +4163,11 @@ Peruuta tehdäksesi suppeampi laiteskannaus.</translation>
     </message>
     <message>
         <source>Azimuth</source>
-        <translation type="vanished">Atsimuutti</translation>
+        <translation>Atsimuutti</translation>
     </message>
     <message>
         <source>Lock Screen</source>
-        <translation type="vanished">Lukitse näyttö</translation>
+        <translation>Lukitse näyttö</translation>
     </message>
     <message>
         <source>Print to Image</source>
@@ -4136,22 +4175,118 @@ Peruuta tehdäksesi suppeampi laiteskannaus.</translation>
     </message>
     <message>
         <source>Printing...</source>
-        <translation type="vanished">Tulostetaan...</translation>
+        <translation>Tulostetaan...</translation>
     </message>
     <message>
         <source>Print</source>
-        <translation type="vanished">Tulosta</translation>
+        <translation>Tulosta</translation>
     </message>
     <message>
         <source>Positioning device error: %1</source>
-        <translation type="vanished">Sijaintilaitteen virhe: %1</translation>
+        <translation>Sijaintilaitteen virhe: %1</translation>
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="unfinished"/>
+        <translation>Monista ominaisuus</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
+        <translation>Ominaisuus monistettu onnistuneesti</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation>Tarttuminen päällä</translation>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation>Tarttuminen pois päältä</translation>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation>Karttapohja seuraa sijaintia ja kompassin suuntaa</translation>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation>Tulosteen asettelua ei käytettävissä</translation>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation>Opi lisää</translation>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation>Sensorit</translation>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation>Sensoria ei käytettävissä</translation>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation>Projektihakemisto</translation>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation>Valitse sensori alta</translation>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation>Sensorivirhe: %1</translation>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation>Poistetaan yhteys sensoriin &apos;%1&apos;...</translation>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation>Yhdistetään sensoriin &apos;%1&apos;...</translation>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation>Valitse asettelu alta</translation>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation>Taso:</translation>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation>Ominaisuus:</translation>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation>Avaa ominaisuuden lomake</translation>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation>Ominaisuuden monistaminen ei käytössä</translation>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation>Tuodaan %1</translation>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation>Tuonti URL:ista epäonnistui</translation>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -4167,7 +4302,7 @@ Peruuta tehdäksesi suppeampi laiteskannaus.</translation>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Ei voida lisätä alakohdetta: pääavaimia ei ole käytettävissä.</translation>
+        <translation type="vanished">Ei voida lisätä alakohdetta: pääavaimia ei ole käytettävissä.</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -4188,6 +4323,10 @@ Peruuta tehdäksesi suppeampi laiteskannaus.</translation>
     <message>
         <source>Failed to delete referencing feature</source>
         <translation>Viittaavan kohteen poisto epäonnistui</translation>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 </TS>

--- a/i18n/qfield_fr.ts
+++ b/i18n/qfield_fr.ts
@@ -665,6 +665,29 @@ Cancel to make a minimal device scan instead.</source>
     </message>
 </context>
 <context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
     <name>FeatureListForm</name>
     <message>
         <source>Stop tracking this feature to edit attributes</source>
@@ -2109,6 +2132,14 @@ Même si vous pouvez toujours voir et utiliser ce projet, il est fortement recom
         <source>No changes to revert</source>
         <translation>Aucune modification à rétablir</translation>
     </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>QFieldCloudProjectsModel</name>
@@ -2344,6 +2375,10 @@ Même si vous pouvez toujours voir et utiliser ce projet, il est fortement recom
     <message>
         <source>Project Actions</source>
         <translation>actions sur le projet</translation>
+    </message>
+    <message>
+        <source>, updated data available on the cloud</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3722,7 +3757,7 @@ Essayez les exemples de projets répertoriés ci-dessous.</translation>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Impossible d&apos;ajouter l&apos;entité enfant: les clés primaires du parent ne sont pas disponibles</translation>
+        <translation type="vanished">Impossible d&apos;ajouter l&apos;entité enfant: les clés primaires du parent ne sont pas disponibles</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -3744,100 +3779,104 @@ Essayez les exemples de projets répertoriés ci-dessous.</translation>
         <source>Failed to delete referencing feature</source>
         <translation>Échec de la suppression de l&apos;entité référencée.</translation>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">Vous êtes maintenant en mode navigation</translation>
+        <translation>Vous êtes maintenant en mode navigation</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">Vous êtes maintenant en mode numérisation sur la couche %1</translation>
+        <translation>Vous êtes maintenant en mode numérisation sur la couche %1</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">Vous êtes maintenant en mode numérisation</translation>
+        <translation>Vous êtes maintenant en mode numérisation</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">Vous êtes maintenant en mode mesure</translation>
+        <translation>Vous êtes maintenant en mode mesure</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">Lon</translation>
+        <translation>Lon</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">Lat</translation>
+        <translation>Lat</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">Segment</translation>
+        <translation>Segment</translation>
     </message>
     <message>
         <source>Perimeter</source>
-        <translation type="vanished">Périmètre</translation>
+        <translation>Périmètre</translation>
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">Longueur</translation>
+        <translation>Longueur</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">Superficie</translation>
+        <translation>Superficie</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">Fermer l&apos;outil de mesure</translation>
+        <translation>Fermer l&apos;outil de mesure</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">Arrêter l&apos;édition</translation>
+        <translation>Arrêter l&apos;édition</translation>
     </message>
     <message>
         <source>Cancel addition</source>
-        <translation type="vanished">Annuler l&apos;addition</translation>
+        <translation>Annuler l&apos;addition</translation>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">Édition topologique activée</translation>
+        <translation>Édition topologique activée</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">Édition topologique désactivée</translation>
+        <translation>Édition topologique désactivée</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">Numérisation à main levée activée</translation>
+        <translation>Numérisation à main levée activée</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">Numérisation à main levée désactivée</translation>
+        <translation>Numérisation à main levée désactivée</translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
-        <translation type="vanished">Le curseur de coordonnées est maintenant bloqué sur la position</translation>
+        <translation>Le curseur de coordonnées est maintenant bloqué sur la position</translation>
     </message>
     <message>
         <source>Coordinate cursor unlocked</source>
-        <translation type="vanished">Curseur de coordonnées débloqué </translation>
+        <translation>Curseur de coordonnées débloqué </translation>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">Position reçue</translation>
+        <translation>Position reçue</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">Recherche de la position</translation>
+        <translation>Recherche de la position</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">Le canevas suit la localisation</translation>
+        <translation>Le canevas suit la localisation</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">En attente de localisation</translation>
+        <translation>En attente de localisation</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3849,19 +3888,19 @@ Essayez les exemples de projets répertoriés ci-dessous.</translation>
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">Le canevas de la carte a arrêté de suivre la localisation</translation>
+        <translation>Le canevas de la carte a arrêté de suivre la localisation</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">Échec de la création de l&apos;entité !</translation>
+        <translation>Échec de la création de l&apos;entité !</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">Échec de l&apos;enregistrement de l&apos;entité !</translation>
+        <translation>Échec de l&apos;enregistrement de l&apos;entité !</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">Menu principal</translation>
+        <translation>Menu principal</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3869,7 +3908,7 @@ Essayez les exemples de projets répertoriés ci-dessous.</translation>
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">Imprimer en PDF</translation>
+        <translation>Imprimer en PDF</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3889,15 +3928,15 @@ Essayez les exemples de projets répertoriés ci-dessous.</translation>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">Paramètres</translation>
+        <translation>Paramètres</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">Liste des messages</translation>
+        <translation>Liste des messages</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">A propos de QField</translation>
+        <translation>A propos de QField</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3905,7 +3944,7 @@ Essayez les exemples de projets répertoriés ci-dessous.</translation>
     </message>
     <message>
         <source>Activating positioning service</source>
-        <translation type="vanished">Activer le service de positionnement</translation>
+        <translation>Activer le service de positionnement</translation>
     </message>
     <message>
         <source>QField has no permissions to use positioning.</source>
@@ -3914,15 +3953,15 @@ pour utiliser la géolocalisation</translation>
     </message>
     <message>
         <source>Map Canvas Options</source>
-        <translation type="vanished">Options du Canevas de Carte</translation>
+        <translation>Options du Canevas de Carte</translation>
     </message>
     <message>
         <source>Add Bookmark</source>
-        <translation type="vanished">Ajouter un marque-page</translation>
+        <translation>Ajouter un marque-page</translation>
     </message>
     <message>
         <source>Set as Destination</source>
-        <translation type="vanished">Définir comme destination</translation>
+        <translation>Définir comme destination</translation>
     </message>
     <message>
         <source>Add Bookmark at Coordinates</source>
@@ -3930,7 +3969,7 @@ pour utiliser la géolocalisation</translation>
     </message>
     <message>
         <source>Untitled bookmark</source>
-        <translation type="vanished">Signet sans nom</translation>
+        <translation>Signet sans nom</translation>
     </message>
     <message>
         <source>Set Coordinates as Destination</source>
@@ -3938,7 +3977,7 @@ pour utiliser la géolocalisation</translation>
     </message>
     <message>
         <source>Copy Coordinates</source>
-        <translation type="vanished">Copier les Coordonnées</translation>
+        <translation>Copier les Coordonnées</translation>
     </message>
     <message>
         <source>X</source>
@@ -3950,11 +3989,11 @@ pour utiliser la géolocalisation</translation>
     </message>
     <message>
         <source>Coordinates copied to clipboard</source>
-        <translation type="vanished">Coordonnées copiées dans le presse-papiers</translation>
+        <translation>Coordonnées copiées dans le presse-papiers</translation>
     </message>
     <message>
         <source>Precise View Settings</source>
-        <translation type="vanished">Paramètres d&apos;affichage précis</translation>
+        <translation>Paramètres d&apos;affichage précis</translation>
     </message>
     <message>
         <source>0.25m Precision</source>
@@ -3982,27 +4021,27 @@ pour utiliser la géolocalisation</translation>
     </message>
     <message>
         <source>Always Show Precise View</source>
-        <translation type="vanished">Toujours afficher une vue précise</translation>
+        <translation>Toujours afficher une vue précise</translation>
     </message>
     <message>
         <source>Center to Location</source>
-        <translation type="vanished">Du centre à l&apos;emplacement</translation>
+        <translation>Du centre à l&apos;emplacement</translation>
     </message>
     <message>
         <source>Add Bookmark at Location</source>
-        <translation type="vanished">Ajouter un signet à l&apos;emplacement</translation>
+        <translation>Ajouter un signet à l&apos;emplacement</translation>
     </message>
     <message>
         <source>Copy Location Coordinates</source>
-        <translation type="vanished">Copier les coordonnées de l&apos;emplacement</translation>
+        <translation>Copier les coordonnées de l&apos;emplacement</translation>
     </message>
     <message>
         <source>Signed out</source>
-        <translation type="vanished">Se déconnecter</translation>
+        <translation>Se déconnecter</translation>
     </message>
     <message>
         <source>Signed in</source>
-        <translation type="vanished">Connecté</translation>
+        <translation>Connecté</translation>
     </message>
     <message>
         <source>Set As Destination</source>
@@ -4010,35 +4049,35 @@ pour utiliser la géolocalisation</translation>
     </message>
     <message>
         <source>Navigation Options</source>
-        <translation type="vanished">Options de Navigation</translation>
+        <translation>Options de Navigation</translation>
     </message>
     <message>
         <source>Clear Destination</source>
-        <translation type="vanished">Effacer la Destination</translation>
+        <translation>Effacer la Destination</translation>
     </message>
     <message>
         <source>%1 Precision</source>
-        <translation type="vanished">Précision %1</translation>
+        <translation>Précision %1</translation>
     </message>
     <message>
         <source>Enable Audio Proximity Feedback</source>
-        <translation type="vanished">Active le son de l&apos;indicateur de proximité</translation>
+        <translation>Active le son de l&apos;indicateur de proximité</translation>
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">Options de géolocalisation</translation>
+        <translation>Options de géolocalisation</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">Activer la géolocalisation</translation>
+        <translation>Activer la géolocalisation</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">Montrer les informations de position</translation>
+        <translation>Montrer les informations de position</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">Paramètres de positionnement</translation>
+        <translation>Paramètres de positionnement</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4050,11 +4089,11 @@ pour utiliser la géolocalisation</translation>
     </message>
     <message>
         <source>Current location unknown</source>
-        <translation type="vanished">Position actuelle non connue</translation>
+        <translation>Position actuelle non connue</translation>
     </message>
     <message>
         <source>My location</source>
-        <translation type="vanished">Ma position</translation>
+        <translation>Ma position</translation>
     </message>
     <message>
         <source>Copy Current Location</source>
@@ -4062,27 +4101,27 @@ pour utiliser la géolocalisation</translation>
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">Précision</translation>
+        <translation>Précision</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">ND</translation>
+        <translation>ND</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
-        <translation type="vanished">Position actuelle copiée dans le presse-papiers</translation>
+        <translation>Position actuelle copiée dans le presse-papiers</translation>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
-        <translation type="vanished">La couche active est devenue celle qui contient la géométrie sélectionnée.</translation>
+        <translation>La couche active est devenue celle qui contient la géométrie sélectionnée.</translation>
     </message>
     <message>
         <source>Editing of multi geometry layer is not supported yet.</source>
-        <translation type="vanished">L&apos;édition des couches de géométries multiples n&apos;est pas encore disponible.</translation>
+        <translation>L&apos;édition des couches de géométries multiples n&apos;est pas encore disponible.</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">Chargement %1</translation>
+        <translation>Chargement %1</translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4090,7 +4129,7 @@ pour utiliser la géolocalisation</translation>
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">Connexion...</translation>
+        <translation>Connexion...</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4098,23 +4137,23 @@ pour utiliser la géolocalisation</translation>
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">Le téléchargement du projet %1 a échoué</translation>
+        <translation>Le téléchargement du projet %1 a échoué</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
-        <translation type="vanished">Le projet %1 a été téléchargé avec succès, il est maintenant disponible pour être ouvert.</translation>
+        <translation>Le projet %1 a été téléchargé avec succès, il est maintenant disponible pour être ouvert.</translation>
     </message>
     <message>
         <source>Changes failed to reach QFieldCloud: %1</source>
-        <translation type="vanished">Les modifications n&apos;ont pas réussi à atteindre QFieldCloud : %1</translation>
+        <translation>Les modifications n&apos;ont pas réussi à atteindre QFieldCloud : %1</translation>
     </message>
     <message>
         <source>Changes successfully pushed to QFieldCloud</source>
-        <translation type="vanished">Les modifications ont été poussées avec succès vers QFieldCloud</translation>
+        <translation>Les modifications ont été poussées avec succès vers QFieldCloud</translation>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">Appuyer deux fois sur retour pour 
+        <translation>Appuyer deux fois sur retour pour 
 fermer le projet et quitter l&apos;application</translation>
     </message>
     <message>
@@ -4123,11 +4162,11 @@ fermer le projet et quitter l&apos;application</translation>
     </message>
     <message>
         <source>Azimuth</source>
-        <translation type="vanished">Azimut</translation>
+        <translation>Azimut</translation>
     </message>
     <message>
         <source>Lock Screen</source>
-        <translation type="vanished">Verrouiller l&apos;écran</translation>
+        <translation>Verrouiller l&apos;écran</translation>
     </message>
     <message>
         <source>Print to Image</source>
@@ -4135,22 +4174,118 @@ fermer le projet et quitter l&apos;application</translation>
     </message>
     <message>
         <source>Printing...</source>
-        <translation type="vanished">Impression...</translation>
+        <translation>Impression...</translation>
     </message>
     <message>
         <source>Print</source>
-        <translation type="vanished">Imprimer</translation>
+        <translation>Imprimer</translation>
     </message>
     <message>
         <source>Positioning device error: %1</source>
-        <translation type="vanished">Erreur de périphérique de positionnement : %1</translation>
+        <translation>Erreur de périphérique de positionnement : %1</translation>
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="unfinished"/>
+        <translation>Dupliquer l&apos;entité</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
+        <translation>Entité dupliquée avec succès</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation>La capture activée</translation>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation>Capture désactivée</translation>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation>Le canevas suit la localisation et l&apos;orientation de la boussole</translation>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation>Pas de mise-en-page disponible</translation>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation>En savoir plus</translation>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation>Capteurs</translation>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation>Pas de capteur disponible</translation>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation>Dossier de projet</translation>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation>Sélectionner un capteur ci-dessous</translation>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation>Erreur de capteur : %1</translation>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation>Déconnexion du capteur &apos;%1&apos;...</translation>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation>Connexion du capteur &apos;%1&apos;...</translation>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation>Sélectionner un modèle ci dessous</translation>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation>Couche : </translation>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation>Entité : </translation>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation>Ouvrir le formulaire de l&apos;entité</translation>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation>La duplication de l&apos;entité n&apos;est pas possible</translation>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation>Importation de %1</translation>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation>L&apos;import de l&apos;URL a échoué</translation>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -4166,7 +4301,7 @@ fermer le projet et quitter l&apos;application</translation>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Impossible d&apos;ajouter l&apos;entité enfant: les clés primaires du parent ne sont pas disponibles</translation>
+        <translation type="vanished">Impossible d&apos;ajouter l&apos;entité enfant: les clés primaires du parent ne sont pas disponibles</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -4187,6 +4322,10 @@ fermer le projet et quitter l&apos;application</translation>
     <message>
         <source>Failed to delete referencing feature</source>
         <translation>Échec de la suppression de l&apos;entité référencée.</translation>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 </TS>

--- a/i18n/qfield_gl.ts
+++ b/i18n/qfield_gl.ts
@@ -230,7 +230,7 @@ Cancela para facer, porén, unha exploración mínima do dispositivo.</translati
     </message>
     <message>
         <source>Scanning error: %1</source>
-        <translation type="unfinished"/>
+        <translation>Erro de escaneado: %1</translation>
     </message>
 </context>
 <context>
@@ -241,7 +241,7 @@ Cancela para facer, porén, unha exploración mínima do dispositivo.</translati
     </message>
     <message>
         <source>Bluetooth permission denied</source>
-        <translation type="unfinished"/>
+        <translation>Permiso do Bluetooth denegado</translation>
     </message>
 </context>
 <context>
@@ -292,7 +292,7 @@ Cancela para facer, porén, unha exploración mínima do dispositivo.</translati
     </message>
     <message>
         <source>Bluetooth permission denied</source>
-        <translation type="unfinished"/>
+        <translation>Permiso do Bluetooth denegado</translation>
     </message>
 </context>
 <context>
@@ -666,6 +666,29 @@ Cancela para facer, porén, unha exploración mínima do dispositivo.</translati
     </message>
 </context>
 <context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation>Non se puideron desfacer as entidades creadas na capa &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation>Non se puido desfacer a eliminación das entidades da capa &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation>Non se puido desfacer a actualización das entidades da capa &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation>Non se puido remitir a modificación de desfacer entidade na capa &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation>Non se puideron reverter as modificación de desfacer entidades na capa &quot;%1&quot;</translation>
+    </message>
+</context>
+<context>
     <name>FeatureListForm</name>
     <message>
         <source>Stop tracking this feature to edit attributes</source>
@@ -943,7 +966,7 @@ As xeometrías das entidades combinaranse na entidade &apos;%1&apos;, a cal cons
     <name>InternalGnssReceiver</name>
     <message>
         <source>Location permission denied</source>
-        <translation type="unfinished"/>
+        <translation>Permiso de posicionamento denegado</translation>
     </message>
 </context>
 <context>
@@ -2109,6 +2132,14 @@ Aínda que podes seguir vendo e utilizando este proxecto, recoméndase fortement
         <source>No changes to revert</source>
         <translation>Sen cambios a reverter</translation>
     </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>QFieldCloudProjectsModel</name>
@@ -2346,6 +2377,10 @@ Aínda que podes seguir vendo e utilizando este proxecto, recoméndase fortement
     <message>
         <source>Project Actions</source>
         <translation>Accións do Proxecto</translation>
+    </message>
+    <message>
+        <source>, updated data available on the cloud</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3723,7 +3758,7 @@ Cancela para facer, porén, unha exploración mínima do dispositivo.</translati
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Non se pode engadir a entidade filla: non están dispoñibles as claves primarias da capa de orixe</translation>
+        <translation type="vanished">Non se pode engadir a entidade filla: non están dispoñibles as claves primarias da capa de orixe</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -3745,100 +3780,104 @@ Cancela para facer, porén, unha exploración mínima do dispositivo.</translati
         <source>Failed to delete referencing feature</source>
         <translation>Non se puido eliminar a entidade de referencia</translation>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation>Non se pode engadir a entidade filla: non se estableceu o valor de atributo que enlaza pais con fillas</translation>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">Agora estás en modo buscador</translation>
+        <translation>Agora estás en modo buscador</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">Agora estás en modo dixitalizar na capa %1</translation>
+        <translation>Agora estás en modo dixitalizar na capa %1</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">Agora estás en modo dixitalizar</translation>
+        <translation>Agora estás en modo dixitalizar</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">Agora estás en modo medición</translation>
+        <translation>Agora estás en modo medición</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">Lon</translation>
+        <translation>Lon</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">Lat</translation>
+        <translation>Lat</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">Segmento</translation>
+        <translation>Segmento</translation>
     </message>
     <message>
         <source>Perimeter</source>
-        <translation type="vanished">Perímetro</translation>
+        <translation>Perímetro</translation>
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">Lonxitude</translation>
+        <translation>Lonxitude</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">Área</translation>
+        <translation>Área</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">Pechar a ferramenta de medición</translation>
+        <translation>Pechar a ferramenta de medición</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">Parar a edición</translation>
+        <translation>Parar a edición</translation>
     </message>
     <message>
         <source>Cancel addition</source>
-        <translation type="vanished">Cancelar o engadido</translation>
+        <translation>Cancelar o engadido</translation>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">Edición topolóxica acesa</translation>
+        <translation>Edición topolóxica acesa</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">Edición topolóxica apagada</translation>
+        <translation>Edición topolóxica apagada</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">Activada a dixitalización a man alzada</translation>
+        <translation>Activada a dixitalización a man alzada</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">Dixitalización a man alzada apagada</translation>
+        <translation>Dixitalización a man alzada apagada</translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
-        <translation type="vanished">Cursor de coordenadas bloqueado agora á posición</translation>
+        <translation>Cursor de coordenadas bloqueado agora á posición</translation>
     </message>
     <message>
         <source>Coordinate cursor unlocked</source>
-        <translation type="vanished">Cursor de coordenadas desbloqueado</translation>
+        <translation>Cursor de coordenadas desbloqueado</translation>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">Posición recibida</translation>
+        <translation>Posición recibida</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">Buscando a posición</translation>
+        <translation>Buscando a posición</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">A vista do mapa segue a localización</translation>
+        <translation>A vista do mapa segue a localización</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">Agardando pola localización</translation>
+        <translation>Agardando pola localización</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3850,19 +3889,19 @@ Cancela para facer, porén, unha exploración mínima do dispositivo.</translati
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">A vista do mapa detivo o seguimento da localización</translation>
+        <translation>A vista do mapa detivo o seguimento da localización</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">Non se puido crear a entidade!</translation>
+        <translation>Non se puido crear a entidade!</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">Non se puido gardar a entidade!</translation>
+        <translation>Non se puido gardar a entidade!</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">Menú Principal</translation>
+        <translation>Menú Principal</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3870,7 +3909,7 @@ Cancela para facer, porén, unha exploración mínima do dispositivo.</translati
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">Imprimir a PDF</translation>
+        <translation>Imprimir a PDF</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3890,15 +3929,15 @@ Cancela para facer, porén, unha exploración mínima do dispositivo.</translati
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">Configuración</translation>
+        <translation>Configuración</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">Rexistro de Mensaxes</translation>
+        <translation>Rexistro de Mensaxes</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">Acerca de QField</translation>
+        <translation>Acerca de QField</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3906,7 +3945,7 @@ Cancela para facer, porén, unha exploración mínima do dispositivo.</translati
     </message>
     <message>
         <source>Activating positioning service</source>
-        <translation type="vanished">Activando o servizo de posicionamento</translation>
+        <translation>Activando o servizo de posicionamento</translation>
     </message>
     <message>
         <source>QField has no permissions to use positioning.</source>
@@ -3914,15 +3953,15 @@ Cancela para facer, porén, unha exploración mínima do dispositivo.</translati
     </message>
     <message>
         <source>Map Canvas Options</source>
-        <translation type="vanished">Opcións da Vista do Mapa</translation>
+        <translation>Opcións da Vista do Mapa</translation>
     </message>
     <message>
         <source>Add Bookmark</source>
-        <translation type="vanished">Engadir Marcador</translation>
+        <translation>Engadir Marcador</translation>
     </message>
     <message>
         <source>Set as Destination</source>
-        <translation type="vanished">Establecer como Destino</translation>
+        <translation>Establecer como Destino</translation>
     </message>
     <message>
         <source>Add Bookmark at Coordinates</source>
@@ -3930,7 +3969,7 @@ Cancela para facer, porén, unha exploración mínima do dispositivo.</translati
     </message>
     <message>
         <source>Untitled bookmark</source>
-        <translation type="vanished">Marcador sen título</translation>
+        <translation>Marcador sen título</translation>
     </message>
     <message>
         <source>Set Coordinates as Destination</source>
@@ -3938,7 +3977,7 @@ Cancela para facer, porén, unha exploración mínima do dispositivo.</translati
     </message>
     <message>
         <source>Copy Coordinates</source>
-        <translation type="vanished">Copiar Coordenadas</translation>
+        <translation>Copiar Coordenadas</translation>
     </message>
     <message>
         <source>X</source>
@@ -3950,11 +3989,11 @@ Cancela para facer, porén, unha exploración mínima do dispositivo.</translati
     </message>
     <message>
         <source>Coordinates copied to clipboard</source>
-        <translation type="vanished">Coordenadas copiadas ó portapapeis</translation>
+        <translation>Coordenadas copiadas ó portapapeis</translation>
     </message>
     <message>
         <source>Precise View Settings</source>
-        <translation type="vanished">Configuración da Vista Precisa</translation>
+        <translation>Configuración da Vista Precisa</translation>
     </message>
     <message>
         <source>0.25m Precision</source>
@@ -3982,27 +4021,27 @@ Cancela para facer, porén, unha exploración mínima do dispositivo.</translati
     </message>
     <message>
         <source>Always Show Precise View</source>
-        <translation type="vanished">Amosar Sempre a Vista Precisa</translation>
+        <translation>Amosar Sempre a Vista Precisa</translation>
     </message>
     <message>
         <source>Center to Location</source>
-        <translation type="vanished">Centrar á Localización</translation>
+        <translation>Centrar á Localización</translation>
     </message>
     <message>
         <source>Add Bookmark at Location</source>
-        <translation type="vanished">Engadir Marcador na Localización</translation>
+        <translation>Engadir Marcador na Localización</translation>
     </message>
     <message>
         <source>Copy Location Coordinates</source>
-        <translation type="vanished">Copiar Coordenadas da Localización</translation>
+        <translation>Copiar Coordenadas da Localización</translation>
     </message>
     <message>
         <source>Signed out</source>
-        <translation type="vanished">Saíches da sesión</translation>
+        <translation>Saíches da sesión</translation>
     </message>
     <message>
         <source>Signed in</source>
-        <translation type="vanished">Iniciaches sesión</translation>
+        <translation>Iniciaches sesión</translation>
     </message>
     <message>
         <source>Set As Destination</source>
@@ -4010,35 +4049,35 @@ Cancela para facer, porén, unha exploración mínima do dispositivo.</translati
     </message>
     <message>
         <source>Navigation Options</source>
-        <translation type="vanished">Opcións de Navegación</translation>
+        <translation>Opcións de Navegación</translation>
     </message>
     <message>
         <source>Clear Destination</source>
-        <translation type="vanished">Borrar Destino</translation>
+        <translation>Borrar Destino</translation>
     </message>
     <message>
         <source>%1 Precision</source>
-        <translation type="vanished">Precisión de %1</translation>
+        <translation>Precisión de %1</translation>
     </message>
     <message>
         <source>Enable Audio Proximity Feedback</source>
-        <translation type="vanished">Activar a Retroalimentación de Proximidade do Audio</translation>
+        <translation>Activar a Retroalimentación de Proximidade do Audio</translation>
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">Opcións de Posicionamento</translation>
+        <translation>Opcións de Posicionamento</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">Activar Posicionamento</translation>
+        <translation>Activar Posicionamento</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">Amosar Información da Posición</translation>
+        <translation>Amosar Información da Posición</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">Configuración do Posicionamento</translation>
+        <translation>Configuración do Posicionamento</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4050,11 +4089,11 @@ Cancela para facer, porén, unha exploración mínima do dispositivo.</translati
     </message>
     <message>
         <source>Current location unknown</source>
-        <translation type="vanished">Posición actual descoñecida</translation>
+        <translation>Posición actual descoñecida</translation>
     </message>
     <message>
         <source>My location</source>
-        <translation type="vanished">A miña posición</translation>
+        <translation>A miña posición</translation>
     </message>
     <message>
         <source>Copy Current Location</source>
@@ -4062,27 +4101,27 @@ Cancela para facer, porén, unha exploración mínima do dispositivo.</translati
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">Precisión</translation>
+        <translation>Precisión</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">Sen Datos</translation>
+        <translation>Sen Datos</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
-        <translation type="vanished">Posición actual copiada ó portapapeis</translation>
+        <translation>Posición actual copiada ó portapapeis</translation>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
-        <translation type="vanished">Cambiouse a capa actual para a que contén a xeometría seleccionada.</translation>
+        <translation>Cambiouse a capa actual para a que contén a xeometría seleccionada.</translation>
     </message>
     <message>
         <source>Editing of multi geometry layer is not supported yet.</source>
-        <translation type="vanished">Aínda non se admite a edición de capas multixeometría.</translation>
+        <translation>Aínda non se admite a edición de capas multixeometría.</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">Cargando %1</translation>
+        <translation>Cargando %1</translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4090,7 +4129,7 @@ Cancela para facer, porén, unha exploración mínima do dispositivo.</translati
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">Conectando....</translation>
+        <translation>Conectando....</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4098,23 +4137,23 @@ Cancela para facer, porén, unha exploración mínima do dispositivo.</translati
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">Non se puido descargar o proxecto %1</translation>
+        <translation>Non se puido descargar o proxecto %1</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
-        <translation type="vanished">Proxecto %1 descargado con éxito, agora está dispoñible para abrir</translation>
+        <translation>Proxecto %1 descargado con éxito, agora está dispoñible para abrir</translation>
     </message>
     <message>
         <source>Changes failed to reach QFieldCloud: %1</source>
-        <translation type="vanished">Os cambios non puideron chegar a QFieldCloud: %1</translation>
+        <translation>Os cambios non puideron chegar a QFieldCloud: %1</translation>
     </message>
     <message>
         <source>Changes successfully pushed to QFieldCloud</source>
-        <translation type="vanished">Cambios enviados con éxito a QFieldCloud</translation>
+        <translation>Cambios enviados con éxito a QFieldCloud</translation>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">Premer atrás de novo para pechar o proxecto e a aplicación</translation>
+        <translation>Premer atrás de novo para pechar o proxecto e a aplicación</translation>
     </message>
     <message>
         <source>Positioning error: %1</source>
@@ -4122,11 +4161,11 @@ Cancela para facer, porén, unha exploración mínima do dispositivo.</translati
     </message>
     <message>
         <source>Azimuth</source>
-        <translation type="vanished">Acimut</translation>
+        <translation>Acimut</translation>
     </message>
     <message>
         <source>Lock Screen</source>
-        <translation type="vanished">Bloquear a Pantalla</translation>
+        <translation>Bloquear a Pantalla</translation>
     </message>
     <message>
         <source>Print to Image</source>
@@ -4134,23 +4173,119 @@ Cancela para facer, porén, unha exploración mínima do dispositivo.</translati
     </message>
     <message>
         <source>Printing...</source>
-        <translation type="vanished">Imprimindo...</translation>
+        <translation>Imprimindo...</translation>
     </message>
     <message>
         <source>Print</source>
-        <translation type="vanished">Imprimir</translation>
+        <translation>Imprimir</translation>
     </message>
     <message>
         <source>Positioning device error: %1</source>
-        <translation type="vanished">Erro do dispositivo de posicionamento: %1</translation>
+        <translation>Erro do dispositivo de posicionamento: %1</translation>
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="unfinished"/>
+        <translation>Duplicar Entidade</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
+        <translation>Entidade duplicada con éxito</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation>Axuste aceso</translation>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation>Axuste apagado</translation>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation>A vista do mapa segue a localización e a orientación da brúxula</translation>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation>Non hai dispoñible ningún deseño para imprimir</translation>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation>Aprender máis</translation>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation>Sensores</translation>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation>Non hai ningún sensor dispoñible</translation>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation>Cartafol de proxecto </translation>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation>Seleccionar sensor abaixo</translation>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation>Erro do sensor: %1</translation>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation>Desconectando o  sensor &apos;%1&apos;...</translation>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation>Conectando o sensor &apos;%1&apos;...</translation>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation>Seleccionar deseño abaixo</translation>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation>Capa:</translation>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation>Entidade:</translation>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation>Abrir Formulario de Entidade</translation>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation>Non está dispoñible a duplicación de entidades</translation>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation>Importando %1</translation>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation>Produciuse un erro na importación do URL</translation>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
+        <translation>Desbloquear a pantalla para pechar o proxecto e a aplicación</translation>
     </message>
 </context>
 <context>
@@ -4165,7 +4300,7 @@ Cancela para facer, porén, unha exploración mínima do dispositivo.</translati
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Non se pode engadir a entidade filla: non están dispoñibles as claves primarias da capa de orixe</translation>
+        <translation type="vanished">Non se pode engadir a entidade filla: non están dispoñibles as claves primarias da capa de orixe</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -4186,6 +4321,10 @@ Cancela para facer, porén, unha exploración mínima do dispositivo.</translati
     <message>
         <source>Failed to delete referencing feature</source>
         <translation>Non se puido eliminar a entidade de referencia</translation>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation>Non se pode engadir a entidade filla: non se estableceu o valor de atributo que enlaza pais con fillas</translation>
     </message>
 </context>
 </TS>

--- a/i18n/qfield_hr.ts
+++ b/i18n/qfield_hr.ts
@@ -666,6 +666,29 @@ Otkažite za pokretanje minimalnog skeniranja uređaja.</translation>
     </message>
 </context>
 <context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
     <name>FeatureListForm</name>
     <message>
         <source>Stop tracking this feature to edit attributes</source>
@@ -2109,6 +2132,14 @@ While you can still view and use the project, it is strongly recommended to rese
         <source>No changes to revert</source>
         <translation>Nema promjena za vraćanje</translation>
     </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>QFieldCloudProjectsModel</name>
@@ -2344,6 +2375,10 @@ While you can still view and use the project, it is strongly recommended to rese
     <message>
         <source>Project Actions</source>
         <translation>Akcije projekta</translation>
+    </message>
+    <message>
+        <source>, updated data available on the cloud</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3721,7 +3756,7 @@ Otkažite da pokrenete minimalno skeniranje uređaja.</translation>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Ne mogu dodati podelement: primarni ključevi roditeljskog elementa nisu dostupni</translation>
+        <translation type="vanished">Ne mogu dodati podelement: primarni ključevi roditeljskog elementa nisu dostupni</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -3743,100 +3778,104 @@ Otkažite da pokrenete minimalno skeniranje uređaja.</translation>
         <source>Failed to delete referencing feature</source>
         <translation>Neuspješno brisanje referenciranog elementa</translation>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">Sada ste u načinu pregledavanja</translation>
+        <translation>Sada ste u načinu pregledavanja</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">Sada ste u načinu digitalizacije na sloju %1</translation>
+        <translation>Sada ste u načinu digitalizacije na sloju %1</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">Sada ste u načinu digitalizacije</translation>
+        <translation>Sada ste u načinu digitalizacije</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">Sada ste u načinu mjerenja</translation>
+        <translation>Sada ste u načinu mjerenja</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">Dužina</translation>
+        <translation>Dužina</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">Širina</translation>
+        <translation>Širina</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">Segment</translation>
+        <translation>Segment</translation>
     </message>
     <message>
         <source>Perimeter</source>
-        <translation type="vanished">Opseg</translation>
+        <translation>Opseg</translation>
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">Dužina</translation>
+        <translation>Dužina</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">Površina</translation>
+        <translation>Površina</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">Zatvori alat za mjerenje</translation>
+        <translation>Zatvori alat za mjerenje</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">Zaustavi uređivanje</translation>
+        <translation>Zaustavi uređivanje</translation>
     </message>
     <message>
         <source>Cancel addition</source>
-        <translation type="vanished">Otkaži dodavanje</translation>
+        <translation>Otkaži dodavanje</translation>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">Topološko uređivanje uključeno</translation>
+        <translation>Topološko uređivanje uključeno</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">Topološko uređivanje isključeno</translation>
+        <translation>Topološko uređivanje isključeno</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">Uključena prostoručna digitalizacija</translation>
+        <translation>Uključena prostoručna digitalizacija</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">Isključena prostoručna digitalizacija</translation>
+        <translation>Isključena prostoručna digitalizacija</translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
-        <translation type="vanished">Koordinate pokazivača zaključane na poziciju</translation>
+        <translation>Koordinate pokazivača zaključane na poziciju</translation>
     </message>
     <message>
         <source>Coordinate cursor unlocked</source>
-        <translation type="vanished">Koordinate pokazivača otključane</translation>
+        <translation>Koordinate pokazivača otključane</translation>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">Pozicija primljena</translation>
+        <translation>Pozicija primljena</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">Traženje lokacije</translation>
+        <translation>Traženje lokacije</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">Okvir prati lokaciju</translation>
+        <translation>Okvir prati lokaciju</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">Čekanje lokacije</translation>
+        <translation>Čekanje lokacije</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3848,19 +3887,19 @@ Otkažite da pokrenete minimalno skeniranje uređaja.</translation>
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">Okvir je prestao pratiti lokaciju</translation>
+        <translation>Okvir je prestao pratiti lokaciju</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">Neuspješno stvaranje elementa!</translation>
+        <translation>Neuspješno stvaranje elementa!</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">Neuspjelo spremanje elementa!</translation>
+        <translation>Neuspjelo spremanje elementa!</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">Glavni izbornik</translation>
+        <translation>Glavni izbornik</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3868,7 +3907,7 @@ Otkažite da pokrenete minimalno skeniranje uređaja.</translation>
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">Isprintaj u PDF</translation>
+        <translation>Isprintaj u PDF</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3888,15 +3927,15 @@ Otkažite da pokrenete minimalno skeniranje uređaja.</translation>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">Postavke</translation>
+        <translation>Postavke</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">Zapisnik poruka</translation>
+        <translation>Zapisnik poruka</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">O aplikaciji QField</translation>
+        <translation>O aplikaciji QField</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3904,7 +3943,7 @@ Otkažite da pokrenete minimalno skeniranje uređaja.</translation>
     </message>
     <message>
         <source>Activating positioning service</source>
-        <translation type="vanished">Aktiviranje usluge lociranja</translation>
+        <translation>Aktiviranje usluge lociranja</translation>
     </message>
     <message>
         <source>QField has no permissions to use positioning.</source>
@@ -3912,15 +3951,15 @@ Otkažite da pokrenete minimalno skeniranje uređaja.</translation>
     </message>
     <message>
         <source>Map Canvas Options</source>
-        <translation type="vanished">Opcije okvira karte</translation>
+        <translation>Opcije okvira karte</translation>
     </message>
     <message>
         <source>Add Bookmark</source>
-        <translation type="vanished">Dodaj oznaku</translation>
+        <translation>Dodaj oznaku</translation>
     </message>
     <message>
         <source>Set as Destination</source>
-        <translation type="vanished">Postavi kao odredište</translation>
+        <translation>Postavi kao odredište</translation>
     </message>
     <message>
         <source>Add Bookmark at Coordinates</source>
@@ -3928,7 +3967,7 @@ Otkažite da pokrenete minimalno skeniranje uređaja.</translation>
     </message>
     <message>
         <source>Untitled bookmark</source>
-        <translation type="vanished">Neimenovana zabilješka</translation>
+        <translation>Neimenovana zabilješka</translation>
     </message>
     <message>
         <source>Set Coordinates as Destination</source>
@@ -3936,7 +3975,7 @@ Otkažite da pokrenete minimalno skeniranje uređaja.</translation>
     </message>
     <message>
         <source>Copy Coordinates</source>
-        <translation type="vanished">Kopiraj Koordinate</translation>
+        <translation>Kopiraj Koordinate</translation>
     </message>
     <message>
         <source>X</source>
@@ -3948,11 +3987,11 @@ Otkažite da pokrenete minimalno skeniranje uređaja.</translation>
     </message>
     <message>
         <source>Coordinates copied to clipboard</source>
-        <translation type="vanished">Koordinate kopirane u međuspremnik</translation>
+        <translation>Koordinate kopirane u međuspremnik</translation>
     </message>
     <message>
         <source>Precise View Settings</source>
-        <translation type="vanished">Postavke prikaza preciznosti</translation>
+        <translation>Postavke prikaza preciznosti</translation>
     </message>
     <message>
         <source>0.25m Precision</source>
@@ -3980,27 +4019,27 @@ Otkažite da pokrenete minimalno skeniranje uređaja.</translation>
     </message>
     <message>
         <source>Always Show Precise View</source>
-        <translation type="vanished">Uvijek pokaži prikaz preciznosti</translation>
+        <translation>Uvijek pokaži prikaz preciznosti</translation>
     </message>
     <message>
         <source>Center to Location</source>
-        <translation type="vanished">Centriraj na lokaciju</translation>
+        <translation>Centriraj na lokaciju</translation>
     </message>
     <message>
         <source>Add Bookmark at Location</source>
-        <translation type="vanished">Dodaj oznaku na lokaciji</translation>
+        <translation>Dodaj oznaku na lokaciji</translation>
     </message>
     <message>
         <source>Copy Location Coordinates</source>
-        <translation type="vanished">Kopiraj koordinate lokacije</translation>
+        <translation>Kopiraj koordinate lokacije</translation>
     </message>
     <message>
         <source>Signed out</source>
-        <translation type="vanished">Uspješna odjava</translation>
+        <translation>Uspješna odjava</translation>
     </message>
     <message>
         <source>Signed in</source>
-        <translation type="vanished">Uspješna prijava</translation>
+        <translation>Uspješna prijava</translation>
     </message>
     <message>
         <source>Set As Destination</source>
@@ -4008,35 +4047,35 @@ Otkažite da pokrenete minimalno skeniranje uređaja.</translation>
     </message>
     <message>
         <source>Navigation Options</source>
-        <translation type="vanished">Opcije Navigacije</translation>
+        <translation>Opcije Navigacije</translation>
     </message>
     <message>
         <source>Clear Destination</source>
-        <translation type="vanished">Očisti odredište</translation>
+        <translation>Očisti odredište</translation>
     </message>
     <message>
         <source>%1 Precision</source>
-        <translation type="vanished">%1 preciznost</translation>
+        <translation>%1 preciznost</translation>
     </message>
     <message>
         <source>Enable Audio Proximity Feedback</source>
-        <translation type="vanished">Uključi zvučnu obavijest za blizinu</translation>
+        <translation>Uključi zvučnu obavijest za blizinu</translation>
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">Opcije Pozicioniranja</translation>
+        <translation>Opcije Pozicioniranja</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">Omogući pozicioniranje</translation>
+        <translation>Omogući pozicioniranje</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">Prikaži informacije o poziciji</translation>
+        <translation>Prikaži informacije o poziciji</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">Postavke Pozicioniranja</translation>
+        <translation>Postavke Pozicioniranja</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4048,11 +4087,11 @@ Otkažite da pokrenete minimalno skeniranje uređaja.</translation>
     </message>
     <message>
         <source>Current location unknown</source>
-        <translation type="vanished">Trenutna lokacija nepoznata</translation>
+        <translation>Trenutna lokacija nepoznata</translation>
     </message>
     <message>
         <source>My location</source>
-        <translation type="vanished">Moja lokacija</translation>
+        <translation>Moja lokacija</translation>
     </message>
     <message>
         <source>Copy Current Location</source>
@@ -4060,27 +4099,27 @@ Otkažite da pokrenete minimalno skeniranje uređaja.</translation>
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">Točnost</translation>
+        <translation>Točnost</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">N/A</translation>
+        <translation>N/A</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
-        <translation type="vanished">Trenutna lokacija kopirana u meduspremnik</translation>
+        <translation>Trenutna lokacija kopirana u meduspremnik</translation>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
-        <translation type="vanished">Trenutni sloj promijenjen na onaj koji sadrži odabranu geometriju.</translation>
+        <translation>Trenutni sloj promijenjen na onaj koji sadrži odabranu geometriju.</translation>
     </message>
     <message>
         <source>Editing of multi geometry layer is not supported yet.</source>
-        <translation type="vanished">Uređivanje sloja sa višestrukom geometrijom još nije podržano.</translation>
+        <translation>Uređivanje sloja sa višestrukom geometrijom još nije podržano.</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">Učitavanje %1</translation>
+        <translation>Učitavanje %1</translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4088,7 +4127,7 @@ Otkažite da pokrenete minimalno skeniranje uređaja.</translation>
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">Povezivanje...</translation>
+        <translation>Povezivanje...</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4096,23 +4135,23 @@ Otkažite da pokrenete minimalno skeniranje uređaja.</translation>
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">Projekt %1 neuspješno preuzimanje</translation>
+        <translation>Projekt %1 neuspješno preuzimanje</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
-        <translation type="vanished">Projekt %1 je uspješno preuzet, od sada je dostupan za otvaranje</translation>
+        <translation>Projekt %1 je uspješno preuzet, od sada je dostupan za otvaranje</translation>
     </message>
     <message>
         <source>Changes failed to reach QFieldCloud: %1</source>
-        <translation type="vanished">Promjene nisu stigle do QFieldCloud: %1</translation>
+        <translation>Promjene nisu stigle do QFieldCloud: %1</translation>
     </message>
     <message>
         <source>Changes successfully pushed to QFieldCloud</source>
-        <translation type="vanished">Promjene uspješno poslane na QFieldCloud</translation>
+        <translation>Promjene uspješno poslane na QFieldCloud</translation>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">Pritisnite opet natrag za zatvaranje projekta i aplikacije</translation>
+        <translation>Pritisnite opet natrag za zatvaranje projekta i aplikacije</translation>
     </message>
     <message>
         <source>Positioning error: %1</source>
@@ -4120,11 +4159,11 @@ Otkažite da pokrenete minimalno skeniranje uređaja.</translation>
     </message>
     <message>
         <source>Azimuth</source>
-        <translation type="vanished">Azimut</translation>
+        <translation>Azimut</translation>
     </message>
     <message>
         <source>Lock Screen</source>
-        <translation type="vanished">Zaključaj zaslon</translation>
+        <translation>Zaključaj zaslon</translation>
     </message>
     <message>
         <source>Print to Image</source>
@@ -4132,22 +4171,118 @@ Otkažite da pokrenete minimalno skeniranje uređaja.</translation>
     </message>
     <message>
         <source>Printing...</source>
-        <translation type="vanished">Ispisujem...</translation>
+        <translation>Ispisujem...</translation>
     </message>
     <message>
         <source>Print</source>
-        <translation type="vanished">Ispiši</translation>
+        <translation>Ispiši</translation>
     </message>
     <message>
         <source>Positioning device error: %1</source>
-        <translation type="vanished">Greška uređaja za pozicioniranje: (%1)</translation>
+        <translation>Greška uređaja za pozicioniranje: (%1)</translation>
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="unfinished"/>
+        <translation>Dupliciraj element</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
+        <translation>Element uspješno dupliciran</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation>Hvatanje elemenata je uključeno</translation>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation>Hvatanje elemenata je isključeno</translation>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation>Okvir karte prati lokaciju i smjer kompasa</translation>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation>Nema dostupnog okvira za ispis</translation>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation>Saznaj više</translation>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation>Senzori</translation>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation>Nema dostupnog senzora</translation>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation>Mapa projekta</translation>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation>Odaberi senzor ispod</translation>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation>Greška senzora: %1</translation>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation>Odspajam senzor &apos;%1&apos;...</translation>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation>Spajam se na senzor &apos;%1&apos;...</translation>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation>Odaberi okvir ispod</translation>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation>Sloj:</translation>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation>Element:</translation>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation>Otvori obrazac za element</translation>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation>Dupliciranje elementa nije dostupno</translation>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation>Uvozim %1</translation>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation>Uvoz URL-a nije uspio</translation>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -4163,7 +4298,7 @@ Otkažite da pokrenete minimalno skeniranje uređaja.</translation>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Ne mogu dodati podelement: primarni ključevi roditeljskog elementa nisu dostupni </translation>
+        <translation type="vanished">Ne mogu dodati podelement: primarni ključevi roditeljskog elementa nisu dostupni </translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -4184,6 +4319,10 @@ Otkažite da pokrenete minimalno skeniranje uređaja.</translation>
     <message>
         <source>Failed to delete referencing feature</source>
         <translation>Neuspješno brisanje referenciranog elementa</translation>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 </TS>

--- a/i18n/qfield_hu.ts
+++ b/i18n/qfield_hu.ts
@@ -666,6 +666,29 @@ Cancel to make a minimal device scan instead.</source>
     </message>
 </context>
 <context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
     <name>FeatureListForm</name>
     <message>
         <source>Stop tracking this feature to edit attributes</source>
@@ -2105,6 +2128,14 @@ While you can still view and use the project, it is strongly recommended to rese
         <source>No changes to revert</source>
         <translation>Nincsenek elvethető változások</translation>
     </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>QFieldCloudProjectsModel</name>
@@ -2340,6 +2371,10 @@ name(string), owner(string), description(string), user_role(string), is_public(b
     <message>
         <source>Project Actions</source>
         <translation>Projekt műveletek</translation>
+    </message>
+    <message>
+        <source>, updated data available on the cloud</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3717,7 +3752,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Nem adható hozzá utód-funkció: a szülői elsődleges kulcsok nem állnak rendelkezésre</translation>
+        <translation type="vanished">Nem adható hozzá utód-funkció: a szülői elsődleges kulcsok nem állnak rendelkezésre</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -3739,100 +3774,104 @@ Cancel to make a minimal device scan instead.</source>
         <source>Failed to delete referencing feature</source>
         <translation>Nem sikerült a hivatkozó elemet törölni</translation>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">Tallózó módban van</translation>
+        <translation>Tallózó módban van</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">Digitalizáló módban van a %1 rétegen</translation>
+        <translation>Digitalizáló módban van a %1 rétegen</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">Digitalizáló módban van</translation>
+        <translation>Digitalizáló módban van</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">Mérés módban van</translation>
+        <translation>Mérés módban van</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">Lon</translation>
+        <translation>Lon</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">Lat</translation>
+        <translation>Lat</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">Szakasz</translation>
+        <translation>Szakasz</translation>
     </message>
     <message>
         <source>Perimeter</source>
-        <translation type="vanished">Kerület</translation>
+        <translation>Kerület</translation>
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">Hossz</translation>
+        <translation>Hossz</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">Terület</translation>
+        <translation>Terület</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">Mérőeszköz bezárása</translation>
+        <translation>Mérőeszköz bezárása</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">Szerkesztés befejezése</translation>
+        <translation>Szerkesztés befejezése</translation>
     </message>
     <message>
         <source>Cancel addition</source>
-        <translation type="vanished">Hozzáadás törlése</translation>
+        <translation>Hozzáadás törlése</translation>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">Topologikus szerkesztést bekapcsoltuk</translation>
+        <translation>Topologikus szerkesztést bekapcsoltuk</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">Topologikus szerkesztést kikapcsoltuk</translation>
+        <translation>Topologikus szerkesztést kikapcsoltuk</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">Szabadkézi digitalizálás bekapcsolva</translation>
+        <translation>Szabadkézi digitalizálás bekapcsolva</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">Szabadkézi digitalizálás kikapcsolva</translation>
+        <translation>Szabadkézi digitalizálás kikapcsolva</translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
-        <translation type="vanished">A koordinátához tartozó kurzor zárolt a pozíciónál</translation>
+        <translation>A koordinátához tartozó kurzor zárolt a pozíciónál</translation>
     </message>
     <message>
         <source>Coordinate cursor unlocked</source>
-        <translation type="vanished">A koordináta kurzor zárolása feloldva</translation>
+        <translation>A koordináta kurzor zárolása feloldva</translation>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">Kapott pozíció</translation>
+        <translation>Kapott pozíció</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">Pozíció keresés</translation>
+        <translation>Pozíció keresés</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">A térkép követi a pozíciót</translation>
+        <translation>A térkép követi a pozíciót</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">Várok a pozícióra</translation>
+        <translation>Várok a pozícióra</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3844,19 +3883,19 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">A térkép befejezte a pozíció követést</translation>
+        <translation>A térkép befejezte a pozíció követést</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">Nem sikerült az elemet létrehozni!</translation>
+        <translation>Nem sikerült az elemet létrehozni!</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">Nem sikerült az elemet menteni!</translation>
+        <translation>Nem sikerült az elemet menteni!</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">Főmenü</translation>
+        <translation>Főmenü</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3864,7 +3903,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">Nyomtatás PDF-be</translation>
+        <translation>Nyomtatás PDF-be</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3884,15 +3923,15 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">Beállítások</translation>
+        <translation>Beállítások</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">Üzenet napló</translation>
+        <translation>Üzenet napló</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">QField névjegy</translation>
+        <translation>QField névjegy</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3900,7 +3939,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Activating positioning service</source>
-        <translation type="vanished">A pozíciós szolgáltatás aktiválása</translation>
+        <translation>A pozíciós szolgáltatás aktiválása</translation>
     </message>
     <message>
         <source>QField has no permissions to use positioning.</source>
@@ -3908,15 +3947,15 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Map Canvas Options</source>
-        <translation type="vanished">Térkép lehetőségek</translation>
+        <translation>Térkép lehetőségek</translation>
     </message>
     <message>
         <source>Add Bookmark</source>
-        <translation type="vanished">Könyvjelző hozzáadása</translation>
+        <translation>Könyvjelző hozzáadása</translation>
     </message>
     <message>
         <source>Set as Destination</source>
-        <translation type="vanished">Beállítás célként</translation>
+        <translation>Beállítás célként</translation>
     </message>
     <message>
         <source>Add Bookmark at Coordinates</source>
@@ -3924,7 +3963,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Untitled bookmark</source>
-        <translation type="vanished">Névtelen könyvjelző</translation>
+        <translation>Névtelen könyvjelző</translation>
     </message>
     <message>
         <source>Set Coordinates as Destination</source>
@@ -3932,7 +3971,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Copy Coordinates</source>
-        <translation type="vanished">Koordináták másolása</translation>
+        <translation>Koordináták másolása</translation>
     </message>
     <message>
         <source>X</source>
@@ -3944,7 +3983,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Coordinates copied to clipboard</source>
-        <translation type="vanished">A koordináták a vágólapra másolva</translation>
+        <translation>A koordináták a vágólapra másolva</translation>
     </message>
     <message>
         <source>Precise View Settings</source>
@@ -3980,23 +4019,23 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Center to Location</source>
-        <translation type="vanished">köpontosítás az elhelyeszkedésre</translation>
+        <translation>köpontosítás az elhelyeszkedésre</translation>
     </message>
     <message>
         <source>Add Bookmark at Location</source>
-        <translation type="vanished">Könyvjelző hozzáadása a helyhez</translation>
+        <translation>Könyvjelző hozzáadása a helyhez</translation>
     </message>
     <message>
         <source>Copy Location Coordinates</source>
-        <translation type="vanished">Helykoordináták másolása</translation>
+        <translation>Helykoordináták másolása</translation>
     </message>
     <message>
         <source>Signed out</source>
-        <translation type="vanished">Kijelentkezve</translation>
+        <translation>Kijelentkezve</translation>
     </message>
     <message>
         <source>Signed in</source>
-        <translation type="vanished">Bejelentkezve</translation>
+        <translation>Bejelentkezve</translation>
     </message>
     <message>
         <source>Set As Destination</source>
@@ -4004,15 +4043,15 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Navigation Options</source>
-        <translation type="vanished">Navigációs beállítások</translation>
+        <translation>Navigációs beállítások</translation>
     </message>
     <message>
         <source>Clear Destination</source>
-        <translation type="vanished">Cél törlése</translation>
+        <translation>Cél törlése</translation>
     </message>
     <message>
         <source>%1 Precision</source>
-        <translation type="vanished">%1 pontosság</translation>
+        <translation>%1 pontosság</translation>
     </message>
     <message>
         <source>Enable Audio Proximity Feedback</source>
@@ -4020,19 +4059,19 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">Pozicionálási beállítások</translation>
+        <translation>Pozicionálási beállítások</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">Pozicionálás engedélyezése</translation>
+        <translation>Pozicionálás engedélyezése</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">Pozíció megjelenítés</translation>
+        <translation>Pozíció megjelenítés</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">Helymeghatározás beállítások</translation>
+        <translation>Helymeghatározás beállítások</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4044,11 +4083,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Current location unknown</source>
-        <translation type="vanished">Jelenlegi helye ismeretlen</translation>
+        <translation>Jelenlegi helye ismeretlen</translation>
     </message>
     <message>
         <source>My location</source>
-        <translation type="vanished">Tartózkodási helyem</translation>
+        <translation>Tartózkodási helyem</translation>
     </message>
     <message>
         <source>Copy Current Location</source>
@@ -4056,27 +4095,27 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">Pontosság</translation>
+        <translation>Pontosság</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">N/A</translation>
+        <translation>N/A</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
-        <translation type="vanished">Az aktuális hely a vágólapra másolva</translation>
+        <translation>Az aktuális hely a vágólapra másolva</translation>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
-        <translation type="vanished">Az aktuális réteget átváltottuk a szelektált geometriát tartalmazó rétegre.</translation>
+        <translation>Az aktuális réteget átváltottuk a szelektált geometriát tartalmazó rétegre.</translation>
     </message>
     <message>
         <source>Editing of multi geometry layer is not supported yet.</source>
-        <translation type="vanished">Multi geometria szerkesztése még nem támogatott.</translation>
+        <translation>Multi geometria szerkesztése még nem támogatott.</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">%1 betöltése</translation>
+        <translation>%1 betöltése</translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4084,7 +4123,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">Kapcsolódás...</translation>
+        <translation>Kapcsolódás...</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4092,23 +4131,23 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">%1 projekt sikertelen letöltés</translation>
+        <translation>%1 projekt sikertelen letöltés</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
-        <translation type="vanished">%1 projektet sikeresen letöltöttem, most megnyitható</translation>
+        <translation>%1 projektet sikeresen letöltöttem, most megnyitható</translation>
     </message>
     <message>
         <source>Changes failed to reach QFieldCloud: %1</source>
-        <translation type="vanished">A módosítások nem jutottak el a QFieldCloud-ba: %1</translation>
+        <translation>A módosítások nem jutottak el a QFieldCloud-ba: %1</translation>
     </message>
     <message>
         <source>Changes successfully pushed to QFieldCloud</source>
-        <translation type="vanished">A módosítások sikeresen átküldve a QFieldCloud-ba</translation>
+        <translation>A módosítások sikeresen átküldve a QFieldCloud-ba</translation>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">Nyomj visszát a projekt és az alkalmazás lezárásához</translation>
+        <translation>Nyomj visszát a projekt és az alkalmazás lezárásához</translation>
     </message>
     <message>
         <source>Positioning error: %1</source>
@@ -4116,11 +4155,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Azimuth</source>
-        <translation type="vanished">Irány</translation>
+        <translation>Irány</translation>
     </message>
     <message>
         <source>Lock Screen</source>
-        <translation type="vanished">Képernyő zárolás</translation>
+        <translation>Képernyő zárolás</translation>
     </message>
     <message>
         <source>Print to Image</source>
@@ -4128,22 +4167,118 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Printing...</source>
-        <translation type="vanished">Nyomtatás...</translation>
+        <translation>Nyomtatás...</translation>
     </message>
     <message>
         <source>Print</source>
-        <translation type="vanished">Nyomtatás</translation>
+        <translation>Nyomtatás</translation>
     </message>
     <message>
         <source>Positioning device error: %1</source>
-        <translation type="vanished">Helymeghatározó eszköz hiba: %1</translation>
+        <translation>Helymeghatározó eszköz hiba: %1</translation>
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="unfinished"/>
+        <translation>Elem megkettőzése</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
+        <translation>Az elem sikeresen megkettőzve</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation>Illesztés bekapcsolva</translation>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation>Illesztés kikapcsolva</translation>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation>A térképvászon követi a pozíciót és az irányt</translation>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation>Szenzorok</translation>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation>Nincs elérhető szenzor</translation>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation>Projekt mappa</translation>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation>Réteg:</translation>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation>Elem:</translation>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation>Elem űrlap megnyitás</translation>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation>Elem duplikálás nem lehetséges</translation>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation>Impotálás %1</translation>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -4159,7 +4294,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Nem adható hozzá utód-elem: a szülői elsődleges kulcsok nem állnak rendelkezésre</translation>
+        <translation type="vanished">Nem adható hozzá utód-elem: a szülői elsődleges kulcsok nem állnak rendelkezésre</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -4180,6 +4315,10 @@ Cancel to make a minimal device scan instead.</source>
     <message>
         <source>Failed to delete referencing feature</source>
         <translation>Nem sikerült a hivatkozó elemet törölni</translation>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 </TS>

--- a/i18n/qfield_id.ts
+++ b/i18n/qfield_id.ts
@@ -666,6 +666,29 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
 </context>
 <context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
     <name>FeatureListForm</name>
     <message>
         <source>Stop tracking this feature to edit attributes</source>
@@ -2107,6 +2130,14 @@ While you can still view and use the project, it is strongly recommended to rese
         <source>No changes to revert</source>
         <translation>No changes to revert</translation>
     </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>QFieldCloudProjectsModel</name>
@@ -2343,6 +2374,10 @@ While you can still view and use the project, it is strongly recommended to rese
     </message>
     <message>
         <source>Project Actions</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>, updated data available on the cloud</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -3721,7 +3756,7 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Cannot add child feature: parent primary keys are not available</translation>
+        <translation type="vanished">Cannot add child feature: parent primary keys are not available</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -3743,100 +3778,104 @@ Cancel to make a minimal device scan instead.</translation>
         <source>Failed to delete referencing feature</source>
         <translation>Failed to delete referencing feature</translation>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">You are now in browse mode</translation>
+        <translation>You are now in browse mode</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">You are now in digitize mode on layer %1</translation>
+        <translation>You are now in digitize mode on layer %1</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">You are now in digitize mode</translation>
+        <translation>You are now in digitize mode</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">You are now in measure mode</translation>
+        <translation>You are now in measure mode</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">Lon</translation>
+        <translation>Lon</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">Lat</translation>
+        <translation>Lat</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">Segment</translation>
+        <translation>Segment</translation>
     </message>
     <message>
         <source>Perimeter</source>
-        <translation type="vanished">Perimeter</translation>
+        <translation>Perimeter</translation>
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">Length</translation>
+        <translation>Length</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">Area</translation>
+        <translation>Area</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">Close measure tool</translation>
+        <translation>Close measure tool</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">Stop editing</translation>
+        <translation>Stop editing</translation>
     </message>
     <message>
         <source>Cancel addition</source>
-        <translation type="vanished">Cancel addition</translation>
+        <translation>Cancel addition</translation>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">Topological editing turned on</translation>
+        <translation>Topological editing turned on</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">Topological editing turned off</translation>
+        <translation>Topological editing turned off</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">Freehand digitizing turned on</translation>
+        <translation>Freehand digitizing turned on</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">Freehand digitizing turned off</translation>
+        <translation>Freehand digitizing turned off</translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
-        <translation type="vanished">Coordinate cursor now locked to position</translation>
+        <translation>Coordinate cursor now locked to position</translation>
     </message>
     <message>
         <source>Coordinate cursor unlocked</source>
-        <translation type="vanished">Coordinate cursor unlocked</translation>
+        <translation>Coordinate cursor unlocked</translation>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">Received position</translation>
+        <translation>Received position</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">Searching for position</translation>
+        <translation>Searching for position</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">Canvas follows location</translation>
+        <translation>Canvas follows location</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">Waiting for location</translation>
+        <translation>Waiting for location</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3848,19 +3887,19 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">Canvas stopped following location</translation>
+        <translation>Canvas stopped following location</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">Failed to create feature!</translation>
+        <translation>Failed to create feature!</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">Failed to save feature!</translation>
+        <translation>Failed to save feature!</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">Main Menu</translation>
+        <translation>Main Menu</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3868,7 +3907,7 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">Print to PDF</translation>
+        <translation>Print to PDF</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3888,15 +3927,15 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">Settings</translation>
+        <translation>Settings</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">Message Log</translation>
+        <translation>Message Log</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">About QField</translation>
+        <translation>About QField</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3904,7 +3943,7 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Activating positioning service</source>
-        <translation type="vanished">Activating positioning service</translation>
+        <translation>Activating positioning service</translation>
     </message>
     <message>
         <source>QField has no permissions to use positioning.</source>
@@ -3912,15 +3951,15 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Map Canvas Options</source>
-        <translation type="vanished">Map Canvas Options</translation>
+        <translation>Map Canvas Options</translation>
     </message>
     <message>
         <source>Add Bookmark</source>
-        <translation type="vanished">Add Bookmark</translation>
+        <translation>Add Bookmark</translation>
     </message>
     <message>
         <source>Set as Destination</source>
-        <translation type="vanished">Set as Destination</translation>
+        <translation>Set as Destination</translation>
     </message>
     <message>
         <source>Add Bookmark at Coordinates</source>
@@ -3928,7 +3967,7 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Untitled bookmark</source>
-        <translation type="vanished">Untitled bookmark</translation>
+        <translation>Untitled bookmark</translation>
     </message>
     <message>
         <source>Set Coordinates as Destination</source>
@@ -3936,7 +3975,7 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Copy Coordinates</source>
-        <translation type="vanished">Copy Coordinates</translation>
+        <translation>Copy Coordinates</translation>
     </message>
     <message>
         <source>X</source>
@@ -3948,11 +3987,11 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Coordinates copied to clipboard</source>
-        <translation type="vanished">Coordinates copied to clipboard</translation>
+        <translation>Coordinates copied to clipboard</translation>
     </message>
     <message>
         <source>Precise View Settings</source>
-        <translation type="vanished">Precise View Settings</translation>
+        <translation>Precise View Settings</translation>
     </message>
     <message>
         <source>0.25m Precision</source>
@@ -3980,27 +4019,27 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Always Show Precise View</source>
-        <translation type="vanished">Always Show Precise View</translation>
+        <translation>Always Show Precise View</translation>
     </message>
     <message>
         <source>Center to Location</source>
-        <translation type="vanished">Center to Location</translation>
+        <translation>Center to Location</translation>
     </message>
     <message>
         <source>Add Bookmark at Location</source>
-        <translation type="vanished">Add Bookmark at Location</translation>
+        <translation>Add Bookmark at Location</translation>
     </message>
     <message>
         <source>Copy Location Coordinates</source>
-        <translation type="vanished">Copy Location Coordinates</translation>
+        <translation>Copy Location Coordinates</translation>
     </message>
     <message>
         <source>Signed out</source>
-        <translation type="vanished">Signed out</translation>
+        <translation>Signed out</translation>
     </message>
     <message>
         <source>Signed in</source>
-        <translation type="vanished">Signed in</translation>
+        <translation>Signed in</translation>
     </message>
     <message>
         <source>Set As Destination</source>
@@ -4008,35 +4047,35 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Navigation Options</source>
-        <translation type="vanished">Navigation Options</translation>
+        <translation>Navigation Options</translation>
     </message>
     <message>
         <source>Clear Destination</source>
-        <translation type="vanished">Clear Destination</translation>
+        <translation>Clear Destination</translation>
     </message>
     <message>
         <source>%1 Precision</source>
-        <translation type="vanished">%1 Precision</translation>
+        <translation>%1 Precision</translation>
     </message>
     <message>
         <source>Enable Audio Proximity Feedback</source>
-        <translation type="vanished">Enable Audio Proximity Feedback</translation>
+        <translation>Enable Audio Proximity Feedback</translation>
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">Positioning Options</translation>
+        <translation>Positioning Options</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">Enable Positioning</translation>
+        <translation>Enable Positioning</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">Show Position Information</translation>
+        <translation>Show Position Information</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">Positioning Settings</translation>
+        <translation>Positioning Settings</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4048,11 +4087,11 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Current location unknown</source>
-        <translation type="vanished">Current location unknown</translation>
+        <translation>Current location unknown</translation>
     </message>
     <message>
         <source>My location</source>
-        <translation type="vanished">My location</translation>
+        <translation>My location</translation>
     </message>
     <message>
         <source>Copy Current Location</source>
@@ -4060,27 +4099,27 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">Accuracy</translation>
+        <translation>Accuracy</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">N/A</translation>
+        <translation>N/A</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
-        <translation type="vanished">Current location copied to clipboard</translation>
+        <translation>Current location copied to clipboard</translation>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
-        <translation type="vanished">Current layer switched to the one holding the selected geometry.</translation>
+        <translation>Current layer switched to the one holding the selected geometry.</translation>
     </message>
     <message>
         <source>Editing of multi geometry layer is not supported yet.</source>
-        <translation type="vanished">Editing of multi geometry layer is not supported yet.</translation>
+        <translation>Editing of multi geometry layer is not supported yet.</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">Loading %1</translation>
+        <translation>Loading %1</translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4088,7 +4127,7 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">Connecting...</translation>
+        <translation>Connecting...</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4096,23 +4135,23 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">Project %1 failed to download</translation>
+        <translation>Project %1 failed to download</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
-        <translation type="vanished">Project %1 successfully downloaded, it&apos;s now available to open</translation>
+        <translation>Project %1 successfully downloaded, it&apos;s now available to open</translation>
     </message>
     <message>
         <source>Changes failed to reach QFieldCloud: %1</source>
-        <translation type="vanished">Changes failed to reach QFieldCloud: %1</translation>
+        <translation>Changes failed to reach QFieldCloud: %1</translation>
     </message>
     <message>
         <source>Changes successfully pushed to QFieldCloud</source>
-        <translation type="vanished">Changes successfully pushed to QFieldCloud</translation>
+        <translation>Changes successfully pushed to QFieldCloud</translation>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">Press back again to close project and app</translation>
+        <translation>Press back again to close project and app</translation>
     </message>
     <message>
         <source>Positioning error: %1</source>
@@ -4144,10 +4183,106 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="unfinished"/>
+        <translation>Duplicate Feature</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
+        <translation>Successfully duplicated feature</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation>Project Folder</translation>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -4163,7 +4298,7 @@ Cancel to make a minimal device scan instead.</translation>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Cannot add child feature: parent primary keys are not available</translation>
+        <translation type="vanished">Cannot add child feature: parent primary keys are not available</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -4184,6 +4319,10 @@ Cancel to make a minimal device scan instead.</translation>
     <message>
         <source>Failed to delete referencing feature</source>
         <translation>Failed to delete referencing feature</translation>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 </TS>

--- a/i18n/qfield_it.ts
+++ b/i18n/qfield_it.ts
@@ -666,6 +666,29 @@ Annullare per eseguire una scansione veloce del dispositivo.</translation>
     </message>
 </context>
 <context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
     <name>FeatureListForm</name>
     <message>
         <source>Stop tracking this feature to edit attributes</source>
@@ -2111,6 +2134,14 @@ Anche se puoi ancora visualizzare e utilizzare questo progetto, è altamente rac
         <source>No changes to revert</source>
         <translation>Nessuna modifica da ripristinare</translation>
     </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>QFieldCloudProjectsModel</name>
@@ -2350,6 +2381,10 @@ Messaggio dell&apos;errore: %4</translation>
     </message>
     <message>
         <source>Project Actions</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>, updated data available on the cloud</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -3728,7 +3763,7 @@ Annullare per eseguire una scansione veloce del dispositivo.</translation>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Impossibile aggiungere elemento figlio: nessuna chiave primaria padre disponibile</translation>
+        <translation type="vanished">Impossibile aggiungere elemento figlio: nessuna chiave primaria padre disponibile</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -3750,100 +3785,104 @@ Annullare per eseguire una scansione veloce del dispositivo.</translation>
         <source>Failed to delete referencing feature</source>
         <translation>Impossibile eliminare l&apos;elemento di riferimento</translation>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">Sei in modalità navigazione</translation>
+        <translation>Sei in modalità navigazione</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">Sei in modalità digitalizzazione sul layer %1</translation>
+        <translation>Sei in modalità digitalizzazione sul layer %1</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">Sei in modalità digitalizzazione</translation>
+        <translation>Sei in modalità digitalizzazione</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">Sei in modalità misurazione</translation>
+        <translation>Sei in modalità misurazione</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">Lon</translation>
+        <translation>Lon</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">Lat</translation>
+        <translation>Lat</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">Segmento</translation>
+        <translation>Segmento</translation>
     </message>
     <message>
         <source>Perimeter</source>
-        <translation type="vanished">Perimetro</translation>
+        <translation>Perimetro</translation>
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">Lunghezza</translation>
+        <translation>Lunghezza</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">Area</translation>
+        <translation>Area</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">Chiudi strumento di misura</translation>
+        <translation>Chiudi strumento di misura</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">Interrompi modifica</translation>
+        <translation>Interrompi modifica</translation>
     </message>
     <message>
         <source>Cancel addition</source>
-        <translation type="vanished">Annulla aggiunta</translation>
+        <translation>Annulla aggiunta</translation>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">Modifica topologica attivata</translation>
+        <translation>Modifica topologica attivata</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">Modifica topologica disattivata</translation>
+        <translation>Modifica topologica disattivata</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">Digitalizzazione a mano libera abilitata</translation>
+        <translation>Digitalizzazione a mano libera abilitata</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">Digitalizzazione a mano libera disabilitata</translation>
+        <translation>Digitalizzazione a mano libera disabilitata</translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
-        <translation type="vanished">Cursore delle coordinate ora bloccato sulla posizione</translation>
+        <translation>Cursore delle coordinate ora bloccato sulla posizione</translation>
     </message>
     <message>
         <source>Coordinate cursor unlocked</source>
-        <translation type="vanished">Cursore delle coordinate sbloccato</translation>
+        <translation>Cursore delle coordinate sbloccato</translation>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">Posizione ricevuta</translation>
+        <translation>Posizione ricevuta</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">Ricerca della posizione</translation>
+        <translation>Ricerca della posizione</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">Il canvas segue la posizione</translation>
+        <translation>Il canvas segue la posizione</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">In attesa della posizione</translation>
+        <translation>In attesa della posizione</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3855,19 +3894,19 @@ Annullare per eseguire una scansione veloce del dispositivo.</translation>
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">Il canvas non segue più la posizione</translation>
+        <translation>Il canvas non segue più la posizione</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">Impossibile creare elemento!</translation>
+        <translation>Impossibile creare elemento!</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">Impossibile salvare elemento!</translation>
+        <translation>Impossibile salvare elemento!</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">Menu principale</translation>
+        <translation>Menu principale</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3875,7 +3914,7 @@ Annullare per eseguire una scansione veloce del dispositivo.</translation>
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">Stampa PDF</translation>
+        <translation>Stampa PDF</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3895,15 +3934,15 @@ Annullare per eseguire una scansione veloce del dispositivo.</translation>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">Impostazioni</translation>
+        <translation>Impostazioni</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">Registro dei messaggi</translation>
+        <translation>Registro dei messaggi</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">Informazioni su QField</translation>
+        <translation>Informazioni su QField</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3911,7 +3950,7 @@ Annullare per eseguire una scansione veloce del dispositivo.</translation>
     </message>
     <message>
         <source>Activating positioning service</source>
-        <translation type="vanished">Servizi di posizionamento in attivazione</translation>
+        <translation>Servizi di posizionamento in attivazione</translation>
     </message>
     <message>
         <source>QField has no permissions to use positioning.</source>
@@ -3919,15 +3958,15 @@ Annullare per eseguire una scansione veloce del dispositivo.</translation>
     </message>
     <message>
         <source>Map Canvas Options</source>
-        <translation type="vanished">Opzioni Mappa</translation>
+        <translation>Opzioni Mappa</translation>
     </message>
     <message>
         <source>Add Bookmark</source>
-        <translation type="vanished">Aggiungi Segnalibro</translation>
+        <translation>Aggiungi Segnalibro</translation>
     </message>
     <message>
         <source>Set as Destination</source>
-        <translation type="vanished">Imposta come Destinazione</translation>
+        <translation>Imposta come Destinazione</translation>
     </message>
     <message>
         <source>Add Bookmark at Coordinates</source>
@@ -3935,7 +3974,7 @@ Annullare per eseguire una scansione veloce del dispositivo.</translation>
     </message>
     <message>
         <source>Untitled bookmark</source>
-        <translation type="vanished">Segnalibro senza titolo</translation>
+        <translation>Segnalibro senza titolo</translation>
     </message>
     <message>
         <source>Set Coordinates as Destination</source>
@@ -3943,7 +3982,7 @@ Annullare per eseguire una scansione veloce del dispositivo.</translation>
     </message>
     <message>
         <source>Copy Coordinates</source>
-        <translation type="vanished">Copia Coordinate</translation>
+        <translation>Copia Coordinate</translation>
     </message>
     <message>
         <source>X</source>
@@ -3955,11 +3994,11 @@ Annullare per eseguire una scansione veloce del dispositivo.</translation>
     </message>
     <message>
         <source>Coordinates copied to clipboard</source>
-        <translation type="vanished">Coordinate copiate negli appunti</translation>
+        <translation>Coordinate copiate negli appunti</translation>
     </message>
     <message>
         <source>Precise View Settings</source>
-        <translation type="vanished">Configurazioni visualizzazione precisa</translation>
+        <translation>Configurazioni visualizzazione precisa</translation>
     </message>
     <message>
         <source>0.25m Precision</source>
@@ -3987,27 +4026,27 @@ Annullare per eseguire una scansione veloce del dispositivo.</translation>
     </message>
     <message>
         <source>Always Show Precise View</source>
-        <translation type="vanished">Mostra sempre visualizzazione precisa</translation>
+        <translation>Mostra sempre visualizzazione precisa</translation>
     </message>
     <message>
         <source>Center to Location</source>
-        <translation type="vanished">Centra sulla Posizione</translation>
+        <translation>Centra sulla Posizione</translation>
     </message>
     <message>
         <source>Add Bookmark at Location</source>
-        <translation type="vanished">Aggiungi Segnalibro alla Posizione</translation>
+        <translation>Aggiungi Segnalibro alla Posizione</translation>
     </message>
     <message>
         <source>Copy Location Coordinates</source>
-        <translation type="vanished">Copia le Coordinate della Posizione</translation>
+        <translation>Copia le Coordinate della Posizione</translation>
     </message>
     <message>
         <source>Signed out</source>
-        <translation type="vanished">Disconnesso</translation>
+        <translation>Disconnesso</translation>
     </message>
     <message>
         <source>Signed in</source>
-        <translation type="vanished">Accesso effettuato</translation>
+        <translation>Accesso effettuato</translation>
     </message>
     <message>
         <source>Set As Destination</source>
@@ -4015,35 +4054,35 @@ Annullare per eseguire una scansione veloce del dispositivo.</translation>
     </message>
     <message>
         <source>Navigation Options</source>
-        <translation type="vanished">Opzioni di Navigazione</translation>
+        <translation>Opzioni di Navigazione</translation>
     </message>
     <message>
         <source>Clear Destination</source>
-        <translation type="vanished">Cancella destinazione</translation>
+        <translation>Cancella destinazione</translation>
     </message>
     <message>
         <source>%1 Precision</source>
-        <translation type="vanished">Precisione %1</translation>
+        <translation>Precisione %1</translation>
     </message>
     <message>
         <source>Enable Audio Proximity Feedback</source>
-        <translation type="vanished">Abilita il feedback audio di prossimità</translation>
+        <translation>Abilita il feedback audio di prossimità</translation>
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">Opzioni posizionamento</translation>
+        <translation>Opzioni posizionamento</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">Abilita posizionamento</translation>
+        <translation>Abilita posizionamento</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">Mostra informazioni sulla posizione</translation>
+        <translation>Mostra informazioni sulla posizione</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">Configurazioni posizionamento</translation>
+        <translation>Configurazioni posizionamento</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4055,11 +4094,11 @@ Annullare per eseguire una scansione veloce del dispositivo.</translation>
     </message>
     <message>
         <source>Current location unknown</source>
-        <translation type="vanished">Posizione attuale sconosciuta</translation>
+        <translation>Posizione attuale sconosciuta</translation>
     </message>
     <message>
         <source>My location</source>
-        <translation type="vanished">La mia posizione</translation>
+        <translation>La mia posizione</translation>
     </message>
     <message>
         <source>Copy Current Location</source>
@@ -4067,27 +4106,27 @@ Annullare per eseguire una scansione veloce del dispositivo.</translation>
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">Accuratezza</translation>
+        <translation>Accuratezza</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">NA</translation>
+        <translation>NA</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
-        <translation type="vanished">Posizione attuale copiata negli appunti</translation>
+        <translation>Posizione attuale copiata negli appunti</translation>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
-        <translation type="vanished">Layer corrente passato a quello contenente la geometria selezionata.</translation>
+        <translation>Layer corrente passato a quello contenente la geometria selezionata.</translation>
     </message>
     <message>
         <source>Editing of multi geometry layer is not supported yet.</source>
-        <translation type="vanished">La modifica di layer multi geometria non é ancora supportata</translation>
+        <translation>La modifica di layer multi geometria non é ancora supportata</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">Caricamento %1</translation>
+        <translation>Caricamento %1</translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4095,7 +4134,7 @@ Annullare per eseguire una scansione veloce del dispositivo.</translation>
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">Collegamento...</translation>
+        <translation>Collegamento...</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4103,23 +4142,23 @@ Annullare per eseguire una scansione veloce del dispositivo.</translation>
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">Download del progetto %1 fallito</translation>
+        <translation>Download del progetto %1 fallito</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
-        <translation type="vanished">Progetto %1 scaricato con successo, è ora disponibile per l&apos;apertura</translation>
+        <translation>Progetto %1 scaricato con successo, è ora disponibile per l&apos;apertura</translation>
     </message>
     <message>
         <source>Changes failed to reach QFieldCloud: %1</source>
-        <translation type="vanished">Le modifiche non hanno raggiunto QFieldCloud: %1</translation>
+        <translation>Le modifiche non hanno raggiunto QFieldCloud: %1</translation>
     </message>
     <message>
         <source>Changes successfully pushed to QFieldCloud</source>
-        <translation type="vanished">Modifiche inviate con successo a QFieldCloud</translation>
+        <translation>Modifiche inviate con successo a QFieldCloud</translation>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">Premi indietro di nuovo per chiudere il progetto e l&apos;app</translation>
+        <translation>Premi indietro di nuovo per chiudere il progetto e l&apos;app</translation>
     </message>
     <message>
         <source>Positioning error: %1</source>
@@ -4127,11 +4166,11 @@ Annullare per eseguire una scansione veloce del dispositivo.</translation>
     </message>
     <message>
         <source>Azimuth</source>
-        <translation type="vanished">Azimuth</translation>
+        <translation>Azimuth</translation>
     </message>
     <message>
         <source>Lock Screen</source>
-        <translation type="vanished">Blocca lo Schermo</translation>
+        <translation>Blocca lo Schermo</translation>
     </message>
     <message>
         <source>Print to Image</source>
@@ -4139,11 +4178,11 @@ Annullare per eseguire una scansione veloce del dispositivo.</translation>
     </message>
     <message>
         <source>Printing...</source>
-        <translation type="vanished">Stampa in corso...</translation>
+        <translation>Stampa in corso...</translation>
     </message>
     <message>
         <source>Print</source>
-        <translation type="vanished">Stampa</translation>
+        <translation>Stampa</translation>
     </message>
     <message>
         <source>Positioning device error: %1</source>
@@ -4151,10 +4190,106 @@ Annullare per eseguire una scansione veloce del dispositivo.</translation>
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="unfinished"/>
+        <translation>Duplica l&apos;elemento</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
+        <translation>Elemento duplicato con successo</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation>Cartella del Progetto</translation>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -4170,7 +4305,7 @@ Annullare per eseguire una scansione veloce del dispositivo.</translation>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Impossibile aggiungere elemento figlio: nessuna chiave primaria padre disponibile</translation>
+        <translation type="vanished">Impossibile aggiungere elemento figlio: nessuna chiave primaria padre disponibile</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -4191,6 +4326,10 @@ Annullare per eseguire una scansione veloce del dispositivo.</translation>
     <message>
         <source>Failed to delete referencing feature</source>
         <translation>Impossibile eliminare l&apos;elemento di riferimento</translation>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 </TS>

--- a/i18n/qfield_ja.ts
+++ b/i18n/qfield_ja.ts
@@ -230,7 +230,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Scanning error: %1</source>
-        <translation type="unfinished"/>
+        <translation>スキャンエラー: %1</translation>
     </message>
 </context>
 <context>
@@ -241,7 +241,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Bluetooth permission denied</source>
-        <translation type="unfinished"/>
+        <translation>Bluetoothのパーミッションが拒否されました</translation>
     </message>
 </context>
 <context>
@@ -292,7 +292,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Bluetooth permission denied</source>
-        <translation type="unfinished"/>
+        <translation>Bluetoothのパーミッションが拒否されました</translation>
     </message>
 </context>
 <context>
@@ -666,6 +666,29 @@ Cancel to make a minimal device scan instead.</source>
     </message>
 </context>
 <context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation>レイヤ &quot;%1&quot; に作成された地物の取り消しに失敗しました。</translation>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation>レイヤ &quot;%1&quot; で削除された地物の取り消しに失敗しました。</translation>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation>レイヤ &quot;%1&quot; で更新された地物の取り消しに失敗しました。</translation>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation>レイヤ &quot;%1&quot; に編集された地物のコミットに失敗しました。</translation>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation>レイヤ &quot;%1&quot; に編集された地物のロールバックに失敗しました。</translation>
+    </message>
+</context>
+<context>
     <name>FeatureListForm</name>
     <message>
         <source>Stop tracking this feature to edit attributes</source>
@@ -941,7 +964,7 @@ The features geometries will be combined into feature &apos;%1&apos;, which will
     <name>InternalGnssReceiver</name>
     <message>
         <source>Location permission denied</source>
-        <translation type="unfinished"/>
+        <translation>位置情報関連のパーミッションが拒否されました</translation>
     </message>
 </context>
 <context>
@@ -1215,7 +1238,7 @@ The features geometries will be combined into feature &apos;%1&apos;, which will
     </message>
     <message>
         <source>Activate a vector layer in the legend first to use this functionality</source>
-        <translation type="unfinished"/>
+        <translation>この機能を使うには、まず凡例のベクター・レイヤーをアクティブにします</translation>
     </message>
 </context>
 <context>
@@ -1273,19 +1296,19 @@ The features geometries will be combined into feature &apos;%1&apos;, which will
     </message>
     <message>
         <source>Type optional details</source>
-        <translation type="unfinished"/>
+        <translation>オプションの詳細を入力する</translation>
     </message>
     <message>
         <source>Include cloud user details</source>
-        <translation type="unfinished"/>
+        <translation>クラウドユーザーの詳細を含める</translation>
     </message>
     <message>
         <source>This will send a log of your current session to the development team. You only need to do this when you are asked for it.</source>
-        <translation type="unfinished"/>
+        <translation>これにより、現在のセッションのログが開発チームに送信されます。これは、要求されたときだけ行う必要があります。</translation>
     </message>
     <message>
         <source>Your application log is being sent…</source>
-        <translation type="unfinished"/>
+        <translation>アプリのログを送信中です...</translation>
     </message>
 </context>
 <context>
@@ -1778,11 +1801,11 @@ The features geometries will be combined into feature &apos;%1&apos;, which will
     </message>
     <message>
         <source>Grid enabled</source>
-        <translation type="unfinished"/>
+        <translation>グリッドが有効にされました</translation>
     </message>
     <message>
         <source>Grid disabled</source>
-        <translation type="unfinished"/>
+        <translation>グリッドが無効にされました</translation>
     </message>
 </context>
 <context>
@@ -2107,6 +2130,14 @@ While you can still view and use the project, it is strongly recommended to rese
         <source>No changes to revert</source>
         <translation>元に戻す変更はありません</translation>
     </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation>このプロジェクトはクラウド上でプロジェクトファイルが更新されています。ファイルの同期をしてください。</translation>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation>このプロジェクトはクラウド上でプロジェクトファイルが更新されています。ファイルの同期をしてください。</translation>
+    </message>
 </context>
 <context>
     <name>QFieldCloudProjectsModel</name>
@@ -2344,6 +2375,10 @@ While you can still view and use the project, it is strongly recommended to rese
     <message>
         <source>Project Actions</source>
         <translation>プロジェクトのアクション</translation>
+    </message>
+    <message>
+        <source>, updated data available on the cloud</source>
+        <translation>クラウド上で利用可能な更新データがあります</translation>
     </message>
 </context>
 <context>
@@ -3721,7 +3756,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>子地物を追加できません。親の主キーが有効ではありません。</translation>
+        <translation type="vanished">子地物を追加できません。親の主キーが有効ではありません。</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -3743,100 +3778,104 @@ Cancel to make a minimal device scan instead.</source>
         <source>Failed to delete referencing feature</source>
         <translation>参照している地物を削除できませんでした</translation>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation>子の地物を追加できません：親と子をつなぐ属性値が設定されていません</translation>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">閲覧モード</translation>
+        <translation>閲覧モード</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">レイヤ %1 は編集モードになりました</translation>
+        <translation>レイヤ %1 は編集モードになりました</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">編集モード</translation>
+        <translation>編集モード</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">計測モード</translation>
+        <translation>計測モード</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">経度</translation>
+        <translation>経度</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">緯度</translation>
+        <translation>緯度</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">セグメント</translation>
+        <translation>セグメント</translation>
     </message>
     <message>
         <source>Perimeter</source>
-        <translation type="vanished">周囲長</translation>
+        <translation>周囲長</translation>
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">長さ</translation>
+        <translation>長さ</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">面積</translation>
+        <translation>面積</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">計測ツールを非表示にする</translation>
+        <translation>計測ツールを非表示にする</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">編集をやめる</translation>
+        <translation>編集をやめる</translation>
     </message>
     <message>
         <source>Cancel addition</source>
-        <translation type="vanished">追加をキャンセルする</translation>
+        <translation>追加をキャンセルする</translation>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">トポロジー編集をオンにする</translation>
+        <translation>トポロジー編集をオンにする</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">トポロジー編集をオフにする</translation>
+        <translation>トポロジー編集をオフにする</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">フリーハンドでの編集をオンにしました</translation>
+        <translation>フリーハンドでの編集をオンにしました</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">フリーハンドでの編集をオフにしました</translation>
+        <translation>フリーハンドでの編集をオフにしました</translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
-        <translation type="vanished">座標カーソルが現在位置にロックされるようになりました</translation>
+        <translation>座標カーソルが現在位置にロックされるようになりました</translation>
     </message>
     <message>
         <source>Coordinate cursor unlocked</source>
-        <translation type="vanished">座標カーソルのロックが解除されました</translation>
+        <translation>座標カーソルのロックが解除されました</translation>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">現在地を受信しました</translation>
+        <translation>現在地を受信しました</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">現在地を探しています</translation>
+        <translation>現在地を探しています</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">地図上で現在の位置情報を追尾します</translation>
+        <translation>地図上で現在の位置情報を追尾します</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">位置情報を受信しています</translation>
+        <translation>位置情報を受信しています</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3848,19 +3887,19 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">地図上で現在の位置情報を追尾するのを停止しました</translation>
+        <translation>地図上で現在の位置情報を追尾するのを停止しました</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">地物を作成できませんでした!</translation>
+        <translation>地物を作成できませんでした!</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">地物を保存できませんでした!</translation>
+        <translation>地物を保存できませんでした!</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">メインメニュー</translation>
+        <translation>メインメニュー</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3868,7 +3907,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">PDFを印刷する</translation>
+        <translation>PDFを印刷する</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3888,15 +3927,15 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">設定</translation>
+        <translation>設定</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">メッセージログ</translation>
+        <translation>メッセージログ</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">QFieldについて</translation>
+        <translation>QFieldについて</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3904,7 +3943,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Activating positioning service</source>
-        <translation type="vanished">位置情報取得機能を有効にしています</translation>
+        <translation>位置情報取得機能を有効にしています</translation>
     </message>
     <message>
         <source>QField has no permissions to use positioning.</source>
@@ -3912,15 +3951,15 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Map Canvas Options</source>
-        <translation type="vanished">地図キャンバスオプション</translation>
+        <translation>地図キャンバスオプション</translation>
     </message>
     <message>
         <source>Add Bookmark</source>
-        <translation type="vanished">ブックマークを追加</translation>
+        <translation>ブックマークを追加</translation>
     </message>
     <message>
         <source>Set as Destination</source>
-        <translation type="vanished">目的地として設定</translation>
+        <translation>目的地として設定</translation>
     </message>
     <message>
         <source>Add Bookmark at Coordinates</source>
@@ -3928,7 +3967,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Untitled bookmark</source>
-        <translation type="vanished">無題のブックマーク</translation>
+        <translation>無題のブックマーク</translation>
     </message>
     <message>
         <source>Set Coordinates as Destination</source>
@@ -3936,7 +3975,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Copy Coordinates</source>
-        <translation type="vanished">座標をコピー</translation>
+        <translation>座標をコピー</translation>
     </message>
     <message>
         <source>X</source>
@@ -3948,11 +3987,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Coordinates copied to clipboard</source>
-        <translation type="vanished">座標をクリップボードにコピー</translation>
+        <translation>座標をクリップボードにコピー</translation>
     </message>
     <message>
         <source>Precise View Settings</source>
-        <translation type="vanished">ビュー精度の設定</translation>
+        <translation>ビュー精度の設定</translation>
     </message>
     <message>
         <source>0.25m Precision</source>
@@ -3980,27 +4019,27 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Always Show Precise View</source>
-        <translation type="vanished">いつもビュー精度を表示する</translation>
+        <translation>いつもビュー精度を表示する</translation>
     </message>
     <message>
         <source>Center to Location</source>
-        <translation type="vanished">現在位置を中央に表示</translation>
+        <translation>現在位置を中央に表示</translation>
     </message>
     <message>
         <source>Add Bookmark at Location</source>
-        <translation type="vanished">現在位置でブックマークを追加</translation>
+        <translation>現在位置でブックマークを追加</translation>
     </message>
     <message>
         <source>Copy Location Coordinates</source>
-        <translation type="vanished">位置座標をコピー</translation>
+        <translation>位置座標をコピー</translation>
     </message>
     <message>
         <source>Signed out</source>
-        <translation type="vanished">サインアウト</translation>
+        <translation>サインアウト</translation>
     </message>
     <message>
         <source>Signed in</source>
-        <translation type="vanished">サインイン</translation>
+        <translation>サインイン</translation>
     </message>
     <message>
         <source>Set As Destination</source>
@@ -4008,35 +4047,35 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Navigation Options</source>
-        <translation type="vanished">ナビゲーションオプション</translation>
+        <translation>ナビゲーションオプション</translation>
     </message>
     <message>
         <source>Clear Destination</source>
-        <translation type="vanished">目的地をクリア</translation>
+        <translation>目的地をクリア</translation>
     </message>
     <message>
         <source>%1 Precision</source>
-        <translation type="vanished">%1精度</translation>
+        <translation>%1精度</translation>
     </message>
     <message>
         <source>Enable Audio Proximity Feedback</source>
-        <translation type="vanished">音声近接フィードバックを有効にする</translation>
+        <translation>音声近接フィードバックを有効にする</translation>
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">位置情報表示オプション</translation>
+        <translation>位置情報表示オプション</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">位置情報表示を有効にする</translation>
+        <translation>位置情報表示を有効にする</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">座標情報を表示する</translation>
+        <translation>座標情報を表示する</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">現在位置表示設定</translation>
+        <translation>現在位置表示設定</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4048,11 +4087,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Current location unknown</source>
-        <translation type="vanished">不明な現在位置</translation>
+        <translation>不明な現在位置</translation>
     </message>
     <message>
         <source>My location</source>
-        <translation type="vanished">マイ・ロケーション</translation>
+        <translation>マイ・ロケーション</translation>
     </message>
     <message>
         <source>Copy Current Location</source>
@@ -4060,27 +4099,27 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">精度</translation>
+        <translation>精度</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">N/A</translation>
+        <translation>N/A</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
-        <translation type="vanished">現在位置をクリップボードにコピー</translation>
+        <translation>現在位置をクリップボードにコピー</translation>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
-        <translation type="vanished">選択されたジオメトリが属するレイヤに切り替わりました</translation>
+        <translation>選択されたジオメトリが属するレイヤに切り替わりました</translation>
     </message>
     <message>
         <source>Editing of multi geometry layer is not supported yet.</source>
-        <translation type="vanished">マルチジオメトリレイヤーの編集は現在サポートされていません。</translation>
+        <translation>マルチジオメトリレイヤーの編集は現在サポートされていません。</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">%1 を読み込んでいます</translation>
+        <translation>%1 を読み込んでいます</translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4088,7 +4127,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">接続しています...</translation>
+        <translation>接続しています...</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4096,23 +4135,23 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">プロジェクト %1 のダウンロードに失敗しました</translation>
+        <translation>プロジェクト %1 のダウンロードに失敗しました</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
-        <translation type="vanished">プロジェクト %1 が正常にダウンロードされて開けるようになりました</translation>
+        <translation>プロジェクト %1 が正常にダウンロードされて開けるようになりました</translation>
     </message>
     <message>
         <source>Changes failed to reach QFieldCloud: %1</source>
-        <translation type="vanished">変更内容がQFieldCloudにプッシュされませんでした: %1</translation>
+        <translation>変更内容がQFieldCloudにプッシュされませんでした: %1</translation>
     </message>
     <message>
         <source>Changes successfully pushed to QFieldCloud</source>
-        <translation type="vanished">変更内容がQFieldCloudに正常にプッシュされました</translation>
+        <translation>変更内容がQFieldCloudに正常にプッシュされました</translation>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">もう一度戻るボタンを押してプロジェクトとアプリを閉じてください。</translation>
+        <translation>もう一度戻るボタンを押してプロジェクトとアプリを閉じてください。</translation>
     </message>
     <message>
         <source>Positioning error: %1</source>
@@ -4120,11 +4159,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Azimuth</source>
-        <translation type="vanished">方位角</translation>
+        <translation>方位角</translation>
     </message>
     <message>
         <source>Lock Screen</source>
-        <translation type="vanished">スクリーンをロック</translation>
+        <translation>スクリーンをロック</translation>
     </message>
     <message>
         <source>Print to Image</source>
@@ -4132,22 +4171,118 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Printing...</source>
-        <translation type="vanished">印刷しています...</translation>
+        <translation>印刷しています...</translation>
     </message>
     <message>
         <source>Print</source>
-        <translation type="vanished">印刷</translation>
+        <translation>印刷</translation>
     </message>
     <message>
         <source>Positioning device error: %1</source>
-        <translation type="vanished">測位デバイスエラー: %1</translation>
+        <translation>測位デバイスエラー: %1</translation>
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="unfinished"/>
+        <translation>地物をコピー</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
+        <translation>地物をコピーしました</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation>スナッピングを有効にしました</translation>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation>スナッピングを無効にしました</translation>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation>キャンバスは位置とコンパスの向きに従います</translation>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation>使用可能な印刷レイアウトがありません</translation>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation>詳細はこちら</translation>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation>センサー</translation>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation>使用可能なセンサーがありません</translation>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation>プロジェクトフォルダ</translation>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation>下からセンサーを選択</translation>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation>センサーエラー: %1</translation>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation>センサー &apos;%1&apos;の接続を解除しています...</translation>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation>センサー &apos;%1&apos; に接続しています...</translation>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation>下からレイヤーを選択</translation>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation>レイヤー:</translation>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation>地物:</translation>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation>属性フォームを開く</translation>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation>地物のコピーは利用できません</translation>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation>%1をインポートしています</translation>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation>URLのインポートに失敗しました</translation>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -4163,7 +4298,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>子地物を追加できません。親の主キーが有効ではありません。</translation>
+        <translation type="vanished">子地物を追加できません。親の主キーが有効ではありません。</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -4184,6 +4319,10 @@ Cancel to make a minimal device scan instead.</source>
     <message>
         <source>Failed to delete referencing feature</source>
         <translation>参照している地物を削除できませんでした</translation>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation>子の地物を追加できません：親と子をつなぐ属性値が設定されていません</translation>
     </message>
 </context>
 </TS>

--- a/i18n/qfield_ka.ts
+++ b/i18n/qfield_ka.ts
@@ -666,6 +666,29 @@ Cancel to make a minimal device scan instead.</source>
     </message>
 </context>
 <context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
     <name>FeatureListForm</name>
     <message>
         <source>Stop tracking this feature to edit attributes</source>
@@ -2100,6 +2123,14 @@ While you can still view and use the project, it is strongly recommended to rese
         <source>No changes to revert</source>
         <translation>დასაბრუნებელი არაფერია</translation>
     </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>QFieldCloudProjectsModel</name>
@@ -2334,6 +2365,10 @@ While you can still view and use the project, it is strongly recommended to rese
     </message>
     <message>
         <source>Project Actions</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>, updated data available on the cloud</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -3712,7 +3747,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>შვილობილი ტოპოგრაფიული ელემენტის დამატება შეუძლებელია: მშობელი საკვანძო ველი არ არის ხელმისაწვდომი</translation>
+        <translation type="vanished">შვილობილი ტოპოგრაფიული ელემენტის დამატება შეუძლებელია: მშობელი საკვანძო ველი არ არის ხელმისაწვდომი</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -3734,56 +3769,60 @@ Cancel to make a minimal device scan instead.</source>
         <source>Failed to delete referencing feature</source>
         <translation>მითითებული ტოპოგრაფიული ელემენტის წაშლა ვერ მოხდა</translation>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">თვალიერების რეჟიმი გააქტიურებულია</translation>
+        <translation>თვალიერების რეჟიმი გააქტიურებულია</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">ციფრული რედაქტირების რეჟიმი ფენაზე %1 გააქტიურებულია</translation>
+        <translation>ციფრული რედაქტირების რეჟიმი ფენაზე %1 გააქტიურებულია</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">ციფრული რედაქტირების რეჟიმი გააქტიურებულია</translation>
+        <translation>ციფრული რედაქტირების რეჟიმი გააქტიურებულია</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">გაზომვების რეჟიმი გააქტიურებულია</translation>
+        <translation>გაზომვების რეჟიმი გააქტიურებულია</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">გრძედი</translation>
+        <translation>გრძედი</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">განედი</translation>
+        <translation>განედი</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">სეგმენტი</translation>
+        <translation>სეგმენტი</translation>
     </message>
     <message>
         <source>Perimeter</source>
-        <translation type="vanished">პერიმეტრი</translation>
+        <translation>პერიმეტრი</translation>
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">სიგრძე</translation>
+        <translation>სიგრძე</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">არეალი</translation>
+        <translation>არეალი</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">ხელსაწყოს დახურვა</translation>
+        <translation>ხელსაწყოს დახურვა</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">რედაქტორების დასრულება</translation>
+        <translation>რედაქტორების დასრულება</translation>
     </message>
     <message>
         <source>Cancel addition</source>
@@ -3791,19 +3830,19 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">ტოპოლოგიური ცვლილების რეჟიმი ჩართულია</translation>
+        <translation>ტოპოლოგიური ცვლილების რეჟიმი ჩართულია</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">ტოპოლოგიური ცვლილების რეჟიმი გამორთულია</translation>
+        <translation>ტოპოლოგიური ცვლილების რეჟიმი გამორთულია</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">გაციფრულების თავისუფალი რეჟიმი ჩართულია</translation>
+        <translation>გაციფრულების თავისუფალი რეჟიმი ჩართულია</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">გაციფრულების თავისუფალი რეჟიმი გამორთულია</translation>
+        <translation>გაციფრულების თავისუფალი რეჟიმი გამორთულია</translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
@@ -3815,19 +3854,19 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">პოზიცია მიღებულია</translation>
+        <translation>პოზიცია მიღებულია</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">პოზიციის ძებნა</translation>
+        <translation>პოზიციის ძებნა</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">რუკის ფენა თვალს ადევნებს ადგილმდებარეობას</translation>
+        <translation>რუკის ფენა თვალს ადევნებს ადგილმდებარეობას</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">ველოდებით ადგილმდებარეობას</translation>
+        <translation>ველოდებით ადგილმდებარეობას</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3839,19 +3878,19 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">რუკის ფენამ შეწყვიტა ადგილმდებარეობის თვალის დევნა</translation>
+        <translation>რუკის ფენამ შეწყვიტა ადგილმდებარეობის თვალის დევნა</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">ტოპოგრაფიული ელემენტის შექმნის პრობლემა!</translation>
+        <translation>ტოპოგრაფიული ელემენტის შექმნის პრობლემა!</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">ტოპოგრაფიული ელემენტის შენახვია ვერ მოხდა!</translation>
+        <translation>ტოპოგრაფიული ელემენტის შენახვია ვერ მოხდა!</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">ძირითადი მენიუ</translation>
+        <translation>ძირითადი მენიუ</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3859,7 +3898,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">PDF-ში ბეჭდვა</translation>
+        <translation>PDF-ში ბეჭდვა</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3879,15 +3918,15 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">პარამეტრები</translation>
+        <translation>პარამეტრები</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">შეტყობინება ჟურნალიდან</translation>
+        <translation>შეტყობინება ჟურნალიდან</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">QField-ის შესახებ</translation>
+        <translation>QField-ის შესახებ</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3903,11 +3942,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Map Canvas Options</source>
-        <translation type="vanished">რუკის ფენის პარამეტრები</translation>
+        <translation>რუკის ფენის პარამეტრები</translation>
     </message>
     <message>
         <source>Add Bookmark</source>
-        <translation type="vanished">სანიშნის დამატება</translation>
+        <translation>სანიშნის დამატება</translation>
     </message>
     <message>
         <source>Set as Destination</source>
@@ -3919,7 +3958,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Untitled bookmark</source>
-        <translation type="vanished">უსათაური სანიშნე</translation>
+        <translation>უსათაური სანიშნე</translation>
     </message>
     <message>
         <source>Set Coordinates as Destination</source>
@@ -3927,7 +3966,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Copy Coordinates</source>
-        <translation type="vanished">კოორდინატების კოპირება</translation>
+        <translation>კოორდინატების კოპირება</translation>
     </message>
     <message>
         <source>X</source>
@@ -3939,7 +3978,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Coordinates copied to clipboard</source>
-        <translation type="vanished">კოორდინატები დაკოპირდა ბუფერში</translation>
+        <translation>კოორდინატები დაკოპირდა ბუფერში</translation>
     </message>
     <message>
         <source>Precise View Settings</source>
@@ -3975,23 +4014,23 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Center to Location</source>
-        <translation type="vanished">ცენტრირება ლოკაციაზე</translation>
+        <translation>ცენტრირება ლოკაციაზე</translation>
     </message>
     <message>
         <source>Add Bookmark at Location</source>
-        <translation type="vanished">სანიშნის დამატება ადგილმდებარეობაზე</translation>
+        <translation>სანიშნის დამატება ადგილმდებარეობაზე</translation>
     </message>
     <message>
         <source>Copy Location Coordinates</source>
-        <translation type="vanished">ადგილმდებარეობის კოორდინატების კოპირება</translation>
+        <translation>ადგილმდებარეობის კოორდინატების კოპირება</translation>
     </message>
     <message>
         <source>Signed out</source>
-        <translation type="vanished">ანგარიშიდან გამოსვლა</translation>
+        <translation>ანგარიშიდან გამოსვლა</translation>
     </message>
     <message>
         <source>Signed in</source>
-        <translation type="vanished">ანგარიშში შესვლა წარმატებით შესრულდა</translation>
+        <translation>ანგარიშში შესვლა წარმატებით შესრულდა</translation>
     </message>
     <message>
         <source>Set As Destination</source>
@@ -3999,11 +4038,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Navigation Options</source>
-        <translation type="vanished">ნავიგაციის საშუალებები</translation>
+        <translation>ნავიგაციის საშუალებები</translation>
     </message>
     <message>
         <source>Clear Destination</source>
-        <translation type="vanished">მიმართულების გაწმენდა</translation>
+        <translation>მიმართულების გაწმენდა</translation>
     </message>
     <message>
         <source>%1 Precision</source>
@@ -4015,19 +4054,19 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">პოზიციონირების პარამეტრები</translation>
+        <translation>პოზიციონირების პარამეტრები</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">პოზიციონირების გააქტიურება</translation>
+        <translation>პოზიციონირების გააქტიურება</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">პოზიციის ინფორმაციის ჩვენება</translation>
+        <translation>პოზიციის ინფორმაციის ჩვენება</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">პოზიციონირების პარამეტრები</translation>
+        <translation>პოზიციონირების პარამეტრები</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4039,11 +4078,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Current location unknown</source>
-        <translation type="vanished">მიმდინარე ადგილმდებარეობა უცნობია</translation>
+        <translation>მიმდინარე ადგილმდებარეობა უცნობია</translation>
     </message>
     <message>
         <source>My location</source>
-        <translation type="vanished">ჩემი ადგილმდებარეობა</translation>
+        <translation>ჩემი ადგილმდებარეობა</translation>
     </message>
     <message>
         <source>Copy Current Location</source>
@@ -4051,15 +4090,15 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">სიზუსტე</translation>
+        <translation>სიზუსტე</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">N/A</translation>
+        <translation>N/A</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
-        <translation type="vanished">მიმდინარე ლოკაცია დაკოპირდა</translation>
+        <translation>მიმდინარე ლოკაცია დაკოპირდა</translation>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
@@ -4071,7 +4110,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">იტვირთება %1</translation>
+        <translation>იტვირთება %1</translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4079,7 +4118,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">დაკავშირება...</translation>
+        <translation>დაკავშირება...</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4087,11 +4126,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">პროექტ %1-ის ჩამოტვირთვის შეცდომა</translation>
+        <translation>პროექტ %1-ის ჩამოტვირთვის შეცდომა</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
-        <translation type="vanished">პროექტი %1 წარმატებით ჩამოიტვირთა და ხელმისაწვდომია გამოსაყენებლად</translation>
+        <translation>პროექტი %1 წარმატებით ჩამოიტვირთა და ხელმისაწვდომია გამოსაყენებლად</translation>
     </message>
     <message>
         <source>Changes failed to reach QFieldCloud: %1</source>
@@ -4103,7 +4142,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">პროექტისა და აპლიკაციის დასახურად დააჭირეთ უკან გასვლა კვლავ</translation>
+        <translation>პროექტისა და აპლიკაციის დასახურად დააჭირეთ უკან გასვლა კვლავ</translation>
     </message>
     <message>
         <source>Positioning error: %1</source>
@@ -4111,11 +4150,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Azimuth</source>
-        <translation type="vanished">აზიმუტი</translation>
+        <translation>აზიმუტი</translation>
     </message>
     <message>
         <source>Lock Screen</source>
-        <translation type="vanished">ჩაკეტილი ეკრანი</translation>
+        <translation>ჩაკეტილი ეკრანი</translation>
     </message>
     <message>
         <source>Print to Image</source>
@@ -4123,22 +4162,118 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Printing...</source>
-        <translation type="vanished">იბეჭდება...</translation>
+        <translation>იბეჭდება...</translation>
     </message>
     <message>
         <source>Print</source>
-        <translation type="vanished">ბეჭდვა</translation>
+        <translation>ბეჭდვა</translation>
     </message>
     <message>
         <source>Positioning device error: %1</source>
-        <translation type="vanished">პოზიციონირების მოწყობილობის შეცდომა: %1</translation>
+        <translation>პოზიციონირების მოწყობილობის შეცდომა: %1</translation>
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="unfinished"/>
+        <translation>ტოპო ელემენტის დუბლირება</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
+        <translation>ტოპო ელემენტის დუბლირება წარმატებით შესრულდა</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation>საბეჭდი შაბლონი ვერ ვიპოვე</translation>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation>გაიგეთ მეტი</translation>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation>სენსორები</translation>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation>სენსორები ხელმისაწვდომი არ არის</translation>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation>პროექტის საქაღალდე</translation>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation>აირჩიეთ სენსორი</translation>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation>სენსორის შეცდომა: %1</translation>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation>სენსორ &apos;%1&apos;-სთან კავშირის გაწყვეტა...</translation>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation>სენსორ &apos;%1&apos;-სთან დაკავშირება...</translation>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation>აირჩიეთ შაბლონი</translation>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation>%1-ის იმპორტი</translation>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation>URL იმპორტის შეცდომა</translation>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -4154,7 +4289,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>შვილობილი ტოპოგრაფიული ელემენტის დამატება შეუძლებელია: მშობელი საკვანძო ველი არ არის ხელმისაწვდომი</translation>
+        <translation type="vanished">შვილობილი ტოპოგრაფიული ელემენტის დამატება შეუძლებელია: მშობელი საკვანძო ველი არ არის ხელმისაწვდომი</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -4175,6 +4310,10 @@ Cancel to make a minimal device scan instead.</source>
     <message>
         <source>Failed to delete referencing feature</source>
         <translation>მითითებული ტოპოგრაფიული ელემენტის წაშლა ვერ მოხდა</translation>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 </TS>

--- a/i18n/qfield_ko.ts
+++ b/i18n/qfield_ko.ts
@@ -666,6 +666,29 @@ Cancel to make a minimal device scan instead.</source>
     </message>
 </context>
 <context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
     <name>FeatureListForm</name>
     <message>
         <source>Stop tracking this feature to edit attributes</source>
@@ -2107,6 +2130,14 @@ While you can still view and use the project, it is strongly recommended to rese
         <source>No changes to revert</source>
         <translation>No changes to revert</translation>
     </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>QFieldCloudProjectsModel</name>
@@ -2343,6 +2374,10 @@ While you can still view and use the project, it is strongly recommended to rese
     </message>
     <message>
         <source>Project Actions</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>, updated data available on the cloud</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -3721,7 +3756,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Cannot add child feature: parent primary keys are not available</translation>
+        <translation type="vanished">Cannot add child feature: parent primary keys are not available</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -3743,36 +3778,40 @@ Cancel to make a minimal device scan instead.</source>
         <source>Failed to delete referencing feature</source>
         <translation>어떤 문제로 참조 레이어를 삭제하는데 실패했습니다.</translation>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">You are now in browse mode</translation>
+        <translation>You are now in browse mode</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">You are now in digitize mode on layer %1</translation>
+        <translation>You are now in digitize mode on layer %1</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">You are now in digitize mode</translation>
+        <translation>You are now in digitize mode</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">You are now in measure mode</translation>
+        <translation>You are now in measure mode</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">Lon</translation>
+        <translation>Lon</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">Lat</translation>
+        <translation>Lat</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">Segment</translation>
+        <translation>Segment</translation>
     </message>
     <message>
         <source>Perimeter</source>
@@ -3780,63 +3819,63 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">Length</translation>
+        <translation>Length</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">Area</translation>
+        <translation>Area</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">Close measure tool</translation>
+        <translation>Close measure tool</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">Stop editing</translation>
+        <translation>Stop editing</translation>
     </message>
     <message>
         <source>Cancel addition</source>
-        <translation type="vanished">Cancel addition</translation>
+        <translation>Cancel addition</translation>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">Topological editing turned on</translation>
+        <translation>Topological editing turned on</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">Topological editing turned off</translation>
+        <translation>Topological editing turned off</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">Freehand digitizing turned on</translation>
+        <translation>Freehand digitizing turned on</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">Freehand digitizing turned off</translation>
+        <translation>Freehand digitizing turned off</translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
-        <translation type="vanished">Coordinate cursor now locked to position</translation>
+        <translation>Coordinate cursor now locked to position</translation>
     </message>
     <message>
         <source>Coordinate cursor unlocked</source>
-        <translation type="vanished">Coordinate cursor unlocked</translation>
+        <translation>Coordinate cursor unlocked</translation>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">Received position</translation>
+        <translation>Received position</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">Searching for position</translation>
+        <translation>Searching for position</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">Canvas follows location</translation>
+        <translation>Canvas follows location</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">Waiting for location</translation>
+        <translation>Waiting for location</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3848,19 +3887,19 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">Canvas stopped following location</translation>
+        <translation>Canvas stopped following location</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">대상을 생성하는데 실패하였습니다!</translation>
+        <translation>대상을 생성하는데 실패하였습니다!</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">대상을 저장하는데 실패하였습니다!</translation>
+        <translation>대상을 저장하는데 실패하였습니다!</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">주 메뉴</translation>
+        <translation>주 메뉴</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3868,7 +3907,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">PDF로 출력</translation>
+        <translation>PDF로 출력</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3888,15 +3927,15 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">설정</translation>
+        <translation>설정</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">Message Log</translation>
+        <translation>Message Log</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">About QField</translation>
+        <translation>About QField</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3904,7 +3943,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Activating positioning service</source>
-        <translation type="vanished">Activating positioning service</translation>
+        <translation>Activating positioning service</translation>
     </message>
     <message>
         <source>QField has no permissions to use positioning.</source>
@@ -3912,7 +3951,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Map Canvas Options</source>
-        <translation type="vanished">Map Canvas Options</translation>
+        <translation>Map Canvas Options</translation>
     </message>
     <message>
         <source>Add Bookmark</source>
@@ -4008,11 +4047,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Navigation Options</source>
-        <translation type="vanished">Navigation Options</translation>
+        <translation>Navigation Options</translation>
     </message>
     <message>
         <source>Clear Destination</source>
-        <translation type="vanished">Clear Destination</translation>
+        <translation>Clear Destination</translation>
     </message>
     <message>
         <source>%1 Precision</source>
@@ -4024,19 +4063,19 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">Positioning Options</translation>
+        <translation>Positioning Options</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">Enable Positioning</translation>
+        <translation>Enable Positioning</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">Show Position Information</translation>
+        <translation>Show Position Information</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">Positioning Settings</translation>
+        <translation>Positioning Settings</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4060,11 +4099,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">정확도</translation>
+        <translation>정확도</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">N/A</translation>
+        <translation>N/A</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
@@ -4072,15 +4111,15 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
-        <translation type="vanished">Current layer switched to the one holding the selected geometry.</translation>
+        <translation>Current layer switched to the one holding the selected geometry.</translation>
     </message>
     <message>
         <source>Editing of multi geometry layer is not supported yet.</source>
-        <translation type="vanished">Editing of multi geometry layer is not supported yet.</translation>
+        <translation>Editing of multi geometry layer is not supported yet.</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">Loading %1</translation>
+        <translation>Loading %1</translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4088,7 +4127,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">Connecting...</translation>
+        <translation>Connecting...</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4096,23 +4135,23 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">Project %1 failed to download</translation>
+        <translation>Project %1 failed to download</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
-        <translation type="vanished">Project %1 successfully downloaded, it&apos;s now available to open</translation>
+        <translation>Project %1 successfully downloaded, it&apos;s now available to open</translation>
     </message>
     <message>
         <source>Changes failed to reach QFieldCloud: %1</source>
-        <translation type="vanished">Changes failed to reach QFieldCloud: %1</translation>
+        <translation>Changes failed to reach QFieldCloud: %1</translation>
     </message>
     <message>
         <source>Changes successfully pushed to QFieldCloud</source>
-        <translation type="vanished">Changes successfully pushed to QFieldCloud</translation>
+        <translation>Changes successfully pushed to QFieldCloud</translation>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">다시 눌러 프로젝트 및 앱을 닫습니다</translation>
+        <translation>다시 눌러 프로젝트 및 앱을 닫습니다</translation>
     </message>
     <message>
         <source>Positioning error: %1</source>
@@ -4144,10 +4183,106 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="unfinished"/>
+        <translation>대상 복사하기</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
+        <translation>대상을 복사하였습니다.</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation>대상 : </translation>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation>대상을 복사할 수 없습니다.</translation>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -4163,7 +4298,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Cannot add child feature: parent primary keys are not available</translation>
+        <translation type="vanished">Cannot add child feature: parent primary keys are not available</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -4184,6 +4319,10 @@ Cancel to make a minimal device scan instead.</source>
     <message>
         <source>Failed to delete referencing feature</source>
         <translation>어떤 문제로 참조 레이어를 삭제하는데 실패했습니다.</translation>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 </TS>

--- a/i18n/qfield_nl.ts
+++ b/i18n/qfield_nl.ts
@@ -230,7 +230,7 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Scanning error: %1</source>
-        <translation type="unfinished"/>
+        <translation>Fout bij het scannen: %1</translation>
     </message>
 </context>
 <context>
@@ -241,7 +241,7 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Bluetooth permission denied</source>
-        <translation type="unfinished"/>
+        <translation>Gebruik van Bluetooth niet toegestaan </translation>
     </message>
 </context>
 <context>
@@ -292,7 +292,7 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Bluetooth permission denied</source>
-        <translation type="unfinished"/>
+        <translation>Gebruik van Bluetooth niet toegestaan </translation>
     </message>
 </context>
 <context>
@@ -306,7 +306,7 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     <name>BookmarkProperties</name>
     <message>
         <source>Bookmark Properties</source>
-        <translation>Bladwijzereigenschappen</translation>
+        <translation>Bladwijzer eigenschappen</translation>
     </message>
     <message>
         <source>Name</source>
@@ -666,6 +666,29 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
 </context>
 <context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
     <name>FeatureListForm</name>
     <message>
         <source>Stop tracking this feature to edit attributes</source>
@@ -909,7 +932,7 @@ De geometrieën van objecten zullen worden gecombineerd tot object &apos;%1&apos
     </message>
     <message>
         <source>Erase Tool</source>
-        <translation type="unfinished"/>
+        <translation>Gum</translation>
     </message>
 </context>
 <context>
@@ -1060,7 +1083,7 @@ De geometrieën van objecten zullen worden gecombineerd tot object &apos;%1&apos
     </message>
     <message>
         <source>Show Features Menu</source>
-        <translation type="unfinished"/>
+        <translation>Toon Objecten Menu</translation>
     </message>
     <message>
         <source>Read-only layer</source>
@@ -1653,7 +1676,7 @@ De geometrieën van objecten zullen worden gecombineerd tot object &apos;%1&apos
     </message>
     <message>
         <source>Leave empty to auto-fill</source>
-        <translation type="unfinished"/>
+        <translation>Niet invullen, gebeurt automatisch</translation>
     </message>
     <message>
         <source>Connection type:</source>
@@ -1751,7 +1774,7 @@ De geometrieën van objecten zullen worden gecombineerd tot object &apos;%1&apos
     </message>
     <message>
         <source>Positioning accuracy too low for this precision level</source>
-        <translation type="unfinished"/>
+        <translation>De nauwkeurigheid van de plaatsbepaling is te laag voor dit precisie niveau</translation>
     </message>
 </context>
 <context>
@@ -1765,26 +1788,26 @@ De geometrieën van objecten zullen worden gecombineerd tot object &apos;%1&apos
     <name>QFieldAudioRecorder</name>
     <message>
         <source>Audio Recorder</source>
-        <translation type="unfinished"/>
+        <translation>Geluids recorder </translation>
     </message>
 </context>
 <context>
     <name>QFieldCamera</name>
     <message>
         <source>Geotagging enabled</source>
-        <translation type="unfinished"/>
+        <translation>Locatie aanduiding aan</translation>
     </message>
     <message>
         <source>Geotagging disabled</source>
-        <translation type="unfinished"/>
+        <translation>Locatie aanduiding uit</translation>
     </message>
     <message>
         <source>Grid enabled</source>
-        <translation type="unfinished"/>
+        <translation>Raster aan</translation>
     </message>
     <message>
         <source>Grid disabled</source>
-        <translation type="unfinished"/>
+        <translation>Raster uit</translation>
     </message>
 </context>
 <context>
@@ -2109,6 +2132,14 @@ Hoewel u het project nog steeds kunt bekijken en gebruiken, wordt het ten zeerst
         <source>No changes to revert</source>
         <translation>Geen wijzigingen om terug te zetten</translation>
     </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation>Dit project heeft een bijgewerkt project bestand in de Cloud, je moet synchroniseren.</translation>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation>Dit project heeft bijgewerkte data in de Cloud, je moet synchroniseren.</translation>
+    </message>
 </context>
 <context>
     <name>QFieldCloudProjectsModel</name>
@@ -2214,7 +2245,7 @@ Hoewel u het project nog steeds kunt bekijken en gebruiken, wordt het ten zeerst
     </message>
     <message>
         <source>Network error. Failed to download file `%1`.</source>
-        <translation>Netwerkfout. Kan bestand `%1` niet downloaden.</translation>
+        <translation>Netwerk fout. Kan bestand `%1` niet downloaden.</translation>
     </message>
     <message>
         <source>File system error. Failed to write file to temporary location `%1`.</source>
@@ -2325,11 +2356,11 @@ Hoewel u het project nog steeds kunt bekijken en gebruiken, wordt het ten zeerst
     </message>
     <message>
         <source>Cancel Project Download</source>
-        <translation>Projectdownload annuleren</translation>
+        <translation>Project download annuleren</translation>
     </message>
     <message>
         <source>Press and hold over a cloud project for a menu of additional actions.</source>
-        <translation>Houd een cloudproject ingedrukt voor een menu met aanvullende acties.</translation>
+        <translation>Houd een cloud project ingedrukt voor een menu met aanvullende acties.</translation>
     </message>
     <message>
         <source>Refresh projects list</source>
@@ -2345,6 +2376,10 @@ Hoewel u het project nog steeds kunt bekijken en gebruiken, wordt het ten zeerst
     </message>
     <message>
         <source>Project Actions</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>, updated data available on the cloud</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -2420,7 +2455,7 @@ Hoewel u het project nog steeds kunt bekijken en gebruiken, wordt het ten zeerst
     </message>
     <message>
         <source>Storage management help</source>
-        <translation type="unfinished"/>
+        <translation>Geheugen beheer hulp</translation>
     </message>
     <message>
         <source>Import URL</source>
@@ -2455,7 +2490,7 @@ Hoewel u het project nog steeds kunt bekijken en gebruiken, wordt het ten zeerst
     </message>
     <message>
         <source>Maximized attribute form</source>
-        <translation>Gemaximaliseerde eigenschappen-formulier</translation>
+        <translation>Gemaximaliseerde eigenschap formulier</translation>
     </message>
     <message>
         <source>Fixed scale navigation</source>
@@ -2479,7 +2514,7 @@ Hoewel u het project nog steeds kunt bekijken en gebruiken, wordt het ten zeerst
     </message>
     <message>
         <source>When switched on, user&apos;s saved and currently opened project bookmarks will be displayed on the map.</source>
-        <translation>Indien ingeschakeld, worden de door de gebruiker opgeslagen en momenteel geopende projectbladwijzers op de kaart weergegeven.</translation>
+        <translation>Indien ingeschakeld, worden de door de gebruiker opgeslagen en momenteel geopende project bladwijzers op de kaart weergegeven.</translation>
     </message>
     <message>
         <source>Use native camera</source>
@@ -2789,15 +2824,15 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Best quality</source>
-        <translation type="unfinished"/>
+        <translation>Beste kwaliteit </translation>
     </message>
     <message>
         <source>Lower quality</source>
-        <translation type="unfinished"/>
+        <translation>Mindere kwaliteit </translation>
     </message>
     <message>
         <source>Lowest quality</source>
-        <translation type="unfinished"/>
+        <translation>Laagste kwaliteit </translation>
     </message>
     <message>
         <source>A lower quality trades rendering precision in favor of lower memory usage and rendering time.</source>
@@ -2813,7 +2848,7 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Use volume keys to digitize</source>
-        <translation type="unfinished"/>
+        <translation>Gebruik de volume knoppen om te digitaliseren </translation>
     </message>
     <message>
         <source>If enabled, pressing the device&apos;s volume up key will add a vertex while pressing volume down key will remove the last entered vertex during digitizing sessions.</source>
@@ -2852,7 +2887,7 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Validation Error</source>
-        <translation>Validatiefout</translation>
+        <translation>Validatie fout</translation>
     </message>
     <message>
         <source>Multiple Projects</source>
@@ -2864,7 +2899,7 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>The project does not contain a valid QGIS project file</source>
-        <translation>Het project bevat geen geldig QGIS projectbestand</translation>
+        <translation>Het project bevat geen geldig QGIS project bestand</translation>
     </message>
     <message>
         <source>Invalid job</source>
@@ -3723,7 +3758,7 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Kan onderliggende object niet toevoegen: primaire sleutels van ouders zijn niet beschikbaar</translation>
+        <translation type="vanished">Kan onderliggende object niet toevoegen: primaire sleutels van ouders zijn niet beschikbaar</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -3745,36 +3780,40 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
         <source>Failed to delete referencing feature</source>
         <translation>Kan verwijzingsobject niet verwijderen</translation>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">U bevindt zich nu in de bladermodus</translation>
+        <translation>U bevindt zich nu in de bladermodus</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">U bevindt zich nu in de digitaliseringsmodus op laag %1</translation>
+        <translation>U bevindt zich nu in de digitaliseringsmodus op laag %1</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">U bevindt zich nu in de digitaliseringsmodus</translation>
+        <translation>U bevindt zich nu in de digitaliseringsmodus</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">U bevindt zich nu in de meetmodus</translation>
+        <translation>U bevindt zich nu in de meetmodus</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">Lon</translation>
+        <translation>Lon</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">Lat</translation>
+        <translation>Lat</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">Segment</translation>
+        <translation>Segment</translation>
     </message>
     <message>
         <source>Perimeter</source>
@@ -3782,63 +3821,63 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">Lengte</translation>
+        <translation>Lengte</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">Oppervlak</translation>
+        <translation>Oppervlak</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">Sluit meetgereedschap</translation>
+        <translation>Sluit meetgereedschap</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">Stop met bewerken</translation>
+        <translation>Stop met bewerken</translation>
     </message>
     <message>
         <source>Cancel addition</source>
-        <translation type="vanished">Toevoeging annuleren</translation>
+        <translation>Toevoeging annuleren</translation>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">Topologische bewerking ingeschakeld</translation>
+        <translation>Topologische bewerking ingeschakeld</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">Topologische bewerking uitgeschakeld</translation>
+        <translation>Topologische bewerking uitgeschakeld</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">Digitaliseren uit de vrije hand ingeschakeld</translation>
+        <translation>Digitaliseren uit de vrije hand ingeschakeld</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">Digitaliseren uit de vrije hand uitgeschakeld</translation>
+        <translation>Digitaliseren uit de vrije hand uitgeschakeld</translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
-        <translation type="vanished">Coördinaatcursor nu vergrendeld op positie</translation>
+        <translation>Coördinaatcursor nu vergrendeld op positie</translation>
     </message>
     <message>
         <source>Coordinate cursor unlocked</source>
-        <translation type="vanished">Coördinaatcursor ontgrendeld</translation>
+        <translation>Coördinaatcursor ontgrendeld</translation>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">Positie ontvangen</translation>
+        <translation>Positie ontvangen</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">Zoeken naar positie</translation>
+        <translation>Zoeken naar positie</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">Canvas volgt locatie</translation>
+        <translation>Canvas volgt locatie</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">Wachten op locatie</translation>
+        <translation>Wachten op locatie</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3850,19 +3889,19 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">Canvas is gestopt met het volgen van de locatie</translation>
+        <translation>Canvas is gestopt met het volgen van de locatie</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">Kan object niet creëren!</translation>
+        <translation>Kan object niet creëren!</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">Kan object niet opslaan!</translation>
+        <translation>Kan object niet opslaan!</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">Hoofdmenu</translation>
+        <translation>Hoofdmenu</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3870,7 +3909,7 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">Afdrukken naar PDF</translation>
+        <translation>Afdrukken naar PDF</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3890,15 +3929,15 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">Instellingen</translation>
+        <translation>Instellingen</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">Logboekmeldingen</translation>
+        <translation>Logboekmeldingen</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">Over QField</translation>
+        <translation>Over QField</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3906,7 +3945,7 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Activating positioning service</source>
-        <translation type="vanished">Positioneringsservice activeren</translation>
+        <translation>Positioneringsservice activeren</translation>
     </message>
     <message>
         <source>QField has no permissions to use positioning.</source>
@@ -3914,15 +3953,15 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Map Canvas Options</source>
-        <translation type="vanished">Kaartcanvas opties</translation>
+        <translation>Kaartcanvas opties</translation>
     </message>
     <message>
         <source>Add Bookmark</source>
-        <translation type="vanished">Voeg bladwijzer toe</translation>
+        <translation>Voeg bladwijzer toe</translation>
     </message>
     <message>
         <source>Set as Destination</source>
-        <translation type="vanished">Instellen als bestemming</translation>
+        <translation>Instellen als bestemming</translation>
     </message>
     <message>
         <source>Add Bookmark at Coordinates</source>
@@ -3930,7 +3969,7 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Untitled bookmark</source>
-        <translation type="vanished">Naamloze bladwijzer</translation>
+        <translation>Naamloze bladwijzer</translation>
     </message>
     <message>
         <source>Set Coordinates as Destination</source>
@@ -3938,7 +3977,7 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Copy Coordinates</source>
-        <translation type="vanished">Kopieer Coördinaten</translation>
+        <translation>Kopieer Coördinaten</translation>
     </message>
     <message>
         <source>X</source>
@@ -3950,7 +3989,7 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Coordinates copied to clipboard</source>
-        <translation type="vanished">Coördinaten gekopieerd naar klembord</translation>
+        <translation>Coördinaten gekopieerd naar klembord</translation>
     </message>
     <message>
         <source>Precise View Settings</source>
@@ -3986,23 +4025,23 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Center to Location</source>
-        <translation type="vanished">Centreren op locatie</translation>
+        <translation>Centreren op locatie</translation>
     </message>
     <message>
         <source>Add Bookmark at Location</source>
-        <translation type="vanished">Bladwijzer toevoegen aan locatie</translation>
+        <translation>Bladwijzer toevoegen aan locatie</translation>
     </message>
     <message>
         <source>Copy Location Coordinates</source>
-        <translation type="vanished">Coördinaten van locatie kopiëren</translation>
+        <translation>Coördinaten van locatie kopiëren</translation>
     </message>
     <message>
         <source>Signed out</source>
-        <translation type="vanished">Uitgelogd</translation>
+        <translation>Uitgelogd</translation>
     </message>
     <message>
         <source>Signed in</source>
-        <translation type="vanished">Ingelogd</translation>
+        <translation>Ingelogd</translation>
     </message>
     <message>
         <source>Set As Destination</source>
@@ -4010,15 +4049,15 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Navigation Options</source>
-        <translation type="vanished">Navigatie-opties</translation>
+        <translation>Navigatie-opties</translation>
     </message>
     <message>
         <source>Clear Destination</source>
-        <translation type="vanished">Bestemming wissen</translation>
+        <translation>Bestemming wissen</translation>
     </message>
     <message>
         <source>%1 Precision</source>
-        <translation type="vanished">%1 Precisie</translation>
+        <translation>%1 Precisie</translation>
     </message>
     <message>
         <source>Enable Audio Proximity Feedback</source>
@@ -4026,19 +4065,19 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">Positioneringsopties</translation>
+        <translation>Positioneringsopties</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">Schakel positionering in</translation>
+        <translation>Schakel positionering in</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">Toon Positie Informatie</translation>
+        <translation>Toon Positie Informatie</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">Positionerings-instellingen</translation>
+        <translation>Positionerings-instellingen</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4050,11 +4089,11 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Current location unknown</source>
-        <translation type="vanished">Huidige locatie onbekend</translation>
+        <translation>Huidige locatie onbekend</translation>
     </message>
     <message>
         <source>My location</source>
-        <translation type="vanished">Mijn locatie</translation>
+        <translation>Mijn locatie</translation>
     </message>
     <message>
         <source>Copy Current Location</source>
@@ -4062,27 +4101,27 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">Nauwkeurigheid</translation>
+        <translation>Nauwkeurigheid</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">N/B</translation>
+        <translation>N/B</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
-        <translation type="vanished">Huidige locatie gekopieerd naar klembord</translation>
+        <translation>Huidige locatie gekopieerd naar klembord</translation>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
-        <translation type="vanished">De huidige laag is overgeschakeld naar de laag die de geselecteerde geometrie bevat.</translation>
+        <translation>De huidige laag is overgeschakeld naar de laag die de geselecteerde geometrie bevat.</translation>
     </message>
     <message>
         <source>Editing of multi geometry layer is not supported yet.</source>
-        <translation type="vanished">Het bewerken van een laag met meerdere geometrieën wordt nog niet ondersteund.</translation>
+        <translation>Het bewerken van een laag met meerdere geometrieën wordt nog niet ondersteund.</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">Laden %1</translation>
+        <translation>Laden %1</translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4090,7 +4129,7 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">Verbinden...</translation>
+        <translation>Verbinden...</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4098,23 +4137,23 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">Kan project %1 niet downloaden</translation>
+        <translation>Kan project %1 niet downloaden</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
-        <translation type="vanished">Project %1 is gedownload, het is nu beschikbaar om te openen</translation>
+        <translation>Project %1 is gedownload, het is nu beschikbaar om te openen</translation>
     </message>
     <message>
         <source>Changes failed to reach QFieldCloud: %1</source>
-        <translation type="vanished">Wijzigingen bereikten QFieldCloud niet: %1</translation>
+        <translation>Wijzigingen bereikten QFieldCloud niet: %1</translation>
     </message>
     <message>
         <source>Changes successfully pushed to QFieldCloud</source>
-        <translation type="vanished">Wijzigingen zijn met succes naar QFieldCloud gepusht</translation>
+        <translation>Wijzigingen zijn met succes naar QFieldCloud gepusht</translation>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">Druk nogmaals op terug om het project en app te sluiten</translation>
+        <translation>Druk nogmaals op terug om het project en app te sluiten</translation>
     </message>
     <message>
         <source>Positioning error: %1</source>
@@ -4126,7 +4165,7 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Lock Screen</source>
-        <translation type="vanished">Vergrendel Scherm</translation>
+        <translation>Vergrendel Scherm</translation>
     </message>
     <message>
         <source>Print to Image</source>
@@ -4134,7 +4173,7 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Printing...</source>
-        <translation type="vanished">Printing...</translation>
+        <translation>Printing...</translation>
     </message>
     <message>
         <source>Print</source>
@@ -4146,10 +4185,106 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="unfinished"/>
+        <translation>Dubbel object</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
+        <translation>Succesvol object gedupliceerd</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation>Canvas volgt locatie en kompas oriëntatie</translation>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation>Geen print layout beschikbaar</translation>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation>Meer info</translation>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation>Sensoren</translation>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation>Geen sensor beschikbaar</translation>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation>Selecteer sensor</translation>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation>Selecteer layout</translation>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation>Laag:</translation>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -4165,7 +4300,7 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Kan onderliggende object niet toevoegen: primaire sleutels van ouders zijn niet beschikbaar</translation>
+        <translation type="vanished">Kan onderliggende object niet toevoegen: primaire sleutels van ouders zijn niet beschikbaar</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -4186,6 +4321,10 @@ Annuleer om in plaats daarvan een minimale apparaatscan uit te voeren.</translat
     <message>
         <source>Failed to delete referencing feature</source>
         <translation>Kan verwijzingsobject niet verwijderen</translation>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 </TS>

--- a/i18n/qfield_pl.ts
+++ b/i18n/qfield_pl.ts
@@ -164,7 +164,7 @@
     </message>
     <message numerus="yes">
         <source>%n device(s) found</source>
-        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
+        <translation><numerusform>znaleziono %n urządzenie</numerusform><numerusform>znaleziono %n urządzenia</numerusform><numerusform>znaleziono %n urządzeń</numerusform><numerusform>znaleziono %n urządzenie</numerusform></translation>
     </message>
     <message>
         <source>Scanning canceled</source>
@@ -465,7 +465,7 @@ Anuluj, aby wykonać zamiast tego minimalne skanowanie urządzeń.</translation>
     </message>
     <message>
         <source>Finish or dimiss the digitizing feature before toggling to browse mode</source>
-        <translation type="unfinished"/>
+        <translation>Zakończ lub odrzuć digitizację obiektu przed przełączeniem do trybu przeglądania</translation>
     </message>
 </context>
 <context>
@@ -534,7 +534,7 @@ Anuluj, aby wykonać zamiast tego minimalne skanowanie urządzeń.</translation>
     </message>
     <message>
         <source>Digitizing logs layer editing failed</source>
-        <translation type="unfinished"/>
+        <translation>Edycja warstwy dziennika digitalizacji nie powiodła się</translation>
     </message>
 </context>
 <context>
@@ -666,6 +666,29 @@ Anuluj, aby wykonać zamiast tego minimalne skanowanie urządzeń.</translation>
     </message>
 </context>
 <context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation>Nie udało się cofnąć utworzenia obiektów na warstwie &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation>Nie udało się cofnąć usunięcia obiektów na warstwie &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation>Nie udało się cofnąć zmian obiektów na warstwie &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
     <name>FeatureListForm</name>
     <message>
         <source>Stop tracking this feature to edit attributes</source>
@@ -716,11 +739,11 @@ The features geometries will be combined into feature &apos;%1&apos;, which will
     </message>
     <message numerus="yes">
         <source>Successfully merged %n feature(s)</source>
-        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
+        <translation><numerusform>Pomyślnie połączono %n obiekt</numerusform><numerusform>Pomyślnie połączono %n obiekty</numerusform><numerusform>Pomyślnie połączono %n obiektów</numerusform><numerusform>Pomyślnie połączono %n obiekt</numerusform></translation>
     </message>
     <message numerus="yes">
         <source>Failed to merge %n feature(s)</source>
-        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
+        <translation><numerusform>Nie udało się połączyć %n obiektu</numerusform><numerusform>Nie udało się połączyć %n obiektów</numerusform><numerusform>Nie udało się połączyć %n obiektów</numerusform><numerusform>Nie udało się połączyć %n obiektu</numerusform></translation>
     </message>
     <message>
         <source>Delete feature(s)</source>
@@ -729,11 +752,11 @@ The features geometries will be combined into feature &apos;%1&apos;, which will
     <message numerus="yes">
         <source>Should the %n feature(s) selected really be deleted?</source>
         <comment>0</comment>
-        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
+        <translation><numerusform>Czy na pewno %n wybrany obiekt ma zostać usunięty?</numerusform><numerusform>Czy na pewno %n wybrane obiekty mają zostać usunięte?</numerusform><numerusform>Czy na pewno %n wybranych obiektów ma zostać usunięte?</numerusform><numerusform>Czy na pewno %n wybrany obiekt ma zostać usunięty?</numerusform></translation>
     </message>
     <message numerus="yes">
         <source>Successfully deleted %n feature(s)</source>
-        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
+        <translation><numerusform>Pomyślnie usunięto %n obiekt</numerusform><numerusform>Pomyślnie usunięto %n obiekty</numerusform><numerusform>Pomyślnie usunięto %n obiektów</numerusform><numerusform>Pomyślnie usunięto %n obiekt</numerusform></translation>
     </message>
     <message numerus="yes">
         <source>Failed to delete %n feature(s)</source>
@@ -748,7 +771,7 @@ The features geometries will be combined into feature &apos;%1&apos;, which will
     <name>FeatureModel</name>
     <message>
         <source>Value &quot;%1&quot; %4 could not be converted to a compatible value for field %2(%3).</source>
-        <translation type="unfinished"/>
+        <translation>Nie można skonwertować wartości &quot;%1&quot; %4 na wartość zgodną dla pola %2(%3).</translation>
     </message>
     <message>
         <source>Cannot update feature</source>
@@ -1986,7 +2009,7 @@ The features geometries will be combined into feature &apos;%1&apos;, which will
     </message>
     <message numerus="yes">
         <source>There is/are %n local change(s)</source>
-        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
+        <translation><numerusform>Jest %n lokalna zmiana</numerusform><numerusform>Są %n lokalne zmiany</numerusform><numerusform>Jest %n lokalnych zmian</numerusform><numerusform>Jest %n lokalna zmiana</numerusform></translation>
     </message>
     <message>
         <source>There are no local changes</source>
@@ -2074,7 +2097,7 @@ Chociaż nadal możesz wyświetlać i używać projektu, zdecydowanie zaleca si�
     </message>
     <message numerus="yes">
         <source>%n attachment(s) are currently being uploaded in the background.</source>
-        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
+        <translation type="vanished"><numerusform>%n załącznik jest wysyłany w tle</numerusform><numerusform>%n załączniki są wysyłane w tle</numerusform><numerusform>%n załączników jest wysyłanych w tle</numerusform><numerusform>%n załącznik jest wysyłany w tle</numerusform></translation>
     </message>
     <message>
         <source>Should local changes be reverted?</source>
@@ -2103,6 +2126,14 @@ Chociaż nadal możesz wyświetlać i używać projektu, zdecydowanie zaleca si�
     <message>
         <source>No changes to revert</source>
         <translation>Brak zmian do cofnięcia</translation>
+    </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation>Ten projekt posiada zaktualizowany plik projektu w chmurze, zalecana jest synchronizacja.</translation>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation>Ten projekt posiada zaktualizowane dane w chmurze, zalecana jest synchronizacja.</translation>
     </message>
 </context>
 <context>
@@ -2149,7 +2180,7 @@ Chociaż nadal możesz wyświetlać i używać projektu, zdecydowanie zaleca si�
     </message>
     <message>
         <source>Job creation finished, but the server response is missing required fields: id(string)</source>
-        <translation type="unfinished"/>
+        <translation>Zakończono tworzenie pracy, ale w odpowiedzi serwera brakuje wymaganych pól: id(string)</translation>
     </message>
     <message>
         <source>Getting job status, but no `%2` job triggered yet.</source>
@@ -2341,6 +2372,10 @@ Chociaż nadal możesz wyświetlać i używać projektu, zdecydowanie zaleca si�
     <message>
         <source>Project Actions</source>
         <translation>Działania projektu</translation>
+    </message>
+    <message>
+        <source>, updated data available on the cloud</source>
+        <translation>, zaktualizowane dane dostępne w chmurze</translation>
     </message>
 </context>
 <context>
@@ -2566,7 +2601,7 @@ Chociaż nadal możesz wyświetlać i używać projektu, zdecydowanie zaleca si�
     </message>
     <message numerus="yes">
         <source>%n device(s) found</source>
-        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
+        <translation type="vanished"><numerusform>znaleziono %n urządzenie</numerusform><numerusform>znaleziono %n urządzenia</numerusform><numerusform>znaleziono %n urządzeń</numerusform><numerusform>znaleziono %n urządzenie</numerusform></translation>
     </message>
     <message>
         <source>Scanning canceled</source>
@@ -3718,7 +3753,7 @@ Anuluj, aby wykonać zamiast tego minimalne skanowanie urządzeń.</translation>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Nie można dodać elementu potomnego: klucze główne dla elementu nadrzędnego są niedostępne</translation>
+        <translation type="vanished">Nie można dodać elementu potomnego: klucze główne dla elementu nadrzędnego są niedostępne</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -3740,100 +3775,104 @@ Anuluj, aby wykonać zamiast tego minimalne skanowanie urządzeń.</translation>
         <source>Failed to delete referencing feature</source>
         <translation>Nie udało się usunąć odnośnego obiektu</translation>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">Jesteś teraz w trybie przeglądania</translation>
+        <translation>Jesteś teraz w trybie przeglądania</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">Jesteś teraz w trybie edycji warstwy %1</translation>
+        <translation>Jesteś teraz w trybie edycji warstwy %1</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">Jesteś teraz w trybie edycji</translation>
+        <translation>Jesteś teraz w trybie edycji</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">Jesteś teraz w trybie pomiaru</translation>
+        <translation>Jesteś teraz w trybie pomiaru</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">Dłu</translation>
+        <translation>Dłu</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">Szer</translation>
+        <translation>Szer</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">Segment</translation>
+        <translation>Segment</translation>
     </message>
     <message>
         <source>Perimeter</source>
-        <translation type="vanished">Obwód</translation>
+        <translation>Obwód</translation>
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">Długość</translation>
+        <translation>Długość</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">Powierzchnia</translation>
+        <translation>Powierzchnia</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">Zamknij narzędzie pomiaru</translation>
+        <translation>Zamknij narzędzie pomiaru</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">Zatrzymaj edycję</translation>
+        <translation>Zatrzymaj edycję</translation>
     </message>
     <message>
         <source>Cancel addition</source>
-        <translation type="vanished">Anuluj edycję</translation>
+        <translation>Anuluj edycję</translation>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">Edycja topologiczna włączona</translation>
+        <translation>Edycja topologiczna włączona</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">Edycja topologiczna wyłączona</translation>
+        <translation>Edycja topologiczna wyłączona</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">Edycja odręczna włączona</translation>
+        <translation>Edycja odręczna włączona</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">Edycja odręczna wyłączona</translation>
+        <translation>Edycja odręczna wyłączona</translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
-        <translation type="vanished">Kursor lokalizacji zablokowany na pozycji</translation>
+        <translation>Kursor lokalizacji zablokowany na pozycji</translation>
     </message>
     <message>
         <source>Coordinate cursor unlocked</source>
-        <translation type="vanished">Kursor lokalizacji odblokowany</translation>
+        <translation>Kursor lokalizacji odblokowany</translation>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">Pobrano pozycję</translation>
+        <translation>Pobrano pozycję</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">Szukanie pozycji</translation>
+        <translation>Szukanie pozycji</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">Widok mapy podąża za lokalizacją</translation>
+        <translation>Widok mapy podąża za lokalizacją</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">Czekanie na lokalizację</translation>
+        <translation>Czekanie na lokalizację</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3845,19 +3884,19 @@ Anuluj, aby wykonać zamiast tego minimalne skanowanie urządzeń.</translation>
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">Widok mapy nie podąża za lokalizacją</translation>
+        <translation>Widok mapy nie podąża za lokalizacją</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">Nie można utworzyć obiektu!</translation>
+        <translation>Nie można utworzyć obiektu!</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">Nie można zapisać obiektu!</translation>
+        <translation>Nie można zapisać obiektu!</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">Menu główne</translation>
+        <translation>Menu główne</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3865,7 +3904,7 @@ Anuluj, aby wykonać zamiast tego minimalne skanowanie urządzeń.</translation>
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">Drukuj do PDF</translation>
+        <translation>Drukuj do PDF</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3885,15 +3924,15 @@ Anuluj, aby wykonać zamiast tego minimalne skanowanie urządzeń.</translation>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">Ustawienia</translation>
+        <translation>Ustawienia</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">Dziennik</translation>
+        <translation>Dziennik</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">O QField</translation>
+        <translation>O QField</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3901,7 +3940,7 @@ Anuluj, aby wykonać zamiast tego minimalne skanowanie urządzeń.</translation>
     </message>
     <message>
         <source>Activating positioning service</source>
-        <translation type="vanished">Aktywacja usługi lokalizacji</translation>
+        <translation>Aktywacja usługi lokalizacji</translation>
     </message>
     <message>
         <source>QField has no permissions to use positioning.</source>
@@ -3909,15 +3948,15 @@ Anuluj, aby wykonać zamiast tego minimalne skanowanie urządzeń.</translation>
     </message>
     <message>
         <source>Map Canvas Options</source>
-        <translation type="vanished">Opcje widoku mapy</translation>
+        <translation>Opcje widoku mapy</translation>
     </message>
     <message>
         <source>Add Bookmark</source>
-        <translation type="vanished">Dodaj zakładkę</translation>
+        <translation>Dodaj zakładkę</translation>
     </message>
     <message>
         <source>Set as Destination</source>
-        <translation type="vanished">Ustaw jako cel</translation>
+        <translation>Ustaw jako cel</translation>
     </message>
     <message>
         <source>Add Bookmark at Coordinates</source>
@@ -3925,7 +3964,7 @@ Anuluj, aby wykonać zamiast tego minimalne skanowanie urządzeń.</translation>
     </message>
     <message>
         <source>Untitled bookmark</source>
-        <translation type="vanished">Nienazwana zakładka</translation>
+        <translation>Nienazwana zakładka</translation>
     </message>
     <message>
         <source>Set Coordinates as Destination</source>
@@ -3933,7 +3972,7 @@ Anuluj, aby wykonać zamiast tego minimalne skanowanie urządzeń.</translation>
     </message>
     <message>
         <source>Copy Coordinates</source>
-        <translation type="vanished">Skopiuj współrzędne</translation>
+        <translation>Skopiuj współrzędne</translation>
     </message>
     <message>
         <source>X</source>
@@ -3945,11 +3984,11 @@ Anuluj, aby wykonać zamiast tego minimalne skanowanie urządzeń.</translation>
     </message>
     <message>
         <source>Coordinates copied to clipboard</source>
-        <translation type="vanished">Skopiowano współrzędne do schowka</translation>
+        <translation>Skopiowano współrzędne do schowka</translation>
     </message>
     <message>
         <source>Precise View Settings</source>
-        <translation type="vanished">Ustawienia Widoku precyzyjnego</translation>
+        <translation>Ustawienia Widoku precyzyjnego</translation>
     </message>
     <message>
         <source>0.25m Precision</source>
@@ -3977,27 +4016,27 @@ Anuluj, aby wykonać zamiast tego minimalne skanowanie urządzeń.</translation>
     </message>
     <message>
         <source>Always Show Precise View</source>
-        <translation type="vanished">Zawsze pokazuj Widok precyzyjny</translation>
+        <translation>Zawsze pokazuj Widok precyzyjny</translation>
     </message>
     <message>
         <source>Center to Location</source>
-        <translation type="vanished">Wyśrodkuj do położenia</translation>
+        <translation>Wyśrodkuj do położenia</translation>
     </message>
     <message>
         <source>Add Bookmark at Location</source>
-        <translation type="vanished">Dodaj zakładkę w tym położeniu</translation>
+        <translation>Dodaj zakładkę w tym położeniu</translation>
     </message>
     <message>
         <source>Copy Location Coordinates</source>
-        <translation type="vanished">Skopiuj współrzędne położenia</translation>
+        <translation>Skopiuj współrzędne położenia</translation>
     </message>
     <message>
         <source>Signed out</source>
-        <translation type="vanished">Wylogowano</translation>
+        <translation>Wylogowano</translation>
     </message>
     <message>
         <source>Signed in</source>
-        <translation type="vanished">Zalogowano</translation>
+        <translation>Zalogowano</translation>
     </message>
     <message>
         <source>Set As Destination</source>
@@ -4005,35 +4044,35 @@ Anuluj, aby wykonać zamiast tego minimalne skanowanie urządzeń.</translation>
     </message>
     <message>
         <source>Navigation Options</source>
-        <translation type="vanished">Opcje nawigacji</translation>
+        <translation>Opcje nawigacji</translation>
     </message>
     <message>
         <source>Clear Destination</source>
-        <translation type="vanished">Wyczyść cel</translation>
+        <translation>Wyczyść cel</translation>
     </message>
     <message>
         <source>%1 Precision</source>
-        <translation type="vanished">Dokładność %1</translation>
+        <translation>Dokładność %1</translation>
     </message>
     <message>
         <source>Enable Audio Proximity Feedback</source>
-        <translation type="vanished">Włącz powiadomienie dźwiękowe zbliżenia</translation>
+        <translation>Włącz powiadomienie dźwiękowe zbliżenia</translation>
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">Ustawienia pozycjonowania</translation>
+        <translation>Ustawienia pozycjonowania</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">Włącz pozycjonowanie</translation>
+        <translation>Włącz pozycjonowanie</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">Pokaż informacje o aktualnej pozycji</translation>
+        <translation>Pokaż informacje o aktualnej pozycji</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">Ustawienia lokalizacji</translation>
+        <translation>Ustawienia lokalizacji</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4045,11 +4084,11 @@ Anuluj, aby wykonać zamiast tego minimalne skanowanie urządzeń.</translation>
     </message>
     <message>
         <source>Current location unknown</source>
-        <translation type="vanished">Bieżąca lokalizacja nieznana</translation>
+        <translation>Bieżąca lokalizacja nieznana</translation>
     </message>
     <message>
         <source>My location</source>
-        <translation type="vanished">Moja lokalizacja</translation>
+        <translation>Moja lokalizacja</translation>
     </message>
     <message>
         <source>Copy Current Location</source>
@@ -4057,27 +4096,27 @@ Anuluj, aby wykonać zamiast tego minimalne skanowanie urządzeń.</translation>
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">Dokładność</translation>
+        <translation>Dokładność</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">Niedostępne</translation>
+        <translation>Niedostępne</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
-        <translation type="vanished">Skopiowano bieżącą lokalizację do schowka</translation>
+        <translation>Skopiowano bieżącą lokalizację do schowka</translation>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
-        <translation type="vanished">Aktualna warstwa została przełączona na warstwę zawierającą wybraną geometrię.</translation>
+        <translation>Aktualna warstwa została przełączona na warstwę zawierającą wybraną geometrię.</translation>
     </message>
     <message>
         <source>Editing of multi geometry layer is not supported yet.</source>
-        <translation type="vanished">Edycja warstw z wieloma geometriami nie jest jeszcze obsługiwana.</translation>
+        <translation>Edycja warstw z wieloma geometriami nie jest jeszcze obsługiwana.</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">Wczytywanie %1</translation>
+        <translation>Wczytywanie %1</translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4085,7 +4124,7 @@ Anuluj, aby wykonać zamiast tego minimalne skanowanie urządzeń.</translation>
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">Łączenie...</translation>
+        <translation>Łączenie...</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4093,23 +4132,23 @@ Anuluj, aby wykonać zamiast tego minimalne skanowanie urządzeń.</translation>
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">Nie można było pobrać projektu %1</translation>
+        <translation>Nie można było pobrać projektu %1</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
-        <translation type="vanished">Pomyślnie pobrano projekt %1, jest on gotowy do otwarcia</translation>
+        <translation>Pomyślnie pobrano projekt %1, jest on gotowy do otwarcia</translation>
     </message>
     <message>
         <source>Changes failed to reach QFieldCloud: %1</source>
-        <translation type="vanished">Nie udało się wysłać zmian do QFieldCloud: %1</translation>
+        <translation>Nie udało się wysłać zmian do QFieldCloud: %1</translation>
     </message>
     <message>
         <source>Changes successfully pushed to QFieldCloud</source>
-        <translation type="vanished">Zmiany wysłane pomyślnie do QFieldCloud</translation>
+        <translation>Zmiany wysłane pomyślnie do QFieldCloud</translation>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">Wciśnij wstecz ponownie, aby zamknąć projekt i aplikację</translation>
+        <translation>Wciśnij wstecz ponownie, aby zamknąć projekt i aplikację</translation>
     </message>
     <message>
         <source>Positioning error: %1</source>
@@ -4117,11 +4156,11 @@ Anuluj, aby wykonać zamiast tego minimalne skanowanie urządzeń.</translation>
     </message>
     <message>
         <source>Azimuth</source>
-        <translation type="vanished">Azymut</translation>
+        <translation>Azymut</translation>
     </message>
     <message>
         <source>Lock Screen</source>
-        <translation type="vanished">Zablokuj ekran</translation>
+        <translation>Zablokuj ekran</translation>
     </message>
     <message>
         <source>Print to Image</source>
@@ -4129,23 +4168,119 @@ Anuluj, aby wykonać zamiast tego minimalne skanowanie urządzeń.</translation>
     </message>
     <message>
         <source>Printing...</source>
-        <translation type="vanished">Drukowanie...</translation>
+        <translation>Drukowanie...</translation>
     </message>
     <message>
         <source>Print</source>
-        <translation type="vanished">Drukuj</translation>
+        <translation>Drukuj</translation>
     </message>
     <message>
         <source>Positioning device error: %1</source>
-        <translation type="vanished">Błąd urządzenia lokalizacyjnego: %1</translation>
+        <translation>Błąd urządzenia lokalizacyjnego: %1</translation>
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="unfinished"/>
+        <translation>Powiel obiekt</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
+        <translation>Obiekt powielony pomyślnie</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation>Przyciąganie włączone</translation>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation>Przyciąganie wyłączone</translation>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation>Widok mapy podąża za lokalizacją i orientacją kompasu</translation>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation>Brak dostępnego układu wydruku</translation>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation>Dowiedz się więcej</translation>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation>Czujniki</translation>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation>Brak dostępnego czujnika</translation>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation>Katalog projektu</translation>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation>Wybierz czujnik poniżej</translation>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation>Błąd czujnika: %1</translation>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation>Rozłączanie czujnika &quot;%1&quot;...</translation>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation>Łączenie z czujnikiem &quot;%1&quot;...</translation>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation>Wybierz układ wydruku poniżej</translation>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation>Warstwa:</translation>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation>Obiekt:</translation>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation>Otwórz formularz obiektu</translation>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation>Duplikacja obiektu niedostępna</translation>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation>Importowanie %1</translation>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation>Import URL nie powiódł się.</translation>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
+        <translation>Odblokuj ekran aby zamknąć projekt i aplikację</translation>
     </message>
 </context>
 <context>
@@ -4160,7 +4295,7 @@ Anuluj, aby wykonać zamiast tego minimalne skanowanie urządzeń.</translation>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Nie można dodać elementu potomnego: klucze główne dla elementu nadrzędnego są niedostępne</translation>
+        <translation type="vanished">Nie można dodać elementu potomnego: klucze główne dla elementu nadrzędnego są niedostępne</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -4181,6 +4316,10 @@ Anuluj, aby wykonać zamiast tego minimalne skanowanie urządzeń.</translation>
     <message>
         <source>Failed to delete referencing feature</source>
         <translation>Nie udało się usunąć odnośnego obiektu</translation>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 </TS>

--- a/i18n/qfield_pt.ts
+++ b/i18n/qfield_pt.ts
@@ -230,7 +230,7 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Scanning error: %1</source>
-        <translation type="unfinished"/>
+        <translation>Erro de verificação: %1</translation>
     </message>
 </context>
 <context>
@@ -241,7 +241,7 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Bluetooth permission denied</source>
-        <translation type="unfinished"/>
+        <translation>Permissão Bluetooth negada</translation>
     </message>
 </context>
 <context>
@@ -292,7 +292,7 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Bluetooth permission denied</source>
-        <translation type="unfinished"/>
+        <translation>Permissão Bluetooth negada</translation>
     </message>
 </context>
 <context>
@@ -666,6 +666,29 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
 </context>
 <context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation>Falha ao desfazer os elementos criados na camada &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation>Falha ao desfazer elementos apagados na camada &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation>Falha ao desfazer a atualização dos elementos na camada &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation>Falha ao confirmar a alteração de desfazer do elemento na camada &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation>Falha aos reverter e desfazer as alterações do elemento na camada &quot;%1&quot;</translation>
+    </message>
+</context>
+<context>
     <name>FeatureListForm</name>
     <message>
         <source>Stop tracking this feature to edit attributes</source>
@@ -945,7 +968,7 @@ As geometrias dos recursos serão combinadas no recurso &apos;% &apos;, que mant
     <name>InternalGnssReceiver</name>
     <message>
         <source>Location permission denied</source>
-        <translation type="unfinished"/>
+        <translation>Permissão de localização negada</translation>
     </message>
 </context>
 <context>
@@ -1219,7 +1242,7 @@ As geometrias dos recursos serão combinadas no recurso &apos;% &apos;, que mant
     </message>
     <message>
         <source>Activate a vector layer in the legend first to use this functionality</source>
-        <translation type="unfinished"/>
+        <translation>Para usar esta funcionalidade, ative primeiro uma camada vetorial na legenda</translation>
     </message>
 </context>
 <context>
@@ -1782,11 +1805,11 @@ As geometrias dos recursos serão combinadas no recurso &apos;% &apos;, que mant
     </message>
     <message>
         <source>Grid enabled</source>
-        <translation type="unfinished"/>
+        <translation>Grelha ativada</translation>
     </message>
     <message>
         <source>Grid disabled</source>
-        <translation type="unfinished"/>
+        <translation>Grelha desativada</translation>
     </message>
 </context>
 <context>
@@ -2111,6 +2134,14 @@ Enquanto pode ver e usar o projeto, recomendamos fortemente a limpá-lo para evi
         <source>No changes to revert</source>
         <translation>Sem alterações para reverter</translation>
     </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation>Este projeto tem um ficheiro de projeto atualizado na nuvem, é recomendado sincronizar.</translation>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation>Este projeto possui dados atualizados na nuvem, você deve sincronizar.</translation>
+    </message>
 </context>
 <context>
     <name>QFieldCloudProjectsModel</name>
@@ -2348,6 +2379,10 @@ Enquanto pode ver e usar o projeto, recomendamos fortemente a limpá-lo para evi
     <message>
         <source>Project Actions</source>
         <translation>Ações de Projeto</translation>
+    </message>
+    <message>
+        <source>, updated data available on the cloud</source>
+        <translation>, dados atualizados disponíveis na nuvem</translation>
     </message>
 </context>
 <context>
@@ -3725,7 +3760,7 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Não é possível adicionar elemento filho: chaves primárias pai não estão disponíveis </translation>
+        <translation type="vanished">Não é possível adicionar elemento filho: chaves primárias pai não estão disponíveis </translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -3747,100 +3782,104 @@ Cancele para fazer uma verificação mínima.</translation>
         <source>Failed to delete referencing feature</source>
         <translation>Falha ao apagar o elemento de referência</translation>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation>Não é possível adicionar elemento filho: o valor do atributo que liga pai e filho não está definido</translation>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">Está agora no modo de navegação</translation>
+        <translation>Está agora no modo de navegação</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">Está agora no modo de digitalização na camada %1</translation>
+        <translation>Está agora no modo de digitalização na camada %1</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">Está agora no modo de digitalização</translation>
+        <translation>Está agora no modo de digitalização</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">Está agora no modo de medição</translation>
+        <translation>Está agora no modo de medição</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">Lon</translation>
+        <translation>Lon</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">Lat</translation>
+        <translation>Lat</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">Segmento</translation>
+        <translation>Segmento</translation>
     </message>
     <message>
         <source>Perimeter</source>
-        <translation type="vanished">Perímetro</translation>
+        <translation>Perímetro</translation>
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">Comprimento</translation>
+        <translation>Comprimento</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">Área</translation>
+        <translation>Área</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">Fechar ferramenta de medição</translation>
+        <translation>Fechar ferramenta de medição</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">Terminar edição</translation>
+        <translation>Terminar edição</translation>
     </message>
     <message>
         <source>Cancel addition</source>
-        <translation type="vanished">Cancelar adição</translation>
+        <translation>Cancelar adição</translation>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">Edição topológica ligada</translation>
+        <translation>Edição topológica ligada</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">Edição topológica desligada</translation>
+        <translation>Edição topológica desligada</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">Digitalização manual ativada</translation>
+        <translation>Digitalização manual ativada</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">Digitalização manual desligada</translation>
+        <translation>Digitalização manual desligada</translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
-        <translation type="vanished">Coordenada do cursor bloqueada na posição</translation>
+        <translation>Coordenada do cursor bloqueada na posição</translation>
     </message>
     <message>
         <source>Coordinate cursor unlocked</source>
-        <translation type="vanished">Coordenada do cursor desbloqueada</translation>
+        <translation>Coordenada do cursor desbloqueada</translation>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">Posição recebida</translation>
+        <translation>Posição recebida</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">Pesquisar por posição</translation>
+        <translation>Pesquisar por posição</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">O ecrã está a seguir a localização</translation>
+        <translation>O ecrã está a seguir a localização</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">A aguardar pela localização</translation>
+        <translation>A aguardar pela localização</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3852,19 +3891,19 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">O ecrã parou de seguir a localização</translation>
+        <translation>O ecrã parou de seguir a localização</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">Falha ao criar o elemento!</translation>
+        <translation>Falha ao criar o elemento!</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">Falha ao guardar o elemento!</translation>
+        <translation>Falha ao guardar o elemento!</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">Menu Principal</translation>
+        <translation>Menu Principal</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3872,7 +3911,7 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">Imprimir para PDF</translation>
+        <translation>Imprimir para PDF</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3892,15 +3931,15 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">Definições</translation>
+        <translation>Definições</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">Mensagens de Registos</translation>
+        <translation>Mensagens de Registos</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">Sobre o QField</translation>
+        <translation>Sobre o QField</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3908,7 +3947,7 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Activating positioning service</source>
-        <translation type="vanished">A ativar o serviço de posicionamento</translation>
+        <translation>A ativar o serviço de posicionamento</translation>
     </message>
     <message>
         <source>QField has no permissions to use positioning.</source>
@@ -3916,15 +3955,15 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Map Canvas Options</source>
-        <translation type="vanished">Opções do mapa</translation>
+        <translation>Opções do mapa</translation>
     </message>
     <message>
         <source>Add Bookmark</source>
-        <translation type="vanished">Adicionar Marcador</translation>
+        <translation>Adicionar Marcador</translation>
     </message>
     <message>
         <source>Set as Destination</source>
-        <translation type="vanished">Definir como Destino</translation>
+        <translation>Definir como Destino</translation>
     </message>
     <message>
         <source>Add Bookmark at Coordinates</source>
@@ -3932,7 +3971,7 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Untitled bookmark</source>
-        <translation type="vanished">Marcador sem título</translation>
+        <translation>Marcador sem título</translation>
     </message>
     <message>
         <source>Set Coordinates as Destination</source>
@@ -3940,7 +3979,7 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Copy Coordinates</source>
-        <translation type="vanished">Copiar coordenadas</translation>
+        <translation>Copiar coordenadas</translation>
     </message>
     <message>
         <source>X</source>
@@ -3952,11 +3991,11 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Coordinates copied to clipboard</source>
-        <translation type="vanished">Coordenadas copiadas para transferência</translation>
+        <translation>Coordenadas copiadas para transferência</translation>
     </message>
     <message>
         <source>Precise View Settings</source>
-        <translation type="vanished">Configuração de Visualização Precisa</translation>
+        <translation>Configuração de Visualização Precisa</translation>
     </message>
     <message>
         <source>0.25m Precision</source>
@@ -3984,27 +4023,27 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Always Show Precise View</source>
-        <translation type="vanished">Mostrar Sempre Visualização Precisa</translation>
+        <translation>Mostrar Sempre Visualização Precisa</translation>
     </message>
     <message>
         <source>Center to Location</source>
-        <translation type="vanished">Centrar para a Localização</translation>
+        <translation>Centrar para a Localização</translation>
     </message>
     <message>
         <source>Add Bookmark at Location</source>
-        <translation type="vanished">Adicionar o Marcador na Localização</translation>
+        <translation>Adicionar o Marcador na Localização</translation>
     </message>
     <message>
         <source>Copy Location Coordinates</source>
-        <translation type="vanished">Copiar Coordenadas de Localização</translation>
+        <translation>Copiar Coordenadas de Localização</translation>
     </message>
     <message>
         <source>Signed out</source>
-        <translation type="vanished">Sair</translation>
+        <translation>Sair</translation>
     </message>
     <message>
         <source>Signed in</source>
-        <translation type="vanished">Ligar</translation>
+        <translation>Ligar</translation>
     </message>
     <message>
         <source>Set As Destination</source>
@@ -4012,35 +4051,35 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Navigation Options</source>
-        <translation type="vanished">Opções de navegação</translation>
+        <translation>Opções de navegação</translation>
     </message>
     <message>
         <source>Clear Destination</source>
-        <translation type="vanished">Limpar destino</translation>
+        <translation>Limpar destino</translation>
     </message>
     <message>
         <source>%1 Precision</source>
-        <translation type="vanished">%1 Precisão</translation>
+        <translation>%1 Precisão</translation>
     </message>
     <message>
         <source>Enable Audio Proximity Feedback</source>
-        <translation type="vanished">Ativar Feedback de Áudio de Proximidade</translation>
+        <translation>Ativar Feedback de Áudio de Proximidade</translation>
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">Opções de Posicionamento</translation>
+        <translation>Opções de Posicionamento</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">Ativar Posicionamento</translation>
+        <translation>Ativar Posicionamento</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">Mostrar a informação da posição</translation>
+        <translation>Mostrar a informação da posição</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">Definições de Posicionamento</translation>
+        <translation>Definições de Posicionamento</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4052,11 +4091,11 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Current location unknown</source>
-        <translation type="vanished">Localização atual desconhecida</translation>
+        <translation>Localização atual desconhecida</translation>
     </message>
     <message>
         <source>My location</source>
-        <translation type="vanished">A minha localização</translation>
+        <translation>A minha localização</translation>
     </message>
     <message>
         <source>Copy Current Location</source>
@@ -4064,27 +4103,27 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">Precisão</translation>
+        <translation>Precisão</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">N/D</translation>
+        <translation>N/D</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
-        <translation type="vanished">Localização atual copiada para transferência</translation>
+        <translation>Localização atual copiada para transferência</translation>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
-        <translation type="vanished">A camada atual mudou para a que contém a geometria selecionada.</translation>
+        <translation>A camada atual mudou para a que contém a geometria selecionada.</translation>
     </message>
     <message>
         <source>Editing of multi geometry layer is not supported yet.</source>
-        <translation type="vanished">A edição de camada com geometria multiparte ainda não é suportada.</translation>
+        <translation>A edição de camada com geometria multiparte ainda não é suportada.</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">A Carregar % 1 </translation>
+        <translation>A Carregar % 1 </translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4092,7 +4131,7 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">Ligando...</translation>
+        <translation>Ligando...</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4100,23 +4139,23 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">Ocorreu uma falha ao transferir o projeto %1</translation>
+        <translation>Ocorreu uma falha ao transferir o projeto %1</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
-        <translation type="vanished">O projeto %1 foi transferido com sucesso e está agora disponível para ser aberto</translation>
+        <translation>O projeto %1 foi transferido com sucesso e está agora disponível para ser aberto</translation>
     </message>
     <message>
         <source>Changes failed to reach QFieldCloud: %1</source>
-        <translation type="vanished">As alterações não foram enviadas para QFieldCloud: %1</translation>
+        <translation>As alterações não foram enviadas para QFieldCloud: %1</translation>
     </message>
     <message>
         <source>Changes successfully pushed to QFieldCloud</source>
-        <translation type="vanished">Alterações enviadas para QFieldCloud com sucesso</translation>
+        <translation>Alterações enviadas para QFieldCloud com sucesso</translation>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">Volte a pressionar novamente o retroceder para fechar o projecto e a aplicação</translation>
+        <translation>Volte a pressionar novamente o retroceder para fechar o projecto e a aplicação</translation>
     </message>
     <message>
         <source>Positioning error: %1</source>
@@ -4124,11 +4163,11 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Azimuth</source>
-        <translation type="vanished">Azimute</translation>
+        <translation>Azimute</translation>
     </message>
     <message>
         <source>Lock Screen</source>
-        <translation type="vanished">Bloquear Ecrã </translation>
+        <translation>Bloquear Ecrã </translation>
     </message>
     <message>
         <source>Print to Image</source>
@@ -4136,22 +4175,118 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Printing...</source>
-        <translation type="vanished">Imprimindo...</translation>
+        <translation>Imprimindo...</translation>
     </message>
     <message>
         <source>Print</source>
-        <translation type="vanished">Imprimir</translation>
+        <translation>Imprimir</translation>
     </message>
     <message>
         <source>Positioning device error: %1</source>
-        <translation type="vanished">Erro do dispositivo de posicionamento: %1</translation>
+        <translation>Erro do dispositivo de posicionamento: %1</translation>
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="unfinished"/>
+        <translation>Duplicar Elemento</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
+        <translation>Elemento duplicado com sucesso</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation>Snapping ligado</translation>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation>Snapping desligado</translation>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation>O enquadramento acompanha a localização e a orientação da bússola.</translation>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation>Sem layout de impressão disponível</translation>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation>Saber mais</translation>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation>Sensores</translation>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation>Sem sensor disponível</translation>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation>Pasta do projeto</translation>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation>Selecionar sensor </translation>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation>Erro no sensor: %1</translation>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation>Desligar sensor &apos;%1&apos;...</translation>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation>Ligar ao sensor &apos;%1&apos;...</translation>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation>Seleciona a composição abaixo</translation>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation>Camada:</translation>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation>Elemento:</translation>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation>Abrir formulário do elemento</translation>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation>Duplicação de elemento não disponível</translation>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation>A importar %1</translation>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation>Falhou a importação do URL</translation>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -4167,7 +4302,7 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Não é possível adicionar elemento filho: chaves primárias pai não estão disponíveis </translation>
+        <translation type="vanished">Não é possível adicionar elemento filho: chaves primárias pai não estão disponíveis </translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -4188,6 +4323,10 @@ Cancele para fazer uma verificação mínima.</translation>
     <message>
         <source>Failed to delete referencing feature</source>
         <translation>Falha ao apagar o elemento de referência</translation>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation>Não é possível adicionar elemento filho: o valor do atributo que liga pai e filho não está definido</translation>
     </message>
 </context>
 </TS>

--- a/i18n/qfield_pt_BR.ts
+++ b/i18n/qfield_pt_BR.ts
@@ -666,6 +666,29 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
 </context>
 <context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
     <name>FeatureListForm</name>
     <message>
         <source>Stop tracking this feature to edit attributes</source>
@@ -2101,6 +2124,14 @@ While you can still view and use the project, it is strongly recommended to rese
         <source>No changes to revert</source>
         <translation>Não há mudanças para reverter</translation>
     </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>QFieldCloudProjectsModel</name>
@@ -2336,6 +2367,10 @@ While you can still view and use the project, it is strongly recommended to rese
     </message>
     <message>
         <source>Project Actions</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>, updated data available on the cloud</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -3714,7 +3749,7 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Não é possível adicionar elemento filho: chaves primárias pai não estão disponíveis </translation>
+        <translation type="vanished">Não é possível adicionar elemento filho: chaves primárias pai não estão disponíveis </translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -3736,100 +3771,104 @@ Cancele para fazer uma verificação mínima.</translation>
         <source>Failed to delete referencing feature</source>
         <translation>Falha ao excluir o recurso de referência</translation>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">Agora você está no modo de navegação</translation>
+        <translation>Agora você está no modo de navegação</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">Está agora no modo de digitalização na camada %1</translation>
+        <translation>Está agora no modo de digitalização na camada %1</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">Agora você está no modo de digitalização</translation>
+        <translation>Agora você está no modo de digitalização</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">Agora você está no modo de medição</translation>
+        <translation>Agora você está no modo de medição</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">Lon</translation>
+        <translation>Lon</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">Lat</translation>
+        <translation>Lat</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">Segmento</translation>
+        <translation>Segmento</translation>
     </message>
     <message>
         <source>Perimeter</source>
-        <translation type="vanished">Perímetro</translation>
+        <translation>Perímetro</translation>
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">Comprimento</translation>
+        <translation>Comprimento</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">Área</translation>
+        <translation>Área</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">Fechar ferramenta de medição</translation>
+        <translation>Fechar ferramenta de medição</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">Pare de editar</translation>
+        <translation>Pare de editar</translation>
     </message>
     <message>
         <source>Cancel addition</source>
-        <translation type="vanished">Cancelar adição</translation>
+        <translation>Cancelar adição</translation>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">Edição topológica ativada</translation>
+        <translation>Edição topológica ativada</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">Edição topológica desativada</translation>
+        <translation>Edição topológica desativada</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">Edição à mão livre ativada</translation>
+        <translation>Edição à mão livre ativada</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">Edição à mão livre desativada</translation>
+        <translation>Edição à mão livre desativada</translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
-        <translation type="vanished">Coordenada do cursor bloqueada na posição</translation>
+        <translation>Coordenada do cursor bloqueada na posição</translation>
     </message>
     <message>
         <source>Coordinate cursor unlocked</source>
-        <translation type="vanished">Coordenada do cursor desbloqueada</translation>
+        <translation>Coordenada do cursor desbloqueada</translation>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">Posição recebida</translation>
+        <translation>Posição recebida</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">Procurando posição</translation>
+        <translation>Procurando posição</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">A tela está seguindo a localização</translation>
+        <translation>A tela está seguindo a localização</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">Aguardando localização</translation>
+        <translation>Aguardando localização</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3841,19 +3880,19 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">A tela parou de seguir a localização</translation>
+        <translation>A tela parou de seguir a localização</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">Falha ao criar o elemento!</translation>
+        <translation>Falha ao criar o elemento!</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">Falha ao salvar o elemento!</translation>
+        <translation>Falha ao salvar o elemento!</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">Menu Principal</translation>
+        <translation>Menu Principal</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3861,7 +3900,7 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">Exportar para PDF</translation>
+        <translation>Exportar para PDF</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3881,15 +3920,15 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">Configurações</translation>
+        <translation>Configurações</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">Log de Mensagens</translation>
+        <translation>Log de Mensagens</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">Sobre o QField</translation>
+        <translation>Sobre o QField</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3897,7 +3936,7 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Activating positioning service</source>
-        <translation type="vanished">Ativando o serviço de posicionamento</translation>
+        <translation>Ativando o serviço de posicionamento</translation>
     </message>
     <message>
         <source>QField has no permissions to use positioning.</source>
@@ -3905,15 +3944,15 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Map Canvas Options</source>
-        <translation type="vanished">Opções do mapa</translation>
+        <translation>Opções do mapa</translation>
     </message>
     <message>
         <source>Add Bookmark</source>
-        <translation type="vanished">Adicionar Marcador</translation>
+        <translation>Adicionar Marcador</translation>
     </message>
     <message>
         <source>Set as Destination</source>
-        <translation type="vanished">Definir como Destino</translation>
+        <translation>Definir como Destino</translation>
     </message>
     <message>
         <source>Add Bookmark at Coordinates</source>
@@ -3921,7 +3960,7 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Untitled bookmark</source>
-        <translation type="vanished">Marcador sem título</translation>
+        <translation>Marcador sem título</translation>
     </message>
     <message>
         <source>Set Coordinates as Destination</source>
@@ -3929,7 +3968,7 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Copy Coordinates</source>
-        <translation type="vanished">Copiar coordenadas</translation>
+        <translation>Copiar coordenadas</translation>
     </message>
     <message>
         <source>X</source>
@@ -3941,7 +3980,7 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Coordinates copied to clipboard</source>
-        <translation type="vanished">Coordenadas copiadas para área de transferência</translation>
+        <translation>Coordenadas copiadas para área de transferência</translation>
     </message>
     <message>
         <source>Precise View Settings</source>
@@ -3977,7 +4016,7 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Center to Location</source>
-        <translation type="vanished">Centralizar na Localização</translation>
+        <translation>Centralizar na Localização</translation>
     </message>
     <message>
         <source>Add Bookmark at Location</source>
@@ -4001,11 +4040,11 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Navigation Options</source>
-        <translation type="vanished">Opções de navegação</translation>
+        <translation>Opções de navegação</translation>
     </message>
     <message>
         <source>Clear Destination</source>
-        <translation type="vanished">Limpar destino</translation>
+        <translation>Limpar destino</translation>
     </message>
     <message>
         <source>%1 Precision</source>
@@ -4017,19 +4056,19 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">Opções de posicionamento</translation>
+        <translation>Opções de posicionamento</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">Ativar posicionamento</translation>
+        <translation>Ativar posicionamento</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">Mostrar informações de posicionamento</translation>
+        <translation>Mostrar informações de posicionamento</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">Configurações de posicionamento</translation>
+        <translation>Configurações de posicionamento</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4041,11 +4080,11 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Current location unknown</source>
-        <translation type="vanished">Localização atual desconhecida</translation>
+        <translation>Localização atual desconhecida</translation>
     </message>
     <message>
         <source>My location</source>
-        <translation type="vanished">Minha localização</translation>
+        <translation>Minha localização</translation>
     </message>
     <message>
         <source>Copy Current Location</source>
@@ -4053,27 +4092,27 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">Precisão</translation>
+        <translation>Precisão</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">N/A</translation>
+        <translation>N/A</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
-        <translation type="vanished">Localização atual copiada para área de transferência</translation>
+        <translation>Localização atual copiada para área de transferência</translation>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
-        <translation type="vanished">A camada atual mudou para a que contém a geometria selecionada.</translation>
+        <translation>A camada atual mudou para a que contém a geometria selecionada.</translation>
     </message>
     <message>
         <source>Editing of multi geometry layer is not supported yet.</source>
-        <translation type="vanished">A edição da camada de multi geometria ainda não é suportada.</translation>
+        <translation>A edição da camada de multi geometria ainda não é suportada.</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">Carregando %1</translation>
+        <translation>Carregando %1</translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4081,7 +4120,7 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">Conectando...</translation>
+        <translation>Conectando...</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4089,23 +4128,23 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">Falha ao baixar o projeto %1</translation>
+        <translation>Falha ao baixar o projeto %1</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
-        <translation type="vanished">Projeto %1 foi baixado com sucesso, agora está disponível para ser aberto</translation>
+        <translation>Projeto %1 foi baixado com sucesso, agora está disponível para ser aberto</translation>
     </message>
     <message>
         <source>Changes failed to reach QFieldCloud: %1</source>
-        <translation type="vanished">As alterações não foram enviadas para QFieldCloud: %1</translation>
+        <translation>As alterações não foram enviadas para QFieldCloud: %1</translation>
     </message>
     <message>
         <source>Changes successfully pushed to QFieldCloud</source>
-        <translation type="vanished">Alterações enviadas para QFieldCloud com sucesso</translation>
+        <translation>Alterações enviadas para QFieldCloud com sucesso</translation>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">Toque novamente para fechar o projeto e o aplicativo</translation>
+        <translation>Toque novamente para fechar o projeto e o aplicativo</translation>
     </message>
     <message>
         <source>Positioning error: %1</source>
@@ -4113,11 +4152,11 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Azimuth</source>
-        <translation type="vanished">Azimute</translation>
+        <translation>Azimute</translation>
     </message>
     <message>
         <source>Lock Screen</source>
-        <translation type="vanished">Bloquear Tela</translation>
+        <translation>Bloquear Tela</translation>
     </message>
     <message>
         <source>Print to Image</source>
@@ -4137,10 +4176,106 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="unfinished"/>
+        <translation>Elemento Duplicado</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
+        <translation>Elemento duplicado com sucesso</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation>Pasta do Projeto</translation>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -4156,7 +4291,7 @@ Cancele para fazer uma verificação mínima.</translation>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Não é possível adicionar elemento filho: chaves primárias pai não estão disponíveis </translation>
+        <translation type="vanished">Não é possível adicionar elemento filho: chaves primárias pai não estão disponíveis </translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -4177,6 +4312,10 @@ Cancele para fazer uma verificação mínima.</translation>
     <message>
         <source>Failed to delete referencing feature</source>
         <translation>Falha ao excluir o recurso de referência</translation>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 </TS>

--- a/i18n/qfield_ro.ts
+++ b/i18n/qfield_ro.ts
@@ -667,6 +667,29 @@ Anulați pentru a efectua o scanare minimă a dispozitivului.</translation>
     </message>
 </context>
 <context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
     <name>FeatureListForm</name>
     <message>
         <source>Stop tracking this feature to edit attributes</source>
@@ -2113,6 +2136,14 @@ While you can still view and use the project, it is strongly recommended to rese
         <source>No changes to revert</source>
         <translation>Nu există modificări de readus</translation>
     </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>QFieldCloudProjectsModel</name>
@@ -2349,6 +2380,10 @@ While you can still view and use the project, it is strongly recommended to rese
     </message>
     <message>
         <source>Project Actions</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>, updated data available on the cloud</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -3727,7 +3762,7 @@ Anulați pentru a efectua o scanare minimă a dispozitivului.</translation>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Nu se poate adăuga elementul secundar: Cheile primare principale nu sunt disponibile</translation>
+        <translation type="vanished">Nu se poate adăuga elementul secundar: Cheile primare principale nu sunt disponibile</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -3749,100 +3784,104 @@ Anulați pentru a efectua o scanare minimă a dispozitivului.</translation>
         <source>Failed to delete referencing feature</source>
         <translation>Nu s-a putut șterge elementul de referențiere</translation>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">Acum sunteți in modul de navigare</translation>
+        <translation>Acum sunteți in modul de navigare</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">Acum sunteți în modul digitizare pe stratul %1</translation>
+        <translation>Acum sunteți în modul digitizare pe stratul %1</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">Acum sunteți in modul de digitizare</translation>
+        <translation>Acum sunteți in modul de digitizare</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">Acum sunteți in modul de măsurare</translation>
+        <translation>Acum sunteți in modul de măsurare</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">Lon</translation>
+        <translation>Lon</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">Lat</translation>
+        <translation>Lat</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">Segment</translation>
+        <translation>Segment</translation>
     </message>
     <message>
         <source>Perimeter</source>
-        <translation type="vanished">Perimetru</translation>
+        <translation>Perimetru</translation>
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">Lungime</translation>
+        <translation>Lungime</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">Arie</translation>
+        <translation>Arie</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">Închide instrumentul pentru măsurare</translation>
+        <translation>Închide instrumentul pentru măsurare</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">Opriți editarea</translation>
+        <translation>Opriți editarea</translation>
     </message>
     <message>
         <source>Cancel addition</source>
-        <translation type="vanished">Anulați adăugarea</translation>
+        <translation>Anulați adăugarea</translation>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">Editarea topologică a pornit</translation>
+        <translation>Editarea topologică a pornit</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">Editarea topologică a fost dezactivată</translation>
+        <translation>Editarea topologică a fost dezactivată</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">Digitizarea cu mâna libera este pornită</translation>
+        <translation>Digitizarea cu mâna libera este pornită</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">Digitizarea cu mâna libera este oprită</translation>
+        <translation>Digitizarea cu mâna libera este oprită</translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
-        <translation type="vanished">Cursorul cu coordonate este blocat în poziție</translation>
+        <translation>Cursorul cu coordonate este blocat în poziție</translation>
     </message>
     <message>
         <source>Coordinate cursor unlocked</source>
-        <translation type="vanished">Cursorul cu coordonate este deblocat</translation>
+        <translation>Cursorul cu coordonate este deblocat</translation>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">Poziție primită</translation>
+        <translation>Poziție primită</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">Căutam poziția</translation>
+        <translation>Căutam poziția</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">Canvasul urmărește locația</translation>
+        <translation>Canvasul urmărește locația</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">Așteptăm după locație</translation>
+        <translation>Așteptăm după locație</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3854,19 +3893,19 @@ Anulați pentru a efectua o scanare minimă a dispozitivului.</translation>
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">Canvasul nu mai urmărește locația</translation>
+        <translation>Canvasul nu mai urmărește locația</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">Creara elementului a eșuat!</translation>
+        <translation>Creara elementului a eșuat!</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">Salvarea elementului a eșuat!</translation>
+        <translation>Salvarea elementului a eșuat!</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">Meniul Principal</translation>
+        <translation>Meniul Principal</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3874,7 +3913,7 @@ Anulați pentru a efectua o scanare minimă a dispozitivului.</translation>
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">Creează PDF</translation>
+        <translation>Creează PDF</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3894,15 +3933,15 @@ Anulați pentru a efectua o scanare minimă a dispozitivului.</translation>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">Setări</translation>
+        <translation>Setări</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">Mesaj Jurnal Modificări</translation>
+        <translation>Mesaj Jurnal Modificări</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">Despre QField</translation>
+        <translation>Despre QField</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3910,7 +3949,7 @@ Anulați pentru a efectua o scanare minimă a dispozitivului.</translation>
     </message>
     <message>
         <source>Activating positioning service</source>
-        <translation type="vanished">Se activează serviciul de poziționare</translation>
+        <translation>Se activează serviciul de poziționare</translation>
     </message>
     <message>
         <source>QField has no permissions to use positioning.</source>
@@ -3918,15 +3957,15 @@ Anulați pentru a efectua o scanare minimă a dispozitivului.</translation>
     </message>
     <message>
         <source>Map Canvas Options</source>
-        <translation type="vanished">Opțiuni ale Canvasului Hărții</translation>
+        <translation>Opțiuni ale Canvasului Hărții</translation>
     </message>
     <message>
         <source>Add Bookmark</source>
-        <translation type="vanished">Adaugați Semn de Carte</translation>
+        <translation>Adaugați Semn de Carte</translation>
     </message>
     <message>
         <source>Set as Destination</source>
-        <translation type="vanished">Setați ca Destinație</translation>
+        <translation>Setați ca Destinație</translation>
     </message>
     <message>
         <source>Add Bookmark at Coordinates</source>
@@ -3934,7 +3973,7 @@ Anulați pentru a efectua o scanare minimă a dispozitivului.</translation>
     </message>
     <message>
         <source>Untitled bookmark</source>
-        <translation type="vanished">Semn de carte nedenumit</translation>
+        <translation>Semn de carte nedenumit</translation>
     </message>
     <message>
         <source>Set Coordinates as Destination</source>
@@ -3942,7 +3981,7 @@ Anulați pentru a efectua o scanare minimă a dispozitivului.</translation>
     </message>
     <message>
         <source>Copy Coordinates</source>
-        <translation type="vanished">Copiați Coordonate</translation>
+        <translation>Copiați Coordonate</translation>
     </message>
     <message>
         <source>X</source>
@@ -3954,11 +3993,11 @@ Anulați pentru a efectua o scanare minimă a dispozitivului.</translation>
     </message>
     <message>
         <source>Coordinates copied to clipboard</source>
-        <translation type="vanished">Coordonate copiate în clipboard</translation>
+        <translation>Coordonate copiate în clipboard</translation>
     </message>
     <message>
         <source>Precise View Settings</source>
-        <translation type="vanished">Setări Vizualizare cu Precizie</translation>
+        <translation>Setări Vizualizare cu Precizie</translation>
     </message>
     <message>
         <source>0.25m Precision</source>
@@ -3986,27 +4025,27 @@ Anulați pentru a efectua o scanare minimă a dispozitivului.</translation>
     </message>
     <message>
         <source>Always Show Precise View</source>
-        <translation type="vanished">Arată întotdeauna Vizualizarea Precisă</translation>
+        <translation>Arată întotdeauna Vizualizarea Precisă</translation>
     </message>
     <message>
         <source>Center to Location</source>
-        <translation type="vanished">Centrați pe Locație</translation>
+        <translation>Centrați pe Locație</translation>
     </message>
     <message>
         <source>Add Bookmark at Location</source>
-        <translation type="vanished">Adăugați un Semn de Carte la Locație</translation>
+        <translation>Adăugați un Semn de Carte la Locație</translation>
     </message>
     <message>
         <source>Copy Location Coordinates</source>
-        <translation type="vanished">Copiază Coordonatele Locației</translation>
+        <translation>Copiază Coordonatele Locației</translation>
     </message>
     <message>
         <source>Signed out</source>
-        <translation type="vanished">Deconectat</translation>
+        <translation>Deconectat</translation>
     </message>
     <message>
         <source>Signed in</source>
-        <translation type="vanished">Conectat</translation>
+        <translation>Conectat</translation>
     </message>
     <message>
         <source>Set As Destination</source>
@@ -4014,35 +4053,35 @@ Anulați pentru a efectua o scanare minimă a dispozitivului.</translation>
     </message>
     <message>
         <source>Navigation Options</source>
-        <translation type="vanished">Opțiuni Navigație</translation>
+        <translation>Opțiuni Navigație</translation>
     </message>
     <message>
         <source>Clear Destination</source>
-        <translation type="vanished">Curăță Destinația</translation>
+        <translation>Curăță Destinația</translation>
     </message>
     <message>
         <source>%1 Precision</source>
-        <translation type="vanished">%1 Precizie</translation>
+        <translation>%1 Precizie</translation>
     </message>
     <message>
         <source>Enable Audio Proximity Feedback</source>
-        <translation type="vanished">Activați Feedback-ul Audio de Proximitate </translation>
+        <translation>Activați Feedback-ul Audio de Proximitate </translation>
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">Opțiuni de Poziționare</translation>
+        <translation>Opțiuni de Poziționare</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">Activare Poziționare</translation>
+        <translation>Activare Poziționare</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">Arată Informațiile Poziției</translation>
+        <translation>Arată Informațiile Poziției</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">Setări de Poziționare</translation>
+        <translation>Setări de Poziționare</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4054,11 +4093,11 @@ Anulați pentru a efectua o scanare minimă a dispozitivului.</translation>
     </message>
     <message>
         <source>Current location unknown</source>
-        <translation type="vanished">Locația Curentă necunoscută</translation>
+        <translation>Locația Curentă necunoscută</translation>
     </message>
     <message>
         <source>My location</source>
-        <translation type="vanished">Locația mea</translation>
+        <translation>Locația mea</translation>
     </message>
     <message>
         <source>Copy Current Location</source>
@@ -4066,27 +4105,27 @@ Anulați pentru a efectua o scanare minimă a dispozitivului.</translation>
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">Acurateţe</translation>
+        <translation>Acurateţe</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">N/A</translation>
+        <translation>N/A</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
-        <translation type="vanished">Locația Curentă a fost copiată în clipboard</translation>
+        <translation>Locația Curentă a fost copiată în clipboard</translation>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
-        <translation type="vanished">Stratul curent a trecut la cel care conține geometria selectată.</translation>
+        <translation>Stratul curent a trecut la cel care conține geometria selectată.</translation>
     </message>
     <message>
         <source>Editing of multi geometry layer is not supported yet.</source>
-        <translation type="vanished">Editarea stratului cu geometrie multiplă nu este permisă încă.</translation>
+        <translation>Editarea stratului cu geometrie multiplă nu este permisă încă.</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">Încărcare %1</translation>
+        <translation>Încărcare %1</translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4094,7 +4133,7 @@ Anulați pentru a efectua o scanare minimă a dispozitivului.</translation>
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">Se contectează...</translation>
+        <translation>Se contectează...</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4102,23 +4141,23 @@ Anulați pentru a efectua o scanare minimă a dispozitivului.</translation>
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">Proiectul %1 nu a reușit descărcarea</translation>
+        <translation>Proiectul %1 nu a reușit descărcarea</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
-        <translation type="vanished">Proiectul %1 descărcat cu succes, acum disponibil pentru deschidere</translation>
+        <translation>Proiectul %1 descărcat cu succes, acum disponibil pentru deschidere</translation>
     </message>
     <message>
         <source>Changes failed to reach QFieldCloud: %1</source>
-        <translation type="vanished">Modificările nu au reușit să ajungă la QFieldCloud: %1</translation>
+        <translation>Modificările nu au reușit să ajungă la QFieldCloud: %1</translation>
     </message>
     <message>
         <source>Changes successfully pushed to QFieldCloud</source>
-        <translation type="vanished">Modificările au reușit să ajungă la QFieldCloud</translation>
+        <translation>Modificările au reușit să ajungă la QFieldCloud</translation>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">Apăsați pe Back pentru a închide proiectul și aplicația</translation>
+        <translation>Apăsați pe Back pentru a închide proiectul și aplicația</translation>
     </message>
     <message>
         <source>Positioning error: %1</source>
@@ -4126,11 +4165,11 @@ Anulați pentru a efectua o scanare minimă a dispozitivului.</translation>
     </message>
     <message>
         <source>Azimuth</source>
-        <translation type="vanished">Azimut</translation>
+        <translation>Azimut</translation>
     </message>
     <message>
         <source>Lock Screen</source>
-        <translation type="vanished">Blocare Ecran</translation>
+        <translation>Blocare Ecran</translation>
     </message>
     <message>
         <source>Print to Image</source>
@@ -4138,22 +4177,118 @@ Anulați pentru a efectua o scanare minimă a dispozitivului.</translation>
     </message>
     <message>
         <source>Printing...</source>
-        <translation type="vanished">Imprimare...</translation>
+        <translation>Imprimare...</translation>
     </message>
     <message>
         <source>Print</source>
-        <translation type="vanished">Imprimare</translation>
+        <translation>Imprimare</translation>
     </message>
     <message>
         <source>Positioning device error: %1</source>
-        <translation type="vanished">Eroare de poziționare a dispozitivului: %1</translation>
+        <translation>Eroare de poziționare a dispozitivului: %1</translation>
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="unfinished"/>
+        <translation>Duplică Element</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
+        <translation>Element duplicat cu succes</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation>Folderul Proiectului</translation>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -4169,7 +4304,7 @@ Anulați pentru a efectua o scanare minimă a dispozitivului.</translation>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Nu se poate adăuga elementul secundar: Cheile primare principale nu sunt disponibile</translation>
+        <translation type="vanished">Nu se poate adăuga elementul secundar: Cheile primare principale nu sunt disponibile</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -4190,6 +4325,10 @@ Anulați pentru a efectua o scanare minimă a dispozitivului.</translation>
     <message>
         <source>Failed to delete referencing feature</source>
         <translation>Nu s-a putut șterge elementul de referențiere</translation>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 </TS>

--- a/i18n/qfield_ru.ts
+++ b/i18n/qfield_ru.ts
@@ -666,6 +666,29 @@ Cancel to make a minimal device scan instead.</source>
     </message>
 </context>
 <context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
     <name>FeatureListForm</name>
     <message>
         <source>Stop tracking this feature to edit attributes</source>
@@ -2113,6 +2136,14 @@ While you can still view and use the project, it is strongly recommended to rese
         <source>No changes to revert</source>
         <translation>Нет изменений для отмены</translation>
     </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>QFieldCloudProjectsModel</name>
@@ -2346,6 +2377,10 @@ While you can still view and use the project, it is strongly recommended to rese
     </message>
     <message>
         <source>Project Actions</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>, updated data available on the cloud</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -3724,7 +3759,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Невозможно добавить дочерний объект: недоступен основной ключ родительского объекта</translation>
+        <translation type="vanished">Невозможно добавить дочерний объект: недоступен основной ключ родительского объекта</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -3746,36 +3781,40 @@ Cancel to make a minimal device scan instead.</source>
         <source>Failed to delete referencing feature</source>
         <translation>Невозможно удалить дочерний объект</translation>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">Вы перешли в режим просмотра</translation>
+        <translation>Вы перешли в режим просмотра</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">Вы перешли в режим оцифровки на слое %1</translation>
+        <translation>Вы перешли в режим оцифровки на слое %1</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">Вы перешли в режим оцифровки</translation>
+        <translation>Вы перешли в режим оцифровки</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">Вы перешли в режим измерения</translation>
+        <translation>Вы перешли в режим измерения</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">Долгота</translation>
+        <translation>Долгота</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">Широта</translation>
+        <translation>Широта</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">Сегмент</translation>
+        <translation>Сегмент</translation>
     </message>
     <message>
         <source>Perimeter</source>
@@ -3783,63 +3822,63 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">Длина</translation>
+        <translation>Длина</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">Площадь</translation>
+        <translation>Площадь</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">Закрыть инструмент измерений</translation>
+        <translation>Закрыть инструмент измерений</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">Прекратить редактирование</translation>
+        <translation>Прекратить редактирование</translation>
     </message>
     <message>
         <source>Cancel addition</source>
-        <translation type="vanished">Отменить добавление</translation>
+        <translation>Отменить добавление</translation>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">Топологическое редактирование включено</translation>
+        <translation>Топологическое редактирование включено</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">Топологическое редактирование отключено</translation>
+        <translation>Топологическое редактирование отключено</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">Свободная оцифровка включена</translation>
+        <translation>Свободная оцифровка включена</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">Свободная оцифровка выключена</translation>
+        <translation>Свободная оцифровка выключена</translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
-        <translation type="vanished">Курсор ввода заблокирован на местоположении</translation>
+        <translation>Курсор ввода заблокирован на местоположении</translation>
     </message>
     <message>
         <source>Coordinate cursor unlocked</source>
-        <translation type="vanished">Курсор ввода разблокирован</translation>
+        <translation>Курсор ввода разблокирован</translation>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">Местоположение получено</translation>
+        <translation>Местоположение получено</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">Поиск местоположения</translation>
+        <translation>Поиск местоположения</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">Карта движется за позицией</translation>
+        <translation>Карта движется за позицией</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">Ожидание местоположения</translation>
+        <translation>Ожидание местоположения</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3851,19 +3890,19 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">Карта прекратила движение за позицией</translation>
+        <translation>Карта прекратила движение за позицией</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">Не удалось создать объект!</translation>
+        <translation>Не удалось создать объект!</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">Не удалось сохранить объект!</translation>
+        <translation>Не удалось сохранить объект!</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">Главное меню</translation>
+        <translation>Главное меню</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3871,7 +3910,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">Печать в PDF</translation>
+        <translation>Печать в PDF</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3891,15 +3930,15 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">Настройки</translation>
+        <translation>Настройки</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">Журнал сообщений</translation>
+        <translation>Журнал сообщений</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">О программе QField</translation>
+        <translation>О программе QField</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3907,7 +3946,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Activating positioning service</source>
-        <translation type="vanished">Активирование службы геолокации</translation>
+        <translation>Активирование службы геолокации</translation>
     </message>
     <message>
         <source>QField has no permissions to use positioning.</source>
@@ -3919,11 +3958,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Add Bookmark</source>
-        <translation type="vanished">Добавить закладку</translation>
+        <translation>Добавить закладку</translation>
     </message>
     <message>
         <source>Set as Destination</source>
-        <translation type="vanished">Установить в качестве пункта назначения</translation>
+        <translation>Установить в качестве пункта назначения</translation>
     </message>
     <message>
         <source>Add Bookmark at Coordinates</source>
@@ -3931,7 +3970,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Untitled bookmark</source>
-        <translation type="vanished">Закладка без названия</translation>
+        <translation>Закладка без названия</translation>
     </message>
     <message>
         <source>Set Coordinates as Destination</source>
@@ -3939,7 +3978,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Copy Coordinates</source>
-        <translation type="vanished">Копировать координаты</translation>
+        <translation>Копировать координаты</translation>
     </message>
     <message>
         <source>X</source>
@@ -3951,7 +3990,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Coordinates copied to clipboard</source>
-        <translation type="vanished">Координаты скопированы в буфер обмена</translation>
+        <translation>Координаты скопированы в буфер обмена</translation>
     </message>
     <message>
         <source>Precise View Settings</source>
@@ -4027,19 +4066,19 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">Настройки геолокации</translation>
+        <translation>Настройки геолокации</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">Включить геолокацию</translation>
+        <translation>Включить геолокацию</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">Показывать информацию о местоположении</translation>
+        <translation>Показывать информацию о местоположении</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">Настройки геолокации</translation>
+        <translation>Настройки геолокации</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4063,11 +4102,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">Точность</translation>
+        <translation>Точность</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">Н/Д</translation>
+        <translation>Н/Д</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
@@ -4075,15 +4114,15 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
-        <translation type="vanished">Слой содержащий выбранную геометрию установлен как текущий</translation>
+        <translation>Слой содержащий выбранную геометрию установлен как текущий</translation>
     </message>
     <message>
         <source>Editing of multi geometry layer is not supported yet.</source>
-        <translation type="vanished">Редактирование слоя с мультигеометрией пока не поддерживается.</translation>
+        <translation>Редактирование слоя с мультигеометрией пока не поддерживается.</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">Загрузка %1</translation>
+        <translation>Загрузка %1</translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4091,7 +4130,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">Соединение...</translation>
+        <translation>Соединение...</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4099,23 +4138,23 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">Не удалось загрузить проект %1</translation>
+        <translation>Не удалось загрузить проект %1</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
-        <translation type="vanished">Проект %1 успешно загружен и доступен для открытия</translation>
+        <translation>Проект %1 успешно загружен и доступен для открытия</translation>
     </message>
     <message>
         <source>Changes failed to reach QFieldCloud: %1</source>
-        <translation type="vanished">Изменения не поступившие в QFieldCloud: %1</translation>
+        <translation>Изменения не поступившие в QFieldCloud: %1</translation>
     </message>
     <message>
         <source>Changes successfully pushed to QFieldCloud</source>
-        <translation type="vanished">Изменения успешно отправлены в QFieldCloud</translation>
+        <translation>Изменения успешно отправлены в QFieldCloud</translation>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">Нажмите назад еще раз чтобы закрыть приложение</translation>
+        <translation>Нажмите назад еще раз чтобы закрыть приложение</translation>
     </message>
     <message>
         <source>Positioning error: %1</source>
@@ -4127,7 +4166,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Lock Screen</source>
-        <translation type="vanished">Заблокировать экран</translation>
+        <translation>Заблокировать экран</translation>
     </message>
     <message>
         <source>Print to Image</source>
@@ -4135,7 +4174,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Printing...</source>
-        <translation type="vanished">Печать…</translation>
+        <translation>Печать…</translation>
     </message>
     <message>
         <source>Print</source>
@@ -4147,10 +4186,106 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="unfinished"/>
+        <translation>Дублировать объект</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
+        <translation>Объект успешно продублирован</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation>Датчики</translation>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation>Каталог проекта</translation>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -4166,7 +4301,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Невозможно добавить дочерний объект: недоступен основной ключ родительского объекта</translation>
+        <translation type="vanished">Невозможно добавить дочерний объект: недоступен основной ключ родительского объекта</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -4187,6 +4322,10 @@ Cancel to make a minimal device scan instead.</source>
     <message>
         <source>Failed to delete referencing feature</source>
         <translation>Невозможно удалить дочерний объект</translation>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 </TS>

--- a/i18n/qfield_sk.ts
+++ b/i18n/qfield_sk.ts
@@ -42,7 +42,7 @@
     </message>
     <message>
         <source>Features from active layer</source>
-        <translation type="unfinished"/>
+        <translation>Prvky z aktívnej hladiny</translation>
     </message>
 </context>
 <context>
@@ -230,7 +230,7 @@ Zrušiť a spraviť minimálny sken.</translation>
     </message>
     <message>
         <source>Scanning error: %1</source>
-        <translation type="unfinished"/>
+        <translation>Skenovanie chyby: %1</translation>
     </message>
 </context>
 <context>
@@ -241,7 +241,7 @@ Zrušiť a spraviť minimálny sken.</translation>
     </message>
     <message>
         <source>Bluetooth permission denied</source>
-        <translation type="unfinished"/>
+        <translation>Povolenie Bluetooth zamietnuté</translation>
     </message>
 </context>
 <context>
@@ -292,7 +292,7 @@ Zrušiť a spraviť minimálny sken.</translation>
     </message>
     <message>
         <source>Bluetooth permission denied</source>
-        <translation type="unfinished"/>
+        <translation>Povolenie Bluetooth zamietnuté</translation>
     </message>
 </context>
 <context>
@@ -442,7 +442,7 @@ Zrušiť a spraviť minimálny sken.</translation>
     <name>CodeReader</name>
     <message>
         <source>NFC text tag detected</source>
-        <translation type="unfinished"/>
+        <translation>Bola rozpoznaná textová značka NFC</translation>
     </message>
     <message>
         <source>Code Reader</source>
@@ -450,7 +450,7 @@ Zrušiť a spraviť minimálny sken.</translation>
     </message>
     <message>
         <source>Center your device on a code</source>
-        <translation type="unfinished"/>
+        <translation>Vycentrujte zariadenie na kód</translation>
     </message>
 </context>
 <context>
@@ -465,7 +465,7 @@ Zrušiť a spraviť minimálny sken.</translation>
     </message>
     <message>
         <source>Finish or dimiss the digitizing feature before toggling to browse mode</source>
-        <translation type="unfinished"/>
+        <translation>Pred spustením prehliadacieho režimu dokončite alebo zrušte digitalizovanie prvku </translation>
     </message>
 </context>
 <context>
@@ -663,6 +663,29 @@ Zrušiť a spraviť minimálny sken.</translation>
     <message>
         <source>You are about to leave editing state, any changes will be lost. Proceed?</source>
         <translation>Chystáte sa opustiť režim úprav, všetky zmeny budú stratené, chcete pokračovať?</translation>
+    </message>
+</context>
+<context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation>Vytvorené prvky v hladine &quot;%1&quot; sa nepodarilo vrátiť späť</translation>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation>Vymazané prvky v hladine &quot;%1&quot; sa nepodarilo vrátiť späť</translation>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation>Aktualizované prvky  v hladine &quot;%1&quot; sa nepodarilo vrátiť späť</translation>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation>Späťvzatie modifikácie prvku v hladine &quot;%1&quot; sa nepodarilo</translation>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation>Späťvzatie modifikácií prvku v hladine &quot;%1&quot; sa nepodarilo</translation>
     </message>
 </context>
 <context>
@@ -945,7 +968,7 @@ Geometrie objektov budú zlúčené do objektu &apos;%1&apos;, ktorý si zachov�
     <name>InternalGnssReceiver</name>
     <message>
         <source>Location permission denied</source>
-        <translation type="unfinished"/>
+        <translation>Povolenie polohy zamietnuté</translation>
     </message>
 </context>
 <context>
@@ -1169,7 +1192,7 @@ Dôvod:
     </message>
     <message>
         <source>Returns a point from a pair of X and Y coordinates typed in the search bar</source>
-        <translation type="vanished">Vráti bod z X a Y súradnic zadaných do vyhľadávacieho panelu.</translation>
+        <translation type="vanished">Zobrazí bod z X a Y súradnic zadaných do vyhľadávacieho panelu.</translation>
     </message>
     <message>
         <source>Returns a list of bookmark with matching names</source>
@@ -1185,27 +1208,27 @@ Dôvod:
     </message>
     <message>
         <source>Returns a list of features from the active layer with matching attributes. Restricting matching to a single attribute is done by identifying its name prefixed with an &apos;@&apos;.</source>
-        <translation type="unfinished"/>
+        <translation>Zobrazí zoznam prvkov z aktívnej vrstvy so zodpovedajúcimi atribútmi. Označenie jedného atribútu: &apos;@&apos; a názov atribútu.</translation>
     </message>
     <message>
         <source>Returns a list of features accross all searchable layers with matching display name.</source>
-        <translation type="unfinished"/>
+        <translation>Zobrazí zoznam prvkov vo všetkých prehľadávateľných vrstvách so zodpovedajúcim názvom.</translation>
     </message>
     <message>
         <source>Returns a point from a pair of X and Y coordinates - or WGS84 latitude and longitude - typed in the search bar.</source>
-        <translation type="unfinished"/>
+        <translation>Po zadaní do vyhľadávacieho panelu zobrazí bod podľa X a Y súradnice, príp. podľa zemepisnej šírky a dĺžky (WGS84)</translation>
     </message>
     <message>
         <source>Returns a list of user and currently open project bookmarks with matching names.</source>
-        <translation type="unfinished"/>
+        <translation>Zobrazí zoznam používateľských a aktuálne otvorených záložiek projektu so zodpovedajúcimi názvami.</translation>
     </message>
     <message>
         <source>Returns the value of an expression typed in the search bar.</source>
-        <translation type="unfinished"/>
+        <translation>Zobrazí hodnotu výrazu vpísaného do vyhľadávacieho panelu.</translation>
     </message>
     <message>
         <source>Returns a list of locations and addresses within Finland with matching terms.</source>
-        <translation type="unfinished"/>
+        <translation>Zobrazí zoznam lokalít a adresných bodov vo Fínsku</translation>
     </message>
 </context>
 <context>
@@ -1216,11 +1239,11 @@ Dôvod:
     </message>
     <message>
         <source>To search features within the active layer, select a vector layer through the legend.</source>
-        <translation type="unfinished"/>
+        <translation>Ak chcete vyhľadávať prvky v aktívnej vrstve, vyberte vektorovú vrstvu cez legendu.</translation>
     </message>
     <message>
         <source>Activate a vector layer in the legend first to use this functionality</source>
-        <translation type="unfinished"/>
+        <translation>Pre použitie tejto funkcie je nutné v legende aktivovať vektorovú vrstvu</translation>
     </message>
 </context>
 <context>
@@ -1274,23 +1297,23 @@ Dôvod:
     </message>
     <message>
         <source>Log runtime profiler</source>
-        <translation type="unfinished"/>
+        <translation>Log runtime profiler</translation>
     </message>
     <message>
         <source>Type optional details</source>
-        <translation type="unfinished"/>
+        <translation>Napíšte ľubovoľné detaily</translation>
     </message>
     <message>
         <source>Include cloud user details</source>
-        <translation type="unfinished"/>
+        <translation>Uveďte údaje cloudového užívateľa</translation>
     </message>
     <message>
         <source>This will send a log of your current session to the development team. You only need to do this when you are asked for it.</source>
-        <translation type="unfinished"/>
+        <translation>Týmto pošlete výpis z aktuálnej relácie vývojovému tímu. Musíte to urobiť len vtedy, keď vás o to požiadajú.</translation>
     </message>
     <message>
         <source>Your application log is being sent…</source>
-        <translation type="unfinished"/>
+        <translation>Výpis z aplikácie za posiela...</translation>
     </message>
 </context>
 <context>
@@ -1775,19 +1798,19 @@ Dôvod:
     <name>QFieldCamera</name>
     <message>
         <source>Geotagging enabled</source>
-        <translation type="unfinished"/>
+        <translation>Geotagging zapnutý</translation>
     </message>
     <message>
         <source>Geotagging disabled</source>
-        <translation type="unfinished"/>
+        <translation>Geotagging vypnutý</translation>
     </message>
     <message>
         <source>Grid enabled</source>
-        <translation type="unfinished"/>
+        <translation>Mriežka zapnutá</translation>
     </message>
     <message>
         <source>Grid disabled</source>
-        <translation type="unfinished"/>
+        <translation>Mriežka vypnutá</translation>
     </message>
 </context>
 <context>
@@ -2112,6 +2135,14 @@ Tento projekt môžete naďalej prezerať a používať, avšak dôrazne odporú
         <source>No changes to revert</source>
         <translation>Žiadne zmeny pre vrátenie</translation>
     </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>QFieldCloudProjectsModel</name>
@@ -2349,6 +2380,10 @@ Tento projekt môžete naďalej prezerať a používať, avšak dôrazne odporú
     <message>
         <source>Project Actions</source>
         <translation>Projektové akcie</translation>
+    </message>
+    <message>
+        <source>, updated data available on the cloud</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2812,7 +2847,7 @@ Zrušiť a spraviť minimálny sken.</translation>
     </message>
     <message>
         <source>Orthometric from device</source>
-        <translation type="unfinished"/>
+        <translation>Ortometricky od zariadenia</translation>
     </message>
     <message>
         <source>Use volume keys to digitize</source>
@@ -3726,7 +3761,7 @@ Zrušiť a spraviť minimálny sken.</translation>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Priradenie podradeného prvku nie je možné: nadradené primárne kľúče nie sú dostupné</translation>
+        <translation type="vanished">Priradenie podradeného prvku nie je možné: nadradené primárne kľúče nie sú dostupné</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -3748,100 +3783,104 @@ Zrušiť a spraviť minimálny sken.</translation>
         <source>Failed to delete referencing feature</source>
         <translation>Odstránenie referenčného prvku zlyhalo</translation>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation>Nie je možné pridať podradený prvok: hodnota atribútu spájajúca nadradený a podradený prvok nie je nastavená</translation>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">Ste v režime prehliadania</translation>
+        <translation>Ste v režime prehliadania</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">Ste v režime digitalizácie vo vrstve %1</translation>
+        <translation>Ste v režime digitalizácie vo vrstve %1</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">Ste v režime digitalizácie</translation>
+        <translation>Ste v režime digitalizácie</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">Ste v režime merania</translation>
+        <translation>Ste v režime merania</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">Zemepisná dĺžka</translation>
+        <translation>Zemepisná dĺžka</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">Zem. výška</translation>
+        <translation>Zem. výška</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">Segment</translation>
+        <translation>Segment</translation>
     </message>
     <message>
         <source>Perimeter</source>
-        <translation type="vanished">Obvod</translation>
+        <translation>Obvod</translation>
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">Dĺžka</translation>
+        <translation>Dĺžka</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">Plocha</translation>
+        <translation>Plocha</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">Zavrieť nástroj merania</translation>
+        <translation>Zavrieť nástroj merania</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">Zastaviť úpravy</translation>
+        <translation>Zastaviť úpravy</translation>
     </message>
     <message>
         <source>Cancel addition</source>
-        <translation type="vanished">Zrušiť pridanie</translation>
+        <translation>Zrušiť pridanie</translation>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">Topologická úprava zapnutá</translation>
+        <translation>Topologická úprava zapnutá</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">Topologická úprava vypnutá</translation>
+        <translation>Topologická úprava vypnutá</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">Ručná digitalizácia zapnutá</translation>
+        <translation>Ručná digitalizácia zapnutá</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">Ručná digitalizácia vypnutá</translation>
+        <translation>Ručná digitalizácia vypnutá</translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
-        <translation type="vanished">Súradnicový kurzor je zamknutý na polohe</translation>
+        <translation>Súradnicový kurzor je zamknutý na polohe</translation>
     </message>
     <message>
         <source>Coordinate cursor unlocked</source>
-        <translation type="vanished">Súradnicový kurzor odomknutý</translation>
+        <translation>Súradnicový kurzor odomknutý</translation>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">Získaná polohy</translation>
+        <translation>Získaná polohy</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">Vyhľadávanie polohy</translation>
+        <translation>Vyhľadávanie polohy</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">Mapové okno nasleduje polohu</translation>
+        <translation>Mapové okno nasleduje polohu</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">Čakanie na určenie polohy</translation>
+        <translation>Čakanie na určenie polohy</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3853,19 +3892,19 @@ Zrušiť a spraviť minimálny sken.</translation>
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">Mapové okno prestalo nasledovať polohu</translation>
+        <translation>Mapové okno prestalo nasledovať polohu</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">Vytvorenie prvku zlyhalo!</translation>
+        <translation>Vytvorenie prvku zlyhalo!</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">Uloženie prvku zlyhalo!</translation>
+        <translation>Uloženie prvku zlyhalo!</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">Hlavné menu</translation>
+        <translation>Hlavné menu</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3873,7 +3912,7 @@ Zrušiť a spraviť minimálny sken.</translation>
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">Vytlačiť do PDF</translation>
+        <translation>Vytlačiť do PDF</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3893,15 +3932,15 @@ Zrušiť a spraviť minimálny sken.</translation>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">Nastavenia</translation>
+        <translation>Nastavenia</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">Výpis správ</translation>
+        <translation>Výpis správ</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">O QField</translation>
+        <translation>O QField</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3909,7 +3948,7 @@ Zrušiť a spraviť minimálny sken.</translation>
     </message>
     <message>
         <source>Activating positioning service</source>
-        <translation type="vanished">Aktivovanie služby určovania polohy</translation>
+        <translation>Aktivovanie služby určovania polohy</translation>
     </message>
     <message>
         <source>QField has no permissions to use positioning.</source>
@@ -3917,15 +3956,15 @@ Zrušiť a spraviť minimálny sken.</translation>
     </message>
     <message>
         <source>Map Canvas Options</source>
-        <translation type="vanished">Možnosti mapového okna</translation>
+        <translation>Možnosti mapového okna</translation>
     </message>
     <message>
         <source>Add Bookmark</source>
-        <translation type="vanished">Pridať záložku</translation>
+        <translation>Pridať záložku</translation>
     </message>
     <message>
         <source>Set as Destination</source>
-        <translation type="vanished">Nastaviť ako cieľ</translation>
+        <translation>Nastaviť ako cieľ</translation>
     </message>
     <message>
         <source>Add Bookmark at Coordinates</source>
@@ -3933,7 +3972,7 @@ Zrušiť a spraviť minimálny sken.</translation>
     </message>
     <message>
         <source>Untitled bookmark</source>
-        <translation type="vanished">Neoznačená záložka</translation>
+        <translation>Neoznačená záložka</translation>
     </message>
     <message>
         <source>Set Coordinates as Destination</source>
@@ -3941,7 +3980,7 @@ Zrušiť a spraviť minimálny sken.</translation>
     </message>
     <message>
         <source>Copy Coordinates</source>
-        <translation type="vanished">Kopírovať súradnice</translation>
+        <translation>Kopírovať súradnice</translation>
     </message>
     <message>
         <source>X</source>
@@ -3953,11 +3992,11 @@ Zrušiť a spraviť minimálny sken.</translation>
     </message>
     <message>
         <source>Coordinates copied to clipboard</source>
-        <translation type="vanished">Súradnice skopírované do schránky</translation>
+        <translation>Súradnice skopírované do schránky</translation>
     </message>
     <message>
         <source>Precise View Settings</source>
-        <translation type="vanished">Nastavenia presného pohľadu</translation>
+        <translation>Nastavenia presného pohľadu</translation>
     </message>
     <message>
         <source>0.25m Precision</source>
@@ -3985,27 +4024,27 @@ Zrušiť a spraviť minimálny sken.</translation>
     </message>
     <message>
         <source>Always Show Precise View</source>
-        <translation type="vanished">Vždy zobrazovať presný pohľad</translation>
+        <translation>Vždy zobrazovať presný pohľad</translation>
     </message>
     <message>
         <source>Center to Location</source>
-        <translation type="vanished">Centrovať na polohu</translation>
+        <translation>Centrovať na polohu</translation>
     </message>
     <message>
         <source>Add Bookmark at Location</source>
-        <translation type="vanished">Pridať záložku na polohu</translation>
+        <translation>Pridať záložku na polohu</translation>
     </message>
     <message>
         <source>Copy Location Coordinates</source>
-        <translation type="vanished">Kopírovať súradnice polohy</translation>
+        <translation>Kopírovať súradnice polohy</translation>
     </message>
     <message>
         <source>Signed out</source>
-        <translation type="vanished">Odhlásené</translation>
+        <translation>Odhlásené</translation>
     </message>
     <message>
         <source>Signed in</source>
-        <translation type="vanished">Prihlásené</translation>
+        <translation>Prihlásené</translation>
     </message>
     <message>
         <source>Set As Destination</source>
@@ -4013,35 +4052,35 @@ Zrušiť a spraviť minimálny sken.</translation>
     </message>
     <message>
         <source>Navigation Options</source>
-        <translation type="vanished">Nastavenia navigácie</translation>
+        <translation>Nastavenia navigácie</translation>
     </message>
     <message>
         <source>Clear Destination</source>
-        <translation type="vanished">Vymazať cieľ</translation>
+        <translation>Vymazať cieľ</translation>
     </message>
     <message>
         <source>%1 Precision</source>
-        <translation type="vanished">Presnosť %1</translation>
+        <translation>Presnosť %1</translation>
     </message>
     <message>
         <source>Enable Audio Proximity Feedback</source>
-        <translation type="vanished">Povoliť zvukovú spätnú väzbu</translation>
+        <translation>Povoliť zvukovú spätnú väzbu</translation>
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">Nastavenia určovania polohy</translation>
+        <translation>Nastavenia určovania polohy</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">Povoliť určovanie polohy</translation>
+        <translation>Povoliť určovanie polohy</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">Ukázať informácie o polohe</translation>
+        <translation>Ukázať informácie o polohe</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">Nastavenia určovania polohy</translation>
+        <translation>Nastavenia určovania polohy</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4053,11 +4092,11 @@ Zrušiť a spraviť minimálny sken.</translation>
     </message>
     <message>
         <source>Current location unknown</source>
-        <translation type="vanished">Aktuálna poloha neznáma</translation>
+        <translation>Aktuálna poloha neznáma</translation>
     </message>
     <message>
         <source>My location</source>
-        <translation type="vanished">Moja poloha</translation>
+        <translation>Moja poloha</translation>
     </message>
     <message>
         <source>Copy Current Location</source>
@@ -4065,27 +4104,27 @@ Zrušiť a spraviť minimálny sken.</translation>
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">Presnosť</translation>
+        <translation>Presnosť</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">N/A</translation>
+        <translation>N/A</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
-        <translation type="vanished">Aktuálna poloha skopírovaná do schránky</translation>
+        <translation>Aktuálna poloha skopírovaná do schránky</translation>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
-        <translation type="vanished">Aktuálna vrstva prepnutá na vrstvu, ktorá má vybranú geometriu.</translation>
+        <translation>Aktuálna vrstva prepnutá na vrstvu, ktorá má vybranú geometriu.</translation>
     </message>
     <message>
         <source>Editing of multi geometry layer is not supported yet.</source>
-        <translation type="vanished">Úprava vrstiev s viacerými geometriami nie je zatiaľ podporovaná.</translation>
+        <translation>Úprava vrstiev s viacerými geometriami nie je zatiaľ podporovaná.</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">Načítavam %1</translation>
+        <translation>Načítavam %1</translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4093,7 +4132,7 @@ Zrušiť a spraviť minimálny sken.</translation>
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">Pripájanie...</translation>
+        <translation>Pripájanie...</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4101,23 +4140,23 @@ Zrušiť a spraviť minimálny sken.</translation>
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">Projekt %1 sa nepodarilo stiahnuť</translation>
+        <translation>Projekt %1 sa nepodarilo stiahnuť</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
-        <translation type="vanished">Projekt %1 bol úspešne stiahnutý, teraz je možné ho otvoriť</translation>
+        <translation>Projekt %1 bol úspešne stiahnutý, teraz je možné ho otvoriť</translation>
     </message>
     <message>
         <source>Changes failed to reach QFieldCloud: %1</source>
-        <translation type="vanished">Zmeny sa nepodarilo preniesť na QFieldCloud: %1</translation>
+        <translation>Zmeny sa nepodarilo preniesť na QFieldCloud: %1</translation>
     </message>
     <message>
         <source>Changes successfully pushed to QFieldCloud</source>
-        <translation type="vanished">Zmeny boli úspešne nahraté na QFieldCloud</translation>
+        <translation>Zmeny boli úspešne nahraté na QFieldCloud</translation>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">Opätovne stlačte/potiahnite pre zatvorenie projektu a aplikácie</translation>
+        <translation>Opätovne stlačte/potiahnite pre zatvorenie projektu a aplikácie</translation>
     </message>
     <message>
         <source>Positioning error: %1</source>
@@ -4125,11 +4164,11 @@ Zrušiť a spraviť minimálny sken.</translation>
     </message>
     <message>
         <source>Azimuth</source>
-        <translation type="vanished">Azimut</translation>
+        <translation>Azimut</translation>
     </message>
     <message>
         <source>Lock Screen</source>
-        <translation type="vanished">Uzamknúť obrazovku</translation>
+        <translation>Uzamknúť obrazovku</translation>
     </message>
     <message>
         <source>Print to Image</source>
@@ -4137,22 +4176,118 @@ Zrušiť a spraviť minimálny sken.</translation>
     </message>
     <message>
         <source>Printing...</source>
-        <translation type="vanished">Tlač...</translation>
+        <translation>Tlač...</translation>
     </message>
     <message>
         <source>Print</source>
-        <translation type="vanished">Tlačiť</translation>
+        <translation>Tlačiť</translation>
     </message>
     <message>
         <source>Positioning device error: %1</source>
-        <translation type="vanished">Chyba polohovacieho zariadenia: %1</translation>
+        <translation>Chyba polohovacieho zariadenia: %1</translation>
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="unfinished"/>
+        <translation>Duplikovať prvok</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
+        <translation>Prvok bol úspešne duplikovaný</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation>Prichytávanie zapnuté</translation>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation>Prichytávanie vypnuté</translation>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation>Mapové okno nasleduje polohu a orientáciu kompasu</translation>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation>Nie je k dispozícii žiadny tlačový layout</translation>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation>Viac informácií</translation>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation>Snímače</translation>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation>Nie je dostupný nijaký snímač</translation>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation>Priečinok projektu</translation>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation>Vyberte snímače nižšie</translation>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation>Chyba snímača: %1</translation>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation>Odpájanie snímača &apos;%1&apos;...</translation>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation>Pripájanie snímača &apos;%1&apos;...</translation>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation>Zvoľte layout nižšie</translation>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation>Vrstva:</translation>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation>Prvok:</translation>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation>Otvoriť formulár prvkov</translation>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation>Duplikovanie prvku nie je dostupné</translation>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation>Importovanie %1</translation>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation>Importovanie URL zlyhalo</translation>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -4168,7 +4303,7 @@ Zrušiť a spraviť minimálny sken.</translation>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Priradenie podradeného prvku nie je možné: nadradené primárne kľúče nie sú dostupné</translation>
+        <translation type="vanished">Priradenie podradeného prvku nie je možné: nadradené primárne kľúče nie sú dostupné</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -4189,6 +4324,10 @@ Zrušiť a spraviť minimálny sken.</translation>
     <message>
         <source>Failed to delete referencing feature</source>
         <translation>Odstránenie referenčného prvku zlyhalo</translation>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation>Nie je možné pridať podradený prvok: hodnota atribútu spájajúca nadradený a podradený prvok nie je nastavená</translation>
     </message>
 </context>
 </TS>

--- a/i18n/qfield_sl.ts
+++ b/i18n/qfield_sl.ts
@@ -665,6 +665,29 @@ Cancel to make a minimal device scan instead.</source>
     </message>
 </context>
 <context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
     <name>FeatureListForm</name>
     <message>
         <source>Stop tracking this feature to edit attributes</source>
@@ -2096,6 +2119,14 @@ While you can still view and use the project, it is strongly recommended to rese
         <source>No changes to revert</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>QFieldCloudProjectsModel</name>
@@ -2330,6 +2361,10 @@ While you can still view and use the project, it is strongly recommended to rese
     </message>
     <message>
         <source>Project Actions</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>, updated data available on the cloud</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -3729,100 +3764,104 @@ Cancel to make a minimal device scan instead.</source>
         <source>Failed to delete referencing feature</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">Način za pregled opisnih podatkov</translation>
+        <translation>Način za pregled opisnih podatkov</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">Zdaj si v načinu digitalizacije na sloju %1</translation>
+        <translation>Zdaj si v načinu digitalizacije na sloju %1</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">Zdaj si v načinu digitalizacije</translation>
+        <translation>Zdaj si v načinu digitalizacije</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">Sedaj uporabljaš orodje za merjenje</translation>
+        <translation>Sedaj uporabljaš orodje za merjenje</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">Lon</translation>
+        <translation>Lon</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">Lat</translation>
+        <translation>Lat</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">Odsek</translation>
+        <translation>Odsek</translation>
     </message>
     <message>
         <source>Perimeter</source>
-        <translation type="vanished">Obseg</translation>
+        <translation>Obseg</translation>
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">Dolžina</translation>
+        <translation>Dolžina</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">Površina</translation>
+        <translation>Površina</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">Zapri orodje za merjenje</translation>
+        <translation>Zapri orodje za merjenje</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">Zaustavi urejanje</translation>
+        <translation>Zaustavi urejanje</translation>
     </message>
     <message>
         <source>Cancel addition</source>
-        <translation type="vanished">Prekliči dodajanje</translation>
+        <translation>Prekliči dodajanje</translation>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">Topološko urejanje vklopljeno</translation>
+        <translation>Topološko urejanje vklopljeno</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">Topološko urejanje izklopljeno</translation>
+        <translation>Topološko urejanje izklopljeno</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">Prostoročno digitaliziranje vklopljeno</translation>
+        <translation>Prostoročno digitaliziranje vklopljeno</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">Prostoročno digitaliziranje izklopljeno </translation>
+        <translation>Prostoročno digitaliziranje izklopljeno </translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
-        <translation type="vanished">Kazalec koordinat je sedaj zaklenjen na lokacijo</translation>
+        <translation>Kazalec koordinat je sedaj zaklenjen na lokacijo</translation>
     </message>
     <message>
         <source>Coordinate cursor unlocked</source>
-        <translation type="vanished">Kazalec koordinat je odklenjen</translation>
+        <translation>Kazalec koordinat je odklenjen</translation>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">Lokacija določena</translation>
+        <translation>Lokacija določena</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">Iskanje lokacije</translation>
+        <translation>Iskanje lokacije</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">Zaslon sledi lokaciji</translation>
+        <translation>Zaslon sledi lokaciji</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">Čakam na lokacijo</translation>
+        <translation>Čakam na lokacijo</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3834,19 +3873,19 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">Zaslon lokaciji ne sledi več</translation>
+        <translation>Zaslon lokaciji ne sledi več</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">Objekta ni mogoče ustvariti!</translation>
+        <translation>Objekta ni mogoče ustvariti!</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">Objekta ni mogoče shraniti!</translation>
+        <translation>Objekta ni mogoče shraniti!</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">Glavni meni</translation>
+        <translation>Glavni meni</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3854,7 +3893,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">Tisk v PDF formatu</translation>
+        <translation>Tisk v PDF formatu</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3874,15 +3913,15 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">Nastavitve</translation>
+        <translation>Nastavitve</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">Dnevnik sporočil</translation>
+        <translation>Dnevnik sporočil</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">O QField-u</translation>
+        <translation>O QField-u</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3890,7 +3929,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Activating positioning service</source>
-        <translation type="vanished">Aktiviranje lociranja</translation>
+        <translation>Aktiviranje lociranja</translation>
     </message>
     <message>
         <source>QField has no permissions to use positioning.</source>
@@ -3902,11 +3941,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Add Bookmark</source>
-        <translation type="vanished">Dodaj zaznamek</translation>
+        <translation>Dodaj zaznamek</translation>
     </message>
     <message>
         <source>Set as Destination</source>
-        <translation type="vanished">Nastavi kot cilj</translation>
+        <translation>Nastavi kot cilj</translation>
     </message>
     <message>
         <source>Add Bookmark at Coordinates</source>
@@ -3914,7 +3953,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Untitled bookmark</source>
-        <translation type="vanished">Zaznamek brez naslova</translation>
+        <translation>Zaznamek brez naslova</translation>
     </message>
     <message>
         <source>Set Coordinates as Destination</source>
@@ -3922,7 +3961,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Copy Coordinates</source>
-        <translation type="vanished">Kopiraj koordinate</translation>
+        <translation>Kopiraj koordinate</translation>
     </message>
     <message>
         <source>X</source>
@@ -3934,11 +3973,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Coordinates copied to clipboard</source>
-        <translation type="vanished">Koordinate so kopirane v odložišče</translation>
+        <translation>Koordinate so kopirane v odložišče</translation>
     </message>
     <message>
         <source>Precise View Settings</source>
-        <translation type="vanished">Natančne nastavitve pogleda</translation>
+        <translation>Natančne nastavitve pogleda</translation>
     </message>
     <message>
         <source>0.25m Precision</source>
@@ -3966,7 +4005,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Always Show Precise View</source>
-        <translation type="vanished">Vedno pokaži natančen pogled</translation>
+        <translation>Vedno pokaži natančen pogled</translation>
     </message>
     <message>
         <source>Center to Location</source>
@@ -3974,19 +4013,19 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Add Bookmark at Location</source>
-        <translation type="vanished">Dodaj zaznamek na lokaciji</translation>
+        <translation>Dodaj zaznamek na lokaciji</translation>
     </message>
     <message>
         <source>Copy Location Coordinates</source>
-        <translation type="vanished">Kopiraj koordinate lokacije</translation>
+        <translation>Kopiraj koordinate lokacije</translation>
     </message>
     <message>
         <source>Signed out</source>
-        <translation type="vanished">Odjavljen</translation>
+        <translation>Odjavljen</translation>
     </message>
     <message>
         <source>Signed in</source>
-        <translation type="vanished">Prijavljen</translation>
+        <translation>Prijavljen</translation>
     </message>
     <message>
         <source>Set As Destination</source>
@@ -3994,35 +4033,35 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Navigation Options</source>
-        <translation type="vanished">Možnosti navigacije</translation>
+        <translation>Možnosti navigacije</translation>
     </message>
     <message>
         <source>Clear Destination</source>
-        <translation type="vanished">Počisti cilj</translation>
+        <translation>Počisti cilj</translation>
     </message>
     <message>
         <source>%1 Precision</source>
-        <translation type="vanished"> Natančnost %1</translation>
+        <translation> Natančnost %1</translation>
     </message>
     <message>
         <source>Enable Audio Proximity Feedback</source>
-        <translation type="vanished">Omogoči povratno informacijo učinka bližine zvoka</translation>
+        <translation>Omogoči povratno informacijo učinka bližine zvoka</translation>
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">Nastavitve lokacije</translation>
+        <translation>Nastavitve lokacije</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">Omogočite lokacijo</translation>
+        <translation>Omogočite lokacijo</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">Pokaži informacije o lokaciji</translation>
+        <translation>Pokaži informacije o lokaciji</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">Nastavitve lokacije</translation>
+        <translation>Nastavitve lokacije</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4034,11 +4073,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Current location unknown</source>
-        <translation type="vanished">Trenutna lokacija neznana</translation>
+        <translation>Trenutna lokacija neznana</translation>
     </message>
     <message>
         <source>My location</source>
-        <translation type="vanished">Moja lokacija</translation>
+        <translation>Moja lokacija</translation>
     </message>
     <message>
         <source>Copy Current Location</source>
@@ -4046,27 +4085,27 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">Natančnost</translation>
+        <translation>Natančnost</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">Ni na voljo</translation>
+        <translation>Ni na voljo</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
-        <translation type="vanished">Trenutna lokacija je kopirana v odložišče</translation>
+        <translation>Trenutna lokacija je kopirana v odložišče</translation>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
-        <translation type="vanished">Preklop trenutnega sloja na tistega, ki vsebuje izbrano geometrijo.</translation>
+        <translation>Preklop trenutnega sloja na tistega, ki vsebuje izbrano geometrijo.</translation>
     </message>
     <message>
         <source>Editing of multi geometry layer is not supported yet.</source>
-        <translation type="vanished">Urejanje večgeometrijskega sloja še ni omogočeno.</translation>
+        <translation>Urejanje večgeometrijskega sloja še ni omogočeno.</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">Nalaganje %1</translation>
+        <translation>Nalaganje %1</translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4074,7 +4113,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">Povezovanje...</translation>
+        <translation>Povezovanje...</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4082,23 +4121,23 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">Projekta %1 ni bilo mogoče prenesti</translation>
+        <translation>Projekta %1 ni bilo mogoče prenesti</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
-        <translation type="vanished">Projekt %1 je bil uspešno prenesen, zdaj ga je mogoče odpreti</translation>
+        <translation>Projekt %1 je bil uspešno prenesen, zdaj ga je mogoče odpreti</translation>
     </message>
     <message>
         <source>Changes failed to reach QFieldCloud: %1</source>
-        <translation type="vanished">Spremembe se niso prenesle v QFieldCloud: %1</translation>
+        <translation>Spremembe se niso prenesle v QFieldCloud: %1</translation>
     </message>
     <message>
         <source>Changes successfully pushed to QFieldCloud</source>
-        <translation type="vanished">Spremembe so bile uspešno prenesene v QFieldCloud</translation>
+        <translation>Spremembe so bile uspešno prenesene v QFieldCloud</translation>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">Pritisni nazaj še enkrat, da zapreš projekt in aplikacijo.</translation>
+        <translation>Pritisni nazaj še enkrat, da zapreš projekt in aplikacijo.</translation>
     </message>
     <message>
         <source>Positioning error: %1</source>
@@ -4106,11 +4145,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Azimuth</source>
-        <translation type="vanished">Azimut</translation>
+        <translation>Azimut</translation>
     </message>
     <message>
         <source>Lock Screen</source>
-        <translation type="vanished">Zakleni zaslon</translation>
+        <translation>Zakleni zaslon</translation>
     </message>
     <message>
         <source>Print to Image</source>
@@ -4118,22 +4157,118 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Printing...</source>
-        <translation type="vanished">Tiskam...</translation>
+        <translation>Tiskam...</translation>
     </message>
     <message>
         <source>Print</source>
-        <translation type="vanished">Tisk</translation>
+        <translation>Tisk</translation>
     </message>
     <message>
         <source>Positioning device error: %1</source>
-        <translation type="vanished">Napaka naprave za določanje lokacije: %1</translation>
+        <translation>Napaka naprave za določanje lokacije: %1</translation>
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="unfinished"/>
+        <translation>Podvoji objekt</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
+        <translation>Objekt je bil uspešno podvojen</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation>Preberi več</translation>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation>Senzorji</translation>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation>Mapa projekta</translation>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation>Spodaj izberite senzor</translation>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation>Napaka senzorja: %1</translation>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation>Odklop senzorja &apos;%1&apos;...</translation>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation>Povezovanje senzorja &apos;%1&apos;...</translation>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation>Sloj:</translation>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation>Objekt:</translation>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation>Uvažam %1</translation>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation>Uvoz URL ni uspel</translation>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -4169,6 +4304,10 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Failed to delete referencing feature</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
         <translation type="unfinished"/>
     </message>
 </context>

--- a/i18n/qfield_uk.ts
+++ b/i18n/qfield_uk.ts
@@ -666,6 +666,29 @@ Cancel to make a minimal device scan instead.</source>
     </message>
 </context>
 <context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
     <name>FeatureListForm</name>
     <message>
         <source>Stop tracking this feature to edit attributes</source>
@@ -2113,6 +2136,14 @@ While you can still view and use the project, it is strongly recommended to rese
         <source>No changes to revert</source>
         <translation>Немає змін для повернення</translation>
     </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>QFieldCloudProjectsModel</name>
@@ -2349,6 +2380,10 @@ While you can still view and use the project, it is strongly recommended to rese
     </message>
     <message>
         <source>Project Actions</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>, updated data available on the cloud</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -3727,7 +3762,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Неможливо додати дочірню функцію: батьківські первинні ключі недоступні</translation>
+        <translation type="vanished">Неможливо додати дочірню функцію: батьківські первинні ключі недоступні</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -3749,100 +3784,104 @@ Cancel to make a minimal device scan instead.</source>
         <source>Failed to delete referencing feature</source>
         <translation>Не вдалося видалити елемент посилання</translation>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">Наразі ви в режимі перегляду</translation>
+        <translation>Наразі ви в режимі перегляду</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">Ви перебуваєте в режимі оцифрування шару %1</translation>
+        <translation>Ви перебуваєте в режимі оцифрування шару %1</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">Ви в режимі оцифрування</translation>
+        <translation>Ви в режимі оцифрування</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">Ви в режимі вимірювання</translation>
+        <translation>Ви в режимі вимірювання</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">Довгота</translation>
+        <translation>Довгота</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">Широта</translation>
+        <translation>Широта</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">Сегмент</translation>
+        <translation>Сегмент</translation>
     </message>
     <message>
         <source>Perimeter</source>
-        <translation type="vanished">Периметр</translation>
+        <translation>Периметр</translation>
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">Довжина</translation>
+        <translation>Довжина</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">Площа</translation>
+        <translation>Площа</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">Закрити інструмент промірів</translation>
+        <translation>Закрити інструмент промірів</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">Припинити редагування</translation>
+        <translation>Припинити редагування</translation>
     </message>
     <message>
         <source>Cancel addition</source>
-        <translation type="vanished">Скасувати додавання</translation>
+        <translation>Скасувати додавання</translation>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">Увімкнути топологічне редагування</translation>
+        <translation>Увімкнути топологічне редагування</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">Вимкнути топологічне редагування</translation>
+        <translation>Вимкнути топологічне редагування</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">Увімкнути ручне оцифрування</translation>
+        <translation>Увімкнути ручне оцифрування</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">Вимкнути ручне оцифрування</translation>
+        <translation>Вимкнути ручне оцифрування</translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
-        <translation type="vanished">Курсор координат тепер зафіксовано в положенні</translation>
+        <translation>Курсор координат тепер зафіксовано в положенні</translation>
     </message>
     <message>
         <source>Coordinate cursor unlocked</source>
-        <translation type="vanished">Курсор координат розблоковано</translation>
+        <translation>Курсор координат розблоковано</translation>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">Отримано місцезнаходження</translation>
+        <translation>Отримано місцезнаходження</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">Пошук позиції</translation>
+        <translation>Пошук позиції</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">Карта рухається за місцеположенням</translation>
+        <translation>Карта рухається за місцеположенням</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">В очікуванні місцезнаходження</translation>
+        <translation>В очікуванні місцезнаходження</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3854,19 +3893,19 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">Карта перестала рухатись за місцеположенням</translation>
+        <translation>Карта перестала рухатись за місцеположенням</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">Не вдалось створити об&apos;єкт!</translation>
+        <translation>Не вдалось створити об&apos;єкт!</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">Не вдалося зберегти об&apos;єкт!</translation>
+        <translation>Не вдалося зберегти об&apos;єкт!</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">Головне меню</translation>
+        <translation>Головне меню</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3874,7 +3913,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">Друк в PDF</translation>
+        <translation>Друк в PDF</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3894,15 +3933,15 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">Налаштування</translation>
+        <translation>Налаштування</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">Журнал сповіщень</translation>
+        <translation>Журнал сповіщень</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">Про QField</translation>
+        <translation>Про QField</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3910,7 +3949,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Activating positioning service</source>
-        <translation type="vanished">Активувати послугу позиціювання</translation>
+        <translation>Активувати послугу позиціювання</translation>
     </message>
     <message>
         <source>QField has no permissions to use positioning.</source>
@@ -3918,15 +3957,15 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Map Canvas Options</source>
-        <translation type="vanished">Параметри полотна карти</translation>
+        <translation>Параметри полотна карти</translation>
     </message>
     <message>
         <source>Add Bookmark</source>
-        <translation type="vanished">Додати закладку</translation>
+        <translation>Додати закладку</translation>
     </message>
     <message>
         <source>Set as Destination</source>
-        <translation type="vanished">Установити як пункт призначення</translation>
+        <translation>Установити як пункт призначення</translation>
     </message>
     <message>
         <source>Add Bookmark at Coordinates</source>
@@ -3934,7 +3973,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Untitled bookmark</source>
-        <translation type="vanished">Закладка без назви</translation>
+        <translation>Закладка без назви</translation>
     </message>
     <message>
         <source>Set Coordinates as Destination</source>
@@ -3942,7 +3981,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Copy Coordinates</source>
-        <translation type="vanished">Копіювати координати</translation>
+        <translation>Копіювати координати</translation>
     </message>
     <message>
         <source>X</source>
@@ -3954,11 +3993,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Coordinates copied to clipboard</source>
-        <translation type="vanished">Координати скопійовано в буфер обміну</translation>
+        <translation>Координати скопійовано в буфер обміну</translation>
     </message>
     <message>
         <source>Precise View Settings</source>
-        <translation type="vanished">Точні налаштування перегляду</translation>
+        <translation>Точні налаштування перегляду</translation>
     </message>
     <message>
         <source>0.25m Precision</source>
@@ -3986,27 +4025,27 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Always Show Precise View</source>
-        <translation type="vanished">Завжди показувати точний огляд</translation>
+        <translation>Завжди показувати точний огляд</translation>
     </message>
     <message>
         <source>Center to Location</source>
-        <translation type="vanished">Центр до розташування</translation>
+        <translation>Центр до розташування</translation>
     </message>
     <message>
         <source>Add Bookmark at Location</source>
-        <translation type="vanished">Додати закладку в місцезнаходження</translation>
+        <translation>Додати закладку в місцезнаходження</translation>
     </message>
     <message>
         <source>Copy Location Coordinates</source>
-        <translation type="vanished">Копіювати координати розташування</translation>
+        <translation>Копіювати координати розташування</translation>
     </message>
     <message>
         <source>Signed out</source>
-        <translation type="vanished">Вийти</translation>
+        <translation>Вийти</translation>
     </message>
     <message>
         <source>Signed in</source>
-        <translation type="vanished">Ви ввійшли</translation>
+        <translation>Ви ввійшли</translation>
     </message>
     <message>
         <source>Set As Destination</source>
@@ -4014,35 +4053,35 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Navigation Options</source>
-        <translation type="vanished">Параметри навігації</translation>
+        <translation>Параметри навігації</translation>
     </message>
     <message>
         <source>Clear Destination</source>
-        <translation type="vanished">Очистити пункт призначення</translation>
+        <translation>Очистити пункт призначення</translation>
     </message>
     <message>
         <source>%1 Precision</source>
-        <translation type="vanished">%1 Точність</translation>
+        <translation>%1 Точність</translation>
     </message>
     <message>
         <source>Enable Audio Proximity Feedback</source>
-        <translation type="vanished">Увімкнути аудіо-відповідь близькості</translation>
+        <translation>Увімкнути аудіо-відповідь близькості</translation>
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">Налаштування позиціонування</translation>
+        <translation>Налаштування позиціонування</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">Дозволити позиціювання</translation>
+        <translation>Дозволити позиціювання</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">Показати інформацію про позицію</translation>
+        <translation>Показати інформацію про позицію</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">Налаштування позиціювання</translation>
+        <translation>Налаштування позиціювання</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4054,11 +4093,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Current location unknown</source>
-        <translation type="vanished">Поточне місцезнаходження невідоме</translation>
+        <translation>Поточне місцезнаходження невідоме</translation>
     </message>
     <message>
         <source>My location</source>
-        <translation type="vanished">Моє місцезнаходження</translation>
+        <translation>Моє місцезнаходження</translation>
     </message>
     <message>
         <source>Copy Current Location</source>
@@ -4066,27 +4105,27 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">Точність</translation>
+        <translation>Точність</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">N/A</translation>
+        <translation>N/A</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
-        <translation type="vanished">Поточне розташування скопійовано в буфер обміну</translation>
+        <translation>Поточне розташування скопійовано в буфер обміну</translation>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
-        <translation type="vanished">Поточний шар перемикнувся на шар, що містить вибрану геометрію.</translation>
+        <translation>Поточний шар перемикнувся на шар, що містить вибрану геометрію.</translation>
     </message>
     <message>
         <source>Editing of multi geometry layer is not supported yet.</source>
-        <translation type="vanished">Редагування шару з кількома геометріями поки що не підтримується.</translation>
+        <translation>Редагування шару з кількома геометріями поки що не підтримується.</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">Завантаження %1</translation>
+        <translation>Завантаження %1</translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4094,7 +4133,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">З&apos;єднання...</translation>
+        <translation>З&apos;єднання...</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4102,23 +4141,23 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">Не вдалось завантажити проєкт %1</translation>
+        <translation>Не вдалось завантажити проєкт %1</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
-        <translation type="vanished">Проект %1 успішно завантажено, тепер його можна відкрити</translation>
+        <translation>Проект %1 успішно завантажено, тепер його можна відкрити</translation>
     </message>
     <message>
         <source>Changes failed to reach QFieldCloud: %1</source>
-        <translation type="vanished">Зміни не вдалося досягти QFieldCloud: %1</translation>
+        <translation>Зміни не вдалося досягти QFieldCloud: %1</translation>
     </message>
     <message>
         <source>Changes successfully pushed to QFieldCloud</source>
-        <translation type="vanished">Зміни успішно переміщено в QFieldCloud</translation>
+        <translation>Зміни успішно переміщено в QFieldCloud</translation>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">Натисніть назад ще раз, щоб закрити проект та додаток</translation>
+        <translation>Натисніть назад ще раз, щоб закрити проект та додаток</translation>
     </message>
     <message>
         <source>Positioning error: %1</source>
@@ -4150,10 +4189,106 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="unfinished"/>
+        <translation>Дублікат об&apos;єкта</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
+        <translation>Об’єкт успішно продубльовано</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation>Папка проектів</translation>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
         <translation type="unfinished"/>
     </message>
 </context>
@@ -4169,7 +4304,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>Неможливо додати дочірню функцію: батьківські первинні ключі недоступні</translation>
+        <translation type="vanished">Неможливо додати дочірню функцію: батьківські первинні ключі недоступні</translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -4190,6 +4325,10 @@ Cancel to make a minimal device scan instead.</source>
     <message>
         <source>Failed to delete referencing feature</source>
         <translation>Не вдалося видалити елемент посилання</translation>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 </TS>

--- a/i18n/qfield_zh.ts
+++ b/i18n/qfield_zh.ts
@@ -666,6 +666,29 @@ Cancel to make a minimal device scan instead.</source>
     </message>
 </context>
 <context>
+    <name>FeatureHistory</name>
+    <message>
+        <source>Failed to undo created features in layer &quot;%1&quot;</source>
+        <translation>无法撤消在图层 &quot;%1&quot; 中已创建的要素</translation>
+    </message>
+    <message>
+        <source>Failed to undo deleted features in layer &quot;%1&quot;</source>
+        <translation>无法撤消在图层 &quot;%1&quot; 中已删除的要素</translation>
+    </message>
+    <message>
+        <source>Failed to undo update features in layer &quot;%1&quot;</source>
+        <translation>无法撤消在图层 &quot;%1&quot; 中已更新的要素</translation>
+    </message>
+    <message>
+        <source>Failed to commit undo feature modification in layer &quot;%1&quot;</source>
+        <translation>无法在图层 &quot;%1&quot; 中提交撤消要素的修改</translation>
+    </message>
+    <message>
+        <source>Failed to rollback undo featurue modifications in layer &quot;%1&quot;</source>
+        <translation>无法在图层 &quot;%1&quot; 中回退撤消要素的修改</translation>
+    </message>
+</context>
+<context>
     <name>FeatureListForm</name>
     <message>
         <source>Stop tracking this feature to edit attributes</source>
@@ -2107,6 +2130,14 @@ While you can still view and use the project, it is strongly recommended to rese
         <source>No changes to revert</source>
         <translation>没有要恢复的修改</translation>
     </message>
+    <message>
+        <source>This project has an updated project file on the cloud, you are advised to synchronize.</source>
+        <translation>该工程在云端有更新的工程文件，建议您进行同步。</translation>
+    </message>
+    <message>
+        <source>This project has updated data on the cloud, you should synchronize.</source>
+        <translation>该工程已更新了云端的数据，您应该同步。</translation>
+    </message>
 </context>
 <context>
     <name>QFieldCloudProjectsModel</name>
@@ -2344,6 +2375,10 @@ While you can still view and use the project, it is strongly recommended to rese
     <message>
         <source>Project Actions</source>
         <translation>工程动作</translation>
+    </message>
+    <message>
+        <source>, updated data available on the cloud</source>
+        <translation>, 云端可用的更新数据</translation>
     </message>
 </context>
 <context>
@@ -3721,7 +3756,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>无法添加子要素：父对象主键不可用 </translation>
+        <translation type="vanished">无法添加子要素：父对象主键不可用 </translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -3743,100 +3778,104 @@ Cancel to make a minimal device scan instead.</source>
         <source>Failed to delete referencing feature</source>
         <translation>删除参考要素失败</translation>
     </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation>无法添加子要素：未设置链接父与子的属性值</translation>
+    </message>
 </context>
 <context>
     <name>qgismobileapp</name>
     <message>
         <source>You are now in browse mode</source>
-        <translation type="vanished">浏览模式</translation>
+        <translation>浏览模式</translation>
     </message>
     <message>
         <source>You are now in digitize mode on layer %1</source>
-        <translation type="vanished">图层 %1 数字化模式</translation>
+        <translation>图层 %1 数字化模式</translation>
     </message>
     <message>
         <source>You are now in digitize mode</source>
-        <translation type="vanished">数字化模式</translation>
+        <translation>数字化模式</translation>
     </message>
     <message>
         <source>You are now in measure mode</source>
-        <translation type="vanished">测量模式</translation>
+        <translation>测量模式</translation>
     </message>
     <message>
         <source>Lon</source>
-        <translation type="vanished">经度</translation>
+        <translation>经度</translation>
     </message>
     <message>
         <source>Lat</source>
-        <translation type="vanished">纬度</translation>
+        <translation>纬度</translation>
     </message>
     <message>
         <source>Segment</source>
-        <translation type="vanished">分段</translation>
+        <translation>分段</translation>
     </message>
     <message>
         <source>Perimeter</source>
-        <translation type="vanished">周长</translation>
+        <translation>周长</translation>
     </message>
     <message>
         <source>Length</source>
-        <translation type="vanished">长度</translation>
+        <translation>长度</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="vanished">面积</translation>
+        <translation>面积</translation>
     </message>
     <message>
         <source>Close measure tool</source>
-        <translation type="vanished">关闭测量工具</translation>
+        <translation>关闭测量工具</translation>
     </message>
     <message>
         <source>Stop editing</source>
-        <translation type="vanished">停止编辑</translation>
+        <translation>停止编辑</translation>
     </message>
     <message>
         <source>Cancel addition</source>
-        <translation type="vanished">取消添加</translation>
+        <translation>取消添加</translation>
     </message>
     <message>
         <source>Topological editing turned on</source>
-        <translation type="vanished">拓扑编辑已打开</translation>
+        <translation>拓扑编辑已打开</translation>
     </message>
     <message>
         <source>Topological editing turned off</source>
-        <translation type="vanished">拓扑编辑已关闭</translation>
+        <translation>拓扑编辑已关闭</translation>
     </message>
     <message>
         <source>Freehand digitizing turned on</source>
-        <translation type="vanished">手绘数字化已打开</translation>
+        <translation>手绘数字化已打开</translation>
     </message>
     <message>
         <source>Freehand digitizing turned off</source>
-        <translation type="vanished">手绘数字化已关闭</translation>
+        <translation>手绘数字化已关闭</translation>
     </message>
     <message>
         <source>Coordinate cursor now locked to position</source>
-        <translation type="vanished">坐标光标现已锁定定位</translation>
+        <translation>坐标光标现已锁定定位</translation>
     </message>
     <message>
         <source>Coordinate cursor unlocked</source>
-        <translation type="vanished">坐标光标已解锁</translation>
+        <translation>坐标光标已解锁</translation>
     </message>
     <message>
         <source>Received position</source>
-        <translation type="vanished">获取定位信息</translation>
+        <translation>获取定位信息</translation>
     </message>
     <message>
         <source>Searching for position</source>
-        <translation type="vanished">搜索定位</translation>
+        <translation>搜索定位</translation>
     </message>
     <message>
         <source>Canvas follows location</source>
-        <translation type="vanished">地图跟随位置</translation>
+        <translation>地图跟随位置</translation>
     </message>
     <message>
         <source>Waiting for location</source>
-        <translation type="vanished">等待位置信息</translation>
+        <translation>等待位置信息</translation>
     </message>
     <message>
         <source>Positioning activated</source>
@@ -3848,19 +3887,19 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Canvas stopped following location</source>
-        <translation type="vanished">地图停止跟随位置</translation>
+        <translation>地图停止跟随位置</translation>
     </message>
     <message>
         <source>Failed to create feature!</source>
-        <translation type="vanished">创建要素失败！</translation>
+        <translation>创建要素失败！</translation>
     </message>
     <message>
         <source>Failed to save feature!</source>
-        <translation type="vanished">保存要素失败！</translation>
+        <translation>保存要素失败！</translation>
     </message>
     <message>
         <source>Main Menu</source>
-        <translation type="vanished">菜单</translation>
+        <translation>菜单</translation>
     </message>
     <message>
         <source>Measure Tool</source>
@@ -3868,7 +3907,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Print to PDF</source>
-        <translation type="vanished">输出为PDF</translation>
+        <translation>输出为PDF</translation>
     </message>
     <message>
         <source>Printing to PDF</source>
@@ -3888,15 +3927,15 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="vanished">设置</translation>
+        <translation>设置</translation>
     </message>
     <message>
         <source>Message Log</source>
-        <translation type="vanished">信息日志</translation>
+        <translation>信息日志</translation>
     </message>
     <message>
         <source>About QField</source>
-        <translation type="vanished">关于QField</translation>
+        <translation>关于QField</translation>
     </message>
     <message>
         <source>Select template below</source>
@@ -3904,7 +3943,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Activating positioning service</source>
-        <translation type="vanished">激活定位设备</translation>
+        <translation>激活定位设备</translation>
     </message>
     <message>
         <source>QField has no permissions to use positioning.</source>
@@ -3912,15 +3951,15 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Map Canvas Options</source>
-        <translation type="vanished">地图画布选项</translation>
+        <translation>地图画布选项</translation>
     </message>
     <message>
         <source>Add Bookmark</source>
-        <translation type="vanished">添加书签</translation>
+        <translation>添加书签</translation>
     </message>
     <message>
         <source>Set as Destination</source>
-        <translation type="vanished">设为目标</translation>
+        <translation>设为目标</translation>
     </message>
     <message>
         <source>Add Bookmark at Coordinates</source>
@@ -3928,7 +3967,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Untitled bookmark</source>
-        <translation type="vanished">无标题书签</translation>
+        <translation>无标题书签</translation>
     </message>
     <message>
         <source>Set Coordinates as Destination</source>
@@ -3936,7 +3975,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Copy Coordinates</source>
-        <translation type="vanished">复制坐标</translation>
+        <translation>复制坐标</translation>
     </message>
     <message>
         <source>X</source>
@@ -3948,11 +3987,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Coordinates copied to clipboard</source>
-        <translation type="vanished">坐标已复制到剪贴板</translation>
+        <translation>坐标已复制到剪贴板</translation>
     </message>
     <message>
         <source>Precise View Settings</source>
-        <translation type="vanished">精确视图设置</translation>
+        <translation>精确视图设置</translation>
     </message>
     <message>
         <source>0.25m Precision</source>
@@ -3980,27 +4019,27 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Always Show Precise View</source>
-        <translation type="vanished">显示精确视图</translation>
+        <translation>显示精确视图</translation>
     </message>
     <message>
         <source>Center to Location</source>
-        <translation type="vanished">定位居中</translation>
+        <translation>定位居中</translation>
     </message>
     <message>
         <source>Add Bookmark at Location</source>
-        <translation type="vanished">在定位处添加书签</translation>
+        <translation>在定位处添加书签</translation>
     </message>
     <message>
         <source>Copy Location Coordinates</source>
-        <translation type="vanished">复制定位坐标</translation>
+        <translation>复制定位坐标</translation>
     </message>
     <message>
         <source>Signed out</source>
-        <translation type="vanished">已注销</translation>
+        <translation>已注销</translation>
     </message>
     <message>
         <source>Signed in</source>
-        <translation type="vanished">已登录</translation>
+        <translation>已登录</translation>
     </message>
     <message>
         <source>Set As Destination</source>
@@ -4008,35 +4047,35 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Navigation Options</source>
-        <translation type="vanished">导航选项</translation>
+        <translation>导航选项</translation>
     </message>
     <message>
         <source>Clear Destination</source>
-        <translation type="vanished">清除目标</translation>
+        <translation>清除目标</translation>
     </message>
     <message>
         <source>%1 Precision</source>
-        <translation type="vanished">%1 精度</translation>
+        <translation>%1 精度</translation>
     </message>
     <message>
         <source>Enable Audio Proximity Feedback</source>
-        <translation type="vanished">启用声音引发回馈</translation>
+        <translation>启用声音引发回馈</translation>
     </message>
     <message>
         <source>Positioning Options</source>
-        <translation type="vanished">定位选项</translation>
+        <translation>定位选项</translation>
     </message>
     <message>
         <source>Enable Positioning</source>
-        <translation type="vanished">启用定位</translation>
+        <translation>启用定位</translation>
     </message>
     <message>
         <source>Show Position Information</source>
-        <translation type="vanished">显示定位信息</translation>
+        <translation>显示定位信息</translation>
     </message>
     <message>
         <source>Positioning Settings</source>
-        <translation type="vanished">定位设置</translation>
+        <translation>定位设置</translation>
     </message>
     <message>
         <source>Center to Current Location</source>
@@ -4048,11 +4087,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Current location unknown</source>
-        <translation type="vanished">当前位置未知</translation>
+        <translation>当前位置未知</translation>
     </message>
     <message>
         <source>My location</source>
-        <translation type="vanished">我的位置</translation>
+        <translation>我的位置</translation>
     </message>
     <message>
         <source>Copy Current Location</source>
@@ -4060,27 +4099,27 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Accuracy</source>
-        <translation type="vanished">精度</translation>
+        <translation>精度</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="vanished">不可用</translation>
+        <translation>不可用</translation>
     </message>
     <message>
         <source>Current location copied to clipboard</source>
-        <translation type="vanished">当前位置已复制到剪贴板</translation>
+        <translation>当前位置已复制到剪贴板</translation>
     </message>
     <message>
         <source>Current layer switched to the one holding the selected geometry.</source>
-        <translation type="vanished">当前图层切换至包含被选中几何对象的图层</translation>
+        <translation>当前图层切换至包含被选中几何对象的图层</translation>
     </message>
     <message>
         <source>Editing of multi geometry layer is not supported yet.</source>
-        <translation type="vanished">尚不支持编辑几何图形集图层。</translation>
+        <translation>尚不支持编辑几何图形集图层。</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="vanished">正在加载 %1</translation>
+        <translation>正在加载 %1</translation>
     </message>
     <message>
         <source>Logged out</source>
@@ -4088,7 +4127,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Connecting...</source>
-        <translation type="vanished">正在连接…</translation>
+        <translation>正在连接…</translation>
     </message>
     <message>
         <source>Logged in</source>
@@ -4096,23 +4135,23 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Project %1 failed to download</source>
-        <translation type="vanished">工程 %1 下载失败</translation>
+        <translation>工程 %1 下载失败</translation>
     </message>
     <message>
         <source>Project %1 successfully downloaded, it&apos;s now available to open</source>
-        <translation type="vanished">工程 %1 已成功下载，现在可以打开</translation>
+        <translation>工程 %1 已成功下载，现在可以打开</translation>
     </message>
     <message>
         <source>Changes failed to reach QFieldCloud: %1</source>
-        <translation type="vanished">修改无法上传至QFieldCloud: %1</translation>
+        <translation>修改无法上传至QFieldCloud: %1</translation>
     </message>
     <message>
         <source>Changes successfully pushed to QFieldCloud</source>
-        <translation type="vanished">修改已成功上传至QFieldCloud</translation>
+        <translation>修改已成功上传至QFieldCloud</translation>
     </message>
     <message>
         <source>Press back again to close project and app</source>
-        <translation type="vanished">再次点击返回键将关闭工程和应用</translation>
+        <translation>再次点击返回键将关闭工程和应用</translation>
     </message>
     <message>
         <source>Positioning error: %1</source>
@@ -4120,11 +4159,11 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Azimuth</source>
-        <translation type="vanished">方位角</translation>
+        <translation>方位角</translation>
     </message>
     <message>
         <source>Lock Screen</source>
-        <translation type="vanished">锁屏</translation>
+        <translation>锁屏</translation>
     </message>
     <message>
         <source>Print to Image</source>
@@ -4132,23 +4171,119 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Printing...</source>
-        <translation type="vanished">正在输出...</translation>
+        <translation>正在输出...</translation>
     </message>
     <message>
         <source>Print</source>
-        <translation type="vanished">输出</translation>
+        <translation>输出</translation>
     </message>
     <message>
         <source>Positioning device error: %1</source>
-        <translation type="vanished">定位设备错误: %1</translation>
+        <translation>定位设备错误: %1</translation>
     </message>
     <message>
         <source>Duplicate Feature</source>
-        <translation type="unfinished"/>
+        <translation>复制要素</translation>
     </message>
     <message>
         <source>Successfully duplicated feature</source>
+        <translation>已成功复制要素</translation>
+    </message>
+    <message>
+        <source>Snapping turned on</source>
+        <translation>捕捉已打开</translation>
+    </message>
+    <message>
+        <source>Snapping turned off</source>
+        <translation>捕捉已关闭</translation>
+    </message>
+    <message>
+        <source>Snap to %1° angle turned on</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap to common angle turned off</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Relative angle</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Snap every %1°</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Canvas follows location and compass orientation</source>
+        <translation>地图遵循位置和指南针方向</translation>
+    </message>
+    <message>
+        <source>No print layout available</source>
+        <translation>无可用打印布局</translation>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation>点击了解更多信息</translation>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation>传感器</translation>
+    </message>
+    <message>
+        <source>No sensor available</source>
+        <translation>无可用传感器</translation>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation>工程文件夹</translation>
+    </message>
+    <message>
+        <source>Select sensor below</source>
+        <translation>请选择传感器</translation>
+    </message>
+    <message>
+        <source>Sensor error: %1</source>
+        <translation>传感器错误: %1</translation>
+    </message>
+    <message>
+        <source>Disconnecting sensor &apos;%1&apos;...</source>
+        <translation>断开传感器 &apos;%1&apos;...</translation>
+    </message>
+    <message>
+        <source>Connecting sensor &apos;%1&apos;...</source>
+        <translation>连接传感器 &apos;%1&apos;...</translation>
+    </message>
+    <message>
+        <source>Select layout below</source>
+        <translation>请选择布局</translation>
+    </message>
+    <message>
+        <source>Layer:</source>
+        <translation>图层:</translation>
+    </message>
+    <message>
+        <source>Feature:</source>
+        <translation>要素:</translation>
+    </message>
+    <message>
+        <source>Open Feature Form</source>
+        <translation>打开要素从</translation>
+    </message>
+    <message>
+        <source>Feature duplication not available</source>
+        <translation>要素复制不可用</translation>
+    </message>
+    <message>
+        <source>Importing %1</source>
+        <translation>导入 %1</translation>
+    </message>
+    <message>
+        <source>Import URL failed</source>
+        <translation>导入URL失败</translation>
+    </message>
+    <message>
+        <source>Unlock the screen to to close project and app</source>
+        <translation>请解锁屏幕以便关闭工程和应用程序</translation>
     </message>
 </context>
 <context>
@@ -4163,7 +4298,7 @@ Cancel to make a minimal device scan instead.</source>
     </message>
     <message>
         <source>Cannot add child feature: parent primary keys are not available</source>
-        <translation>无法添加子要素：父对象主键不可用 </translation>
+        <translation type="vanished">无法添加子要素：父对象主键不可用 </translation>
     </message>
     <message>
         <source>Unlink feature %1 (%2) of %3</source>
@@ -4184,6 +4319,10 @@ Cancel to make a minimal device scan instead.</source>
     <message>
         <source>Failed to delete referencing feature</source>
         <translation>删除参考要素失败</translation>
+    </message>
+    <message>
+        <source>Cannot add child feature: attribute value linking parent and children is not set</source>
+        <translation>无法添加子要素：未设置链接父与子的属性值</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
Thanks to @zhuwq75 for alerting us to the fact that our translation synchronization was broken. 

The lupdate version we were using in the relevant workflows until now was 5.12 (ubuntu 20.04). After updating the workflow to ubuntu 22.04 to get lupdate version 5.15, over a hundred crucial strings that had disappeared are now back. 

This is a backport fix, master has been fixed by the updated workflows already.