### PR TITLE
Fix value relation editor widget serious warnings

### DIFF
--- a/src/core/featurechecklistmodel.cpp
+++ b/src/core/featurechecklistmodel.cpp
@@ -206,25 +206,23 @@ void FeatureCheckListModel::toggleCheckAll( const bool toggleChecked )
   }
 }
 
-void FeatureCheckListModel::setChecked( const QModelIndex &index )
+void FeatureCheckListModel::setChecked( const QModelIndex &idx )
 {
-  beginResetModel();
-
   if ( !mAllowMulti )
+  {
     mCheckedEntries.clear();
+    emit dataChanged( index( 0, 0, QModelIndex() ), index( rowCount() - 1, 0, QModelIndex() ), QList<int>() << CheckedRole );
+  }
 
-  mCheckedEntries.append( FeatureListModel::data( index, FeatureListModel::KeyFieldRole ).toString() );
-  endResetModel();
-
+  mCheckedEntries.append( FeatureListModel::data( idx, FeatureListModel::KeyFieldRole ).toString() );
+  emit dataChanged( idx, idx, QList<int>() << CheckedRole );
   emit listUpdated();
 }
 
-void FeatureCheckListModel::setUnchecked( const QModelIndex &index )
+void FeatureCheckListModel::setUnchecked( const QModelIndex &idx )
 {
-  beginResetModel();
-  mCheckedEntries.removeAll( FeatureListModel::data( index, FeatureListModel::KeyFieldRole ).toString() );
-  endResetModel();
-
+  mCheckedEntries.removeAll( FeatureListModel::data( idx, FeatureListModel::KeyFieldRole ).toString() );
+  emit dataChanged( idx, idx, QList<int>() << CheckedRole );
   emit listUpdated();
 }
 

--- a/src/core/featurechecklistmodel.h
+++ b/src/core/featurechecklistmodel.h
@@ -95,8 +95,8 @@ class FeatureCheckListModel : public FeatureListModel
     void listUpdated();
 
   private:
-    void setChecked( const QModelIndex &index );
-    void setUnchecked( const QModelIndex &index );
+    void setChecked( const QModelIndex &idx );
+    void setUnchecked( const QModelIndex &idx );
     QMetaType::Type fkType() const;
 
     QgsField mAttributeField;

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -116,10 +116,6 @@ EditorWidgetBase {
 
             checked: model.checked
 
-            onCheckedChanged: {
-              model.checked = checked
-            }
-
             indicator.height: 16
             indicator.width: 16
             indicator.implicitHeight: 24
@@ -147,7 +143,7 @@ EditorWidgetBase {
 
           onClicked: {
             if (isEnabled) {
-              checkBox.checked = !checkBox.checked
+              model.checked = !model.checked
             }
           }
         }


### PR DESCRIPTION
Spotted while fixing https://github.com/opengisch/QField/pull/5397

Less warnings == better world. In this case, I think the warnings were indicating a possible scenario in which we get our model wires crossed. 

Possibly fixing https://github.com/opengisch/QField/issues/5374 