### PR TITLE
Rest feature form tabs on confirmed or cancelled.

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -46,6 +46,10 @@ Page {
     }
   }
 
+  function resetTabs() {
+    tabRow.currentIndex = 0;
+  }
+
   clip: true
   states: [
     State {

--- a/src/qml/OverlayFeatureFormDrawer.qml
+++ b/src/qml/OverlayFeatureFormDrawer.qml
@@ -103,6 +103,7 @@ Drawer {
         overlayFeatureForm.isSaved = false; //reset
       }
       digitizingToolbar.digitizingLogger.writeCoordinates();
+      resetTabs();
     }
 
     onCancelled: {
@@ -115,6 +116,7 @@ Drawer {
         overlayFeatureForm.isSaved = false; //reset
       }
       digitizingToolbar.digitizingLogger.clearCoordinates();
+      resetTabs();
     }
 
     Keys.onReleased: event => {


### PR DESCRIPTION
This PR tries to resolve this issue: 

**Steps to remake issue:**
- Select the apiary layer in the legend, then insure that editing is ON
- Add an apiary point onto the map (fill in the required info), and make sure you click on the OK check mark button when - you are in the 2nd or 3rd tab.
- Then when the form is gone, add another apiary point.
- You'll see the feature form opens at the tab you last  had focused.
- What we should do here is that when we create a new feature, it should reset to the 1st tab.

**Fix:**
we add a reset tab function in `FeatureForm.qml` and after `confirm` or `cancel` we call that.  

Closes #5417