### PR TITLE
[Backport release-3_2] Avoid last averaged position not taken into account when adding vertex

### DIFF
--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -279,7 +279,6 @@ void Positioning::lastGnssPositionInformationChanged( const GnssPositionInformat
   {
     mCollectedPositionInformations << positionInformation;
     mPositionInformation = PositioningUtils::averagedPositionInformation( mCollectedPositionInformations );
-    emit averagedPositionCountChanged();
   }
   else
   {
@@ -301,6 +300,10 @@ void Positioning::lastGnssPositionInformationChanged( const GnssPositionInformat
   }
 
   emit positionInformationChanged();
+  if ( mAveragedPosition )
+  {
+    emit averagedPositionCountChanged();
+  }
 }
 
 void Positioning::processCompassReading()


### PR DESCRIPTION
Backport #5131
 **Authored by:** @nirvn