### PR TITLE
Instead of reloading a whole project, reset data sources

### DIFF
--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -78,6 +78,11 @@ void FlatLayerTreeModel::unfreeze( bool resetModel )
   mSourceModel->unfreeze( resetModel );
 }
 
+void FlatLayerTreeModel::flushIsValid()
+{
+  mSourceModel->flushIsValid();
+}
+
 void FlatLayerTreeModel::setLayerInTracking( QgsLayerTreeLayer *nodeLayer, bool tracking )
 {
   mSourceModel->setLayerInTracking( nodeLayer, tracking );
@@ -134,6 +139,11 @@ void FlatLayerTreeModelBase::unfreeze( bool resetModel )
   mFrozen = 0;
   if ( resetModel )
     buildMap( mLayerTreeModel );
+}
+
+void FlatLayerTreeModelBase::flushIsValid()
+{
+  emit dataChanged( index( 0, 0 ), index( mIndexMap.size() - 1, 0 ), QVector<int>() << FlatLayerTreeModel::IsValid );
 }
 
 void FlatLayerTreeModelBase::updateMap( const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles )

--- a/src/core/layertreemodel.h
+++ b/src/core/layertreemodel.h
@@ -71,6 +71,8 @@ class FlatLayerTreeModelBase : public QAbstractProxyModel
     Q_INVOKABLE void freeze();
     //! Unfreezes the model and resume listening to source model signals
     Q_INVOKABLE void unfreeze( bool resetModel = false );
+    //! Resets the IsValid value for all layers
+    Q_INVOKABLE void flushIsValid();
 
     //! Sets the information if the \a nodeLayer is currently in \a tracking state
     void setLayerInTracking( QgsLayerTreeLayer *nodeLayer, bool tracking );
@@ -161,6 +163,8 @@ class FlatLayerTreeModel : public QSortFilterProxyModel
     Q_INVOKABLE void freeze();
     //! Unfreezes the model and resume listening to source model signals
     Q_INVOKABLE void unfreeze( bool resetModel = false );
+    //! Resets the IsValid value for all layers
+    Q_INVOKABLE void flushIsValid();
 
     //! Sets the information if the \a nodeLayer is currently in \a tracking state
     void setLayerInTracking( QgsLayerTreeLayer *nodeLayer, bool tracking );

--- a/src/core/qfieldappauthrequesthandler.cpp
+++ b/src/core/qfieldappauthrequesthandler.cpp
@@ -21,7 +21,9 @@
 #include <QThread>
 #include <qgscredentials.h>
 #include <qgsdatasourceuri.h>
+#include <qgsmaplayer.h>
 #include <qgsmessagelog.h>
+#include <qgsproject.h>
 
 QFieldAppAuthRequestHandler::QFieldAppAuthRequestHandler()
 {
@@ -83,7 +85,15 @@ bool QFieldAppAuthRequestHandler::handleLayerLogins()
       }
       else
       {
-        emit reloadEverything();
+        const QList<QgsMapLayer *> mapLayers = QgsProject::instance()->mapLayers().values();
+        for ( QgsMapLayer *mapLayer : mapLayers )
+        {
+          if ( !mapLayer->isValid() && mapLayer->dataProvider() )
+          {
+            mapLayer->setDataSource( mapLayer->source(), mapLayer->name(), mapLayer->dataProvider()->name() );
+          }
+        }
+        emit flushIsValid();
       }
     } );
   }

--- a/src/core/qfieldappauthrequesthandler.h
+++ b/src/core/qfieldappauthrequesthandler.h
@@ -61,9 +61,9 @@ class QFieldAppAuthRequestHandler : public QObject, public QgsCredentials, publi
   signals:
     void showLoginDialog( const QString &realm, const QString &title );
     void loginDialogClosed( const QString &realm, const bool canceled );
-    void reloadEverything();
     void showLoginBrowser( const QString &url );
     void hideLoginBrowser();
+    void flushIsValid();
 
   protected:
     bool request( const QString &realm, QString &username, QString &password, const QString &message = QString() ) override;

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3574,8 +3574,8 @@ ApplicationWindow {
           loginDialogPopup.open()
       }
 
-      function onReloadEverything() {
-          iface.reloadProject()
+      function onFlushIsValid() {
+          flatLayerTree.flushIsValid()
       }
 
       function onShowLoginBrowser(url) {


### PR DESCRIPTION
ATM, we force reload a whole project to apply credentials for as few as a single layer. Let's be more surgical about things :) 

@m-kuhn , keen to hear what you think of this alternative approach.