### PR TITLE
Plugins permission UI/UX improvements

### DIFF
--- a/src/core/pluginmanager.cpp
+++ b/src/core/pluginmanager.cpp
@@ -184,7 +184,7 @@ void PluginManager::clearPluginPermissions()
   const QStringList pluginKeys = settings.childGroups();
   for ( const QString &pluginKey : pluginKeys )
   {
-    if ( settings.value( QStringLiteral( "%1/userEnabled" ).arg( pluginKey ), false ).toBool() )
+    if ( !settings.value( QStringLiteral( "%1/userEnabled" ).arg( pluginKey ), false ).toBool() )
     {
       settings.remove( QStringLiteral( "%1/permissionGranted" ).arg( pluginKey ) );
     }

--- a/src/qml/PluginManagerSettings.qml
+++ b/src/qml/PluginManagerSettings.qml
@@ -171,22 +171,44 @@ Popup {
       QfButton {
         id: installFromUrlButton
         Layout.fillWidth: true
+        dropdown: true
 
         text: qsTr("Install plugin from URL")
 
         onClicked: {
           installFromUrlDialog.open()
         }
+
+        onDropdownClicked: {
+          pluginsManagementMenu.popup(installFromUrlButton.width - pluginsManagementMenu.width + 10, installFromUrlButton.y + 10)
+        }
       }
 
-      QfButton {
-        id: clearPermissionsButton
-        Layout.fillWidth: true
+      Menu {
+        id: pluginsManagementMenu
+        title: qsTr('Plugins management menu')
 
-        text: qsTr("Clear remembered permissions")
+        width: {
+          let result = 50;
+          let padding = 0;
+          for (let i = 0; i < count; ++i) {
+              let item = itemAt(i);
+              result = Math.max(item.contentItem.implicitWidth, result);
+              padding = Math.max(item.leftPadding + item.rightPadding, padding);
+          }
+          return mainWindow.width > 0 ? Math.min(result + padding, mainWindow.width - 20) : result + padding;
+        }
 
-        onClicked: {
-          pluginManager.clearPluginPermissions()
+        MenuItem {
+          text: qsTr('Clear remembered permissions')
+
+          font: Theme.defaultFont
+          height: 48
+          leftPadding: Theme.menuItemLeftPadding
+
+          onTriggered: {
+            pluginManager.clearPluginPermissions()
+          }
         }
       }
     }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3549,6 +3549,10 @@ ApplicationWindow {
     Connections {
       target: iface
 
+      function onLoadProjectTriggered(path) {
+        messageLogModel.suppressTags(["WFS","WMS"])
+      }
+
       function onLoadProjectEnded() {
         dashBoard.layerTree.unfreeze( true );
         if( !qfieldAuthRequestHandler.handleLayerLogins() )
@@ -3557,13 +3561,6 @@ ApplicationWindow {
           messageLogModel.unsuppressTags(["WFS","WMS"])
         }
       }
-    }
-    Connections {
-        target: iface
-
-        function onLoadProjectTriggered(path) {
-          messageLogModel.suppressTags(["WFS","WMS"])
-        }
     }
 
     Connections {
@@ -3591,14 +3588,19 @@ ApplicationWindow {
       }
     }
 
-    BrowserPanel {
-      id: browserPopup
-      parent: Overlay.overlay
+    Connections {
+      target: browserPopup
 
-      onCancel: {
+      function onCancel() {
         qfieldAuthRequestHandler.abortAuthBrowser();
         browserPopup.close();
       }
+    }
+
+    BrowserPanel {
+      id: browserPopup
+      objectName: "browserPopup"
+      parent: Overlay.overlay
     }
 
     Popup {


### PR DESCRIPTION
Fixing a couple of issues identified while preparing the plugins blog post:
- It's way too easy to hit the clear permissions button, I've moved it into a dropdown menu attached to the install plugins button. Bonus: makes the UI look a lot better on screen with narrow height (e.g. a phone in landscape orientation).
- The permission clearing logic was broken for app-wide plugins, fixed that.

How it looks now:
![Screenshot from 2024-06-15 09-58-34](https://github.com/opengisch/QField/assets/1728657/b8258c20-c2ab-4982-9f39-f339c8298583)

Dropdown menu:
![image](https://github.com/opengisch/QField/assets/1728657/7e0ed674-0cf2-4715-a35b-a384c188e5cd)
