### PR TITLE
Insure that the navigation information and position precise view panels respect the project's distance unit

### DIFF
--- a/src/qml/NavigationInformationView.qml
+++ b/src/qml/NavigationInformationView.qml
@@ -180,7 +180,7 @@ Rectangle {
           color: textColor
           text: qsTr( "Dist." ) + ': ' +
                 ( positionSource.active && positionSource.positionInformation && positionSource.positionInformation.latitudeValid
-                 ? ( UnitTypes.formatDistance( navigation.distance, 3, navigation.distanceUnits ) )
+                 ? ( UnitTypes.formatDistance( navigation.distance * UnitTypes.fromUnitToUnitFactor( navigation.distanceUnits, projectInfo.distanceUnits ), 3, projectInfo.distanceUnits ) )
                  : qsTr( "N/A" ) )
         }
       }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -949,7 +949,7 @@ ApplicationWindow {
 
       visible: !isNaN(navigation.distance)
                && (positioningSettings.alwaysShowPreciseView
-                   || (hasAcceptableAccuracy && navigation.distance < precision))
+                   || (hasAcceptableAccuracy && projectDistance < precision))
                && !elevationProfile.visible
       width: parent.width
       height: Math.min(mainWindow.height / 2.5, 400)
@@ -2955,7 +2955,7 @@ ApplicationWindow {
     }
 
     MenuItem {
-      text: qsTr( "%1 Precision" ).arg(UnitTypes.formatDistance(0.10, 2, navigation.distanceUnits))
+      text: qsTr( "%1 Precision" ).arg(UnitTypes.formatDistance(0.10, 2, projectInfo.distanceUnits))
       height: 48
       leftPadding: Theme.menuItemCheckLeftPadding
       font: Theme.defaultFont
@@ -2971,7 +2971,7 @@ ApplicationWindow {
     }
 
     MenuItem {
-      text: qsTr( "%1 Precision" ).arg(UnitTypes.formatDistance(0.25, 2, navigation.distanceUnits))
+      text: qsTr( "%1 Precision" ).arg(UnitTypes.formatDistance(0.25, 2, projectInfo.distanceUnits))
       height: 48
       leftPadding: Theme.menuItemCheckLeftPadding
       font: Theme.defaultFont
@@ -2987,7 +2987,7 @@ ApplicationWindow {
     }
 
     MenuItem {
-      text: qsTr( "%1 Precision" ).arg(UnitTypes.formatDistance(0.5, 2, navigation.distanceUnits))
+      text: qsTr( "%1 Precision" ).arg(UnitTypes.formatDistance(0.5, 2, projectInfo.distanceUnits))
       height: 48
       leftPadding: Theme.menuItemCheckLeftPadding
       font: Theme.defaultFont
@@ -3003,7 +3003,7 @@ ApplicationWindow {
     }
 
     MenuItem {
-      text: qsTr( "%1 Precision" ).arg(UnitTypes.formatDistance(1, 2, navigation.distanceUnits))
+      text: qsTr( "%1 Precision" ).arg(UnitTypes.formatDistance(1, 2, projectInfo.distanceUnits))
       height: 48
       leftPadding: Theme.menuItemCheckLeftPadding
       font: Theme.defaultFont
@@ -3019,7 +3019,7 @@ ApplicationWindow {
     }
 
     MenuItem {
-      text: qsTr( "%1 Precision" ).arg(UnitTypes.formatDistance(2.5, 2, navigation.distanceUnits))
+      text: qsTr( "%1 Precision" ).arg(UnitTypes.formatDistance(2.5, 2, projectInfo.distanceUnits))
       height: 48
       leftPadding: Theme.menuItemCheckLeftPadding
       font: Theme.defaultFont
@@ -3035,7 +3035,7 @@ ApplicationWindow {
     }
 
     MenuItem {
-      text: qsTr( "%1 Precision" ).arg(UnitTypes.formatDistance(5, 2, navigation.distanceUnits))
+      text: qsTr( "%1 Precision" ).arg(UnitTypes.formatDistance(5, 2, projectInfo.distanceUnits))
       height: 48
       leftPadding: Theme.menuItemCheckLeftPadding
       font: Theme.defaultFont
@@ -3051,7 +3051,7 @@ ApplicationWindow {
     }
 
     MenuItem {
-      text: qsTr( "%1 Precision" ).arg(UnitTypes.formatDistance(10, 2, navigation.distanceUnits))
+      text: qsTr( "%1 Precision" ).arg(UnitTypes.formatDistance(10, 2, projectInfo.distanceUnits))
       height: 48
       leftPadding: Theme.menuItemCheckLeftPadding
       font: Theme.defaultFont


### PR DESCRIPTION
I think that's the last bit of our UI that wasn't respecting the project distance unit :partying_face: 

Proof of life:

![image](https://github.com/opengisch/QField/assets/1728657/3025fa05-5c85-41b2-a6c8-de67d76f2bc8)

@ConJaySten , this fixes the issue you raised here (https://github.com/opengisch/QField/pull/5127#issuecomment-2028673711). 