### PR TITLE
Implement invokable functions for plugins to handle global/project/layer variables

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -51,6 +51,7 @@
 #include "digitizinglogger.h"
 #include "distancearea.h"
 #include "drawingcanvas.h"
+#include "expressioncontextutils.h"
 #include "expressionevaluator.h"
 #include "expressionvariablemodel.h"
 #include "featurechecklistmodel.h"
@@ -525,6 +526,7 @@ void QgisMobileapp::initDeclarative()
   qmlRegisterType<ProcessingAlgorithmParametersModel>( "org.qfield", 1, 0, "ProcessingAlgorithmParametersModel" );
   qmlRegisterType<ProcessingAlgorithmsModel>( "org.qfield", 1, 0, "ProcessingAlgorithmsModel" );
 
+  REGISTER_SINGLETON( "org.qfield", ExpressionContextUtils, "ExpressionContextUtils" );
   REGISTER_SINGLETON( "org.qfield", GeometryEditorsModel, "GeometryEditorsModelSingleton" );
   REGISTER_SINGLETON( "org.qfield", GeometryUtils, "GeometryUtils" );
   REGISTER_SINGLETON( "org.qfield", FeatureUtils, "FeatureUtils" );

--- a/src/core/utils/expressioncontextutils.h
+++ b/src/core/utils/expressioncontextutils.h
@@ -25,15 +25,132 @@
 
 #include <qgsexpressioncontext.h>
 
-class ExpressionContextUtils
+class ExpressionContextUtils : public QObject
 {
+    Q_OBJECT
+
   public:
+    explicit ExpressionContextUtils( QObject *parent = nullptr );
+
     static QgsExpressionContextScope *positionScope( const GnssPositionInformation &positionInformation, bool positionLocked );
     static QgsExpressionContextScope *mapToolCaptureScope( const SnappingResult &topSnappingResult );
     static QgsExpressionContextScope *cloudUserScope( const CloudUserInformation &cloudUserInformation );
 
-  private:
-    ExpressionContextUtils() = default;
+    /**
+      * Returns a layer context variables.
+      * \param layer map layer
+      * \see setLayerVariable()
+      * \see setLayerVariables()
+      * \see removeLayerVariable()
+      */
+    Q_INVOKABLE static QVariantMap layerVariables( QgsMapLayer *layer );
+
+    /**
+      * Sets a layer context variable.
+      * \param layer map layer
+      * \param name variable name
+      * \param value variable value
+      * \see layerVariables()
+      * \see setLayerVariables()
+      * \see removeLayerVariable()
+      */
+    Q_INVOKABLE static void setLayerVariable( QgsMapLayer *layer, const QString &name, const QVariant &value );
+
+    /**
+      * Sets a layer context variables.
+      * \param layer map layer
+      * \param variables new set of layer variables
+      * \see layerVariables()
+      * \see setLayerVariable()
+      * \see removeLayerVariable()
+      */
+    Q_INVOKABLE static void setLayerVariables( QgsMapLayer *layer, const QVariantMap &variables );
+
+    /**
+      * Removes a layer context variable.
+      * \param layer map layer
+      * \param name variable name
+      * \see layerVariables()
+      * \see setLayerVariable()
+      * \see setLayerVariables()
+      */
+    Q_INVOKABLE static void removeLayerVariable( QgsMapLayer *layer, const QString &name );
+
+    /**
+      * Returns a project context variables.
+      * \param project project
+      * \see setProjectVariable()
+      * \see setProjectVariables()
+      * \see removeProjectVariable()
+      */
+    Q_INVOKABLE static QVariantMap projectVariables( QgsProject *project );
+
+    /**
+      * Sets a project context variable.
+      * \param project project
+      * \param name variable name
+      * \param value variable value
+      * \see projectVariables()
+      * \see setProjectVariables()
+      * \see removeProjectVariable()
+      */
+    Q_INVOKABLE static void setProjectVariable( QgsProject *project, const QString &name, const QVariant &value );
+
+    /**
+      * Sets a project context variables.
+      * \param project project
+      * \param variables new set of project variables
+      * \see projectVariables()
+      * \see setProjectVariable()
+      * \see removeProjectVariable()
+      */
+    Q_INVOKABLE static void setProjectVariables( QgsProject *project, const QVariantMap &variables );
+
+    /**
+      * Removes a project context variable.
+      * \param project project
+      * \param name variable name
+      * \see projectVariables()
+      * \see setProjectVariable()
+      * \see setProjectVariables()
+      */
+    Q_INVOKABLE static void removeProjectVariable( QgsProject *project, const QString &name );
+
+    /**
+      * Returns the global context variables.
+      * \see setGlobalVariable()
+      * \see setGlobalVariables()
+      * \see removeGlobalVariable()
+      */
+    Q_INVOKABLE static QVariantMap globalVariables();
+
+    /**
+      * Sets a global context variable.
+      * \param name variable name
+      * \param value variable value
+      * \see globalVariables()
+      * \see setGlobalVariables()
+      * \see removeGlobalVariable()
+      */
+    Q_INVOKABLE static void setGlobalVariable( const QString &name, const QVariant &value );
+
+    /**
+      * Sets the global context variables.
+      * \param variables new set of global variables
+      * \see globalVariables()
+      * \see setGlobalVariable()
+      * \see removeGlobalVariable()
+      */
+    Q_INVOKABLE static void setGlobalVariables( const QVariantMap &variables );
+
+    /**
+      * Removes a global context variable.
+      * \param name variable name
+      * \see globalVariables()
+      * \see setGlobalVariable()
+      * \see setGlobalVariables()
+      */
+    Q_INVOKABLE static void removeGlobalVariable( const QString &name );
 };
 
 #endif // EXPRESSIONCONTEXTUTILS_H


### PR DESCRIPTION
Based on a good plugin framework suggestion raised here (https://github.com/opengisch/qfield-template-plugin/issues/1), this PR implements a mechanism through which global/project/layer expression variables can be added/edited/removed via javascript.

This allows for plugin authors to develop interesting UI/UX to define these variables alongside default expressions attached to layers. 