### PR TITLE
Lock map rotation

### DIFF
--- a/src/qml/MapCanvas.qml
+++ b/src/qml/MapCanvas.qml
@@ -422,7 +422,7 @@ Item {
       }
 
       onRotationChanged: {
-          if ( active )
+          if ( active && isMapRotationEnabled )
           {
               if (rotationTresholdReached)
               {

--- a/src/qml/MapCanvas.qml
+++ b/src/qml/MapCanvas.qml
@@ -35,6 +35,7 @@ Item {
   property bool hovered: false
   property bool pinched: pinchHandler.active
   property bool freehandDigitizing: false
+  property bool isMapRotationEnabled: false
 
   // for signals, type can be "stylus" for any device click or "touch"
 
@@ -346,7 +347,7 @@ Item {
 
   DragHandler {
     target: null
-    enabled: interactive
+    enabled: interactive && isMapRotationEnabled
     acceptedDevices: PointerDevice.Stylus | PointerDevice.Mouse
     acceptedModifiers: Qt.ShiftModifier
     grabPermissions: PointerHandler.TakeOverForbidden

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -82,7 +82,7 @@ Page {
       }
       ListElement {
         title: qsTr( "Enable map rotation" )
-        description: qsTr( "When switched on, user allow's to rotate map." )
+        description: qsTr( "When switched on, the map can be rotated by the user." )
         settingAlias: "enableMapRotation"
         isVisible: true
       }

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -23,6 +23,7 @@ Page {
   property alias fingerTapDigitizing: registry.fingerTapDigitizing
   property alias mouseAsTouchScreen: registry.mouseAsTouchScreen
   property alias enableInfoCollection: registry.enableInfoCollection
+  property alias enableMapRotation: registry.enableMapRotation
   property alias quality: registry.quality
 
   Component.onCompleted: {
@@ -45,6 +46,7 @@ Page {
     property bool fingerTapDigitizing: false
     property bool mouseAsTouchScreen: false
     property bool enableInfoCollection: true
+    property bool enableMapRotation: true
     property double quality: 1.0
 
     onEnableInfoCollectionChanged: {
@@ -77,6 +79,12 @@ Page {
           description: qsTr( "When switched on, user's saved and currently opened project bookmarks will be displayed on the map." )
           settingAlias: "showBookmarks"
           isVisible: true
+      }
+      ListElement {
+        title: qsTr( "Enable map rotation" )
+        description: qsTr( "When switched on, user allow's to rotate map." )
+        settingAlias: "enableMapRotation"
+        isVisible: true
       }
   }
 

--- a/src/qml/imports/Theme/Theme.qml
+++ b/src/qml/imports/Theme/Theme.qml
@@ -77,9 +77,9 @@ QtObject {
 
     readonly property int popupScreenEdgeMargin: 40
 
-    readonly property int menuItemIconlessLeftPadding: 54
-    readonly property int menuItemLeftPadding: 14
-    readonly property int menuItemCheckLeftPadding: 20
+    readonly property int menuItemIconlessLeftPadding: 52
+    readonly property int menuItemLeftPadding: 12
+    readonly property int menuItemCheckLeftPadding: 16
 
     function getThemeIcon(name) {
       var ppiName

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2727,6 +2727,19 @@ ApplicationWindow {
       }
     }
 
+    MenuItem {
+      id: lockMapRotation
+      text: mapCanvasMap.isMapRotationEnabled? "Lock map rotation": "Unlock map rotation"
+      height: 48
+      leftPadding: Theme.menuItemLeftPadding
+      font: Theme.defaultFont
+      icon.source: mapCanvasMap.isMapRotationEnabled? Theme.getThemeVectorIcon( "ic_dissatisfied_white_24dp" ): Theme.getThemeIcon( "ic_copy_black_24dp" )
+
+      onTriggered: {
+        mapCanvasMap.isMapRotationEnabled = !mapCanvasMap.isMapRotationEnabled
+      }
+    }
+
     MenuSeparator { width: parent.width }
 
     MenuItem {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2736,6 +2736,11 @@ ApplicationWindow {
       font: Theme.defaultFont
       checkable: true
       checked: qfieldSettings.enableMapRotation
+      indicator.height: 20
+      indicator.width: 20
+      indicator.implicitHeight: 24
+      indicator.implicitWidth: 24
+
       onTriggered: qfieldSettings.enableMapRotation = checked
     }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2730,15 +2730,13 @@ ApplicationWindow {
 
     MenuItem {
       id: lockMapRotation
-      text: mapCanvasMap.isMapRotationEnabled? "Lock map rotation": "Unlock map rotation"
+      text: "Enable Map Rotation"
       height: 48
-      leftPadding: Theme.menuItemLeftPadding
+      leftPadding: Theme.menuItemCheckLeftPadding
       font: Theme.defaultFont
-      icon.source: mapCanvasMap.isMapRotationEnabled? Theme.getThemeVectorIcon( "ic_dissatisfied_white_24dp" ): Theme.getThemeIcon( "ic_copy_black_24dp" )
-
-      onTriggered: {
-        qfieldSettings.enableMapRotation = !qfieldSettings.enableMapRotation
-      }
+      checkable: true
+      checked: qfieldSettings.enableMapRotation
+      onTriggered: qfieldSettings.enableMapRotation = checked
     }
 
     MenuSeparator { width: parent.width }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -455,6 +455,7 @@ ApplicationWindow {
                                !sketcher.visible &&
                                !overlayFeatureFormDrawer.visible
       interactive: isEnabled && !screenLocker.enabled
+      isMapRotationEnabled: qfieldSettings.enableMapRotation
       incrementalRendering: true
       quality: qfieldSettings.quality
       forceDeferredLayersRepaint: trackings.count > 0
@@ -2736,7 +2737,7 @@ ApplicationWindow {
       icon.source: mapCanvasMap.isMapRotationEnabled? Theme.getThemeVectorIcon( "ic_dissatisfied_white_24dp" ): Theme.getThemeIcon( "ic_copy_black_24dp" )
 
       onTriggered: {
-        mapCanvasMap.isMapRotationEnabled = !mapCanvasMap.isMapRotationEnabled
+        qfieldSettings.enableMapRotation = !qfieldSettings.enableMapRotation
       }
     }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2636,12 +2636,14 @@ ApplicationWindow {
       var xValue = Number( displayPoint.x ).toLocaleString( Qt.locale(), 'f', isGeographic ? 7 : 3 )
       var yLabel = isGeographic ? qsTr( 'Lat' ) : 'Y'
       var yValue = Number( displayPoint.y ).toLocaleString( Qt.locale(), 'f', isGeographic ? 7 : 3 )
-      xItem.text = isXY
+      let xItemText = isXY
                    ? xLabel + ': ' + xValue
                    : yLabel + ': ' + yValue
-      yItem.text = isXY
+      let yItemText = isXY
                    ? yLabel + ': ' + yValue
                    : xLabel + ': ' + xValue
+
+      cordinateItem.text = xItemText + "   " + yItemText
     }
 
     topMargin: sceneTopMargin
@@ -2675,19 +2677,18 @@ ApplicationWindow {
     MenuSeparator { width: parent.width; height: canvasMenuActionsToolbar.children.length > 0 ? undefined : 0 }
 
     MenuItem {
-        id: xItem
-        text: ""
-        height: 48
-        font: Theme.defaultFont
-        enabled:false
-    }
+      id: cordinateItem
+      text: ""
+      height: 48
+      leftPadding: Theme.menuItemLeftPadding
+      font: Theme.defaultFont
+      icon.source: Theme.getThemeVectorIcon( "ic_copy_black_24dp" )
 
-    MenuItem {
-        id: yItem
-        text: ""
-        height: 48
-        font: Theme.defaultFont
-        enabled:false
+      onTriggered: {
+        var displayPoint = GeometryUtils.reprojectPoint(canvasMenu.point, mapCanvas.mapSettings.destinationCrs, projectInfo.coordinateDisplayCrs)
+        platformUtilities.copyTextToClipboard(StringUtils.pointInformation(displayPoint, projectInfo.coordinateDisplayCrs))
+        displayToast(qsTr('Coordinates copied to clipboard'));
+      }
     }
 
     MenuSeparator { width: parent.width }
@@ -2723,21 +2724,6 @@ ApplicationWindow {
 
       onTriggered: {
         navigation.destination = canvasMenu.point
-      }
-    }
-
-    MenuItem {
-      id: copyCoordinatesItem
-      text: qsTr( "Copy Coordinates" )
-      height: 48
-      leftPadding: Theme.menuItemLeftPadding
-      font: Theme.defaultFont
-      icon.source: Theme.getThemeVectorIcon( "ic_copy_black_24dp" )
-
-      onTriggered: {
-        var displayPoint = GeometryUtils.reprojectPoint(canvasMenu.point, mapCanvas.mapSettings.destinationCrs, projectInfo.coordinateDisplayCrs)
-        platformUtilities.copyTextToClipboard(StringUtils.pointInformation(displayPoint, projectInfo.coordinateDisplayCrs))
-        displayToast(qsTr('Coordinates copied to clipboard'));
       }
     }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2637,10 +2637,10 @@ ApplicationWindow {
       var xValue = Number( displayPoint.x ).toLocaleString( Qt.locale(), 'f', isGeographic ? 7 : 3 )
       var yLabel = isGeographic ? qsTr( 'Lat' ) : 'Y'
       var yValue = Number( displayPoint.y ).toLocaleString( Qt.locale(), 'f', isGeographic ? 7 : 3 )
-      let xItemText = isXY
+      const xItemText = isXY
                    ? xLabel + ': ' + xValue
                    : yLabel + ': ' + yValue
-      let yItemText = isXY
+      const yItemText = isXY
                    ? yLabel + ': ' + yValue
                    : xLabel + ': ' + xValue
 
@@ -2686,7 +2686,7 @@ ApplicationWindow {
       icon.source: Theme.getThemeVectorIcon( "ic_copy_black_24dp" )
 
       onTriggered: {
-        var displayPoint = GeometryUtils.reprojectPoint(canvasMenu.point, mapCanvas.mapSettings.destinationCrs, projectInfo.coordinateDisplayCrs)
+        const displayPoint = GeometryUtils.reprojectPoint(canvasMenu.point, mapCanvas.mapSettings.destinationCrs, projectInfo.coordinateDisplayCrs)
         platformUtilities.copyTextToClipboard(StringUtils.pointInformation(displayPoint, projectInfo.coordinateDisplayCrs))
         displayToast(qsTr('Coordinates copied to clipboard'));
       }


### PR DESCRIPTION
So in this PR i am going to add an option that enables or disables the mapRotation, so if user don't wants rotation it wont rotate accidentally.   
  
**In first step** I merged 3 rows in `canvasMenu`. previously there was 3 row showing X, Y, Copy coordinates. Now we show all the info in one row.    
  
**In second step** I also added this option in Settings page.
    
### Previous: 
![image](https://github.com/opengisch/QField/assets/36326627/62ede4d4-0f6a-4c63-a191-30470fda13b0)


### Current:   
![image](https://github.com/opengisch/QField/assets/36326627/a98c217a-e42a-4917-a81e-5051736a613b)


### Settings:   
![image](https://github.com/opengisch/QField/assets/36326627/eb216d4d-8837-4f95-ae3e-c6e599db2ae9)

