### PR TITLE
Fix snappingToAngle while editing geometry (reshape).

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -375,7 +375,11 @@ ApplicationWindow {
             } else {
                 if ( currentRubberband && currentRubberband.model.vertexCount > 1 ) {
                   coordinateLocator.sourceLocation = mapCanvas.mapSettings.coordinateToScreen( currentRubberband.model.lastCoordinate )
-                } else {
+                }
+                else if ( geometryEditorsToolbar.editorRubberbandModel && geometryEditorsToolbar.editorRubberbandModel.vertexCount > 1 ) {
+                  coordinateLocator.sourceLocation = mapCanvas.mapSettings.coordinateToScreen( geometryEditorsToolbar.editorRubberbandModel.lastCoordinate )
+                }
+                else {
                   coordinateLocator.sourceLocation = undefined
                 }
             }
@@ -764,7 +768,7 @@ ApplicationWindow {
       currentLayer: dashBoard.activeLayer
       positionInformation: positionSource.positionInformation
       positionLocked: positionSource.active && positioningSettings.positioningCoordinateLock
-      rubberbandModel: digitizingToolbar.rubberbandModel
+      rubberbandModel: geometryEditorsToolbar.stateVisible ? geometryEditorsToolbar.editorRubberbandModel : digitizingToolbar.rubberbandModel
       averagedPosition: positionSource.averagedPosition
       averagedPositionCount: positionSource.averagedPositionCount
       overrideLocation: positionLocked ? positionSource.projectedPosition : undefined

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -375,11 +375,9 @@ ApplicationWindow {
             } else {
                 if ( currentRubberband && currentRubberband.model.vertexCount > 1 ) {
                   coordinateLocator.sourceLocation = mapCanvas.mapSettings.coordinateToScreen( currentRubberband.model.lastCoordinate )
-                }
-                else if ( geometryEditorsToolbar.editorRubberbandModel && geometryEditorsToolbar.editorRubberbandModel.vertexCount > 1 ) {
+                } else if ( geometryEditorsToolbar.editorRubberbandModel && geometryEditorsToolbar.editorRubberbandModel.vertexCount > 1 ) {
                   coordinateLocator.sourceLocation = mapCanvas.mapSettings.coordinateToScreen( geometryEditorsToolbar.editorRubberbandModel.lastCoordinate )
-                }
-                else {
+                } else {
                   coordinateLocator.sourceLocation = undefined
                 }
             }


### PR DESCRIPTION
This PR Resolves an issue where the `snappingToAngle` functionality was not working while Geometry editor mode was enabled. The issue was caused by a incorrect setting of the `rubberbandModel` for the `CoordinateLocator`. This commit corrects the setting, ensuring that `snappingToAngle` functionality works as expected in GeometryEditor mode.

**What was the problem?**
`rubberbandModel` in `CoordinateLocator` was `digitizingToolbar.rubberbandModel` but we know when we enable `geometryEditors` there is `geometryEditorsToolbar.editorRubberbandModel` that handles vertexes.  

```QML
CoordinateLocator {
      ...
      rubberbandModel: digitizingToolbar.rubberbandModel
      ...
    }
```

**Fix:**  
```QML
rubberbandModel: geometryEditorsToolbar.stateVisible ? geometryEditorsToolbar.editorRubberbandModel : digitizingToolbar.rubberbandModel
```

Also in `onHoveredChange` we need to add this:
```QML
else if ( geometryEditorsToolbar.editorRubberbandModel && geometryEditorsToolbar.editorRubberbandModel.vertexCount > 1 ) {
  coordinateLocator.sourceLocation = mapCanvas.mapSettings.coordinateToScreen( geometryEditorsToolbar.editorRubberbandModel.lastCoordinate )
}
               
```
this condition is to make sure that after changing hover (e.g. by clicking on green confirm button) `sourceLocation` in `coordinateLocator` to set.   

**Extra** details about currentRubberband [here](https://github.com/opengisch/QField/pull/5293#issuecomment-2143824585) 

**Result:** 
[See here](https://github.com/opengisch/QField/assets/36326627/b99a8521-c116-43ce-8990-988135bfa0b8)
