### PR TITLE
Add remaining properties needed to unlock beautiful dark theme support to the elevation profile canvas

### DIFF
--- a/src/core/qgsquick/qgsquickelevationprofilecanvas.h
+++ b/src/core/qgsquick/qgsquickelevationprofilecanvas.h
@@ -37,6 +37,8 @@ class QgsQuickElevationProfileCanvas : public QQuickItem
     Q_PROPERTY( QgsGeometry profileCurve READ profileCurve WRITE setProfileCurve NOTIFY profileCurveChanged )
     Q_PROPERTY( double tolerance READ tolerance WRITE setTolerance NOTIFY toleranceChanged )
 
+    Q_PROPERTY( QColor backgroundColor READ backgroundColor WRITE setBackgroundColor NOTIFY backgroundColorChanged )
+    Q_PROPERTY( QColor borderColor READ borderColor WRITE setBorderColor NOTIFY borderColorChanged )
     Q_PROPERTY( QColor axisLabelColor READ axisLabelColor WRITE setAxisLabelColor NOTIFY axisLabelColorChanged )
     Q_PROPERTY( double axisLabelSize READ axisLabelSize WRITE setAxisLabelSize NOTIFY axisLabelSizeChanged )
 
@@ -170,6 +172,34 @@ class QgsQuickElevationProfileCanvas : public QQuickItem
     QgsDoubleRange visibleElevationRange() const;
 
     /**
+     * Returns the background color used when rendering the elevation profile.
+     *
+     * \see setBackgroundColor
+     */
+    QColor backgroundColor() const;
+
+    /**
+     * Sets the background color used when rendering the elevation profile.
+     *
+     * \see backgroundColor
+     */
+    void setBackgroundColor( const QColor &color );
+
+    /**
+     * Returns the border color used when rendering the elevation profile.
+     *
+     * \see setBorderColor
+     */
+    QColor borderColor() const;
+
+    /**
+     * Sets the border color used when rendering the elevation profile.
+     *
+     * \see borderColor
+     */
+    void setBorderColor( const QColor &color );
+
+    /**
      * Returns the axis label color used when rendering the elevation profile.
      *
      * \see setAxisLabelColor
@@ -217,6 +247,12 @@ class QgsQuickElevationProfileCanvas : public QQuickItem
     //! \copydoc QgsQuickMapCanvasMap::isRendering
     void isRenderingChanged();
 
+    //! Emitted when the background color changes.
+    void backgroundColorChanged();
+
+    //! Emitted when the border color changes.
+    void borderColorChanged();
+
     //! Emitted when the axis label color changes.
     void axisLabelColorChanged();
 
@@ -262,7 +298,7 @@ class QgsQuickElevationProfileCanvas : public QQuickItem
 
   private:
     void setupLayerConnections( QgsMapLayer *layer, bool isDisconnect );
-    void updateAxisLabelStyle();
+    void updateStyle();
 
     QgsCoordinateReferenceSystem mCrs;
     QgsProject *mProject = nullptr;
@@ -292,6 +328,8 @@ class QgsQuickElevationProfileCanvas : public QQuickItem
 
     bool mDirty = false;
 
+    QColor mBackgroundColor = QColor( 255, 255, 255 );
+    QColor mBorderColor = QColor( 0, 0, 0 );
     QColor mAxisLabelColor = QColor( 0, 0, 0 );
     double mAxisLabelSize = 16;
 };

--- a/src/qml/ElevationProfile.qml
+++ b/src/qml/ElevationProfile.qml
@@ -38,7 +38,9 @@ Rectangle {
 
     tolerance: crs.isGeographic ? 0.00005 : 5
 
-    axisLabelColor: Theme.mainTextColor
+    backgroundColor: Theme.mainBackgroundColorSemiOpaque
+    borderColor: Theme.controlBackgroundAlternateColor
+    axisLabelColor: Theme.secondaryTextColor
     axisLabelSize: Theme.tipFont
   }
 


### PR DESCRIPTION
Light theme:
![Screenshot from 2024-05-21 16-39-39](https://github.com/opengisch/QField/assets/1728657/3e5be2ee-6ebc-49ac-b196-a26cd3823d3b)

Dark theme:
![Screenshot from 2024-05-21 16-39-25](https://github.com/opengisch/QField/assets/1728657/4d58d0bf-6e57-435a-be66-83e8ed51f7a0)
