### PR TITLE
Adjust value map editor widget to be responsive to new qfieldsync configuration

### DIFF
--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -67,8 +67,10 @@ EditorWidgetBase {
 
   // Using the search and comboBox when there are less than X items in the dropdown proves to be poor UI on normally
   // sized and oriented phones. Some empirical tests proved 6 to be a good number for now.
-  readonly property int minimumItemCount: 6
-  state: currentItemCount >= minimumItemCount ? "comboBoxItemView" : "toggleButtonsView"
+  readonly property int toggleButtonsThreshold: currentLayer && currentLayer.customProperty('QFieldSync/value_map_button_interface_threshold') !== undefined
+                                                ? currentLayer.customProperty('QFieldSync/value_map_button_interface_threshold')
+                                                : 0
+  state: currentItemCount < toggleButtonsThreshold ? "toggleButtonsView" : "comboBoxItemView"
 
   property real currentItemCount: comboBox.count
 


### PR DESCRIPTION
Alright, this is the last bit needed to ship the nice new value map editor widget's toggle buttons UX:

![image](https://github.com/opengisch/QField/assets/1728657/971c0918-f1f4-44ff-88f6-46b58efc6103)

While I was hoping we could have a reasonable threshold to hard-code the switch between combo box and toggle buttons, I just tested a couple of projects, and the change is too disruptive to now make it an opt-in. 

In the future, I wouldn't be surprised to see QGIS implement the UX here, but for now let's rely on our beloved qfieldsync plugin.