### PR TITLE
[Backport release-3_3] Don't show the snapping badge for geometryless vector layers

### DIFF
--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -326,7 +326,12 @@ ListView {
 
         QfToolButton {
           id: snappingBadge
-          property bool isVisible: stateMachine.state === "digitize" && qgisProject.snappingConfig.mode === Qgis.SnappingMode.AdvancedConfiguration && Type === 'layer' && LayerType === "vectorlayer"
+          property bool isVisible: stateMachine.state === "digitize" &&
+                                   qgisProject.snappingConfig.mode === Qgis.SnappingMode.AdvancedConfiguration &&
+                                   Type === "layer" &&
+                                   LayerType === "vectorlayer" &&
+                                   VectorLayerPointer.geometryType() !== Qgis.GeometryType.Null &&
+                                   VectorLayerPointer.geometryType() !== Qgis.GeometryType.Unknown
           visible: isVisible
           height: 24
           width: 24


### PR DESCRIPTION
Backport #5377
 **Authored by:** @nirvn