### PR TITLE
Fix wrong usage of 'exclude' for the clang-tidy CI check

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           build_dir: "build"
           lgtm_comment_body: ''
-          exclude: 'cppcoreguidelines-avoid-magic-numbers,bugprone-easily-swappable-parameters,misc-non-private-member-variables-in-classes,cppcoreguidelines-macro-usage,readability-braces-around-statements,readability-implicit-bool-conversion,cppcoreguidelines-avoid-magic-numbers'
+          clang_tidy_checks: '-*,performance-*,bugprone-*,clang-analyzer-*,mpi-*,misc-*'
 
       - name: Package
         run: |


### PR DESCRIPTION
The exclude parameter covers files, not check names. I've tried to come up with a narrower set of checks to insure we actually look at what's being told to us vs. ignoring :)