### PR TITLE
Fix color of text and button elements in the navigation to geometry bar [on light theme]

### DIFF
--- a/src/qml/NavigationInformationView.qml
+++ b/src/qml/NavigationInformationView.qml
@@ -64,6 +64,7 @@ Rectangle {
           round: true
           bgcolor: "transparent"
           iconSource: Theme.getThemeIcon("ic_chevron_left_white_24dp")
+          iconColor: Theme.mainTextColor
 
           onPressed: {
             navigation.previousDestinationVertex()
@@ -87,7 +88,7 @@ Rectangle {
           font: Theme.strongTipFont
           elide: Text.ElideMiddle
           wrapMode: Text.NoWrap
-          color: "#FFFFFF"
+          color: Theme.mainTextColor
           text: navigation.destinationName
         }
 
@@ -100,6 +101,7 @@ Rectangle {
           round: true
           bgcolor: "transparent"
           iconSource: Theme.getThemeIcon("ic_chevron_right_white_24dp")
+          iconColor: Theme.mainTextColor
 
           onPressed: {
             navigation.nextDestinationVertex()


### PR DESCRIPTION
When we upgraded our information panels, we tweaked the look of the navigation to geometry bar from an opaque purple to a lighter semi opaque background color, leading to white-on-light-white situation using QField's light theme.

This PR fixes that. Proof of life:
![Screenshot from 2024-06-21 11-20-55](https://github.com/opengisch/QField/assets/1728657/85b331c7-c2d6-45ed-9ec0-0517c233316d)

Fixes issue raised in https://github.com/opengisch/QField/discussions/5370 