### PR TITLE
Enable concurrency groups on android workflows

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,6 +9,9 @@ on:
   release:
     types: ['published']
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
We live in a world with limited resources