### PR TITLE
[Backport release-3_3] Fix @current_parent_* default value not saved on child creation

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -289,8 +289,11 @@ void AttributeFormModelBase::applyParentDefaultValues()
         QgsExpression exp( fields.at( fidx ).defaultValueDefinition().expression() );
         exp.prepare( &mExpressionContext );
         const QVariant defaultValue = exp.evaluate( &mExpressionContext );
-        item->setData( defaultValue, AttributeFormModel::AttributeValue );
-        synchronizeFieldValue( fidx, defaultValue );
+        const bool success = mFeatureModel->setData( mFeatureModel->index( fidx ), defaultValue, FeatureModel::AttributeValue );
+        if ( success )
+        {
+          synchronizeFieldValue( fidx, defaultValue );
+        }
       }
     }
   }


### PR DESCRIPTION
Backport #5356
 **Authored by:** @nirvn