### PR TITLE
Make geofencing digitizing prohibition a project-level setting via qfieldsync

### DIFF
--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -1336,43 +1336,6 @@ Page {
               }
 
               Label {
-                text: qsTr("Prevent digitizing while geofencing is in alert mode")
-                font: Theme.defaultFont
-                color: Theme.mainTextColor
-                wrapMode: Text.WordWrap
-                Layout.fillWidth: true
-
-                MouseArea {
-                  anchors.fill: parent
-                  onClicked: geofencingPreventDigitizingDuringAlert.toggle()
-                }
-              }
-
-              QfSwitch {
-                id: geofencingPreventDigitizingDuringAlert
-                Layout.preferredWidth: implicitContentWidth
-                Layout.alignment: Qt.AlignTop
-                checked: positioningSettings.geofencingPreventDigitizingDuringAlert
-                onCheckedChanged: {
-                  positioningSettings.geofencingPreventDigitizingDuringAlert = checked;
-                }
-              }
-
-              Label {
-                text: qsTr("When enabled, the digitizing of new features will be blocked if a project's geofencing is active and the current position triggers an alert.")
-                font: Theme.tipFont
-                color: Theme.secondaryTextColor
-
-                wrapMode: Text.WordWrap
-                Layout.fillWidth: true
-              }
-
-              Item {
-                // empty cell in grid layout
-                width: 1
-              }
-
-              Label {
                 text: qsTr("Antenna height compensation")
                 font: Theme.defaultFont
                 color: Theme.mainTextColor

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3373,6 +3373,7 @@ ApplicationWindow {
       }
       layoutListInstantiator.model.reloadModel();
       geofencer.applyProjectSettings(qgisProject);
+      positioningSettings.geofencingPreventDigitizingDuringAlert = iface.readProjectBoolEntry("qfieldsync", "/geofencingShouldPreventDigitizing", false);
     }
 
     function onSetMapExtent(extent) {


### PR DESCRIPTION
@mbernasocchi , as discussed. The setting is now project-level, and can be enabled/disabled in qfieldsync.

![image](https://github.com/opengisch/QField/assets/1728657/6451e94f-fdef-46a6-854c-e9721bfcfda2)

Much better.