### PR TITLE
Update QGIS to 3.36.0 final (+fix windows build following runner image update)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,6 +35,9 @@ jobs:
 
       - name: 🧽 Developer Command Prompt for Microsoft Visual C++
         uses: ilammy/msvc-dev-cmd@v1
+        with:
+          # See https://github.com/actions/runner-images/issues/9398
+          toolset: 14.39
 
       - name: 🔨 Prepare build env
         shell: bash

--- a/cmake/qgis-cmake-wrapper.cmake
+++ b/cmake/qgis-cmake-wrapper.cmake
@@ -63,10 +63,6 @@ endfunction()
 #  set(CMAKE_USE_PTHREADS_INIT 1)
 #endif()
 
-if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
-  target_compile_definitions(QGIS::Core INTERFACE QT_NO_PRINTER=1)
-endif()
-
 if(TRUE) # Should possibly have a "static only" check
   find_package(PkgConfig QUIET)
 

--- a/vcpkg/ports/qgis-qt6/portfile.cmake
+++ b/vcpkg/ports/qgis-qt6/portfile.cmake
@@ -1,5 +1,5 @@
-set(QGIS_REF ef1d7a1104e5d574e3ba4949feab2a350e1c4d2e)
-set(QGIS_SHA512 fa70b54d0e319333dd0576798adf74c107969ff93a6658d34af16d169933fcce74e55ea1bade9f52fe3ad541b5b57372b608d2212e2ba455f200803fdbe53420)
+set(QGIS_REF final-3_36_0)
+set(QGIS_SHA512 9617d049bd41a58d179fdccff0576727e03dba84bfe23c233f98ffa621575d80c772200f82aa0d75c6ad9e7d7f7d4d4ef4182a03cd6f58a6970307bd2aeb1d93)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -15,6 +15,7 @@ vcpkg_from_github(
         bigobj.patch
         mesh.patch
         wrongattributeerrormessage.patch
+        sts.patch # Obsolete in QGIS >= 3.36.1
 )
 
 file(REMOVE ${SOURCE_PATH}/cmake/FindGDAL.cmake)
@@ -28,6 +29,7 @@ vcpkg_find_acquire_program(BISON)
 
 list(APPEND QGIS_OPTIONS "-DENABLE_TESTS:BOOL=OFF")
 list(APPEND QGIS_OPTIONS "-DWITH_QTWEBKIT:BOOL=OFF")
+list(APPEND QGIS_OPTIONS "-DWITH_QTPRINTER:BOOL=OFF")
 list(APPEND QGIS_OPTIONS "-DWITH_GRASS7:BOOL=OFF")
 list(APPEND QGIS_OPTIONS "-DWITH_SPATIALITE:BOOL=ON")
 list(APPEND QGIS_OPTIONS "-DWITH_QSPATIALITE:BOOL=OFF")

--- a/vcpkg/ports/qgis-qt6/sts.patch
+++ b/vcpkg/ports/qgis-qt6/sts.patch
@@ -1,0 +1,23 @@
+From f6e8c7bf6986c8f92b006a674cf671a22bf0784e Mon Sep 17 00:00:00 2001
+From: Mathieu Pellerin <nirvn.asia@gmail.com>
+Date: Sat, 24 Feb 2024 17:23:01 +0700
+Subject: [PATCH] [network] Enable strict transport security to fix http->https
+ WMS (et al) data sources
+
+---
+ src/core/network/qgsnetworkaccessmanager.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/core/network/qgsnetworkaccessmanager.cpp b/src/core/network/qgsnetworkaccessmanager.cpp
+index 0833680c2e32..022cd2363fd0 100644
+--- a/src/core/network/qgsnetworkaccessmanager.cpp
++++ b/src/core/network/qgsnetworkaccessmanager.cpp
+@@ -216,6 +216,8 @@ QgsNetworkAccessManager::QgsNetworkAccessManager( QObject *parent )
+ {
+   setProxyFactory( new QgsNetworkProxyFactory() );
+   setCookieJar( new QgsNetworkCookieJar( this ) );
++  enableStrictTransportSecurityStore( true );
++  setStrictTransportSecurityEnabled( true );
+ }
+ 
+ void QgsNetworkAccessManager::setSslErrorHandler( std::unique_ptr<QgsSslErrorHandler> handler )


### PR DESCRIPTION
Windows builds are broken with the following error:

```
FAILED: output/bin/qfield_spix.exe 
C:\Windows\system32\cmd.exe /C "cd . && D:\a\_temp\390076282\cmake-3.28.3-windows-x86_64\bin\cmake.exe -E vs_link_exe --intdir=src\app\CMakeFiles\qfield_spix.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\Llvm\x64\bin\lld-link.exe /nologo @CMakeFiles\qfield_spix.rsp  /out:output\bin\qfield_spix.exe /implib:src\app\qfield_spix.lib /pdb:output\bin\qfield_spix.pdb /version:0.0 /machine:x64 /INCREMENTAL:NO /subsystem:console  /DEBUG /OPT:REF /OPT:ICF  && C:\Windows\system32\cmd.exe /C "cd /D C:\builddir\src\app && "C:\Program Files\PowerShell\7\pwsh.exe" -noprofile -executionpolicy Bypass -file C:/builddir/_deps/vcpkg-src/scripts/buildsystems/msbuild/applocal.ps1 -targetBinary C:/builddir/output/bin/qfield_spix.exe -installedDir C:/builddir/vcpkg_installed/x64-windows-static/bin -OutVariable out""
LINK: command "C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\Llvm\x64\bin\lld-link.exe /nologo @CMakeFiles\qfield_spix.rsp /out:output\bin\qfield_spix.exe /implib:src\app\qfield_spix.lib /pdb:output\bin\qfield_spix.pdb /version:0.0 /machine:x64 /INCREMENTAL:NO /subsystem:console /DEBUG /OPT:REF /OPT:ICF /MANIFEST:EMBED,ID=1" failed (exit code 1) with the following output:
lld-link: error: undefined symbol: _Thrd_sleep_for
>>> referenced by C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.39.33519\include\thread:215
>>>               exiv2.lib(http.cpp.obj):($LN184)
```

Let's see if this will fix it.