### PR TITLE
Do not collapse width of the expand/collapse button when layer has no children to help visual glance at legend

### DIFF
--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -85,17 +85,14 @@ ListView {
       // Collapsed state visual feedback
       Row {
         id: collapsedState
-        property bool isVisible: HasChildren
         anchors.verticalCenter: parent.verticalCenter
         height: 24
-        visible: isVisible
 
         Item {
           height: 24
-          width: HasChildren ? 24 : 0
+          width: 24
           clip: true
           anchors.verticalCenter: parent.verticalCenter
-          visible: HasChildren
 
           QfToolButton {
             height: 35
@@ -105,6 +102,7 @@ ListView {
             iconColor: isSelectedLayer ? "white" : Theme.mainTextColor
             bgcolor: "transparent"
             visible: HasChildren
+            enabled: HasChildren
             rotation: !IsCollapsed ? 90 : 0
 
             Behavior on rotation  {


### PR DESCRIPTION
Valid issue raised by the Groupement Forestiers Quebec via email.

ATM, with the improved legend allowing for collapsing/expanding and toggling visibility within the legend itself, it has become really hard to understand the relationship between layers and symbol children:

![image](https://github.com/user-attachments/assets/272c5c02-ba2e-4719-b57a-7c833b528ecf)

This is what it looked like before:

![image](https://github.com/user-attachments/assets/1dded1a0-152a-4d7e-8be4-bde05ef3db53)

This PR addresses this by insuring we're never collapsing the horizontal space occupied by the collapse/expand button.

![Screenshot from 2024-07-20 18-47-27](https://github.com/user-attachments/assets/926ad01f-b64c-49d0-aed9-3410416118db)

