### PR TITLE
Insure that the coordinate cursor center around non-obstructed area of the canvas

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -757,6 +757,7 @@ ApplicationWindow {
     CoordinateLocator {
       id: coordinateLocator
       anchors.fill: parent
+      anchors.bottomMargin: informationDrawer.height > mainWindow.sceneBottomMargin ? informationDrawer.height : 0
       visible: stateMachine.state === "digitize" || stateMachine.state === 'measure'
       highlightColor: digitizingToolbar.isDigitizing ? currentRubberband.color : "#CFD8DC"
       mapSettings: mapCanvas.mapSettings


### PR DESCRIPTION
Follow up to our great information overlay revamp: this fixes the coordinate cursor going _under_ the elevation profile panel or the positioning + navigation panels.