### PR TITLE
Fix deployment target for x64-osx

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -10,6 +10,10 @@ on:
   release:
     types: ['published']
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: build (ios)

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,6 +9,9 @@ on:
   release:
     types: ['published']
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-12
+          - os: macos-13
             triplet: x64-osx
             deployment-target: "10.15"
           - os: macos-14

--- a/vcpkg/triplets/arm64-osx.cmake
+++ b/vcpkg/triplets/arm64-osx.cmake
@@ -7,5 +7,6 @@ set(VCPKG_OSX_ARCHITECTURES arm64)
 set(VCPKG_BUILD_TYPE release)
 
 set(VCPKG_OSX_DEPLOYMENT_TARGET 11.0)
-set(VCPKG_C_FLAGS -mmacosx-version-min=11.0)
-set(VCPKG_CXX_FLAGS -mmacosx-version-min=11.0)
+# See https://github.com/microsoft/vcpkg/issues/10038
+set(VCPKG_C_FLAGS -mmacosx-version-min=${VCPKG_OSX_DEPLOYMENT_TARGET})
+set(VCPKG_CXX_FLAGS -mmacosx-version-min=${VCPKG_OSX_DEPLOYMENT_TARGET})

--- a/vcpkg/triplets/x64-osx.cmake
+++ b/vcpkg/triplets/x64-osx.cmake
@@ -5,3 +5,8 @@ set(VCPKG_LIBRARY_LINKAGE static)
 set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
 set(VCPKG_OSX_ARCHITECTURES x86_64)
 set(VCPKG_BUILD_TYPE release)
+
+set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
+# See https://github.com/microsoft/vcpkg/issues/10038
+set(VCPKG_C_FLAGS -mmacosx-version-min=${VCPKG_OSX_DEPLOYMENT_TARGET})
+set(VCPKG_CXX_FLAGS -mmacosx-version-min=${VCPKG_OSX_DEPLOYMENT_TARGET})


### PR DESCRIPTION
So far we have build dependencies and application for different versions of x64-osx. This is now fixed to 10.15 (should hopefully be old enough to keep some hardware working).
Also introduces cancellation of parallel jobs on the same PR.
And uses a newer macos version (13) to build for mac