### PR TITLE
Add the ability to use `cloud_username` and `cloud_email` in offline

### DIFF
--- a/src/core/projectinfo.cpp
+++ b/src/core/projectinfo.cpp
@@ -47,6 +47,7 @@ void ProjectInfo::setFilePath( const QString &filePath )
   emit filePathChanged();
   emit stateModeChanged();
   emit activeLayerChanged();
+  emit cloudUserInformationChanged();
 }
 
 QString ProjectInfo::filePath() const
@@ -291,6 +292,34 @@ void ProjectInfo::setSnappingEnabled( bool enabled )
   mSettings.endGroup();
 
   emit snappingEnabledChanged();
+}
+
+CloudUserInformation ProjectInfo::cloudUserInformation() const
+{
+  if ( mFilePath.isEmpty() )
+    return CloudUserInformation( QString(), QString() );
+
+  CloudUserInformation userinfo(
+    mSettings.value( QStringLiteral( "/qgis/projectInfo/%1/cloudUserInfo/json" ).arg( mFilePath ), QStringLiteral( "{}" ) )
+      .toJsonValue()
+      .toObject() );
+
+  return userinfo;
+}
+
+void ProjectInfo::setCloudUserInformation( const CloudUserInformation cloudUserInformation )
+{
+  if ( mFilePath.isEmpty() )
+    return;
+
+  if ( cloudUserInformation.isEmpty() )
+    return;
+
+  mSettings.beginGroup( QStringLiteral( "/qgis/projectInfo/%1/cloudUserInfo" ).arg( mFilePath ) );
+  mSettings.setValue( QStringLiteral( "json" ), cloudUserInformation.toJson() );
+  mSettings.endGroup();
+
+  emit cloudUserInformationChanged();
 }
 
 void ProjectInfo::saveLayerSnappingConfiguration( QgsMapLayer *layer )

--- a/src/core/projectinfo.h
+++ b/src/core/projectinfo.h
@@ -19,6 +19,7 @@
 #define PROJECTINFO_H
 
 #include "layertreemodel.h"
+#include "qfieldcloudutils.h"
 #include "qgsquickmapcanvasmap.h"
 #include "qgsquickmapsettings.h"
 #include "trackingmodel.h"
@@ -72,6 +73,11 @@ class ProjectInfo : public QObject
      * The snapping enabled state for the currently opened project.
      */
     Q_PROPERTY( bool snappingEnabled READ snappingEnabled WRITE setSnappingEnabled NOTIFY snappingEnabledChanged )
+
+    /**
+     * Set cloud user information for offline usage.
+     */
+    Q_PROPERTY( CloudUserInformation cloudUserInformation READ cloudUserInformation WRITE setCloudUserInformation NOTIFY cloudUserInformationChanged )
 
   public:
     explicit ProjectInfo( QObject *parent = nullptr );
@@ -148,6 +154,16 @@ class ProjectInfo : public QObject
      */
     void setSnappingEnabled( bool enabled );
 
+    /**
+     * Returns the saved cloud user infomation for offline usage
+     */
+    CloudUserInformation cloudUserInformation() const;
+
+    /**
+     * Saves the cloud user infomation for offline usage
+     */
+    void setCloudUserInformation( const CloudUserInformation cloudUserInformation );
+
     //! Save an ongoing vector \a layer tracking session details
     Q_INVOKABLE void saveTracker( QgsVectorLayer *layer );
 
@@ -170,6 +186,7 @@ class ProjectInfo : public QObject
     void activeLayerChanged();
     void trackingModelChanged();
     void snappingEnabledChanged();
+    void cloudUserInformationChanged();
 
   private slots:
 

--- a/src/core/qfieldcloudconnection.h
+++ b/src/core/qfieldcloudconnection.h
@@ -18,6 +18,7 @@
 
 #include "networkmanager.h"
 #include "networkreply.h"
+#include "qfieldcloudutils.h"
 
 #include <QJsonDocument>
 #include <QObject>
@@ -26,21 +27,6 @@
 
 class QNetworkRequest;
 
-struct CloudUserInformation
-{
-    Q_GADGET
-
-  public:
-    CloudUserInformation() = default;
-
-    CloudUserInformation( const QString &username, const QString &email )
-      : username( username )
-      , email( email )
-    {}
-
-    QString username;
-    QString email;
-};
 
 class QFieldCloudConnection : public QObject
 {

--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -27,6 +27,7 @@
 
 static QString sLocalCloudDirectory;
 
+
 void QFieldCloudUtils::setLocalCloudDirectory( const QString &path )
 {
   sLocalCloudDirectory = path;

--- a/src/core/utils/qfieldcloudutils.h
+++ b/src/core/utils/qfieldcloudutils.h
@@ -25,6 +25,40 @@ class QFieldCloudProjectsModel;
 class DeltaFileWrapperTest;
 class TestLayerObserver;
 
+struct CloudUserInformation
+{
+    Q_GADGET
+
+  public:
+    CloudUserInformation() = default;
+
+    CloudUserInformation( const QString &username, const QString &email )
+    {}
+
+    explicit CloudUserInformation( const QJsonObject cloudUserInformation )
+      : username( cloudUserInformation.value( QStringLiteral( "username" ) ).toString() )
+      , email( cloudUserInformation.value( QStringLiteral( "email" ) ).toString() )
+    {}
+
+    QJsonObject toJson() const
+    {
+      QJsonObject cloudUserInformation;
+
+      cloudUserInformation.insert( "username", username );
+      cloudUserInformation.insert( "email", email );
+
+      return cloudUserInformation;
+    }
+
+    bool isEmpty() const
+    {
+      return username.isEmpty() && email.isEmpty();
+    }
+
+    QString username;
+    QString email;
+};
+
 class QFieldCloudUtils : public QObject
 {
     Q_OBJECT

--- a/src/qml/DigitizingToolbar.qml
+++ b/src/qml/DigitizingToolbar.qml
@@ -81,7 +81,7 @@ VisibilityFadingRow {
     positionInformation: positionSource.positionInformation
     positionLocked: gnssLockButton.checked
     topSnappingResult: coordinateLocator.topSnappingResult
-    cloudUserInformation: cloudConnection.userInformation
+    cloudUserInformation: projectInfo.cloudUserInformation
   }
 
   QfToolButton {

--- a/src/qml/EmbeddedFeatureForm.qml
+++ b/src/qml/EmbeddedFeatureForm.qml
@@ -68,7 +68,7 @@ Popup {
                 positionInformation: coordinateLocator.positionInformation
                 positionLocked: coordinateLocator.overrideLocation !== undefined
                 topSnappingResult: coordinateLocator.topSnappingResult
-                cloudUserInformation: cloudConnection.userInformation
+                cloudUserInformation: projectInfo.cloudUserInformation
             }
         }
 

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -359,7 +359,7 @@ Rectangle {
         currentLayer: featureForm.selection.focusedLayer
         feature: featureForm.selection.focusedFeature
         features: featureForm.selection.model.selectedFeatures
-        cloudUserInformation: cloudConnection.userInformation
+        cloudUserInformation: projectInfo.cloudUserInformation
       }
     }
 

--- a/src/qml/OverlayFeatureFormDrawer.qml
+++ b/src/qml/OverlayFeatureFormDrawer.qml
@@ -90,7 +90,7 @@ Drawer {
             positionInformation: coordinateLocator.positionInformation
             positionLocked: coordinateLocator.overrideLocation !== undefined
             topSnappingResult: coordinateLocator.topSnappingResult
-            cloudUserInformation: cloudConnection.userInformation
+            cloudUserInformation: projectInfo.cloudUserInformation
         }
     }
 

--- a/src/qml/TrackerSettings.qml
+++ b/src/qml/TrackerSettings.qml
@@ -534,7 +534,7 @@ Popup {
 
     positionInformation: coordinateLocator.positionInformation
     positionLocked: true
-    cloudUserInformation: cloudConnection.userInformation
+    cloudUserInformation: projectInfo.cloudUserInformation
   }
 
   AttributeFormModel {

--- a/src/qml/TrackingSession.qml
+++ b/src/qml/TrackingSession.qml
@@ -119,6 +119,6 @@ Item {
 
     positionInformation: coordinateLocator.positionInformation
     positionLocked: true
-    cloudUserInformation: cloudConnection.userInformation
+    cloudUserInformation: projectInfo.cloudUserInformation
   }
 }

--- a/src/qml/geometryeditors/VertexEditor.qml
+++ b/src/qml/geometryeditors/VertexEditor.qml
@@ -203,7 +203,7 @@ VisibilityFadingRow {
     positionInformation: positionSource.positionInformation
     positionLocked: gnssLockButton.checked
     topSnappingResult: coordinateLocator.topSnappingResult
-    cloudUserInformation: cloudConnection.userInformation
+    cloudUserInformation: projectInfo.cloudUserInformation
   }
 
   Connections {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2002,7 +2002,7 @@ ApplicationWindow {
         positionInformation: positionSource.positionInformation
         topSnappingResult: coordinateLocator.topSnappingResult
         positionLocked: positionSource.active && positioningSettings.positioningCoordinateLock
-        cloudUserInformation: cloudConnection.userInformation
+        cloudUserInformation: projectInfo.cloudUserInformation
         geometry: Geometry {
           id: digitizingGeometry
           rubberbandModel: digitizingRubberband.model
@@ -3457,6 +3457,7 @@ ApplicationWindow {
     mapSettings: mapCanvas.mapSettings
     layerTree: dashBoard.layerTree
     trackingModel: trackings.model
+    cloudUserInformation: cloudConnection.userInformation
 
     property var distanceUnits: Qgis.DistanceUnit.Meters
     property var areaUnits: Qgis.AreaUnit.SquareMeters
@@ -3951,7 +3952,7 @@ ApplicationWindow {
     positionInformation: positionSource.positionInformation
     positionLocked: positionSource.active && positioningSettings.positioningCoordinateLock
     vertexModel: geometryEditingVertexModel
-    cloudUserInformation: cloudConnection.userInformation
+    cloudUserInformation: projectInfo.cloudUserInformation
   }
 
   VertexModel {


### PR DESCRIPTION
So far the `cloud_username` and `cloud_email` variables were only available if the user successfully logs in. This PR stores the project's cloud username and email as project info that can be retrieved even when offline.

Tested when the username changes or very slow login, the QGIS expression variable value updates as soon as the cloud response is received.

Fixes #5116 and https://github.com/opengisch/QField/discussions/5088

