### PR TITLE
Add a link to "Portable project" docs instead of reference only

### DIFF
--- a/src/qml/BadLayerItem.qml
+++ b/src/qml/BadLayerItem.qml
@@ -91,7 +91,8 @@ Page {
     }
 
     Label {
-      text: qsTr( "You may check the Portable Project section in the QField documentation for more help." )
+      text: qsTr( "You may check the [Portable Project](https://docs.qfield.org/how-to/movable-project) documentation page for more help." )
+      textFormat: Text.MarkdownText
       font: Theme.tipFont
       color: Theme.secondaryTextColor
 
@@ -101,6 +102,8 @@ Page {
       Layout.minimumHeight: contentHeight
       Layout.maximumHeight: contentHeight
       Layout.topMargin: 5
+
+      onLinkActivated: Qt.openUrlExternally(link)
     }
   }
 }

--- a/src/qml/BadLayerItem.qml
+++ b/src/qml/BadLayerItem.qml
@@ -91,8 +91,8 @@ Page {
     }
 
     Label {
-      text: qsTr( "You may check the [Portable Project](https://docs.qfield.org/how-to/movable-project) documentation page for more help." )
-      textFormat: Text.MarkdownText
+      text: qsTr( "You may check the <a href=\"https://docs.qfield.org/how-to/movable-project\">Portable Project</a> documentation page for more help." )
+      textFormat: Text.RichText
       font: Theme.tipFont
       color: Theme.secondaryTextColor
 
@@ -103,7 +103,7 @@ Page {
       Layout.maximumHeight: contentHeight
       Layout.topMargin: 5
 
-      onLinkActivated: Qt.openUrlExternally(link)
+      onLinkActivated: (link) => { Qt.openUrlExternally(link) }
     }
   }
 }

--- a/src/qml/BadLayerItem.qml
+++ b/src/qml/BadLayerItem.qml
@@ -91,7 +91,10 @@ Page {
     }
 
     Label {
-      text: qsTr( "You may check the <a href=\"https://docs.qfield.org/how-to/movable-project\">Portable Project</a> documentation page for more help." )
+      text: qsTr( 'You may check the %1Portable Project%2 documentation page for more help.')
+        .arg( "<a href=\"https://docs.qfield.org/how-to/movable-project\">" )
+        .arg( "</a>" )
+
       textFormat: Text.RichText
       font: Theme.tipFont
       color: Theme.secondaryTextColor


### PR DESCRIPTION
| before | after |
|-|-|
| ![image](https://github.com/opengisch/QField/assets/2820439/715080dc-c3e5-47a7-9705-a699353c379e) | ![image](https://github.com/opengisch/QField/assets/2820439/51c7be24-1a21-434b-8b9c-348781c89cd7) |
