### PR TITLE
Write settings to permanent storage when OS or user force kills app

### DIFF
--- a/src/core/navigation.cpp
+++ b/src/core/navigation.cpp
@@ -49,7 +49,6 @@ Navigation::Navigation()
 
 Navigation::~Navigation()
 {
-  mModel->save();
 }
 
 bool Navigation::isActive() const

--- a/src/core/navigationmodel.cpp
+++ b/src/core/navigationmodel.cpp
@@ -77,6 +77,7 @@ void NavigationModel::setDestination( const QgsPoint &point )
     endInsertRows();
   }
 
+  save();
   emit destinationChanged();
 }
 
@@ -125,6 +126,7 @@ void NavigationModel::setCrs( QgsCoordinateReferenceSystem crs )
   }
 
   mCrs = crs;
+  save();
 }
 
 QHash<int, QByteArray> NavigationModel::roleNames() const
@@ -184,4 +186,5 @@ void NavigationModel::clear()
   beginResetModel();
   mPoints.clear();
   endResetModel();
+  save();
 }

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -347,6 +347,24 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
 
   // Set GDAL option to fix loading of datasets within ZIP containers
   CPLSetConfigOption( "CPL_ZIP_ENCODING", "UTF-8" );
+
+  connect( QgsApplication::instance(), &QGuiApplication::applicationStateChanged, this, [=]( Qt::ApplicationState state ) {
+    switch ( state )
+    {
+      case Qt::ApplicationSuspended:
+      case Qt::ApplicationHidden:
+      case Qt::ApplicationInactive:
+      {
+        // Write settings to permanent storage
+        QSettings().sync();
+      }
+
+      case Qt::ApplicationActive:
+      {
+        break;
+      }
+    }
+  } );
 }
 
 void QgisMobileapp::initDeclarative()

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -871,18 +871,18 @@ Page {
   function adjustWelcomeScreen() {
     if (visible) {
       const currentProjectButtonVisible = !!qgisProject.fileName;
+      currentProjectButton.visible = currentProjectButtonVisible
 
       if (firstShown) {
         welcomeText.text = " ";
-        currentProjectButton.visible = currentProjectButtonVisible
       } else {
-        var firstRun = !settings.value( "/QField/FirstRunFlag", false )
+        var firstRun = !settings.valueBool( "/QField/FirstRunDone", false )
         if ( firstRun ) {
           welcomeText.text = qsTr( "Welcome to QField. First time using this application? Try the sample projects listed below." )
+          settings.setValue( "/QField/FirstRunDone", true )
         } else {
           welcomeText.text = qsTr( "Welcome back to QField." )
         }
-        currentProjectButton.visible = currentProjectButtonVisible
       }
     }
   }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3351,8 +3351,6 @@ ApplicationWindow {
       }
 
       layoutListInstantiator.model.reloadModel()
-
-      settings.setValue( "/QField/FirstRunFlag", false )
     }
 
     function onSetMapExtent(extent) {


### PR DESCRIPTION
I was testing https://github.com/opengisch/QField/pull/4988 on iOS yesterday when I realized modified settings were for the most part never saved. That's because on iOS, there's no double back button quitting per say, only force quitting by swiping the app up.

This commit remedies to that situation. It also benefits Android when people force kill app. Simple step to reproduce issue:
- Open QField
- Load bees project
- Add a navigation destination (long press on canvas -> set as destination)
- Suspend QField, then force kill it by showing running apps and swipping QField up into nonexistence)
- Re-open QField, destination gone.