### PR TITLE
[Backport release-3_2] Only show the attachment widget's image frame for supported types by Qt

### DIFF
--- a/src/core/utils/fileutils.cpp
+++ b/src/core/utils/fileutils.cpp
@@ -22,6 +22,7 @@
 #include <QDirIterator>
 #include <QFileInfo>
 #include <QImage>
+#include <QImageReader>
 #include <QMimeDatabase>
 #include <qgis.h>
 #include <qgsexiftools.h>
@@ -37,6 +38,11 @@ QString FileUtils::mimeTypeName( const QString &filePath )
   QMimeDatabase db;
   QMimeType mimeType = db.mimeTypeForFile( filePath );
   return mimeType.name();
+}
+
+bool FileUtils::isImageMimeTypeSupported( const QString &mimeType )
+{
+  return QImageReader::supportedMimeTypes().contains( mimeType.toLatin1() );
 }
 
 QString FileUtils::fileName( const QString &filePath )

--- a/src/core/utils/fileutils.h
+++ b/src/core/utils/fileutils.h
@@ -35,6 +35,8 @@ class QFIELD_CORE_EXPORT FileUtils : public QObject
 
     //! Returns the mimetype of a filepath as string
     Q_INVOKABLE static QString mimeTypeName( const QString &filePath );
+    //! Returns TRUE if the provided mimetype is a supported image
+    Q_INVOKABLE static bool isImageMimeTypeSupported( const QString &mimeType );
     //! Returns the filename of a filepath - if no file name exists it's empty
     Q_INVOKABLE static QString fileName( const QString &filePath );
     //! Returns true if the file exists (false if it's a directory)

--- a/src/qml/editorwidgets/+Qt5/ExternalResource.qml
+++ b/src/qml/editorwidgets/+Qt5/ExternalResource.qml
@@ -80,9 +80,10 @@ EditorWidgetBase {
     {
       const isHttp = value.startsWith('http://') || value.startsWith('https://');
       var fullValue = isHttp ? value : prefixToRelativePath + value
-      isImage = !config.UseLink && FileUtils.mimeTypeName(fullValue).startsWith("image/")
-      isAudio = !config.UseLink && FileUtils.mimeTypeName(fullValue).startsWith("audio/")
-      isVideo = !config.UseLink && FileUtils.mimeTypeName(fullValue).startsWith("video/")
+      var mimeType = FileUtils.mimeTypeName(fullValue)
+      isImage = !config.UseLink && mimeType.startsWith("image/") && FileUtils.isImageMimeTypeSupported(mimeType)
+      isAudio = !config.UseLink && mimeType.startsWith("audio/")
+      isVideo = !config.UseLink && mimeType.startsWith("video/")
 
       image.visible = isImage
       geoTagBadge.visible = isImage

--- a/src/qml/editorwidgets/+Qt6/ExternalResource.qml
+++ b/src/qml/editorwidgets/+Qt6/ExternalResource.qml
@@ -79,9 +79,10 @@ EditorWidgetBase {
     if (currentValue != undefined && currentValue !== '') {
       const isHttp = value.startsWith('http://') || value.startsWith('https://');
       var fullValue = isHttp ? value : prefixToRelativePath + value
-      isImage = !config.UseLink && FileUtils.mimeTypeName(fullValue).startsWith("image/")
-      isAudio = !config.UseLink && FileUtils.mimeTypeName(fullValue).startsWith("audio/")
-      isVideo = !config.UseLink && FileUtils.mimeTypeName(fullValue).startsWith("video/")
+      var mimeType = FileUtils.mimeTypeName(fullValue)
+      isImage = !config.UseLink && mimeType.startsWith("image/") && FileUtils.isImageMimeTypeSupported(mimeType)
+      isAudio = !config.UseLink && mimeType.startsWith("audio/")
+      isVideo = !config.UseLink && mimeType.startsWith("video/")
 
       image.visible = isImage
       geoTagBadge.visible = isImage


### PR DESCRIPTION
Backport #5136
 **Authored by:** @nirvn