### PR TITLE
Avoid flagging internal positioning device as invalid caused by access error, cleanup positioning includes

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,6 +9,10 @@ on:
   release:
     types: ['published']
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: build (linux)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,6 +10,9 @@ on:
     types: ['published']
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -20,7 +20,6 @@
 #include "layerutils.h"
 #include "vertexmodel.h"
 
-#include <QGeoPositionInfoSource>
 #include <QJSValue>
 #include <QMutex>
 #include <qgscurvepolygon.h>

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -25,7 +25,6 @@
 #include "vertexmodel.h"
 
 #include <QAbstractListModel>
-#include <QtPositioning/QGeoPositionInfoSource>
 #include <qgsfeature.h>
 #include <qgsrelationmanager.h>
 

--- a/src/core/positioning/gnsspositioninformation.h
+++ b/src/core/positioning/gnsspositioninformation.h
@@ -16,13 +16,11 @@
 #ifndef GNSSPOSITIONINFORMATION_H
 #define GNSSPOSITIONINFORMATION_H
 
-#include "qgis.h"
-#include "qgsgpsconnection.h"
-
 #include <QDateTime>
 #include <QObject>
 #include <QString>
-#include <QtPositioning/QGeoPositionInfoSource>
+#include <qgis.h>
+#include <qgssatelliteinformation.h>
 
 /* Statics from external/nmea/info.h:*/
 #define NMEA_SIG_BAD ( 0 )

--- a/src/core/positioning/internalgnssreceiver.cpp
+++ b/src/core/positioning/internalgnssreceiver.cpp
@@ -27,8 +27,9 @@
 InternalGnssReceiver::InternalGnssReceiver( QObject *parent )
   : AbstractGnssReceiver( parent )
   , mGeoPositionSource( std::unique_ptr<QGeoPositionInfoSource>( QGeoPositionInfoSource::createDefaultSource( nullptr ) ) )
+  , mGeoSatelliteSource( std::unique_ptr<QGeoSatelliteInfoSource>( QGeoSatelliteInfoSource::createDefaultSource( nullptr ) ) )
 {
-  if ( mGeoPositionSource && mGeoPositionSource->error() == QGeoPositionInfoSource::NoError )
+  if ( mGeoPositionSource )
   {
     mGeoPositionSource->setPreferredPositioningMethods( QGeoPositionInfoSource::AllPositioningMethods );
     mGeoPositionSource->setUpdateInterval( 1000 );
@@ -45,8 +46,7 @@ InternalGnssReceiver::InternalGnssReceiver( QObject *parent )
     setValid( true );
   }
 
-  mGeoSatelliteSource = std::unique_ptr<QGeoSatelliteInfoSource>( QGeoSatelliteInfoSource::createDefaultSource( nullptr ) );
-  if ( mGeoSatelliteSource && mGeoSatelliteSource->error() == QGeoSatelliteInfoSource::NoError )
+  if ( mGeoSatelliteSource )
   {
     mGeoSatelliteSource->setUpdateInterval( 1000 );
 

--- a/src/core/utils/expressioncontextutils.cpp
+++ b/src/core/utils/expressioncontextutils.cpp
@@ -19,8 +19,6 @@
 #include "expressioncontextutils.h"
 #include "qgsgeometry.h"
 
-#include <QtPositioning/QGeoPositionInfoSource>
-
 
 void addPositionVariable( QgsExpressionContextScope *scope, const QString &name, const QVariant &value, bool positionLocked, const QVariant &defaultValue = QVariant() )
 {


### PR DESCRIPTION
The macos spix tests already revealed something interesting: on that platform, when creating the internal positioning device, we get an AccessError (as permission has not yet been asked to the user). However in our code, we invalidate the device upon creation when any error is detected. This PR addresses that by allowing for the device to be created, allowing for users to ask for permission afterwards when turning the positioning on.

I've also taken the opportunity to cleanup obsolete includes.