### PR TITLE
Plugins management UI implementation

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -7,6 +7,7 @@ set(QFIELD_CORE_SRCS
     utils/geometryutils.cpp
     utils/layerutils.cpp
     utils/positioningutils.cpp
+    utils/projectutils.cpp
     utils/qfieldcloudutils.cpp
     utils/relationutils.cpp
     utils/snappingutils.cpp
@@ -116,6 +117,7 @@ set(QFIELD_CORE_HDRS
     utils/geometryutils.h
     utils/layerutils.h
     utils/positioningutils.h
+    utils/projectutils.h
     utils/qfieldcloudutils.h
     utils/relationutils.h
     utils/snappingutils.h

--- a/src/core/platforms/platformutilities.cpp
+++ b/src/core/platforms/platformutilities.cpp
@@ -102,6 +102,7 @@ void PlatformUtilities::afterUpdate()
     appDir.mkpath( QStringLiteral( "fonts" ) );
     appDir.mkpath( QStringLiteral( "basemaps" ) );
     appDir.mkpath( QStringLiteral( "logs" ) );
+    appDir.mkpath( QStringLiteral( "plugins" ) );
   }
 }
 

--- a/src/core/pluginmanager.cpp
+++ b/src/core/pluginmanager.cpp
@@ -38,7 +38,9 @@ void PluginManager::loadPlugin( const QString &pluginPath, const QString &plugin
   if ( !skipPermissionCheck )
   {
     QSettings settings;
-    settings.beginGroup( QStringLiteral( "/qfield/plugins/%1" ).arg( pluginPath ) );
+    QString pluginKey = pluginPath;
+    pluginKey.replace( QChar( '/' ), QChar( '_' ) );
+    settings.beginGroup( QStringLiteral( "/qfield/plugins/%1" ).arg( pluginKey ) );
     const QStringList keys = settings.childKeys();
     if ( keys.contains( QStringLiteral( "permissionGranted" ) ) )
     {
@@ -104,7 +106,9 @@ void PluginManager::grantRequestedPluginPermission( bool permanent )
   if ( permanent )
   {
     QSettings settings;
-    settings.beginGroup( QStringLiteral( "/qfield/plugins/%1" ).arg( mPermissionRequestPluginPath ) );
+    QString pluginKey = mPermissionRequestPluginPath;
+    pluginKey.replace( QChar( '/' ), QChar( '_' ) );
+    settings.beginGroup( QStringLiteral( "/qfield/plugins/%1" ).arg( pluginKey ) );
     settings.setValue( QStringLiteral( "permissionGranted" ), true );
     settings.endGroup();
   }
@@ -118,12 +122,26 @@ void PluginManager::denyRequestedPluginPermission( bool permanent )
   if ( permanent )
   {
     QSettings settings;
-    settings.beginGroup( QStringLiteral( "/qfield/plugins/%1" ).arg( mPermissionRequestPluginPath ) );
+    QString pluginKey = mPermissionRequestPluginPath;
+    pluginKey.replace( QChar( '/' ), QChar( '_' ) );
+    settings.beginGroup( QStringLiteral( "/qfield/plugins/%1" ).arg( pluginKey ) );
     settings.setValue( QStringLiteral( "permissionGranted" ), false );
     settings.endGroup();
   }
 
   mPermissionRequestPluginPath.clear();
+}
+
+void PluginManager::clearPluginPermissions()
+{
+  QSettings settings;
+  settings.beginGroup( QStringLiteral( "/qfield/plugins/" ) );
+  const QStringList pluginKeys = settings.childGroups();
+  for ( const QString &pluginKey : pluginKeys )
+  {
+    settings.remove( QStringLiteral( "%1/permissionGranted" ).arg( pluginKey ) );
+  }
+  settings.endGroup();
 }
 
 void PluginManager::refreshAppPlugins()

--- a/src/core/pluginmanager.cpp
+++ b/src/core/pluginmanager.cpp
@@ -94,6 +94,15 @@ void PluginManager::unloadPlugin( const QString &pluginPath )
   }
 }
 
+void PluginManager::unloadPlugins()
+{
+  const QStringList loadedPluginPaths = mLoadedPlugins.keys();
+  for ( const QString &loadedPluginPath : loadedPluginPaths )
+  {
+    unloadPlugin( loadedPluginPath );
+  }
+}
+
 void PluginManager::handleWarnings( const QList<QQmlError> &warnings )
 {
   for ( const QQmlError &warning : warnings )
@@ -324,6 +333,9 @@ void PluginManager::installFromUrl( const QString &url )
           QStringList zipFiles = ZipUtils::files( filePath );
           if ( zipFiles.contains( QStringLiteral( "main.qml" ) ) )
           {
+            // Insure no previous version is running
+            disableAppPlugin( fileInfo.completeBaseName() );
+
             QDir pluginDirectory = QStringLiteral( "%1/plugins/%2" ).arg( dataDir, fileInfo.completeBaseName() );
             if ( pluginDirectory.exists() )
             {

--- a/src/core/pluginmanager.cpp
+++ b/src/core/pluginmanager.cpp
@@ -16,7 +16,7 @@
 
 #include "platformutilities.h"
 #include "pluginmanager.h"
-#include "ziputils.h"
+#include "qgsziputils.h"
 
 #include <QDir>
 #include <QFileInfo>
@@ -356,7 +356,7 @@ void PluginManager::installFromUrl( const QString &url )
           file.write( data );
           file.close();
 
-          QStringList zipFiles = ZipUtils::files( filePath );
+          QStringList zipFiles = QgsZipUtils::files( filePath );
           if ( zipFiles.contains( QStringLiteral( "main.qml" ) ) )
           {
             // Insure no previous version is running
@@ -368,7 +368,7 @@ void PluginManager::installFromUrl( const QString &url )
               pluginDirectory.removeRecursively();
             }
             pluginDirectory.mkpath( "." );
-            if ( ZipUtils::unzip( filePath, pluginDirectory.absolutePath(), zipFiles, false ) )
+            if ( QgsZipUtils::unzip( filePath, pluginDirectory.absolutePath(), zipFiles, false ) )
             {
               file.remove();
 

--- a/src/core/pluginmanager.cpp
+++ b/src/core/pluginmanager.cpp
@@ -154,10 +154,17 @@ void PluginManager::refreshAppPlugins()
           author = metadata.value( "author" ).toString();
           icon = metadata.value( "icon" ).toString();
         }
-        mAvailableAppPlugins << PluginInformation( name, description, author, icon, path );
+        mAvailableAppPlugins << PluginInformation( candidate.fileName(), name, description, author, icon, path );
       }
     }
   }
+
+  emit availableAppPluginsChanged();
+}
+
+QList<PluginInformation> PluginManager::availableAppPlugins() const
+{
+  return mAvailableAppPlugins;
 }
 
 QString PluginManager::findProjectPlugin( const QString &projectPath )

--- a/src/core/pluginmanager.cpp
+++ b/src/core/pluginmanager.cpp
@@ -411,10 +411,19 @@ void PluginManager::installFromUrl( const QString &url )
 QString PluginManager::findProjectPlugin( const QString &projectPath )
 {
   const QFileInfo fi( projectPath );
-  const QString pluginPath = QStringLiteral( "%1/%2.qml" ).arg( fi.absolutePath(), fi.completeBaseName() );
-  if ( QFileInfo::exists( pluginPath ) )
+  const QString completeBaseName = fi.completeBaseName();
+  QStringList possiblePluginPaths = QStringList() << QStringLiteral( "%1/%2.qml" ).arg( fi.absolutePath(), completeBaseName );
+  // Cloud-served projects come with a _cloud suffix, take that into account
+  if ( completeBaseName.endsWith( "_cloud" ) )
   {
-    return pluginPath;
+    possiblePluginPaths << QStringLiteral( "%1/%2.qml" ).arg( fi.absolutePath(), fi.completeBaseName().mid( 0, completeBaseName.size() - 6 ) );
+  }
+  for ( QString &possiblePluginPath : possiblePluginPaths )
+  {
+    if ( QFileInfo::exists( possiblePluginPath ) )
+    {
+      return possiblePluginPath;
+    }
   }
   return QString();
 }

--- a/src/core/pluginmanager.cpp
+++ b/src/core/pluginmanager.cpp
@@ -132,14 +132,17 @@ void PluginManager::denyRequestedPluginPermission( bool permanent )
   mPermissionRequestPluginPath.clear();
 }
 
-void PluginManager::clearPluginPermissions()
+void PluginManager::clearProjectPluginPermissions()
 {
   QSettings settings;
   settings.beginGroup( QStringLiteral( "/qfield/plugins/" ) );
   const QStringList pluginKeys = settings.childGroups();
   for ( const QString &pluginKey : pluginKeys )
   {
-    settings.remove( QStringLiteral( "%1/permissionGranted" ).arg( pluginKey ) );
+    if ( settings.value( QStringLiteral( "%1/uuid" ).arg( pluginKey ) ).toString().isEmpty() )
+    {
+      settings.remove( QStringLiteral( "%1/permissionGranted" ).arg( pluginKey ) );
+    }
   }
   settings.endGroup();
 }

--- a/src/core/pluginmanager.cpp
+++ b/src/core/pluginmanager.cpp
@@ -188,7 +188,10 @@ void PluginManager::refreshAppPlugins()
           name = metadata.value( "name", candidate.fileName() ).toString();
           description = metadata.value( "description" ).toString();
           author = metadata.value( "author" ).toString();
-          icon = metadata.value( "icon" ).toString();
+          if ( !metadata.value( "icon" ).toString().isEmpty() )
+          {
+            icon = QStringLiteral( "%1/%2" ).arg( candidate.absoluteFilePath(), metadata.value( "icon" ).toString() );
+          }
         }
         mAvailableAppPlugins.insert( candidate.fileName(), PluginInformation( candidate.fileName(), name, description, author, icon, path ) );
       }

--- a/src/core/pluginmanager.cpp
+++ b/src/core/pluginmanager.cpp
@@ -65,7 +65,11 @@ void PluginManager::loadPlugin( const QString &pluginPath, const QString &plugin
     unloadPlugin( pluginPath );
   }
 
-  QQmlComponent component( mEngine, pluginPath, this );
+  // Bypass caching to insure updated QML content is loaded
+  QUrl url = QUrl::fromLocalFile( pluginPath );
+  url.setQuery( QStringLiteral( "t=%1" ).arg( QDateTime::currentSecsSinceEpoch() ) );
+
+  QQmlComponent component( mEngine, url, this );
   if ( component.status() == QQmlComponent::Status::Error )
   {
     for ( const QQmlError &error : component.errors() )

--- a/src/core/pluginmanager.cpp
+++ b/src/core/pluginmanager.cpp
@@ -113,6 +113,10 @@ void PluginManager::grantRequestedPluginPermission( bool permanent )
     pluginKey.replace( QChar( '/' ), QChar( '_' ) );
     settings.beginGroup( QStringLiteral( "/qfield/plugins/%1" ).arg( pluginKey ) );
     settings.setValue( QStringLiteral( "permissionGranted" ), true );
+    if ( !settings.value( QStringLiteral( "uuid" ) ).toString().isEmpty() )
+    {
+      settings.setValue( QStringLiteral( "userEnabled" ), true );
+    }
     settings.endGroup();
   }
 
@@ -135,14 +139,14 @@ void PluginManager::denyRequestedPluginPermission( bool permanent )
   mPermissionRequestPluginPath.clear();
 }
 
-void PluginManager::clearProjectPluginPermissions()
+void PluginManager::clearPluginPermissions()
 {
   QSettings settings;
   settings.beginGroup( QStringLiteral( "/qfield/plugins/" ) );
   const QStringList pluginKeys = settings.childGroups();
   for ( const QString &pluginKey : pluginKeys )
   {
-    if ( settings.value( QStringLiteral( "%1/uuid" ).arg( pluginKey ) ).toString().isEmpty() )
+    if ( settings.value( QStringLiteral( "%1/userEnabled" ).arg( pluginKey ), false ).toBool() )
     {
       settings.remove( QStringLiteral( "%1/permissionGranted" ).arg( pluginKey ) );
     }
@@ -222,9 +226,11 @@ void PluginManager::enableAppPlugin( const QString &uuid )
       QString pluginKey = mAvailableAppPlugins[uuid].path();
       pluginKey.replace( QChar( '/' ), QChar( '_' ) );
       settings.beginGroup( QStringLiteral( "/qfield/plugins/%1" ).arg( pluginKey ) );
-      settings.setValue( QStringLiteral( "permissionGranted" ), true );
-      settings.setValue( QStringLiteral( "userEnabled" ), true );
       settings.setValue( QStringLiteral( "uuid" ), uuid );
+      if ( settings.value( QStringLiteral( "permissionGranted" ), false ).toBool() )
+      {
+        settings.setValue( QStringLiteral( "userEnabled" ), true );
+      }
       settings.endGroup();
 
       loadPlugin( mAvailableAppPlugins[uuid].path(), mAvailableAppPlugins[uuid].name() );
@@ -242,7 +248,6 @@ void PluginManager::disableAppPlugin( const QString &uuid )
       QString pluginKey = mAvailableAppPlugins[uuid].path();
       pluginKey.replace( QChar( '/' ), QChar( '_' ) );
       settings.beginGroup( QStringLiteral( "/qfield/plugins/%1" ).arg( pluginKey ) );
-      settings.setValue( QStringLiteral( "permissionGranted" ), false );
       settings.setValue( QStringLiteral( "userEnabled" ), false );
       settings.endGroup();
 

--- a/src/core/pluginmanager.h
+++ b/src/core/pluginmanager.h
@@ -20,6 +20,34 @@
 #include <QObject>
 #include <QQmlEngine>
 
+class PluginInformation
+{
+    Q_GADGET
+
+  public:
+    PluginInformation( const QString &name, const QString &description, const QString &author, const QString &icon, const QString &path )
+      : mName( name )
+      , mDescription( description )
+      , mAuthor( author )
+      , mIcon( icon )
+      , mPath( path )
+    {}
+    ~PluginInformation() = default;
+
+    QString name() const { return mName; }
+    QString description() const { return mDescription; }
+    QString author() const { return mAuthor; }
+    QString icon() const { return mIcon; }
+    QString path() const { return mPath; }
+
+  private:
+    QString mName;
+    QString mDescription;
+    QString mAuthor;
+    QString mIcon;
+    QString mPath;
+};
+
 class PluginManager : public QObject
 {
     Q_OBJECT
@@ -34,6 +62,9 @@ class PluginManager : public QObject
     Q_INVOKABLE void grantRequestedPluginPermission( bool permanent = false );
     Q_INVOKABLE void denyRequestedPluginPermission( bool permanent = false );
 
+    void refreshAppPlugins();
+    QList<PluginInformation> availableAppPlugins();
+
     static QString findProjectPlugin( const QString &projectPath );
 
   signals:
@@ -47,6 +78,8 @@ class PluginManager : public QObject
     QMap<QString, QPointer<QObject>> mLoadedPlugins;
 
     QString mPermissionRequestPluginPath;
+
+    QList<PluginInformation> mAvailableAppPlugins;
 };
 
 #endif // PLUGINMANAGER_H

--- a/src/core/pluginmanager.h
+++ b/src/core/pluginmanager.h
@@ -72,6 +72,8 @@ class PluginManager : public QObject
     void loadPlugin( const QString &pluginPath, const QString &pluginName, bool skipPermissionCheck = false );
     void unloadPlugin( const QString &pluginPath );
 
+    void unloadPlugins();
+
     Q_INVOKABLE void grantRequestedPluginPermission( bool permanent = false );
     Q_INVOKABLE void denyRequestedPluginPermission( bool permanent = false );
 

--- a/src/core/pluginmanager.h
+++ b/src/core/pluginmanager.h
@@ -94,7 +94,10 @@ class PluginManager : public QObject
 
   signals:
     void pluginPermissionRequested( const QString &pluginName );
+
     void availableAppPluginsChanged();
+    void appPluginEnabled( const QString &uuid );
+    void appPluginDisabled( const QString &uuid );
 
     void installTriggered( const QString &name );
     void installProgress( double progress );

--- a/src/core/pluginmanager.h
+++ b/src/core/pluginmanager.h
@@ -74,7 +74,8 @@ class PluginManager : public QObject
 
     Q_INVOKABLE void grantRequestedPluginPermission( bool permanent = false );
     Q_INVOKABLE void denyRequestedPluginPermission( bool permanent = false );
-    Q_INVOKABLE void clearPluginPermissions();
+
+    Q_INVOKABLE void clearProjectPluginPermissions();
 
     QList<PluginInformation> availableAppPlugins() const;
 

--- a/src/core/pluginmanager.h
+++ b/src/core/pluginmanager.h
@@ -75,7 +75,7 @@ class PluginManager : public QObject
     Q_INVOKABLE void grantRequestedPluginPermission( bool permanent = false );
     Q_INVOKABLE void denyRequestedPluginPermission( bool permanent = false );
 
-    Q_INVOKABLE void clearProjectPluginPermissions();
+    Q_INVOKABLE void clearPluginPermissions();
 
     QList<PluginInformation> availableAppPlugins() const;
 

--- a/src/core/pluginmanager.h
+++ b/src/core/pluginmanager.h
@@ -86,11 +86,17 @@ class PluginManager : public QObject
     void refreshAppPlugins();
     void restoreAppPlugins();
 
+    Q_INVOKABLE void installFromUrl( const QString &url );
+
     static QString findProjectPlugin( const QString &projectPath );
 
   signals:
     void pluginPermissionRequested( const QString &pluginName );
     void availableAppPluginsChanged();
+
+    void installTriggered( const QString &name );
+    void installProgress( double progress );
+    void installEnded( const QString &uuid = QString(), const QString &error = QString() );
 
   private slots:
     void handleWarnings( const QList<QQmlError> &warnings );

--- a/src/core/pluginmanager.h
+++ b/src/core/pluginmanager.h
@@ -74,6 +74,7 @@ class PluginManager : public QObject
 
     Q_INVOKABLE void grantRequestedPluginPermission( bool permanent = false );
     Q_INVOKABLE void denyRequestedPluginPermission( bool permanent = false );
+    Q_INVOKABLE void clearPluginPermissions();
 
     Q_INVOKABLE void refreshAppPlugins();
     QList<PluginInformation> availableAppPlugins() const;

--- a/src/core/pluginmanager.h
+++ b/src/core/pluginmanager.h
@@ -31,7 +31,7 @@ class PluginInformation
     Q_PROPERTY( QString icon READ icon )
 
   public:
-    PluginInformation( const QString uuid = QString(), const QString &name = QString(), const QString &description = QString(), const QString &author = QString(), const QString &icon = QString(), const QString &path = QString() )
+    PluginInformation( const QString &uuid = QString(), const QString &name = QString(), const QString &description = QString(), const QString &author = QString(), const QString &icon = QString(), const QString &path = QString() )
       : mUuid( uuid )
       , mName( name )
       , mDescription( description )
@@ -76,8 +76,14 @@ class PluginManager : public QObject
     Q_INVOKABLE void denyRequestedPluginPermission( bool permanent = false );
     Q_INVOKABLE void clearPluginPermissions();
 
-    Q_INVOKABLE void refreshAppPlugins();
     QList<PluginInformation> availableAppPlugins() const;
+
+    Q_INVOKABLE void enableAppPlugin( const QString &uuid );
+    Q_INVOKABLE void disableAppPlugin( const QString &uuid );
+    Q_INVOKABLE bool isAppPluginEnabled( const QString &uuid ) const;
+
+    void refreshAppPlugins();
+    void restoreAppPlugins();
 
     static QString findProjectPlugin( const QString &projectPath );
 
@@ -94,7 +100,7 @@ class PluginManager : public QObject
 
     QString mPermissionRequestPluginPath;
 
-    QList<PluginInformation> mAvailableAppPlugins;
+    QMap<QString, PluginInformation> mAvailableAppPlugins;
 };
 
 #endif // PLUGINMANAGER_H

--- a/src/core/pluginmanager.h
+++ b/src/core/pluginmanager.h
@@ -24,9 +24,16 @@ class PluginInformation
 {
     Q_GADGET
 
+    Q_PROPERTY( QString uuid READ uuid )
+    Q_PROPERTY( QString name READ name )
+    Q_PROPERTY( QString description READ description )
+    Q_PROPERTY( QString author READ author )
+    Q_PROPERTY( QString icon READ icon )
+
   public:
-    PluginInformation( const QString &name, const QString &description, const QString &author, const QString &icon, const QString &path )
-      : mName( name )
+    PluginInformation( const QString uuid = QString(), const QString &name = QString(), const QString &description = QString(), const QString &author = QString(), const QString &icon = QString(), const QString &path = QString() )
+      : mUuid( uuid )
+      , mName( name )
       , mDescription( description )
       , mAuthor( author )
       , mIcon( icon )
@@ -34,6 +41,7 @@ class PluginInformation
     {}
     ~PluginInformation() = default;
 
+    QString uuid() const { return mUuid; }
     QString name() const { return mName; }
     QString description() const { return mDescription; }
     QString author() const { return mAuthor; }
@@ -41,6 +49,7 @@ class PluginInformation
     QString path() const { return mPath; }
 
   private:
+    QString mUuid;
     QString mName;
     QString mDescription;
     QString mAuthor;
@@ -48,9 +57,13 @@ class PluginInformation
     QString mPath;
 };
 
+Q_DECLARE_METATYPE( PluginInformation )
+
 class PluginManager : public QObject
 {
     Q_OBJECT
+
+    Q_PROPERTY( QList<PluginInformation> availableAppPlugins READ availableAppPlugins NOTIFY availableAppPluginsChanged )
 
   public:
     explicit PluginManager( QQmlEngine *engine );
@@ -62,13 +75,14 @@ class PluginManager : public QObject
     Q_INVOKABLE void grantRequestedPluginPermission( bool permanent = false );
     Q_INVOKABLE void denyRequestedPluginPermission( bool permanent = false );
 
-    void refreshAppPlugins();
-    QList<PluginInformation> availableAppPlugins();
+    Q_INVOKABLE void refreshAppPlugins();
+    QList<PluginInformation> availableAppPlugins() const;
 
     static QString findProjectPlugin( const QString &projectPath );
 
   signals:
     void pluginPermissionRequested( const QString &pluginName );
+    void availableAppPluginsChanged();
 
   private slots:
     void handleWarnings( const QList<QQmlError> &warnings );

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -510,6 +510,7 @@ void QgisMobileapp::initDeclarative()
   qmlRegisterUncreatableType<AbstractGnssReceiver>( "org.qfield", 1, 0, "AbstractGnssReceiver", "" );
   qmlRegisterUncreatableType<Tracker>( "org.qfield", 1, 0, "Tracker", "" );
   qRegisterMetaType<GnssPositionInformation>( "GnssPositionInformation" );
+  qRegisterMetaType<PluginInformation>( "PluginInformation" );
 
   REGISTER_SINGLETON( "org.qfield", GeometryEditorsModel, "GeometryEditorsModelSingleton" );
   REGISTER_SINGLETON( "org.qfield", GeometryUtils, "GeometryUtils" );

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -646,9 +646,9 @@ void QgisMobileapp::onAfterFirstRendering()
 {
   // This should get triggered exactly once, so we disconnect it right away
   // disconnect( this, &QgisMobileapp::afterRendering, this, &QgisMobileapp::onAfterFirstRendering );
-
   if ( mFirstRenderingFlag )
   {
+    mPluginManager->restoreAppPlugins();
     if ( PlatformUtilities::instance()->hasQgsProject() )
     {
       PlatformUtilities::instance()->checkWriteExternalStoragePermissions();

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -1429,6 +1429,8 @@ QgisMobileapp::~QgisMobileapp()
 {
   saveProjectPreviewImage();
 
+  mPluginManager->unloadPlugins();
+
   delete mOfflineEditing;
   mProject->clear();
   delete mProject;

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -92,6 +92,7 @@
 #include "projectinfo.h"
 #include "projectsimageprovider.h"
 #include "projectsource.h"
+#include "projectutils.h"
 #include "qfield.h"
 #include "qfieldcloudconnection.h"
 #include "qfieldcloudprojectsmodel.h"
@@ -522,6 +523,7 @@ void QgisMobileapp::initDeclarative()
   REGISTER_SINGLETON( "org.qfield", UrlUtils, "UrlUtils" );
   REGISTER_SINGLETON( "org.qfield", QFieldCloudUtils, "QFieldCloudUtils" );
   REGISTER_SINGLETON( "org.qfield", PositioningUtils, "PositioningUtils" );
+  REGISTER_SINGLETON( "org.qfield", ProjectUtils, "ProjectUtils" );
   REGISTER_SINGLETON( "org.qfield", CoordinateReferenceSystemUtils, "CoordinateReferenceSystemUtils" );
 
   qmlRegisterUncreatableType<AppInterface>( "org.qfield", 1, 0, "AppInterface", "AppInterface is only provided by the environment and cannot be created ad-hoc" );

--- a/src/core/utils/featureutils.cpp
+++ b/src/core/utils/featureutils.cpp
@@ -20,18 +20,27 @@
 #include <qgsexpressioncontextutils.h>
 #include <qgsproject.h>
 #include <qgsvectorlayer.h>
-
+#include <qgsvectorlayerutils.h>
 
 FeatureUtils::FeatureUtils( QObject *parent )
   : QObject( parent )
 {
 }
 
+QgsFeature FeatureUtils::createBlankFeature( const QgsFields &fields, const QgsGeometry &geometry )
+{
+  QgsFeature feature( fields );
+  feature.setGeometry( geometry );
+  return feature;
+}
+
 QgsFeature FeatureUtils::createFeature( QgsVectorLayer *layer, const QgsGeometry &geometry )
 {
-  QgsFeature f( layer ? layer->fields() : QgsFields() );
-  f.setGeometry( geometry );
-  return f;
+  QgsFeature feature;
+  QgsAttributeMap attributes;
+  QgsExpressionContext context = layer->createExpressionContext();
+  feature = QgsVectorLayerUtils::createFeature( layer, geometry, attributes, &context );
+  return feature;
 }
 
 QString FeatureUtils::displayName( QgsVectorLayer *layer, const QgsFeature &feature )

--- a/src/core/utils/featureutils.h
+++ b/src/core/utils/featureutils.h
@@ -31,7 +31,8 @@ class QFIELD_CORE_EXPORT FeatureUtils : public QObject
   public:
     explicit FeatureUtils( QObject *parent = nullptr );
 
-    static Q_INVOKABLE QgsFeature createFeature( QgsVectorLayer *layer = nullptr, const QgsGeometry &geometry = QgsGeometry() );
+    static Q_INVOKABLE QgsFeature createBlankFeature( const QgsFields &fields = QgsFields(), const QgsGeometry &geometry = QgsGeometry() );
+    static Q_INVOKABLE QgsFeature createFeature( QgsVectorLayer *layer, const QgsGeometry &geometry = QgsGeometry() );
 
     /**
     * Returns the display name of a given feature.

--- a/src/core/utils/projectutils.cpp
+++ b/src/core/utils/projectutils.cpp
@@ -1,0 +1,39 @@
+/***************************************************************************
+  projectutils.cpp - ProjectUtils
+
+ ---------------------
+ begin                : 19.04.2024
+ copyright            : (C) 2024 by Mathieu Pellerin
+ email                : mathieu@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "projectutils.h"
+
+#include <qgsmaplayer.h>
+
+ProjectUtils::ProjectUtils( QObject *parent )
+  : QObject( parent )
+{
+}
+
+QVariantMap ProjectUtils::mapLayers( QgsProject *project )
+{
+  if ( !project )
+    return QVariantMap();
+
+  QVariantMap mapLayers;
+  const QMap<QString, QgsMapLayer *> projectMapLayers = project->mapLayers();
+  for ( const QString &layerId : projectMapLayers.keys() )
+  {
+    mapLayers.insert( layerId, QVariant::fromValue<QgsMapLayer *>( projectMapLayers[layerId] ) );
+  }
+
+  return mapLayers;
+}

--- a/src/core/utils/projectutils.h
+++ b/src/core/utils/projectutils.h
@@ -1,0 +1,38 @@
+/***************************************************************************
+  projectutils.h - ProjectUtils
+
+ ---------------------
+ begin                : 19.04.2024
+ copyright            : (C) 2024 by Mathieu Pellerin
+ email                : mathieu@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef PROJECTUTILS_H
+#define PROJECTUTILS_H
+
+#include <QObject>
+#include <qgsproject.h>
+
+class ProjectUtils : public QObject
+{
+    Q_OBJECT
+
+  public:
+    explicit ProjectUtils( QObject *parent = nullptr );
+
+    /**
+     * Returns a map of all registered layers by layer ID.
+     * \note This function mimics QgsProject::mapLayers with a return type
+     * that is QML compatible.
+     */
+    Q_INVOKABLE static QVariantMap mapLayers( QgsProject *project = nullptr );
+};
+
+#endif // PROJECTUTILS_H

--- a/src/qml/BadLayerItem.qml
+++ b/src/qml/BadLayerItem.qml
@@ -15,7 +15,7 @@ Page {
   width: mainWindow.width
   height: mainWindow.height
 
-  header: PageHeader {
+  header: QfPageHeader {
     title: qsTr( 'Unable to load some layers' )
 
     showBackButton: false

--- a/src/qml/BookmarkProperties.qml
+++ b/src/qml/BookmarkProperties.qml
@@ -31,7 +31,7 @@ Popup {
     Page {
         width: parent.width
         padding: 10
-        header: PageHeader {
+        header: QfPageHeader {
           id: pageHeader
           title: qsTr( "Bookmark Properties" )
 

--- a/src/qml/BookmarkProperties.qml
+++ b/src/qml/BookmarkProperties.qml
@@ -31,41 +31,18 @@ Popup {
     Page {
         width: parent.width
         padding: 10
-        header: ToolBar {
-            id: toolBar
+        header: PageHeader {
+          id: pageHeader
+          title: qsTr( "Bookmark Properties" )
 
-            background: Rectangle {
-                color: "transparent"
-                height: 48
-            }
+          showBackButton: false
+          showApplyButton: false
+          showCancelButton: true
+          backgroundFill: false
 
-            RowLayout {
-                width: parent.width
-                height: 48
-
-                Label {
-                    Layout.leftMargin: 48
-                    Layout.fillWidth: true
-                    Layout.alignment: Qt.AlignVCenter
-                    text: qsTr('Bookmark Properties')
-                    font: Theme.strongFont
-                    color: Theme.mainColor
-                    horizontalAlignment: Text.AlignHCenter
-                    wrapMode: Text.WordWrap
-                }
-
-                QfToolButton {
-                    id: closeButton
-                    Layout.alignment: Qt.AlignVCenter
-                    iconSource: Theme.getThemeIcon( 'ic_close_black_24dp' )
-                    iconColor: Theme.mainTextColor
-                    bgcolor: "transparent"
-
-                    onClicked: {
-                        bookmarkProperties.close();
-                    }
-                }
-            }
+          onCancel: {
+            bookmarkProperties.close()
+          }
         }
 
         ColumnLayout {

--- a/src/qml/BrowserPanel.qml
+++ b/src/qml/BrowserPanel.qml
@@ -29,7 +29,7 @@ Popup {
   Page {
     id: browserContainer
     anchors.fill: parent
-    header: PageHeader {
+    header: QfPageHeader {
       id: pageHeader
       title: browserView && !browserView.loading && browserView.title !== ''
              ? browserView.title

--- a/src/qml/Changelog.qml
+++ b/src/qml/Changelog.qml
@@ -22,7 +22,7 @@ Popup {
         focus: true
         anchors.fill: parent
 
-        header: PageHeader {
+        header: QfPageHeader {
             title: qsTr("What's new in QField")
 
             showApplyButton: false

--- a/src/qml/LayerLoginDialog.qml
+++ b/src/qml/LayerLoginDialog.qml
@@ -12,7 +12,7 @@ Page {
   property string realm
   property var inCancelation
 
-    header: PageHeader {
+    header: QfPageHeader {
         title: qsTr("Login information")
 
         showBackButton: false

--- a/src/qml/LocatorSettings.qml
+++ b/src/qml/LocatorSettings.qml
@@ -22,39 +22,17 @@ Popup {
         width: parent.width
         height: locatorfiltersList.height + 60
         padding: 10
-        header: ToolBar {
-          id: toolBar
-          height: 48
+        header: PageHeader {
+          id: pageHeader
+          title: qsTr( "Search Bar Settings" )
 
-          background: Rectangle {
-            color: "transparent"
-          }
+          showBackButton: false
+          showApplyButton: false
+          showCancelButton: true
+          backgroundFill: false
 
-          Label {
-            anchors.centerIn: parent
-            leftPadding: 48
-            rightPadding: 48
-            width: parent.width - 20
-            text: qsTr( "Search Bar Settings" )
-            font: Theme.strongFont
-            color: Theme.mainColor
-            horizontalAlignment: Text.AlignHCenter
-            wrapMode: Text.WordWrap
-          }
-
-          QfToolButton {
-            id: closeButton
-            anchors {
-              top: parent.top
-              right: parent.right
-            }
-            iconSource: Theme.getThemeIcon( 'ic_close_black_24dp' )
-            iconColor: Theme.mainTextColor
-            bgcolor: "transparent"
-
-            onClicked: {
-              popup.close();
-            }
+          onCancel: {
+            popup.close()
           }
         }
 

--- a/src/qml/LocatorSettings.qml
+++ b/src/qml/LocatorSettings.qml
@@ -22,7 +22,7 @@ Popup {
         width: parent.width
         height: locatorfiltersList.height + 60
         padding: 10
-        header: PageHeader {
+        header: QfPageHeader {
           id: pageHeader
           title: qsTr( "Search Bar Settings" )
 

--- a/src/qml/MessageLog.qml
+++ b/src/qml/MessageLog.qml
@@ -13,7 +13,7 @@ Page {
 
   signal finished
 
-  header: PageHeader {
+  header: QfPageHeader {
       title: qsTr( 'Message Logs' )
 
       showBackButton: true

--- a/src/qml/PageHeader.qml
+++ b/src/qml/PageHeader.qml
@@ -8,6 +8,8 @@ import Theme 1.0
 ToolBar {
   property alias title: titleLabel.text
 
+  property bool backgroundFill: true
+
   property alias showBackButton: backButton.visible
   property alias showApplyButton: applyButton.visible
   property alias showCancelButton: cancelButton.visible
@@ -32,7 +34,7 @@ ToolBar {
 
   background: Rectangle {
     id: backgroundRect
-    color: Theme.mainColor
+    color: backgroundFill ? Theme.mainColor : "transparent"
 
     ProgressBar {
       id: busyIndicator
@@ -112,7 +114,7 @@ ToolBar {
       leftPadding: !showApplyButton && showCancelButton ? 48: 0
       rightPadding: (showApplyButton || showBackButton) && !showCancelButton ? 48: 0
       font: Theme.strongFont
-      color: Theme.light
+      color: backgroundFill ? Theme.light : Theme.mainColor
       elide: Label.ElideRight
       horizontalAlignment: Qt.AlignHCenter
       verticalAlignment: Qt.AlignVCenter

--- a/src/qml/PageHeader.qml
+++ b/src/qml/PageHeader.qml
@@ -13,6 +13,7 @@ ToolBar {
   property alias showCancelButton: cancelButton.visible
 
   property alias busyIndicatorState: busyIndicator.state
+  property alias busyIndicatorValue: busyIndicator.value
 
   property double topMargin: 0.0
 
@@ -40,7 +41,7 @@ ToolBar {
       width: parent.width
       height: 6
       value: 50
-      indeterminate: true
+      indeterminate: value == 0 ? true : false
 
       state: "off"
 

--- a/src/qml/PluginManagerSettings.qml
+++ b/src/qml/PluginManagerSettings.qml
@@ -111,9 +111,10 @@ Popup {
             QfSwitch {
               id: toggleEnabledPlugin
               Layout.preferredWidth: implicitContentWidth
-              checked: pluginManager.isAppPluginEnabled(Uuid)
+              checked: Enabled
 
               onClicked: {
+                Enabled = checked == true
                 if (checked) {
                   pluginManager.enableAppPlugin(Uuid)
                 } else {
@@ -239,6 +240,22 @@ Popup {
       }
     }
 
+    function onAppPluginEnabled(uuid) {
+      for(let i = 0; i < pluginsList.model.count; i++) {
+        if (pluginsList.model.get(i).Uuid === uuid) {
+          pluginsList.model.get(i).Enabled = true
+        }
+      }
+    }
+
+    function onAppPluginDisabled(uuid) {
+      for(let i = 0; i < pluginsList.model.count; i++) {
+        if (pluginsList.model.get(i).Uuid === uuid) {
+          pluginsList.model.get(i).Enabled = false
+        }
+      }
+    }
+
     function onAvailableAppPluginsChanged() {
       refreshAppPluginsList()
     }
@@ -248,7 +265,7 @@ Popup {
     pluginsList.model.clear()
 
     for (const plugin of pluginManager.availableAppPlugins) {
-      pluginsList.model.append({"Uuid":plugin.uuid, "Name":plugin.name, "Description":plugin.description, "Author":plugin.author, "Icon": plugin.icon})
+      pluginsList.model.append({"Uuid":plugin.uuid, "Enabled":pluginManager.isAppPluginEnabled(plugin.uuid), "Name":plugin.name, "Description":plugin.description, "Author":plugin.author, "Icon": plugin.icon})
     }
   }
 

--- a/src/qml/PluginManagerSettings.qml
+++ b/src/qml/PluginManagerSettings.qml
@@ -1,0 +1,200 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import org.qgis 1.0
+import org.qfield 1.0
+
+import Theme 1.0
+
+Popup {
+  id: popup
+
+  width: Math.min(400, mainWindow.width - Theme.popupScreenEdgeMargin)
+  height: mainWindow.height - 160
+  x: (parent.width - width) / 2
+  y: (parent.height - height) / 2
+  padding: 0
+
+  Page {
+    id: page
+    width: parent.width
+    height: parent.height
+    padding: 10
+    header: ToolBar {
+      id: toolBar
+      height: 48
+
+      background: Rectangle {
+        color: "transparent"
+      }
+
+      Label {
+        anchors.centerIn: parent
+        leftPadding: 48
+        rightPadding: 48
+        width: parent.width - 20
+        text: qsTr( "Plugins" )
+        font: Theme.strongFont
+        color: Theme.mainColor
+        horizontalAlignment: Text.AlignHCenter
+        wrapMode: Text.WordWrap
+      }
+
+      QfToolButton {
+        id: closeButton
+        anchors {
+          top: parent.top
+          right: parent.right
+        }
+        iconSource: Theme.getThemeIcon( 'ic_close_black_24dp' )
+        iconColor: Theme.mainTextColor
+        bgcolor: "transparent"
+
+        onClicked: {
+          popup.close();
+        }
+      }
+    }
+
+    ColumnLayout {
+      spacing: 4
+      width: parent.width
+      height: parent.height
+
+      Label {
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        Layout.margins: 20
+        visible: pluginsList.model.count === 0
+
+        text: qsTr('No plugins have been installed yet. To learn more about plugins, %1read the documentation%2.').arg('<a href="https://docs.qfield.org/">').arg('</a>')
+        font: Theme.defaultFont
+        wrapMode: Text.WordWrap
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+        onLinkActivated: Qt.openUrlExternally(link)
+      }
+
+      ListView {
+        id: pluginsList
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        visible: model.count > 0
+        clip: true
+
+        model: ListModel {}
+
+        delegate: Rectangle {
+          id: rectangle
+          width: parent.width
+          height: inner.height
+          color: "transparent"
+
+          GridLayout {
+            id: inner
+            width: parent.width
+            anchors.leftMargin: 20
+            anchors.rightMargin: 20
+
+            columns: 2
+            columnSpacing: 0
+            rowSpacing: 2
+
+            RowLayout {
+              Layout.fillWidth: true
+
+              Image {
+                Layout.preferredWidth: 24
+                Layout.preferredHeight: 24
+
+                source: Icon !== '' ? 'file://' + Icon : ''
+              }
+
+              Label {
+                Layout.fillWidth: true
+                leftPadding: 4
+                text: Name
+                font: Theme.defaultFont
+                color: Theme.mainTextColor
+                wrapMode: Text.WordWrap
+
+                MouseArea {
+                  anchors.fill: parent
+                  onClicked: {
+                    toggleEnabledPlugin.checked = !toggleEnabledPlugin.checked
+                    toggleEnabledPlugin.clicked()
+                  }
+                }
+              }
+            }
+
+            QfSwitch {
+              id: toggleEnabledPlugin
+              Layout.preferredWidth: implicitContentWidth
+              checked: pluginManager.isAppPluginEnabled(Uuid)
+
+              onClicked: {
+                if (checked) {
+                  pluginManager.enableAppPlugin(Uuid)
+                } else {
+                  pluginManager.disableAppPlugin(Uuid)
+                }
+              }
+            }
+
+            ColumnLayout {
+              Layout.fillWidth: true
+
+              Label {
+                Layout.fillWidth: true
+                text: qsTr('Authored by %1').arg(Author)
+                font: Theme.tipFont
+                color: Theme.secondaryTextColor
+                wrapMode: Text.WordWrap
+              }
+
+              Label {
+                Layout.fillWidth: true
+                text: Description
+                font: Theme.tipFont
+                color: Theme.secondaryTextColor
+                wrapMode: Text.WordWrap
+              }
+            }
+          }
+        }
+      }
+
+      QfButton {
+        id: installFromUrlButton
+        Layout.fillWidth: true
+
+        text: qsTr("Install plugin from URL")
+
+        onClicked: {
+          pluginManager.clearProjectPluginPermissions()
+        }
+      }
+
+      QfButton {
+        id: clearPermissionsButton
+        Layout.fillWidth: true
+
+        text: qsTr("Clear project permissions")
+
+        onClicked: {
+          pluginManager.clearProjectPluginPermissions()
+        }
+      }
+    }
+  }
+
+  Component.onCompleted: {
+    pluginsList.model.clear()
+
+    for (const plugin of pluginManager.availableAppPlugins) {
+      pluginsList.model.append({"Uuid":plugin.uuid, "Name":plugin.name, "Description":plugin.description, "Author":plugin.author, "Icon": plugin.icon})
+    }
+  }
+}

--- a/src/qml/PluginManagerSettings.qml
+++ b/src/qml/PluginManagerSettings.qml
@@ -21,7 +21,7 @@ Popup {
     width: parent.width
     height: parent.height
     padding: 10
-    header: PageHeader {
+    header: QfPageHeader {
       id: pageHeader
       title: qsTr( "Plugins" )
 

--- a/src/qml/PluginManagerSettings.qml
+++ b/src/qml/PluginManagerSettings.qml
@@ -21,15 +21,16 @@ Popup {
     width: parent.width
     height: parent.height
     padding: 10
-    header:PageHeader {
+    header: PageHeader {
       id: pageHeader
       title: qsTr( "Plugins" )
 
-      showBackButton: true
+      showBackButton: false
       showApplyButton: false
-      showCancelButton: false
+      showCancelButton: true
+      backgroundFill: false
 
-      onBack: {
+      onCancel: {
         popup.close()
       }
     }
@@ -65,7 +66,7 @@ Popup {
         delegate: Rectangle {
           id: rectangle
           width: parent.width
-          height: inner.height
+          height: inner.height + 10
           color: "transparent"
 
           GridLayout {
@@ -86,11 +87,12 @@ Popup {
                 Layout.preferredHeight: 24
 
                 source: Icon !== '' ? 'file://' + Icon : ''
+                fillMode: Image.PreserveAspectFit
+                mipmap: true
               }
 
               Label {
                 Layout.fillWidth: true
-                leftPadding: 4
                 text: Name
                 font: Theme.defaultFont
                 color: Theme.mainTextColor

--- a/src/qml/PluginManagerSettings.qml
+++ b/src/qml/PluginManagerSettings.qml
@@ -160,10 +160,10 @@ Popup {
         id: clearPermissionsButton
         Layout.fillWidth: true
 
-        text: qsTr("Clear project permissions")
+        text: qsTr("Clear remembered permissions")
 
         onClicked: {
-          pluginManager.clearProjectPluginPermissions()
+          pluginManager.clearPluginPermissions()
         }
       }
     }

--- a/src/qml/PositioningDeviceSettings.qml
+++ b/src/qml/PositioningDeviceSettings.qml
@@ -58,7 +58,7 @@ Popup {
         width: parent.width
         height: parent.height
         padding: 10
-        header: PageHeader {
+        header: QfPageHeader {
           id: pageHeader
           title: qsTr("Positioning Device Settings")
 

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -12,7 +12,7 @@ Popup {
   Page {
     anchors.fill: parent
 
-    header: PageHeader {
+    header: QfPageHeader {
       title: qsTr('QFieldCloud')
 
       showBackButton: true

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -15,7 +15,7 @@ Page {
 
   property LayerObserver layerObserver
 
-  header: PageHeader {
+  header: QfPageHeader {
       title: qsTr("QFieldCloud Projects")
 
       showBackButton: true

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -14,7 +14,7 @@ Page {
 
   signal finished(var loading)
 
-  header: PageHeader {
+  header: QfPageHeader {
     title: projectFolderView
            ? qsTr("Project Folder")
            : qsTr("Local Projects & Datasets")

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -471,6 +471,36 @@ Page {
                               locatorSettings.focus = true;
                           }
                       }
+
+                      Label {
+                          text: qsTr("Manage plugins")
+                          font: Theme.defaultFont
+                          color: Theme.mainTextColor
+                          wrapMode: Text.WordWrap
+                          Layout.fillWidth: true
+                          Layout.topMargin: 5
+
+                          MouseArea {
+                              anchors.fill: parent
+                              onClicked: showPluginManagerSettings.clicked()
+                          }
+                      }
+
+                      QfToolButton {
+                          id: showPluginManagerSettings
+                          Layout.preferredWidth: 48
+                          Layout.preferredHeight: 48
+                          Layout.alignment: Qt.AlignVCenter
+                          clip: true
+
+                          iconSource: Theme.getThemeIcon( "ic_ellipsis_green_24dp" )
+                          bgcolor: "transparent"
+
+                          onClicked: {
+                              pluginManagerSettings.open();
+                              pluginManagerSettings.focus = true;
+                          }
+                      }
                   }
 
 

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -478,7 +478,6 @@ Page {
                           color: Theme.mainTextColor
                           wrapMode: Text.WordWrap
                           Layout.fillWidth: true
-                          Layout.topMargin: 5
 
                           MouseArea {
                               anchors.fill: parent

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -1613,7 +1613,7 @@ Page {
     }
   }
 
-  header: PageHeader {
+  header: QfPageHeader {
     title: qsTr("QField Settings")
 
     showBackButton: true

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -84,7 +84,7 @@ Item {
       Page {
         anchors.fill: parent
 
-        header: PageHeader {
+        header: QfPageHeader {
           title: fieldLabel
           showBackButton: false
           showApplyButton: false

--- a/src/qml/TrackerSettings.qml
+++ b/src/qml/TrackerSettings.qml
@@ -78,7 +78,7 @@ Popup {
     focus: true
     anchors.fill: parent
 
-    header: PageHeader {
+    header: QfPageHeader {
       title: tracker !== undefined && tracker.vectorLayer
              ? qsTr("Tracking: %1").arg(tracker.vectorLayer.name)
              : qsTr("Tracking")

--- a/src/qml/geometryeditors/FillRing.qml
+++ b/src/qml/geometryeditors/FillRing.qml
@@ -144,7 +144,7 @@ VisibilityFadingRow {
   function fillWithPolygon()
   {
     var polygonGeometry = GeometryUtils.polygonFromRubberband(drawPolygonToolbar.rubberbandModel, featureModel.currentLayer.crs)
-    var feature = FeatureUtils.createFeature(featureModel.currentLayer, polygonGeometry)
+    var feature = FeatureUtils.createBlankFeature(featureModel.currentLayer.fields, polygonGeometry)
 
     // Show form
     formPopupLoader.onFeatureSaved.connect(commitRing)

--- a/src/qml/imports/Theme/QfPageHeader.qml
+++ b/src/qml/imports/Theme/QfPageHeader.qml
@@ -87,6 +87,7 @@ ToolBar {
       Layout.alignment: Qt.AlignTop | Qt.AlignLeft
       clip: true
       iconSource: Theme.getThemeVectorIcon( 'ic_arrow_left_white_24dp' )
+      iconColor: backgroundFill ? Theme.light : Theme.mainTextColor
 
       onClicked:
       {
@@ -101,6 +102,7 @@ ToolBar {
       Layout.alignment: Qt.AlignTop | Qt.AlignLeft
       clip: true
       iconSource: Theme.getThemeIcon( 'ic_check_white_48dp' )
+      iconColor: backgroundFill ? Theme.light : Theme.mainTextColor
 
       onClicked:
       {
@@ -127,6 +129,7 @@ ToolBar {
       Layout.alignment: Qt.AlignTop | Qt.AlignRight
       clip: true
       iconSource: Theme.getThemeIcon( 'ic_close_white_24dp' )
+      iconColor: backgroundFill ? Theme.light : Theme.mainTextColor
 
       onClicked: {
         cancel()

--- a/src/qml/imports/Theme/qmldir
+++ b/src/qml/imports/Theme/qmldir
@@ -11,3 +11,4 @@ QfCollapsibleMessage 1.0 QfCollapsibleMessage.qml
 QfDropShadow 1.0 QfDropShadow.qml
 QfOpacityMask 1.0 QfOpacityMask.qml
 QfCalendarPanel 1.0 QfCalendarPanel.qml
+QfPageHeader 1.0 QfPageHeader.qml

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -4051,6 +4051,8 @@ ApplicationWindow {
     x: ( mainWindow.width - width ) / 2
     y: ( mainWindow.height - height ) / 2
 
+    property alias permanent: permanentCheckBox.checked
+
     title: ''
 
     Column {
@@ -4068,11 +4070,13 @@ ApplicationWindow {
     }
 
     onAccepted: {
-      pluginManager.grantRequestedPluginPermission(permanentCheckBox.checked)
+      pluginManager.grantRequestedPluginPermission(permanent)
+      permanent = false
     }
 
     onRejected: {
-      pluginManager.denyRequestedPluginPermission(permanentCheckBox.checked)
+      pluginManager.denyRequestedPluginPermission(permanent)
+      permanent = false
     }
 
     standardButtons: Dialog.Yes | Dialog.No

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1255,6 +1255,14 @@ ApplicationWindow {
       parent: Overlay.overlay
   }
 
+  PluginManagerSettings {
+      id: pluginManagerSettings
+
+      modal: true
+      closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+      parent: Overlay.overlay
+  }
+
   QfDropShadow {
     anchors.fill: locatorItem
     visible: locatorItem.searchFieldVisible

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -101,5 +101,6 @@
         <file>QFieldCloudPackageLayersFeedback.qml</file>
         <file>QFieldLocalDataPickerScreen.qml</file>
         <file>QFieldSketcher.qml</file>
+        <file>PluginManagerSettings.qml</file>
     </qresource>
 </RCC>

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -86,8 +86,8 @@
         <file>imports/Theme/QfCollapsibleMessage.qml</file>
         <file>imports/Theme/QfSlider.qml</file>
         <file>imports/Theme/QfCalendarPanel.qml</file>
+        <file>imports/Theme/QfPageHeader.qml</file>
         <file>imports/Theme/qmldir</file>
-        <file>PageHeader.qml</file>
         <file>TrackerSettings.qml</file>
         <file>TrackingSession.qml</file>
         <file>EmbeddedFeatureForm.qml</file>


### PR DESCRIPTION
~~(This PR temporarily includes https://github.com/opengisch/QField/pull/5189 , that should be reviewed and merged first)~~

This PR is the last foundational stone to the plugin framework. It implements a basic plugins popup where users can clear their remembered project plugin permissions, as well as install (from a URL) and activate/deactivate app plugins. 

Here's an exciting screencast:

https://github.com/opengisch/QField/assets/1728657/f187657b-d5f3-4092-a184-6dad5755a679

Plugins pop up when no plugin is present:

![Screenshot from 2024-04-19 14-49-25](https://github.com/opengisch/QField/assets/1728657/e54cfd08-528b-4a71-8689-5980b3621cee)
