### PR TITLE
[Backport release-3_3] Avoid double-storing photos taken by QField when using the native camera

### DIFF
--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -1357,6 +1357,7 @@ public class QFieldActivity extends QtActivity {
                     InputStream in = new FileInputStream(file);
                     QFieldUtils.inputStreamToFile(in, result.getPath(),
                                                   file.length());
+                    file.delete();
                 } catch (Exception e) {
                     e.printStackTrace();
                 }


### PR DESCRIPTION
Backport #5398
 **Authored by:** @nirvn