### PR TITLE
Cloud projects where a given user role isn't originating from 'public' should be in My Projects tab

### DIFF
--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -65,6 +65,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
       LastLocalExportedAtRole,
       LastLocalPushDeltasRole,
       UserRoleRole,
+      UserRoleOriginRole,
       DeltaListRole,
     };
 
@@ -356,6 +357,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
           const QString &name,
           const QString &description,
           const QString &userRole,
+          const QString &userRoleOrigin,
           const ProjectCheckouts &checkout,
           const ProjectStatus &status,
           const QDateTime &dataLastUpdatedAt,
@@ -367,6 +369,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
           , name( name )
           , description( description )
           , userRole( userRole )
+          , userRoleOrigin( userRoleOrigin )
           , checkout( checkout )
           , status( status )
           , dataLastUpdatedAt( dataLastUpdatedAt )
@@ -383,6 +386,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
         QString name;
         QString description;
         QString userRole;
+        QString userRoleOrigin;
         ProjectErrorStatus errorStatus = ProjectErrorStatus::NoErrorStatus;
         ProjectCheckouts checkout;
         ProjectStatus status;


### PR DESCRIPTION
This fixes situations where projects made public are not appearing in the "My Projects" tab even though they should when the user role origin is *not* 'public' (i.e. owner, collaborator, team_member).

This made it virtually impossible to find your own collaborating projects as soon as they were made public as on QField it'd mean opening the community tab, which triggers a loooong projects fetch.