### PR TITLE
WIP Button interface for value map

### DIFF
--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -21,13 +21,65 @@ EditorWidgetBase {
   // Workaround to get a signal when the value has changed
   onCurrentKeyValueChanged: {
     comboBox.currentIndex = comboBox.model.keyToIndex(currentKeyValue)
+
+    console.log("->", currentKeyValue)
   }
 
   height: childrenRect.height
   enabled: isEnabled
 
+  states: [
+    // showing QfToggleButton without search
+    State {
+      name: "individualItemView"
+      PropertyChanges {
+        target: toggleButtons
+        visible: true
+      }
+      PropertyChanges {
+        target: comboBox
+        visible: false
+      }
+    },
+    // showing ComboBox with search option
+    State {
+      name: "comboBoxItemView"
+      PropertyChanges {
+        target: toggleButtons
+        visible: false
+      }
+      PropertyChanges {
+        target: comboBox
+        visible: true
+      }
+    }
+  ]
+
+  // TODO: after testing use this condition: [currentItemCount >= minimumItemCount] and remove testSwitch
+  state: testSwitch ? "comboBoxItemView": "individualItemView"
+
+  // Using the search and comboBox when there are less than X items in the dropdown proves to be poor UI on normally
+  // sized and oriented phones. Some empirical tests proved 6 to be a good number for now.
+  readonly property int minimumItemCount: 6
+  property real currentItemCount: comboBox.count
+  property bool testSwitch: true
+
+
   RowLayout {
     anchors { left: parent.left; right: parent.right }
+
+    Button{
+      text: "tst"
+      onClicked:{
+        testSwitch = !testSwitch
+      }
+    }
+
+    QfToggleButtons{
+      id: toggleButtons
+      Layout.fillWidth: true
+      Layout.minimumHeight: visible? 200: 0
+    }
 
     ComboBox {
       id: comboBox
@@ -120,10 +172,6 @@ EditorWidgetBase {
 
         Layout.preferredWidth: enabled ? 48 : 0
         Layout.preferredHeight: 48
-
-        // Using the search when there are less than X items in the dropdown proves to be poor UI on normally
-        // sized and oriented phones. Some empirical tests proved 6 to be a good number for now.
-        readonly property int minimumItemCount: 6
 
         bgcolor: "transparent"
         iconSource: Theme.getThemeIcon("ic_baseline_search_black")

--- a/src/qml/imports/Theme/QfRipple.qml
+++ b/src/qml/imports/Theme/QfRipple.qml
@@ -1,0 +1,118 @@
+// used: https://github.com/rschiang/material/blob/master/qml/material/PaperRipple.qml
+
+import QtQuick 2.14
+import Qt5Compat.GraphicalEffects
+
+Item {
+  id: control
+  anchors.fill: parent
+
+  property alias radius: mask.radius
+  property color color: "#de000000"
+  property alias mouseArea: connections.target
+
+  Rectangle {
+    id: mask
+    anchors.fill: parent
+    color: "black"
+    visible: false
+  }
+
+  Item {
+    id: container
+    anchors.fill: parent
+    visible: false
+  }
+
+  OpacityMask {
+    anchors.fill: parent
+    source: container
+    maskSource: mask
+  }
+
+  Component {
+    id: ripple
+
+    Rectangle {
+      id: ink
+      radius: 0
+      opacity: 0.25
+      color: control.color
+      property int startX
+      property int startY
+      property int maxRadius: 150
+
+      x: startX - radius
+      y: startY - radius
+      width: radius * 2
+      height: radius * 2
+
+      NumberAnimation {
+        id: growAnimation
+        target: ink
+        property: "radius"
+        from: 0
+        to: maxRadius
+        duration: 550
+        easing.type: Easing.OutCubic
+      }
+
+      SequentialAnimation {
+        id: fadeAnimation
+        NumberAnimation {
+          target: ink
+          property: "opacity"
+          from: 0.25
+          to: 0
+          duration: 312
+        }
+        ScriptAction {
+          script: ink.destroy()
+        }
+      }
+
+      Connections {
+        target: mouseArea
+        function onReleased() {
+          fadeIfApplicable()
+        }
+        function onExited() {
+          fadeIfApplicable()
+        }
+        function onCanceled() {
+          fadeIfApplicable()
+        }
+      }
+
+      Component.onCompleted: {
+        growAnimation.start()
+        if (!(mouseArea.pressed || fadeAnimation.running))
+          fadeAnimation.start()
+      }
+
+      function fadeIfApplicable() {
+        if (!fadeAnimation.running)
+          fadeAnimation.start()
+      }
+    }
+  }
+
+  Connections {
+    id: connections
+    function onPressed() {
+      var wave = ripple.createObject(container, {
+                                       "startX": target.mouseX,
+                                       "startY": target.mouseY,
+                                       "maxRadius": furthestDistance(target.mouseX, target.mouseY)
+                                     })
+    }
+  }
+
+  function distance(x1, y1, x2, y2) {
+    return Math.sqrt(Math.pow(x1 - x2, 2) + Math.pow(y1 - y2, 2))
+  }
+
+  function furthestDistance(x, y) {
+    return Math.max(distance(x, y, 0, 0), distance(x, y, width, height), distance(x, y, 0, height), distance(x, y, width, 0))
+  }
+}

--- a/src/qml/imports/Theme/QfToggleButtons.qml
+++ b/src/qml/imports/Theme/QfToggleButtons.qml
@@ -1,0 +1,21 @@
+import QtQuick
+
+Rectangle {
+  width: 200
+  height: 200
+  color: "green"
+
+  Flow{
+    anchors.fill: parent
+    spacing: 8
+    Repeater{
+      model: 20
+
+      Rectangle{
+        width: index * 5
+        height: 20
+        color: "red"
+      }
+    }
+  }
+}

--- a/src/qml/imports/Theme/QfToggleButtons.qml
+++ b/src/qml/imports/Theme/QfToggleButtons.qml
@@ -1,20 +1,77 @@
 import QtQuick
 
-Rectangle {
-  width: 200
-  height: 200
-  color: "green"
+Item {
+  id: controller
 
-  Flow{
-    anchors.fill: parent
+  property var model
+  property real selectedIndex: 0
+  property real contentHeight: flow.height
+  property string currentSelectedKey: ""
+  property string currentSelectedValue: ""
+
+  signal currentValueChanged
+
+  Flow {
+    id: flow
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.top: parent.top
     spacing: 8
-    Repeater{
-      model: 20
 
-      Rectangle{
-        width: index * 5
-        height: 20
-        color: "red"
+    Repeater {
+      id: repeater
+      model: controller.model
+
+      Rectangle {
+        id: item
+        width: txt.width + 16
+        height: 35
+        radius: 4
+
+        border.width: 1
+        border.color: selected ? Theme.mainColor : Theme.accentColor
+        color: selected ? Theme.mainColor : "transparent"
+
+        property bool selected: selectedIndex == index
+        property string key: Object.keys(modelData)[0]
+        property string value: modelData[key]
+
+        Component.onCompleted: {
+          if(selected){
+            currentSelectedKey = key
+            currentSelectedValue = value
+          }
+        }
+
+        Behavior on color {
+          ColorAnimation {
+            duration: 200
+          }
+        }
+
+        Text {
+          id: txt
+          text: key
+          anchors.centerIn: parent
+          font: Theme.defaultFont
+          color: Theme.mainTextColor
+
+        }
+
+        MouseArea {
+          anchors.fill: parent
+          onClicked: {
+            selectedIndex = index
+            currentSelectedKey = key
+            currentSelectedValue = value
+            currentValueChanged()
+          }
+
+          QfRipple {
+            mouseArea: parent
+            anchors.fill: parent
+          }
+        }
       }
     }
   }

--- a/src/qml/imports/Theme/qmldir
+++ b/src/qml/imports/Theme/qmldir
@@ -14,3 +14,5 @@ QfOpacityMask 1.0 QfOpacityMask.qml
 QfCalendarPanel 1.0 QfCalendarPanel.qml
 QfPageHeader 1.0 QfPageHeader.qml
 QfOverlayContainer 1.0 QfOverlayContainer.qml
+QfRipple 1.0 QfRipple.qml
+

--- a/src/qml/imports/Theme/qmldir
+++ b/src/qml/imports/Theme/qmldir
@@ -1,6 +1,7 @@
 module Theme
 singleton Theme 1.0 Theme.qml
 QfCloseButton 1.0 QfCloseButton.qml
+QfToggleButtons 1.0 QfToggleButtons.qml
 QfSlider 1.0 QfSlider.qml
 QfSwitch 1.0 QfSwitch.qml
 QfButton 1.0 QfButton.qml

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -75,6 +75,7 @@
         <file>Nyuki.qml</file>
         <file>LayerLoginDialog.qml</file>
         <file>imports/Theme/Theme.qml</file>
+        <file>imports/Theme/QfToggleButtons.qml</file>
         <file>imports/Theme/QfCloseButton.qml</file>
         <file>imports/Theme/QfDropShadow.qml</file>
         <file>imports/Theme/QfOpacityMask.qml</file>

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -90,6 +90,7 @@
         <file>imports/Theme/QfPageHeader.qml</file>
         <file>imports/Theme/QfOverlayContainer.qml</file>
         <file>imports/Theme/qmldir</file>
+        <file>imports/Theme/QfRipple.qml</file>
         <file>TrackerSettings.qml</file>
         <file>TrackingSession.qml</file>
         <file>EmbeddedFeatureForm.qml</file>


### PR DESCRIPTION
### In This PR we are going to modify `ValueMap.qml` ui.   
**Current design:** user select option with a comboBox and search is enabled when `minimumItemCount` is more than 6.     
  
**Note:** Number 6 is selected by some empirical tests.    
  
**New design:** for `ValueMap.qml`:   
if `minimumItemCount` < 6: display buttons and user can select between them
else show comboBox and search button.  

**Demo:**
[Screencast from 2024-05-25 21-02-17.webm](https://github.com/opengisch/QField/assets/36326627/0b4aa8a1-7ee7-4b30-b5db-7d08de332daa)

**TODO: (WIP)**   
- [ ] Remove `QfToggleButtons.qml`.    
- [ ] Clean Up codes.  