### PR TITLE
Prevent deltas having empty strings as WKT geometry

### DIFF
--- a/src/core/deltafilewrapper.cpp
+++ b/src/core/deltafilewrapper.cpp
@@ -996,9 +996,18 @@ void DeltaFileWrapper::setIsPushing( bool isPushing )
 QJsonValue DeltaFileWrapper::geometryToJsonValue( const QgsGeometry &geom ) const
 {
   if ( geom.isNull() )
+  {
     return QJsonValue::Null;
+  }
 
-  return QJsonValue( geom.asWkt() );
+  QString wkt = geom.asWkt();
+
+  if ( wkt.trimmed().isEmpty() )
+  {
+    return QJsonValue::Null;
+  }
+
+  return QJsonValue( wkt );
 }
 
 


### PR DESCRIPTION
For some reason a geometryless layer would produce WKTs that are empty strings. Did not manage to reproduce locally, but this later fails in posgres, as `ST_GeomFromText( '' )` raises.

Related PR: https://github.com/opengisch/qfieldcloud/pull/917
Fix: https://github.com/opengisch/QField/issues/4796