### PR TITLE
Fix cloud user information @variables gone missing

### DIFF
--- a/src/core/utils/qfieldcloudutils.h
+++ b/src/core/utils/qfieldcloudutils.h
@@ -29,10 +29,15 @@ struct CloudUserInformation
 {
     Q_GADGET
 
+    Q_PROPERTY( QString username MEMBER username )
+    Q_PROPERTY( QString email MEMBER email )
+
   public:
     CloudUserInformation() = default;
 
     CloudUserInformation( const QString &username, const QString &email )
+      : username( username )
+      , email( email )
     {}
 
     explicit CloudUserInformation( const QJsonObject cloudUserInformation )


### PR DESCRIPTION
Follow up to https://github.com/opengisch/QField/commit/89d4ca2a8126ebb22fc3903110d9b55560e4bb8b , fix @cloud_{username,email} gone blank.

@suricactus , all good? Sorry I didn't catch this when reviewing your PR back then.