### PR TITLE
Close current project while digitizing

### DIFF
--- a/src/qml/DigitizingToolbar.qml
+++ b/src/qml/DigitizingToolbar.qml
@@ -93,6 +93,7 @@ VisibilityFadingRow {
     bgcolor: Theme.darkRed
 
     onClicked: {
+      homeButton.waitingForDigitizingFinish = false
       if (stateMachine.state !== "measure") {
         cancelDialog.open();
       } else {

--- a/src/qml/DigitizingToolbar.qml
+++ b/src/qml/DigitizingToolbar.qml
@@ -123,6 +123,7 @@ VisibilityFadingRow {
     bgcolor: Theme.mainColor
 
     onClicked: {
+      homeButton.waitingForDigitizingFinish = false
       confirm()
     }
   }

--- a/src/qml/DigitizingToolbar.qml
+++ b/src/qml/DigitizingToolbar.qml
@@ -19,6 +19,7 @@ VisibilityFadingRow {
   property VectorLayer geometryRequestedLayer
 
   property alias digitizingLogger: digitizingLogger
+  property alias cancelDialog: cancelDialog
 
   readonly property bool isDigitizing: rubberbandModel ? rubberbandModel.vertexCount > 1 : false //!< Readonly
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2251,7 +2251,7 @@ ApplicationWindow {
         property bool waitingForDigitizingFinish: false
 
         onClicked: {
-          if (digitizingToolbar.rubberbandModel.vertexCount > 1) {
+          if (currentRubberband && currentRubberband.model.vertexCount > 1) {
             digitizingToolbar.cancelDialog.open();
             waitingForDigitizingFinish = true
           } else if (!waitingForDigitizingFinish) {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2006,6 +2006,11 @@ ApplicationWindow {
               geometryRequested = false
             }
           }
+
+          if(homeButton.waitingForDigitizingFinish){
+            openWelcomeScreen()
+            homeButton.waitingForDigitizingFinish = false
+          }
         }
 
         onConfirmed: {
@@ -2195,6 +2200,13 @@ ApplicationWindow {
     id: bookmarkProperties
   }
 
+  function openWelcomeScreen(){
+    mainMenu.close()
+    dashBoard.close()
+    welcomeScreen.visible = true
+    welcomeScreen.focus = true
+  }
+
   Menu {
     id: mainMenu
     title: qsTr( "Main Menu" )
@@ -2227,6 +2239,7 @@ ApplicationWindow {
       property color hoveredColor: Qt.hsla(Theme.mainTextColor.hslHue, Theme.mainTextColor.hslSaturation, Theme.mainTextColor.hslLightness, 0.2)
 
       QfToolButton {
+        id: homeButton
         anchors.verticalCenter: parent.verticalCenter
         height: 48
         width: 48
@@ -2235,12 +2248,16 @@ ApplicationWindow {
         iconColor: Theme.mainTextColor
         bgcolor: hovered ? parent.hoveredColor : "#00ffffff"
 
+        property bool waitingForDigitizingFinish: false
+
         onClicked: {
-          mainMenu.close()
-          dashBoard.close()
-          welcomeScreen.visible = true
-          welcomeScreen.focus = true
-          highlighted = false
+          if (digitizingToolbar.rubberbandModel.vertexCount > 1) {
+            digitizingToolbar.cancelDialog.open();
+            waitingForDigitizingFinish = true
+          } else if (!waitingForDigitizingFinish) {
+            openWelcomeScreen()
+            highlighted = false
+          }
         }
       }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2007,9 +2007,8 @@ ApplicationWindow {
             }
           }
 
-          if(homeButton.waitingForDigitizingFinish){
+          if (homeButton.waitingForDigitizingFinish) {
             openWelcomeScreen()
-            homeButton.waitingForDigitizingFinish = false
           }
         }
 
@@ -2205,6 +2204,7 @@ ApplicationWindow {
     dashBoard.close()
     welcomeScreen.visible = true
     welcomeScreen.focus = true
+    homeButton.waitingForDigitizingFinish = false
   }
 
   Menu {


### PR DESCRIPTION
This PR addresses issue #2252, resolving a bug in the current project workflow. 

**Issue:** When a user is in `digitizing` mode and attempts to exit the current project, they are not properly confirmed to discard their digitizing work. This PR ensures that the user is prompted to confirm discarding their digitizing work before exiting the project.

With this fix, users can now confidently switch between projects without worrying about unintended data persisting.

**Demo** 

[**Demo of functionality**](https://github.com/opengisch/QField/assets/36326627/e2e531ec-531a-444d-866e-2fcf72992fcd)

**About Code Review**  

reason for this line in `DigitizingToolbar.qml`  
```QML
homeButton.waitingForDigitizingFinish = false
```

Imagine this process: click on homeButton, dont discard, discard from redButton of `DigitizingToolbar` 
this process returns to home screen but should not, i add this line to avoid this problem. if you have any cleaner idea please let me know.
