### PR TITLE
[Backport release-3_3] Do not collapse width of the expand/collapse button when layer has no children to help visual glance at legend

### DIFF
--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -89,17 +89,14 @@ ListView {
       // Collapsed state visual feedback
       Row {
         id: collapsedState
-        property bool isVisible: HasChildren
         anchors.verticalCenter: parent.verticalCenter
         height: 24
-        visible: isVisible
 
         Item {
           height: 24
-          width: HasChildren ? 24 : 0
+          width: 24
           clip: true
           anchors.verticalCenter: parent.verticalCenter
-          visible: HasChildren
 
           QfToolButton {
             height: 35
@@ -109,6 +106,7 @@ ListView {
             iconColor: isSelectedLayer ? "white" : Theme.mainTextColor
             bgcolor: "transparent"
             visible: HasChildren
+            enabled: HasChildren
             rotation: !IsCollapsed ? 90 : 0
 
             Behavior on rotation {


### PR DESCRIPTION
Backport #5456
 **Authored by:** @nirvn