### PR TITLE
Implement margins concept for map canvas

### DIFF
--- a/src/core/bookmarkmodel.cpp
+++ b/src/core/bookmarkmodel.cpp
@@ -139,7 +139,7 @@ void BookmarkModel::setExtentFromBookmark( const QModelIndex &index )
     return;
   }
 
-  mMapSettings->setExtent( transformedRect );
+  mMapSettings->setExtent( transformedRect, true );
 }
 
 QString BookmarkModel::addBookmarkAtPoint( QgsPoint point, const QString &name, const QString &group )

--- a/src/core/featurelistextentcontroller.cpp
+++ b/src/core/featurelistextentcontroller.cpp
@@ -55,9 +55,9 @@ void FeatureListExtentController::zoomToSelected( bool skipIfIntersects ) const
 
     if ( layer && layer->geometryType() != Qgis::GeometryType::Unknown && layer->geometryType() != Qgis::GeometryType::Null )
     {
-      QgsRectangle extent = FeatureUtils::extent( mMapSettings, layer, feat, mFeatureForm ? mFeatureForm->x() : 0.0, mFeatureForm ? mFeatureForm->y() : 0.0 );
+      QgsRectangle extent = FeatureUtils::extent( mMapSettings, layer, feat );
       if ( !skipIfIntersects || !mMapSettings->extent().intersects( extent ) )
-        mMapSettings->setExtent( extent );
+        mMapSettings->setExtent( extent, true );
     }
   }
 }

--- a/src/core/featurelistextentcontroller.h
+++ b/src/core/featurelistextentcontroller.h
@@ -31,7 +31,6 @@ class FeatureListExtentController : public QObject
     Q_PROPERTY( FeatureListModelSelection *selection MEMBER mSelection NOTIFY selectionChanged )
     Q_PROPERTY( bool autoZoom MEMBER mAutoZoom NOTIFY autoZoomChanged )
     Q_PROPERTY( QgsQuickMapSettings *mapSettings MEMBER mMapSettings NOTIFY mapSettingsChanged )
-    Q_PROPERTY( QQuickItem *featureForm MEMBER mFeatureForm NOTIFY featureFormChanged )
 
   public:
     explicit FeatureListExtentController( QObject *parent = nullptr );
@@ -56,7 +55,6 @@ class FeatureListExtentController : public QObject
     void selectionChanged();
     void modelChanged();
     void mapSettingsChanged();
-    void featureFormChanged();
     void featureFormStateRequested();
 
   private slots:
@@ -67,7 +65,6 @@ class FeatureListExtentController : public QObject
     MultiFeatureListModel *mModel = nullptr;
     FeatureListModelSelection *mSelection = nullptr;
     QgsQuickMapSettings *mMapSettings = nullptr;
-    QQuickItem *mFeatureForm = nullptr;
     bool mAutoZoom = false;
 };
 

--- a/src/core/locator/activelayerfeatureslocatorfilter.cpp
+++ b/src/core/locator/activelayerfeatureslocatorfilter.cpp
@@ -429,11 +429,11 @@ void ActiveLayerFeaturesLocatorFilter::triggerResultFromAction( const QgsLocator
 
           if ( r.isEmpty() || mLocatorBridge->keepScale() )
           {
-            mLocatorBridge->mapSettings()->setCenter( QgsPoint( r.center() ) );
+            mLocatorBridge->mapSettings()->setCenter( QgsPoint( r.center() ), true );
           }
           else
           {
-            mLocatorBridge->mapSettings()->setExtent( r );
+            mLocatorBridge->mapSettings()->setExtent( r, true );
           }
 
           mLocatorBridge->locatorHighlightGeometry()->setProperty( "qgsGeometry", geom );

--- a/src/core/locator/featureslocatorfilter.cpp
+++ b/src/core/locator/featureslocatorfilter.cpp
@@ -236,9 +236,9 @@ void FeaturesLocatorFilter::triggerResultFromAction( const QgsLocatorResult &res
     }
 
     if ( r.isEmpty() || mLocatorBridge->keepScale() )
-      mLocatorBridge->mapSettings()->setCenter( QgsPoint( r.center() ) );
+      mLocatorBridge->mapSettings()->setCenter( QgsPoint( r.center() ), true );
     else
-      mLocatorBridge->mapSettings()->setExtent( r );
+      mLocatorBridge->mapSettings()->setExtent( r, true );
 
 
     mLocatorBridge->locatorHighlightGeometry()->setProperty( "qgsGeometry", geom );

--- a/src/core/locator/finlandlocatorfilter.cpp
+++ b/src/core/locator/finlandlocatorfilter.cpp
@@ -59,7 +59,7 @@ void FinlandLocatorFilter::handleGeocodeResult( const QgsGeocoderResult &result 
     return;
   }
 
-  mLocatorBridge->mapSettings()->setCenter( transformedGeometry.centroid().vertexAt( 0 ) );
+  mLocatorBridge->mapSettings()->setCenter( transformedGeometry.centroid().vertexAt( 0 ), true );
 
   mLocatorBridge->locatorHighlightGeometry()->setProperty( "qgsGeometry", result.geometry() );
   mLocatorBridge->locatorHighlightGeometry()->setProperty( "crs", result.crs() );

--- a/src/core/locator/gotolocatorfilter.cpp
+++ b/src/core/locator/gotolocatorfilter.cpp
@@ -204,7 +204,7 @@ void GotoLocatorFilter::triggerResultFromAction( const QgsLocatorResult &result,
   }
   else
   {
-    mLocatorBridge->mapSettings()->setCenter( geom.vertexAt( 0 ) );
+    mLocatorBridge->mapSettings()->setCenter( geom.vertexAt( 0 ), true );
 
     mLocatorBridge->locatorHighlightGeometry()->setProperty( "qgsGeometry", geom );
     mLocatorBridge->locatorHighlightGeometry()->setProperty( "crs", mLocatorBridge->mapSettings()->mapSettings().destinationCrs() );

--- a/src/core/qgsquick/qgsquickmapcanvasmap.cpp
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.cpp
@@ -370,6 +370,34 @@ void QgsQuickMapCanvasMap::setQuality( double quality )
   refresh();
 }
 
+double QgsQuickMapCanvasMap::bottomMargin() const
+{
+  return mMapSettings->bottomMargin();
+}
+
+void QgsQuickMapCanvasMap::setBottomMargin( double bottomMargin )
+{
+  if ( mMapSettings->bottomMargin() == bottomMargin )
+    return;
+
+  mMapSettings->setBottomMargin( bottomMargin );
+  emit bottomMarginChanged();
+}
+
+double QgsQuickMapCanvasMap::rightMargin() const
+{
+  return mMapSettings->rightMargin();
+}
+
+void QgsQuickMapCanvasMap::setRightMargin( double rightMargin )
+{
+  if ( mMapSettings->rightMargin() == rightMargin )
+    return;
+
+  mMapSettings->setRightMargin( rightMargin );
+  emit rightMarginChanged();
+}
+
 bool QgsQuickMapCanvasMap::forceDeferredLayersRepaint() const
 {
   return mForceDeferredLayersRepaint;

--- a/src/core/qgsquick/qgsquickmapcanvasmap.h
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.h
@@ -60,6 +60,16 @@ class QgsQuickMapCanvasMap : public QQuickItem
     Q_PROPERTY( QgsQuickMapSettings *mapSettings READ mapSettings )
 
     /**
+     * The bottom margin used by the map settings when calculating map extent or center.
+     */
+    Q_PROPERTY( double bottomMargin READ bottomMargin WRITE setBottomMargin NOTIFY bottomMarginChanged )
+
+    /**
+     * The right margin used by the map settings when calculating map extent or center.
+     */
+    Q_PROPERTY( double rightMargin READ rightMargin WRITE setRightMargin NOTIFY rightMarginChanged )
+
+    /**
      * When freeze property is set to true, the map canvas does not refresh.
      * The value temporary changes during the rendering process.
      */
@@ -141,6 +151,18 @@ class QgsQuickMapCanvasMap : public QQuickItem
     //!\copydoc QgsQuickMapCanvasMap::forceDeferredLayersRepaint
     void setForceDeferredLayersRepaint( bool deferred );
 
+    //!\copydoc QgsQuickMapCanvasMap::bottomMargin
+    double bottomMargin() const;
+
+    //!\copydoc QgsQuickMapCanvasMap::bottomMargin
+    void setBottomMargin( double bottomMargin );
+
+    //!\copydoc QgsQuickMapCanvasMap::rightMargin
+    double rightMargin() const;
+
+    //!\copydoc QgsQuickMapCanvasMap::rightMargin
+    void setRightMargin( double rightMargin );
+
     /**
      * Returns an image of the last successful map canvas rendering
      */
@@ -175,6 +197,12 @@ class QgsQuickMapCanvasMap : public QQuickItem
 
     //!\copydoc QgsQuickMapCanvasMap::forceDeferredLayersRepaint
     void forceDeferredLayersRepaintChanged();
+
+    //!\copydoc QgsQuickMapCanvasMap::bottomMargin
+    void bottomMarginChanged();
+
+    //!\copydoc QgsQuickMapCanvasMap::rightMargin
+    void rightMarginChanged();
 
   protected:
 #if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )

--- a/src/core/qgsquick/qgsquickmapsettings.h
+++ b/src/core/qgsquick/qgsquickmapsettings.h
@@ -132,6 +132,16 @@ class QFIELD_CORE_EXPORT QgsQuickMapSettings : public QObject
      */
     Q_PROPERTY( QDateTime temporalEnd READ temporalEnd WRITE setTemporalEnd NOTIFY temporalStateChanged )
 
+    /**
+     * The bottom margin used by the map settings when calculating map extent or center.
+     */
+    Q_PROPERTY( double bottomMargin READ bottomMargin WRITE setBottomMargin NOTIFY bottomMarginChanged )
+
+    /**
+     * The right margin used by the map settings when calculating map extent or center.
+     */
+    Q_PROPERTY( double rightMargin READ rightMargin WRITE setRightMargin NOTIFY rightMarginChanged )
+
   public:
     //! Create new map settings
     explicit QgsQuickMapSettings( QObject *parent = nullptr );
@@ -144,7 +154,7 @@ class QFIELD_CORE_EXPORT QgsQuickMapSettings : public QObject
     QgsRectangle extent() const;
 
     //! \copydoc QgsMapSettings::setExtent()
-    void setExtent( const QgsRectangle &extent );
+    void setExtent( const QgsRectangle &extent, bool handleMargins = false );
 
     //! \copydoc QgsQuickMapSettings::project
     void setProject( QgsProject *project );
@@ -156,13 +166,13 @@ class QFIELD_CORE_EXPORT QgsQuickMapSettings : public QObject
     QgsPoint center() const;
 
     //! Move current map extent to have center point defined by \a center
-    Q_INVOKABLE void setCenter( const QgsPoint &center );
+    Q_INVOKABLE void setCenter( const QgsPoint &center, bool handleMargins = false );
 
     //! Move current map extent to have center point defined by \a layer. Optionally only pan to the layer if \a shouldZoom is false.
     Q_INVOKABLE void setCenterToLayer( QgsMapLayer *layer, bool shouldZoom = true );
 
     //! Move current map extent to center around the list of \a points provided
-    Q_INVOKABLE void setExtentFromPoints( const QVariantList &points, const double &minimumScale = 0 );
+    Q_INVOKABLE void setExtentFromPoints( const QVariantList &points, const double &minimumScale = 0, bool handleMargins = false );
 
     //! \copydoc QgsQuickMapSettings::mapUnitsPerPoint
     double mapUnitsPerPoint() const;
@@ -280,6 +290,18 @@ class QFIELD_CORE_EXPORT QgsQuickMapSettings : public QObject
     //! \copydoc QgsQuickMapSettings::temporalEnd
     void setTemporalEnd( const QDateTime &end );
 
+    //!\copydoc QgsQuickMapSettings::bottomMargin
+    double bottomMargin() const;
+
+    //!\copydoc QgsQuickMapSettings::bottomMargin
+    void setBottomMargin( double bottomMargin );
+
+    //!\copydoc QgsQuickMapSettings::rightMargin
+    double rightMargin() const;
+
+    //!\copydoc QgsQuickMapSettings::rightMargin
+    void setRightMargin( double rightMargin );
+
   signals:
     //! \copydoc QgsQuickMapSettings::project
     void projectChanged();
@@ -313,6 +335,12 @@ class QFIELD_CORE_EXPORT QgsQuickMapSettings : public QObject
 
     void temporalStateChanged();
 
+    //!\copydoc QgsQuickMapSettings::bottomMargin
+    void bottomMarginChanged();
+
+    //!\copydoc QgsQuickMapSettings::rightMargin
+    void rightMarginChanged();
+
   private slots:
 
     /**
@@ -331,6 +359,8 @@ class QFIELD_CORE_EXPORT QgsQuickMapSettings : public QObject
     QgsProject *mProject = nullptr;
     QgsMapSettings mMapSettings;
     qreal mDevicePixelRatio = 1.0;
+    double mBottomMargin = 0;
+    double mRightMargin = 0;
 };
 
 #endif // QGSQUICKMAPSETTINGS_H

--- a/src/core/utils/featureutils.cpp
+++ b/src/core/utils/featureutils.cpp
@@ -61,7 +61,7 @@ QString FeatureUtils::displayName( QgsVectorLayer *layer, const QgsFeature &feat
   return name;
 }
 
-QgsRectangle FeatureUtils::extent( QgsQuickMapSettings *mapSettings, QgsVectorLayer *layer, const QgsFeature &feature, const double &rightEdge, const double &bottomEdge )
+QgsRectangle FeatureUtils::extent( QgsQuickMapSettings *mapSettings, QgsVectorLayer *layer, const QgsFeature &feature )
 {
   if ( mapSettings && layer && layer->geometryType() != Qgis::GeometryType::Unknown && layer->geometryType() != Qgis::GeometryType::Null )
   {
@@ -72,15 +72,12 @@ QgsRectangle FeatureUtils::extent( QgsQuickMapSettings *mapSettings, QgsVectorLa
       geom.transform( transf );
 
       QgsRectangle extent;
-      QSizeF outputSize = mapSettings->outputSize() / mapSettings->devicePixelRatio();
-      const double rightPercentage = rightEdge / outputSize.width();
-      const double bottomPercentage = bottomEdge / outputSize.height();
       if ( geom.type() == Qgis::GeometryType::Point )
       {
         extent = mapSettings->extent();
         QgsVector delta = QgsPointXY( geom.asPoint() ) - extent.center();
-        const double deltaX = delta.x() + ( rightEdge > 0.0 ? mapSettings->mapUnitsPerPoint() * outputSize.width() * ( 0.5 - rightPercentage / 2.0 ) : 0.0 );
-        const double deltaY = delta.y() - ( bottomEdge > 0.0 ? mapSettings->mapUnitsPerPoint() * outputSize.height() * ( 0.5 - ( 1.0 - bottomPercentage ) / 2.0 ) : 0.0 );
+        const double deltaX = delta.x();
+        const double deltaY = delta.y();
         extent.setXMinimum( extent.xMinimum() + deltaX );
         extent.setXMaximum( extent.xMaximum() + deltaX );
         extent.setYMinimum( extent.yMinimum() + deltaY );
@@ -90,15 +87,6 @@ QgsRectangle FeatureUtils::extent( QgsQuickMapSettings *mapSettings, QgsVectorLa
       {
         extent = geom.boundingBox();
         extent = extent.buffered( std::max( extent.width(), extent.height() ) / 6.0 );
-
-        if ( rightEdge > 0.0 )
-        {
-          extent.setXMaximum( extent.xMaximum() + ( extent.xMaximum() - extent.xMinimum() ) * rightPercentage );
-        }
-        if ( bottomEdge > 0.0 )
-        {
-          extent.setYMinimum( extent.yMinimum() - ( extent.yMaximum() - extent.yMinimum() ) * bottomPercentage * 2 );
-        }
       }
 
       return extent;

--- a/src/core/utils/featureutils.h
+++ b/src/core/utils/featureutils.h
@@ -46,11 +46,9 @@ class QFIELD_CORE_EXPORT FeatureUtils : public QObject
      * \param mapSettings the map settings used to determine the CRS
      * \param layer the vector layer containing the feature
      * \param feature the feature from which the geometry will be used
-     * \param righeEdge provide a right edge beyond which the canvas is hidden and extent shouldn't overlap with
-     * \param bottomEdge provide a bottom edge beyond which the canvas is hidden and extent shouldn't overlap with
      * \returns a QgsRectangle extent
      */
-    static Q_INVOKABLE QgsRectangle extent( QgsQuickMapSettings *mapSettings, QgsVectorLayer *layer, const QgsFeature &feature, const double &rightEdge = 0.0, const double &bottomEdge = 0.0 );
+    static Q_INVOKABLE QgsRectangle extent( QgsQuickMapSettings *mapSettings, QgsVectorLayer *layer, const QgsFeature &feature );
 };
 
 #endif // FEATUREUTILS_H

--- a/src/qml/DigitizingToolbar.qml
+++ b/src/qml/DigitizingToolbar.qml
@@ -328,7 +328,7 @@ VisibilityFadingRow {
   function removeVertex() {
     digitizingLogger.removeLastCoordinate();
     rubberbandModel.removeVertex()
-    mapSettings.setCenter( rubberbandModel.currentCoordinate )
+    mapSettings.setCenter( rubberbandModel.currentCoordinate, true )
   }
 
   function confirm() {

--- a/src/qml/ElevationProfile.qml
+++ b/src/qml/ElevationProfile.qml
@@ -7,15 +7,13 @@ import org.qfield 1.0
 
 import Theme 1.0
 
-Item {
+Rectangle {
   id: elevationProfile
 
   property alias project: elevationProfileCanvas.project
   property alias crs: elevationProfileCanvas.crs
   property alias profileCurve: elevationProfileCanvas.profileCurve
   property alias tolerance: elevationProfileCanvas.tolerance
-
-  property alias radius: backgroundRect.radius
 
   function populateLayersFromProject() {
     elevationProfileCanvas.populateLayersFromProject();
@@ -29,14 +27,8 @@ Item {
     elevationProfileCanvas.clear();
   }
 
-  Rectangle {
-      id: backgroundRect
-
-      width: elevationProfile.width
-      height: elevationProfile.height
-      color: "#ffffff"
-      radius: 8
-  }
+  color: "#bbfafafa"
+  radius: 0
 
   ElevationProfileCanvas {
     id: elevationProfileCanvas

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -184,7 +184,7 @@ Rectangle {
     anchors.left: parent.left
     anchors.right: parent.right
     anchors.bottom: parent.bottom
-    bottomMargin: mainWindow.sceneBottomMargin
+    anchors.bottomMargin: mainWindow.sceneBottomMargin
 
     property bool shown: false
 
@@ -389,7 +389,6 @@ Rectangle {
       model: globalFeaturesList.model
       selection: featureForm.selection
       mapSettings: featureForm.mapSettings
-      featureForm: featureForm
 
       onFeatureFormStateRequested: {
         featureForm.state = "FeatureForm"

--- a/src/qml/InformationDrawer.qml
+++ b/src/qml/InformationDrawer.qml
@@ -71,6 +71,7 @@ Item {
           text: "Navigation"
           font: Theme.strongTipFont
           color: Theme.mainTextColor
+          leftPadding: 6
         }
 
         NavigationInformationView {
@@ -101,6 +102,7 @@ Item {
           text: "Positioning"
           font: Theme.strongTipFont
           color: Theme.mainTextColor
+          leftPadding: 6
         }
 
         PositioningInformationView {
@@ -131,6 +133,7 @@ Item {
           text: "Precise view"
           font: Theme.strongTipFont
           color: Theme.mainTextColor
+          leftPadding: 6
         }
 
         PositioningPreciseView {
@@ -162,6 +165,7 @@ Item {
           text: "Sensors"
           font: Theme.strongTipFont
           color: Theme.mainTextColor
+          leftPadding: 6
         }
 
         SensorInformationView {
@@ -190,6 +194,7 @@ Item {
           text: "Elevation profile"
           font: Theme.strongTipFont
           color: Theme.mainTextColor
+          leftPadding: 6
         }
 
         ElevationProfile {

--- a/src/qml/InformationDrawer.qml
+++ b/src/qml/InformationDrawer.qml
@@ -19,8 +19,6 @@ Item {
     }
   }
 
-  property real itemRadius: 8
-
   // SensorInformationView
   property bool sensorInformationViewEnabled: sensorInformationView.activeSensors > 0
 
@@ -52,160 +50,71 @@ Item {
     rightPadding: 5
     spacing: 8
 
-    Rectangle {
+    QfOverlayContainer {
       visible: navigationInformationViewEnabled
-      width: parent.width
-      height: childrenRect.height
-      color: Theme.mainBackgroundColorSemiOpaque
-      radius: itemRadius
-      clip: true
 
-      Column {
-        width: parent.width - 10
-        anchors.horizontalCenter: parent.horizontalCenter
-        topPadding: 5
-        bottomPadding: 5
-        spacing: 4
+      title: qsTr("Navigation")
 
-        Text {
-          text: "Navigation"
-          font: Theme.strongTipFont
-          color: Theme.mainTextColor
-          leftPadding: 6
-        }
-
-        NavigationInformationView {
-          id: navigationInformationView
-          width: parent.width
-          height: contentHeight
-          navigation: controller.navigation
-        }
+      NavigationInformationView {
+        id: navigationInformationView
+        width: parent.width
+        height: contentHeight
+        navigation: controller.navigation
       }
     }
 
-    Rectangle {
+    QfOverlayContainer {
       visible: positioningInformationViewEnabled
-      width: parent.width
-      height: childrenRect.height
-      color: Theme.mainBackgroundColorSemiOpaque
-      radius: itemRadius
-      clip: true
 
-      Column {
-        width: parent.width - 10
-        anchors.horizontalCenter: parent.horizontalCenter
-        topPadding: 5
-        bottomPadding: 5
-        spacing: 4
+      title: qsTr("Positioning")
 
-        Text {
-          text: "Positioning"
-          font: Theme.strongTipFont
-          color: Theme.mainTextColor
-          leftPadding: 6
-        }
-
-        PositioningInformationView {
-          id: positioningInformationView
-          width: parent.width
-          height: contentHeight
-          visible: positioningInformationViewEnabled
-          positionSource: controller.positionSource
-          antennaHeight: positioningSettings.antennaHeightActivated ? positioningSettings.antennaHeight : NaN
-        }
+      PositioningInformationView {
+        id: positioningInformationView
+        width: parent.width
+        height: contentHeight
+        visible: positioningInformationViewEnabled
+        positionSource: controller.positionSource
+        antennaHeight: positioningSettings.antennaHeightActivated ? positioningSettings.antennaHeight : NaN
       }
     }
 
-    Rectangle {
+    QfOverlayContainer {
       visible: positioningPreciseEnabled
-      width: parent.width
-      height: childrenRect.height
-      color: Theme.mainBackgroundColorSemiOpaque
 
-      Column {
-        width: parent.width - 10
-        anchors.horizontalCenter: parent.horizontalCenter
-        topPadding: 5
-        bottomPadding: 5
-        spacing: 4
+      title: qsTr("Precise view")
 
-        Text {
-          text: "Precise view"
-          font: Theme.strongTipFont
-          color: Theme.mainTextColor
-          leftPadding: 6
-        }
-
-        PositioningPreciseView {
-          id: positioningPreciseView
-          width: parent.width
-          height: Math.min(mainWindow.height / 2.5, 400)
-          clip: true
-          precision: positioningSettings.preciseViewPrecision
-        }
+      PositioningPreciseView {
+        id: positioningPreciseView
+        width: parent.width
+        height: Math.min(mainWindow.height / 2.5, 400)
+        precision: positioningSettings.preciseViewPrecision
       }
     }
 
-    Rectangle {
+    QfOverlayContainer {
       visible: sensorInformationViewEnabled
-      width: parent.width
-      height: childrenRect.height
-      color: Theme.mainBackgroundColorSemiOpaque
-      radius: itemRadius
-      clip: true
 
-      Column {
-        width: parent.width - 10
-        anchors.horizontalCenter: parent.horizontalCenter
-        topPadding: 5
-        bottomPadding: 5
-        spacing: 4
+      title: qsTr("Sensors")
 
-        Text {
-          text: "Sensors"
-          font: Theme.strongTipFont
-          color: Theme.mainTextColor
-          leftPadding: 6
-        }
-
-        SensorInformationView {
-          id: sensorInformationView
-          height: contentHeight
-        }
+      SensorInformationView {
+        id: sensorInformationView
+        height: contentHeight
       }
     }
 
-    Rectangle {
+    QfOverlayContainer {
       visible: stateMachine.state === 'measure' && elevationProfileButton.elevationProfileActive
-      width: parent.width
-      height: childrenRect.height
-      color: Theme.mainBackgroundColorSemiOpaque
-      radius: itemRadius
-      clip: true
 
-      Column {
-        width: parent.width - 10
-        anchors.horizontalCenter: parent.horizontalCenter
-        topPadding: 5
-        bottomPadding: 5
-        spacing: 4
+      title: qsTr("Elevation profile")
 
-        Text {
-          text: "Elevation profile"
-          font: Theme.strongTipFont
-          color: Theme.mainTextColor
-          leftPadding: 6
-        }
+      ElevationProfile {
+        id: elevationProfile
 
-        ElevationProfile {
-          id: elevationProfile
+        width: parent.width
+        height: Math.max(220, mainWindow.height / 4)
 
-          width: parent.width
-          height: Math.max(220, mainWindow.height / 4)
-
-          project: qgisProject
-          crs: mapCanvas.mapSettings.destinationCrs
-        }
+        project: qgisProject
+        crs: mapCanvas.mapSettings.destinationCrs
       }
     }
   }

--- a/src/qml/InformationDrawer.qml
+++ b/src/qml/InformationDrawer.qml
@@ -35,7 +35,6 @@ Item {
   property alias positioningPreciseView: positioningPreciseView
   property PositioningSettings positioningSettings
   property Positioning positionSource
-  property real positioningPreciseViewHeight
   property bool positioningPreciseEnabled: !elevationProfile.visible
                                            && !isNaN(navigation.distance)
                                            && navigation.isActive
@@ -49,56 +48,160 @@ Item {
   Column {
     id: mainContent
     width: parent.width - 10
-    anchors.horizontalCenter: parent.horizontalCenter
+    leftPadding: 5
+    rightPadding: 5
     spacing: 8
 
-    NavigationInformationView {
-      id: navigationInformationView
+    Rectangle {
+      visible: navigationInformationViewEnabled
       width: parent.width
-      height: navigationInformationViewEnabled ? contentHeight : 0
+      height: childrenRect.height
+      color: Theme.mainBackgroundColorSemiOpaque
       radius: itemRadius
       clip: true
-      navigation: controller.navigation
+
+      Column {
+        width: parent.width - 10
+        anchors.horizontalCenter: parent.horizontalCenter
+        topPadding: 5
+        bottomPadding: 5
+        spacing: 4
+
+        Text {
+          text: "Navigation"
+          font: Theme.strongTipFont
+          color: Theme.mainTextColor
+        }
+
+        NavigationInformationView {
+          id: navigationInformationView
+          width: parent.width
+          height: contentHeight
+          navigation: controller.navigation
+        }
+      }
     }
 
-    PositioningInformationView {
-      id: positioningInformationView
-      width: parent.width
-      height: positioningInformationViewEnabled ? contentHeight : 0
-      radius: itemRadius
-      clip: true
+    Rectangle {
       visible: positioningInformationViewEnabled
-      positionSource: controller.positionSource
-      antennaHeight: positioningSettings.antennaHeightActivated ? positioningSettings.antennaHeight : NaN
-    }
-
-    PositioningPreciseView {
-      id: positioningPreciseView
       width: parent.width
-      height: positioningPreciseEnabled ? positioningPreciseViewHeight : 0
-      clip: true
-      precision: positioningSettings.preciseViewPrecision
-    }
-
-    SensorInformationView {
-      id: sensorInformationView
-      height: sensorInformationViewEnabled ? contentHeight : 0
+      height: childrenRect.height
+      color: Theme.mainBackgroundColorSemiOpaque
       radius: itemRadius
       clip: true
+
+      Column {
+        width: parent.width - 10
+        anchors.horizontalCenter: parent.horizontalCenter
+        topPadding: 5
+        bottomPadding: 5
+        spacing: 4
+
+        Text {
+          text: "Positioning"
+          font: Theme.strongTipFont
+          color: Theme.mainTextColor
+        }
+
+        PositioningInformationView {
+          id: positioningInformationView
+          width: parent.width
+          height: contentHeight
+          visible: positioningInformationViewEnabled
+          positionSource: controller.positionSource
+          antennaHeight: positioningSettings.antennaHeightActivated ? positioningSettings.antennaHeight : NaN
+        }
+      }
     }
 
-    ElevationProfile {
-        id: elevationProfile
+    Rectangle {
+      visible: positioningPreciseEnabled
+      width: parent.width
+      height: childrenRect.height
+      color: Theme.mainBackgroundColorSemiOpaque
 
-        visible: stateMachine.state === 'measure' && elevationProfileButton.elevationProfileActive
+      Column {
+        width: parent.width - 10
+        anchors.horizontalCenter: parent.horizontalCenter
+        topPadding: 5
+        bottomPadding: 5
+        spacing: 4
 
-        width: parent.width
-        height: Math.max(220, mainWindow.height / 4)
-        radius: itemRadius
-        clip: true
+        Text {
+          text: "Precise view"
+          font: Theme.strongTipFont
+          color: Theme.mainTextColor
+        }
 
-        project: qgisProject
-        crs: mapCanvas.mapSettings.destinationCrs
+        PositioningPreciseView {
+          id: positioningPreciseView
+          width: parent.width
+          height: Math.min(mainWindow.height / 2.5, 400)
+          clip: true
+          precision: positioningSettings.preciseViewPrecision
+        }
+      }
+    }
+
+    Rectangle {
+      visible: sensorInformationViewEnabled
+      width: parent.width
+      height: childrenRect.height
+      color: Theme.mainBackgroundColorSemiOpaque
+      radius: itemRadius
+      clip: true
+
+      Column {
+        width: parent.width - 10
+        anchors.horizontalCenter: parent.horizontalCenter
+        topPadding: 5
+        bottomPadding: 5
+        spacing: 4
+
+        Text {
+          text: "Sensors"
+          font: Theme.strongTipFont
+          color: Theme.mainTextColor
+        }
+
+        SensorInformationView {
+          id: sensorInformationView
+          height: contentHeight
+        }
+      }
+    }
+
+    Rectangle {
+      visible: stateMachine.state === 'measure' && elevationProfileButton.elevationProfileActive
+      width: parent.width
+      height: childrenRect.height
+      color: Theme.mainBackgroundColorSemiOpaque
+      radius: itemRadius
+      clip: true
+
+      Column {
+        width: parent.width - 10
+        anchors.horizontalCenter: parent.horizontalCenter
+        topPadding: 5
+        bottomPadding: 5
+        spacing: 4
+
+        Text {
+          text: "Elevation profile"
+          font: Theme.strongTipFont
+          color: Theme.mainTextColor
+        }
+
+        ElevationProfile {
+          id: elevationProfile
+
+          width: parent.width
+          height: Math.max(220, mainWindow.height / 4)
+
+          project: qgisProject
+          crs: mapCanvas.mapSettings.destinationCrs
+        }
+      }
     }
   }
 }

--- a/src/qml/MapCanvas.qml
+++ b/src/qml/MapCanvas.qml
@@ -24,6 +24,8 @@ import org.qgis 1.0
 Item {
   id: mapArea
   property alias mapSettings: mapCanvasWrapper.mapSettings
+  property alias bottomMargin: mapCanvasWrapper.bottomMargin
+  property alias rightMargin: mapCanvasWrapper.rightMargin
   property alias isRendering: mapCanvasWrapper.isRendering
   property alias incrementalRendering: mapCanvasWrapper.incrementalRendering
   property alias quality: mapCanvasWrapper.quality

--- a/src/qml/NavigationInformationView.qml
+++ b/src/qml/NavigationInformationView.qml
@@ -23,8 +23,6 @@ Rectangle {
   property real contentHeight: content.height
 
   color: Theme.mainBackgroundColorSemiOpaque
-  border.color: alternateBackgroundColor
-  border.width: 2
 
   Timer {
     id: featureVertexTimer

--- a/src/qml/NavigationInformationView.qml
+++ b/src/qml/NavigationInformationView.qml
@@ -16,7 +16,8 @@ Rectangle {
   property bool coordinatesIsGeographic: projectInfo.coordinateDisplayCrs.isGeographic
 
   property int ceilsCount: 4
-  property double rowHeight: 30
+  property double cellHeight: 26
+  property double cellPadding: 6
   property color backgroundColor: "transparent"
   property color alternateBackgroundColor: Theme.navigationBackgroundColor
   property color textColor: Theme.mainTextColor
@@ -121,18 +122,18 @@ Rectangle {
       Layout.fillWidth: true
       Layout.preferredHeight: childrenRect.height
       width: parent.width
-      height: grid.rows * navigationInformationView.rowHeight
+      height: grid.rows * navigationInformationView.cellHeight
       flow: GridLayout.TopToBottom
       rows: parent.width > 620? 1 : 2
       property double cellWidth: grid.width / ( ceilsCount / grid.rows )
 
       Rectangle {
-        height: rowHeight
+        height: cellHeight
         width: grid.cellWidth
         color: alternateBackgroundColor
 
         Text {
-          anchors.margins:  10
+          anchors.margins: cellPadding
           anchors.verticalCenter: parent.verticalCenter
           anchors.left: parent.left
           font: Theme.tipFont
@@ -146,12 +147,12 @@ Rectangle {
       }
 
       Rectangle {
-        height: rowHeight
+        height: cellHeight
         width: grid.cellWidth
         color: backgroundColor
 
         Text {
-          anchors.margins:  10
+          anchors.margins: cellPadding
           anchors.verticalCenter: parent.verticalCenter
           anchors.left: parent.left
           font: Theme.tipFont
@@ -165,12 +166,12 @@ Rectangle {
       }
 
       Rectangle {
-        height: rowHeight
+        height: cellHeight
         width: grid.cellWidth
         color: grid.rows == 2 ? backgroundColor : alternateBackgroundColor
 
         Text {
-          anchors.margins:  10
+          anchors.margins: cellPadding
           anchors.verticalCenter: parent.verticalCenter
           anchors.left: parent.left
           font: Theme.tipFont
@@ -183,12 +184,12 @@ Rectangle {
       }
 
       Rectangle {
-        height: rowHeight
+        height: cellHeight
         width: grid.cellWidth
         color: grid.rows == 2 ? alternateBackgroundColor : backgroundColor
 
         Text {
-          anchors.margins:  10
+          anchors.margins: cellPadding
           anchors.verticalCenter: parent.verticalCenter
           anchors.left: parent.left
           font: Theme.tipFont

--- a/src/qml/PositioningInformationView.qml
+++ b/src/qml/PositioningInformationView.qml
@@ -18,12 +18,13 @@ Rectangle {
   property string distanceUnitAbbreviation: UnitTypes.toAbbreviatedString(projectInfo.distanceUnits)
 
   property double antennaHeight: NaN
-  property double rowHeight: 30
+  property double cellHeight: 26
+  property double cellPadding: 6
   property color backgroundColor: "transparent"
   property color alternateBackgroundColor: Theme.positionBackgroundColor
   property color textColor: positionSource.currentness ? Theme.mainTextColor : Theme.secondaryTextColor
 
-  property real contentHeight: grid.rows * positioningInformationView.rowHeight
+  property real contentHeight: grid.rows * positioningInformationView.cellHeight
   width: parent.width
   anchors.margins: 20
 
@@ -38,12 +39,12 @@ Rectangle {
 
     Rectangle {
       id: x
-      height: rowHeight
+      height: cellHeight
       width: grid.cellWidth
       color: alternateBackgroundColor
 
       Text {
-        anchors.margins:  10
+        anchors.margins: cellPadding
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
         font: Theme.tipFont
@@ -61,12 +62,12 @@ Rectangle {
     }
 
     Rectangle {
-      height: rowHeight
+      height: cellHeight
       width: grid.cellWidth
       color: backgroundColor
 
       Text {
-        anchors.margins:  10
+        anchors.margins: cellPadding
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
         font: Theme.tipFont
@@ -85,11 +86,11 @@ Rectangle {
     }
 
     Rectangle {
-      height: rowHeight
+      height: cellHeight
       width: grid.cellWidth
       color: grid.rows === 2 ? backgroundColor : alternateBackgroundColor
       Text {
-        anchors.margins:  10
+        anchors.margins: cellPadding
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
         font: Theme.tipFont
@@ -121,12 +122,12 @@ Rectangle {
     }
 
     Rectangle {
-      height: rowHeight
+      height: cellHeight
       width: grid.cellWidth
       color: grid.rows === 2 ? alternateBackgroundColor : backgroundColor
 
       Text {
-        anchors.margins:  10
+        anchors.margins: cellPadding
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
         font: Theme.tipFont
@@ -136,12 +137,12 @@ Rectangle {
     }
 
     Rectangle {
-      height: rowHeight
+      height: cellHeight
       width: grid.cellWidth
       color: grid.rows === 4 ? backgroundColor : alternateBackgroundColor
 
       Text {
-        anchors.margins:  10
+        anchors.margins: cellPadding
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
         font: Theme.tipFont
@@ -153,12 +154,12 @@ Rectangle {
     }
 
     Rectangle {
-      height: rowHeight
+      height: cellHeight
       width: grid.cellWidth
       color: grid.rows === 4 ? alternateBackgroundColor : backgroundColor
 
       Text {
-        anchors.margins:  10
+        anchors.margins: cellPadding
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
         font: Theme.tipFont
@@ -170,13 +171,13 @@ Rectangle {
     }
 
     Rectangle {
-      height: rowHeight
+      height: cellHeight
       width: grid.cellWidth
       color: grid.rows % 2 === 0 ? backgroundColor : alternateBackgroundColor
       visible: positionSource.deviceId !== ''
 
       Text {
-        anchors.margins:  10
+        anchors.margins: cellPadding
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
         font: Theme.tipFont
@@ -189,13 +190,13 @@ Rectangle {
     }
 
     Rectangle {
-      height: rowHeight
+      height: cellHeight
       width: grid.cellWidth
       color: grid.rows % 2 === 0 ? alternateBackgroundColor : backgroundColor
       visible: positionSource.deviceId !== ''
 
       Text {
-        anchors.margins:  10
+        anchors.margins: cellPadding
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
         font: Theme.tipFont
@@ -208,13 +209,13 @@ Rectangle {
     }
 
     Rectangle {
-      height: rowHeight
+      height: cellHeight
       width: grid.cellWidth
       color: grid.rows === 6 ? backgroundColor : alternateBackgroundColor
       visible: positionSource.deviceId !== ''
 
       Text {
-        anchors.margins:  10
+        anchors.margins: cellPadding
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
         font: Theme.tipFont
@@ -227,13 +228,13 @@ Rectangle {
     }
 
     Rectangle {
-      height: rowHeight
+      height: cellHeight
       width: grid.cellWidth
       color: grid.rows === 6 ? alternateBackgroundColor : backgroundColor
       visible: positionSource.deviceId !== ''
 
       Text {
-        anchors.margins:  10
+        anchors.margins: cellPadding
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
         font: Theme.tipFont
@@ -243,13 +244,13 @@ Rectangle {
     }
 
     Rectangle {
-      height: rowHeight
+      height: cellHeight
       width: grid.cellWidth
       color: grid.rows === 2 || grid.rows === 6 ? backgroundColor : alternateBackgroundColor
       visible: positionSource.deviceId !== ''
 
       Text {
-        anchors.margins:  10
+        anchors.margins: cellPadding
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
         font: Theme.tipFont
@@ -259,13 +260,13 @@ Rectangle {
     }
 
     Rectangle {
-      height: rowHeight
+      height: cellHeight
       width: grid.cellWidth
       color: grid.rows === 2 || grid.rows === 6 ? alternateBackgroundColor : backgroundColor
       visible: positionSource.deviceId !== ''
 
       Text {
-        anchors.margins:  10
+        anchors.margins: cellPadding
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
         font: Theme.tipFont

--- a/src/qml/PositioningPreciseView.qml
+++ b/src/qml/PositioningPreciseView.qml
@@ -32,7 +32,6 @@ Item {
   Rectangle {
     anchors.fill: parent
     color: Theme.mainBackgroundColorSemiOpaque
-    radius: 8
   }
 
   Row {

--- a/src/qml/PositioningPreciseView.qml
+++ b/src/qml/PositioningPreciseView.qml
@@ -31,7 +31,7 @@ Item {
 
   Rectangle {
     anchors.fill: parent
-    color: "#ee" + Theme.mainBackgroundColor.toString().slice(1)
+    color: Theme.mainBackgroundColorSemiOpaque
     radius: 8
   }
 

--- a/src/qml/SensorInformationView.qml
+++ b/src/qml/SensorInformationView.qml
@@ -12,13 +12,14 @@ Rectangle {
   property alias activeSensors: grid.count
 
   property int ceilsCount: 4
-  property double rowHeight: 30
+  property double cellHeight: 26
+  property double cellPadding: 6
   property color backgroundColor: Theme.mainBackgroundColor
   property color alternateBackgroundColor: Theme.sensorBackgroundColor
   property color textColor: Theme.mainTextColor
   property real contentHeight: parent.width > 620
-          ? rowHeight * Math.ceil(grid.count / 3)
-          : rowHeight * Math.ceil(grid.count / 2)
+          ? cellHeight * Math.ceil(grid.count / 3)
+          : cellHeight * Math.ceil(grid.count / 2)
 
   width: parent.width
   anchors.margins: 20
@@ -34,7 +35,7 @@ Rectangle {
     cellWidth: parent.width > 620
                ? parent.width / 3
                : parent.width / 2
-    cellHeight: rowHeight
+    cellHeight: cellHeight
     flow: GridLayout.TopToBottom
 
     model: SensorListModel {
@@ -48,7 +49,7 @@ Rectangle {
       color: index % 2 == 0 ? sensorInformationView.alternateBackgroundColor : sensorInformationView.backgroundColor
 
       Text {
-        anchors.margins:  10
+        anchors.margins: cellPadding
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
         width: grid.cellWidth - 20

--- a/src/qml/geometryeditors/VertexEditor.qml
+++ b/src/qml/geometryeditors/VertexEditor.qml
@@ -77,7 +77,7 @@ VisibilityFadingRow {
     bgcolor: Theme.darkGray
     onClicked: {
       featureModel.vertexModel.undoHistory()
-      mapSettings.setCenter(featureModel.vertexModel.currentPoint)
+      mapSettings.setCenter(featureModel.vertexModel.currentPoint, true)
     }
   }
 
@@ -215,7 +215,7 @@ VisibilityFadingRow {
            && !screenHovering
            && featureModel.vertexModel.editingMode !== VertexModel.NoEditing )
       {
-        mapSettings.setCenter(featureModel.vertexModel.currentPoint)
+        mapSettings.setCenter(featureModel.vertexModel.currentPoint, true)
         vertexEditorToolbar.currentVertexId = featureModel.vertexModel.currentVertexIndex
         vertexEditorToolbar.currentVertexModified = false
       }

--- a/src/qml/imports/Theme/QfOverlayContainer.qml
+++ b/src/qml/imports/Theme/QfOverlayContainer.qml
@@ -1,0 +1,32 @@
+import QtQuick 2.14
+import Theme 1.0
+
+Rectangle {
+  id: container
+
+  default property alias contents: containerLayout.children
+  property alias title: title.text
+
+  width: parent.width
+  height: childrenRect.height
+  color: Theme.mainBackgroundColorSemiOpaque
+  radius: 8
+  clip: true
+
+  Column {
+    id: containerLayout
+    width: parent.width - 10
+    anchors.horizontalCenter: parent.horizontalCenter
+    topPadding: 5
+    bottomPadding: 5
+    spacing: 4
+
+    Text {
+      id: title
+      text: "Sensors"
+      font: Theme.strongTipFont
+      color: Theme.mainTextColor
+      leftPadding: 6
+    }
+  }
+}

--- a/src/qml/imports/Theme/Theme.qml
+++ b/src/qml/imports/Theme/Theme.qml
@@ -7,7 +7,7 @@ QtObject {
     property bool darkTheme: false
 
     property color mainBackgroundColor: darkTheme ? "#303030" : "#fafafa"
-    property color mainBackgroundColorSemiOpaque: darkTheme ? "#dd303030" : "#ddfafafa"
+    property color mainBackgroundColorSemiOpaque: darkTheme ? "#bb303030" : "#bbfafafa"
 
     property color mainTextColor: darkTheme ? "#EEEEEE" : "#000000"
     readonly property color mainTextDisabledColor: darkTheme ? "#73EEEEEE" : "#73000000"

--- a/src/qml/imports/Theme/qmldir
+++ b/src/qml/imports/Theme/qmldir
@@ -12,3 +12,4 @@ QfDropShadow 1.0 QfDropShadow.qml
 QfOpacityMask 1.0 QfOpacityMask.qml
 QfCalendarPanel 1.0 QfCalendarPanel.qml
 QfPageHeader 1.0 QfPageHeader.qml
+QfOverlayContainer 1.0 QfOverlayContainer.qml

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -444,6 +444,7 @@ ApplicationWindow {
     /* The map canvas */
     MapCanvas {
       id: mapCanvasMap
+
       property bool isEnabled: !dashBoard.opened &&
                                !welcomeScreen.visible &&
                                !qfieldSettings.visible &&
@@ -458,6 +459,9 @@ ApplicationWindow {
       quality: qfieldSettings.quality
       forceDeferredLayersRepaint: trackings.count > 0
       freehandDigitizing: freehandButton.freehandDigitizing && freehandHandler.active
+
+      rightMargin: featureForm.x > 0 ? featureForm.width : 0
+      bottomMargin: informationDrawer.height > mainWindow.sceneBottomMargin ? informationDrawer.height : 0
 
       anchors.fill: parent
 
@@ -1814,7 +1818,7 @@ ApplicationWindow {
                       && Math.abs(screenDestination.y - screenLocation.y) < mainWindow.height / 3)) {
                 gnssButton.followActiveSkipExtentChanged = true;
                 var points = [positionSource.projectedPosition, navigation.destination];
-                mapCanvas.mapSettings.setExtentFromPoints(points, followLocationMinScale)
+                mapCanvas.mapSettings.setExtentFromPoints(points, followLocationMinScale, true)
               }
             }
           } else {
@@ -1826,7 +1830,7 @@ ApplicationWindow {
                 || screenLocation.y > mapCanvas.height - threshold )
             {
               gnssButton.followActiveSkipExtentChanged = true;
-              mapCanvas.mapSettings.setCenter(positionSource.projectedPosition);
+              mapCanvas.mapSettings.setCenter(positionSource.projectedPosition, true);
             }
           }
         }
@@ -3162,7 +3166,7 @@ ApplicationWindow {
       font: Theme.defaultFont
 
       onTriggered: {
-        mapCanvas.mapSettings.setCenter(positionSource.projectedPosition)
+        mapCanvas.mapSettings.setCenter(positionSource.projectedPosition, true)
       }
     }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1085,7 +1085,7 @@ ApplicationWindow {
       mapSettings: mapCanvas.mapSettings
       anchors.left: parent.left
       anchors.bottom: parent.bottom
-      anchors.leftMargin: 4
+      anchors.leftMargin: 8
       anchors.bottomMargin: 10
     }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -866,7 +866,6 @@ ApplicationWindow {
     navigation: navigation
     positionSource: positionSource
     positioningSettings: positioningSettings
-    positioningPreciseViewHeight: Math.min(mainWindow.height / 2.5, 400)
   }
 
   /**************************************************

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -87,6 +87,7 @@
         <file>imports/Theme/QfSlider.qml</file>
         <file>imports/Theme/QfCalendarPanel.qml</file>
         <file>imports/Theme/QfPageHeader.qml</file>
+        <file>imports/Theme/QfOverlayContainer.qml</file>
         <file>imports/Theme/qmldir</file>
         <file>TrackerSettings.qml</file>
         <file>TrackingSession.qml</file>


### PR DESCRIPTION
This PR implements the concept of margins (bottom and right for now) to the map canvas. Those margins allow for us to overlay elements on top of the map canvas and take those margins into account when setting the map extent / center. 

Practically speaking, this allows for zooming to feature / point to recenter around the portion of the map that's not covered by overlaid elements.

Needed for the ongoing revamp of information panel -> drawer (see https://github.com/opengisch/QField/pull/5251)

Here's a screencast of what it does:

https://github.com/opengisch/QField/assets/1728657/e49496db-af2d-4c59-8691-9a7293ec7518

Note how the auto re-centering to positioning and destination is contained within the part of the map canvas that's not partially hidden by the information drawer. Big win! This was not needed before as we were shrinking the map canvas to show information below it (booouh;) ).

Margin magic in action, this time with zooming into features:

https://github.com/opengisch/QField/assets/1728657/f480520e-37d6-4c13-8790-0d087ca8f778

You can see the feature nicely fits within the top-left region that's not obstructed by either the feature form nor the information drawers.