### PR TITLE
Fix Button interface: highlight issue when default is selected.

### DIFF
--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -24,7 +24,6 @@ EditorWidgetBase {
   // Workaround to get a signal when the value has changed
   onCurrentKeyValueChanged: {
     comboBox.currentIndex = comboBox.model.keyToIndex(currentKeyValue)
-    toggleButtons.selectedIndex = comboBox.currentIndex
   }
 
   height: childrenRect.height
@@ -131,7 +130,7 @@ EditorWidgetBase {
 
             Behavior on color {
               ColorAnimation {
-                duration: 200
+                duration: 150
               }
             }
 
@@ -150,11 +149,11 @@ EditorWidgetBase {
               anchors.fill: parent
               onClicked: {
                 if (toggleButtons.selectedIndex != index) {
-                  toggleButtons.selectedIndex = index
+                  comboBox.currentIndex = index
                   toggleButtons.currentSelectedKey = key
                   toggleButtons.currentSelectedValue = value
                 } else {
-                  toggleButtons.selectedIndex = -1
+                  comboBox.currentIndex = -1
                   toggleButtons.currentSelectedKey = ""
                   toggleButtons.currentSelectedValue = ""
                 }


### PR DESCRIPTION
This PR tries to resolve this (https://github.com/opengisch/QField/issues/2193#issuecomment-2166436054).

**Issue:** Button interface widget must be bind with `ComboBox` all the time to ensure its functionality, but in some cases we had assignment on `toggleButtons.selectedIndex`. this assignment breaks the binding so we need to remove the assignment.

**Fix** instead of assignment on `toggleButtons.selectedIndex` we can assign to `comboBox.currentIndex` and binding will do the rest.