### PR TITLE
Fix RelationCombobox not autocompleting on secon feature

### DIFF
--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -526,6 +526,7 @@ Item {
               searchableLabel.completer = '';
             }
           } else {
+            iface.logMessage("onActiveFocusChanged: isLastKeyPressedReturn=%1 text=%2".arg(isLastKeyPressedReturn).arg(text));
             if (!isLastKeyPressedReturn) {
               if (text === '' && featureListModel.addNull) {
                 comboBox.currentIndex = 0;

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -516,7 +516,6 @@ Item {
 
         onActiveFocusChanged: {
           searchableLabel.useCompleter = activeFocus;
-          iface.logMessage("onActiveFocusChanged: activeFocus=" + activeFocus);
           if (activeFocus) {
             if (text === '') {
               if (!featureListModel.addNull || comboBox.currentIndex != 0) {
@@ -526,13 +525,11 @@ Item {
               searchableLabel.completer = '';
             }
           } else {
-            iface.logMessage("onActiveFocusChanged: isLastKeyPressedReturn=%1 text=%2".arg(isLastKeyPressedReturn).arg(text));
             if (!isLastKeyPressedReturn) {
               if (text === '' && featureListModel.addNull) {
                 comboBox.currentIndex = 0;
                 searchableLabel.completer = comboBox.displayText;
               } else {
-                iface.logMessage("applyAutoCompletion(true);");
                 applyAutoCompletion(true);
               }
             } else if (text !== '') {
@@ -546,7 +543,6 @@ Item {
 
         property bool isLastKeyPressedReturn: false
         Keys.onPressed: event => {
-          iface.logMessage("Keys.onPressed: event.key=" + event.key);
           if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
             if (!isLastKeyPressedReturn) {
               applyAutoCompletion();
@@ -558,7 +554,6 @@ Item {
         }
 
         function applyAutoCompletion(resetIfNone = false) {
-          iface.logMessage("applyAutoCompletion: resetIfNone=" + resetIfNone);
           var trimmedText = text.trim();
           var matches = featureListModel.findDisplayValueMatches(trimmedText);
           if (matches.length > 0) {

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -516,6 +516,7 @@ Item {
 
         onActiveFocusChanged: {
           searchableLabel.useCompleter = activeFocus;
+          iface.logMessage("onActiveFocusChanged: activeFocus=" + activeFocus);
           if (activeFocus) {
             if (text === '') {
               if (!featureListModel.addNull || comboBox.currentIndex != 0) {
@@ -530,6 +531,7 @@ Item {
                 comboBox.currentIndex = 0;
                 searchableLabel.completer = comboBox.displayText;
               } else {
+                iface.logMessage("applyAutoCompletion(true);");
                 applyAutoCompletion(true);
               }
             } else if (text !== '') {
@@ -553,6 +555,7 @@ Item {
         }
 
         function applyAutoCompletion(resetIfNone = false) {
+          iface.logMessage("applyAutoCompletion: resetIfNone=" + resetIfNone);
           var trimmedText = text.trim();
           var matches = featureListModel.findDisplayValueMatches(trimmedText);
           if (matches.length > 0) {

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -541,10 +541,12 @@ Item {
               searchableLabel.completer = comboBox.displayText;
             }
           }
+          isLastKeyPressedReturn = false;
         }
 
         property bool isLastKeyPressedReturn: false
         Keys.onPressed: event => {
+          iface.logMessage("Keys.onPressed: event.key=" + event.key);
           if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
             if (!isLastKeyPressedReturn) {
               applyAutoCompletion();


### PR DESCRIPTION
Reset of the flag `isLastKeyPressedReturn` was missing.
This issue is happening only when using the enter button of the virtual keyboard