### PR TITLE
Empower plugins with more functionalities

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -373,11 +373,14 @@ void QgisMobileapp::initDeclarative()
 
   qRegisterMetaType<QgsGeometry>( "QgsGeometry" );
   qRegisterMetaType<QgsFeature>( "QgsFeature" );
+  qRegisterMetaType<QgsFeatureRequest>( "QgsFeatureRequest" );
+  qRegisterMetaType<QgsFeatureIterator>( "QgsFeatureIterator" );
   qRegisterMetaType<QgsPoint>( "QgsPoint" );
   qRegisterMetaType<QgsPointXY>( "QgsPointXY" );
   qRegisterMetaType<QgsPointSequence>( "QgsPointSequence" );
   qRegisterMetaType<QgsCoordinateTransformContext>( "QgsCoordinateTransformContext" );
   qRegisterMetaType<QgsFeatureId>( "QgsFeatureId" );
+  qRegisterMetaType<QgsFeatureIds>( "QgsFeatureIds" );
   qRegisterMetaType<QgsAttributes>( "QgsAttributes" );
   qRegisterMetaType<QgsSnappingConfig>( "QgsSnappingConfig" );
   qRegisterMetaType<QgsRelation>( "QgsRelation" );

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -428,6 +428,7 @@ void QgisMobileapp::initDeclarative()
   qRegisterMetaType<Positioning::ElevationCorrectionMode>( "Positioning::ElevationCorrectionMode" );
 
   qmlRegisterType<MultiFeatureListModel>( "org.qfield", 1, 0, "MultiFeatureListModel" );
+  qmlRegisterType<FeatureIterator>( "org.qfield", 1, 0, "FeatureIterator" );
   qmlRegisterType<FeatureListModel>( "org.qfield", 1, 0, "FeatureListModel" );
   qmlRegisterType<FeatureListModelSelection>( "org.qfield", 1, 0, "FeatureListModelSelection" );
   qmlRegisterType<FeatureListExtentController>( "org.qfield", 1, 0, "FeaturelistExtentController" );

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -385,6 +385,7 @@ void QgisMobileapp::initDeclarative()
   qRegisterMetaType<QgsSnappingConfig>( "QgsSnappingConfig" );
   qRegisterMetaType<QgsRelation>( "QgsRelation" );
   qRegisterMetaType<QgsPolymorphicRelation>( "QgsPolymorphicRelation" );
+  qRegisterMetaType<QgsFields>( "QgsFields" );
   qRegisterMetaType<QgsField>( "QgsField" );
   qRegisterMetaType<QgsDefaultValue>( "QgsDefaultValue" );
   qRegisterMetaType<QgsFieldConstraints>( "QgsFieldConstraints" );

--- a/src/core/utils/featureutils.cpp
+++ b/src/core/utils/featureutils.cpp
@@ -27,7 +27,7 @@ FeatureUtils::FeatureUtils( QObject *parent )
 {
 }
 
-QgsFeature FeatureUtils::createFeature( QgsVectorLayer *layer, QgsGeometry geometry )
+QgsFeature FeatureUtils::createFeature( QgsVectorLayer *layer, const QgsGeometry &geometry )
 {
   QgsFeature f( layer ? layer->fields() : QgsFields() );
   f.setGeometry( geometry );

--- a/src/core/utils/featureutils.cpp
+++ b/src/core/utils/featureutils.cpp
@@ -27,9 +27,9 @@ FeatureUtils::FeatureUtils( QObject *parent )
 {
 }
 
-QgsFeature FeatureUtils::initFeature( QgsVectorLayer *layer, QgsGeometry geometry )
+QgsFeature FeatureUtils::createFeature( QgsVectorLayer *layer, QgsGeometry geometry )
 {
-  QgsFeature f( layer->fields() );
+  QgsFeature f( layer ? layer->fields() : QgsFields() );
   f.setGeometry( geometry );
   return f;
 }

--- a/src/core/utils/featureutils.h
+++ b/src/core/utils/featureutils.h
@@ -31,7 +31,7 @@ class QFIELD_CORE_EXPORT FeatureUtils : public QObject
   public:
     explicit FeatureUtils( QObject *parent = nullptr );
 
-    static Q_INVOKABLE QgsFeature initFeature( QgsVectorLayer *layer, QgsGeometry geometry = QgsGeometry() );
+    static Q_INVOKABLE QgsFeature createFeature( QgsVectorLayer *layer = nullptr, QgsGeometry geometry = QgsGeometry() );
 
     /**
     * Returns the display name of a given feature.

--- a/src/core/utils/featureutils.h
+++ b/src/core/utils/featureutils.h
@@ -31,7 +31,7 @@ class QFIELD_CORE_EXPORT FeatureUtils : public QObject
   public:
     explicit FeatureUtils( QObject *parent = nullptr );
 
-    static Q_INVOKABLE QgsFeature createFeature( QgsVectorLayer *layer = nullptr, QgsGeometry geometry = QgsGeometry() );
+    static Q_INVOKABLE QgsFeature createFeature( QgsVectorLayer *layer = nullptr, const QgsGeometry &geometry = QgsGeometry() );
 
     /**
     * Returns the display name of a given feature.

--- a/src/core/utils/layerutils.cpp
+++ b/src/core/utils/layerutils.cpp
@@ -368,3 +368,8 @@ bool LayerUtils::hasMValue( QgsVectorLayer *layer )
 
   return QgsWkbTypes::hasM( layer->wkbType() );
 }
+
+QgsFeatureRequest LayerUtils::createFeatureRequestFromExpression( const QString &expression )
+{
+  return QgsFeatureRequest( QgsExpression( expression ) );
+}

--- a/src/core/utils/layerutils.cpp
+++ b/src/core/utils/layerutils.cpp
@@ -369,7 +369,8 @@ bool LayerUtils::hasMValue( QgsVectorLayer *layer )
   return QgsWkbTypes::hasM( layer->wkbType() );
 }
 
-QgsFeatureRequest LayerUtils::createFeatureRequestFromExpression( const QString &expression )
+FeatureIterator LayerUtils::createFeatureIteratorFromExpression( QgsVectorLayer *layer, const QString &expression )
 {
-  return QgsFeatureRequest( QgsExpression( expression ) );
+  const QgsFeatureRequest request = QgsFeatureRequest( QgsExpression( expression ) );
+  return FeatureIterator( layer, request );
 }

--- a/src/core/utils/layerutils.cpp
+++ b/src/core/utils/layerutils.cpp
@@ -199,6 +199,15 @@ QString LayerUtils::fieldType( const QgsField &field )
   return QVariant( field.type() ).typeName();
 }
 
+bool LayerUtils::addFeature( QgsVectorLayer *layer, QgsFeature feature )
+{
+  if ( layer )
+  {
+    return layer->addFeature( feature );
+  }
+  return false;
+}
+
 bool LayerUtils::deleteFeature( QgsProject *project, QgsVectorLayer *layer, const QgsFeatureId fid, bool shouldWriteChanges )
 {
   if ( !project )

--- a/src/core/utils/layerutils.h
+++ b/src/core/utils/layerutils.h
@@ -39,20 +39,35 @@ class FeatureIterator
       }
     }
 
-    Q_INVOKABLE QgsFeature getNextFeature()
+    Q_INVOKABLE bool hasNext()
     {
-      QgsFeature feature;
-      mFeatureIterator.nextFeature( feature );
-      return feature;
+      if ( !mHasNextChecked )
+      {
+        mHasNext = mFeatureIterator.nextFeature( mCurrentFeature );
+        mHasNextChecked = true;
+      }
+      return mHasNext;
     }
 
-    Q_INVOKABLE bool isValid()
+    Q_INVOKABLE QgsFeature next()
     {
-      return mFeatureIterator.isValid();
+      if ( !mHasNextChecked )
+      {
+        mFeatureIterator.nextFeature( mCurrentFeature );
+      }
+      else
+      {
+        mHasNextChecked = false;
+      }
+      return mCurrentFeature;
     }
 
   private:
     QgsFeatureIterator mFeatureIterator;
+    QgsFeature mCurrentFeature;
+
+    bool mHasNext = false;
+    bool mHasNextChecked = false;
 };
 
 class LayerUtils : public QObject

--- a/src/core/utils/layerutils.h
+++ b/src/core/utils/layerutils.h
@@ -78,6 +78,11 @@ class LayerUtils : public QObject
      * Returns TRUE if the vector \a layer geometry has an M value.
      */
     Q_INVOKABLE static bool hasMValue( QgsVectorLayer *layer );
+
+    /**
+     * Returns a feature request to get features.
+     */
+    Q_INVOKABLE static QgsFeatureRequest createFeatureRequestFromExpression( const QString &expression );
 };
 
 #endif // LAYERUTILS_H

--- a/src/core/utils/layerutils.h
+++ b/src/core/utils/layerutils.h
@@ -26,6 +26,35 @@ class QgsVectorLayer;
 class QgsRasterLayer;
 class QgsSymbol;
 
+class FeatureIterator
+{
+    Q_GADGET
+
+  public:
+    FeatureIterator( QgsVectorLayer *layer = nullptr, const QgsFeatureRequest &request = QgsFeatureRequest() )
+    {
+      if ( layer )
+      {
+        mFeatureIterator = layer->getFeatures( request );
+      }
+    }
+
+    Q_INVOKABLE QgsFeature getNextFeature()
+    {
+      QgsFeature feature;
+      mFeatureIterator.nextFeature( feature );
+      return feature;
+    }
+
+    Q_INVOKABLE bool isValid()
+    {
+      return mFeatureIterator.isValid();
+    }
+
+  private:
+    QgsFeatureIterator mFeatureIterator;
+};
+
 class LayerUtils : public QObject
 {
     Q_OBJECT
@@ -82,7 +111,7 @@ class LayerUtils : public QObject
     /**
      * Returns a feature request to get features.
      */
-    Q_INVOKABLE static QgsFeatureRequest createFeatureRequestFromExpression( const QString &expression );
+    Q_INVOKABLE static FeatureIterator createFeatureIteratorFromExpression( QgsVectorLayer *layer, const QString &expression );
 };
 
 #endif // LAYERUTILS_H

--- a/src/core/utils/layerutils.h
+++ b/src/core/utils/layerutils.h
@@ -113,6 +113,12 @@ class LayerUtils : public QObject
     static QgsFeature duplicateFeature( QgsVectorLayer *layer, const QgsFeature &feature );
 
     /**
+     * Adds a \a feature into the \a layer.
+     * \note The function will not call startEditing() and commitChanges()
+     */
+    Q_INVOKABLE static bool addFeature( QgsVectorLayer *layer, QgsFeature feature );
+
+    /**
      * Returns the QVariant typeName of a \a field.
      * This is a stable identifier (compared to the provider field name).
      */

--- a/src/qml/geometryeditors/FillRing.qml
+++ b/src/qml/geometryeditors/FillRing.qml
@@ -144,7 +144,7 @@ VisibilityFadingRow {
   function fillWithPolygon()
   {
     var polygonGeometry = GeometryUtils.polygonFromRubberband(drawPolygonToolbar.rubberbandModel, featureModel.currentLayer.crs)
-    var feature = FeatureUtils.initFeature(featureModel.currentLayer, polygonGeometry)
+    var feature = FeatureUtils.createFeature(featureModel.currentLayer, polygonGeometry)
 
     // Show form
     formPopupLoader.onFeatureSaved.connect(commitRing)

--- a/src/qml/imports/Theme/Theme.qml
+++ b/src/qml/imports/Theme/Theme.qml
@@ -94,14 +94,14 @@ QtObject {
 
       var theme = 'qfield';
 
-      var path = '/themes/' + theme + '/' + ppiName + '/' + name + '.png';
+      var path = 'qrc:/themes/' + theme + '/' + ppiName + '/' + name + '.png';
       return path;
     }
 
     function getThemeVectorIcon(name) {
       var theme = 'qfield';
 
-      var path = '/themes/' + theme + '/nodpi/' + name + '.svg';
+      var path = 'qrc:/themes/' + theme + '/nodpi/' + name + '.svg';
       return path;
     }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3930,6 +3930,7 @@ ApplicationWindow {
 
   CodeReader {
     id: codeReader
+    objectName: 'codeReader'
     visible: false
   }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3277,8 +3277,8 @@ ApplicationWindow {
   /* The feature form */
   FeatureListForm {
     id: featureForm
-
     objectName: "featureForm"
+
     mapSettings: mapCanvas.mapSettings
     digitizingToolbar: digitizingToolbar
     moveFeaturesToolbar: moveFeaturesToolbar
@@ -3350,10 +3350,10 @@ ApplicationWindow {
     featureModel.currentLayer: dashBoard.activeLayer
   }
 
-  function displayToast( message, type ) {
+  function displayToast(message, type, action_text, action_function) {
     //toastMessage.text = message
-    if( !welcomeScreen.visible )
-      toast.show(message, type)
+    if(!welcomeScreen.visible)
+      toast.show(message, type, action_text, action_function)
   }
 
   Timer {

--- a/test/test_featureutils.cpp
+++ b/test/test_featureutils.cpp
@@ -26,7 +26,7 @@ TEST_CASE( "FeatureUtils" )
 
   QgsGeometry geometry = QgsGeometry::fromWkt( QStringLiteral( "Polygon (((8 8, 9 8, 8 9, 8 8)))" ) );
 
-  QgsFeature f = FeatureUtils::initFeature( vl.get(), geometry );
+  QgsFeature f = FeatureUtils::createFeature( vl.get(), geometry );
 
   REQUIRE( f.fields() == vl->fields() );
   REQUIRE( f.geometry().equals( geometry ) );

--- a/vcpkg/ports/qgis/invoke.patch
+++ b/vcpkg/ports/qgis/invoke.patch
@@ -81,6 +81,46 @@ index ca541a2f914..6a8f901f562 100644
  
      /**
       * Retrieves a list of matching registered layers by layer \a shortName.
+diff --git a/src/core/qgsfeature.h b/src/core/qgsfeature.h
+index aec448b1f3a..2c86a70c4a9 100644
+--- a/src/core/qgsfeature.h
++++ b/src/core/qgsfeature.h
+@@ -337,7 +337,7 @@ class CORE_EXPORT QgsFeature
+      * \returns FALSE, if the field index does not exist
+      * \see setAttributes()
+      */
+-    bool setAttribute( int field, const QVariant &attr );
++    Q_INVOKABLE bool setAttribute( int field, const QVariant &attr );
+ #else
+ 
+     /**
+@@ -589,7 +589,7 @@ class CORE_EXPORT QgsFeature
+      * \returns FALSE if attribute name could not be converted to index
+      * \see setFields()
+      */
+-    bool setAttribute( const QString &name, const QVariant &value );
++    Q_INVOKABLE bool setAttribute( const QString &name, const QVariant &value );
+ #else
+ 
+     /**
+@@ -711,7 +711,7 @@ class CORE_EXPORT QgsFeature
+      * \returns The value of the attribute, or an invalid/null variant if no such name exists
+      * \see setFields
+      */
+-    QVariant attribute( const QString &name ) const;
++    Q_INVOKABLE QVariant attribute( const QString &name ) const;
+ #else
+ 
+     /**
+@@ -739,7 +739,7 @@ class CORE_EXPORT QgsFeature
+      * \throws KeyError if the field is not found
+      * \see setFields
+      */
+-    SIP_PYOBJECT attribute( const QString &name ) const;
++    Q_INVOKABLE SIP_PYOBJECT attribute( const QString &name ) const;
+     % MethodCode
+     int fieldIdx = sipCpp->fieldNameIndex( *a0 );
+     if ( fieldIdx == -1 )
 diff --git a/src/core/qgsfields.h b/src/core/qgsfields.h
 index 4384248ef4d..63d16aa95dd 100644
 --- a/src/core/qgsfields.h

--- a/vcpkg/ports/qgis/invoke.patch
+++ b/vcpkg/ports/qgis/invoke.patch
@@ -1,3 +1,49 @@
+diff --git a/python/PyQt6/core/auto_generated/qgsfields.sip.in b/python/PyQt6/core/auto_generated/qgsfields.sip.in
+index 2a3168fa393..2df5fa580d3 100644
+--- a/python/PyQt6/core/auto_generated/qgsfields.sip.in
++++ b/python/PyQt6/core/auto_generated/qgsfields.sip.in
+@@ -28,6 +28,9 @@ In addition to storing a list of :py:class:`QgsField` instances, it also:
+ %TypeHeaderCode
+ #include "qgsfields.h"
+ %End
++  public:
++    static const QMetaObject staticMetaObject;
++
+   public:
+ 
+     enum FieldOrigin /BaseType=IntEnum/
+@@ -289,7 +292,7 @@ name of the field.
+ .. seealso:: :py:func:`lookupField`
+ %End
+ 
+-    int lookupField( const QString &fieldName ) const;
++     int lookupField( const QString &fieldName ) const;
+ %Docstring
+ Looks up field's index from the field name.
+ This method matches in the following order:
+diff --git a/python/core/auto_generated/qgsfields.sip.in b/python/core/auto_generated/qgsfields.sip.in
+index b898d911e6a..f94f5c453b7 100644
+--- a/python/core/auto_generated/qgsfields.sip.in
++++ b/python/core/auto_generated/qgsfields.sip.in
+@@ -28,6 +28,9 @@ In addition to storing a list of :py:class:`QgsField` instances, it also:
+ %TypeHeaderCode
+ #include "qgsfields.h"
+ %End
++  public:
++    static const QMetaObject staticMetaObject;
++
+   public:
+ 
+     enum FieldOrigin
+@@ -289,7 +292,7 @@ name of the field.
+ .. seealso:: :py:func:`lookupField`
+ %End
+ 
+-    int lookupField( const QString &fieldName ) const;
++     int lookupField( const QString &fieldName ) const;
+ %Docstring
+ Looks up field's index from the field name.
+ This method matches in the following order:
 diff --git a/scripts/sipify.pl b/scripts/sipify.pl
 index e6f842ac504..f7602158bbd 100755
 --- a/scripts/sipify.pl
@@ -35,8 +81,84 @@ index ca541a2f914..6a8f901f562 100644
  
      /**
       * Retrieves a list of matching registered layers by layer \a shortName.
+diff --git a/src/core/qgsfields.h b/src/core/qgsfields.h
+index 4384248ef4d..63d16aa95dd 100644
+--- a/src/core/qgsfields.h
++++ b/src/core/qgsfields.h
+@@ -43,6 +43,8 @@ class QgsFieldsPrivate;
+  */
+ class CORE_EXPORT  QgsFields
+ {
++    Q_GADGET
++
+   public:
+ 
+     enum FieldOrigin
+@@ -142,10 +144,10 @@ class CORE_EXPORT  QgsFields
+     void extend( const QgsFields &other );
+ 
+     //! Checks whether the container is empty
+-    bool isEmpty() const;
++    Q_INVOKABLE bool isEmpty() const;
+ 
+     //! Returns number of items
+-    int count() const;
++    Q_INVOKABLE int count() const;
+ 
+ #ifdef SIP_RUN
+     int __len__() const;
+@@ -161,19 +163,19 @@ class CORE_EXPORT  QgsFields
+ #endif
+ 
+     //! Returns number of items
+-    int size() const;
++    Q_INVOKABLE int size() const;
+ 
+     /**
+      * Returns a list with field names
+      */
+-    QStringList names() const;
++    Q_INVOKABLE QStringList names() const;
+ 
+     /**
+      * Returns if a field index is valid
+      * \param i  Index of the field which needs to be checked
+      * \returns   TRUE if the field exists
+      */
+-    bool exists( int i ) const;
++    Q_INVOKABLE bool exists( int i ) const;
+ 
+ #ifndef SIP_RUN
+     //! Gets field at particular index (must be in range 0..N-1)
+@@ -354,7 +356,7 @@ class CORE_EXPORT  QgsFields
+      * \returns The field index if found or -1 in case it cannot be found.
+      * \see lookupField For a more tolerant alternative.
+      */
+-    int indexFromName( const QString &fieldName ) const;
++    Q_INVOKABLE int indexFromName( const QString &fieldName ) const;
+ 
+     /**
+      * Gets the field index from the field name.
+@@ -367,7 +369,7 @@ class CORE_EXPORT  QgsFields
+      * \returns The field index if found or -1 in case it cannot be found.
+      * \see lookupField For a more tolerant alternative.
+      */
+-    int indexOf( const QString &fieldName ) const;
++    Q_INVOKABLE int indexOf( const QString &fieldName ) const;
+ 
+     /**
+      * Looks up field's index from the field name.
+@@ -382,7 +384,7 @@ class CORE_EXPORT  QgsFields
+      * \returns The field index if found or -1 in case it cannot be found.
+      * \see indexFromName For a more performant and precise but less tolerant alternative.
+      */
+-    int lookupField( const QString &fieldName ) const;
++    Q_INVOKABLE  int lookupField( const QString &fieldName ) const;
+ 
+     /**
+      * Utility function to get list of attribute indexes
 diff --git a/src/core/vector/qgsvectorlayer.h b/src/core/vector/qgsvectorlayer.h
-index 7a9145141a2..81e0b988ebd 100644
+index 7a9145141a2..cc5f7b8124c 100644
 --- a/src/core/vector/qgsvectorlayer.h
 +++ b/src/core/vector/qgsvectorlayer.h
 @@ -1143,7 +1143,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
@@ -48,7 +170,13 @@ index 7a9145141a2..81e0b988ebd 100644
      {
        QgsFeature feature;
        getFeatures( QgsFeatureRequest( fid ) ).nextFeature( feature );
-@@ -1665,7 +1665,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
+@@ -1660,12 +1660,12 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
+      *
+      * \returns A list of fields
+      */
+-    QgsFields fields() const FINAL;
++    Q_INVOKABLE QgsFields fields() const FINAL;
+ 
      /**
       * Returns list of attribute indexes. i.e. a list from 0 ... fieldCount()
       */

--- a/vcpkg/ports/qgis/invoke.patch
+++ b/vcpkg/ports/qgis/invoke.patch
@@ -1,59 +1,3 @@
-diff --git a/python/PyQt6/core/auto_generated/qgsfeatureiterator.sip.in b/python/PyQt6/core/auto_generated/qgsfeatureiterator.sip.in
-index 9f8f93d183c..fb171835e72 100644
---- a/python/PyQt6/core/auto_generated/qgsfeatureiterator.sip.in
-+++ b/python/PyQt6/core/auto_generated/qgsfeatureiterator.sip.in
-@@ -214,6 +214,9 @@ Wrapper for iterator of features from vector data provider or vector layer
- %TypeHeaderCode
- #include "qgsfeatureiterator.h"
- %End
-+  public:
-+    static const QMetaObject staticMetaObject;
-+
-   public:
- 
-     QgsFeatureIterator *__iter__();
-diff --git a/python/PyQt6/core/auto_generated/qgsfeaturerequest.sip.in b/python/PyQt6/core/auto_generated/qgsfeaturerequest.sip.in
-index 09dd1033485..9f457db2ba1 100644
---- a/python/PyQt6/core/auto_generated/qgsfeaturerequest.sip.in
-+++ b/python/PyQt6/core/auto_generated/qgsfeaturerequest.sip.in
-@@ -63,6 +63,9 @@ Examples:
- %TypeHeaderCode
- #include "qgsfeaturerequest.h"
- %End
-+  public:
-+    static const QMetaObject staticMetaObject;
-+
-   public:
- 
-     class OrderByClause
-diff --git a/python/core/auto_generated/qgsfeatureiterator.sip.in b/python/core/auto_generated/qgsfeatureiterator.sip.in
-index 3f274b03058..d540916ff8b 100644
---- a/python/core/auto_generated/qgsfeatureiterator.sip.in
-+++ b/python/core/auto_generated/qgsfeatureiterator.sip.in
-@@ -214,6 +214,9 @@ Wrapper for iterator of features from vector data provider or vector layer
- %TypeHeaderCode
- #include "qgsfeatureiterator.h"
- %End
-+  public:
-+    static const QMetaObject staticMetaObject;
-+
-   public:
- 
-     QgsFeatureIterator *__iter__();
-diff --git a/python/core/auto_generated/qgsfeaturerequest.sip.in b/python/core/auto_generated/qgsfeaturerequest.sip.in
-index 09dd1033485..9f457db2ba1 100644
---- a/python/core/auto_generated/qgsfeaturerequest.sip.in
-+++ b/python/core/auto_generated/qgsfeaturerequest.sip.in
-@@ -63,6 +63,9 @@ Examples:
- %TypeHeaderCode
- #include "qgsfeaturerequest.h"
- %End
-+  public:
-+    static const QMetaObject staticMetaObject;
-+
-   public:
- 
-     class OrderByClause
 diff --git a/scripts/sipify.pl b/scripts/sipify.pl
 index e6f842ac504..f7602158bbd 100755
 --- a/scripts/sipify.pl
@@ -91,81 +35,10 @@ index ca541a2f914..6a8f901f562 100644
  
      /**
       * Retrieves a list of matching registered layers by layer \a shortName.
-diff --git a/src/core/qgsfeatureiterator.h b/src/core/qgsfeatureiterator.h
-index b1f0a2c9b44..912f4ae4448 100644
---- a/src/core/qgsfeatureiterator.h
-+++ b/src/core/qgsfeatureiterator.h
-@@ -288,6 +288,9 @@ class QgsAbstractFeatureIteratorFromSource : public QgsAbstractFeatureIterator
-  */
- class CORE_EXPORT QgsFeatureIterator
- {
-+
-+    Q_GADGET
-+
-   public:
- 
- #ifdef SIP_RUN
-@@ -326,17 +329,17 @@ class CORE_EXPORT QgsFeatureIterator
-     /**
-      * Fetch next feature and stores in \a f, returns TRUE on success.
-      */
--    bool nextFeature( QgsFeature &f );
-+    Q_INVOKABLE bool nextFeature( QgsFeature &f );
- 
-     /**
-      * Resets the iterator to the starting position.
-      */
--    bool rewind();
-+    Q_INVOKABLE bool rewind();
- 
-     /**
-      * Call to end the iteration. This frees any resources used by the iterator.
-      */
--    bool close();
-+    Q_INVOKABLE bool close();
- 
-     /**
-      * Will return if this iterator is valid.
-@@ -346,10 +349,10 @@ class CORE_EXPORT QgsFeatureIterator
-      * \see isClosed to check if the iterator successfully completed and returned all the features.
-      *
-      */
--    bool isValid() const;
-+    Q_INVOKABLE bool isValid() const;
- 
-     //! find out whether the iterator is still valid or closed already
--    bool isClosed() const;
-+    Q_INVOKABLE bool isClosed() const;
- 
-     /**
-      * Attach an object that can be queried regularly by the iterator to check
-diff --git a/src/core/qgsfeaturerequest.h b/src/core/qgsfeaturerequest.h
-index 33bd00b83b9..50191e87dfc 100644
---- a/src/core/qgsfeaturerequest.h
-+++ b/src/core/qgsfeaturerequest.h
-@@ -82,6 +82,9 @@
-  */
- class CORE_EXPORT QgsFeatureRequest
- {
-+
-+    Q_GADGET
-+
-   public:
- 
-     /**
 diff --git a/src/core/vector/qgsvectorlayer.h b/src/core/vector/qgsvectorlayer.h
-index 7a9145141a2..7dbb4d76fb9 100644
+index 7a9145141a2..81e0b988ebd 100644
 --- a/src/core/vector/qgsvectorlayer.h
 +++ b/src/core/vector/qgsvectorlayer.h
-@@ -1129,7 +1129,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
-      * \param request feature request describing parameters of features to return
-      * \returns iterator for matching features from provider
-      */
--    QgsFeatureIterator getFeatures( const QgsFeatureRequest &request = QgsFeatureRequest() ) const FINAL;
-+    Q_INVOKABLE QgsFeatureIterator getFeatures( const QgsFeatureRequest &request = QgsFeatureRequest() ) const FINAL;
- 
-     /**
-      * Queries the layer for features matching a given expression.
 @@ -1143,7 +1143,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
       * Queries the layer for the feature with the given id.
       * If there is no such feature, the returned feature will be invalid.
@@ -175,24 +48,15 @@ index 7a9145141a2..7dbb4d76fb9 100644
      {
        QgsFeature feature;
        getFeatures( QgsFeatureRequest( fid ) ).nextFeature( feature );
-@@ -1172,7 +1172,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
-       return getFeatures( QgsFeatureRequest( rectangle ) );
-     }
- 
--    bool addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() ) FINAL;
-+    Q_INVOKABLE bool addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() ) FINAL;
- 
+@@ -1665,7 +1665,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      /**
-      * Updates an existing \a feature in the layer, replacing the attributes and geometry for the feature
-@@ -1714,7 +1714,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
-      * \see changeAttributeValue()
-      * \see updateFeature()
+      * Returns list of attribute indexes. i.e. a list from 0 ... fieldCount()
       */
--    bool changeGeometry( QgsFeatureId fid, QgsGeometry &geometry, bool skipDefaultValue = false );
-+    Q_INVOKABLE bool changeGeometry( QgsFeatureId fid, QgsGeometry &geometry, bool skipDefaultValue = false );
+-    inline QgsAttributeList attributeList() const { return mFields.allAttributesList(); }
++    Q_INVOKABLE inline QgsAttributeList attributeList() const { return mFields.allAttributesList(); }
  
      /**
-      * Changes an attribute value for a feature (but does not immediately commit the changes).
+      * Returns the list of attributes which make up the layer's primary keys.
 @@ -1746,7 +1746,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
       * \see changeGeometry()
       * \see updateFeature()

--- a/vcpkg/ports/qgis/invoke.patch
+++ b/vcpkg/ports/qgis/invoke.patch
@@ -21,6 +21,28 @@ index 2a3168fa393..2df5fa580d3 100644
  %Docstring
  Looks up field's index from the field name.
  This method matches in the following order:
+diff --git a/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in b/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
+index 169b1823725..f67099d84c9 100644
+--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
++++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
+@@ -1991,7 +1991,7 @@ Deletes a list of attribute fields (but does not commit it)
+     virtual bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() ) ${SIP_FINAL};
+ 
+ 
+-    bool deleteFeature( QgsFeatureId fid, DeleteContext *context = 0 );
++    bool deleteFeature( QgsFeatureId fid, QgsVectorLayer::DeleteContext *context = 0 );
+ %Docstring
+ Deletes a feature from the layer (but does not commit it).
+ 
+@@ -2006,7 +2006,7 @@ Deletes a feature from the layer (but does not commit it).
+    changes can be discarded by calling :py:func:`~QgsVectorLayer.rollBack`.
+ %End
+ 
+-    bool deleteFeatures( const QgsFeatureIds &fids, DeleteContext *context = 0 );
++    bool deleteFeatures( const QgsFeatureIds &fids, QgsVectorLayer::DeleteContext *context = 0 );
+ %Docstring
+ Deletes a set of features from the layer (but does not commit it)
+ 
 diff --git a/python/core/auto_generated/qgsfields.sip.in b/python/core/auto_generated/qgsfields.sip.in
 index b898d911e6a..f94f5c453b7 100644
 --- a/python/core/auto_generated/qgsfields.sip.in
@@ -44,6 +66,28 @@ index b898d911e6a..f94f5c453b7 100644
  %Docstring
  Looks up field's index from the field name.
  This method matches in the following order:
+diff --git a/python/core/auto_generated/vector/qgsvectorlayer.sip.in b/python/core/auto_generated/vector/qgsvectorlayer.sip.in
+index 169b1823725..f67099d84c9 100644
+--- a/python/core/auto_generated/vector/qgsvectorlayer.sip.in
++++ b/python/core/auto_generated/vector/qgsvectorlayer.sip.in
+@@ -1991,7 +1991,7 @@ Deletes a list of attribute fields (but does not commit it)
+     virtual bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() ) ${SIP_FINAL};
+ 
+ 
+-    bool deleteFeature( QgsFeatureId fid, DeleteContext *context = 0 );
++    bool deleteFeature( QgsFeatureId fid, QgsVectorLayer::DeleteContext *context = 0 );
+ %Docstring
+ Deletes a feature from the layer (but does not commit it).
+ 
+@@ -2006,7 +2006,7 @@ Deletes a feature from the layer (but does not commit it).
+    changes can be discarded by calling :py:func:`~QgsVectorLayer.rollBack`.
+ %End
+ 
+-    bool deleteFeatures( const QgsFeatureIds &fids, DeleteContext *context = 0 );
++    bool deleteFeatures( const QgsFeatureIds &fids, QgsVectorLayer::DeleteContext *context = 0 );
+ %Docstring
+ Deletes a set of features from the layer (but does not commit it)
+ 
 diff --git a/scripts/sipify.pl b/scripts/sipify.pl
 index e6f842ac504..f7602158bbd 100755
 --- a/scripts/sipify.pl
@@ -122,46 +166,23 @@ index aec448b1f3a..2c86a70c4a9 100644
      int fieldIdx = sipCpp->fieldNameIndex( *a0 );
      if ( fieldIdx == -1 )
 diff --git a/src/core/qgsfields.h b/src/core/qgsfields.h
-index 4384248ef4d..63d16aa95dd 100644
+index 4384248ef4d..975ebdcaf75 100644
 --- a/src/core/qgsfields.h
 +++ b/src/core/qgsfields.h
-@@ -43,6 +43,8 @@ class QgsFieldsPrivate;
+@@ -43,6 +43,12 @@ class QgsFieldsPrivate;
   */
  class CORE_EXPORT  QgsFields
  {
 +    Q_GADGET
 +
++    Q_PROPERTY( bool isEmpty READ isEmpty )
++    Q_PROPERTY( int count READ count )
++    Q_PROPERTY( QStringList names READ names )
++
    public:
  
      enum FieldOrigin
-@@ -142,10 +144,10 @@ class CORE_EXPORT  QgsFields
-     void extend( const QgsFields &other );
- 
-     //! Checks whether the container is empty
--    bool isEmpty() const;
-+    Q_INVOKABLE bool isEmpty() const;
- 
-     //! Returns number of items
--    int count() const;
-+    Q_INVOKABLE int count() const;
- 
- #ifdef SIP_RUN
-     int __len__() const;
-@@ -161,19 +163,19 @@ class CORE_EXPORT  QgsFields
- #endif
- 
-     //! Returns number of items
--    int size() const;
-+    Q_INVOKABLE int size() const;
- 
-     /**
-      * Returns a list with field names
-      */
--    QStringList names() const;
-+    Q_INVOKABLE QStringList names() const;
- 
-     /**
-      * Returns if a field index is valid
+@@ -173,7 +179,7 @@ class CORE_EXPORT  QgsFields
       * \param i  Index of the field which needs to be checked
       * \returns   TRUE if the field exists
       */
@@ -170,7 +191,7 @@ index 4384248ef4d..63d16aa95dd 100644
  
  #ifndef SIP_RUN
      //! Gets field at particular index (must be in range 0..N-1)
-@@ -354,7 +356,7 @@ class CORE_EXPORT  QgsFields
+@@ -354,7 +360,7 @@ class CORE_EXPORT  QgsFields
       * \returns The field index if found or -1 in case it cannot be found.
       * \see lookupField For a more tolerant alternative.
       */
@@ -179,7 +200,7 @@ index 4384248ef4d..63d16aa95dd 100644
  
      /**
       * Gets the field index from the field name.
-@@ -367,7 +369,7 @@ class CORE_EXPORT  QgsFields
+@@ -367,7 +373,7 @@ class CORE_EXPORT  QgsFields
       * \returns The field index if found or -1 in case it cannot be found.
       * \see lookupField For a more tolerant alternative.
       */
@@ -188,7 +209,7 @@ index 4384248ef4d..63d16aa95dd 100644
  
      /**
       * Looks up field's index from the field name.
-@@ -382,7 +384,7 @@ class CORE_EXPORT  QgsFields
+@@ -382,7 +388,7 @@ class CORE_EXPORT  QgsFields
       * \returns The field index if found or -1 in case it cannot be found.
       * \see indexFromName For a more performant and precise but less tolerant alternative.
       */
@@ -198,10 +219,18 @@ index 4384248ef4d..63d16aa95dd 100644
      /**
       * Utility function to get list of attribute indexes
 diff --git a/src/core/vector/qgsvectorlayer.h b/src/core/vector/qgsvectorlayer.h
-index 7a9145141a2..cc5f7b8124c 100644
+index 7a9145141a2..3ecfc116e2c 100644
 --- a/src/core/vector/qgsvectorlayer.h
 +++ b/src/core/vector/qgsvectorlayer.h
-@@ -1143,7 +1143,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
+@@ -405,6 +405,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
+     Q_PROPERTY( QgsEditFormConfig editFormConfig READ editFormConfig WRITE setEditFormConfig NOTIFY editFormConfigChanged )
+     Q_PROPERTY( bool readOnly READ isReadOnly WRITE setReadOnly NOTIFY readOnlyChanged )
+     Q_PROPERTY( bool supportsEditing READ supportsEditing NOTIFY supportsEditingChanged )
++    Q_PROPERTY( QgsFields fields READ fields NOTIFY updatedFields )
+ 
+   public:
+ 
+@@ -1143,7 +1144,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
       * Queries the layer for the feature with the given id.
       * If there is no such feature, the returned feature will be invalid.
       */
@@ -210,13 +239,7 @@ index 7a9145141a2..cc5f7b8124c 100644
      {
        QgsFeature feature;
        getFeatures( QgsFeatureRequest( fid ) ).nextFeature( feature );
-@@ -1660,12 +1660,12 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
-      *
-      * \returns A list of fields
-      */
--    QgsFields fields() const FINAL;
-+    Q_INVOKABLE QgsFields fields() const FINAL;
- 
+@@ -1665,7 +1666,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      /**
       * Returns list of attribute indexes. i.e. a list from 0 ... fieldCount()
       */
@@ -225,7 +248,7 @@ index 7a9145141a2..cc5f7b8124c 100644
  
      /**
       * Returns the list of attributes which make up the layer's primary keys.
-@@ -1746,7 +1746,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
+@@ -1746,7 +1747,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
       * \see changeGeometry()
       * \see updateFeature()
       */
@@ -234,7 +257,7 @@ index 7a9145141a2..cc5f7b8124c 100644
  
      /**
       * Changes attributes' values for a feature (but does not immediately
-@@ -1782,7 +1782,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
+@@ -1782,7 +1783,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
       * \see changeAttributeValue()
       *
       */
@@ -243,21 +266,21 @@ index 7a9145141a2..cc5f7b8124c 100644
  
      /**
       * Add an attribute field (but does not commit it)
-@@ -1918,7 +1918,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
+@@ -1918,7 +1919,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
       * to the underlying data provider until a commitChanges() call is made. Any uncommitted
       * changes can be discarded by calling rollBack().
       */
 -    bool deleteFeature( QgsFeatureId fid, DeleteContext *context = nullptr );
-+    Q_INVOKABLE bool deleteFeature( QgsFeatureId fid, DeleteContext *context = nullptr );
++    Q_INVOKABLE bool deleteFeature( QgsFeatureId fid, QgsVectorLayer::DeleteContext *context = nullptr );
  
      /**
       * Deletes a set of features from the layer (but does not commit it)
-@@ -1933,7 +1933,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
+@@ -1933,7 +1934,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
       * to the underlying data provider until a commitChanges() call is made. Any uncommitted
       * changes can be discarded by calling rollBack().
       */
 -    bool deleteFeatures( const QgsFeatureIds &fids, DeleteContext *context = nullptr );
-+    Q_INVOKABLE bool deleteFeatures( const QgsFeatureIds &fids, DeleteContext *context = nullptr );
++    Q_INVOKABLE bool deleteFeatures( const QgsFeatureIds &fids, QgsVectorLayer::DeleteContext *context = nullptr );
  
      /**
       * Attempts to commit to the underlying data provider any buffered changes made since the

--- a/vcpkg/ports/qgis/invoke.patch
+++ b/vcpkg/ports/qgis/invoke.patch
@@ -1,0 +1,231 @@
+diff --git a/python/PyQt6/core/auto_generated/qgsfeatureiterator.sip.in b/python/PyQt6/core/auto_generated/qgsfeatureiterator.sip.in
+index 9f8f93d183c..fb171835e72 100644
+--- a/python/PyQt6/core/auto_generated/qgsfeatureiterator.sip.in
++++ b/python/PyQt6/core/auto_generated/qgsfeatureiterator.sip.in
+@@ -214,6 +214,9 @@ Wrapper for iterator of features from vector data provider or vector layer
+ %TypeHeaderCode
+ #include "qgsfeatureiterator.h"
+ %End
++  public:
++    static const QMetaObject staticMetaObject;
++
+   public:
+ 
+     QgsFeatureIterator *__iter__();
+diff --git a/python/PyQt6/core/auto_generated/qgsfeaturerequest.sip.in b/python/PyQt6/core/auto_generated/qgsfeaturerequest.sip.in
+index 09dd1033485..9f457db2ba1 100644
+--- a/python/PyQt6/core/auto_generated/qgsfeaturerequest.sip.in
++++ b/python/PyQt6/core/auto_generated/qgsfeaturerequest.sip.in
+@@ -63,6 +63,9 @@ Examples:
+ %TypeHeaderCode
+ #include "qgsfeaturerequest.h"
+ %End
++  public:
++    static const QMetaObject staticMetaObject;
++
+   public:
+ 
+     class OrderByClause
+diff --git a/python/core/auto_generated/qgsfeatureiterator.sip.in b/python/core/auto_generated/qgsfeatureiterator.sip.in
+index 3f274b03058..d540916ff8b 100644
+--- a/python/core/auto_generated/qgsfeatureiterator.sip.in
++++ b/python/core/auto_generated/qgsfeatureiterator.sip.in
+@@ -214,6 +214,9 @@ Wrapper for iterator of features from vector data provider or vector layer
+ %TypeHeaderCode
+ #include "qgsfeatureiterator.h"
+ %End
++  public:
++    static const QMetaObject staticMetaObject;
++
+   public:
+ 
+     QgsFeatureIterator *__iter__();
+diff --git a/python/core/auto_generated/qgsfeaturerequest.sip.in b/python/core/auto_generated/qgsfeaturerequest.sip.in
+index 09dd1033485..9f457db2ba1 100644
+--- a/python/core/auto_generated/qgsfeaturerequest.sip.in
++++ b/python/core/auto_generated/qgsfeaturerequest.sip.in
+@@ -63,6 +63,9 @@ Examples:
+ %TypeHeaderCode
+ #include "qgsfeaturerequest.h"
+ %End
++  public:
++    static const QMetaObject staticMetaObject;
++
+   public:
+ 
+     class OrderByClause
+diff --git a/scripts/sipify.pl b/scripts/sipify.pl
+index e6f842ac504..f7602158bbd 100755
+--- a/scripts/sipify.pl
++++ b/scripts/sipify.pl
+@@ -1755,6 +1755,9 @@ while ($LINE_IDX < $LINE_COUNT){
+     $IS_OVERRIDE_OR_MAKE_PRIVATE = PREPEND_CODE_VIRTUAL if ( $LINE =~ m/\bFINAL\b/);
+     $IS_OVERRIDE_OR_MAKE_PRIVATE = PREPEND_CODE_MAKE_PRIVATE if ( $LINE =~ m/\bSIP_MAKE_PRIVATE\b/);
+ 
++    # remove Q_INVOKABLE
++    $LINE =~ s/^(\s*)Q_INVOKABLE /$1/;
++
+     # keyword fixes
+     do {no warnings 'uninitialized';
+         $LINE =~ s/^(\s*template\s*<)(?:class|typename) (\w+>)(.*)$/$1$2$3/;
+@@ -1861,9 +1864,6 @@ while ($LINE_IDX < $LINE_COUNT){
+         }
+     }
+ 
+-    # remove Q_INVOKABLE
+-    $LINE =~ s/^(\s*)Q_INVOKABLE /$1/;
+-
+     do {no warnings 'uninitialized';
+         # remove keywords
+         if ( $IS_OVERRIDE_OR_MAKE_PRIVATE != PREPEND_CODE_NO ){
+diff --git a/src/core/project/qgsproject.h b/src/core/project/qgsproject.h
+index ca541a2f914..6a8f901f562 100644
+--- a/src/core/project/qgsproject.h
++++ b/src/core/project/qgsproject.h
+@@ -1185,7 +1185,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
+      * \see mapLayer()
+      * \see mapLayers()
+      */
+-    QList<QgsMapLayer *> mapLayersByName( const QString &layerName ) const;
++    Q_INVOKABLE QList<QgsMapLayer *> mapLayersByName( const QString &layerName ) const;
+ 
+     /**
+      * Retrieves a list of matching registered layers by layer \a shortName.
+diff --git a/src/core/qgsfeatureiterator.h b/src/core/qgsfeatureiterator.h
+index b1f0a2c9b44..912f4ae4448 100644
+--- a/src/core/qgsfeatureiterator.h
++++ b/src/core/qgsfeatureiterator.h
+@@ -288,6 +288,9 @@ class QgsAbstractFeatureIteratorFromSource : public QgsAbstractFeatureIterator
+  */
+ class CORE_EXPORT QgsFeatureIterator
+ {
++
++    Q_GADGET
++
+   public:
+ 
+ #ifdef SIP_RUN
+@@ -326,17 +329,17 @@ class CORE_EXPORT QgsFeatureIterator
+     /**
+      * Fetch next feature and stores in \a f, returns TRUE on success.
+      */
+-    bool nextFeature( QgsFeature &f );
++    Q_INVOKABLE bool nextFeature( QgsFeature &f );
+ 
+     /**
+      * Resets the iterator to the starting position.
+      */
+-    bool rewind();
++    Q_INVOKABLE bool rewind();
+ 
+     /**
+      * Call to end the iteration. This frees any resources used by the iterator.
+      */
+-    bool close();
++    Q_INVOKABLE bool close();
+ 
+     /**
+      * Will return if this iterator is valid.
+@@ -346,10 +349,10 @@ class CORE_EXPORT QgsFeatureIterator
+      * \see isClosed to check if the iterator successfully completed and returned all the features.
+      *
+      */
+-    bool isValid() const;
++    Q_INVOKABLE bool isValid() const;
+ 
+     //! find out whether the iterator is still valid or closed already
+-    bool isClosed() const;
++    Q_INVOKABLE bool isClosed() const;
+ 
+     /**
+      * Attach an object that can be queried regularly by the iterator to check
+diff --git a/src/core/qgsfeaturerequest.h b/src/core/qgsfeaturerequest.h
+index 33bd00b83b9..50191e87dfc 100644
+--- a/src/core/qgsfeaturerequest.h
++++ b/src/core/qgsfeaturerequest.h
+@@ -82,6 +82,9 @@
+  */
+ class CORE_EXPORT QgsFeatureRequest
+ {
++
++    Q_GADGET
++
+   public:
+ 
+     /**
+diff --git a/src/core/vector/qgsvectorlayer.h b/src/core/vector/qgsvectorlayer.h
+index 7a9145141a2..7dbb4d76fb9 100644
+--- a/src/core/vector/qgsvectorlayer.h
++++ b/src/core/vector/qgsvectorlayer.h
+@@ -1129,7 +1129,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
+      * \param request feature request describing parameters of features to return
+      * \returns iterator for matching features from provider
+      */
+-    QgsFeatureIterator getFeatures( const QgsFeatureRequest &request = QgsFeatureRequest() ) const FINAL;
++    Q_INVOKABLE QgsFeatureIterator getFeatures( const QgsFeatureRequest &request = QgsFeatureRequest() ) const FINAL;
+ 
+     /**
+      * Queries the layer for features matching a given expression.
+@@ -1143,7 +1143,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
+      * Queries the layer for the feature with the given id.
+      * If there is no such feature, the returned feature will be invalid.
+      */
+-    inline QgsFeature getFeature( QgsFeatureId fid ) const
++    Q_INVOKABLE inline QgsFeature getFeature( QgsFeatureId fid ) const
+     {
+       QgsFeature feature;
+       getFeatures( QgsFeatureRequest( fid ) ).nextFeature( feature );
+@@ -1172,7 +1172,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
+       return getFeatures( QgsFeatureRequest( rectangle ) );
+     }
+ 
+-    bool addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() ) FINAL;
++    Q_INVOKABLE bool addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() ) FINAL;
+ 
+     /**
+      * Updates an existing \a feature in the layer, replacing the attributes and geometry for the feature
+@@ -1714,7 +1714,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
+      * \see changeAttributeValue()
+      * \see updateFeature()
+      */
+-    bool changeGeometry( QgsFeatureId fid, QgsGeometry &geometry, bool skipDefaultValue = false );
++    Q_INVOKABLE bool changeGeometry( QgsFeatureId fid, QgsGeometry &geometry, bool skipDefaultValue = false );
+ 
+     /**
+      * Changes an attribute value for a feature (but does not immediately commit the changes).
+@@ -1746,7 +1746,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
+      * \see changeGeometry()
+      * \see updateFeature()
+      */
+-    bool changeAttributeValue( QgsFeatureId fid, int field, const QVariant &newValue, const QVariant &oldValue = QVariant(), bool skipDefaultValues = false );
++    Q_INVOKABLE bool changeAttributeValue( QgsFeatureId fid, int field, const QVariant &newValue, const QVariant &oldValue = QVariant(), bool skipDefaultValues = false );
+ 
+     /**
+      * Changes attributes' values for a feature (but does not immediately
+@@ -1782,7 +1782,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
+      * \see changeAttributeValue()
+      *
+      */
+-    bool changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues = QgsAttributeMap(), bool skipDefaultValues = false );
++    Q_INVOKABLE bool changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues = QgsAttributeMap(), bool skipDefaultValues = false );
+ 
+     /**
+      * Add an attribute field (but does not commit it)
+@@ -1918,7 +1918,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
+      * to the underlying data provider until a commitChanges() call is made. Any uncommitted
+      * changes can be discarded by calling rollBack().
+      */
+-    bool deleteFeature( QgsFeatureId fid, DeleteContext *context = nullptr );
++    Q_INVOKABLE bool deleteFeature( QgsFeatureId fid, DeleteContext *context = nullptr );
+ 
+     /**
+      * Deletes a set of features from the layer (but does not commit it)
+@@ -1933,7 +1933,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
+      * to the underlying data provider until a commitChanges() call is made. Any uncommitted
+      * changes can be discarded by calling rollBack().
+      */
+-    bool deleteFeatures( const QgsFeatureIds &fids, DeleteContext *context = nullptr );
++    Q_INVOKABLE bool deleteFeatures( const QgsFeatureIds &fids, DeleteContext *context = nullptr );
+ 
+     /**
+      * Attempts to commit to the underlying data provider any buffered changes made since the

--- a/vcpkg/ports/qgis/portfile.cmake
+++ b/vcpkg/ports/qgis/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_from_github(
         sts.patch # Obsolete in QGIS >= 3.36.1
         crssync-no-install.patch
         include-qthread.patch
+        invoke.patch
 )
 
 file(REMOVE ${SOURCE_PATH}/cmake/FindGDAL.cmake)


### PR DESCRIPTION
This PR enables plugins to do the following:
- retrieve map layers by name from a QgsProject instance
- iterate through features from a vector layer
- change a feature attribute value through the vector layer's changeAttributeValue(s) functions
- retrieve field information (such as attribute index from a given field name)

The invoke.patch changes are being upstreamed, but since we're on 3.36 for now, we can enjoy vcpkg's patching powers :muscle: 

Upstream PRs:
- https://github.com/qgis/QGIS/pull/57161
- https://github.com/qgis/QGIS/pull/57166

Iterating through features is done like this:

```
let layers = qgisProject.mapLayersByName('Apiary')      
let layer = layers[0]      
let it = LayerUtils.createFeatureIteratorFromExpression(layer, "fid IN (47,48,49)")
while (it.hasNext())
{
  let feature = it.next()
  console.log(feature.id)
}
```

Editing a feature attribute is done like this:

```
let layers = qgisProject.mapLayersByName('Apiary')      
let layer = layers[0]      
let featureId = 47
let fieldIndex = layer.fields.lookupField('beekeeper')

layer.startEditing()
layer.changeAttributeValue(featureId, fieldIndex, "work!")
layer.commitChanges()
```

Creating a new feature, editing an attribute, and adding to a layer is done  like this:

```
let feature = FeatureUtils.createFeature(layer)
feature.setAttribute("bin_uuid", string)
feature.setAttribute("check_datetime", new Date().toLocaleString())
        
layer.startEditing()
LayerUtils.addFeature(layer, feature)
layer.commitChanges()
```

Some more information to explain/justify some of the choices done here. 

First, QML Javascript engine does not allow for non-const parameter by reference. This means that any C++ function that has a non-const & parameter can't be made Q_INVOKABLE. In practice, this is most impactful for the feature iterator here because we can't simply expose the QgsFeatureIterator::nextFeature( QgsFeature &feature ). It's a good lesson learned that is good to internalize now as we move forward :)

To deal with this, I've come up with a FeatureIterator which is Javascript friendly, with a bool hasNext() function and a QgsFeature next() function. I settled on this form after researching what kind of iterator template there is out there for Javascript.

This could eventually be upstreamed into QgsFeatureIterator itself. Looking at Qt's QList iterator for example, it does support Java-style iterators with hasNext() / next()  / etc. (https://doc.qt.io/qt-6/java-style-iterators.html#java-style-iterators). This is a discussion that's worth having upstream as to whether we want this or not there.

Also, for the record, QML's Javascript engine does _not_ have the capability to expand an object type via Object.prototype.my_function() = function {}, so adding functions to a given QObject or QGadget requires us to do it on the C++ side of things.

Finally, QML's Javascript engine does not allow the creation of objects directly in Javascript (other than via Qt.createComponent / Qt.createQmlObject which is not super graceful). This is why for e.g. Qt has a Qt.point() function to create a point object. That's why for e.g. we can't go let request = QgsFeatureRequest(...) on the Javascript side of things.