### PR TITLE
Performance boost when downloading packages

### DIFF
--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -378,19 +378,19 @@ void QFieldCloudProjectsModel::refreshProjectFileOutdatedStatus( const QString &
     }
 
     const QJsonArray files = QJsonDocument::fromJson( rawReply->readAll() ).array();
-    const QString lastProjectFileSha256 = QFieldCloudUtils::projectSetting( project->id, QStringLiteral( "lastProjectFileSha256" ), QString() ).toString();
+    const QString lastProjectFileMd5 = QFieldCloudUtils::projectSetting( project->id, QStringLiteral( "lastProjectFileMd5" ), QString() ).toString();
     for ( const auto file : files )
     {
       QVariantHash fileDetails = file.toObject().toVariantHash();
       const QString fileName = fileDetails.value( "name" ).toString().toLower();
       if ( fileName.endsWith( QStringLiteral( ".qgs" ) ) || fileName.endsWith( QStringLiteral( ".qgz" ) ) )
       {
-        if ( lastProjectFileSha256.isEmpty() )
+        if ( lastProjectFileMd5.isEmpty() )
         {
           // First check, store for future comparison
-          QFieldCloudUtils::setProjectSetting( project->id, QStringLiteral( "lastProjectFileSha256" ), fileDetails.value( "sha256" ).toString() );
+          QFieldCloudUtils::setProjectSetting( project->id, QStringLiteral( "lastProjectFileMd5" ), fileDetails.value( "md5sum" ).toString() );
         }
-        else if ( lastProjectFileSha256 != fileDetails.value( "sha256" ).toString() )
+        else if ( lastProjectFileMd5 != fileDetails.value( "md5sum" ).toString() )
         {
           project->projectFileIsOutdated = true;
           QFieldCloudUtils::setProjectSetting( project->id, QStringLiteral( "projectFileOudated" ), true );
@@ -955,7 +955,7 @@ void QFieldCloudProjectsModel::projectDownload( const QString &projectId )
     return;
   }
 
-  NetworkReply *reply = mCloudConnection->get( QStringLiteral( "/api/v1/packages/%1/latest/" ).arg( projectId ) );
+  NetworkReply *reply = mCloudConnection->get( QStringLiteral( "/api/v1/packages/%1/latest/?skip_metadata=1" ).arg( projectId ) );
 
   emit dataChanged( projectIndex, projectIndex, QVector<int>() << PackagingStatusRole << StatusRole );
 
@@ -1005,20 +1005,20 @@ void QFieldCloudProjectsModel::projectDownload( const QString &projectId )
       int fileSize = fileObject.value( QStringLiteral( "size" ) ).toInt();
       QString fileName = fileObject.value( QStringLiteral( "name" ) ).toString();
       QString projectFileName = QStringLiteral( "%1/%2/%3/%4" ).arg( QFieldCloudUtils::localCloudDirectory(), mUsername, projectId, fileName );
-      QString cloudChecksum = fileObject.value( QStringLiteral( "sha256" ) ).toString();
-      QString localChecksum = FileUtils::fileChecksum( projectFileName, QCryptographicHash::Sha256 ).toHex();
+      QString cloudChecksumMd5 = fileObject.value( QStringLiteral( "md5sum" ) ).toString();
+      QString localChecksumMd5 = FileUtils::fileChecksum( projectFileName, QCryptographicHash::Md5 ).toHex();
 
       if (
         !fileObject.value( QStringLiteral( "size" ) ).isDouble()
         || fileName.isEmpty()
-        || cloudChecksum.isEmpty() )
+        || cloudChecksumMd5.isEmpty() )
       {
-        QgsLogger::debug( QStringLiteral( "Project %1: package in \"files\" list does not contain the expected fields: size(int), name(string), sha256(string)" ).arg( projectId ) );
+        QgsLogger::debug( QStringLiteral( "Project %1: package in \"files\" list does not contain the expected fields: size(int), name(string), md5sum(string)" ).arg( projectId ) );
         emit projectDownloadFinished( projectId, tr( "Latest package data structure error." ) );
         return;
       }
 
-      if ( cloudChecksum == localChecksum )
+      if ( cloudChecksumMd5 == localChecksumMd5 )
         continue;
 
       project->downloadFileTransfers.insert( fileName, FileTransfer( fileName, fileSize ) );
@@ -1884,7 +1884,7 @@ void QFieldCloudProjectsModel::downloadFileConnections( const QString &projectId
         QFieldCloudUtils::setProjectSetting( projectId, QStringLiteral( "lastLocalExportedAt" ), project->lastLocalExportedAt );
         QFieldCloudUtils::setProjectSetting( projectId, QStringLiteral( "lastLocalExportId" ), project->lastLocalExportId );
         QFieldCloudUtils::setProjectSetting( projectId, QStringLiteral( "lastLocalDataLastUpdatedAt" ), project->lastLocalDataLastUpdatedAt );
-        QFieldCloudUtils::setProjectSetting( projectId, QStringLiteral( "lastProjectFileSha256" ), QString() );
+        QFieldCloudUtils::setProjectSetting( projectId, QStringLiteral( "lastProjectFileMd5" ), QString() );
         QFieldCloudUtils::setProjectSetting( projectId, QStringLiteral( "projectFileOudated" ), false );
 
         rolesChanged << StatusRole << ProjectOutdatedRole << ProjectFileOutdatedRole << LocalPathRole << CheckoutRole << LastLocalExportedAtRole;

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -955,7 +955,10 @@ void QFieldCloudProjectsModel::projectDownload( const QString &projectId )
     return;
   }
 
-  NetworkReply *reply = mCloudConnection->get( QStringLiteral( "/api/v1/packages/%1/latest/?skip_metadata=1" ).arg( projectId ) );
+  QVariantMap params;
+  params.insert( "skip_metadata", "1" );
+
+  NetworkReply *reply = mCloudConnection->get( QStringLiteral( "/api/v1/packages/%1/latest/" ).arg( projectId ), params );
 
   emit dataChanged( projectIndex, projectIndex, QVector<int>() << PackagingStatusRole << StatusRole );
 

--- a/src/core/utils/fileutils.h
+++ b/src/core/utils/fileutils.h
@@ -61,7 +61,7 @@ class QFIELD_CORE_EXPORT FileUtils : public QObject
      * @param hashAlgorithm hash algorithm (md5, sha1, sha256 etc)
      * @return QByteArray checksum
      */
-    Q_INVOKABLE static QByteArray fileChecksum( const QString &fileName, const QCryptographicHash::Algorithm hashAlgorithm = QCryptographicHash::Sha256 );
+    Q_INVOKABLE static QByteArray fileChecksum( const QString &fileName, const QCryptographicHash::Algorithm hashAlgorithm );
 
   private:
     static int copyRecursivelyPrepare( const QString &sourceFolder, const QString &destFolder, QList<QPair<QString, QString>> &mapping );

--- a/test/test_deltafilewrapper.cpp
+++ b/test/test_deltafilewrapper.cpp
@@ -156,7 +156,7 @@ TEST_CASE( "DeltaFileWrapper" )
   REQUIRE( attachmentFile.flush() );
 
   QString attachmentFileName = attachmentFile.fileName();
-  QString attachmentFileChecksum = FileUtils::fileChecksum( attachmentFileName ).toHex();
+  QString attachmentFileChecksumSha256 = FileUtils::fileChecksum( attachmentFileName, QCryptographicHash::Sha256 ).toHex();
 
   std::unique_ptr<QgsVectorLayer> layer = std::make_unique<QgsVectorLayer>( QStringLiteral( "Point?crs=EPSG:3857&field=fid:integer&field=int:integer&field=dbl:double&field=str:string&field=attachment:string" ), QStringLiteral( "layer_name" ), QStringLiteral( "memory" ) );
   layer->setEditorWidgetSetup( layer->fields().indexFromName( QStringLiteral( "attachment" ) ), QgsEditorWidgetSetup( QStringLiteral( "ExternalResource" ), QVariantMap() ) );
@@ -835,7 +835,7 @@ TEST_CASE( "DeltaFileWrapper" )
           }
         ]
       )"""" )
-                                                           .arg( attachmentFileName, attachmentFileChecksum )
+                                                           .arg( attachmentFileName, attachmentFileChecksumSha256 )
                                                            .toUtf8() );
     REQUIRE( QJsonDocument( getDeltasArray( dfw.toString() ) ) == expectedDoc );
 
@@ -981,7 +981,7 @@ TEST_CASE( "DeltaFileWrapper" )
           }
         ]
       )"""" )
-                                                           .arg( attachmentFileName, attachmentFileChecksum )
+                                                           .arg( attachmentFileName, attachmentFileChecksumSha256 )
                                                            .toUtf8() );
     REQUIRE( QJsonDocument( getDeltasArray( dfw.toString() ) ) == expectedDoc );
 
@@ -1384,7 +1384,7 @@ TEST_CASE( "DeltaFileWrapper" )
           }
         ]
       )"""" )
-                                                           .arg( attachmentFileName, attachmentFileChecksum )
+                                                           .arg( attachmentFileName, attachmentFileChecksumSha256 )
                                                            .toUtf8() );
     REQUIRE( QJsonDocument( getDeltasArray( dfw.toString() ) ) == expectedDoc );
 
@@ -1826,7 +1826,7 @@ TEST_CASE( "DeltaFileWrapper" )
           "version": "1.0"
         }
       )"""" )
-                                .arg( layer->id(), attachmentFileName, attachmentFileChecksum )
+                                .arg( layer->id(), attachmentFileName, attachmentFileChecksumSha256 )
                                 .toUtf8() ) );
     REQUIRE( deltaFile.flush() );
 
@@ -1943,7 +1943,7 @@ TEST_CASE( "DeltaFileWrapper" )
           }
         ]
       )"""" )
-                                                                                             .arg( attachmentFileName, attachmentFileChecksum )
+                                                                                             .arg( attachmentFileName, attachmentFileChecksumSha256 )
                                                                                              .toUtf8() ) );
   }
 
@@ -2000,7 +2000,7 @@ TEST_CASE( "DeltaFileWrapper" )
           }
         ]
       )"""" )
-                                                                                             .arg( attachmentFileName, attachmentFileChecksum )
+                                                                                             .arg( attachmentFileName, attachmentFileChecksumSha256 )
                                                                                              .toUtf8() ) );
   }
 


### PR DESCRIPTION
Use `md5` checksum instead of `sha256` checksum to gain extra performance
when downloading packaged files in QField. The `sha256` causes N+1 requests
to the S3 storage, therefore makes the QFieldCloud response on the 
`packages/<projec-id>/latest` endpoint super slow.

This change will cause an extra initial download of the project file for
all users when they sync, since we renamed `lastProjectFileSha256` to
`lastProjectFileMd5`. IMO it is acceptable, otherwise we have to handle
extra code that I would prefer not to maintain.

See https://github.com/opengisch/qfieldcloud/pull/885