### PR TITLE
Implementation of geofencing functionality

### DIFF
--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -62,6 +62,7 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.Vibrator;
 import android.provider.MediaStore;
 import android.provider.Settings;
 import android.text.Html;
@@ -241,6 +242,16 @@ public class QFieldActivity extends QtActivity {
                 return false;
         }
         return false;
+    }
+
+    private void vibrate(int milliseconds) {
+        Vibrator v = (Vibrator)getSystemService(Context.VIBRATOR_SERVICE);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            v.vibrate(VibrationEffect.createOneShot(
+                milliseconds, VibrationEffect.DEFAULT_AMPLITUDE));
+        } else {
+            v.vibrate(milliseconds);
+        }
     }
 
     private void processProjectIntent() {

--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -62,6 +62,7 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.provider.MediaStore;
 import android.provider.Settings;

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -172,11 +172,11 @@ set(QFIELD_CORE_HDRS
     expressionevaluator.h
     expressionvariablemodel.h
     featurechecklistmodel.h
+    featureexpressionvaluesgatherer.h
     featurelistextentcontroller.h
     featurelistmodel.h
     featurelistmodelselection.h
     featuremodel.h
-    fieldexpressionvaluesgatherer.h
     focusstack.h
     geometry.h
     geometryeditorsmodel.h

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -32,6 +32,7 @@ set(QFIELD_CORE_SRCS
     positioning/udpreceiver.cpp
     positioning/positioning.cpp
     positioning/positioningdevicemodel.cpp
+    positioning/geofencer.cpp
     processing/processingalgorithm.cpp
     processing/processingalgorithmparametersmodel.cpp
     processing/processingalgorithmsmodel.cpp
@@ -148,6 +149,7 @@ set(QFIELD_CORE_HDRS
     positioning/nmeagnssreceiver.h
     positioning/tcpreceiver.h
     positioning/udpreceiver.h
+    positioning/geofencer.h
     processing/processingalgorithm.h
     processing/processingalgorithmparametersmodel.h
     processing/processingalgorithmsmodel.h

--- a/src/core/featureexpressionvaluesgatherer.h
+++ b/src/core/featureexpressionvaluesgatherer.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-  fieldexpressionvaluesgatherer.h - FieldExpressionValuesGatherer
+  featureexpressionvaluesgatherer.h - FeatureExpressionValuesGatherer
 
  ---------------------
  begin                : 29.1.2021
@@ -15,8 +15,8 @@
  ***************************************************************************/
 
 
-#ifndef FIELDEXPRESSIONVALUESGATHERER_H
-#define FIELDEXPRESSIONVALUESGATHERER_H
+#ifndef FEATUREEXPRESSIONVALUESGATHERER_H
+#define FEATUREEXPRESSIONVALUESGATHERER_H
 
 #include <QMutex>
 #include <QThread>
@@ -29,7 +29,7 @@
 /**
  * \class FieldExpressionValuesGatherer
  * Gathers features with substring matching on an expression.
- * \note This is a is an exact copy of QGIS' QgsFieldExpressionValuesGatherer
+ * \note This is a is an exact copy of QGIS' QgsFeatureExpressionValuesGatherer
  */
 class FeatureExpressionValuesGatherer : public QThread
 {
@@ -169,4 +169,4 @@ class FeatureExpressionValuesGatherer : public QThread
     QVariant mData;
 };
 
-#endif // FIELDEXPRESSIONVALUESGATHERER_H
+#endif // FEATUREEXPRESSIONVALUESGATHERER_H

--- a/src/core/featurelistmodel.h
+++ b/src/core/featurelistmodel.h
@@ -17,7 +17,7 @@
 #ifndef FEATURELISTMODEL_H
 #define FEATURELISTMODEL_H
 
-#include "fieldexpressionvaluesgatherer.h"
+#include "featureexpressionvaluesgatherer.h"
 
 #include <QAbstractItemModel>
 #include <QTimer>

--- a/src/core/orderedrelationmodel.cpp
+++ b/src/core/orderedrelationmodel.cpp
@@ -14,7 +14,7 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "fieldexpressionvaluesgatherer.h"
+#include "featureexpressionvaluesgatherer.h"
 #include "orderedrelationmodel.h"
 #include "qfield_core_export.h"
 #include "qgsexpressioncontextutils.h"

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -880,7 +880,7 @@ void AndroidPlatformUtilities::vibrate( int milliseconds ) const
 {
   if ( mActivity.isValid() )
   {
-    runOnAndroidMainThread( [handle] {
+    runOnAndroidMainThread( [milliseconds] {
       auto activity = qtAndroidContext();
       if ( activity.isValid() )
       {

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -876,6 +876,20 @@ bool AndroidPlatformUtilities::isSystemDarkTheme() const
   return false;
 }
 
+void AndroidPlatformUtilities::vibrate( int milliseconds ) const
+{
+  if ( mActivity.isValid() )
+  {
+    runOnAndroidMainThread( [handle] {
+      auto activity = qtAndroidContext();
+      if ( activity.isValid() )
+      {
+        activity.callMethod<void>( "vibrate", "(I)V", milliseconds );
+      }
+    } );
+  }
+}
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/core/platforms/android/androidplatformutilities.h
+++ b/src/core/platforms/android/androidplatformutilities.h
@@ -86,6 +86,8 @@ class AndroidPlatformUtilities : public PlatformUtilities
 
     bool isSystemDarkTheme() const override;
 
+    void vibrate( int milliseconds ) const override;
+
   private:
     // separate multiple permissions using a semi-column (;)
     bool checkAndAcquirePermissions( const QString &permissions ) const;

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -45,17 +45,18 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
   public:
     enum Capability
     {
-      NoCapabilities = 0,                //!< No capabilities
-      NativeCamera = 1,                  //!< Native camera handling support
-      AdjustBrightness = 1 << 1,         //!< Screen brightness adjustment support
-      SentryFramework = 1 << 2,          //!< Sentry framework support
-      CustomLocalDataPicker = 1 << 3,    //!< Custom QML local data picker support
-      CustomImport = 1 << 4,             //!< Import project and dataset support
-      CustomExport = 1 << 5,             //!< Export project and dataset support
-      CustomSend = 1 << 6,               //!< Send/share files support
-      FilePicker = 1 << 7,               //!< File picker support
-      VolumeKeys = 1 << 8,               //!< Volume keys handling support
-      UpdateProjectFromArchive = 1 << 9, //!< Update local project from a ZIP archive support
+      NoCapabilities = 0,                 //!< No capabilities
+      NativeCamera = 1,                   //!< Native camera handling support
+      AdjustBrightness = 1 << 1,          //!< Screen brightness adjustment support
+      SentryFramework = 1 << 2,           //!< Sentry framework support
+      CustomLocalDataPicker = 1 << 3,     //!< Custom QML local data picker support
+      CustomImport = 1 << 4,              //!< Import project and dataset support
+      CustomExport = 1 << 5,              //!< Export project and dataset support
+      CustomSend = 1 << 6,                //!< Send/share files support
+      FilePicker = 1 << 7,                //!< File picker support
+      VolumeKeys = 1 << 8,                //!< Volume keys handling support
+      Vibrate = 1 << 9,                   //!< Haptic feedback / vibration support
+      UpdateProjectFromArchive = 1 << 10, //!< Update local project from a ZIP archive support
     };
     Q_DECLARE_FLAGS( Capabilities, Capability )
     Q_FLAGS( Capabilities )
@@ -306,6 +307,11 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
      * Returns TRUE is the system uses a dark theme.
      */
     Q_INVOKABLE virtual bool isSystemDarkTheme() const;
+
+    /**
+     * Vibrates the device on supported platforms.
+     */
+    Q_INVOKABLE virtual void vibrate( int milliseconds ) const { Q_UNUSED( milliseconds ) }
 
     static PlatformUtilities *instance();
 

--- a/src/core/positioning/geofencer.cpp
+++ b/src/core/positioning/geofencer.cpp
@@ -28,59 +28,110 @@ Geofencer::~Geofencer()
 {
 }
 
-void Geofencer::fetchAreas()
+void Geofencer::cleanupGatherer()
 {
-  clearAreas();
-
-  if ( !mAreasLayer )
+  if ( mGatherer )
   {
-    return;
-  }
-
-  QgsFeatureRequest request;
-  request.setNoAttributes();
-  if ( mPositionCrs.isValid() )
-  {
-    request.setDestinationCrs( mPositionCrs, QgsProject::instance()->transformContext() );
-  }
-
-  QgsFeatureIterator it = mAreasLayer->getFeatures( request );
-  QgsFeature feature;
-  while ( it.nextFeature( feature ) )
-  {
-    if ( !feature.geometry().isEmpty() )
-    {
-      mFetchedAreaGeometries[feature.id()] = QgsGeometry::createGeometryEngine( feature.geometry().get() );
-    }
+    disconnect( mGatherer, &QThread::finished, this, &Geofencer::processAreas );
+    connect( mGatherer, &QThread::finished, mGatherer, &QObject::deleteLater );
+    mGatherer->stop();
+    mGatherer = nullptr;
   }
 }
 
-void Geofencer::clearAreas()
+void Geofencer::gatherAreas()
 {
-  qDeleteAll( mFetchedAreaGeometries );
+  if ( !mAreasLayer || !mAreasLayer->isValid() || !mPositionCrs.isValid() )
+    return;
+
+  QgsFeatureRequest request;
+  request.setDestinationCrs( mPositionCrs, QgsProject::instance()->transformContext() );
+
+  QgsExpressionContext context = mAreasLayer->createExpressionContext();
+  QgsExpression expression( mAreasLayer->displayExpression() );
+  expression.prepare( &context );
+
+  QSet<QString> referencedColumns = expression.referencedColumns();
+  QgsFields fields = mAreasLayer->fields();
+  request.setSubsetOfAttributes( referencedColumns, fields );
+
+  cleanupGatherer();
+
+  mGatherer = new FeatureExpressionValuesGatherer( mAreasLayer, mAreasLayer->displayExpression(), request );
+  connect( mGatherer, &QThread::finished, this, &Geofencer::processAreas );
+  mGatherer->start();
+}
+
+void Geofencer::processAreas()
+{
+  if ( !mGatherer )
+    return;
+
+  mAreas.clear();
+
+  mAreas = mGatherer->entries();
+  mGatherer->deleteLater();
+  mGatherer = nullptr;
+
+  if ( mActive )
+  {
+    checkWithin();
+  }
 }
 
 void Geofencer::checkWithin()
 {
-  bool isWithin = false;
-
-  if ( mActive && !mPosition.isEmpty() && mPositionCrs.isValid() && mAreasLayer )
+  int isWithinIndex = -1;
+  if ( mActive && !mAreas.isEmpty() )
   {
-    for ( auto [key, value] : mFetchedAreaGeometries.asKeyValueRange() )
+    std::unique_ptr<QgsGeometryEngine> geometryEngine;
+    geometryEngine.reset( QgsGeometry::createGeometryEngine( &mPosition ) );
+    for ( int i = 0; i < mAreas.size(); i++ )
     {
-      if ( value->within( &mPosition ) )
+      if ( geometryEngine->within( mAreas.at( i ).feature.geometry().get() ) )
       {
-        isWithin = true;
+        isWithinIndex = i;
+        break;
       }
     }
   }
 
-  if ( isWithin != mIsWithin )
+  if ( mIsWithinIndex != isWithinIndex )
   {
-    mIsWithin = isWithin;
+    if ( mIsWithinIndex != -1 )
+    {
+      mLastWithinIndex = mIsWithinIndex;
+    }
+
+    mIsWithinIndex = isWithinIndex;
 
     emit isWithinChanged();
   }
+}
+
+bool Geofencer::isWithin() const
+{
+  return mIsWithinIndex > -1;
+}
+
+QString Geofencer::isWithinAreaName() const
+{
+  if ( mIsWithinIndex < 0 || mIsWithinIndex >= mAreas.size() )
+  {
+    return QString();
+  }
+
+  return mAreas.at( mIsWithinIndex ).value;
+}
+
+QString Geofencer::lastWithinAreaName() const
+{
+  if ( mLastWithinIndex < 0 || mLastWithinIndex >= mAreas.size() )
+  {
+    return QString();
+  }
+
+  return mAreas.at( mLastWithinIndex ).value;
 }
 
 void Geofencer::setActive( bool active )
@@ -119,12 +170,7 @@ void Geofencer::setPositionCrs( const QgsCoordinateReferenceSystem &crs )
   mPositionCrs = crs;
   emit positionCrsChanged();
 
-  if ( mAreasLayer && mAreasLayer->crs() != mPositionCrs )
-  {
-    fetchAreas();
-  }
-
-  checkWithin();
+  gatherAreas();
 }
 
 void Geofencer::setAreasLayer( QgsVectorLayer *layer )
@@ -137,5 +183,5 @@ void Geofencer::setAreasLayer( QgsVectorLayer *layer )
   mAreasLayer = layer;
   emit areasLayerChanged();
 
-  fetchAreas();
+  gatherAreas();
 }

--- a/src/core/positioning/geofencer.cpp
+++ b/src/core/positioning/geofencer.cpp
@@ -1,0 +1,141 @@
+/***************************************************************************
+  geofencer.h - Geofencer
+
+ ---------------------
+ begin                : 27.06.2024
+ copyright            : (C) 2024 by Mathieu Pellerin
+ email                : mathieu at opengis dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "geofencer.h"
+
+#include <qgsgeometryengine.h>
+#include <qgsproject.h>
+
+Geofencer::Geofencer( QObject *parent )
+  : QObject( parent )
+{
+}
+
+Geofencer::~Geofencer()
+{
+}
+
+void Geofencer::fetchAreas()
+{
+  clearAreas();
+
+  if ( !mAreasLayer )
+  {
+    return;
+  }
+
+  QgsFeatureRequest request;
+  request.setNoAttributes();
+  if ( mPositionCrs.isValid() )
+  {
+    request.setDestinationCrs( mPositionCrs, QgsProject::instance()->transformContext() );
+  }
+
+  QgsFeatureIterator it = mAreasLayer->getFeatures( request );
+  QgsFeature feature;
+  while ( it.nextFeature( feature ) )
+  {
+    if ( !feature.geometry().isEmpty() )
+    {
+      mFetchedAreaGeometries[feature.id()] = QgsGeometry::createGeometryEngine( feature.geometry().get() );
+    }
+  }
+}
+
+void Geofencer::clearAreas()
+{
+  qDeleteAll( mFetchedAreaGeometries );
+}
+
+void Geofencer::checkWithin()
+{
+  bool isWithin = false;
+
+  if ( mActive && !mPosition.isEmpty() && mPositionCrs.isValid() && mAreasLayer )
+  {
+    for ( auto [key, value] : mFetchedAreaGeometries.asKeyValueRange() )
+    {
+      if ( value->within( &mPosition ) )
+      {
+        isWithin = true;
+      }
+    }
+  }
+
+  if ( isWithin != mIsWithin )
+  {
+    mIsWithin = isWithin;
+
+    emit isWithinChanged();
+  }
+}
+
+void Geofencer::setActive( bool active )
+{
+  if ( mActive == active )
+  {
+    return;
+  }
+
+  mActive = active;
+  emit activeChanged();
+
+  checkWithin();
+}
+
+void Geofencer::setPosition( const QgsPoint &position )
+{
+  if ( mPosition == position )
+  {
+    return;
+  }
+
+  mPosition = position;
+  emit positionChanged();
+
+  checkWithin();
+}
+
+void Geofencer::setPositionCrs( const QgsCoordinateReferenceSystem &crs )
+{
+  if ( mPositionCrs == crs )
+  {
+    return;
+  }
+
+  mPositionCrs = crs;
+  emit positionCrsChanged();
+
+  if ( mAreasLayer && mAreasLayer->crs() != mPositionCrs )
+  {
+    fetchAreas();
+  }
+
+  checkWithin();
+}
+
+void Geofencer::setAreasLayer( QgsVectorLayer *layer )
+{
+  if ( mAreasLayer == layer )
+  {
+    return;
+  }
+
+  mAreasLayer = layer;
+  emit areasLayerChanged();
+
+  fetchAreas();
+}

--- a/src/core/positioning/geofencer.cpp
+++ b/src/core/positioning/geofencer.cpp
@@ -185,3 +185,22 @@ void Geofencer::setAreasLayer( QgsVectorLayer *layer )
 
   gatherAreas();
 }
+
+void Geofencer::applyProjectSettings( QgsProject *project )
+{
+  bool active = false;
+  QgsVectorLayer *layer = nullptr;
+
+  if ( project )
+  {
+    active = project->readBoolEntry( QStringLiteral( "qfieldsync" ), QStringLiteral( "geofencingActive" ), false );
+    const QString layerId = project->readEntry( QStringLiteral( "qfieldsync" ), QStringLiteral( "geofencingLayer" ) );
+    if ( !layerId.isEmpty() )
+    {
+      layer = qobject_cast<QgsVectorLayer *>( project->mapLayer( layerId ) );
+    }
+  }
+
+  setActive( active );
+  setAreasLayer( layer );
+}

--- a/src/core/positioning/geofencer.h
+++ b/src/core/positioning/geofencer.h
@@ -1,0 +1,116 @@
+/***************************************************************************
+  geofencer.h - Geofencer
+
+ ---------------------
+ begin                : 27.06.2024
+ copyright            : (C) 2024 by Mathieu Pellerin
+ email                : mathieu at opengis dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef GEOFENCER_H
+#define GEOFENCER_H
+
+#include <QObject>
+#include <QTimer>
+#include <qgscoordinatereferencesystem.h>
+#include <qgspoint.h>
+#include <qgsvectorlayer.h>
+
+/**
+ * This class provides an interface to manage geofencing of areas as well as
+ * providing feedback whenever the position trespasses into or out of those
+ * areas.
+ */
+class Geofencer : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY( bool active READ active WRITE setActive NOTIFY activeChanged )
+
+    Q_PROPERTY( QgsPoint position READ position WRITE setPosition NOTIFY positionChanged )
+    Q_PROPERTY( QgsCoordinateReferenceSystem positionCrs READ positionCrs WRITE setPositionCrs NOTIFY positionCrsChanged )
+
+    Q_PROPERTY( QgsVectorLayer *areasLayer READ areasLayer WRITE setAreasLayer NOTIFY areasLayerChanged )
+
+    Q_PROPERTY( bool isWithin READ isWithin NOTIFY isWithinChanged );
+
+  public:
+    explicit Geofencer( QObject *parent = nullptr );
+    virtual ~Geofencer();
+
+    /**
+     * Returns TRUE when geofencing is active.
+     * \see setActive
+     */
+    bool active() const { return mActive; }
+
+    /**
+     * Sets the geofencing \a active state.
+     * \see active
+     */
+    void setActive( bool active );
+
+    /**
+     * Returns the position to be used to check for overlap with areas.
+     */
+    QgsPoint position() const { return mPosition; }
+
+    /**
+     * Sets the \a position to be used to check for overlap with areas.
+     */
+    void setPosition( const QgsPoint &position );
+
+    /**
+     * Returns the position's coordinate reference system (CRS).
+     */
+    QgsCoordinateReferenceSystem positionCrs() const { return mPositionCrs; }
+
+    /**
+     * Sets the position's coordinate reference system (CRS).
+     */
+    void setPositionCrs( const QgsCoordinateReferenceSystem &crs );
+
+    /**
+     * Returns the polygon layer from which areas will be taken from.
+     */
+    QgsVectorLayer *areasLayer() const { return mAreasLayer.data(); }
+
+    /**
+     * Sets the polygon layer from which areas will be taken from
+     */
+    void setAreasLayer( QgsVectorLayer *layer );
+
+  signals:
+
+    void activeChanged();
+    void invertLogicChanged();
+    void positionChanged();
+    void positionCrsChanged();
+    void areasLayerChanged();
+    void isWithinChanged();
+
+  private:
+    void fetchAreas();
+    void clearAreas();
+
+    void checkWithin();
+
+    bool mActive = false;
+
+    QgsPoint mPosition;
+    QgsCoordinateReferenceSystem mPositionCrs;
+
+    QPointer<QgsVectorLayer> mAreasLayer;
+    QMap<QgsFeatureId, QgsGeometryEngine *> mFetchedAreaGeometries;
+
+    bool mIsWithin = false;
+};
+
+#endif // GEOFENCER_H

--- a/src/core/positioning/geofencer.h
+++ b/src/core/positioning/geofencer.h
@@ -50,6 +50,11 @@ class Geofencer : public QObject
     virtual ~Geofencer();
 
     /**
+     * Sets the polygon layer holding areas from a given \a project.
+     */
+    Q_INVOKABLE void applyProjectSettings( QgsProject *project );
+
+    /**
      * Returns TRUE when geofencing is active.
      * \see setActive
      */
@@ -82,12 +87,12 @@ class Geofencer : public QObject
     void setPositionCrs( const QgsCoordinateReferenceSystem &crs );
 
     /**
-     * Returns the polygon layer from which areas will be taken from.
+     * Returns the polygon layer holding areas.
      */
     QgsVectorLayer *areasLayer() const { return mAreasLayer.data(); }
 
     /**
-     * Sets the polygon layer from which areas will be taken from
+     * Sets the polygon layer holding areas.
      */
     void setAreasLayer( QgsVectorLayer *layer );
 
@@ -116,6 +121,7 @@ class Geofencer : public QObject
     void positionCrsChanged();
     void areasLayerChanged();
     void isWithinChanged();
+    void projectChanged();
 
   private:
     void cleanupGatherer();

--- a/src/core/projectinfo.h
+++ b/src/core/projectinfo.h
@@ -80,6 +80,14 @@ class ProjectInfo : public QObject
     Q_PROPERTY( CloudUserInformation cloudUserInformation READ cloudUserInformation WRITE setCloudUserInformation NOTIFY cloudUserInformationChanged )
 
   public:
+    enum GeofencingBehaviors
+    {
+      AlertWhenInsideGeofencedArea = 1,
+      AlertWhenOutsideGeofencedArea,
+      InformWhenEnteringLeavingGeofencedArea,
+    };
+    Q_ENUM( GeofencingBehaviors )
+
     explicit ProjectInfo( QObject *parent = nullptr );
 
     virtual ~ProjectInfo() = default;

--- a/src/core/projectinfo.h
+++ b/src/core/projectinfo.h
@@ -80,14 +80,6 @@ class ProjectInfo : public QObject
     Q_PROPERTY( CloudUserInformation cloudUserInformation READ cloudUserInformation WRITE setCloudUserInformation NOTIFY cloudUserInformationChanged )
 
   public:
-    enum GeofencingBehaviors
-    {
-      AlertWhenInsideGeofencedArea = 1,
-      AlertWhenOutsideGeofencedArea,
-      InformWhenEnteringLeavingGeofencedArea,
-    };
-    Q_ENUM( GeofencingBehaviors )
-
     explicit ProjectInfo( QObject *parent = nullptr );
 
     virtual ~ProjectInfo() = default;

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -63,6 +63,7 @@
 #include "featureutils.h"
 #include "fileutils.h"
 #include "focusstack.h"
+#include "geofencer.h"
 #include "geometry.h"
 #include "geometryeditorsmodel.h"
 #include "geometryutils.h"
@@ -451,6 +452,7 @@ void QgisMobileapp::initDeclarative()
   qmlRegisterType<ProjectSource>( "org.qfield", 1, 0, "ProjectSource" );
   qmlRegisterType<ViewStatus>( "org.qfield", 1, 0, "ViewStatus" );
 
+  qmlRegisterType<Geofencer>( "org.qfield", 1, 0, "Geofencer" );
   qmlRegisterType<DigitizingLogger>( "org.qfield", 1, 0, "DigitizingLogger" );
   qmlRegisterType<AttributeFormModel>( "org.qfield", 1, 0, "AttributeFormModel" );
   qmlRegisterType<FeatureModel>( "org.qfield", 1, 0, "FeatureModel" );

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -45,4 +45,6 @@ Settings {
 
     property int trackerMeasureType: 0
     property int digitizingMeasureType: 1
+
+    property bool geofencingPreventDigitizingDuringAlarm: false
 }

--- a/src/qml/PositioningSettings.qml
+++ b/src/qml/PositioningSettings.qml
@@ -46,5 +46,5 @@ Settings {
     property int trackerMeasureType: 0
     property int digitizingMeasureType: 1
 
-    property bool geofencingPreventDigitizingDuringAlarm: false
+    property bool geofencingPreventDigitizingDuringAlert: false
 }

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -1312,7 +1312,7 @@ Page {
                   }
 
                   Label {
-                      text: qsTr("Prevent digitizing while geofencing is in alarm mode")
+                      text: qsTr("Prevent digitizing while geofencing is in alert mode")
                       font: Theme.defaultFont
                       color: Theme.mainTextColor
                       wrapMode: Text.WordWrap
@@ -1320,22 +1320,22 @@ Page {
 
                       MouseArea {
                           anchors.fill: parent
-                          onClicked: geofencingPreventDigitizingDuringAlarm.toggle()
+                          onClicked: geofencingPreventDigitizingDuringAlert.toggle()
                       }
                   }
 
                   QfSwitch {
-                      id: geofencingPreventDigitizingDuringAlarm
+                      id: geofencingPreventDigitizingDuringAlert
                       Layout.preferredWidth: implicitContentWidth
                       Layout.alignment: Qt.AlignTop
-                      checked: positioningSettings.geofencingPreventDigitizingDuringAlarm
+                      checked: positioningSettings.geofencingPreventDigitizingDuringAlert
                       onCheckedChanged: {
-                          positioningSettings.geofencingPreventDigitizingDuringAlarm = checked
+                          positioningSettings.geofencingPreventDigitizingDuringAlert = checked
                       }
                   }
 
                   Label {
-                      text: qsTr( "When enabled, the digitizing of new features will be blocked if a project's geofencing is active and the current position triggers an alarm." )
+                      text: qsTr( "When enabled, the digitizing of new features will be blocked if a project's geofencing is active and the current position triggers an alert." )
                       font: Theme.tipFont
                       color: Theme.secondaryTextColor
 

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -1312,6 +1312,43 @@ Page {
                   }
 
                   Label {
+                      text: qsTr("Prevent digitizing while geofencing is in alarm mode")
+                      font: Theme.defaultFont
+                      color: Theme.mainTextColor
+                      wrapMode: Text.WordWrap
+                      Layout.fillWidth: true
+
+                      MouseArea {
+                          anchors.fill: parent
+                          onClicked: geofencingPreventDigitizingDuringAlarm.toggle()
+                      }
+                  }
+
+                  QfSwitch {
+                      id: geofencingPreventDigitizingDuringAlarm
+                      Layout.preferredWidth: implicitContentWidth
+                      Layout.alignment: Qt.AlignTop
+                      checked: positioningSettings.geofencingPreventDigitizingDuringAlarm
+                      onCheckedChanged: {
+                          positioningSettings.geofencingPreventDigitizingDuringAlarm = checked
+                      }
+                  }
+
+                  Label {
+                      text: qsTr( "When enabled, the digitizing of new features will be blocked if a project's geofencing is active and the current position triggers an alarm." )
+                      font: Theme.tipFont
+                      color: Theme.secondaryTextColor
+
+                      wrapMode: Text.WordWrap
+                      Layout.fillWidth: true
+                  }
+
+                  Item {
+                      // empty cell in grid layout
+                      width: 1
+                  }
+
+                  Label {
                       text: qsTr("Antenna height compensation")
                       font: Theme.defaultFont
                       color: Theme.mainTextColor

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3569,6 +3569,8 @@ ApplicationWindow {
 
       layoutListInstantiator.model.reloadModel()
 
+      projectInfo.geofencingBehavior = iface.readProjectNumEntry("qfieldsync", "geofencingBehavior", ProjectInfo.AlertWhenInsideGeofencedArea)
+      console.log(projectInfo.geofencingBehavior)
       geofencer.applyProjectSettings(qgisProject)
     }
 
@@ -3594,6 +3596,8 @@ ApplicationWindow {
 
     property bool insertRights: hasInsertRights
     property bool editRights: hasEditRights
+
+    property int geofencingBehavior: ProjectInfo.AlertWhenInsideGeofencedArea
   }
 
   MessageLog {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -869,6 +869,7 @@ ApplicationWindow {
 
     onIsWithinChanged: {
       if (isWithin) {
+        platformUtilities.vibrate(500)
         displayToast(qsTr("Position has trespassed into ‘%1’").arg(isWithinAreaName), 'error')
       }
     }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -877,8 +877,10 @@ ApplicationWindow {
         displayToast(qsTr("Position outside areas after leaving ‘%1’").arg(lastWithinAreaName), 'error')
       } else if (behavior == Geofencer.InformWhenEnteringLeavingGeofencedArea) {
         if (isWithin) {
+          platformUtilities.vibrate(250)
           displayToast(qsTr("Position entered into ‘%1’").arg(isWithinAreaName))
         } else if (lastWithinAreaName != '') {
+          platformUtilities.vibrate(250)
           displayToast(qsTr("Position left from ‘%1’").arg(lastWithinAreaName))
         }
       }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -868,9 +868,18 @@ ApplicationWindow {
     positionCrs: mapCanvas.mapSettings.destinationCrs
 
     onIsWithinChanged: {
-      if (isWithin) {
+      if (projectInfo.geofencingBehavior == ProjectInfo.AlertWhenInsideGeofencedArea && geofencer.isWithin) {
         platformUtilities.vibrate(500)
         displayToast(qsTr("Position has trespassed into ‘%1’").arg(isWithinAreaName), 'error')
+      } else if (projectInfo.geofencingBehavior == ProjectInfo.AlertWhenOutsideGeofencedArea && !geofencer.isWithin) {
+        platformUtilities.vibrate(500)
+        displayToast(qsTr("Position outside areas after leaving ‘%1’").arg(lastWithinAreaName), 'error')
+      } else if (projectInfo.geofencingBehavior == ProjectInfo.InformWhenEnteringLeavingGeofencedArea) {
+        if (isWithin) {
+          displayToast(qsTr("Position entered into ‘%1’").arg(isWithinAreaName))
+        } else if (lastWithinAreaName != '') {
+          displayToast(qsTr("Position left from ‘%1’").arg(lastWithinAreaName))
+        }
       }
     }
   }
@@ -887,7 +896,9 @@ ApplicationWindow {
 
     SequentialAnimation {
       id: geofencerFeedbackAnimation
-      running: geofencer.active && geofencer.isWithin
+      running: geofencer.active &&
+               ((projectInfo.geofencingBehavior == ProjectInfo.AlertWhenInsideGeofencedArea && geofencer.isWithin) ||
+                (projectInfo.geofencingBehavior == ProjectInfo.AlertWhenOutsideGeofencedArea && !geofencer.isWithin))
       loops: Animation.Infinite
 
       OpacityAnimator {
@@ -3570,7 +3581,6 @@ ApplicationWindow {
       layoutListInstantiator.model.reloadModel()
 
       projectInfo.geofencingBehavior = iface.readProjectNumEntry("qfieldsync", "geofencingBehavior", ProjectInfo.AlertWhenInsideGeofencedArea)
-      console.log(projectInfo.geofencingBehavior)
       geofencer.applyProjectSettings(qgisProject)
     }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1982,7 +1982,7 @@ ApplicationWindow {
         id: digitizingToolbar
 
         stateVisible: !screenLocker.enabled &&
-                      (!positioningSettings.geofencingPreventDigitizingDuringAlarm || !geofencer.isAlerting) &&
+                      (!positioningSettings.geofencingPreventDigitizingDuringAlert || !geofencer.isAlerting) &&
                       ((stateMachine.state === "digitize"
                         && dashBoard.activeLayer
                         && !dashBoard.activeLayer.readOnly

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -18,6 +18,7 @@
 import QtQuick 2.14
 import QtQuick.Controls 2.14
 import QtQuick.Controls.Material 2.14
+import QtQuick.Effects
 import QtQuick.Window 2.14
 import QtQml 2.14
 import QtSensors 5.14
@@ -859,6 +860,63 @@ ApplicationWindow {
       algorithm: featureForm.algorithm
       mapSettings: mapCanvas.mapSettings
     }
+  }
+
+  Geofencer {
+    id: geofencer
+    position: positionSource.projectedPosition
+    positionCrs: mapCanvas.mapSettings.destinationCrs
+
+    onIsWithinChanged: {
+      if (isWithin) {
+        displayToast(qsTr("Position has trespassed into ‘%1’").arg(isWithinAreaName), 'error')
+      }
+    }
+  }
+
+  MultiEffect {
+    id: geofencerFeedback
+    anchors.fill: geofencerFeedbackSource
+    source: geofencerFeedbackSource
+    visible: true
+    blurEnabled: true
+    blurMax: 64
+    blur: 2.0
+    opacity: 0
+
+    SequentialAnimation {
+      id: geofencerFeedbackAnimation
+      running: geofencer.active && geofencer.isWithin
+      loops: Animation.Infinite
+
+      OpacityAnimator {
+        target: geofencerFeedback
+        from: 0;
+        to: 0.75;
+        duration: 1000
+      }
+      OpacityAnimator {
+        target: geofencerFeedback
+        from: 0.75;
+        to: 0;
+        duration: 1000
+      }
+    }
+  }
+
+  Rectangle {
+    id: geofencerFeedbackSource
+    width: Math.min(250, mainWindow.width / 2)
+    height: width
+    radius: width / 2
+    visible: false
+
+    x: parent.width - width / 2
+    y: locationToolbar.y + gnssButton.y + (gnssButton.height / 2) - height / 2
+
+    color: Theme.errorColor
+    border.width: 2
+    border.color: "#ffffff"
   }
 
   InformationDrawer {
@@ -3509,6 +3567,8 @@ ApplicationWindow {
       }
 
       layoutListInstantiator.model.reloadModel()
+
+      geofencer.applyProjectSettings(qgisProject)
     }
 
     function onSetMapExtent(extent) {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -868,19 +868,22 @@ ApplicationWindow {
     position: positionSource.projectedPosition
     positionCrs: mapCanvas.mapSettings.destinationCrs
 
+    readonly property int longVibration: 1000
+    readonly property int shortVibration: 500
+
     onIsWithinChanged: {
       if (behavior == Geofencer.AlertWhenInsideGeofencedArea && geofencer.isWithin) {
-        platformUtilities.vibrate(500)
+        platformUtilities.vibrate(longVibration)
         displayToast(qsTr("Position has trespassed into ‘%1’").arg(isWithinAreaName), 'error')
       } else if (behavior == Geofencer.AlertWhenOutsideGeofencedArea && !geofencer.isWithin) {
-        platformUtilities.vibrate(500)
+        platformUtilities.vibrate(longVibration)
         displayToast(qsTr("Position outside areas after leaving ‘%1’").arg(lastWithinAreaName), 'error')
       } else if (behavior == Geofencer.InformWhenEnteringLeavingGeofencedArea) {
         if (isWithin) {
-          platformUtilities.vibrate(250)
+          platformUtilities.vibrate(shortVibration)
           displayToast(qsTr("Position entered into ‘%1’").arg(isWithinAreaName))
         } else if (lastWithinAreaName != '') {
-          platformUtilities.vibrate(250)
+          platformUtilities.vibrate(shortVibration)
           displayToast(qsTr("Position left from ‘%1’").arg(lastWithinAreaName))
         }
       }
@@ -934,8 +937,6 @@ ApplicationWindow {
     y: locationToolbar.y + gnssButton.y + (gnssButton.height / 2) - height / 2
 
     color: Theme.errorColor
-    border.width: 2
-    border.color: "#ffffff"
   }
 
   InformationDrawer {


### PR DESCRIPTION
This PR adds geofencing capabilities to QField configured via qfieldsync. The geofencing functionality features three behavior that can:
- alert users when within areas (default behavior)
- alert users when outside all areas
- inform users when entering and leaving an area

The configuration in qfieldsync is done so through the project properties dialog's qfieldsync panel:

![image](https://github.com/opengisch/QField/assets/1728657/9578f051-e3b0-4359-b27f-71243d9b0dfd)

On the QField side, opening a project will automatically adopt the geofencing settings. The picked polygon layer's display name setting will be used as area name.

UX when geofencing is set to alert users when entering geofenced areas:

https://github.com/opengisch/QField/assets/1728657/fcb169d2-5442-414c-a8e0-a5a4060b8e64

UX when geofencing is set to alert users when outside all geofenced areas:

https://github.com/opengisch/QField/assets/1728657/da1a7ce6-98b7-4598-8a12-b739dc0a6450

UX when geofencing is set to inform users when entering/leaving geofenced areas:

https://github.com/opengisch/QField/assets/1728657/225ba369-4a40-404c-89e1-1ca5de490953

Finally, a new option found in the settings' positioning tab allows for users to prevent digitizing while in geofencing 'alert' mode:

![image](https://github.com/opengisch/QField/assets/1728657/2262366c-49b8-4e75-b013-1fab4eb869ae)
