### PR TITLE
Project image decoration support

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -78,6 +78,7 @@ set(QFIELD_CORE_SRCS
     networkmanager.cpp
     networkreply.cpp
     orderedrelationmodel.cpp
+    parametizedimage.cpp
     peliasgeocoder.cpp
     pluginmanager.cpp
     resourcesource.cpp
@@ -190,6 +191,7 @@ set(QFIELD_CORE_HDRS
     networkmanager.h
     networkreply.h
     orderedrelationmodel.h
+    parametizedimage.h
     peliasgeocoder.h
     pluginmanager.h
     resourcesource.h

--- a/src/core/parametizedimage.cpp
+++ b/src/core/parametizedimage.cpp
@@ -56,6 +56,7 @@ void ParametizedImage::setSource( const QString &source )
       mSourceSize = QgsApplication::instance()->svgCache()->svgViewboxSize( mSource, size().width(), QColor( 0, 0, 0 ), QColor( 255, 0, 0 ), 10, 1, 0, true );
     }
   }
+
   if ( mIsValid )
     update();
 }

--- a/src/core/parametizedimage.cpp
+++ b/src/core/parametizedimage.cpp
@@ -1,0 +1,137 @@
+/***************************************************************************
+ parametizedimage.cpp - ParametizedImage
+
+ ---------------------
+ begin                : 21.05.2024
+ copyright            : (C) 2024 by Mathieu Pellerin
+ email                : mathieu (at) opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "parametizedimage.h"
+
+#include <QPainter>
+#include <QQuickWindow>
+#include <QScreen>
+#include <qgsapplication.h>
+#include <qgsimagecache.h>
+#include <qgssvgcache.h>
+
+ParametizedImage::ParametizedImage( QQuickItem *parent )
+  : QQuickPaintedItem( parent )
+{
+}
+
+QString ParametizedImage::source() const
+{
+  return mSource;
+}
+
+void ParametizedImage::setSource( const QString &source )
+{
+  if ( mSource == source )
+    return;
+
+  mSource = source;
+  emit sourceChanged();
+
+  QFileInfo fi( mSource );
+  mIsValid = fi.exists();
+  mIsRaster = fi.suffix().toLower() != QStringLiteral( "svg" );
+
+  if ( mIsValid )
+  {
+    if ( mIsRaster )
+    {
+      mSourceSize = QgsApplication::instance()->imageCache()->originalSize( mSource, true );
+    }
+    else
+    {
+      mSourceSize = QgsApplication::instance()->svgCache()->svgViewboxSize( mSource, size().width(), QColor( 0, 0, 0 ), QColor( 255, 0, 0 ), 10, 1, 0, true );
+    }
+  }
+  if ( mIsValid )
+    update();
+}
+
+QColor ParametizedImage::fillColor() const
+{
+  return mFillColor;
+}
+
+void ParametizedImage::setFillColor( const QColor &color )
+{
+  if ( mFillColor == color )
+    return;
+
+  mFillColor = color;
+  emit fillColorChanged();
+
+  if ( mIsValid && !mIsRaster )
+    update();
+}
+
+QColor ParametizedImage::strokeColor() const
+{
+  return mStrokeColor;
+}
+
+void ParametizedImage::setStrokeColor( const QColor &color )
+{
+  if ( mStrokeColor == color )
+    return;
+
+  mStrokeColor = color;
+  emit strokeColorChanged();
+
+  if ( mIsValid && !mIsRaster )
+    update();
+}
+
+double ParametizedImage::strokeWidth() const
+{
+  return mStrokeWidth;
+}
+
+void ParametizedImage::setStrokeWidth( double width )
+{
+  if ( mStrokeWidth == width )
+    return;
+
+  mStrokeWidth = width;
+  emit strokeWidthChanged();
+
+  if ( mIsValid && !mIsRaster )
+    update();
+}
+
+void ParametizedImage::paint( QPainter *painter )
+{
+  if ( !mIsValid )
+    return;
+
+  const double sourceRatio = mSourceSize.width() / mSourceSize.height();
+  const double itemRatio = size().width() / size().height();
+
+  bool fitsInCache = false;
+  if ( mIsRaster )
+  {
+    const double drawnWidth = std::ceil( sourceRatio >= itemRatio ? size().width() : mSourceSize.width() * size().height() / mSourceSize.height() );
+    const double drawnHeight = std::ceil( sourceRatio >= itemRatio ? mSourceSize.height() * size().width() / mSourceSize.width() : size().height() );
+    const double devicePixelRatio = window()->screen()->devicePixelRatio();
+    QImage sourceImage = QgsApplication::instance()->imageCache()->pathAsImage( mSource, QSize( drawnWidth * devicePixelRatio, drawnHeight * devicePixelRatio ), true, 1, fitsInCache, true );
+    painter->drawImage( ( size().width() - drawnWidth ) / 2, ( size().height() - drawnHeight ) / 2, sourceImage );
+  }
+  else
+  {
+    const double drawnWidth = sourceRatio >= itemRatio ? size().width() : size().height() * sourceRatio;
+    QPicture sourcePicture = QgsApplication::instance()->svgCache()->svgAsPicture( mSource, drawnWidth, mFillColor, mStrokeColor, mStrokeWidth, 1, fitsInCache, 0, true );
+    painter->drawPicture( size().width() / 2, size().height() / 2, sourcePicture );
+  }
+}

--- a/src/core/parametizedimage.cpp
+++ b/src/core/parametizedimage.cpp
@@ -55,10 +55,9 @@ void ParametizedImage::setSource( const QString &source )
     {
       mSourceSize = QgsApplication::instance()->svgCache()->svgViewboxSize( mSource, size().width(), QColor( 0, 0, 0 ), QColor( 255, 0, 0 ), 10, 1, 0, true );
     }
-  }
 
-  if ( mIsValid )
     update();
+  }
 }
 
 QColor ParametizedImage::fillColor() const

--- a/src/core/parametizedimage.h
+++ b/src/core/parametizedimage.h
@@ -26,9 +26,27 @@ class ParametizedImage : public QQuickPaintedItem
 {
     Q_OBJECT
 
+    /**
+     * Returns the current source image.
+     */
     Q_PROPERTY( QString source READ source WRITE setSource NOTIFY sourceChanged )
+
+    /**
+     * Returns the current fill color used to paint an image.
+     * \note Compatible with parametized SVG images only.
+     */
     Q_PROPERTY( QColor fillColor READ fillColor WRITE setFillColor NOTIFY fillColorChanged )
+
+    /**
+     * Returns the current stroke color used to paint an image.
+     * \note Compatible with parametized SVG images only.
+     */
     Q_PROPERTY( QColor strokeColor READ strokeColor WRITE setStrokeColor NOTIFY strokeColorChanged )
+
+    /**
+     * Returns the current stroke width used to paint an image.
+     * \note Compatible with parametized SVG images only.
+     */
     Q_PROPERTY( double strokeWidth READ strokeWidth WRITE setStrokeWidth NOTIFY strokeWidthChanged )
 
   public:
@@ -37,16 +55,24 @@ class ParametizedImage : public QQuickPaintedItem
 
     void paint( QPainter *painter ) override;
 
+    //! \copydoc ParametizedImage::source
     QString source() const;
-    void setSource( const QString &string );
+    //! \copydoc ParametizedImage::source
+    void setSource( const QString &source );
 
+    //! \copydoc ParametizedImage::fillColor
     QColor fillColor() const;
+    //! \copydoc ParametizedImage::fillColor
     void setFillColor( const QColor &color );
 
+    //! \copydoc ParametizedImage::strokeColor
     QColor strokeColor() const;
+    //! \copydoc ParametizedImage::strokeColor
     void setStrokeColor( const QColor &color );
 
+    //! \copydoc ParametizedImage::strokeWidth
     double strokeWidth() const;
+    //! \copydoc ParametizedImage::strokeWidth
     void setStrokeWidth( double width );
 
   signals:

--- a/src/core/parametizedimage.h
+++ b/src/core/parametizedimage.h
@@ -1,0 +1,70 @@
+/***************************************************************************
+ parametizedimage.h - ParametizedImage
+
+ ---------------------
+ begin                : 21.05.2024
+ copyright            : (C) 2024 by Mathieu Pellerin
+ email                : mathieu (at) opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef PARAMETIZEDIMAGE_H
+#define PARAMETIZEDIMAGE_H
+
+#include <QObject>
+#include <QQuickPaintedItem>
+
+#define DEFAULT_STROKE_WIDTH 5
+
+class ParametizedImage : public QQuickPaintedItem
+{
+    Q_OBJECT
+
+    Q_PROPERTY( QString source READ source WRITE setSource NOTIFY sourceChanged )
+    Q_PROPERTY( QColor fillColor READ fillColor WRITE setFillColor NOTIFY fillColorChanged )
+    Q_PROPERTY( QColor strokeColor READ strokeColor WRITE setStrokeColor NOTIFY strokeColorChanged )
+    Q_PROPERTY( double strokeWidth READ strokeWidth WRITE setStrokeWidth NOTIFY strokeWidthChanged )
+
+  public:
+    ParametizedImage( QQuickItem *parent = nullptr );
+    ~ParametizedImage() = default;
+
+    void paint( QPainter *painter ) override;
+
+    QString source() const;
+    void setSource( const QString &string );
+
+    QColor fillColor() const;
+    void setFillColor( const QColor &color );
+
+    QColor strokeColor() const;
+    void setStrokeColor( const QColor &color );
+
+    double strokeWidth() const;
+    void setStrokeWidth( double width );
+
+  signals:
+    void sourceChanged();
+    void fillColorChanged();
+    void strokeColorChanged();
+    void strokeWidthChanged();
+
+  private:
+    bool mIsValid = false;
+    bool mIsRaster = true;
+
+    QString mSource;
+    QSizeF mSourceSize;
+
+    QColor mFillColor = QColor( 0, 0, 0 );
+    QColor mStrokeColor = QColor( 255, 255, 255 );
+    double mStrokeWidth = 1.0;
+};
+
+#endif // PARAMETIZEDIMAGE_H

--- a/src/core/projectinfo.cpp
+++ b/src/core/projectinfo.cpp
@@ -25,6 +25,7 @@
 #include <qgslayertree.h>
 #include <qgslayertreemodel.h>
 #include <qgsmaplayerstyle.h>
+#include <qgssymbollayerutils.h>
 
 ProjectInfo::ProjectInfo( QObject *parent )
   : QObject( parent )
@@ -739,6 +740,42 @@ QVariantMap ProjectInfo::getCopyrightDecorationConfiguration()
     configuration["color"] = QColor( Qt::black );
     configuration["hasOutline"] = false;
     configuration["outlineColor"] = QColor( Qt::white );
+  }
+
+  return configuration;
+}
+
+QVariantMap ProjectInfo::getImageDecorationConfiguration()
+{
+  QVariantMap configuration;
+  const QString configurationName = QStringLiteral( "Image" );
+
+  if ( QgsProject::instance()->readBoolEntry( configurationName, QStringLiteral( "/Enabled" ), false ) )
+  {
+    QString imagePath = QgsProject::instance()->readEntry( configurationName, QStringLiteral( "/ImagePath" ), QString() );
+    const QString resolvedPath = QgsSymbolLayerUtils::svgSymbolNameToPath( imagePath, QgsProject::instance()->pathResolver() );
+    const QFileInfo fileInfo( resolvedPath );
+    if ( fileInfo.exists() )
+    {
+      imagePath = resolvedPath;
+    }
+    else
+    {
+      imagePath = QStringLiteral( ":/images/qfield_logo.svg" );
+    }
+
+    QColor fillColor = QgsColorUtils::colorFromString( QgsProject::instance()->readEntry( configurationName, QStringLiteral( "/Color" ), QStringLiteral( "#000000" ) ) );
+    QColor strokeColor = QgsColorUtils::colorFromString( QgsProject::instance()->readEntry( configurationName, QStringLiteral( "/OutlineColor" ), QStringLiteral( "#FFFFFF" ) ) );
+
+    configuration["source"] = imagePath;
+    configuration["fillColor"] = fillColor;
+    configuration["strokeColor"] = strokeColor;
+  }
+  else
+  {
+    configuration["source"] = QString();
+    configuration["fillColor"] = QColor( Qt::black );
+    configuration["strokeColor"] = QColor( Qt::white );
   }
 
   return configuration;

--- a/src/core/projectinfo.h
+++ b/src/core/projectinfo.h
@@ -178,9 +178,14 @@ class ProjectInfo : public QObject
     //! Restore various project settings
     static void restoreSettings( QString &projectFilePath, QgsProject *project, QgsQuickMapCanvasMap *mapCanvas, FlatLayerTreeModel *layerTree );
 
+    //! Retrieves configuration of the title decoration
     Q_INVOKABLE QVariantMap getTitleDecorationConfiguration();
 
+    //! Retrieves configuration of the copyright decoration
     Q_INVOKABLE QVariantMap getCopyrightDecorationConfiguration();
+
+    //! Retrieves configuration of the image decoration
+    Q_INVOKABLE QVariantMap getImageDecorationConfiguration();
 
   signals:
 

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -84,6 +84,7 @@
 #include "navigationmodel.h"
 #include "nearfieldreader.h"
 #include "orderedrelationmodel.h"
+#include "parametizedimage.h"
 #include "platformutilities.h"
 #include "positioning.h"
 #include "positioningdevicemodel.h"
@@ -454,6 +455,7 @@ void QgisMobileapp::initDeclarative()
   qmlRegisterType<SnappingUtils>( "org.qfield", 1, 0, "SnappingUtils" );
   qmlRegisterType<DistanceArea>( "org.qfield", 1, 0, "DistanceArea" );
   qmlRegisterType<FocusStack>( "org.qfield", 1, 0, "FocusStack" );
+  qmlRegisterType<ParametizedImage>( "org.qfield", 1, 0, "ParametizedImage" );
   qmlRegisterType<PrintLayoutListModel>( "org.qfield", 1, 0, "PrintLayoutListModel" );
   qmlRegisterType<VertexModel>( "org.qfield", 1, 0, "VertexModel" );
   qmlRegisterType<MapToScreen>( "org.qfield", 1, 0, "MapToScreen" );

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -889,15 +889,17 @@ ApplicationWindow {
       anchors.bottomMargin: 56
 
       width: parent.width - anchors.leftMargin * 2
-      height: 48
+      height: visible ? Math.min(copyrightDecoration.height, 48) : 0
       radius: 4
+      clip: true
 
       color:'#55000000'
       Text {
         id: copyrightDecoration
 
+        anchors.bottom: parent.bottom
+
         width: parent.width - 4
-        height: parent.height
         leftPadding: 2
         rightPadding: 2
 
@@ -910,6 +912,22 @@ ApplicationWindow {
 
         text: ''
       }
+    }
+
+    ParametizedImage {
+      id: imageDecoration
+
+      visible: source != ''
+
+      anchors.left: parent.left
+      anchors.leftMargin: 56
+      anchors.bottom: copyrightDecorationBackground.top
+      anchors.bottomMargin: 4
+
+      width: parent.width - anchors.leftMargin * 2
+      height: 48
+
+      source: ""
     }
   }
 
@@ -3450,19 +3468,24 @@ ApplicationWindow {
 
       mapCanvasBackground.color = mapCanvas.mapSettings.backgroundColor
 
-      var titleDecorationConfiguration = projectInfo.getTitleDecorationConfiguration();
-      titleDecoration.text = titleDecorationConfiguration["text"];
-      titleDecoration.color = titleDecorationConfiguration["color"];
-      titleDecoration.style = titleDecorationConfiguration["hasOutline"] === true ? Text.Outline : Text.Normal;
-      titleDecoration.styleColor = titleDecorationConfiguration["outlineColor"];
-      titleDecorationBackground.color = titleDecorationConfiguration["backgroundColor"];
+      var titleDecorationConfiguration = projectInfo.getTitleDecorationConfiguration()
+      titleDecoration.text = titleDecorationConfiguration["text"]
+      titleDecoration.color = titleDecorationConfiguration["color"]
+      titleDecoration.style = titleDecorationConfiguration["hasOutline"] === true ? Text.Outline : Text.Normal
+      titleDecoration.styleColor = titleDecorationConfiguration["outlineColor"]
+      titleDecorationBackground.color = titleDecorationConfiguration["backgroundColor"]
 
-      var copyrightDecorationConfiguration = projectInfo.getCopyrightDecorationConfiguration();
-      copyrightDecoration.text = copyrightDecorationConfiguration["text"];
-      copyrightDecoration.color = copyrightDecorationConfiguration["color"];
-      copyrightDecoration.style = copyrightDecorationConfiguration["hasOutline"] === true ? Text.Outline : Text.Normal;
-      copyrightDecoration.styleColor = copyrightDecorationConfiguration["outlineColor"];
-      copyrightDecorationBackground.color = copyrightDecorationConfiguration["backgroundColor"];
+      var copyrightDecorationConfiguration = projectInfo.getCopyrightDecorationConfiguration()
+      copyrightDecoration.text = copyrightDecorationConfiguration["text"]
+      copyrightDecoration.color = copyrightDecorationConfiguration["color"]
+      copyrightDecoration.style = copyrightDecorationConfiguration["hasOutline"] === true ? Text.Outline : Text.Normal
+      copyrightDecoration.styleColor = copyrightDecorationConfiguration["outlineColor"]
+      copyrightDecorationBackground.color = copyrightDecorationConfiguration["backgroundColor"]
+
+      var imageDecorationConfiguration = projectInfo.getImageDecorationConfiguration()
+      imageDecoration.source = imageDecorationConfiguration["source"]
+      imageDecoration.fillColor = imageDecorationConfiguration["fillColor"]
+      imageDecoration.strokeColor = imageDecorationConfiguration["strokeColor"]
 
       recentProjectListModel.reloadModel()
 


### PR DESCRIPTION
This PR implements support for projects' image decoration (joining the title and copyright decorations implement in QField 3.2).

To support fill and outline settings, a new ParametizedImage item was added, which relies on SVG and image cache to configure the fill and stroke color of the image. It will probably come in handy in other scenarios too.

As per the two other decorations we have, QField will enforce an harmonious position for the decoration.

In action:

![image](https://github.com/opengisch/QField/assets/1728657/3ddb1a4e-10d7-445f-a428-349871b6ec10)

The decoration gives users a simple way to further "brand" their projects.

Relevant QGIS documentation: https://docs.qgis.org/3.34/en/docs/user_manual/map_views/map_view.html#image-decoration

_Sponsored by Deutsches Archäologisches Institut (DAI)_