### PR TITLE
Embrace QGIS' reuse last entered value setting

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -20,6 +20,7 @@
         <file>themes/qfield/nodpi/ic_flash_off_black_24dp.svg</file>
         <file>themes/qfield/nodpi/ic_pause_black_24dp.svg</file>
         <file>themes/qfield/nodpi/ic_play_black_24dp.svg</file>
+        <file>themes/qfield/nodpi/ic_pin_black_24dp.svg</file>
         <file>themes/qfield/nodpi/ic_internal_receiver_black_24dp.svg</file>
         <file>themes/qfield/nodpi/ic_bluetooth_receiver_black_24dp.svg</file>
         <file>themes/qfield/nodpi/ic_tcp_receiver_black_24dp.svg</file>

--- a/images/themes/qfield/nodpi/ic_pin_black_24dp.svg
+++ b/images/themes/qfield/nodpi/ic_pin_black_24dp.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24" height="24" version="1.1" viewBox="0 -960 960 960" xmlns="http://www.w3.org/2000/svg">
+ <path d="m640-480 80 80v80h-200v240l-40 40-40-40v-240h-200v-80l80-80v-280h-40v-80h400v80h-40v280zm-286 80h252l-46-46v-314h-160v314l-46 46z"/>
+</svg>

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -383,6 +383,11 @@ bool FeatureModel::setData( const QModelIndex &index, const QVariant &value, int
       QMutex *mutex = sMutex;
       QMutexLocker locker( mutex );
       ( *sRememberings )[mLayer].rememberedAttributes[index.row()] = value.toBool();
+
+      QgsEditFormConfig config = mLayer->editFormConfig();
+      config.setReuseLastValue( index.row(), value.toBool() );
+      mLayer->setEditFormConfig( config );
+
       emit dataChanged( index, index, QVector<int>() << role );
       break;
     }

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -138,7 +138,12 @@ void FeatureModel::setCurrentLayer( QgsVectorLayer *layer )
       QMutex *mutex = sMutex;
       QMutexLocker locker( mutex );
       ( *sRememberings )[mLayer].rememberedFeature = mFeature;
-      ( *sRememberings )[mLayer].rememberedAttributes.fill( false, layer->fields().size() );
+      ( *sRememberings )[mLayer].rememberedAttributes.reserve( layer->fields().size() );
+      const QgsEditFormConfig config = mLayer->editFormConfig();
+      for ( int i = 0; i < layer->fields().size(); i++ )
+      {
+        ( *sRememberings )[mLayer].rememberedAttributes << config.reuseLastValue( i );
+      }
     }
 
     mGeometryLockedByDefault = mLayer->customProperty( QStringLiteral( "QFieldSync/is_geometry_locked" ), false ).toBool();

--- a/src/core/projectinfo.h
+++ b/src/core/projectinfo.h
@@ -118,6 +118,11 @@ class ProjectInfo : public QObject
     Q_INVOKABLE void saveLayerSnappingConfiguration( QgsMapLayer *layer );
 
     /**
+     * Saves the vector \a layer fields that are remembered during feature additions
+     */
+    Q_INVOKABLE void saveLayerRememberedFields( QgsMapLayer *layer );
+
+    /**
      * Saves the state \a mode for the current project
      */
     void setStateMode( const QString &mode );

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -667,7 +667,7 @@ Page {
 
           QfToolButton {
             id: menuButton
-            anchors { right: rememberCheckbox.left; top: constraintDescriptionLabel.bottom; rightMargin: 10; }
+            anchors { right: rememberButton.left; top: constraintDescriptionLabel.bottom; }
 
             visible: attributeEditorLoader.isEnabled && attributeEditorLoader.item.hasMenu
             enabled: visible
@@ -682,22 +682,25 @@ Page {
             }
           }
 
-          CheckBox {
-            id: rememberCheckbox
-            checked: RememberValue ? true : false
+          QfToolButton {
+            id: rememberButton
             visible: form.state === "Add" && EditorWidget !== "Hidden" && EditorWidget !== 'RelationEditor'
-            width: visible ? undefined : 0
+            width: visible ? 48 : 0
+
+            iconSource: Theme.getThemeVectorIcon("ic_pin_black_24dp")
+            iconColor: RememberValue ? Theme.mainColor : Theme.mainTextDisabledColor
+            bgcolor: "transparent"
 
             anchors { right: parent.right; top: constraintDescriptionLabel.bottom; verticalCenter: menuButton.verticalCenter }
 
             onClicked: {
-              RememberValue = checked
+              RememberValue = !RememberValue
+              if (RememberValue) {
+                displayToast(qsTr("The last entered value for this field will be remembered and reused when creating new features"))
+              } else {
+                displayToast(qsTr("The last entered value for this field will not be reused when creating new features"))
+              }
             }
-
-            indicator.height: 16
-            indicator.width: 16
-            icon.height: 16
-            icon.width: 16
           }
 
           Label {

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -700,6 +700,7 @@ Page {
               } else {
                 displayToast(qsTr("The last entered value for this field will not be reused when creating new features"))
               }
+              projectInfo.saveLayerRememberedFields(form.model.featureModel.currentLayer)
             }
           }
 

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -690,7 +690,7 @@ Page {
 
             anchors { right: parent.right; top: constraintDescriptionLabel.bottom; verticalCenter: menuButton.verticalCenter }
 
-            onCheckedChanged: {
+            onClicked: {
               RememberValue = checked
             }
 


### PR DESCRIPTION
QGIS has a nice attribute form field configuration that defines whether entered attribute values while digitizing a new feature should be remembered when adding subsequent feature(s):

![image](https://github.com/opengisch/QField/assets/1728657/576bcfe4-32ac-4d60-85b5-e8b703a340d1)

QField has had that option for a long time, in fact longer than when this was introduced, which explains why when the configuration was added upstream, we skipped that beat. This PR embraces the QGIS setting.

This decomplexify data entry for field users as it removes the need to click on that 'remember' checkbox at least once per session, and can help project managers in not having to teach users how to activate this as they can configure it on behalf of users in the project file itself.

The PR also tries to improve the QField UI around this functionality by moving away from a label-less checkbox towards a more descriptive icon tool button. A toaster message was also added to inform users of what is happening when the button is toggled.

Before vs. PR (updated looks with a toast message):
![image](https://github.com/opengisch/QField/assets/1728657/2f113196-3831-4740-a1d4-d91b0885cb3e)

Last but not least, we now remember across sessions what fields users want remembered for a given project. 