### PR TITLE
Enable background pushing of changes to the cloud as well as automated auto-push

### DIFF
--- a/src/core/deltafilewrapper.cpp
+++ b/src/core/deltafilewrapper.cpp
@@ -942,6 +942,24 @@ void DeltaFileWrapper::mergeDelta( const QJsonObject &delta )
   }
 }
 
+void DeltaFileWrapper::setIsPushing( bool isPushing )
+{
+  if ( mIsPushing == isPushing )
+    return;
+
+  mIsPushing = isPushing;
+  emit isPushingChanged();
+
+  if ( !mIsPushing && !mPendingDeltas.isEmpty() )
+  {
+    for ( const QJsonObject delta : std::as_const( mPendingDeltas ) )
+    {
+      mergeDelta( delta );
+    }
+    mPendingDeltas.clear();
+  }
+}
+
 QJsonValue DeltaFileWrapper::geometryToJsonValue( const QgsGeometry &geom ) const
 {
   if ( geom.isNull() )

--- a/src/core/deltafilewrapper.cpp
+++ b/src/core/deltafilewrapper.cpp
@@ -795,6 +795,8 @@ void DeltaFileWrapper::appendDelta( const QJsonObject &delta )
 
 void DeltaFileWrapper::mergeCreateDelta( const QJsonObject &delta )
 {
+  Q_ASSERT( delta.value( QStringLiteral( "method" ) ) == "create" );
+
   const QString localPk = delta.value( QStringLiteral( "localPk" ) ).toString();
   const QString localLayerId = delta.value( QStringLiteral( "localLayerId" ) ).toString();
   mLocalPkDeltaIdx[localLayerId][localPk] = static_cast<int>( mDeltas.count() );
@@ -808,6 +810,8 @@ void DeltaFileWrapper::mergeCreateDelta( const QJsonObject &delta )
 
 void DeltaFileWrapper::mergeDeleteDelta( const QJsonObject &delta )
 {
+  Q_ASSERT( delta.value( QStringLiteral( "method" ) ) == "delete" );
+
   const QString localLayerId = delta.value( QStringLiteral( "localLayerId" ) ).toString();
   QMap<QString, int> layerPkDeltaIdx = mLocalPkDeltaIdx.value( localLayerId );
   QString localPk = delta.value( QStringLiteral( "localPk" ) ).toString();
@@ -828,6 +832,8 @@ void DeltaFileWrapper::mergeDeleteDelta( const QJsonObject &delta )
 
 void DeltaFileWrapper::mergePatchDelta( const QJsonObject &delta )
 {
+  Q_ASSERT( delta.value( QStringLiteral( "method" ) ) == "patch" );
+
   QJsonObject oldData = delta.value( QStringLiteral( "old" ) ).toObject();
   QJsonObject newData = delta.value( QStringLiteral( "new" ) ).toObject();
 

--- a/src/core/deltafilewrapper.cpp
+++ b/src/core/deltafilewrapper.cpp
@@ -783,7 +783,168 @@ void DeltaFileWrapper::addCreate( const QString &localLayerId, const QString &so
 
 void DeltaFileWrapper::appendDelta( const QJsonObject &delta )
 {
-  mergeDelta( delta );
+  if ( mIsPushing )
+  {
+    mPendingDeltas << delta;
+  }
+  else
+  {
+    mergeDelta( delta );
+  }
+}
+
+void DeltaFileWrapper::mergeCreateDelta( const QJsonObject &delta )
+{
+  const QString localPk = delta.value( QStringLiteral( "localPk" ) ).toString();
+  const QString localLayerId = delta.value( QStringLiteral( "localLayerId" ) ).toString();
+  mLocalPkDeltaIdx[localLayerId][localPk] = static_cast<int>( mDeltas.count() );
+
+  mDeltas.append( delta );
+  mIsDirty = true;
+
+  qInfo() << "DeltaFileWrapper::addCreate: Added a new create delta: " << delta;
+  emit countChanged();
+}
+
+void DeltaFileWrapper::mergeDeleteDelta( const QJsonObject &delta )
+{
+  const QString localLayerId = delta.value( QStringLiteral( "localLayerId" ) ).toString();
+  QMap<QString, int> layerPkDeltaIdx = mLocalPkDeltaIdx.value( localLayerId );
+  QString localPk = delta.value( QStringLiteral( "localPk" ) ).toString();
+  if ( layerPkDeltaIdx.contains( localPk ) )
+  {
+    // Feature creation/deletion occured in the same delta session, just remove as if nothing had ever occured
+    mDeltas.removeAt( layerPkDeltaIdx.take( localPk ) );
+    emit countChanged();
+    return;
+  }
+
+  mDeltas.append( delta );
+  mIsDirty = true;
+
+  qInfo() << "DeltaFileWrapper::addDelete: Added a new delete delta: " << delta;
+  emit countChanged();
+}
+
+void DeltaFileWrapper::mergePatchDelta( const QJsonObject &delta )
+{
+  QJsonObject oldData = delta.value( QStringLiteral( "old" ) ).toObject();
+  QJsonObject newData = delta.value( QStringLiteral( "new" ) ).toObject();
+
+  QJsonObject tmpOldAttrs;
+  if ( oldData.contains( QStringLiteral( "attributes" ) ) )
+  {
+    tmpOldAttrs = oldData.value( QStringLiteral( "attributes" ) ).toObject();
+  }
+
+  QString newGeomString;
+  QJsonObject tmpNewAttrs;
+  if ( newData.contains( QStringLiteral( "geometry" ) ) )
+  {
+    newGeomString = oldData.value( QStringLiteral( "geometry" ) ).toString();
+  }
+  if ( newData.contains( QStringLiteral( "attributes" ) ) )
+  {
+    tmpNewAttrs = newData.value( QStringLiteral( "attributes" ) ).toObject();
+  }
+
+  mIsDirty = true;
+
+  const QString localPk = delta.value( QStringLiteral( "localPk" ) ).toString();
+  const QString localLayerId = delta.value( QStringLiteral( "localLayerId" ) ).toString();
+  QMap<QString, int> layerPkDeltaIdx = mLocalPkDeltaIdx.value( localLayerId );
+
+  qInfo() << "DeltaFileWrapper::addPatch: localPk=" << localPk << " layerPkDeltaIdx=" << layerPkDeltaIdx;
+
+  if ( layerPkDeltaIdx.contains( localPk ) )
+  {
+    int deltaIdx = layerPkDeltaIdx.take( localPk );
+    QJsonObject deltaCreate = mDeltas.at( deltaIdx ).toObject();
+
+    Q_ASSERT( deltaCreate.value( QStringLiteral( "method" ) ).toString() == QStringLiteral( "create" ) );
+
+    QJsonObject newCreate = deltaCreate.value( QStringLiteral( "new" ) ).toObject();
+    QJsonObject attributesCreate = newCreate.value( QStringLiteral( "attributes" ) ).toObject();
+
+    qInfo() << "DeltaFileWrapper::addPatch: replacing an existing create delta: " << deltaCreate << "at" << deltaIdx;
+
+    if ( !newData.value( QStringLiteral( "geometry" ) ).isUndefined() )
+    {
+      newCreate.insert( QStringLiteral( "geometry" ), newData.value( QStringLiteral( "geometry" ) ) );
+    }
+
+    const QStringList attributeNames = tmpNewAttrs.keys();
+    for ( const QString &attributeName : attributeNames )
+    {
+      attributesCreate.insert( attributeName, tmpNewAttrs.value( attributeName ) );
+    }
+
+    newCreate.insert( QStringLiteral( "attributes" ), newGeomString );
+    newCreate.insert( QStringLiteral( "attributes" ), attributesCreate );
+    deltaCreate.insert( QStringLiteral( "new" ), newCreate );
+    deltaCreate.insert( QStringLiteral( "sourcePk" ), delta.value( QStringLiteral( "sourcePk" ) ) );
+
+    mDeltas.replace( deltaIdx, deltaCreate );
+
+    qInfo() << "DeltaFileWrapper::addPatch: replaced an existing create delta: " << deltaCreate;
+
+    return;
+  }
+  else
+  {
+    for ( qsizetype i = mDeltas.size() - 1; i >= 0; i-- )
+    {
+      QJsonObject existingDelta = mDeltas[i].toObject();
+      const QString existingLayerId = existingDelta.value( QStringLiteral( "localLayerId" ) ).toString();
+      const QString existingLocalPk = existingDelta.value( QStringLiteral( "localPk" ) ).toString();
+      const QString existingMethod = existingDelta.value( QStringLiteral( "method" ) ).toString();
+      if ( existingLayerId == localLayerId && existingLocalPk == localPk && existingMethod == "patch" )
+      {
+        QJsonObject existingOldData = existingDelta.value( QStringLiteral( "old" ) ).toObject();
+        QJsonObject existingNewData = existingDelta.value( QStringLiteral( "new" ) ).toObject();
+        if ( newData.contains( "geometry" ) )
+        {
+          existingNewData.insert( "geometry", newData.value( QStringLiteral( "geometry" ) ).toString() );
+          if ( !existingOldData.contains( "geometry" ) )
+          {
+            // Previous patch did not contain a geometry change, add old geometry data
+            existingOldData.insert( "geometry", oldData.value( QStringLiteral( "geometry" ) ) );
+          }
+        }
+        const QStringList attributeNames = tmpNewAttrs.keys();
+        if ( !attributeNames.isEmpty() )
+        {
+          QJsonObject existingOldAttributes = existingOldData.value( QStringLiteral( "attributes" ) ).toObject();
+          QJsonObject existingNewAttributes = existingNewData.value( QStringLiteral( "attributes" ) ).toObject();
+          for ( const QString &attributeName : attributeNames )
+          {
+            existingNewAttributes.insert( attributeName, tmpNewAttrs.value( attributeName ) );
+            if ( !existingOldAttributes.contains( attributeName ) )
+            {
+              // Previous patch did not contain this attribute change, add old attribute value
+              existingOldAttributes.insert( attributeName, tmpOldAttrs.value( attributeName ) );
+            }
+          }
+          existingOldData.insert( "attributes", existingOldAttributes );
+          existingNewData.insert( "attributes", existingNewAttributes );
+        }
+        existingDelta.insert( "old", existingOldData );
+        existingDelta.insert( "new", existingNewData );
+
+        mDeltas.replace( i, existingDelta );
+
+        qInfo() << "DeltaFileWrapper::addPatch: replaced an existing patch delta: " << existingDelta;
+
+        return;
+      }
+    }
+
+    mDeltas.append( delta );
+
+    qInfo() << "DeltaFileWrapper::addPatch: Added a new patch delta: " << delta;
+
+    emit countChanged();
+  }
 }
 
 void DeltaFileWrapper::mergeDelta( const QJsonObject &delta )
@@ -791,154 +952,19 @@ void DeltaFileWrapper::mergeDelta( const QJsonObject &delta )
   const QString deltaMethod = delta.value( "method" ).toString();
   if ( deltaMethod == "create" )
   {
-    const QString localPk = delta.value( QStringLiteral( "localPk" ) ).toString();
-    const QString localLayerId = delta.value( QStringLiteral( "localLayerId" ) ).toString();
-    mLocalPkDeltaIdx[localLayerId][localPk] = static_cast<int>( mDeltas.count() );
-
-    mDeltas.append( delta );
-    mIsDirty = true;
-
-    qInfo() << "DeltaFileWrapper::addCreate: Added a new create delta: " << delta;
-    emit countChanged();
+    mergeCreateDelta( delta );
   }
   else if ( deltaMethod == "delete" )
   {
-    const QString localLayerId = delta.value( QStringLiteral( "localLayerId" ) ).toString();
-    QMap<QString, int> layerPkDeltaIdx = mLocalPkDeltaIdx.value( localLayerId );
-    QString localPk = delta.value( QStringLiteral( "localPk" ) ).toString();
-    if ( layerPkDeltaIdx.contains( localPk ) )
-    {
-      // Feature creation/deletion occured in the same delta session, just remove as if nothing had ever occured
-      mDeltas.removeAt( layerPkDeltaIdx.take( localPk ) );
-      emit countChanged();
-      return;
-    }
-
-    mDeltas.append( delta );
-    mIsDirty = true;
-
-    qInfo() << "DeltaFileWrapper::addDelete: Added a new delete delta: " << delta;
-    emit countChanged();
+    mergeDeleteDelta( delta );
   }
   else if ( deltaMethod == "patch" )
   {
-    QJsonObject oldData = delta.value( QStringLiteral( "old" ) ).toObject();
-    QJsonObject newData = delta.value( QStringLiteral( "new" ) ).toObject();
-
-    QJsonObject tmpOldAttrs;
-    if ( oldData.contains( QStringLiteral( "attributes" ) ) )
-    {
-      tmpOldAttrs = oldData.value( QStringLiteral( "attributes" ) ).toObject();
-    }
-
-    QString newGeomString;
-    QJsonObject tmpNewAttrs;
-    if ( newData.contains( QStringLiteral( "geometry" ) ) )
-    {
-      newGeomString = oldData.value( QStringLiteral( "geometry" ) ).toString();
-    }
-    if ( newData.contains( QStringLiteral( "attributes" ) ) )
-    {
-      tmpNewAttrs = newData.value( QStringLiteral( "attributes" ) ).toObject();
-    }
-
-    mIsDirty = true;
-
-    const QString localPk = delta.value( QStringLiteral( "localPk" ) ).toString();
-    const QString localLayerId = delta.value( QStringLiteral( "localLayerId" ) ).toString();
-    QMap<QString, int> layerPkDeltaIdx = mLocalPkDeltaIdx.value( localLayerId );
-
-    qInfo() << "DeltaFileWrapper::addPatch: localPk=" << localPk << " layerPkDeltaIdx=" << layerPkDeltaIdx;
-
-    if ( layerPkDeltaIdx.contains( localPk ) )
-    {
-      int deltaIdx = layerPkDeltaIdx.take( localPk );
-      QJsonObject deltaCreate = mDeltas.at( deltaIdx ).toObject();
-
-      Q_ASSERT( deltaCreate.value( QStringLiteral( "method" ) ).toString() == QStringLiteral( "create" ) );
-
-      QJsonObject newCreate = deltaCreate.value( QStringLiteral( "new" ) ).toObject();
-      QJsonObject attributesCreate = newCreate.value( QStringLiteral( "attributes" ) ).toObject();
-
-      qInfo() << "DeltaFileWrapper::addPatch: replacing an existing create delta: " << deltaCreate << "at" << deltaIdx;
-
-      if ( !newData.value( QStringLiteral( "geometry" ) ).isUndefined() )
-      {
-        newCreate.insert( QStringLiteral( "geometry" ), newData.value( QStringLiteral( "geometry" ) ) );
-      }
-
-      const QStringList attributeNames = tmpNewAttrs.keys();
-      for ( const QString &attributeName : attributeNames )
-      {
-        attributesCreate.insert( attributeName, tmpNewAttrs.value( attributeName ) );
-      }
-
-      newCreate.insert( QStringLiteral( "attributes" ), newGeomString );
-      newCreate.insert( QStringLiteral( "attributes" ), attributesCreate );
-      deltaCreate.insert( QStringLiteral( "new" ), newCreate );
-      deltaCreate.insert( QStringLiteral( "sourcePk" ), delta.value( QStringLiteral( "sourcePk" ) ) );
-
-      mDeltas.replace( deltaIdx, deltaCreate );
-
-      qInfo() << "DeltaFileWrapper::addPatch: replaced an existing create delta: " << deltaCreate;
-
-      return;
-    }
-    else
-    {
-      for ( qsizetype i = mDeltas.size() - 1; i >= 0; i-- )
-      {
-        QJsonObject existingDelta = mDeltas[i].toObject();
-        const QString existingLayerId = existingDelta.value( QStringLiteral( "localLayerId" ) ).toString();
-        const QString existingLocalPk = existingDelta.value( QStringLiteral( "localPk" ) ).toString();
-        const QString existingMethod = existingDelta.value( QStringLiteral( "method" ) ).toString();
-        if ( existingLayerId == localLayerId && existingLocalPk == localPk && existingMethod == "patch" )
-        {
-          QJsonObject existingOldData = existingDelta.value( QStringLiteral( "old" ) ).toObject();
-          QJsonObject existingNewData = existingDelta.value( QStringLiteral( "new" ) ).toObject();
-          if ( newData.contains( "geometry" ) )
-          {
-            existingNewData.insert( "geometry", newData.value( QStringLiteral( "geometry" ) ).toString() );
-            if ( !existingOldData.contains( "geometry" ) )
-            {
-              // Previous patch did not contain a geometry change, add old geometry data
-              existingOldData.insert( "geometry", oldData.value( QStringLiteral( "geometry" ) ) );
-            }
-          }
-          const QStringList attributeNames = tmpNewAttrs.keys();
-          if ( !attributeNames.isEmpty() )
-          {
-            QJsonObject existingOldAttributes = existingOldData.value( QStringLiteral( "attributes" ) ).toObject();
-            QJsonObject existingNewAttributes = existingNewData.value( QStringLiteral( "attributes" ) ).toObject();
-            for ( const QString &attributeName : attributeNames )
-            {
-              existingNewAttributes.insert( attributeName, tmpNewAttrs.value( attributeName ) );
-              if ( !existingOldAttributes.contains( attributeName ) )
-              {
-                // Previous patch did not contain this attribute change, add old attribute value
-                existingOldAttributes.insert( attributeName, tmpOldAttrs.value( attributeName ) );
-              }
-            }
-            existingOldData.insert( "attributes", existingOldAttributes );
-            existingNewData.insert( "attributes", existingNewAttributes );
-          }
-          existingDelta.insert( "old", existingOldData );
-          existingDelta.insert( "new", existingNewData );
-
-          mDeltas.replace( i, existingDelta );
-
-          qInfo() << "DeltaFileWrapper::addPatch: replaced an existing patch delta: " << existingDelta;
-
-          return;
-        }
-      }
-
-      mDeltas.append( delta );
-
-      qInfo() << "DeltaFileWrapper::addPatch: Added a new patch delta: " << delta;
-
-      emit countChanged();
-    }
+    mergePatchDelta( delta );
+  }
+  else
+  {
+    Q_ASSERT( 0 );
   }
 }
 

--- a/src/core/deltafilewrapper.h
+++ b/src/core/deltafilewrapper.h
@@ -36,6 +36,7 @@ class DeltaFileWrapper : public QObject
     Q_OBJECT
 
     Q_PROPERTY( int count READ count NOTIFY countChanged )
+    Q_PROPERTY( bool isPushing READ isPushing NOTIFY isPushingChanged )
 
   public:
     /**
@@ -321,6 +322,10 @@ class DeltaFileWrapper : public QObject
      */
     Q_INVOKABLE bool applyReversed();
 
+    bool isPushing() const { return mIsPushing; }
+
+    void setIsPushing( bool isPushing );
+
   signals:
     /**
      * Emitted when the `deltas` list has changed.
@@ -328,6 +333,9 @@ class DeltaFileWrapper : public QObject
      * @todo TEST
      */
     void countChanged();
+
+
+    void isPushingChanged();
 
 
     /**
@@ -395,7 +403,7 @@ class DeltaFileWrapper : public QObject
     /**
      * The list of pending JSON deltas.
      */
-    QJsonArray mPendingDeltas;
+    QList<QJsonObject> mPendingDeltas;
 
     /**
      * The root deltas JSON object.
@@ -432,6 +440,8 @@ class DeltaFileWrapper : public QObject
      */
     bool mIsDirty = false;
 
+
+    bool mIsPushing = false;
 
     /**
      * Whether the delta file is currently being applied.

--- a/src/core/deltafilewrapper.h
+++ b/src/core/deltafilewrapper.h
@@ -396,8 +396,22 @@ class DeltaFileWrapper : public QObject
      */
     void mergeDelta( const QJsonObject &delta );
 
+
+    /**
+     * Merge the generated create \a delta into stored deltas. Should only be called from `mergeDelta` method.
+     */
     void mergeCreateDelta( const QJsonObject &delta );
+
+
+    /**
+     * Merge the generated delete \a delta into stored deltas. Should only be called from `mergeDelta` method.
+     */
     void mergeDeleteDelta( const QJsonObject &delta );
+
+
+    /**
+     * Merge the generated patch \a delta into stored deltas. Should only be called from `mergeDelta` method.
+     */
     void mergePatchDelta( const QJsonObject &delta );
 
 

--- a/src/core/deltafilewrapper.h
+++ b/src/core/deltafilewrapper.h
@@ -364,6 +364,19 @@ class DeltaFileWrapper : public QObject
      */
     QJsonValue attributeToJsonValue( const QVariant &value );
 
+
+    /**
+     * Append generated \a delta.
+     */
+    void appendDelta( const QJsonObject &delta );
+
+
+    /**
+     * Merge the generated \a delta into stored deltas.
+     */
+    void mergeDelta( const QJsonObject &delta );
+
+
     /**
      * The current project instance
      */
@@ -379,6 +392,10 @@ class DeltaFileWrapper : public QObject
      */
     QJsonArray mDeltas;
 
+    /**
+     * The list of pending JSON deltas.
+     */
+    QJsonArray mPendingDeltas;
 
     /**
      * The root deltas JSON object.

--- a/src/core/deltafilewrapper.h
+++ b/src/core/deltafilewrapper.h
@@ -322,8 +322,17 @@ class DeltaFileWrapper : public QObject
      */
     Q_INVOKABLE bool applyReversed();
 
+    /**
+     * Returns TRUE if the pushing state is active.
+     */
     bool isPushing() const { return mIsPushing; }
 
+
+    /**
+     * Sets the pushing state.
+     *
+     * @param isPushing set to TRUE to reflect an ongoing pushing state.
+     */
     void setIsPushing( bool isPushing );
 
   signals:
@@ -335,6 +344,9 @@ class DeltaFileWrapper : public QObject
     void countChanged();
 
 
+    /**
+     * Emmitted when the pushing state has changed.
+     */
     void isPushingChanged();
 
 
@@ -383,6 +395,10 @@ class DeltaFileWrapper : public QObject
      * Merge the generated \a delta into stored deltas.
      */
     void mergeDelta( const QJsonObject &delta );
+
+    void mergeCreateDelta( const QJsonObject &delta );
+    void mergeDeleteDelta( const QJsonObject &delta );
+    void mergePatchDelta( const QJsonObject &delta );
 
 
     /**
@@ -441,7 +457,11 @@ class DeltaFileWrapper : public QObject
     bool mIsDirty = false;
 
 
+    /**
+     * Holds whether the pushing state has been activated.
+     */
     bool mIsPushing = false;
+
 
     /**
      * Whether the delta file is currently being applied.

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -1949,7 +1949,7 @@ QHash<int, QByteArray> QFieldCloudProjectsModel::roleNames() const
   roles[UserRoleOriginRole] = "UserRoleOrigin";
   roles[DeltaListRole] = "DeltaList";
   roles[AutoPushEnabledRole] = "AutoPushEnabled";
-  roles[AutoPushDelayRole] = "AutoPushDelay";
+  roles[AutoPushIntervalMinsRole] = "AutoPushIntervalMins";
 
   return roles;
 }
@@ -1960,10 +1960,8 @@ void QFieldCloudProjectsModel::projectSetAutoPushEnabled( const QString &project
 
   if ( projectIndex.isValid() )
   {
-    qDebug() << "IN!";
     CloudProject *project = mProjects[projectIndex.row()];
     project->autoPushEnabled = !project->autoPushEnabled;
-    qDebug() << ( project->autoPushEnabled ? "enabled" : "disabled" );
     QFieldCloudUtils::setProjectSetting( project->id, QStringLiteral( "autoPushEnabled" ), project->autoPushEnabled );
     emit dataChanged( projectIndex, projectIndex, QVector<int>() << AutoPushEnabledRole );
   }
@@ -1987,7 +1985,7 @@ void QFieldCloudProjectsModel::reload( const QJsonArray &remoteProjects )
     cloudProject->isOutdated = cloudProject->dataLastUpdatedAt > cloudProject->lastLocalDataLastUpdatedAt;
     cloudProject->projectFileIsOutdated = QFieldCloudUtils::projectSetting( cloudProject->id, QStringLiteral( "projectFileOudated" ), false ).toBool();
     cloudProject->autoPushEnabled = QFieldCloudUtils::projectSetting( cloudProject->id, QStringLiteral( "autoPushEnabled" ), false ).toBool();
-    cloudProject->autoPushDelay = QFieldCloudUtils::projectSetting( cloudProject->id, QStringLiteral( "autoPushDelay" ), 30 ).toInt();
+    cloudProject->autoPushIntervalMins = QFieldCloudUtils::projectSetting( cloudProject->id, QStringLiteral( "autoPushIntervalMins" ), 30 ).toInt();
 
     // generate local export id if not present. Possible reasons for missing localExportId are:
     // - just upgraded QField that introduced the field
@@ -2165,8 +2163,8 @@ QVariant QFieldCloudProjectsModel::data( const QModelIndex &index, int role ) co
       return QVariant::fromValue<DeltaListModel *>( mProjects.at( index.row() )->deltaListModel );
     case AutoPushEnabledRole:
       return mProjects.at( index.row() )->autoPushEnabled;
-    case AutoPushDelayRole:
-      return mProjects.at( index.row() )->autoPushDelay;
+    case AutoPushIntervalMinsRole:
+      return mProjects.at( index.row() )->autoPushIntervalMins;
   }
 
   return QVariant();

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -69,7 +69,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
       UserRoleOriginRole,
       DeltaListRole,
       AutoPushEnabledRole,
-      AutoPushDelayRole,
+      AutoPushIntervalMinsRole,
     };
 
     Q_ENUM( ColumnRole )
@@ -435,7 +435,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
         QDateTime lastRefreshedAt;
 
         bool autoPushEnabled = false;
-        int autoPushDelay = 30; // in minutes
+        int autoPushIntervalMins = 30;
 
         QMap<JobType, Job> jobs;
     };

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -68,6 +68,8 @@ class QFieldCloudProjectsModel : public QAbstractListModel
       UserRoleRole,
       UserRoleOriginRole,
       DeltaListRole,
+      AutoPushEnabledRole,
+      AutoPushDelayRole,
     };
 
     Q_ENUM( ColumnRole )
@@ -274,6 +276,9 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     //! Cancels ongoing cloud project download with \a projectId.
     Q_INVOKABLE void projectCancelDownload( const QString &projectId );
 
+    //! Toggles the cloud project auto-push enabled state
+    Q_INVOKABLE void projectSetAutoPushEnabled( const QString &projectId, bool enabled );
+
   signals:
     void cloudConnectionChanged();
     void layerObserverChanged();
@@ -290,7 +295,6 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     void projectDownloadFinished( const QString &projectId, const QString &errorString = QString() );
     void deltaListModelChanged();
 
-    //
     void networkDeltaUploaded( const QString &projectId );
     void networkDeltaStatusChecked( const QString &projectId );
     void networkAttachmentsUploaded( const QString &projectId );
@@ -429,6 +433,10 @@ class QFieldCloudProjectsModel : public QAbstractListModel
 
         QDateTime lastLocalDataLastUpdatedAt;
         QDateTime lastRefreshedAt;
+
+        bool autoPushEnabled = false;
+        int autoPushDelay = 30; // in minutes
+
         QMap<JobType, Job> jobs;
     };
 

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -412,6 +412,59 @@ Popup {
             onClicked: projectUpload(false)
           }
 
+          Text {
+            id: pushText
+            font: Theme.tipFont
+            color: Theme.secondaryTextColor
+            visible: !cloudProjectsModel.layerObserver.deltaFileWrapper.hasError()
+            text: qsTr('Save internet bandwidth by only pushing the local features and pictures to the cloud, without updating the whole project.')
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
+            Layout.bottomMargin: 20
+            Layout.fillWidth: true
+          }
+
+          QfButton {
+            id: discardButton
+            Layout.fillWidth: true
+            bgcolor: Theme.darkRed
+            text: !cloudProjectsModel.layerObserver.deltaFileWrapper.hasError()
+                  ? qsTr('Revert local changes')
+                  : qsTr('Reset project')
+            enabled: cloudProjectsModel.layerObserver.deltaFileWrapper.count > 0 || cloudProjectsModel.layerObserver.deltaFileWrapper.hasError()
+            icon.source: Theme.getThemeVectorIcon('ic_undo_black_24dp')
+
+            onClicked: {
+              if (!cloudProjectsModel.layerObserver.deltaFileWrapper.hasError()) {
+                revertDialog.open();
+              } else {
+                resetDialog.open();
+              }
+            }
+          }
+
+          Text {
+            id: discardText
+            font: Theme.tipFont
+            color: Theme.secondaryTextColor
+            text: !cloudProjectsModel.layerObserver.deltaFileWrapper.hasError()
+                  ? qsTr('Revert all modified features in the local layers. You cannot restore those changes.')
+                  : qsTr('The local copy of this cloud project has been corrupted. Resetting the project will re-download the cloud version and will remove any local changes, make sure those were copied first if needed.\n\nWhile you can still view and use the project, it is strongly recommended to reset to avoid any accidental data loss as none of the changes made will be pushed back to the cloud.')
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
+            Layout.bottomMargin: 10
+            Layout.fillWidth: true
+          }
+
+          Rectangle {
+            color: Theme.controlBorderColor
+            height: 1
+            Layout.fillWidth: true
+            Layout.leftMargin: 10
+            Layout.rightMargin: 10
+            Layout.bottomMargin: 5
+          }
+
           RowLayout {
             Layout.leftMargin: 10
             Layout.rightMargin: 10
@@ -471,59 +524,6 @@ Popup {
                 }
               }
             }
-          }
-
-          Text {
-            id: pushText
-            font: Theme.tipFont
-            color: Theme.secondaryTextColor
-            visible: !cloudProjectsModel.layerObserver.deltaFileWrapper.hasError()
-            text: qsTr('Save internet bandwidth by only pushing the local features and pictures to the cloud, without updating the whole project.')
-            wrapMode: Text.WordWrap
-            horizontalAlignment: Text.AlignHCenter
-            Layout.bottomMargin: 20
-            Layout.fillWidth: true
-          }
-
-          QfButton {
-            id: discardButton
-            Layout.fillWidth: true
-            bgcolor: Theme.darkRed
-            text: !cloudProjectsModel.layerObserver.deltaFileWrapper.hasError()
-                  ? qsTr('Revert local changes')
-                  : qsTr('Reset project')
-            enabled: cloudProjectsModel.layerObserver.deltaFileWrapper.count > 0 || cloudProjectsModel.layerObserver.deltaFileWrapper.hasError()
-            icon.source: Theme.getThemeVectorIcon('ic_undo_black_24dp')
-
-            onClicked: {
-              if (!cloudProjectsModel.layerObserver.deltaFileWrapper.hasError()) {
-                revertDialog.open();
-              } else {
-                resetDialog.open();
-              }
-            }
-          }
-
-          Text {
-            id: discardText
-            font: Theme.tipFont
-            color: Theme.secondaryTextColor
-            text: !cloudProjectsModel.layerObserver.deltaFileWrapper.hasError()
-                  ? qsTr('Revert all modified features in the local layers. You cannot restore those changes.')
-                  : qsTr('The local copy of this cloud project has been corrupted. Resetting the project will re-download the cloud version and will remove any local changes, make sure those were copied first if needed.\n\nWhile you can still view and use the project, it is strongly recommended to reset to avoid any accidental data loss as none of the changes made will be pushed back to the cloud.')
-            wrapMode: Text.WordWrap
-            horizontalAlignment: Text.AlignHCenter
-            Layout.bottomMargin: 10
-            Layout.fillWidth: true
-          }
-
-          Rectangle {
-            color: Theme.controlBorderColor
-            height: 1
-            Layout.fillWidth: true
-            Layout.leftMargin: 10
-            Layout.rightMargin: 10
-            Layout.bottomMargin: 5
           }
 
           Text {

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -412,6 +412,41 @@ Popup {
             onClicked: projectUpload(false)
           }
 
+          RowLayout {
+            Layout.leftMargin: 10
+            Layout.rightMargin: 10
+
+            Label {
+              Layout.fillWidth: true
+              Layout.alignment: Qt.AlignVCenter
+              topPadding: 10
+              bottomPadding: 10
+              font: Theme.tipFont
+              wrapMode: Text.WordWrap
+              color: autoPush.checked ? Theme.mainTextColor : Theme.secondaryTextColor
+
+              text:  qsTr('Automatically push changes every %n minute(s)','',0 + cloudProjectsModel.currentProjectData.AutoPushDelay)
+
+              MouseArea {
+                anchors.fill: parent
+                onClicked: cloudProjectsModel.projectSetAutoPushEnabled(cloudProjectsModel.currentProjectId, !autoPush.checked)
+              }
+            }
+
+            QfSwitch {
+              id: autoPush
+              Layout.preferredWidth: implicitContentWidth
+              Layout.alignment: Qt.AlignVCenter
+              width: implicitContentWidth
+              small: true
+
+              checked: !!cloudProjectsModel.currentProjectData.AutoPushEnabled
+              onClicked:  {
+                cloudProjectsModel.projectSetAutoPushEnabled(cloudProjectsModel.currentProjectId, checked)
+              }
+            }
+          }
+
           Text {
             id: pushText
             font: Theme.tipFont

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -425,7 +425,7 @@ Popup {
               wrapMode: Text.WordWrap
               color: autoPush.checked ? Theme.mainTextColor : Theme.secondaryTextColor
 
-              text:  qsTr('Automatically push changes every %n minute(s)','',0 + cloudProjectsModel.currentProjectData.AutoPushDelay)
+              text:  qsTr('Automatically push changes every %n minute(s)','',0 + cloudProjectsModel.currentProjectData.AutoPushIntervalMins)
 
               MouseArea {
                 anchors.fill: parent
@@ -449,15 +449,15 @@ Popup {
             Timer {
               id: autoPushTimer
               running: !!cloudProjectsModel.currentProjectData.AutoPushEnabled
-              interval: (!cloudProjectsModel.currentProjectData.AutoPushDelay - 0) * 60 * 1000
+              interval: (!cloudProjectsModel.currentProjectData.AutoPushIntervalMins - 0) * 60 * 1000
               repeat: true
 
               onRunningChanged: {
                 if (running && pushButton.enabled) {
-                  var dt = cloudProjectsModel.currentProjectData.LastLocalPushDeltas
-                  if (dt) {
-                    dt = new Date(dt)
-                    var now = new Date()
+                  const dtStr = cloudProjectsModel.currentProjectData.LastLocalPushDeltas
+                  if (dtStr) {
+                    const dt = new Date(dtStr)
+                    const now = new Date()
                     if ((now - dt) >= interval) {
                       projectUpload(false)
                     }
@@ -707,13 +707,14 @@ Popup {
 
   function revertLocalChangesFromCurrentProject() {
     if (cloudProjectsModel.currentProjectData && cloudProjectsModel.currentProjectData.CanSync) {
-      if ( cloudProjectsModel.revertLocalChangesFromCurrentProject(cloudProjectsModel.currentProjectId) )
+      if (cloudProjectsModel.revertLocalChangesFromCurrentProject(cloudProjectsModel.currentProjectId)) {
         displayToast(qsTr('Local changes reverted'))
-      else
+      } else {
         displayToast(qsTr('Failed to revert changes'), 'error')
+      }
+    } else {
+      displayToast(qsTr('No changes to revert'))
     }
-
-    displayToast(qsTr('No changes to revert'))
   }
 
   function resetCurrentProject() {

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -30,7 +30,6 @@ Popup {
       onFinished: {
         if (connectionSettings.visible) {
           connectionSettings.visible = false;
-          projects.visible = true;
         } else {
           popup.close()
         }
@@ -642,7 +641,6 @@ Popup {
   function projectUpload(shouldDownloadUpdates) {
     if (cloudProjectsModel.currentProjectData && cloudProjectsModel.currentProjectData.CanSync) {
       cloudProjectsModel.projectUpload(cloudProjectsModel.currentProjectId, shouldDownloadUpdates)
-      return
     }
   }
 
@@ -652,8 +650,6 @@ Popup {
         displayToast(qsTr('Local changes reverted'))
       else
         displayToast(qsTr('Failed to revert changes'), 'error')
-
-      return
     }
 
     displayToast(qsTr('No changes to revert'))

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -445,6 +445,32 @@ Popup {
                 cloudProjectsModel.projectSetAutoPushEnabled(cloudProjectsModel.currentProjectId, checked)
               }
             }
+
+            Timer {
+              id: autoPushTimer
+              running: !!cloudProjectsModel.currentProjectData.AutoPushEnabled
+              interval: (!cloudProjectsModel.currentProjectData.AutoPushDelay - 0) * 60 * 1000
+              repeat: true
+
+              onRunningChanged: {
+                if (running && pushButton.enabled) {
+                  var dt = cloudProjectsModel.currentProjectData.LastLocalPushDeltas
+                  if (dt) {
+                    dt = new Date(dt)
+                    var now = new Date()
+                    if ((now - dt) >= interval) {
+                      projectUpload(false)
+                    }
+                  }
+                }
+              }
+
+              onTriggered: {
+                if (pushButton.enabled) {
+                  projectUpload(false)
+                }
+              }
+            }
           }
 
           Text {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3372,8 +3372,8 @@ ApplicationWindow {
     property bool hasInsertRights: true
     property bool hasEditRights: true
 
-    property bool insertRights: hasInsertRights && (cloudProjectsModel.currentProjectId == '' || cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Idle)
-    property bool editRights: hasEditRights && (cloudProjectsModel.currentProjectId == '' || cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Idle)
+    property bool insertRights: hasInsertRights
+    property bool editRights: hasEditRights
   }
 
   BusyIndicator {


### PR DESCRIPTION
First, a glorious image:

![image](https://github.com/opengisch/QField/assets/1728657/92f3345f-2ea0-4324-9b05-07dd73164354)

Now the description :wink: 

This PR improves the delta file wrapper (keeping track of changes done by users) by adding an awareness of a "pushing" state. When in that state, the delta file wrapper will continue collecting changes, but will keep them pending until we either:
- successfully pushed the previous deltas, upon which the deltas collected during the "pushing" state are added to a new deltas "ID"; or
- fail at pushing the previous deltas, upon which the deltas collected during the "pushing" state are added *on top* of the previous deltas.

This means that we have a fully functional QField _while pushing_, insuring that no data addition/editing/deletion is loss while communicating to the cloud server. 

At this stage, this already fixes a known data loss scenario: ongoing tracking would have the changes made while pushing disappear after the deltas were pushed (because until now the code assumed that no activity would happen during the pushing).

Where it gets cool is that the improvements allow us to do background pushing of changes _in an automated and regular interval_, which QField now does if the user toggles that option on (see above screenshot).

The auto-push every 30 minutes setting is not on by default, and is a cloud project-level setting, allowing for users to turn this on for cloud project A but not make use of it for cloud project B.

