### PR TITLE
Temporarily add jasper overlay to fix windows build

### DIFF
--- a/vcpkg/overlay/jasper/check-for-atomics-support.patch
+++ b/vcpkg/overlay/jasper/check-for-atomics-support.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8d2e9f9..110c245 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -591,6 +591,7 @@ set(JAS_HAVE_WIN32_THREADS FALSE)
+ if(JAS_ENABLE_MULTITHREADING_SUPPORT)
+ 	check_c_source_compiles("
+ 	#include <threads.h>
++	#include <stdatomic.h>
+ 	int main() {
+ 		thrd_t thread;
+ 		mtx_t mutex;

--- a/vcpkg/overlay/jasper/fix-library-name.patch
+++ b/vcpkg/overlay/jasper/fix-library-name.patch
@@ -1,0 +1,13 @@
+diff --git a/build/jasper.pc.in b/build/jasper.pc.in
+index a4ce38f..a9a7bc4 100644
+--- a/build/jasper.pc.in
++++ b/build/jasper.pc.in
+@@ -6,7 +6,7 @@ Name: JasPer
+ Description: Image Processing/Coding Tool Kit with JPEG-2000 Support
+ Version: @JAS_VERSION@
+ 
+-Libs: -L${libdir} -ljasper
++Libs: -L${libdir} -ljasper@CMAKE_DEBUG_POSTFIX@
+ Requires.private: @JAS_PKGCONFIG_REQUIRES@
+ Cflags: -I${includedir}/jasper -I${includedir}
+ Cflags.private: -DLIBJASPER_STATIC_DEFINE

--- a/vcpkg/overlay/jasper/no_stdc_check.patch
+++ b/vcpkg/overlay/jasper/no_stdc_check.patch
@@ -1,0 +1,25 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ba6f117..8d2e9f9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -424,7 +424,7 @@ if((DEFINED JAS_CROSSCOMPILING AND JAS_CROSSCOMPILING) OR
+ 	# (e.g., using -DJAS_STDC_VERSION=YYYYMML) or by changing the line below.
+ if(NOT JAS_WASM)
+ 	set(JAS_STDC_VERSION "0L" CACHE INTERNAL "The value of __STDC_VERSION__.")
+-	if (JAS_STDC_VERSION STREQUAL "0L")
++	if (0)
+ 		message(FATAL_ERROR
+ 		  "The value of __STDC_VERSION__ cannot be automatically determined "
+ 		  "when cross-compiling.  Please set JAS_STDC_VERSION to the value "
+@@ -434,8 +434,9 @@ if(NOT JAS_WASM)
+ 	endif()
+ endif()
+ else()
+-	jas_get_stdc_version(status JAS_STDC_VERSION)
+-	if(NOT status)
++	#jas_get_stdc_version(status JAS_STDC_VERSION)
++	set(JAS_STDC_VERSION 0L)
++	if(0)
+ 		message(FATAL_ERROR "Cannot determine the value of __STDC_VERSION__.")
+ 	endif()
+ endif()

--- a/vcpkg/overlay/jasper/portfile.cmake
+++ b/vcpkg/overlay/jasper/portfile.cmake
@@ -1,0 +1,47 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO jasper-software/jasper
+    REF "version-${VERSION}"
+    SHA512 940841f4094987526ee23aed84f2b028b0f4d58cd2be91dcf737102018d8da111870959ad64710b14ae1ca4ca8361fc900ff6ecee31f0f23ef435bf7f0935462
+    HEAD_REF master
+    PATCHES
+        no_stdc_check.patch
+        fix-library-name.patch
+        check-for-atomics-support.patch # https://github.com/jasper-software/jasper/pull/370
+)
+
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    set(VCPKG_CXX_FLAGS "/D_CRT_DECLARE_NONSTDC_NAMES ${VCPKG_CXX_FLAGS}")
+    set(VCPKG_C_FLAGS "/D_CRT_DECLARE_NONSTDC_NAMES ${VCPKG_C_FLAGS}")
+endif()
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" JAS_ENABLE_SHARED)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        opengl    JAS_ENABLE_OPENGL
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DJAS_ENABLE_LIBHEIF=OFF # found via find_library instead of find_package
+        -DJAS_ENABLE_LIBJPEG=ON
+        -DJAS_ENABLE_DOC=OFF
+        -DJAS_ENABLE_LATEX=OFF
+        -DJAS_ENABLE_PROGRAMS=OFF
+        -DJAS_ENABLE_SHARED=${JAS_ENABLE_SHARED}
+    OPTIONS_DEBUG
+        -DCMAKE_DEBUG_POSTFIX=d # Due to CMakes FindJasper; Default for multi config generators.
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share")
+
+vcpkg_install_copyright(FILE_LIST ${SOURCE_PATH}/LICENSE.txt)

--- a/vcpkg/overlay/jasper/vcpkg.json
+++ b/vcpkg/overlay/jasper/vcpkg.json
@@ -1,0 +1,50 @@
+{
+  "name": "jasper",
+  "version": "4.1.0",
+  "port-version": 1,
+  "description": "Open source implementation of the JPEG-2000 Part-1 standard",
+  "homepage": "https://github.com/jasper-software/jasper",
+  "license": null,
+  "dependencies": [
+    "libjpeg-turbo",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "default-features"
+  ],
+  "features": {
+    "default-features": {
+      "description": "Platform-dependent default features",
+      "dependencies": [
+        {
+          "name": "jasper",
+          "default-features": false,
+          "features": [
+            "opengl"
+          ],
+          "platform": "!(windows & arm) & !uwp & !ios"
+        }
+      ]
+    },
+    "opengl": {
+      "description": "Enable the use of the OpenGL/GLUT Library",
+      "dependencies": [
+        {
+          "name": "freeglut",
+          "platform": "!osx & !(windows & arm) & !uwp"
+        },
+        {
+          "name": "opengl",
+          "platform": "!(windows & arm) & !uwp"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
See chatter on jasper here (https://github.com/microsoft/vcpkg/pull/36143). For now, play it safe, just add a jasper overlay so we can backport to release-3_1.