### PR TITLE
Clear project in readProjectFile to avoid threading issues

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -690,8 +690,6 @@ bool QgisMobileapp::loadProjectFile( const QString &path, const QString &name )
 
     mAuthRequestHandler->clearStoredRealms();
 
-    // Clear project to empty the layer tree prior to freezing during project load
-    mProject->clear();
     mProjectFilePath = path;
     mProjectFileName = !name.isEmpty() ? name : fi.completeBaseName();
 
@@ -707,9 +705,6 @@ void QgisMobileapp::reloadProjectFile()
   if ( mProjectFilePath.isEmpty() )
     QgsMessageLog::logMessage( tr( "No project file currently opened" ), QStringLiteral( "QField" ), Qgis::Warning );
 
-  // Clear project to empty the layer tree prior to freezing during project load
-  mProject->clear();
-
   emit loadProjectTriggered( mProjectFilePath, mProjectFileName );
 }
 
@@ -723,6 +718,7 @@ void QgisMobileapp::readProjectFile()
 
   const QString suffix = fi.suffix().toLower();
 
+  mProject->clear();
   mProject->layerTreeRegistryBridge()->setLayerInsertionMethod( Qgis::LayerTreeInsertionMethod::OptimalInInsertionGroup );
 
   mTrackingModel->reset();


### PR DESCRIPTION
See https://opengisch.sentry.io/issues/4868150364/events/5b17c754818442d7865406c574cdca77/?project=6119013&query=is%3Aunresolved&referrer=next-event&statsPeriod=14d&stream_index=8

To reproduce the crash on Android with QField 3.1.8, follow these steps:
- Open QField, load a project (sample bees)
- Put QField in the background, and through file association (say a messenger app with a geopackage), open a dataset or zipped project
- QField is brought back to the front, and *boom*

That's because we were clearing the project in QgisMobileapp::loadProjectFile when called by AppInterface::instance()->loadFile _from the java the activity thread_. Solution is to clear the project somewhere else when that is triggered by the QML scene, which is on the same thread as the QgsProject member.