### PR TITLE
Disable Finnish address search locator until API access can be restored

### DIFF
--- a/src/core/locator/locatormodelsuperbridge.cpp
+++ b/src/core/locator/locatormodelsuperbridge.cpp
@@ -42,9 +42,9 @@ LocatorModelSuperBridge::LocatorModelSuperBridge( QObject *parent )
   locator()->registerFilter( new BookmarkLocatorFilter( this ) );
   locator()->registerFilter( new ExpressionCalculatorLocatorFilter( this ) );
 
-  // Finnish's Digitransit geocoder
-  mFinlandGeocoder = new PeliasGeocoder( QStringLiteral( "https://api.digitransit.fi/geocoding/v1/search" ) );
-  locator()->registerFilter( new FinlandLocatorFilter( mFinlandGeocoder, this ) );
+  // Finnish's Digitransit geocoder (disabled until API access can be sorted)
+  //mFinlandGeocoder = new PeliasGeocoder( QStringLiteral( "https://api.digitransit.fi/geocoding/v1/search" ) );
+  //locator()->registerFilter( new FinlandLocatorFilter( mFinlandGeocoder, this ) );
 }
 
 Navigation *LocatorModelSuperBridge::navigation() const


### PR DESCRIPTION
Let's disable it for QField 3.2 release. There's no point in shipping a broken locator, it just leads to confusing UI. We can re-enable once the API access situation is resolved.