### PR TITLE
Add a couple of properties to the elevation profile canvas to style axis labels + information cells tweaking

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           build_dir: "build"
           lgtm_comment_body: ''
-          exclude: 'cppcoreguidelines-avoid-magic-numbers,bugprone-easily-swappable-parameters,misc-non-private-member-variables-in-classes,cppcoreguidelines-macro-usage'
+          exclude: 'cppcoreguidelines-avoid-magic-numbers,bugprone-easily-swappable-parameters,misc-non-private-member-variables-in-classes,cppcoreguidelines-macro-usage,readability-braces-around-statements,readability-implicit-bool-conversion,cppcoreguidelines-avoid-magic-numbers'
 
       - name: Package
         run: |

--- a/src/core/qgsquick/qgsquickelevationprofilecanvas.cpp
+++ b/src/core/qgsquick/qgsquickelevationprofilecanvas.cpp
@@ -171,6 +171,7 @@ QgsQuickElevationProfileCanvas::QgsQuickElevationProfileCanvas( QQuickItem *pare
   connect( mDeferredRedrawTimer, &QTimer::timeout, this, &QgsQuickElevationProfileCanvas::startDeferredRedraw );
 
   mPlotItem = new QgsElevationProfilePlotItem( this );
+  updateAxisLabelStyle();
 
   setTransformOrigin( QQuickItem::TopLeft );
   setFlags( QQuickItem::ItemHasContents );
@@ -724,6 +725,59 @@ void QgsQuickElevationProfileCanvas::setVisiblePlotRange( double minimumDistance
   mPlotItem->setXMinimum( minimumDistance );
   mPlotItem->setXMaximum( maximumDistance );
   refineResults();
+}
+
+QColor QgsQuickElevationProfileCanvas::axisLabelColor() const
+{
+  return mAxisLabelColor;
+}
+
+void QgsQuickElevationProfileCanvas::setAxisLabelColor( const QColor &color )
+{
+  if ( mAxisLabelColor == color )
+    return;
+
+  mAxisLabelColor = color;
+  emit axisLabelColorChanged();
+
+  updateAxisLabelStyle();
+}
+
+double QgsQuickElevationProfileCanvas::axisLabelSize() const
+{
+  return mAxisLabelSize;
+}
+
+void QgsQuickElevationProfileCanvas::setAxisLabelSize( double size )
+{
+  if ( mAxisLabelSize == size )
+    return;
+
+  mAxisLabelSize = size;
+  emit axisLabelSizeChanged();
+
+  updateAxisLabelStyle();
+}
+
+void QgsQuickElevationProfileCanvas::updateAxisLabelStyle()
+{
+  if ( mPlotItem )
+  {
+    QgsTextFormat textFormat = mPlotItem->xAxis().textFormat();
+    textFormat.setColor( mAxisLabelColor );
+    textFormat.setSize( mAxisLabelSize );
+    textFormat.setSizeUnit( Qgis::RenderUnit::Points );
+    mPlotItem->xAxis().setTextFormat( textFormat );
+
+    textFormat = mPlotItem->yAxis().textFormat();
+    textFormat.setColor( mAxisLabelColor );
+    textFormat.setSize( mAxisLabelSize );
+    textFormat.setSizeUnit( Qgis::RenderUnit::Points );
+    mPlotItem->yAxis().setTextFormat( textFormat );
+
+    mDirty = true;
+    refresh();
+  }
 }
 
 QgsDoubleRange QgsQuickElevationProfileCanvas::visibleDistanceRange() const

--- a/src/core/qgsquick/qgsquickelevationprofilecanvas.h
+++ b/src/core/qgsquick/qgsquickelevationprofilecanvas.h
@@ -34,10 +34,11 @@ class QgsQuickElevationProfileCanvas : public QQuickItem
     Q_PROPERTY( QgsProject *project READ project WRITE setProject NOTIFY projectChanged )
 
     Q_PROPERTY( QgsCoordinateReferenceSystem crs READ crs WRITE setCrs NOTIFY crsChanged )
-
     Q_PROPERTY( QgsGeometry profileCurve READ profileCurve WRITE setProfileCurve NOTIFY profileCurveChanged )
-
     Q_PROPERTY( double tolerance READ tolerance WRITE setTolerance NOTIFY toleranceChanged )
+
+    Q_PROPERTY( QColor axisLabelColor READ axisLabelColor WRITE setAxisLabelColor NOTIFY axisLabelColorChanged )
+    Q_PROPERTY( double axisLabelSize READ axisLabelSize WRITE setAxisLabelSize NOTIFY axisLabelSizeChanged )
 
     /**
      * The isRendering property is set to true while a rendering job is pending for this
@@ -168,6 +169,34 @@ class QgsQuickElevationProfileCanvas : public QQuickItem
      */
     QgsDoubleRange visibleElevationRange() const;
 
+    /**
+     * Returns the axis label color used when rendering the elevation profile.
+     *
+     * \see setAxisLabelColor
+     */
+    QColor axisLabelColor() const;
+
+    /**
+     * Sets the axis label color used when rendering the elevation profile.
+     *
+     * \see axisLabelColor
+     */
+    void setAxisLabelColor( const QColor &color );
+
+    /**
+     * Returns the axis label size (in point) used when rendering the elevation profile.
+     *
+     * \see setAxisLabelSize
+     */
+    double axisLabelSize() const;
+
+    /**
+     * Sets the axis label size (in point) used when rendering the elevation profile.
+     *
+     * \see axisLabelSize
+     */
+    void setAxisLabelSize( double size );
+
   signals:
 
     //! Emitted when the number of active background jobs changes.
@@ -187,6 +216,12 @@ class QgsQuickElevationProfileCanvas : public QQuickItem
 
     //! \copydoc QgsQuickMapCanvasMap::isRendering
     void isRenderingChanged();
+
+    //! Emitted when the axis label color changes.
+    void axisLabelColorChanged();
+
+    //! Emitted when the axis label size (in point) changes.
+    void axisLabelSizeChanged();
 
   protected:
 #if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
@@ -227,6 +262,7 @@ class QgsQuickElevationProfileCanvas : public QQuickItem
 
   private:
     void setupLayerConnections( QgsMapLayer *layer, bool isDisconnect );
+    void updateAxisLabelStyle();
 
     QgsCoordinateReferenceSystem mCrs;
     QgsProject *mProject = nullptr;
@@ -255,6 +291,9 @@ class QgsQuickElevationProfileCanvas : public QQuickItem
     static constexpr double MAX_ERROR_PIXELS = 2;
 
     bool mDirty = false;
+
+    QColor mAxisLabelColor = QColor( 0, 0, 0 );
+    double mAxisLabelSize = 16;
 };
 
 #endif // QGSELEVATIONPROFILECANVAS_H

--- a/src/qml/ElevationProfile.qml
+++ b/src/qml/ElevationProfile.qml
@@ -27,7 +27,7 @@ Rectangle {
     elevationProfileCanvas.clear();
   }
 
-  color: "#bbfafafa"
+  color: Theme.mainBackgroundColorSemiOpaque
   radius: 0
 
   ElevationProfileCanvas {
@@ -37,6 +37,9 @@ Rectangle {
     height: elevationProfile.height
 
     tolerance: crs.isGeographic ? 0.00005 : 5
+
+    axisLabelColor: Theme.mainTextColor
+    axisLabelSize: Theme.tipFont
   }
 
   ProgressBar {
@@ -82,7 +85,7 @@ Rectangle {
     visible: elevationProfileCanvas.isRendering || elevationProfileCanvas.profileCurve.isNull
     anchors.centerIn: parent
     width: parent.width
-    color: Theme.gray
+    color: Theme.mainTextColor
     font: Theme.tinyFont
     horizontalAlignment: Text.AlignHCenter
     wrapMode: Text.WordWrap
@@ -90,6 +93,6 @@ Rectangle {
           ? qsTr('Rendering elevation profile…')
           : qsTr('Digitize a path to render the elevation profile')
     style: Text.Outline
-    styleColor: "white"
+    styleColor: Theme.mainBackgroundColorSemiOpaque
   }
 }

--- a/src/qml/NavigationInformationView.qml
+++ b/src/qml/NavigationInformationView.qml
@@ -132,17 +132,28 @@ Rectangle {
         width: grid.cellWidth
         color: alternateBackgroundColor
 
-        Text {
+        RowLayout {
           anchors.margins: cellPadding
           anchors.verticalCenter: parent.verticalCenter
           anchors.left: parent.left
-          font: Theme.tipFont
-          color: textColor
-          text: coordinatesIsXY
-                ? (coordinatesIsGeographic ? qsTr( "Lon" ) : qsTr( "X" )) + ': '
-                  + Number( coordinates.x ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
-                : (coordinatesIsGeographic ? qsTr( "Lat" ) : qsTr( "Y" )) + ': '
-                  + Number( coordinates.y ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
+
+          Text {
+            Layout.fillWidth: false
+            font: Theme.tipFont
+            color: Theme.secondaryTextColor
+            text: coordinatesIsXY
+                  ? coordinatesIsGeographic ? qsTr( "Lon" ) : qsTr( "X" )
+                  : coordinatesIsGeographic ? qsTr( "Lat" ) : qsTr( "Y" )
+          }
+
+          Text {
+            Layout.fillWidth: true
+            font: Theme.tipFont
+            color: textColor
+            text: coordinatesIsXY
+                  ? Number( coordinates.x ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
+                  : Number( coordinates.y ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
+          }
         }
       }
 
@@ -151,17 +162,28 @@ Rectangle {
         width: grid.cellWidth
         color: backgroundColor
 
-        Text {
+        RowLayout {
           anchors.margins: cellPadding
           anchors.verticalCenter: parent.verticalCenter
           anchors.left: parent.left
-          font: Theme.tipFont
-          color: textColor
-          text: coordinatesIsXY
-                ? (coordinatesIsGeographic ? qsTr( "Lat" ) : qsTr( "Y" )) + ': '
-                  + Number( coordinates.y ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
-                : (coordinatesIsGeographic ? qsTr( "Lon" ) : qsTr( "X" )) + ': '
-                  + Number( coordinates.x ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
+
+          Text {
+            Layout.fillWidth: false
+            font: Theme.tipFont
+            color: Theme.secondaryTextColor
+            text: coordinatesIsXY
+                  ? coordinatesIsGeographic ? qsTr( "Lat" ) : qsTr( "Y" )
+                  : coordinatesIsGeographic ? qsTr( "Lon" ) : qsTr( "X" )
+          }
+
+          Text {
+            Layout.fillWidth: true
+            font: Theme.tipFont
+            color: textColor
+            text: coordinatesIsXY
+                  ? Number( coordinates.y ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
+                  : Number( coordinates.x ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
+          }
         }
       }
 
@@ -170,16 +192,26 @@ Rectangle {
         width: grid.cellWidth
         color: grid.rows == 2 ? backgroundColor : alternateBackgroundColor
 
-        Text {
+        RowLayout {
           anchors.margins: cellPadding
           anchors.verticalCenter: parent.verticalCenter
           anchors.left: parent.left
-          font: Theme.tipFont
-          color: textColor
-          text: qsTr( "Dist." ) + ': ' +
-                ( positionSource.active && positionSource.positionInformation && positionSource.positionInformation.latitudeValid
-                 ? ( UnitTypes.formatDistance( navigation.distance * UnitTypes.fromUnitToUnitFactor( navigation.distanceUnits, projectInfo.distanceUnits ), 3, projectInfo.distanceUnits ) )
-                 : qsTr( "N/A" ) )
+
+          Text {
+            Layout.fillWidth: false
+            font: Theme.tipFont
+            color: Theme.secondaryTextColor
+            text: qsTr("Dist.")
+          }
+
+          Text {
+            Layout.fillWidth: true
+            font: Theme.tipFont
+            color: textColor
+            text:  positionSource.active && positionSource.positionInformation && positionSource.positionInformation.latitudeValid
+                   ? UnitTypes.formatDistance( navigation.distance * UnitTypes.fromUnitToUnitFactor( navigation.distanceUnits, projectInfo.distanceUnits ), 3, projectInfo.distanceUnits )
+                   : qsTr( "N/A" )
+          }
         }
       }
 
@@ -188,16 +220,26 @@ Rectangle {
         width: grid.cellWidth
         color: grid.rows == 2 ? alternateBackgroundColor : backgroundColor
 
-        Text {
+        RowLayout {
           anchors.margins: cellPadding
           anchors.verticalCenter: parent.verticalCenter
           anchors.left: parent.left
-          font: Theme.tipFont
-          color: textColor
-          text: qsTr( "Bearing" ) + ': ' +
-                ( positionSource.active && positionSource.positionInformation && positionSource.positionInformation.latitudeValid
-                 ? ( Number( navigation.bearing ).toLocaleString( Qt.locale(), 'f', 1 ) ) + '°'
-                 : qsTr( "N/A" ) )
+
+          Text {
+            Layout.fillWidth: false
+            font: Theme.tipFont
+            color: Theme.secondaryTextColor
+            text: qsTr("Bearing")
+          }
+
+          Text {
+            Layout.fillWidth: true
+            font: Theme.tipFont
+            color: textColor
+            text: positionSource.active && positionSource.positionInformation && positionSource.positionInformation.latitudeValid
+                  ? Number( navigation.bearing ).toLocaleString( Qt.locale(), 'f', 1 ) + '°'
+                  : qsTr( "N/A" )
+          }
         }
       }
     }

--- a/src/qml/PositioningInformationView.qml
+++ b/src/qml/PositioningInformationView.qml
@@ -43,21 +43,32 @@ Rectangle {
       width: grid.cellWidth
       color: alternateBackgroundColor
 
-      Text {
+      RowLayout {
         anchors.margins: cellPadding
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
-        font: Theme.tipFont
-        color: textColor
-        text: coordinatesIsXY
-              ? (coordinatesIsGeographic ? qsTr( "Lon" ) : qsTr( "X" )) + ': '
-                + ( positionSource.positionInformation && positionSource.positionInformation.longitudeValid
-                   ? Number( coordinates.x ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
-                   : qsTr( "N/A" ) )
-              : (coordinatesIsGeographic ? qsTr( "Lat" ) : qsTr( "Y" )) + ': '
-                + ( positionSource.positionInformation && positionSource.positionInformation.latitudeValid
-                   ? Number( coordinates.y ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
-                   : qsTr( "N/A" ) )
+
+        Text {
+          Layout.fillWidth: false
+          font: Theme.tipFont
+          color: Theme.secondaryTextColor
+          text: coordinatesIsXY
+                ? coordinatesIsGeographic ? qsTr( "Lon" ) : qsTr( "X" )
+                : coordinatesIsGeographic ? qsTr( "Lat" ) : qsTr( "Y" )
+        }
+
+        Text {
+          Layout.fillWidth: true
+          font: Theme.tipFont
+          color: textColor
+          text: coordinatesIsXY
+                ? positionSource.positionInformation && positionSource.positionInformation.longitudeValid
+                  ? Number( coordinates.x ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
+                  : qsTr( "N/A" )
+                : positionSource.positionInformation && positionSource.positionInformation.latitudeValid
+                  ? Number( coordinates.y ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
+                  : qsTr( "N/A" )
+        }
       }
     }
 
@@ -66,22 +77,34 @@ Rectangle {
       width: grid.cellWidth
       color: backgroundColor
 
-      Text {
+      RowLayout {
         anchors.margins: cellPadding
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
-        font: Theme.tipFont
-        color: textColor
-        text: coordinatesIsXY
-              ? (coordinatesIsGeographic ? qsTr( "Lat" ) : qsTr( "Y" )) + ': '
-                + ( positionSource.positionInformation && positionSource.positionInformation.longitudeValid
-                   ? Number( coordinates.y ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
-                   : qsTr( "N/A" ) )
-              : (coordinatesIsGeographic ? qsTr( "Lon" ) : qsTr( "X" )) + ': '
-                + ( positionSource.positionInformation && positionSource.positionInformation.latitudeValid
-                   ? Number( coordinates.x ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
-                   : qsTr( "N/A" ) )
 
+        Text {
+          Layout.fillWidth: false
+          font: Theme.tipFont
+          color: Theme.secondaryTextColor
+          text: coordinatesIsXY
+                ? coordinatesIsGeographic ? qsTr( "Lat" ) : qsTr( "Y" )
+                : coordinatesIsGeographic ? qsTr( "Lon" ) : qsTr( "X" )
+
+        }
+
+        Text {
+          Layout.fillWidth: true
+          font: Theme.tipFont
+          color: textColor
+          text: coordinatesIsXY
+                ? positionSource.positionInformation && positionSource.positionInformation.longitudeValid
+                  ? Number( coordinates.y ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
+                  : qsTr( "N/A" )
+                : positionSource.positionInformation && positionSource.positionInformation.latitudeValid
+                  ? Number( coordinates.x ).toLocaleString( Qt.locale(), 'f', coordinatesIsGeographic ? 7 : 3 )
+                  : qsTr( "N/A" )
+
+        }
       }
     }
 
@@ -89,34 +112,46 @@ Rectangle {
       height: cellHeight
       width: grid.cellWidth
       color: grid.rows === 2 ? backgroundColor : alternateBackgroundColor
-      Text {
+
+      RowLayout {
         anchors.margins: cellPadding
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
-        font: Theme.tipFont
-        color: textColor
-        text: {
-          var altitude = qsTr( "Altitude" ) + ': '
-          if (positionSource.positionInformation && positionSource.positionInformation.elevationValid) {
-            altitude += Number(positionSource.projectedPosition.z * distanceUnitFactor).toLocaleString(Qt.locale(), 'f', 3) + ' ' + distanceUnitAbbreviation + ' '
-            var details = []
-            if (positionSource.elevationCorrectionMode === Positioning.ElevationCorrectionMode.OrthometricFromGeoidFile) {
-              details.push('grid')
-            } else if (positionSource.elevationCorrectionMode === Positioning.ElevationCorrectionMode.OrthometricFromDevice) {
-              details.push('ortho.')
+
+        Text {
+          Layout.fillWidth: false
+          font: Theme.tipFont
+          color: Theme.secondaryTextColor
+          text: qsTr("Altitude")
+        }
+
+        Text {
+          Layout.fillWidth: true
+          font: Theme.tipFont
+          color: textColor
+          text: {
+            var altitude = ''
+            if (positionSource.positionInformation && positionSource.positionInformation.elevationValid) {
+              altitude += Number(positionSource.projectedPosition.z * distanceUnitFactor).toLocaleString(Qt.locale(), 'f', 3) + ' ' + distanceUnitAbbreviation + ' '
+              var details = []
+              if (positionSource.elevationCorrectionMode === Positioning.ElevationCorrectionMode.OrthometricFromGeoidFile) {
+                details.push('grid')
+              } else if (positionSource.elevationCorrectionMode === Positioning.ElevationCorrectionMode.OrthometricFromDevice) {
+                details.push('ortho.')
+              }
+              if (!isNaN(parseFloat(antennaHeight))) {
+                details.push('ant.')
+              }
+              if (details.length > 0) {
+                altitude += ' (%1)'.arg( details.join(', '))
+              }
             }
-            if (!isNaN(parseFloat(antennaHeight))) {
-              details.push('ant.')
+            else
+            {
+              altitude += qsTr('N/A');
             }
-            if (details.length > 0) {
-              altitude += ' (%1)'.arg( details.join(', '))
-            }
+            return altitude
           }
-          else
-          {
-            altitude += qsTr('N/A');
-          }
-          return altitude
         }
       }
     }
@@ -126,13 +161,26 @@ Rectangle {
       width: grid.cellWidth
       color: grid.rows === 2 ? alternateBackgroundColor : backgroundColor
 
-      Text {
+      RowLayout {
         anchors.margins: cellPadding
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
-        font: Theme.tipFont
-        color: textColor
-        text: qsTr( "Speed" ) + ': ' + ( positionSource.positionInformation && positionSource.positionInformation.speedValid ? positionSource.positionInformation.speed.toLocaleString(Qt.locale(), 'f', 3) + " m/s" : qsTr( "N/A" ) )
+
+        Text {
+          Layout.fillWidth: false
+          font: Theme.tipFont
+          color: Theme.secondaryTextColor
+          text: qsTr("Speed")
+        }
+
+        Text {
+          Layout.fillWidth: true
+          font: Theme.tipFont
+          color: textColor
+          text: positionSource.positionInformation && positionSource.positionInformation.speedValid
+                ? positionSource.positionInformation.speed.toLocaleString(Qt.locale(), 'f', 3) + " m/s"
+                : qsTr( "N/A" )
+        }
       }
     }
 
@@ -141,15 +189,26 @@ Rectangle {
       width: grid.cellWidth
       color: grid.rows === 4 ? backgroundColor : alternateBackgroundColor
 
-      Text {
+      RowLayout {
         anchors.margins: cellPadding
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
-        font: Theme.tipFont
-        color: textColor
-        text: qsTr("H. Accuracy") + ': ' + (positionSource.positionInformation && positionSource.positionInformation.haccValid
-                                            ? Number(positionSource.positionInformation.hacc * distanceUnitFactor).toLocaleString(Qt.locale(), 'f', 3) + ' ' + distanceUnitAbbreviation
-                                            : qsTr("N/A"))
+
+        Text {
+          Layout.fillWidth: false
+          font: Theme.tipFont
+          color: Theme.secondaryTextColor
+          text: qsTr("H. Accuracy")
+        }
+
+        Text {
+          Layout.fillWidth: true
+          font: Theme.tipFont
+          color: textColor
+          text: positionSource.positionInformation && positionSource.positionInformation.haccValid
+                ? Number(positionSource.positionInformation.hacc * distanceUnitFactor).toLocaleString(Qt.locale(), 'f', 3) + ' ' + distanceUnitAbbreviation
+                : qsTr("N/A")
+        }
       }
     }
 
@@ -158,15 +217,26 @@ Rectangle {
       width: grid.cellWidth
       color: grid.rows === 4 ? alternateBackgroundColor : backgroundColor
 
-      Text {
+      RowLayout {
         anchors.margins: cellPadding
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
-        font: Theme.tipFont
-        color: textColor
-        text: qsTr( "V. Accuracy" ) + ': ' + (positionSource.positionInformation && positionSource.positionInformation.vaccValid
-                                              ? Number(positionSource.positionInformation.vacc * distanceUnitFactor).toLocaleString(Qt.locale(), 'f', 3) + ' ' + distanceUnitAbbreviation
-                                              : qsTr("N/A"))
+
+        Text {
+          Layout.fillWidth: false
+          font: Theme.tipFont
+          color: Theme.secondaryTextColor
+          text: qsTr("V. Accuracy")
+        }
+
+        Text {
+          Layout.fillWidth: true
+          font: Theme.tipFont
+          color: textColor
+          text: positionSource.positionInformation && positionSource.positionInformation.vaccValid
+                ? Number(positionSource.positionInformation.vacc * distanceUnitFactor).toLocaleString(Qt.locale(), 'f', 3) + ' ' + distanceUnitAbbreviation
+                : qsTr("N/A")
+        }
       }
     }
 
@@ -176,16 +246,26 @@ Rectangle {
       color: grid.rows % 2 === 0 ? backgroundColor : alternateBackgroundColor
       visible: positionSource.deviceId !== ''
 
-      Text {
+      RowLayout {
         anchors.margins: cellPadding
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
-        font: Theme.tipFont
-        color: textColor
-        text: qsTr( "PDOP" ) + ': ' +
-              (positionSource.positionInformation && !isNaN(positionSource.positionInformation.pdop)
-               ? positionSource.positionInformation.pdop.toLocaleString(Qt.locale(), 'f', 1)
-               : qsTr('N/A'))
+
+        Text {
+          Layout.fillWidth: false
+          font: Theme.tipFont
+          color: Theme.secondaryTextColor
+          text: qsTr("PDOP")
+        }
+
+        Text {
+          Layout.fillWidth: true
+          font: Theme.tipFont
+          color: textColor
+          text: positionSource.positionInformation && !isNaN(positionSource.positionInformation.pdop)
+                ? positionSource.positionInformation.pdop.toLocaleString(Qt.locale(), 'f', 1)
+                : qsTr('N/A')
+        }
       }
     }
 
@@ -195,16 +275,26 @@ Rectangle {
       color: grid.rows % 2 === 0 ? alternateBackgroundColor : backgroundColor
       visible: positionSource.deviceId !== ''
 
-      Text {
+      RowLayout {
         anchors.margins: cellPadding
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
-        font: Theme.tipFont
-        color: textColor
-        text: qsTr( "HDOP" ) + ': ' +
-              (positionSource.positionInformation && !isNaN(positionSource.positionInformation.hdop)
-               ? positionSource.positionInformation.hdop.toLocaleString(Qt.locale(), 'f', 1)
-               : qsTr('N/A'))
+
+        Text {
+          Layout.fillWidth: false
+          font: Theme.tipFont
+          color: Theme.secondaryTextColor
+          text: qsTr("HDOP")
+        }
+
+        Text {
+          Layout.fillWidth: true
+          font: Theme.tipFont
+          color: textColor
+          text: positionSource.positionInformation && !isNaN(positionSource.positionInformation.hdop)
+                ? positionSource.positionInformation.hdop.toLocaleString(Qt.locale(), 'f', 1)
+                : qsTr('N/A')
+        }
       }
     }
 
@@ -214,16 +304,26 @@ Rectangle {
       color: grid.rows === 6 ? backgroundColor : alternateBackgroundColor
       visible: positionSource.deviceId !== ''
 
-      Text {
+      RowLayout {
         anchors.margins: cellPadding
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
-        font: Theme.tipFont
-        color: textColor
-        text: qsTr( "VDOP" ) + ': ' +
-              (positionSource.positionInformation && !isNaN(positionSource.positionInformation.vdop)
-               ? positionSource.positionInformation.vdop.toLocaleString(Qt.locale(), 'f', 1)
-               : qsTr('N/A'))
+
+        Text {
+          Layout.fillWidth: false
+          font: Theme.tipFont
+          color: Theme.secondaryTextColor
+          text: qsTr("VDOP")
+        }
+
+        Text {
+          Layout.fillWidth: true
+          font: Theme.tipFont
+          color: textColor
+          text: positionSource.positionInformation && !isNaN(positionSource.positionInformation.vdop)
+                ? positionSource.positionInformation.vdop.toLocaleString(Qt.locale(), 'f', 1)
+                : qsTr('N/A')
+        }
       }
     }
 
@@ -233,13 +333,24 @@ Rectangle {
       color: grid.rows === 6 ? alternateBackgroundColor : backgroundColor
       visible: positionSource.deviceId !== ''
 
-      Text {
+      RowLayout {
         anchors.margins: cellPadding
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
-        font: Theme.tipFont
-        color: textColor
-        text: qsTr( "Valid" ) + ': ' + ( positionSource.positionInformation && positionSource.positionInformation.isValid ? 'True' : 'False' )
+
+        Text {
+          Layout.fillWidth: false
+          font: Theme.tipFont
+          color: Theme.secondaryTextColor
+          text: qsTr("Valid")
+        }
+
+        Text {
+          Layout.fillWidth: true
+          font: Theme.tipFont
+          color: textColor
+          text: positionSource.positionInformation && positionSource.positionInformation.isValid ? 'True' : 'False'
+        }
       }
     }
 
@@ -249,13 +360,24 @@ Rectangle {
       color: grid.rows === 2 || grid.rows === 6 ? backgroundColor : alternateBackgroundColor
       visible: positionSource.deviceId !== ''
 
-      Text {
+      RowLayout {
         anchors.margins: cellPadding
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
-        font: Theme.tipFont
-        color: textColor
-        text: qsTr( "Fix" ) + ': ' + ( positionSource.positionInformation ? positionSource.positionInformation.fixStatusDescription : qsTr('N/A') )
+
+        Text {
+          Layout.fillWidth: false
+          font: Theme.tipFont
+          color: Theme.secondaryTextColor
+          text: qsTr("Fix")
+        }
+
+        Text {
+          Layout.fillWidth: true
+          font: Theme.tipFont
+          color: textColor
+          text: positionSource.positionInformation ? positionSource.positionInformation.fixStatusDescription : qsTr('N/A')
+        }
       }
     }
 
@@ -265,13 +387,24 @@ Rectangle {
       color: grid.rows === 2 || grid.rows === 6 ? alternateBackgroundColor : backgroundColor
       visible: positionSource.deviceId !== ''
 
-      Text {
+      RowLayout {
         anchors.margins: cellPadding
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
-        font: Theme.tipFont
-        color: textColor
-        text: qsTr( "Quality" ) + ': ' + ( positionSource.positionInformation ? positionSource.positionInformation.qualityDescription : qsTr('N/A') )
+
+        Text {
+          Layout.fillWidth: false
+          font: Theme.tipFont
+          color: Theme.secondaryTextColor
+          text: qsTr("Quality")
+        }
+
+        Text {
+          Layout.fillWidth: true
+          font: Theme.tipFont
+          color: textColor
+          text: positionSource.positionInformation ? positionSource.positionInformation.qualityDescription : qsTr('N/A')
+        }
       }
     }
   }

--- a/src/qml/SensorInformationView.qml
+++ b/src/qml/SensorInformationView.qml
@@ -48,17 +48,28 @@ Rectangle {
       height: grid.cellHeight
       color: index % 2 == 0 ? sensorInformationView.alternateBackgroundColor : sensorInformationView.backgroundColor
 
-      Text {
+      RowLayout {
         anchors.margins: cellPadding
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
-        width: grid.cellWidth - 20
-        height: grid.cellHeight - 20
-        font: Theme.tipFont
-        color: sensorInformationView.textColor
-        text: SensorName + ': ' + (SensorLastValue ? (SensorLastValue + '').trim() : 'N/A')
-        verticalAlignment: Text.AlignVCenter
-        elide: Text.ElideRight
+
+        Text {
+          Layout.fillWidth: false
+          font: Theme.tipFont
+          color: Theme.secondaryTextColor
+          text: SensorName
+        }
+
+        Text {
+          Layout.fillWidth: true
+          width: grid.cellWidth - 20
+          height: grid.cellHeight - 20
+          font: Theme.tipFont
+          color: sensorInformationView.textColor
+          text: SensorLastValue ? (SensorLastValue + '').trim() : qsTr( "N/A" )
+          verticalAlignment: Text.AlignVCenter
+          elide: Text.ElideRight
+        }
       }
     }
   }


### PR DESCRIPTION
This allows us to have an harmonized looks with other information overlays. Proof of life:

![image](https://github.com/opengisch/QField/assets/1728657/65435c9b-471a-462c-8022-de6f2775f08f)

The PR also further tweaks the positioning/navigation/sensors panel to have the values stand out more against their labels. In action:

![image](https://github.com/opengisch/QField/assets/1728657/bc168980-c560-42bc-b5c1-1d16b0adb6e0)

@m-kuhn , I think that's what you were requesting right? Looking good :)