### PR TITLE
Avoid last averaged position not taken into account when adding vertex

### DIFF
--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -279,7 +279,6 @@ void Positioning::lastGnssPositionInformationChanged( const GnssPositionInformat
   {
     mCollectedPositionInformations << positionInformation;
     mPositionInformation = PositioningUtils::averagedPositionInformation( mCollectedPositionInformations );
-    emit averagedPositionCountChanged();
   }
   else
   {
@@ -301,6 +300,10 @@ void Positioning::lastGnssPositionInformationChanged( const GnssPositionInformat
   }
 
   emit positionInformationChanged();
+  if ( mAveragedPosition )
+  {
+    emit averagedPositionCountChanged();
+  }
 }
 
 void Positioning::processCompassReading()


### PR DESCRIPTION
If we emit the averagedPositionCountChanged() signal before positionInformationChanged(), we end up with QML code handling the averaged position information from the previous averaging. Moving the signal at the very end insures that the right averaged location & information is used when adding vertices.