### PR TITLE
Always track file-based layers in QFieldCloud

### DIFF
--- a/src/core/layerobserver.cpp
+++ b/src/core/layerobserver.cpp
@@ -311,9 +311,9 @@ void LayerObserver::addLayerListeners()
           continue;
         }
 
-        qInfo() << "LayerObserver::addLayerListeners: vl->getLocalPkAttribute()=" << DeltaFileWrapper::getLocalPkAttribute( vl );
-        qInfo() << "LayerObserver::addLayerListeners: vl->getSourcePkAttribute()=" << DeltaFileWrapper::getSourcePkAttribute( vl );
-        qInfo() << "LayerObserver::addLayerListeners: vl->customProperties()=" << vl->customProperties().keys();
+        qInfo() << "LayerObserver::addLayerListeners: " << layer->name() << "; vl->getLocalPkAttribute()=" << DeltaFileWrapper::getLocalPkAttribute( vl );
+        qInfo() << "LayerObserver::addLayerListeners: " << layer->name() << "; vl->getSourcePkAttribute()=" << DeltaFileWrapper::getSourcePkAttribute( vl );
+        qInfo() << "LayerObserver::addLayerListeners: " << layer->name() << "; vl->customProperties()=" << vl->customProperties().keys();
 
         disconnect( vl, &QgsVectorLayer::beforeCommitChanges, this, &LayerObserver::onBeforeCommitChanges );
         disconnect( vl, &QgsVectorLayer::committedFeaturesAdded, this, &LayerObserver::onCommittedFeaturesAdded );

--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -24,6 +24,8 @@
 #include <QString>
 #include <qgsapplication.h>
 #include <qgsmessagelog.h>
+#include <qgsprovidermetadata.h>
+#include <qgsproviderregistry.h>
 
 static QString sLocalCloudDirectory;
 
@@ -58,9 +60,50 @@ bool QFieldCloudUtils::isCloudAction( const QgsMapLayer *layer )
 
   const QString layerAction( layer->customProperty( QStringLiteral( "QFieldSync/cloud_action" ) ).toString().toUpper() );
 
-  if ( layerAction == QStringLiteral( "NO_ACTION" ) || layerAction == QStringLiteral( "REMOVE" ) )
-    return false;
+  if ( isFileBasedLayer( layer ) )
+  {
+    if ( layerAction == QStringLiteral( "REMOVE" ) )
+    {
+      return false;
+    }
+  }
+  else
+  {
+    if ( layerAction == QStringLiteral( "NO_ACTION" ) || layerAction == QStringLiteral( "REMOVE" ) )
+    {
+      return false;
+    }
+  }
+
   return true;
+}
+
+bool QFieldCloudUtils::isFileBasedLayer( const QgsMapLayer *layer )
+{
+  if ( layer->type() == Qgis::LayerType::VectorTile )
+  {
+    QgsDataSourceUri uri;
+    uri.setEncodedUri( layer->source() );
+    return QFile::exists( uri.param( "url" ) );
+  }
+
+  if ( !layer->dataProvider() )
+  {
+    return false;
+  }
+
+  QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( layer->dataProvider()->name() );
+  QVariantMap metadata = providerMetadata->decodeUri( layer->source() );
+
+  const QString filename = metadata.value( QStringLiteral( "path" ), QString() ).toString();
+  const QString resolvedFilename = QgsProject::instance()->pathResolver().writePath( filename );
+
+  if ( resolvedFilename.startsWith( QStringLiteral( "localized:" ) ) )
+  {
+    return QFile::exists( resolvedFilename.mid( 10 ) );
+  }
+
+  return QFile::exists( filename );
 }
 
 const QString QFieldCloudUtils::getProjectId( const QString &fileName )

--- a/src/core/utils/qfieldcloudutils.h
+++ b/src/core/utils/qfieldcloudutils.h
@@ -53,7 +53,7 @@ class QFieldCloudUtils : public QObject
     static bool isCloudAction( const QgsMapLayer *layer );
 
     /**
-     * Returns if the \layer is file-based or online layer.
+     * Returns if the \a layer is a file-based or a remote layer.
      *
      * @param layer to be checked
      * @return const bool true if the layer is file-based

--- a/src/core/utils/qfieldcloudutils.h
+++ b/src/core/utils/qfieldcloudutils.h
@@ -53,6 +53,14 @@ class QFieldCloudUtils : public QObject
     static bool isCloudAction( const QgsMapLayer *layer );
 
     /**
+     * Returns if the \layer is file-based or online layer.
+     *
+     * @param layer to be checked
+     * @return const bool true if the layer is file-based
+     */
+    static bool isFileBasedLayer( const QgsMapLayer *layer );
+
+    /**
      * Returns the cloud project id.
      *
      * @param fileName file name of the project to be checked


### PR DESCRIPTION
If the layer is configured as "NO_ACTION" for QFieldCloud, then this layer is never tracked for changes in QFieldCloud. This means any  changes on this layer will never reach QFieldCloud.

This development ignores whatever is configured as cloud action. When the layer is file-based and it is not configured as "REMOVE", then the layer will be tracked by QFielCloud.