### PR TITLE
Cache for 1s instead of 5s because of impatient users reportining bugs

### DIFF
--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -40,7 +40,7 @@
 
 #define MAX_REDIRECTS_ALLOWED 10
 #define MAX_PARALLEL_REQUESTS 6
-#define CACHE_PROJECT_DATA_SECS 5
+#define CACHE_PROJECT_DATA_SECS 1
 
 QFieldCloudProjectsModel::QFieldCloudProjectsModel()
   : mProject( QgsProject::instance() )


### PR DESCRIPTION
The expected workflow is to either "push" or "sync" changes to QFC. If one is just pushing, then it is weird to "sync", because one should have clicked "sync" in the first place.

Anyway, my assumptions were wrong and people were reporting a non-existent bug. Therefore I suggest we reduce the cache just 1s, so at least we don't bombard the QFC API with multiple requests per second.