### PR TITLE
Always (try to) save parent features prior to adding children

### DIFF
--- a/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
@@ -131,9 +131,10 @@ EditorWidgetBase {
         repeat: false
 
         onTriggered: {
+          let saved = save();
           if (ProjectUtils.transactionMode(qgisProject) !== Qgis.TransactionMode.Disabled) {
             // When a transaction mode is enabled, we must fallback to saving the parent feature to have provider-side issues
-            if (!save()) {
+            if (!saved) {
               displayToast(qsTr('Cannot add child feature: insure the parent feature meets all constraints and can be saved'), 'warning');
               return;
             }

--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -150,9 +150,10 @@ EditorWidgetBase {
           repeat: false
 
           onTriggered: {
+            let saved = save();
             if (ProjectUtils.transactionMode(qgisProject) !== Qgis.TransactionMode.Disabled) {
               // When a transaction mode is enabled, we must fallback to saving the parent feature to have provider-side issues
-              if (!save()) {
+              if (!saved) {
                 addingIndicator.running = false;
                 displayToast(qsTr('Cannot add child feature: insure the parent feature meets all constraints and can be saved'), 'warning');
                 return;


### PR DESCRIPTION
This PR fixes https://github.com/opengisch/QField/issues/5445 -- long story short here: a while back, we allowed for addition of children while a parent had yet to be saved due to unmet constraints. This can be useful for some workflows, but it turns out to break a couple of scenarios, including the one reported here where geopackage have foreign key constraints.

To be safe, let's always try to save().