### PR TITLE
[Backport release-3_3] Ignore content of .qfieldsync folder when seeking project file

### DIFF
--- a/platform/android/src/ch/opengis/qfield/QFieldUtils.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldUtils.java
@@ -73,7 +73,9 @@ public class QFieldUtils {
             ZipEntry entry;
             while ((entry = zin.getNextEntry()) != null) {
                 String entryName = entry.getName().toLowerCase();
-                if (entryName.endsWith(".qgs") || entryName.endsWith(".qgz")) {
+                if ((entryName.endsWith(".qgs") ||
+                     entryName.endsWith(".qgz")) &&
+                    !entryName.contains(".qfieldsync")) {
                     projectName = entry.getName();
                     break;
                 }

--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -125,6 +125,7 @@ bool AppInterface::hasProjectOnLaunch() const
 
 bool AppInterface::loadFile( const QString &path, const QString &name )
 {
+  qInfo() << QStringLiteral( "AppInterface loading file: %1" ).arg( path );
   if ( QFileInfo::exists( path ) )
   {
     return mApp->loadProjectFile( path, name );


### PR DESCRIPTION
Backport #5453
 **Authored by:** @nirvn