### PR TITLE
Allow for http(s) images and videos to display in attachment widgets

### DIFF
--- a/src/qml/editorwidgets/+Qt5/ExternalResource.qml
+++ b/src/qml/editorwidgets/+Qt5/ExternalResource.qml
@@ -78,6 +78,12 @@ EditorWidgetBase {
   onCurrentValueChanged: {
     if (currentValue != undefined && currentValue !== '')
     {
+      const isHttp = value.startsWith('http://') || value.startsWith('https://');
+      var fullValue = isHttp ? value : prefixToRelativePath + value
+      isImage = !config.UseLink && FileUtils.mimeTypeName(fullValue).startsWith("image/")
+      isAudio = !config.UseLink && FileUtils.mimeTypeName(fullValue).startsWith("audio/")
+      isVideo = !config.UseLink && FileUtils.mimeTypeName(fullValue).startsWith("video/")
+
       image.visible = isImage
       geoTagBadge.visible = isImage
       player.visible = isVideo
@@ -89,11 +95,11 @@ EditorWidgetBase {
         image.hasImage = true
         image.opacity = 1
         image.anchors.topMargin = 0
-        image.source = 'file://' + prefixToRelativePath + value
-        geoTagBadge.hasGeoTag = ExifTools.hasGeoTag(prefixToRelativePath + value)
+        image.source = (!isHttp ? 'file://' : '') + fullValue
+        geoTagBadge.hasGeoTag = ExifTools.hasGeoTag(fullValue)
       } else if (isAudio || isVideo) {
         mediaFrame.height = 48
-        player.source = 'file://' + prefixToRelativePath + value
+        player.source = (!isHttp ? 'file://' : '') + fullValue
       }
     } else {
       image.source = ''

--- a/src/qml/editorwidgets/+Qt6/ExternalResource.qml
+++ b/src/qml/editorwidgets/+Qt6/ExternalResource.qml
@@ -76,11 +76,13 @@ EditorWidgetBase {
   //to not break any binding of image.source
   property var currentValue: value
   onCurrentValueChanged: {
-    isImage = !config.UseLink && FileUtils.mimeTypeName(prefixToRelativePath + value ).startsWith("image/")
-    isAudio = !config.UseLink && FileUtils.mimeTypeName(prefixToRelativePath + value).startsWith("audio/")
-    isVideo = !config.UseLink && FileUtils.mimeTypeName(prefixToRelativePath + value).startsWith("video/")
-
     if (currentValue != undefined && currentValue !== '') {
+      const isHttp = value.startsWith('http://') || value.startsWith('https://');
+      var fullValue = isHttp ? value : prefixToRelativePath + value
+      isImage = !config.UseLink && FileUtils.mimeTypeName(fullValue).startsWith("image/")
+      isAudio = !config.UseLink && FileUtils.mimeTypeName(fullValue).startsWith("audio/")
+      isVideo = !config.UseLink && FileUtils.mimeTypeName(fullValue).startsWith("video/")
+
       image.visible = isImage
       geoTagBadge.visible = isImage
       if (isImage) {
@@ -90,11 +92,11 @@ EditorWidgetBase {
         image.hasImage = true
         image.opacity = 1
         image.anchors.topMargin = 0
-        image.source = 'file://' + prefixToRelativePath + value
-        geoTagBadge.hasGeoTag = ExifTools.hasGeoTag(prefixToRelativePath + value)
+        image.source = (!isHttp ? 'file://' : '') + fullValue
+        geoTagBadge.hasGeoTag = ExifTools.hasGeoTag(fullValue)
       } else if (isAudio || isVideo) {
         player.firstFrameDrawn = false
-        player.sourceUrl = 'file://' + prefixToRelativePath + value
+        player.sourceUrl = (!isHttp ? 'file://' : '') + fullValue
       }
     } else {
       image.source = ''


### PR DESCRIPTION
Fixes issue reported here: https://github.com/opengisch/QField/issues/5057

Edit: it's halfway in-between bug fix and new functionality as loading of http(s) images was never officially supported :)