### PR TITLE
Remove a couple of QGIS deprecated function warnings

### DIFF
--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -707,7 +707,7 @@ void FeatureModel::applyGeometry()
         {
           ignoredFeature.insert( mLayer, QSet<QgsFeatureId>() << mFeature.id() );
         }
-        geometry.avoidIntersections( intersectionLayers, ignoredFeature );
+        geometry.avoidIntersectionsV2( intersectionLayers, ignoredFeature );
       }
     }
   }

--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -648,6 +648,9 @@ QVariant FlatLayerTreeModelBase::data( const QModelIndex &index, int role ) cons
           case Qgis::LayerType::Group:
             layerType = QStringLiteral( "grouplayer" );
             break;
+          case Qgis::LayerType::TiledScene:
+            layerType = QStringLiteral( "tiledscenelayer" );
+            break;
         }
       }
       return layerType;
@@ -1262,7 +1265,7 @@ void FlatLayerTreeModelBase::setLayerInTracking( QgsLayerTreeLayer *nodeLayer, b
 QgsRectangle FlatLayerTreeModelBase::nodeExtent( const QModelIndex &index, QgsQuickMapSettings *mapSettings, const float buffer )
 {
   QgsRectangle extent;
-  extent.setMinimal();
+  extent.setNull();
 
   const QModelIndex sourceIndex = mapToSource( index );
   if ( !sourceIndex.isValid() )

--- a/src/core/qgsquick/qgsquickelevationprofilecanvas.cpp
+++ b/src/core/qgsquick/qgsquickelevationprofilecanvas.cpp
@@ -244,6 +244,7 @@ void QgsQuickElevationProfileCanvas::setupLayerConnections( QgsMapLayer *layer, 
     case Qgis::LayerType::Annotation:
     case Qgis::LayerType::PointCloud:
     case Qgis::LayerType::Group:
+    case Qgis::LayerType::TiledScene:
       break;
   }
 }

--- a/src/core/utils/geometryutils.cpp
+++ b/src/core/utils/geometryutils.cpp
@@ -88,7 +88,7 @@ GeometryUtils::GeometryOperationResult GeometryUtils::reshapeFromRubberband( Qgs
       {
         QHash<QgsVectorLayer *, QSet<QgsFeatureId>> ignoredFeature;
         ignoredFeature.insert( layer, QSet<QgsFeatureId>() << fid );
-        geom.avoidIntersections( avoidIntersectionsLayers, ignoredFeature );
+        geom.avoidIntersectionsV2( avoidIntersectionsLayers, ignoredFeature );
       }
 
       if ( geom.isEmpty() ) //intersection removal might have removed the whole geometry


### PR DESCRIPTION
We can't get rid of Qt deprecated warnings, but we sure can deal with the QGIS ones :)