### PR TITLE
Implement basic support for title and copyright decoration

### DIFF
--- a/src/core/projectinfo.cpp
+++ b/src/core/projectinfo.cpp
@@ -20,6 +20,8 @@
 #include <QDateTime>
 #include <QFileInfo>
 #include <QString>
+#include <QTextDocument>
+#include <qgscolorutils.h>
 #include <qgslayertree.h>
 #include <qgslayertreemodel.h>
 #include <qgsmaplayerstyle.h>
@@ -507,4 +509,126 @@ void ProjectInfo::restoreSettings( QString &projectFilePath, QgsProject *project
     project->setSnappingConfig( config );
   }
   settings.endGroup();
+}
+
+QVariantMap ProjectInfo::getTitleDecorationConfiguration()
+{
+  QVariantMap configuration;
+  const QString configurationName = QStringLiteral( "TitleLabel" );
+
+  if ( QgsProject::instance()->readBoolEntry( configurationName, QStringLiteral( "/Enabled" ), false ) )
+  {
+    QString text = QgsProject::instance()->readEntry( configurationName, QStringLiteral( "/Label" ), QString() );
+    if ( !text.isEmpty() )
+    {
+      text.replace( QStringLiteral( "\n" ), QStringLiteral( "<br>" ) );
+      QTextDocument doc;
+      doc.setHtml( text );
+      text = doc.toPlainText();
+    }
+
+    QColor backgroundColor = QgsColorUtils::colorFromString( QgsProject::instance()->readEntry( configurationName, QStringLiteral( "/BackgroundColor" ), QStringLiteral( "0,0,0,99" ) ) );
+    QColor color = QColor( Qt::black );
+    QColor outlineColor = QColor( Qt::white );
+    bool hasOutline = false;
+
+    QDomDocument doc;
+    QDomElement elem;
+    const QString textXml = QgsProject::instance()->readEntry( configurationName, QStringLiteral( "/Font" ) );
+    if ( !textXml.isEmpty() )
+    {
+      doc.setContent( textXml );
+      elem = doc.documentElement();
+      QgsReadWriteContext rwContext;
+      rwContext.setPathResolver( QgsProject::instance()->pathResolver() );
+      QgsTextFormat textFormat;
+      textFormat.readXml( elem, rwContext );
+
+      color = textFormat.color();
+      color.setAlphaF( textFormat.opacity() );
+      if ( textFormat.buffer().enabled() )
+      {
+        hasOutline = true;
+        outlineColor = textFormat.buffer().color();
+        outlineColor.setAlphaF( textFormat.buffer().opacity() );
+      }
+    }
+
+    configuration["text"] = text;
+    configuration["backgroundColor"] = backgroundColor;
+    configuration["color"] = color;
+    configuration["hasOutline"] = hasOutline;
+    configuration["outlineColor"] = outlineColor;
+  }
+  else
+  {
+    configuration["text"] = QString();
+    configuration["backgroundColor"] = QColor( Qt::transparent );
+    configuration["color"] = QColor( Qt::black );
+    configuration["hasOutline"] = false;
+    configuration["outlineColor"] = QColor( Qt::white );
+  }
+
+  return configuration;
+}
+
+QVariantMap ProjectInfo::getCopyrightDecorationConfiguration()
+{
+  QVariantMap configuration;
+  const QString configurationName = QStringLiteral( "CopyrightLabel" );
+
+  if ( QgsProject::instance()->readBoolEntry( configurationName, QStringLiteral( "/Enabled" ), false ) )
+  {
+    QString text = QgsProject::instance()->readEntry( configurationName, QStringLiteral( "/Label" ), QString() );
+    if ( !text.isEmpty() )
+    {
+      text.replace( QStringLiteral( "\n" ), QStringLiteral( "<br>" ) );
+      QTextDocument doc;
+      doc.setHtml( text );
+      text = doc.toPlainText();
+    }
+
+    QColor backgroundColor = QColor( Qt::transparent );
+    QColor color = QColor( Qt::black );
+    QColor outlineColor = QColor( Qt::white );
+    bool hasOutline = false;
+
+    QDomDocument doc;
+    QDomElement elem;
+    const QString textXml = QgsProject::instance()->readEntry( configurationName, QStringLiteral( "/Font" ) );
+    if ( !textXml.isEmpty() )
+    {
+      doc.setContent( textXml );
+      elem = doc.documentElement();
+      QgsReadWriteContext rwContext;
+      rwContext.setPathResolver( QgsProject::instance()->pathResolver() );
+      QgsTextFormat textFormat;
+      textFormat.readXml( elem, rwContext );
+
+      color = textFormat.color();
+      color.setAlphaF( textFormat.opacity() );
+      if ( textFormat.buffer().enabled() )
+      {
+        hasOutline = true;
+        outlineColor = textFormat.buffer().color();
+        outlineColor.setAlphaF( textFormat.buffer().opacity() );
+      }
+    }
+
+    configuration["text"] = text;
+    configuration["backgroundColor"] = backgroundColor;
+    configuration["color"] = color;
+    configuration["hasOutline"] = hasOutline;
+    configuration["outlineColor"] = outlineColor;
+  }
+  else
+  {
+    configuration["text"] = QString();
+    configuration["backgroundColor"] = QColor( Qt::transparent );
+    configuration["color"] = QColor( Qt::black );
+    configuration["hasOutline"] = false;
+    configuration["outlineColor"] = QColor( Qt::white );
+  }
+
+  return configuration;
 }

--- a/src/core/projectinfo.h
+++ b/src/core/projectinfo.h
@@ -157,6 +157,10 @@ class ProjectInfo : public QObject
     //! Restore various project settings
     static void restoreSettings( QString &projectFilePath, QgsProject *project, QgsQuickMapCanvasMap *mapCanvas, FlatLayerTreeModel *layerTree );
 
+    Q_INVOKABLE QVariantMap getTitleDecorationConfiguration();
+
+    Q_INVOKABLE QVariantMap getCopyrightDecorationConfiguration();
+
   signals:
 
     void filePathChanged();

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -794,6 +794,76 @@ ApplicationWindow {
       mapSettings: mapCanvas.mapSettings
       mapDistance: moveFeaturesToolbar.moveFeaturesRequested ? mapCanvas.mapSettings.center.y - moveFeaturesToolbar.startPoint.y : 0
     }
+
+    Rectangle {
+      id: titleDecorationBackground
+
+      visible: titleDecoration.text != ''
+
+      anchors.left: parent.left
+      anchors.leftMargin: 56
+      anchors.top: parent.top
+      anchors.topMargin: mainWindow.sceneTopMargin + 4
+
+      width: parent.width - anchors.leftMargin * 2
+      height: 48
+      radius: 4
+
+      color:'#55000000'
+
+      Text {
+        id: titleDecoration
+
+        width: parent.width - 4
+        height: parent.height
+        leftPadding: 2
+        rightPadding: 2
+
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+        wrapMode: Text.WordWrap
+        elide: Text.ElideRight
+
+        font.pointSize: Theme.tipFont.pointSize
+        font.bold: true
+
+        text: ''
+      }
+    }
+
+    Rectangle {
+      id: copyrightDecorationBackground
+
+      visible: copyrightDecoration.text != ''
+
+      anchors.left: parent.left
+      anchors.leftMargin: 56
+      anchors.bottom: parent.bottom
+      anchors.bottomMargin: 56
+
+      width: parent.width - anchors.leftMargin * 2
+      height: 48
+      radius: 4
+
+      color:'#55000000'
+      Text {
+        id: copyrightDecoration
+
+        width: parent.width - 4
+        height: parent.height
+        leftPadding: 2
+        rightPadding: 2
+
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignBottom
+        wrapMode: Text.WordWrap
+        elide: Text.ElideRight
+
+        font: Theme.tinyFont
+
+        text: ''
+      }
+    }
   }
 
   Column {
@@ -3290,6 +3360,20 @@ ApplicationWindow {
       dashBoard.activeLayer = projectInfo.activeLayer
 
       mapCanvasBackground.color = mapCanvas.mapSettings.backgroundColor
+
+      var titleDecorationConfiguration = projectInfo.getTitleDecorationConfiguration();
+      titleDecoration.text = titleDecorationConfiguration["text"];
+      titleDecoration.color = titleDecorationConfiguration["color"];
+      titleDecoration.style = titleDecorationConfiguration["hasOutline"] === true ? Text.Outline : Text.Normal;
+      titleDecoration.styleColor = titleDecorationConfiguration["outlineColor"];
+      titleDecorationBackground.color = titleDecorationConfiguration["backgroundColor"];
+
+      var copyrightDecorationConfiguration = projectInfo.getCopyrightDecorationConfiguration();
+      copyrightDecoration.text = copyrightDecorationConfiguration["text"];
+      copyrightDecoration.color = copyrightDecorationConfiguration["color"];
+      copyrightDecoration.style = copyrightDecorationConfiguration["hasOutline"] === true ? Text.Outline : Text.Normal;
+      copyrightDecoration.styleColor = copyrightDecorationConfiguration["outlineColor"];
+      copyrightDecorationBackground.color = copyrightDecorationConfiguration["backgroundColor"];
 
       recentProjectListModel.reloadModel()
 


### PR DESCRIPTION
Quiet weekend means a surprise enhancement :wink:

This PR implements basic support for tile and copyright decoration handling (provided those have been enabled in the QGIS project file).

In action:

[Screencast from 2024-02-20 10-15-12.webm](https://github.com/opengisch/QField/assets/1728657/5d9444c0-23ef-4419-af28-29a27c01b131)
