### PR TITLE
Enforce auto-push settings coming from the project file

### DIFF
--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -96,6 +96,11 @@ double AppInterface::readProjectDoubleEntry( const QString &scope, const QString
   return mApp->readProjectDoubleEntry( scope, key, def );
 }
 
+bool AppInterface::readProjectBoolEntry( const QString &scope, const QString &key, bool def ) const
+{
+  return mApp->readProjectBoolEntry( scope, key, def );
+}
+
 bool AppInterface::print( const QString &layoutName )
 {
   return mApp->print( layoutName );

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -49,6 +49,7 @@ class AppInterface : public QObject
     Q_INVOKABLE QString readProjectEntry( const QString &scope, const QString &key, const QString &def = QString() ) const;
     Q_INVOKABLE int readProjectNumEntry( const QString &scope, const QString &key, int def = 0 ) const;
     Q_INVOKABLE double readProjectDoubleEntry( const QString &scope, const QString &key, double def = 0.0 ) const;
+    Q_INVOKABLE bool readProjectBoolEntry( const QString &scope, const QString &key, bool def = false ) const;
 
     Q_INVOKABLE bool print( const QString &layoutName );
     Q_INVOKABLE bool printAtlasFeatures( const QString &layoutName, const QList<long long> &featureIds );

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -1961,9 +1961,22 @@ void QFieldCloudProjectsModel::projectSetAutoPushEnabled( const QString &project
   if ( projectIndex.isValid() )
   {
     CloudProject *project = mProjects[projectIndex.row()];
-    project->autoPushEnabled = !project->autoPushEnabled;
+    project->autoPushEnabled = enabled;
     QFieldCloudUtils::setProjectSetting( project->id, QStringLiteral( "autoPushEnabled" ), project->autoPushEnabled );
     emit dataChanged( projectIndex, projectIndex, QVector<int>() << AutoPushEnabledRole );
+  }
+}
+
+void QFieldCloudProjectsModel::projectSetAutoPushIntervalMins( const QString &projectId, int minutes )
+{
+  const QModelIndex projectIndex = findProjectIndex( projectId );
+
+  if ( projectIndex.isValid() )
+  {
+    CloudProject *project = mProjects[projectIndex.row()];
+    project->autoPushIntervalMins = minutes;
+    QFieldCloudUtils::setProjectSetting( project->id, QStringLiteral( "autoPushIntervalMins" ), project->autoPushIntervalMins );
+    emit dataChanged( projectIndex, projectIndex, QVector<int>() << AutoPushIntervalMinsRole );
   }
 }
 

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -279,6 +279,9 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     //! Toggles the cloud project auto-push enabled state
     Q_INVOKABLE void projectSetAutoPushEnabled( const QString &projectId, bool enabled );
 
+    //! Sets the interval in \a minutes between which the project will auto-push changes
+    Q_INVOKABLE void projectSetAutoPushIntervalMins( const QString &projectId, int minutes );
+
   signals:
     void cloudConnectionChanged();
     void layerObserverChanged();

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -68,6 +68,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
       UserRoleRole,
       UserRoleOriginRole,
       DeltaListRole,
+      ForceAutoPushRole,
       AutoPushEnabledRole,
       AutoPushIntervalMinsRole,
     };
@@ -276,6 +277,9 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     //! Cancels ongoing cloud project download with \a projectId.
     Q_INVOKABLE void projectCancelDownload( const QString &projectId );
 
+    //! Forces the cloud project auto-push enabled state to be TRUE
+    Q_INVOKABLE void projectSetForceAutoPush( const QString &projectId, bool force );
+
     //! Toggles the cloud project auto-push enabled state
     Q_INVOKABLE void projectSetAutoPushEnabled( const QString &projectId, bool enabled );
 
@@ -437,6 +441,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
         QDateTime lastLocalDataLastUpdatedAt;
         QDateTime lastRefreshedAt;
 
+        bool forceAutoPush = false;
         bool autoPushEnabled = false;
         int autoPushIntervalMins = 30;
 

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -1194,6 +1194,14 @@ double QgisMobileapp::readProjectDoubleEntry( const QString &scope, const QStrin
   return mProject->readDoubleEntry( scope, key, def );
 }
 
+bool QgisMobileapp::readProjectBoolEntry( const QString &scope, const QString &key, bool def ) const
+{
+  if ( !mProject )
+    return def;
+
+  return mProject->readBoolEntry( scope, key, def );
+}
+
 bool QgisMobileapp::print( const QString &layoutName )
 {
   const QList<QgsPrintLayout *> printLayouts = mProject->layoutManager()->printLayouts();

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -138,6 +138,8 @@ class QFIELD_CORE_EXPORT QgisMobileapp : public QQmlApplicationEngine
      */
     double readProjectDoubleEntry( const QString &scope, const QString &key, double def = 0.0 ) const;
 
+    bool readProjectBoolEntry( const QString &scope, const QString &key, bool def = false ) const;
+
     /**
      * Prints a given layout from the currently opened project to a PDF file
      * \param layoutName the layout name that will be printed

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -138,6 +138,15 @@ class QFIELD_CORE_EXPORT QgisMobileapp : public QQmlApplicationEngine
      */
     double readProjectDoubleEntry( const QString &scope, const QString &key, double def = 0.0 ) const;
 
+    /**
+     * Reads a boolean from the specified \a scope and \a key from the currently opened project
+     *
+     * \param scope entry scope (group) name
+     * \param key entry key name. Keys are '/'-delimited entries, implying a hierarchy of keys and corresponding values
+     * \param def default value to return if the specified \a key does not exist within the \a scope
+     *
+     * \returns entry value as boolean from \a scope given its \a key
+     */
     bool readProjectBoolEntry( const QString &scope, const QString &key, bool def = false ) const;
 
     /**

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -476,14 +476,14 @@ Popup {
               bottomPadding: 10
               font: Theme.tipFont
               wrapMode: Text.WordWrap
-              color: autoPush.checked || autoPush.forceAutoPush ? Theme.mainTextColor : Theme.secondaryTextColor
+              color: autoPush.checked ? Theme.mainTextColor : Theme.secondaryTextColor
 
               text:  qsTr('Automatically push changes every %n minute(s)','',0 + cloudProjectsModel.currentProjectData.AutoPushIntervalMins)
 
               MouseArea {
                 anchors.fill: parent
                 onClicked: {
-                  if (autoPush.forceAutoPush) {
+                  if (!!cloudProjectsModel.currentProjectData.ForceAutoPush) {
                     displayToast(qsTr('The current project does not allow for auto-push to be turned off'))
                   } else {
                     cloudProjectsModel.projectSetAutoPushEnabled(cloudProjectsModel.currentProjectId, !autoPush.checked)
@@ -498,8 +498,7 @@ Popup {
               Layout.alignment: Qt.AlignVCenter
               width: implicitContentWidth
               small: true
-
-              property bool forceAutoPush: false
+              enabled: !cloudProjectsModel.currentProjectData.ForceAutoPush
               checked: !!cloudProjectsModel.currentProjectData.AutoPushEnabled
 
               onClicked:  {
@@ -728,21 +727,5 @@ Popup {
   function resetCurrentProject() {
     cloudProjectsModel.discardLocalChangesFromCurrentProject(cloudProjectsModel.currentProjectId)
     cloudProjectsModel.downloadProject(cloudProjectsModel.currentProjectId, true)
-  }
-
-  function applyAutoPushProjectSettings() {
-    if (cloudProjectsModel.currentProjectId !== '') {
-      const forceAutoPush = iface.readProjectBoolEntry("qfieldsync", "forceAutoPush", false)
-      if (forceAutoPush) {
-        autoPush.forceAutoPush = true
-        autoPush.enabled = false
-        const forceAutoPushIntervalMins = iface.readProjectNumEntry("qfieldsync", "forceAutoPushIntervalMins", 30)
-        cloudProjectsModel.projectSetAutoPushEnabled(cloudProjectsModel.currentProjectId, true)
-        cloudProjectsModel.projectSetAutoPushIntervalMins(cloudProjectsModel.currentProjectId, forceAutoPushIntervalMins)
-      } else {
-        autoPush.forceAutoPush = false
-        autoPush.enabled = true
-      }
-    }
   }
 }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3377,7 +3377,7 @@ ApplicationWindow {
 
       recentProjectListModel.reloadModel()
 
-      var cloudProjectId = QFieldCloudUtils.getProjectId(qgisProject.fileName)
+      const cloudProjectId = QFieldCloudUtils.getProjectId(qgisProject.fileName)
       cloudProjectsModel.currentProjectId = cloudProjectId
       cloudProjectsModel.refreshProjectModification(cloudProjectId)
       if (cloudProjectId !== '') {
@@ -3411,6 +3411,8 @@ ApplicationWindow {
         if (cloudConnection.status === QFieldCloudConnection.LoggedIn) {
           cloudProjectsModel.refreshProjectFileOutdatedStatus(cloudProjectId)
         }
+
+        cloudPopup.applyAutoPushProjectSettings();
       } else {
         projectInfo.hasInsertRights = true
         projectInfo.hasEditRights = true

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3411,8 +3411,6 @@ ApplicationWindow {
         if (cloudConnection.status === QFieldCloudConnection.LoggedIn) {
           cloudProjectsModel.refreshProjectFileOutdatedStatus(cloudProjectId)
         }
-
-        cloudPopup.applyAutoPushProjectSettings();
       } else {
         projectInfo.hasInsertRights = true
         projectInfo.hasEditRights = true


### PR DESCRIPTION
This PR ties in with the following qfieldsync improvement: https://github.com/opengisch/qfieldsync/pull/566

QField will now read and respect the auto-push settings defined in a project file, insuring that people managing a 'fleet' of QField users can easily deploy auto push to their users and insure it's turned on.