### PR TITLE
Implement support for map theme default active layer

### DIFF
--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -36,6 +36,7 @@ FlatLayerTreeModel::FlatLayerTreeModel( QgsLayerTree *layerTree, QgsProject *pro
   setSourceModel( mSourceModel );
   connect( mSourceModel, &FlatLayerTreeModelBase::mapThemeChanged, this, &FlatLayerTreeModel::mapThemeChanged );
   connect( mSourceModel, &FlatLayerTreeModelBase::isTemporalChanged, this, &FlatLayerTreeModel::isTemporalChanged );
+  connect( mSourceModel, &FlatLayerTreeModelBase::isFrozenChanged, this, &FlatLayerTreeModel::isFrozenChanged );
 }
 
 QVariant FlatLayerTreeModel::data( const QModelIndex &index, int role ) const
@@ -66,6 +67,11 @@ bool FlatLayerTreeModel::isTemporal() const
 void FlatLayerTreeModel::updateCurrentMapTheme()
 {
   mSourceModel->updateCurrentMapTheme();
+}
+
+bool FlatLayerTreeModel::isFrozen() const
+{
+  return mSourceModel->isFrozen();
 }
 
 void FlatLayerTreeModel::freeze()
@@ -124,14 +130,22 @@ FlatLayerTreeModelBase::FlatLayerTreeModelBase( QgsLayerTree *layerTree, QgsProj
   connect( mLayerTreeModel, &QAbstractItemModel::rowsInserted, this, &FlatLayerTreeModelBase::insertInMap );
 }
 
+bool FlatLayerTreeModelBase::isFrozen() const
+{
+  return mFrozen > 0;
+}
+
 void FlatLayerTreeModelBase::freeze()
 {
   mFrozen++;
+  emit isFrozenChanged();
 }
 
 void FlatLayerTreeModelBase::unfreeze( bool resetModel )
 {
   mFrozen = 0;
+  emit isFrozenChanged();
+
   if ( resetModel )
     buildMap( mLayerTreeModel );
 }

--- a/src/core/layertreemodel.h
+++ b/src/core/layertreemodel.h
@@ -67,6 +67,8 @@ class FlatLayerTreeModelBase : public QAbstractProxyModel
     //! This should be triggered after a project has been loaded
     Q_INVOKABLE void updateCurrentMapTheme();
 
+    //! Returns TRUE if the model is frozen
+    bool isFrozen() const;
     //! Freezes the model as is, with any source model signals ignored
     Q_INVOKABLE void freeze();
     //! Unfreezes the model and resume listening to source model signals
@@ -84,6 +86,7 @@ class FlatLayerTreeModelBase : public QAbstractProxyModel
   signals:
     void mapThemeChanged();
     void isTemporalChanged();
+    void isFrozenChanged();
 
   private:
     void featureCountChanged();
@@ -111,6 +114,7 @@ class FlatLayerTreeModel : public QSortFilterProxyModel
 
     Q_PROPERTY( QString mapTheme READ mapTheme WRITE setMapTheme NOTIFY mapThemeChanged )
     Q_PROPERTY( bool isTemporal READ isTemporal NOTIFY isTemporalChanged )
+    Q_PROPERTY( bool isFrozen READ isFrozen NOTIFY isFrozenChanged )
 
   public:
     enum Roles
@@ -157,6 +161,8 @@ class FlatLayerTreeModel : public QSortFilterProxyModel
     //! This should be triggered after a project has been loaded
     Q_INVOKABLE void updateCurrentMapTheme();
 
+    //! Returns TRUE if the model is frozen
+    bool isFrozen() const;
     //! Freezes the model as is, with any source model signals ignored
     Q_INVOKABLE void freeze();
     //! Unfreezes the model and resume listening to source model signals
@@ -177,6 +183,7 @@ class FlatLayerTreeModel : public QSortFilterProxyModel
   signals:
     void mapThemeChanged();
     void isTemporalChanged();
+    void isFrozenChanged();
 
   protected:
     virtual bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const override;

--- a/src/core/projectinfo.cpp
+++ b/src/core/projectinfo.cpp
@@ -780,3 +780,23 @@ QVariantMap ProjectInfo::getImageDecorationConfiguration()
 
   return configuration;
 }
+
+QgsMapLayer *ProjectInfo::getDefaultActiveLayerForMapTheme( const QString &mapTheme )
+{
+  if ( mapTheme.isEmpty() )
+  {
+    return nullptr;
+  }
+
+  const QString json = QgsProject::instance()->readEntry( QStringLiteral( "qfieldsync" ), QStringLiteral( "/mapThemesActiveLayers" ) );
+  const QJsonDocument document = QJsonDocument::fromJson( json.toUtf8() );
+
+  QJsonObject entries = document.object();
+  if ( entries.contains( mapTheme ) )
+  {
+    const QString mapLayerId = entries.value( mapTheme ).toString();
+    return QgsProject::instance()->mapLayer( mapLayerId );
+  }
+
+  return nullptr;
+}

--- a/src/core/projectinfo.h
+++ b/src/core/projectinfo.h
@@ -187,6 +187,9 @@ class ProjectInfo : public QObject
     //! Retrieves configuration of the image decoration
     Q_INVOKABLE QVariantMap getImageDecorationConfiguration();
 
+    //! Retrieves the default active layer for a given map theme
+    Q_INVOKABLE QgsMapLayer *getDefaultActiveLayerForMapTheme( const QString &mapTheme );
+
   signals:
 
     void filePathChanged();

--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -151,8 +151,8 @@ ListView {
             enabled: (allowActiveLayerChange || (projectInfo.activeLayer != VectorLayerPointer))
             onClicked: {
               layerTree.setData(legend.model.index(index, 0), !Visible, FlatLayerTreeModel.Visible);
-              flatLayerTree.mapTheme = '';
               projectInfo.saveLayerTreeState();
+              flatLayerTree.mapTheme = '';
             }
           }
         }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3305,7 +3305,7 @@ ApplicationWindow {
       platformUtilities.setHandleVolumeKeys(qfieldSettings.digitizingVolumeKeys && stateMachine.state != 'browse');
       let activeLayer = projectInfo.activeLayer;
       if (flatLayerTree.mapTheme != '') {
-        let defaultActiveLayer = projectInfo.getDefaultActiveLayerForMapTheme(flatLayerTree.mapTheme);
+        const defaultActiveLayer = projectInfo.getDefaultActiveLayerForMapTheme(flatLayerTree.mapTheme);
         if (defaultActiveLayer !== null) {
           activeLayer = defaultActiveLayer;
         }
@@ -3394,7 +3394,7 @@ ApplicationWindow {
 
     function onMapThemeChanged() {
       if (!flatLayerTree.isFrozen && flatLayerTree.mapTheme != '') {
-        let defaultActiveLayer = projectInfo.getDefaultActiveLayerForMapTheme(flatLayerTree.mapTheme);
+        const defaultActiveLayer = projectInfo.getDefaultActiveLayerForMapTheme(flatLayerTree.mapTheme);
         if (defaultActiveLayer !== null) {
           dashBoard.activeLayer = defaultActiveLayer;
         }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3303,7 +3303,14 @@ ApplicationWindow {
       projectInfo.filePath = path;
       stateMachine.state = projectInfo.stateMode;
       platformUtilities.setHandleVolumeKeys(qfieldSettings.digitizingVolumeKeys && stateMachine.state != 'browse');
-      dashBoard.activeLayer = projectInfo.activeLayer;
+      let activeLayer = projectInfo.activeLayer;
+      if (flatLayerTree.mapTheme != '') {
+        let defaultActiveLayer = projectInfo.getDefaultActiveLayerForMapTheme(flatLayerTree.mapTheme);
+        if (defaultActiveLayer !== null) {
+          activeLayer = defaultActiveLayer;
+        }
+      }
+      dashBoard.activeLayer = activeLayer;
       drawingTemplateModel.projectFilePath = path;
       mapCanvasBackground.color = mapCanvas.mapSettings.backgroundColor;
       var titleDecorationConfiguration = projectInfo.getTitleDecorationConfiguration();
@@ -3379,6 +3386,19 @@ ApplicationWindow {
 
     function onSetMapExtent(extent) {
       mapCanvas.mapSettings.extent = extent;
+    }
+  }
+
+  Connections {
+    target: flatLayerTree
+
+    function onMapThemeChanged() {
+      if (!flatLayerTree.isFrozen && flatLayerTree.mapTheme != '') {
+        let defaultActiveLayer = projectInfo.getDefaultActiveLayerForMapTheme(flatLayerTree.mapTheme);
+        if (defaultActiveLayer !== null) {
+          dashBoard.activeLayer = defaultActiveLayer;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Alongside a development build of qfieldsync (see https://github.com/opengisch/qfieldsync/pull/601) which will be released when we launch QField 3.4, this PR implements support for map theme's default active layer.

When a given project defines a default active layer for a given map theme, QField will now automatically activate that layer in the legend, enabling faster digitizing and easier UX for users.

In action:

https://github.com/user-attachments/assets/2422fbc0-87b7-4e4d-9a2d-37433ee5ca62

