### PR TITLE
Do not allow to return to current project if it is a deleted cloud project

### DIFF
--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -194,7 +194,7 @@ void AppInterface::closeSentry() const
 
 void AppInterface::clearProject() const
 {
-  QgsProject::instance()->clear();
+  mApp->clearProject();
 }
 
 void AppInterface::importUrl( const QString &url )

--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -29,6 +29,7 @@
 #include <QImageReader>
 #include <qgsapplication.h>
 #include <qgsmessagelog.h>
+#include <qgsproject.h>
 #include <qgsruntimeprofiler.h>
 #include <qgsziputils.h>
 
@@ -189,6 +190,11 @@ void AppInterface::closeSentry() const
 #if WITH_SENTRY
   sentry_wrapper::close();
 #endif
+}
+
+void AppInterface::clearProject() const
+{
+  QgsProject::instance()->clear();
 }
 
 void AppInterface::importUrl( const QString &url )

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -88,6 +88,11 @@ class AppInterface : public QObject
      */
     Q_INVOKABLE void closeSentry() const;
 
+    /**
+     * Clears the currently opened project
+     */
+    Q_INVOKABLE void clearProject() const;
+
     static void setInstance( AppInterface *instance ) { sAppInterface = instance; }
     static AppInterface *instance() { return sAppInterface; }
 

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -1364,6 +1364,14 @@ bool QgisMobileapp::event( QEvent *event )
   return QQmlApplicationEngine::event( event );
 }
 
+void QgisMobileapp::clearProject()
+{
+  mAuthRequestHandler->clearStoredRealms();
+  mProjectFileName = QString();
+  mProjectFilePath = QString();
+  mProject->clear();
+}
+
 void QgisMobileapp::saveProjectPreviewImage()
 {
   if ( !mProjectFilePath.isEmpty() && mMapCanvas && !mMapCanvas->isRendering() )

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -161,6 +161,11 @@ class QFIELD_CORE_EXPORT QgisMobileapp : public QQmlApplicationEngine
 
     bool event( QEvent *event ) override;
 
+    /**
+     * Clear the currently opened project back to a blank project
+     */
+    void clearProject();
+
   signals:
     /**
      * Emitted when a project file is being loaded

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -556,7 +556,7 @@ Page {
             welcomeScreen.model.reloadModel()
 
             if (projectActions.projectLocalPath === qgisProject.fileName) {
-              qgisProject.fileName = ""
+              iface.clearProject()
             }
           }
         }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -554,6 +554,10 @@ Page {
             cloudProjectsModel.removeLocalProject(projectActions.projectId)
             iface.removeRecentProject(projectActions.projectLocalPath);
             welcomeScreen.model.reloadModel()
+
+            if (projectActions.projectLocalPath === qgisProject.fileName) {
+              qgisProject.fileName = ""
+            }
           }
         }
 


### PR DESCRIPTION
1) download cloud project
2) open it
3) go back to qfc projects screen
4) delete it
5) go to main screen
6) clicking top-right back to current project shows some non-sense