### PR TITLE
Clear project on exit instead of only removing all layers

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -1388,7 +1388,7 @@ QgisMobileapp::~QgisMobileapp()
   saveProjectPreviewImage();
 
   delete mOfflineEditing;
-  mProject->removeAllMapLayers();
+  mProject->clear();
   delete mProject;
   delete mAppMissingGridHandler;
 


### PR DESCRIPTION
At the very least, that will trigger an aboutToBeCleared signal which will freeze the layer tree from responding to layer removal signals, which should speed exit time.

Also hoping it'll address this: https://opengisch.sentry.io/issues/4832201805/?project=6119013&query=is%3Aunresolved+release%3A%22ch.opengis.qfield%403.1.9%2A%22&referrer=issue-stream&sort=user&statsPeriod=24h&stream_index=2