### PR TITLE
Improve cloud project download/synchronization feedback

### DIFF
--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -1879,8 +1879,6 @@ void QFieldCloudProjectsModel::downloadFileConnections( const QString &projectId
         }
 
         project->errorStatus = NoErrorStatus;
-        project->packagingStatus = PackagingFinishedStatus;
-        project->packagingStatusString = QString();
         project->checkout = ProjectCheckout::LocalAndRemoteCheckout;
         project->localPath = QFieldCloudUtils::localProjectFilePath( mUsername, projectId );
         project->lastLocalExportedAt = QDateTime::currentDateTimeUtc().toString( Qt::ISODate );

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -478,7 +478,7 @@ void QFieldCloudProjectsModel::projectCancelDownload( const QString &projectId )
   project->packagingStatusString = tr( "aborted" );
   project->status = ProjectStatus::Idle;
 
-  emit dataChanged( projectIndex, projectIndex, QVector<int>() << StatusRole << ErrorStatusRole << PackagingErrorStatus );
+  emit dataChanged( projectIndex, projectIndex, QVector<int>() << StatusRole << ErrorStatusRole << PackagingStatusRole );
 }
 
 void QFieldCloudProjectsModel::projectRefreshData( const QString &projectId, const ProjectRefreshReason &refreshReason )
@@ -769,6 +769,8 @@ void QFieldCloudProjectsModel::projectPackageAndDownload( const QString &project
     {
       QgsLogger::debug( QStringLiteral( "Project %1: repackaging triggered." ).arg( projectId ) );
 
+      project->packagingStatus = PackagingBusyStatus;
+      emit dataChanged( projectIndex, projectIndex, QVector<int>() << PackagingStatusRole );
       projectStartJob( projectId, JobType::Package );
 
       QObject *tempProjectJobFinishedParent = new QObject( this ); // we need this to unsubscribe
@@ -809,11 +811,19 @@ void QFieldCloudProjectsModel::projectPackageAndDownload( const QString &project
 
           project->jobs.take( jobType );
 
+          project->packagingStatus = PackagingErrorStatus;
+          project->packagingStatusString = errorString;
+          emit dataChanged( projectIndex, projectIndex, QVector<int>() << PackagingStatusRole );
+
           emit projectDownloadFinished( projectId, tr( "Packaging job finished unsuccessfully for `%1`. %2" )
                                                      .arg( project->name )
                                                      .arg( errorString ) );
           return;
         }
+
+        project->packagingStatus = PackagingFinishedStatus;
+        project->packagingStatusString = QString();
+        emit dataChanged( projectIndex, projectIndex, QVector<int>() << PackagingStatusRole );
 
         projectDownload( projectId );
       } );
@@ -915,16 +925,11 @@ void QFieldCloudProjectsModel::projectPackageAndDownload( const QString &project
     if ( hasError )
     {
       project->errorStatus = DownloadErrorStatus;
-      project->packagingStatus = PackagingErrorStatus;
-      project->packagingStatusString = errorString;
-
-      QgsMessageLog::logMessage( QStringLiteral( "Downloading project `%1` finished with an error: %2" ).arg( projectId ).arg( project->packagingStatusString ) );
+      QgsMessageLog::logMessage( QStringLiteral( "Downloading project `%1` finished with an error: %2" ).arg( projectId ).arg( errorString ) );
     }
     else
     {
       project->errorStatus = NoErrorStatus;
-      project->packagingStatus = PackagingFinishedStatus;
-      project->packagingStatusString = QString();
     }
 
     project->status = ProjectStatus::Idle;

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -1751,12 +1751,10 @@ void QFieldCloudProjectsModel::downloadFileConnections( const QString &projectId
 
     Q_UNUSED( bytesTotal )
 
-    // it means the NetworkReply has failed and retried
     project->downloadBytesReceived -= project->downloadFileTransfers[fileName].bytesTransferred;
     project->downloadBytesReceived += bytesReceived;
     project->downloadFileTransfers[fileName].bytesTransferred = bytesReceived;
     project->downloadProgress = std::clamp( ( static_cast<double>( project->downloadBytesReceived ) / std::max( project->downloadBytesTotal, 1 ) ), 0., 1. );
-
     emit dataChanged( projectIndex, projectIndex, QVector<int>() << DownloadProgressRole );
   } );
 
@@ -1795,6 +1793,11 @@ void QFieldCloudProjectsModel::downloadFileConnections( const QString &projectId
 
     if ( !hasError )
     {
+      project->downloadBytesReceived -= project->downloadFileTransfers[fileName].bytesTransferred;
+      project->downloadBytesReceived += project->downloadFileTransfers[fileName].bytesTotal;
+      project->downloadProgress = std::clamp( ( static_cast<double>( project->downloadBytesReceived ) / std::max( project->downloadBytesTotal, 1 ) ), 0., 1. );
+      emit dataChanged( projectIndex, projectIndex, QVector<int>() << DownloadProgressRole );
+
       QFile file( project->downloadFileTransfers[fileName].tmpFile );
 
       if ( file.open( QIODevice::ReadWrite ) )

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -1032,6 +1032,8 @@ void QFieldCloudProjectsModel::projectDownload( const QString &projectId )
       project->downloadBytesTotal += std::max( fileSize, 0 );
     }
 
+    emit dataChanged( projectIndex, projectIndex, QVector<int>() << DownloadSizeRole );
+
     const QJsonObject layers = payload.value( QStringLiteral( "layers" ) ).toObject();
     bool hasLayerExportErrror = false;
     for ( const QString &layerKey : layers.keys() )
@@ -1923,6 +1925,7 @@ QHash<int, QByteArray> QFieldCloudProjectsModel::roleNames() const
   roles[ProjectFileOutdatedRole] = "ProjectFileOutdated";
   roles[ErrorStatusRole] = "ErrorStatus";
   roles[ErrorStringRole] = "ErrorString";
+  roles[DownloadSizeRole] = "DownloadSize";
   roles[DownloadProgressRole] = "DownloadProgress";
   roles[PackagingStatusRole] = "PackagingStatus";
   roles[PackagedLayerErrorsRole] = "PackagedLayerErrors";
@@ -2107,6 +2110,8 @@ QVariant QFieldCloudProjectsModel::data( const QModelIndex &index, int role ) co
       return mProjects.at( index.row() )->packagingStatus;
     case PackagedLayerErrorsRole:
       return QVariant( mProjects.at( index.row() )->packagedLayerErrors );
+    case DownloadSizeRole:
+      return mProjects.at( index.row() )->downloadBytesTotal;
     case DownloadProgressRole:
       return mProjects.at( index.row() )->downloadProgress;
     case UploadDeltaProgressRole:

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -54,6 +54,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
       ErrorStatusRole,
       ErrorStringRole,
       DownloadProgressRole,
+      DownloadSizeRole,
       PackagingStatusRole,
       PackagedLayerErrorsRole,
       UploadDeltaProgressRole,

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -190,7 +190,7 @@ Popup {
           text: switch(cloudProjectsModel.currentProjectData.Status ) {
                   case QFieldCloudProjectsModel.Downloading:
                     if (cloudProjectsModel.currentProjectData.PackagingStatus === QFieldCloudProjectsModel.PackagingBusyStatus) {
-                      return qsTr('QFieldCloud is preparing the latest data just for you; this might take some time, please hold tight')
+                      return qsTr('QFieldCloud is packaging the latest data just for you; this might take some time, please hold tight')
                     } else {
                       if (cloudProjectsModel.currentProjectData.PackagingStatus === QFieldCloudProjectsModel.PackagingFinishedStatus
                           || cloudProjectsModel.currentProjectData.DownloadProgress > 0.0) {
@@ -206,7 +206,7 @@ Popup {
                   case QFieldCloudProjectsModel.Uploading:
                     switch ( cloudProjectsModel.currentProjectData.UploadDeltaStatus ) {
                       case QFieldCloudProjectsModel.DeltaFileLocalStatus:
-                        return qsTr('Uploading %1%…').arg( parseInt(cloudProjectsModel.currentProjectData.UploadDeltaProgress * 100) );
+                        return qsTr('Uploading %1%…').arg( Math.round(cloudProjectsModel.currentProjectData.UploadDeltaProgress * 100 ) );
                       default:
                         return qsTr('QFieldCloud is applying the latest uploaded changes. This might take some time, please hold tight…')
                     }

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -189,11 +189,15 @@ Popup {
           color: Theme.secondaryTextColor
           text: switch(cloudProjectsModel.currentProjectData.Status ) {
                   case QFieldCloudProjectsModel.Downloading:
-                    switch ( cloudProjectsModel.currentProjectData.PackagingStatus ) {
-                      case QFieldCloudProjectsModel.PackagingFinishedStatus || cloudProjectsModel.currentProjectData.DownloadProgress > 0.0:
-                        return qsTr('Downloading %1%…').arg( parseInt(cloudProjectsModel.currentProjectData.DownloadProgress * 100) )
-                      default:
-                        return qsTr('QFieldCloud is preparing the latest data just for you. This might take some time, please hold tight…')
+                    if (cloudProjectsModel.currentProjectData.PackagingStatus === QFieldCloudProjectsModel.PackagingBusyStatus) {
+                      return qsTr('QFieldCloud is preparing the latest data just for you; this might take some time, please hold tight')
+                    } else {
+                      if (cloudProjectsModel.currentProjectData.PackagingStatus === QFieldCloudProjectsModel.PackagingFinishedStatus
+                          || cloudProjectsModel.currentProjectData.DownloadProgress > 0.0) {
+                        return qsTr( 'Downloading, %1% fetched' ).arg( Math.round(cloudProjectsModel.currentProjectData.DownloadProgress * 100) )
+                      } else {
+                        return qsTr( 'Reaching out to QFieldCloud to download project' )
+                      }
                     }
                   case QFieldCloudProjectsModel.Uploading:
                     switch ( cloudProjectsModel.currentProjectData.UploadDeltaStatus ) {
@@ -215,8 +219,8 @@ Popup {
           id: cloudAnimation
           Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
           Layout.margins: 10
-          width: 64
-          height: 64
+          width: 128
+          height: 128
           color: 'transparent'
           visible: cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Downloading ||
                    cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Uploading
@@ -229,7 +233,7 @@ Popup {
             source: switch(cloudProjectsModel.currentProjectData.Status ) {
                     case QFieldCloudProjectsModel.Downloading:
                       switch ( cloudProjectsModel.currentProjectData.PackagingStatus ) {
-                        case QFieldCloudProjectsModel.PackagingFinishedStatus:
+                        case QFieldCloudProjectsModel.PackagingFinishedStatus || cloudProjectsModel.currentProjectData.DownloadProgress > 0.0:
                           return Theme.getThemeVectorIcon('ic_cloud_download_24dp');
                         default:
                           return Theme.getThemeVectorIcon('ic_cloud_active_24dp');
@@ -265,6 +269,16 @@ Popup {
               running: cloudAnimation.visible
               loops: Animation.Infinite
             }
+          }
+
+          ProgressBar {
+            anchors.bottom: parent.bottom
+            anchors.horizontalCenter: parent.horizontalCenter
+            width: parent.width
+            height: 6
+            indeterminate: cloudProjectsModel.currentProjectData.PackagingStatus !== QFieldCloudProjectsModel.PackagingFinishedStatus && cloudProjectsModel.currentProjectData.DownloadProgress === 0.0
+            value: cloudProjectsModel.currentProjectData.DownloadProgress ? cloudProjectsModel.currentProjectData.DownloadProgress : 0
+            visible: cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.ProjectStatus.Downloading
           }
         }
 

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -190,7 +190,7 @@ Popup {
           text: switch(cloudProjectsModel.currentProjectData.Status ) {
                   case QFieldCloudProjectsModel.Downloading:
                     switch ( cloudProjectsModel.currentProjectData.PackagingStatus ) {
-                      case QFieldCloudProjectsModel.PackagingFinishedStatus:
+                      case QFieldCloudProjectsModel.PackagingFinishedStatus || cloudProjectsModel.currentProjectData.DownloadProgress > 0.0:
                         return qsTr('Downloading %1%…').arg( parseInt(cloudProjectsModel.currentProjectData.DownloadProgress * 100) )
                       default:
                         return qsTr('QFieldCloud is preparing the latest data just for you. This might take some time, please hold tight…')

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -194,7 +194,11 @@ Popup {
                     } else {
                       if (cloudProjectsModel.currentProjectData.PackagingStatus === QFieldCloudProjectsModel.PackagingFinishedStatus
                           || cloudProjectsModel.currentProjectData.DownloadProgress > 0.0) {
-                        return qsTr( 'Downloading, %1% fetched' ).arg( Math.round(cloudProjectsModel.currentProjectData.DownloadProgress * 100) )
+                        if (cloudProjectsModel.currentProjectData.DownloadSize > 0) {
+                          return qsTr( 'Downloading, %1% of %2 fetched' ).arg( Math.round(cloudProjectsModel.currentProjectData.DownloadProgress * 100 ) ).arg( FileUtils.representFileSize( cloudProjectsModel.currentProjectData.DownloadSize ) )
+                        } else {
+                          return qsTr( 'Downloading, %1% fetched' ).arg( Math.round(cloudProjectsModel.currentProjectData.DownloadProgress * 100 ) )
+                        }
                       } else {
                         return qsTr( 'Reaching out to QFieldCloud to download project' )
                       }
@@ -212,7 +216,10 @@ Popup {
           wrapMode: Text.WordWrap
           horizontalAlignment: Text.AlignHCenter
           Layout.fillWidth: true
-          Layout.margins: 10
+          Layout.leftMargin: 10
+          Layout.rightMargin: 10
+          Layout.topMargin: 60
+          Layout.bottomMargin: 20
         }
 
         Rectangle {

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -340,6 +340,8 @@ Page {
                             id: projectNote
                             leftPadding: 3
                             text: {
+                              return 'PackagingStatus: ' + PackagingStatus + ', DownloadProgress: ' + DownloadProgress + ', Status: ' + Status;
+
                               if ( cloudConnection.status !== QFieldCloudConnection.LoggedIn ) {
                                 return qsTr( '(Available locally)' )
                               } else {

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -270,7 +270,7 @@ Page {
                     anchors.leftMargin: line.leftPadding
                     width: line.width - 20
                     height: 6
-                    indeterminate: PackagingStatus !== QFieldCloudProjectsModel.PackagingFinishedStatus
+                    indeterminate: DownloadProgress === 0
                     value: DownloadProgress
                     visible: Status === QFieldCloudProjectsModel.ProjectStatus.Downloading
                     z: 1
@@ -340,8 +340,6 @@ Page {
                             id: projectNote
                             leftPadding: 3
                             text: {
-                              return 'PackagingStatus: ' + PackagingStatus + ', DownloadProgress: ' + DownloadProgress + ', Status: ' + Status;
-
                               if ( cloudConnection.status !== QFieldCloudConnection.LoggedIn ) {
                                 return qsTr( '(Available locally)' )
                               } else {
@@ -352,13 +350,14 @@ Page {
                                   case QFieldCloudProjectsModel.ProjectStatus.Idle:
                                     break
                                   case QFieldCloudProjectsModel.ProjectStatus.Downloading:
-                                    switch (PackagingStatus) {
-                                      case QFieldCloudProjectsModel.PackagingFinishedStatus:
-                                        status = qsTr( 'Downloading, %1% fetched…' ).arg( Math.round(DownloadProgress * 100) )
-                                        break;
-                                      default:
-                                        status = qsTr('QFieldCloud is preparing the latest data just for you. This might take some time, please hold tight…')
-                                        break;
+                                    if (PackagingStatus === QFieldCloudProjectsModel.PackagingFinishedStatus) {
+                                      status = qsTr('QFieldCloud is preparing the latest data just for you; this might take some time, please hold tight')
+                                    } else {
+                                      if (DownloadProgress > 0.0) {
+                                        status = qsTr( 'Downloading, %1% fetched' ).arg( Math.round(DownloadProgress * 100) )
+                                      } else {
+                                        status = qsTr( 'Reaching out to QFieldCloud to download project' )
+                                      }
                                     }
                                     break
                                   case QFieldCloudProjectsModel.ProjectStatus.Uploading:

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -265,7 +265,7 @@ Page {
 
                 ProgressBar {
                     anchors.bottom: line.bottom
-                    anchors.bottomMargin: -4
+                    anchors.bottomMargin: -6
                     anchors.left: line.left
                     anchors.leftMargin: line.leftPadding
                     width: line.width - 20
@@ -354,7 +354,11 @@ Page {
                                       status = qsTr('QFieldCloud is preparing the latest data just for you; this might take some time, please hold tight')
                                     } else {
                                       if (PackagingStatus === QFieldCloudProjectsModel.PackagingFinishedStatus || DownloadProgress > 0.0) {
-                                        status = qsTr( 'Downloading, %1% fetched' ).arg( Math.round(DownloadProgress * 100) )
+                                        if (DownloadSize > 0) {
+                                          status = qsTr( 'Downloading, %1% of %2 fetched' ).arg( Math.round(DownloadProgress * 100) ).arg( FileUtils.representFileSize( DownloadSize ) )
+                                        } else {
+                                          status = qsTr( 'Downloading, %1% fetched' ).arg( Math.round(DownloadProgress * 100) )
+                                        }
                                       } else {
                                         status = qsTr( 'Reaching out to QFieldCloud to download project' )
                                       }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -351,7 +351,7 @@ Page {
                                     break
                                   case QFieldCloudProjectsModel.ProjectStatus.Downloading:
                                     if (PackagingStatus === QFieldCloudProjectsModel.PackagingBusyStatus) {
-                                      status = qsTr('QFieldCloud is preparing the latest data just for you; this might take some time, please hold tight')
+                                      status = qsTr('QFieldCloud is packaging the latest data just for you; this might take some time, please hold tight')
                                     } else {
                                       if (PackagingStatus === QFieldCloudProjectsModel.PackagingFinishedStatus || DownloadProgress > 0.0) {
                                         if (DownloadSize > 0) {

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -270,7 +270,7 @@ Page {
                     anchors.leftMargin: line.leftPadding
                     width: line.width - 20
                     height: 6
-                    indeterminate: DownloadProgress === 0
+                    indeterminate: PackagingStatus !== QFieldCloudProjectsModel.PackagingFinishedStatus && DownloadProgress === 0.0
                     value: DownloadProgress
                     visible: Status === QFieldCloudProjectsModel.ProjectStatus.Downloading
                     z: 1
@@ -350,10 +350,10 @@ Page {
                                   case QFieldCloudProjectsModel.ProjectStatus.Idle:
                                     break
                                   case QFieldCloudProjectsModel.ProjectStatus.Downloading:
-                                    if (PackagingStatus === QFieldCloudProjectsModel.PackagingFinishedStatus) {
+                                    if (PackagingStatus === QFieldCloudProjectsModel.PackagingBusyStatus) {
                                       status = qsTr('QFieldCloud is preparing the latest data just for you; this might take some time, please hold tight')
                                     } else {
-                                      if (DownloadProgress > 0.0) {
+                                      if (PackagingStatus === QFieldCloudProjectsModel.PackagingFinishedStatus || DownloadProgress > 0.0) {
                                         status = qsTr( 'Downloading, %1% fetched' ).arg( Math.round(DownloadProgress * 100) )
                                       } else {
                                         status = qsTr( 'Reaching out to QFieldCloud to download project' )


### PR DESCRIPTION
This PR improves the cloud project download/synchronization UX  by providing better feedback to users, including:
- Having a functional progress bar reflecting download % in the cloud projects list (until now, it was always indefinite)
- Adding a progress bar in the cloud project popup when hitting synchronize
- Making a better job at differentiating packaging job waiting vs. initial communication to server vs. download (on the projects list, due to a broken logic, it could be stuck never reaching the download % feedback)
- Adding total download size detail (e.g., Downloading, fetched %10 of 200MB).

In action:

[Screencast from 2024-02-23 16-24-11.webm](https://github.com/opengisch/QField/assets/1728657/45ee1fd9-7dea-4b9c-be27-8893c86a8134)

[Screencast from 2024-02-23 16-53-46.webm](https://github.com/opengisch/QField/assets/1728657/ee7720b1-d557-46d7-a3e3-8e9746c9e296)

With these in, when access to the cloud server is slower are likely to find the wait more tolerable, and at least will not have the impression that QField is "frozen".