### PR TITLE
Grouping functionality for the value relation editor widget

### DIFF
--- a/src/core/featurelistmodel.cpp
+++ b/src/core/featurelistmodel.cpp
@@ -90,6 +90,9 @@ QVariant FeatureListModel::data( const QModelIndex &index, int role ) const
       return mEntries.value( index.row() ).displayString;
 
     case KeyFieldRole:
+      return mEntries.value( index.row() ).key;
+
+    case GroupFieldRole:
       return mEntries.value( index.row() ).group;
   }
 
@@ -102,7 +105,7 @@ QHash<int, QByteArray> FeatureListModel::roleNames() const
 
   roles[KeyFieldRole] = "keyFieldValue";
   roles[DisplayStringRole] = "displayString";
-  roles[GroupRole] = "GroupRole";
+  roles[GroupFieldRole] = "groupFieldValue";
 
   return roles;
 }

--- a/src/core/featurelistmodel.cpp
+++ b/src/core/featurelistmodel.cpp
@@ -94,9 +94,6 @@ QVariant FeatureListModel::data( const QModelIndex &index, int role ) const
 
     case GroupFieldRole:
       return mEntries.value( index.row() ).group;
-
-    case FirstInGroupRole:
-      return mEntries.value( index.row() ).firstInGroup;
   }
 
   return QVariant();
@@ -109,7 +106,6 @@ QHash<int, QByteArray> FeatureListModel::roleNames() const
   roles[KeyFieldRole] = "keyFieldValue";
   roles[DisplayStringRole] = "displayString";
   roles[GroupFieldRole] = "groupFieldValue";
-  roles[FirstInGroupRole] = "firstInGroup";
 
   return roles;
 }
@@ -422,19 +418,6 @@ void FeatureListModel::processFeatureList()
                ? entry1.displayString.toLower() < entry2.displayString.toLower()
                : entry1.fuzzyScore > entry2.fuzzyScore;
     } );
-  }
-
-  if ( !mGroupField.isEmpty() )
-  {
-    QVariant currentGroupValue;
-    for ( Entry &entry : entries )
-    {
-      if ( entry.group != currentGroupValue )
-      {
-        entry.firstInGroup = true;
-        currentGroupValue = entry.group;
-      }
-    }
   }
 
   beginResetModel();

--- a/src/core/featurelistmodel.cpp
+++ b/src/core/featurelistmodel.cpp
@@ -94,6 +94,9 @@ QVariant FeatureListModel::data( const QModelIndex &index, int role ) const
 
     case GroupFieldRole:
       return mEntries.value( index.row() ).group;
+
+    case FirstInGroupRole:
+      return mEntries.value( index.row() ).firstInGroup;
   }
 
   return QVariant();
@@ -106,6 +109,7 @@ QHash<int, QByteArray> FeatureListModel::roleNames() const
   roles[KeyFieldRole] = "keyFieldValue";
   roles[DisplayStringRole] = "displayString";
   roles[GroupFieldRole] = "groupFieldValue";
+  roles[FirstInGroupRole] = "firstInGroup";
 
   return roles;
 }
@@ -418,6 +422,19 @@ void FeatureListModel::processFeatureList()
                ? entry1.displayString.toLower() < entry2.displayString.toLower()
                : entry1.fuzzyScore > entry2.fuzzyScore;
     } );
+  }
+
+  if ( !mGroupField.isEmpty() )
+  {
+    QVariant currentGroupValue;
+    for ( Entry &entry : entries )
+    {
+      if ( entry.group != currentGroupValue )
+      {
+        entry.firstInGroup = true;
+        currentGroupValue = entry.group;
+      }
+    }
   }
 
   beginResetModel();

--- a/src/core/featurelistmodel.cpp
+++ b/src/core/featurelistmodel.cpp
@@ -80,13 +80,17 @@ int FeatureListModel::columnCount( const QModelIndex &parent ) const
 
 QVariant FeatureListModel::data( const QModelIndex &index, int role ) const
 {
-  if ( role == Qt::DisplayRole || role == DisplayStringRole )
+  if ( index.row() < 0 || index.row() >= mEntries.size() )
+    return QVariant();
+
+  switch ( role )
   {
-    return mEntries.value( index.row() ).displayString;
-  }
-  else if ( role == KeyFieldRole )
-  {
-    return mEntries.value( index.row() ).key;
+    case Qt::DisplayRole:
+    case DisplayStringRole:
+      return mEntries.value( index.row() ).displayString;
+
+    case KeyFieldRole:
+      return mEntries.value( index.row() ).group;
   }
 
   return QVariant();
@@ -98,6 +102,7 @@ QHash<int, QByteArray> FeatureListModel::roleNames() const
 
   roles[KeyFieldRole] = "keyFieldValue";
   roles[DisplayStringRole] = "displayString";
+  roles[GroupRole] = "GroupRole";
 
   return roles;
 }
@@ -165,6 +170,38 @@ void FeatureListModel::setDisplayValueField( const QString &displayValueField )
   reloadLayer();
 
   emit displayValueFieldChanged();
+}
+
+QString FeatureListModel::groupField() const
+{
+  return mGroupField;
+}
+
+void FeatureListModel::setGroupField( const QString &groupField )
+{
+  if ( mGroupField == groupField )
+    return;
+
+  mGroupField = groupField;
+
+  reloadLayer();
+
+  emit groupFieldChanged();
+}
+
+bool FeatureListModel::displayGroupName() const
+{
+  return mDisplayGroupName;
+}
+
+void FeatureListModel::setDisplayGroupName( bool displayGroupName )
+{
+  if ( mDisplayGroupName == displayGroupName )
+    return;
+
+  mDisplayGroupName = displayGroupName;
+
+  emit displayGroupNameChanged();
 }
 
 int FeatureListModel::findKey( const QVariant &key ) const
@@ -255,6 +292,9 @@ void FeatureListModel::gatherFeatureList()
   if ( !keyField().isNull() )
     referencedColumns << mKeyField;
 
+  if ( !groupField().isNull() )
+    referencedColumns << mGroupField;
+
   referencedColumns << mDisplayValueField;
 
   QgsFields fields = mCurrentLayer->fields();
@@ -303,7 +343,7 @@ void FeatureListModel::gatherFeatureList()
 
   cleanupGatherer();
 
-  mGatherer = new FeatureExpressionValuesGatherer( mCurrentLayer, fieldDisplayString, request, QStringList() << keyField() );
+  mGatherer = new FeatureExpressionValuesGatherer( mCurrentLayer, fieldDisplayString, request, QStringList() << keyField() << groupField() );
   connect( mGatherer, &QThread::finished, this, &FeatureListModel::processFeatureList );
   mGatherer->start();
 }
@@ -318,7 +358,7 @@ void FeatureListModel::processFeatureList()
   QList<Entry> entries;
 
   if ( mAddNull )
-    entries.append( Entry( QStringLiteral( "<i>NULL</i>" ), QVariant(), QgsFeatureId() ) );
+    entries.append( Entry( QStringLiteral( "<i>NULL</i>" ), QVariant(), QVariant(), QgsFeatureId() ) );
 
   const QVector<FeatureExpressionValuesGatherer::Entry> gatheredEntries = mGatherer->entries();
   mGatherer->deleteLater();
@@ -328,7 +368,7 @@ void FeatureListModel::processFeatureList()
   {
     Entry entry;
 
-    entry = Entry( gatheredEntry.value, gatheredEntry.identifierFields.at( 0 ), gatheredEntry.featureId );
+    entry = Entry( gatheredEntry.value, gatheredEntry.identifierFields.at( 0 ), gatheredEntry.identifierFields.at( 1 ), gatheredEntry.featureId );
 
     if ( !mSearchTerm.isEmpty() )
     {
@@ -340,7 +380,7 @@ void FeatureListModel::processFeatureList()
     entries.append( entry );
   }
 
-  if ( mOrderByValue || !mSearchTerm.isEmpty() )
+  if ( mOrderByValue || !mGroupField.isEmpty() || !mSearchTerm.isEmpty() )
   {
     std::sort( entries.begin(), entries.end(), [=]( const Entry &entry1, const Entry &entry2 ) {
       if ( entry1.key.isNull() )
@@ -348,6 +388,11 @@ void FeatureListModel::processFeatureList()
 
       if ( entry2.key.isNull() )
         return false;
+
+      if ( !mGroupField.isEmpty() && entry1.group != entry2.group )
+      {
+        return entry1.group < entry2.group;
+      }
 
       if ( !mSearchTerm.isEmpty() )
       {

--- a/src/core/featurelistmodel.h
+++ b/src/core/featurelistmodel.h
@@ -42,22 +42,34 @@ class FeatureListModel : public QAbstractItemModel
        * The vector layer to list
        */
     Q_PROPERTY( QgsVectorLayer *currentLayer READ currentLayer WRITE setCurrentLayer NOTIFY currentLayerChanged )
+
     /**
        * The primary key field
        */
     Q_PROPERTY( QString keyField READ keyField WRITE setKeyField NOTIFY keyFieldChanged )
+
     /**
        * The display value field
        */
     Q_PROPERTY( QString displayValueField READ displayValueField WRITE setDisplayValueField NOTIFY displayValueFieldChanged )
 
     /**
-      * Whether the features should be ordered by value
+       * The grouping key field
+       */
+    Q_PROPERTY( QString groupField READ groupField WRITE setGroupField NOTIFY groupFieldChanged )
+
+    /**
+      * Set to TRUE if the group name will be displayed in the list
+      */
+    Q_PROPERTY( bool displayGroupName READ displayGroupName WRITE setDisplayGroupName NOTIFY displayGroupNameChanged )
+
+    /**
+      * Set to TRUE if features should be ordered by value
       */
     Q_PROPERTY( bool orderByValue READ orderByValue WRITE setOrderByValue NOTIFY orderByValueChanged )
 
     /**
-      * Whether a null values is allowed in the list
+      * Set to TRUE if null values are allowed in the list
       */
     Q_PROPERTY( bool addNull READ addNull WRITE setAddNull NOTIFY addNullChanged )
 
@@ -81,6 +93,7 @@ class FeatureListModel : public QAbstractItemModel
     {
       KeyFieldRole = Qt::UserRole + 1,
       DisplayStringRole,
+      GroupRole,
     };
 
     Q_ENUM( FeatureListRoles )
@@ -111,6 +124,12 @@ class FeatureListModel : public QAbstractItemModel
 
     QString displayValueField() const;
     void setDisplayValueField( const QString &displayValueField );
+
+    QString groupField() const;
+    void setGroupField( const QString &groupField );
+
+    bool displayGroupName() const;
+    void setDisplayGroupName( bool displayGroupName );
 
     /**
      * Get the row for a given key value.
@@ -176,6 +195,8 @@ class FeatureListModel : public QAbstractItemModel
     void currentLayerChanged();
     void keyFieldChanged();
     void displayValueFieldChanged();
+    void groupFieldChanged();
+    void displayGroupNameChanged();
     void orderByValueChanged();
     void addNullChanged();
     void filterExpressionChanged();
@@ -198,9 +219,10 @@ class FeatureListModel : public QAbstractItemModel
   private:
     struct Entry
     {
-        Entry( const QString &displayString, const QVariant &key, const QgsFeatureId &fid )
+        Entry( const QString &displayString, const QVariant &key, const QVariant &group, const QgsFeatureId &fid )
           : displayString( displayString )
           , key( key )
+          , group( group )
           , fid( fid )
           , fuzzyScore( 0 )
         {}
@@ -215,6 +237,7 @@ class FeatureListModel : public QAbstractItemModel
 
         QString displayString;
         QVariant key;
+        QVariant group;
         QgsFeatureId fid;
         double fuzzyScore;
     };
@@ -237,6 +260,8 @@ class FeatureListModel : public QAbstractItemModel
     QList<Entry> mEntries;
     QString mKeyField;
     QString mDisplayValueField;
+    QString mGroupField;
+    bool mDisplayGroupName = false;
     bool mOrderByValue = false;
     bool mAddNull = false;
     QString mFilterExpression;

--- a/src/core/featurelistmodel.h
+++ b/src/core/featurelistmodel.h
@@ -93,7 +93,7 @@ class FeatureListModel : public QAbstractItemModel
     {
       KeyFieldRole = Qt::UserRole + 1,
       DisplayStringRole,
-      GroupRole,
+      GroupFieldRole,
     };
 
     Q_ENUM( FeatureListRoles )

--- a/src/core/featurelistmodel.h
+++ b/src/core/featurelistmodel.h
@@ -94,7 +94,6 @@ class FeatureListModel : public QAbstractItemModel
       KeyFieldRole = Qt::UserRole + 1,
       DisplayStringRole,
       GroupFieldRole,
-      FirstInGroupRole,
     };
 
     Q_ENUM( FeatureListRoles )
@@ -239,7 +238,6 @@ class FeatureListModel : public QAbstractItemModel
         QString displayString;
         QVariant key;
         QVariant group;
-        bool firstInGroup = false;
         QgsFeatureId fid;
         double fuzzyScore;
     };

--- a/src/core/featurelistmodel.h
+++ b/src/core/featurelistmodel.h
@@ -94,6 +94,7 @@ class FeatureListModel : public QAbstractItemModel
       KeyFieldRole = Qt::UserRole + 1,
       DisplayStringRole,
       GroupFieldRole,
+      FirstInGroupRole,
     };
 
     Q_ENUM( FeatureListRoles )
@@ -238,6 +239,7 @@ class FeatureListModel : public QAbstractItemModel
         QString displayString;
         QVariant key;
         QVariant group;
+        bool firstInGroup = false;
         QgsFeatureId fid;
         double fuzzyScore;
     };

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -169,7 +169,7 @@ Item {
             Rectangle {
               width:parent.width
               height: featureListModel.displayGroupName ? 30 : 5
-              color: Theme.controlBorderColor
+              color: Theme.controlBackgroundAlternateColor
 
               Text {
                 anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
@@ -194,7 +194,7 @@ Item {
             anchors.margins: 10
             height: radioButton.visible ? radioButton.height : checkBoxButton.height
             width: parent ? parent.width : undefined
-            color: model.checked ? Theme.mainColor : Theme.controlBackgroundAlternateColor
+            color: model.checked ? Theme.mainColor : searchFeaturePopup.Material ? searchFeaturePopup.Material.dialogColor : Theme.mainBackgroundColor
 
             Row {
               RadioButton {

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -321,15 +321,15 @@ Item {
                 anchors.fill: parent
                 propagateComposedEvents: true
 
-                onClicked: { mouse.accepted = false; }
-                onPressed: {
-                    forceActiveFocus();
-                    mouse.accepted = false;
+                onClicked: (mouse) => { mouse.accepted = false }
+                onPressed: (mouse) => {
+                    forceActiveFocus()
+                    mouse.accepted = false
                 }
-                onReleased: mouse.accepted = false;
-                onDoubleClicked: mouse.accepted = false;
-                onPositionChanged: mouse.accepted = false;
-                onPressAndHold: mouse.accepted = false;
+                onReleased: (mouse) => { mouse.accepted = false }
+                onDoubleClicked: (mouse) => { mouse.accepted = false }
+                onPositionChanged: (mouse) => { mouse.accepted = false }
+                onPressAndHold: (mouse) => { mouse.accepted = false }
             }
 
             Component.onCompleted: {
@@ -337,9 +337,6 @@ Item {
             }
 
             font: Theme.defaultFont
-            popup.font: Theme.defaultFont
-            popup.topMargin: mainWindow.sceneTopMargin
-            popup.bottomMargin: mainWindow.sceneTopMargin
 
             contentItem: Text {
                 leftPadding: enabled ? 5 : 0
@@ -354,28 +351,42 @@ Item {
                 elide: Text.ElideRight
             }
 
-            delegate: ItemDelegate {
-                    topPadding: firstInGroup ? sectionBackground.height + padding / 2 : padding / 2
-                    implicitWidth: comboBox.width
-                    width: comboBox.width
-                    text: displayString
+            popup: Popup {
+                y: comboBox.height - 1
+                width: comboBox.width
+                implicitHeight: contentItem.implicitHeight
+                padding: 1
+                font: Theme.defaultFont
+                topMargin: mainWindow.sceneTopMargin
+                bottomMargin: mainWindow.sceneTopMargin
 
-                    Rectangle {
-                      id: sectionBackground
-                      width:parent.width
-                      height: featureListModel.displayGroupName ? 30 : 1
-                      color: Theme.mainBackgroundColor
-                      visible: firstInGroup
+                contentItem: ListView {
+                    clip: true
+                    implicitHeight: contentHeight
+                    model: comboBox.popup.visible ? comboBox.delegateModel : null
+                    currentIndex: comboBox.highlightedIndex
 
-                      Text {
-                        anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
-                        font.bold: true
-                        font.pointSize: Theme.resultFont.pointSize
-                        color: Theme.mainTextColor
-                        text: groupFieldValue
-                        visible: featureListModel.displayGroupName
+                    section.property: featureListModel.groupField != "" ? "groupFieldValue" : ""
+                    section.labelPositioning: ViewSection.CurrentLabelAtStart | ViewSection.InlineLabels
+                    section.delegate: Component {
+                      Rectangle {
+                        width:parent.width
+                        height: featureListModel.displayGroupName ? 30 : 5
+                        color: Theme.mainBackgroundColor
+
+                        Text {
+                          anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
+                          font.bold: true
+                          font.pointSize: Theme.resultFont.pointSize
+                          color: Theme.mainTextColor
+                          text: section
+                          visible: featureListModel.displayGroupName
+                        }
                       }
                     }
+
+                    ScrollIndicator.vertical: ScrollIndicator { }
+                }
             }
 
 

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -362,7 +362,7 @@ Item {
 
                 contentItem: ListView {
                     clip: true
-                    implicitHeight: contentHeight
+                    implicitHeight: Math.min(mainWindow.height - mainWindow.sceneTopMargin - mainWindow.sceneTopMargin, contentHeight)
                     model: comboBox.popup.visible ? comboBox.delegateModel : null
                     currentIndex: comboBox.highlightedIndex
 

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -163,12 +163,12 @@ Item {
             }
           }
 
-          section.property: featureListModel.displayGroupName && featureListModel.groupField != "" ? "groupFieldValue" : ""
+          section.property: featureListModel.groupField != "" ? "groupFieldValue" : ""
           section.labelPositioning: ViewSection.CurrentLabelAtStart | ViewSection.InlineLabels
           section.delegate: Component {
             Rectangle {
               width:parent.width
-              height: 30
+              height: featureListModel.displayGroupName ? 30 : 5
               color: Theme.controlBorderColor
 
               Text {
@@ -177,6 +177,7 @@ Item {
                 font.pointSize: Theme.resultFont.pointSize
                 color: Theme.mainTextColor
                 text: section
+                visible: featureListModel.displayGroupName
               }
             }
           }
@@ -352,6 +353,31 @@ Item {
                 verticalAlignment: Text.AlignVCenter
                 elide: Text.ElideRight
             }
+
+            delegate: ItemDelegate {
+                    topPadding: firstInGroup ? sectionBackground.height + padding / 2 : padding / 2
+                    implicitWidth: comboBox.width
+                    width: comboBox.width
+                    text: displayString
+
+                    Rectangle {
+                      id: sectionBackground
+                      width:parent.width
+                      height: featureListModel.displayGroupName ? 30 : 1
+                      color: Theme.mainBackgroundColor
+                      visible: firstInGroup
+
+                      Text {
+                        anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
+                        font.bold: true
+                        font.pointSize: Theme.resultFont.pointSize
+                        color: Theme.mainTextColor
+                        text: groupFieldValue
+                        visible: featureListModel.displayGroupName
+                      }
+                    }
+            }
+
 
             background: Item {
                 implicitWidth: 120

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -163,6 +163,24 @@ Item {
             }
           }
 
+          section.property: featureListModel.displayGroupName && featureListModel.groupField != "" ? "groupFieldValue" : ""
+          section.labelPositioning: ViewSection.CurrentLabelAtStart | ViewSection.InlineLabels
+          section.delegate: Component {
+            Rectangle {
+              width:parent.width
+              height: 30
+              color: Theme.controlBorderColor
+
+              Text {
+                anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
+                font.bold: true
+                font.pointSize: Theme.resultFont.pointSize
+                color: Theme.mainTextColor
+                text: section
+              }
+            }
+          }
+
           delegate: Rectangle {
             id: delegateRect
 

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -98,7 +98,7 @@ Item {
           anchors.left: parent.left
           anchors.right: parent.right
 
-          placeholderText: displayText == '' ? qsTr("Search…") : ''
+          placeholderText: !focus && displayText == '' ? qsTr("Search…") : ''
           placeholderTextColor: Theme.mainColor
 
           height: fontMetrics.height * 2.5

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -34,6 +34,8 @@ EditorWidgetBase {
     currentFormFeature: currentFeature
     keyField: config['Key']
     displayValueField: config['Value']
+    groupField: config['Group']
+    displayGroupName: config['DisplayGroupName']
     addNull: config['AllowNull']
     orderByValue: config['OrderByValue']
     filterExpression: config['FilterExpression']


### PR DESCRIPTION
This PR implements grouping functionality to the value relation editor widget (the QGIS counterpart having been implemented here: https://github.com/qgis/QGIS/pull/56655). 

Here's how the UI looks when both a group field has been picked, as well as the [x] display group name checkbox has been toggled on.

First, the relation combobox dropdown list:
![Screenshot from 2024-03-24 13-58-53](https://github.com/opengisch/QField/assets/1728657/94fe446a-d488-498f-8fd3-1318e1ab2d1c)

Then, the relation combobox's search popup list:
![image](https://github.com/opengisch/QField/assets/1728657/eccda1b4-708b-4ccd-bb26-31dde1a59f49)

_Note that you will need a QGIS development build to configure the value relation in your QGIS project until QGIS 3.38._

