### PR TITLE
[Backport release-3_3] Fix accidental mixup between value<->key<->description in the value map editor widget

### DIFF
--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -136,7 +136,7 @@ EditorWidgetBase {
             Text {
               id: innerText
               width: Math.min(flow.width - 32 , implicitWidth)
-              text: key
+              text: value
               elide: Text.ElideRight
               anchors.centerIn: parent
               font: Theme.defaultFont


### PR DESCRIPTION
Backport #5385
 **Authored by:** @nirvn