### PR TITLE
Add layer observer signal handlers even if the layer is invalid

### DIFF
--- a/src/core/layerobserver.cpp
+++ b/src/core/layerobserver.cpp
@@ -291,7 +291,7 @@ void LayerObserver::addLayerListeners()
   {
     QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( layer );
 
-    if ( vl && vl->isValid() )
+    if ( vl )
     {
       if ( mObservedLayerIds.contains( vl->id() ) )
         continue;


### PR DESCRIPTION
In theory it is possible to have a layer becoming from invalid to valid, even though not directly observed. IMO having the signal handlers will not hurt even if the layer remains invalid.