### PR TITLE
Fix changes list popup looking broken when empty

### DIFF
--- a/src/core/deltalistmodel.cpp
+++ b/src/core/deltalistmodel.cpp
@@ -88,6 +88,9 @@ DeltaListModel::DeltaListModel( QJsonDocument deltasStatusList )
     mIsValid = true;
     mDeltas.append( delta );
   }
+
+  connect( this, &DeltaListModel::rowsInserted, this, &DeltaListModel::rowCountChanged );
+  connect( this, &DeltaListModel::rowsRemoved, this, &DeltaListModel::rowCountChanged );
 }
 
 int DeltaListModel::rowCount( const QModelIndex &parent ) const

--- a/src/core/deltalistmodel.h
+++ b/src/core/deltalistmodel.h
@@ -65,8 +65,10 @@ class DeltaListModel : public QAbstractListModel
     DeltaListModel() = default;
     explicit DeltaListModel( QJsonDocument deltasStatusList );
 
+    Q_PROPERTY( int rowCount READ rowCount NOTIFY rowCountChanged )
+
     //! Returns number of rows.
-    int rowCount( const QModelIndex &parent ) const override;
+    int rowCount( const QModelIndex &parent = QModelIndex() ) const override;
 
     //! Returns the data at given \a index with given \a role.
     QVariant data( const QModelIndex &index, int role ) const override;
@@ -88,6 +90,9 @@ class DeltaListModel : public QAbstractListModel
 
     //! Returns a combined output for all deltas, separated by a new line.
     QString combinedOutput() const;
+
+  signals:
+    void rowCountChanged();
 
   private:
     QJsonDocument mJson;

--- a/src/qml/QFieldCloudDeltaHistory.qml
+++ b/src/qml/QFieldCloudDeltaHistory.qml
@@ -62,7 +62,7 @@ Popup {
             }
             iconSource: Theme.getThemeIcon( 'ic_close_black_24dp' )
             iconColor: Theme.mainTextColor
-            bgcolor: "white"
+            bgcolor: Theme.mainBackgroundColor
 
             onClicked: {
               popup.close();

--- a/src/qml/QFieldCloudDeltaHistory.qml
+++ b/src/qml/QFieldCloudDeltaHistory.qml
@@ -74,10 +74,23 @@ Popup {
             spacing: 4
             width: parent.width
 
+            Label {
+              leftPadding: 48
+              rightPadding: 48
+              width: parent.width
+              visible: !!model && model.rowCount === 0
+
+              text: qsTr( "No changes have been pushed yet!" )
+              color: Theme.mainTextDisabledColor
+              horizontalAlignment: Text.AlignHCenter
+              wrapMode: Text.WordWrap
+            }
+
             ListView {
                 id: deltaList
                 width: parent.width
-                height: mainWindow.height - 160
+                height: visible ? mainWindow.height - 160 : 0
+                visible: deltaList.model && deltaList.model.rowCount !== 0
                 clip: true
 
                 delegate: Rectangle {


### PR DESCRIPTION
At least show some indication that no changes have been pushed yet.

| before | after |
|-|-|
| ![image](https://github.com/opengisch/QField/assets/2820439/044c9c04-0f1b-4386-b3b9-6d4a766bb4d9) | ![image](https://github.com/opengisch/QField/assets/2820439/af280764-b1b8-4c0f-9d1b-7796f5ad457c) |

Here how it looks in the white theme:
![image](https://github.com/opengisch/QField/assets/2820439/532eff2a-4894-486d-b8ba-73637daf0db1)

