### PR TITLE
Implement a finger tap digitizing mode

### DIFF
--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -104,7 +104,7 @@ Page {
       }
       ListElement {
           title: qsTr( "Consider mouse as a touchscreen device" )
-          description: qsTr( "If disabled, the mouse will act as a stylus pen." )
+          description: qsTr( "When enabled, the mouse will act as if it was a finger. When disabled, the mouse will match the stylus behavior." )
           settingAlias: "mouseAsTouchScreen"
           isVisible: true
       }

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -58,6 +58,10 @@ Page {
     onDigitizingVolumeKeysChanged: {
       platformUtilities.setHandleVolumeKeys(digitizingVolumeKeys && stateMachine.state != 'browse')
     }
+
+    onFingerTapDigitizingChanged: {
+      coordinateLocator.sourceLocation = undefined
+    }
   }
 
   ListModel {

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -20,6 +20,7 @@ Page {
   property alias nativeCamera: registry.nativeCamera
   property alias digitizingVolumeKeys: registry.digitizingVolumeKeys
   property alias autoSave: registry.autoSave
+  property alias fingerTapDigitizing: registry.fingerTapDigitizing
   property alias mouseAsTouchScreen: registry.mouseAsTouchScreen
   property alias enableInfoCollection: registry.enableInfoCollection
   property alias quality: registry.quality
@@ -41,6 +42,7 @@ Page {
     property bool nativeCamera: platformUtilities.capabilities & PlatformUtilities.NativeCamera
     property bool digitizingVolumeKeys: platformUtilities.capabilities & PlatformUtilities.VolumeKeys
     property bool autoSave: false
+    property bool fingerTapDigitizing: false
     property bool mouseAsTouchScreen: false
     property bool enableInfoCollection: true
     property double quality: 1.0
@@ -92,6 +94,12 @@ Page {
           title: qsTr( "Use volume keys to digitize" )
           description: qsTr( "If enabled, pressing the device's volume up key will add a vertex while pressing volume down key will remove the last entered vertex during digitizing sessions." )
           settingAlias: "digitizingVolumeKeys"
+          isVisible: true
+      }
+      ListElement {
+          title: qsTr( "Allow finger tap on canvas to add vertices" )
+          description: qsTr( "When enabled, tapping on the map canvas with a finger will add a vertex at the tapped location." )
+          settingAlias: "fingerTapDigitizing"
           isVisible: true
       }
       ListElement {

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -59,29 +59,11 @@ Page {
   }
 
   ListModel {
-      id: settingsModel
+      id: canvasSettingsModel
       ListElement {
           title: qsTr( "Show scale bar" )
           description: ''
           settingAlias: "showScaleBar"
-          isVisible: true
-      }
-      ListElement {
-          title: qsTr( "Maximized attribute form" )
-          description: ''
-          settingAlias: "fullScreenIdentifyView"
-          isVisible: true
-      }
-      ListElement {
-          title: qsTr( "Fixed scale navigation" )
-          description: qsTr( "When fixed scale navigation is active, focusing on a search result will pan to the feature. With fixed scale navigation disabled it will pan and zoom to the feature." )
-          settingAlias: "locatorKeepScale"
-          isVisible: true
-      }
-      ListElement {
-          title: qsTr( "Show digitizing information" )
-          description: qsTr( "When switched on, coordinate information, such as latitude and longitude, is overlayed onto the map while digitizing new features or using the measure tool." )
-          settingAlias: "numericalDigitizingInformation"
           isVisible: true
       }
       ListElement {
@@ -90,10 +72,14 @@ Page {
           settingAlias: "showBookmarks"
           isVisible: true
       }
+  }
+
+  ListModel {
+      id: digitizingEditingSettingsModel
       ListElement {
-          title: qsTr( "Use native camera" )
-          description: qsTr( "If disabled, QField will use a minimalist internal camera instead of the camera app on the device.<br>Tip: Enable this option and install the open camera app to create geo tagged photos." )
-          settingAlias: "nativeCamera"
+          title: qsTr( "Show digitizing information" )
+          description: qsTr( "When switched on, coordinate information, such as latitude and longitude, is overlayed onto the map while digitizing new features or using the measure tool." )
+          settingAlias: "numericalDigitizingInformation"
           isVisible: true
       }
       ListElement {
@@ -114,6 +100,41 @@ Page {
           settingAlias: "mouseAsTouchScreen"
           isVisible: true
       }
+      Component.onCompleted: {
+          for (var i = 0; i < count; i++) {
+              if (get(i).settingAlias === 'digitizingVolumeKeys') {
+                  setProperty(i, 'isVisible', platformUtilities.capabilities & PlatformUtilities.VolumeKeys ? true : false)
+              } else {
+                  setProperty(i, 'isVisible', true)
+              }
+          }
+      }
+  }
+
+  ListModel {
+      id: interfaceSettingsModel
+      ListElement {
+          title: qsTr( "Maximized attribute form" )
+          description: ''
+          settingAlias: "fullScreenIdentifyView"
+          isVisible: true
+      }
+      ListElement {
+          title: qsTr( "Fixed scale navigation" )
+          description: qsTr( "When fixed scale navigation is active, focusing on a search result will pan to the feature. With fixed scale navigation disabled it will pan and zoom to the feature." )
+          settingAlias: "locatorKeepScale"
+          isVisible: true
+      }
+  }
+
+  ListModel {
+      id: advancedSettingsModel
+      ListElement {
+          title: qsTr( "Use native camera" )
+          description: qsTr( "If disabled, QField will use a minimalist internal camera instead of the camera app on the device.<br>Tip: Enable this option and install the open camera app to create geo tagged photos." )
+          settingAlias: "nativeCamera"
+          isVisible: true
+      }
       ListElement {
           title: qsTr( "Send anonymized metrics" )
           description: qsTr( "If enabled, anonymized metrics will be collected and sent to help improve QField for everyone." )
@@ -121,15 +142,13 @@ Page {
           isVisible: true
       }
       Component.onCompleted: {
-          for (var i = 0; i < settingsModel.count; i++) {
-              if (settingsModel.get(i).settingAlias === 'digitizingVolumeKeys') {
-                  settingsModel.setProperty(i, 'isVisible', platformUtilities.capabilities & PlatformUtilities.VolumeKeys ? true : false)
-              } else if (settingsModel.get(i).settingAlias === 'nativeCamera') {
-                  settingsModel.setProperty(i, 'isVisible', platformUtilities.capabilities & PlatformUtilities.NativeCamera ? true : false)
-              } else if (settingsModel.get(i).settingAlias === 'enableInfoCollection') {
-                  settingsModel.setProperty(i, 'isVisible', platformUtilities.capabilities & PlatformUtilities.SentryFramework ? true : false)
+          for (var i = 0; i < count; i++) {
+              if (get(i).settingAlias === 'nativeCamera') {
+                  setProperty(i, 'isVisible', platformUtilities.capabilities & PlatformUtilities.NativeCamera ? true : false)
+              } else if (get(i).settingAlias === 'enableInfoCollection') {
+                  setProperty(i, 'isVisible', platformUtilities.capabilities & PlatformUtilities.SentryFramework ? true : false)
               } else {
-                  settingsModel.setProperty(i, 'isVisible', true)
+                  setProperty(i, 'isVisible', true)
               }
           }
       }
@@ -176,6 +195,60 @@ Page {
       }
     }
 
+    Component {
+      id: listItem
+
+      Rectangle {
+        width: parent ? parent.width - 16 : undefined
+        height: isVisible ? line.height : 0
+        color: "transparent"
+        clip: true
+
+        Row {
+          id: line
+          width: parent.width
+
+          Column {
+            width: parent.width - toggle.width
+
+            Label {
+              width: parent.width
+              padding: 8
+              leftPadding: 20
+              text: title
+              font: Theme.defaultFont
+              color: Theme.mainTextColor
+              wrapMode: Text.WordWrap
+              MouseArea {
+                anchors.fill: parent
+                onClicked: toggle.toggle()
+              }
+            }
+
+            Label {
+              width: parent.width
+              visible: description !== ''
+              padding: description !== '' ? 8 : 0
+              topPadding: 0
+              leftPadding: 20
+              text: description
+              font: Theme.tipFont
+              color: Theme.secondaryTextColor
+              wrapMode: Text.WordWrap
+            }
+          }
+
+          QfSwitch {
+            id: toggle
+            width: implicitContentWidth
+            checked: registry[settingAlias]
+            Layout.alignment: Qt.AlignTop | Qt.AlignRight
+            onCheckedChanged: registry[settingAlias] = checked
+          }
+        }
+      }
+    }
+
     SwipeView {
       id: swipeView
       width: mainWindow.width
@@ -211,11 +284,159 @@ Page {
                       rowSpacing: 5
 
                       Label {
+                        text: qsTr('Map Canvas')
+                        font: Theme.strongFont
+                        color: Theme.mainColor
+                        wrapMode: Text.WordWrap
+                        Layout.fillWidth: true
+                        Layout.topMargin: 5
+                        Layout.columnSpan: 2
+                      }
+
+                      Rectangle {
+                        Layout.fillWidth: true
+                        Layout.columnSpan: 2
+                        height: 1
+                        color: Theme.mainColor
+                      }
+                  }
+
+                  ListView {
+                    Layout.preferredWidth: mainWindow.width
+                    Layout.preferredHeight: childrenRect.height
+                    interactive: false
+
+                    model: canvasSettingsModel
+
+                    delegate: listItem
+                  }
+
+                  GridLayout {
+                      Layout.fillWidth: true
+                      Layout.leftMargin: 20
+                      Layout.rightMargin: 20
+
+                      columns: 2
+                      columnSpacing: 0
+                      rowSpacing: 5
+
+                      Label {
+                          Layout.fillWidth: true
+                          Layout.columnSpan: 2
+                          text: qsTr( "Map canvas rendering quality:" )
+                          font: Theme.defaultFont
+                          color: Theme.mainTextColor
+
+                          wrapMode: Text.WordWrap
+                      }
+
+                      ComboBox {
+                          id: renderingQualityComboBox
+                          enabled: true
+                          Layout.fillWidth: true
+                          Layout.columnSpan: 2
+                          Layout.alignment: Qt.AlignVCenter
+                          font: Theme.defaultFont
+
+                          popup.font: Theme.defaultFont
+                          popup.topMargin: mainWindow.sceneTopMargin
+                          popup.bottomMargin: mainWindow.sceneTopMargin
+
+                          model: ListModel {
+                            ListElement { name: qsTr('Best quality'); value: 1.0 }
+                            ListElement { name: qsTr('Lower quality'); value: 0.75 }
+                            ListElement { name: qsTr('Lowest quality'); value: 0.5 }
+                          }
+                          textRole: "name"
+                          valueRole: "value"
+
+                          property bool initialized: false
+
+                          onCurrentValueChanged: {
+                              if (initialized) {
+                                quality = currentValue
+                              }
+                          }
+
+                          Component.onCompleted: {
+                              currentIndex = indexOfValue(quality)
+                              initialized = true
+                          }
+                      }
+
+                      Label {
+                          text: qsTr( "A lower quality trades rendering precision in favor of lower memory usage and rendering time." )
+                          font: Theme.tipFont
+                          color: Theme.secondaryTextColor
+                          textFormat: Qt.RichText
+                          wrapMode: Text.WordWrap
+                          Layout.fillWidth: true
+                          Layout.columnSpan: 2
+
+                          onLinkActivated: (link) => { Qt.openUrlExternally(link) }
+                      }
+
+                      Label {
+                        text: qsTr('Digitizing & Editing')
+                        font: Theme.strongFont
+                        color: Theme.mainColor
+                        wrapMode: Text.WordWrap
+                        Layout.fillWidth: true
+                        Layout.topMargin: 5
+                        Layout.columnSpan: 2
+                      }
+
+                      Rectangle {
+                        Layout.fillWidth: true
+                        Layout.columnSpan: 2
+                        height: 1
+                        color: Theme.mainColor
+                      }
+                  }
+
+                  ListView {
+                    Layout.preferredWidth: mainWindow.width
+                    Layout.preferredHeight: childrenRect.height
+                    interactive: false
+
+                    model: digitizingEditingSettingsModel
+
+                    delegate: listItem
+                  }
+
+                  GridLayout {
+                      Layout.fillWidth: true
+                      Layout.leftMargin: 20
+                      Layout.rightMargin: 20
+
+                      columns: 2
+                      columnSpacing: 0
+                      rowSpacing: 5
+
+                      Label {
+                        text: qsTr('User Interface')
+                        font: Theme.strongFont
+                        color: Theme.mainColor
+                        wrapMode: Text.WordWrap
+                        Layout.fillWidth: true
+                        Layout.topMargin: 5
+                        Layout.columnSpan: 2
+                      }
+
+                      Rectangle {
+                        Layout.fillWidth: true
+                        Layout.columnSpan: 2
+                        height: 1
+                        color: Theme.mainColor
+                      }
+
+                      Label {
                           text: qsTr("Customize search bar")
                           font: Theme.defaultFont
                           color: Theme.mainTextColor
                           wrapMode: Text.WordWrap
                           Layout.fillWidth: true
+                          Layout.topMargin: 5
 
                           MouseArea {
                               anchors.fill: parent
@@ -240,62 +461,15 @@ Page {
                       }
                   }
 
+
                   ListView {
                     Layout.preferredWidth: mainWindow.width
                     Layout.preferredHeight: childrenRect.height
                     interactive: false
 
-                    model: settingsModel
+                    model: interfaceSettingsModel
 
-                    delegate: Rectangle {
-                      width: parent ? parent.width - 16 : undefined
-                      height: isVisible ? line.height : 0
-                      color: "transparent"
-                      clip: true
-
-                      Row {
-                        id: line
-                        width: parent.width
-
-                        Column {
-                          width: parent.width - toggle.width
-
-                          Label {
-                            width: parent.width
-                            padding: 8
-                            leftPadding: 20
-                            text: title
-                            font: Theme.defaultFont
-                            color: Theme.mainTextColor
-                            wrapMode: Text.WordWrap
-                            MouseArea {
-                              anchors.fill: parent
-                              onClicked: toggle.toggle()
-                            }
-                          }
-
-                          Label {
-                            width: parent.width
-                            visible: description !== ''
-                            padding: description !== '' ? 8 : 0
-                            topPadding: 0
-                            leftPadding: 20
-                            text: description
-                            font: Theme.tipFont
-                            color: Theme.secondaryTextColor
-                            wrapMode: Text.WordWrap
-                          }
-                        }
-
-                        QfSwitch {
-                          id: toggle
-                          width: implicitContentWidth
-                          checked: registry[settingAlias]
-                          Layout.alignment: Qt.AlignTop | Qt.AlignRight
-                          onCheckedChanged: registry[settingAlias] = checked
-                        }
-                      }
-                    }
+                    delegate: listItem
                   }
 
                   GridLayout {
@@ -360,7 +534,7 @@ Page {
 
                       Label {
                           Layout.fillWidth: true
-                          text: qsTr( "User interface appearance:" )
+                          text: qsTr( "Appearance:" )
                           font: Theme.defaultFont
                           color: Theme.mainTextColor
 
@@ -404,7 +578,7 @@ Page {
 
                       Label {
                           Layout.fillWidth: true
-                          text: qsTr( "User interface font size:" )
+                          text: qsTr( "Font size:" )
                           font: Theme.defaultFont
                           color: Theme.mainTextColor
 
@@ -449,7 +623,7 @@ Page {
 
                       Label {
                           Layout.fillWidth: true
-                          text: qsTr( "User interface language:" )
+                          text: qsTr( "Language:" )
                           font: Theme.defaultFont
                           color: Theme.mainTextColor
 
@@ -517,59 +691,45 @@ Page {
 
                           onLinkActivated: (link) => { Qt.openUrlExternally(link) }
                       }
+                  }
+
+                  GridLayout {
+                      Layout.fillWidth: true
+                      Layout.leftMargin: 20
+                      Layout.rightMargin: 20
+
+                      columns: 2
+                      columnSpacing: 0
+                      rowSpacing: 5
+
+                      visible: platformUtilities.capabilities & PlatformUtilities.NativeCamera || platformUtilities.capabilities & PlatformUtilities.SentryFramework
 
                       Label {
-                          Layout.fillWidth: true
-                          text: qsTr( "Map canvas rendering quality:" )
-                          font: Theme.defaultFont
-                          color: Theme.mainTextColor
-
-                          wrapMode: Text.WordWrap
+                        text: qsTr('Advanced')
+                        font: Theme.strongFont
+                        color: Theme.mainColor
+                        wrapMode: Text.WordWrap
+                        Layout.fillWidth: true
+                        Layout.topMargin: 5
+                        Layout.columnSpan: 2
                       }
 
-                      ComboBox {
-                          id: renderingQualityComboBox
-                          enabled: true
-                          Layout.fillWidth: true
-                          Layout.alignment: Qt.AlignVCenter
-                          font: Theme.defaultFont
-
-                          popup.font: Theme.defaultFont
-                          popup.topMargin: mainWindow.sceneTopMargin
-                          popup.bottomMargin: mainWindow.sceneTopMargin
-
-                          model: ListModel {
-                            ListElement { name: qsTr('Best quality'); value: 1.0 }
-                            ListElement { name: qsTr('Lower quality'); value: 0.75 }
-                            ListElement { name: qsTr('Lowest quality'); value: 0.5 }
-                          }
-                          textRole: "name"
-                          valueRole: "value"
-
-                          property bool initialized: false
-
-                          onCurrentValueChanged: {
-                              if (initialized) {
-                                quality = currentValue
-                              }
-                          }
-
-                          Component.onCompleted: {
-                              currentIndex = indexOfValue(quality)
-                              initialized = true
-                          }
+                      Rectangle {
+                        Layout.fillWidth: true
+                        Layout.columnSpan: 2
+                        height: 1
+                        color: Theme.mainColor
                       }
+                  }
 
-                      Label {
-                          text: qsTr( "A lower quality trades rendering precision in favor of lower memory usage and rendering time." )
-                          font: Theme.tipFont
-                          color: Theme.secondaryTextColor
-                          textFormat: Qt.RichText
-                          wrapMode: Text.WordWrap
-                          Layout.fillWidth: true
+                  ListView {
+                    Layout.preferredWidth: mainWindow.width
+                    Layout.preferredHeight: childrenRect.height
+                    interactive: false
 
-                          onLinkActivated: (link) => { Qt.openUrlExternally(link) }
-                      }
+                    model: advancedSettingsModel
+
+                    delegate: listItem
                   }
 
                   Item {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -398,7 +398,9 @@ ApplicationWindow {
                 // Unfortunately, Qt fails to set the hovered property to false when stylus leaves proximity
                 // of the screen, we've got to compensate for that
                 mapCanvasMap.hovered = false
-                coordinateLocator.sourceLocation = undefined
+                if ( !qfieldSettings.fingerTapDigitizing ) {
+                    coordinateLocator.sourceLocation = undefined
+                }
             }
         }
     }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -471,19 +471,27 @@ ApplicationWindow {
               }
 
               // Check if geometry editor is taking over
-              if ( !( positionSource.active && positioningSettings.positioningCoordinateLock ) && geometryEditorsToolbar.canvasClicked( point, type ) )
-                  return;
-
-              if ( !(positionSource.active && positioningSettings.positioningCoordinateLock) && (!featureForm.visible || digitizingToolbar.geometryRequested ) &&
-                   ( ( stateMachine.state === "digitize" && digitizingFeature.currentLayer ) || stateMachine.state === 'measure' ) ) {
-                  if ( Number( currentRubberband.model.geometryType ) === Qgis.GeometryType.Point ||
-                          Number( currentRubberband.model.geometryType ) === Qgis.GeometryType.Null ) {
-                      digitizingToolbar.confirm()
-                  } else {
-                      digitizingToolbar.addVertex()
+              const positionLocked = positionSource.active && positioningSettings.positioningCoordinateLock
+              if ( geometryEditorsToolbar.stateVisible ) {
+                  if ( !positionLocked ) {
+                       geometryEditorsToolbar.canvasClicked( point, type )
                   }
+                  return
+              }
+
+              if ( !featureForm.visible || digitizingToolbar.geometryRequested ) {
+                 if ( !positionLocked ) {
+                     if ( ( stateMachine.state === "digitize" && digitizingFeature.currentLayer ) || stateMachine.state === "measure" ) {
+                         if ( Number( currentRubberband.model.geometryType ) === Qgis.GeometryType.Point ||
+                                 Number( currentRubberband.model.geometryType ) === Qgis.GeometryType.Null ) {
+                             digitizingToolbar.confirm()
+                         } else {
+                             digitizingToolbar.addVertex()
+                         }
+                     }
+                 }
               } else {
-                  if (!overlayFeatureFormDrawer.visible || !featureForm.canvasOperationRequested) {
+                  if (!featureForm.canvasOperationRequested && !overlayFeatureFormDrawer.visible && featureForm.state !== "FeatureFormEdit" ) {
                       identifyTool.isMenuRequest = false
                       identifyTool.identify(point)
                   }
@@ -493,15 +501,15 @@ ApplicationWindow {
 
       onConfirmedClicked: (point) => {
           // Check if geometry editor is taking over
+          const positionLocked = positionSource.active && positioningSettings.positioningCoordinateLock
           if ( geometryEditorsToolbar.stateVisible ) {
-            if ( !( positionSource.active && positioningSettings.positioningCoordinateLock ) ) {
-              geometryEditorsToolbar.canvasClicked( point, '' )
-            }
-            return
+              if ( !positionLocked ) {
+                geometryEditorsToolbar.canvasClicked( point, '' )
+              }
+              return
           }
 
-          if (!featureForm.canvasOperationRequested && !overlayFeatureFormDrawer.visible && featureForm.state != "FeatureFormEdit")
-          {
+          if (!featureForm.canvasOperationRequested && !overlayFeatureFormDrawer.visible && featureForm.state !== "FeatureFormEdit") {
               identifyTool.isMenuRequest = false
               identifyTool.identify(point)
           }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -358,7 +358,11 @@ ApplicationWindow {
             if ( hovered ) {
                 hasBeenHovered = true;
             } else {
-                coordinateLocator.sourceLocation = undefined
+                if ( currentRubberband.model.vertexCount > 1 ) {
+                  coordinateLocator.sourceLocation = mapCanvas.mapSettings.coordinateToScreen( currentRubberband.model.lastCoordinate )
+                } else {
+                  coordinateLocator.sourceLocation = undefined
+                }
             }
         }
     }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2096,6 +2096,7 @@ ApplicationWindow {
       }
 
       onCancel: {
+          coordinateLocator.sourceLocation = undefined
           if ( stateMachine.state === 'measure' && elevationProfileButton.elevationProfileActive ) {
               elevationProfile.clear()
               elevationProfile.refresh()
@@ -2121,6 +2122,7 @@ ApplicationWindow {
             geometryRequestedItem.requestedGeometryReceived(digitizingFeature.geometry)
             digitizingRubberband.model.reset()
             geometryRequested = false
+            coordinateLocator.sourceLocation = undefined
             return;
         }
 
@@ -2162,6 +2164,7 @@ ApplicationWindow {
           digitizingRubberband.model.reset()
           digitizingFeature.resetFeature();
         }
+        coordinateLocator.sourceLocation = undefined
       }
     }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -479,15 +479,13 @@ ApplicationWindow {
                   return
               }
 
-              if ( !featureForm.visible || digitizingToolbar.geometryRequested ) {
-                 if ( !positionLocked ) {
-                     if ( ( stateMachine.state === "digitize" && digitizingFeature.currentLayer ) || stateMachine.state === "measure" ) {
-                         if ( Number( currentRubberband.model.geometryType ) === Qgis.GeometryType.Point ||
-                                 Number( currentRubberband.model.geometryType ) === Qgis.GeometryType.Null ) {
-                             digitizingToolbar.confirm()
-                         } else {
-                             digitizingToolbar.addVertex()
-                         }
+              if ( ( stateMachine.state === "digitize" && digitizingFeature.currentLayer ) || stateMachine.state === "measure" ) {
+                 if ( !positionLocked && ( !featureForm.visible || digitizingToolbar.geometryRequested ) ) {
+                     if ( Number( currentRubberband.model.geometryType ) === Qgis.GeometryType.Point ||
+                             Number( currentRubberband.model.geometryType ) === Qgis.GeometryType.Null ) {
+                         digitizingToolbar.confirm()
+                     } else {
+                         digitizingToolbar.addVertex()
                      }
                  }
               } else {
@@ -509,7 +507,19 @@ ApplicationWindow {
               return
           }
 
-          if (!featureForm.canvasOperationRequested && !overlayFeatureFormDrawer.visible && featureForm.state !== "FeatureFormEdit") {
+          if ( qfieldSettings.fingerTapDigitizing && ( ( stateMachine.state === "digitize" && digitizingFeature.currentLayer ) || stateMachine.state === "measure" ) ) {
+              if ( !positionLocked && ( !featureForm.visible || digitizingToolbar.geometryRequested ) ) {
+                  console.log(point.position)
+                  coordinateLocator.sourceLocation = point.position
+                  coordinateLocator.sourceLocation = point
+                  if ( Number( currentRubberband.model.geometryType ) === Qgis.GeometryType.Point ||
+                          Number( currentRubberband.model.geometryType ) === Qgis.GeometryType.Null ) {
+                      digitizingToolbar.confirm()
+                  } else {
+                      digitizingToolbar.addVertex()
+                  }
+              }
+          } else if (!featureForm.canvasOperationRequested && !overlayFeatureFormDrawer.visible && featureForm.state !== "FeatureFormEdit") {
               identifyTool.isMenuRequest = false
               identifyTool.identify(point)
           }


### PR DESCRIPTION
This PR implements a new finger tap digitizing mode whereas users can tap anywhere on the canvas to add vertices. It resembles stylus/mouse digitizing, except it's with the finger. For those willing to sacrifice accuracy for speed, this is a great mode.

The mode can be enabled in the settings panel. To avoid a sense of chaos/overcrowding in the settings' general tab, I have added section (much like we did for tracker settings):

![image](https://github.com/opengisch/QField/assets/1728657/4d539284-ce2d-4383-8106-e7b23ef11949)

A bunch of pointer/finger interaction code has been cleaned up too to try and make it slightly more readable, with a couple of fixes in (inc. a crucial one for mouse digitizing).