### PR TITLE
Insure that the positioning information panel respects project distance unit type for altitude and accuracy

### DIFF
--- a/src/qml/PositioningInformationView.qml
+++ b/src/qml/PositioningInformationView.qml
@@ -14,6 +14,9 @@ Rectangle {
   property bool coordinatesIsXY: CoordinateReferenceSystemUtils.defaultCoordinateOrderForCrsIsXY(projectInfo.coordinateDisplayCrs)
   property bool coordinatesIsGeographic: projectInfo.coordinateDisplayCrs.isGeographic
 
+  property double distanceUnitFactor: UnitTypes.fromUnitToUnitFactor(Qgis.DistanceUnit.Meters, projectInfo.distanceUnits)
+  property string distanceUnitAbbreviation: UnitTypes.toAbbreviatedString(projectInfo.distanceUnits)
+
   property double antennaHeight: NaN
   property double rowHeight: 30
   property color backgroundColor: Theme.mainBackgroundColor
@@ -93,15 +96,15 @@ Rectangle {
         color: textColor
         text: {
           var altitude = qsTr( "Altitude" ) + ': '
-          if ( positionSource.positionInformation && positionSource.positionInformation.elevationValid ) {
-            altitude += Number( positionSource.projectedPosition.z ).toLocaleString( Qt.locale(), 'f', 3 ) + ' m '
+          if (positionSource.positionInformation && positionSource.positionInformation.elevationValid) {
+            altitude += Number(positionSource.projectedPosition.z * distanceUnitFactor).toLocaleString(Qt.locale(), 'f', 3) + ' ' + distanceUnitAbbreviation + ' '
             var details = []
             if (positionSource.elevationCorrectionMode === Positioning.ElevationCorrectionMode.OrthometricFromGeoidFile) {
               details.push('grid')
             } else if (positionSource.elevationCorrectionMode === Positioning.ElevationCorrectionMode.OrthometricFromDevice) {
               details.push('ortho.')
             }
-            if ( !isNaN( parseFloat( antennaHeight ) ) ) {
+            if (!isNaN(parseFloat(antennaHeight))) {
               details.push('ant.')
             }
             if (details.length > 0) {
@@ -143,7 +146,9 @@ Rectangle {
         anchors.left: parent.left
         font: Theme.tipFont
         color: textColor
-        text: qsTr( "H. Accuracy" ) + ': ' + ( positionSource.positionInformation && positionSource.positionInformation.haccValid ? positionSource.positionInformation.hacc.toLocaleString(Qt.locale(), 'f', 3) + " m" : qsTr( "N/A" ) )
+        text: qsTr("H. Accuracy") + ': ' + (positionSource.positionInformation && positionSource.positionInformation.haccValid
+                                            ? Number(positionSource.positionInformation.hacc * distanceUnitFactor).toLocaleString(Qt.locale(), 'f', 3) + ' ' + distanceUnitAbbreviation
+                                            : qsTr("N/A"))
       }
     }
 
@@ -158,7 +163,9 @@ Rectangle {
         anchors.left: parent.left
         font: Theme.tipFont
         color: textColor
-        text: qsTr( "V. Accuracy" ) + ': ' + ( positionSource.positionInformation && positionSource.positionInformation.vaccValid ? positionSource.positionInformation.vacc.toLocaleString(Qt.locale(), 'f', 3) + " m" : qsTr( "N/A" ) )
+        text: qsTr( "V. Accuracy" ) + ': ' + (positionSource.positionInformation && positionSource.positionInformation.vaccValid
+                                              ? Number(positionSource.positionInformation.vacc * distanceUnitFactor).toLocaleString(Qt.locale(), 'f', 3) + ' ' + distanceUnitAbbreviation
+                                              : qsTr("N/A"))
       }
     }
 


### PR DESCRIPTION
Fixes the bug raised within the enhancement request here (https://github.com/opengisch/QField/issues/4899) whereas the positioning information panel didn't respect the project distance unit type. Now, when people set distance to feet, they'll see altitude and accuracy numbers in feet:

![Screenshot from 2024-03-22 11-37-08](https://github.com/opengisch/QField/assets/1728657/89ab9cc7-43d2-4e63-aa18-b40d2e8781ae)
