### PR TITLE
Polish guides looks, font sizes, and colors

### DIFF
--- a/src/qml/QFieldGuide.qml
+++ b/src/qml/QFieldGuide.qml
@@ -190,8 +190,9 @@ Popup {
     }
 
     Text {
+      id: title
       objectName: "guideInternalTitle"
-      font.bold: true
+      font: Theme.strongFont
       elide: Text.ElideRight
       text: {
         if (internalObject.step) {
@@ -213,6 +214,7 @@ Popup {
     Text {
       id: description
       objectName: "guideInternalDescription"
+      font: Theme.tipFont
       wrapMode: Text.WordWrap
       color: Theme.mainTextColor
       text: {
@@ -245,13 +247,11 @@ Popup {
 
     QfButton {
       id: nextButton
+      objectName: "nextButton"
 
       property bool isLast: guide.index === steps.length - 1
 
-      objectName: "nextButton"
       text: isLast ? guide.finishText : guide.nextText
-      verticalPadding: 0
-      horizontalPadding: 12
       anchors {
         bottom: parent.bottom
         bottomMargin: 8
@@ -259,7 +259,6 @@ Popup {
         rightMargin: 15
       }
       bgcolor: Theme.mainColor
-      color: "white"
       height: 32
       radius: 5
       onClicked: {
@@ -275,9 +274,7 @@ Popup {
       id: previousButton
       objectName: "previousButton"
       text: guide.previousText
-      verticalPadding: 0
-      horizontalPadding: 12
-      bgcolor: "#00000000"
+      bgcolor: "transparent"
       color: Theme.mainColor
       height: 32
       radius: 5
@@ -297,14 +294,13 @@ Popup {
       anchors {
         right: parent.right
         top: parent.top
-        margins: 2
+        topMargin: 8
+        rightMargin: 8
       }
       width: 30
       height: width
       icon.color: Theme.mainTextColor
       icon.source: Theme.getThemeIcon('ic_close_black_24dp')
-      icon.width: 45
-      icon.height: 45
       padding: 0
       bgcolor: "transparent"
 

--- a/src/qml/QFieldGuide.qml
+++ b/src/qml/QFieldGuide.qml
@@ -237,12 +237,14 @@ Popup {
       id: animatedHint
       visible: internalObject.step.animatedGuide !== undefined
       source: visible ? internalObject.step.animatedGuide : ""
-      anchors.top: description.bottom
-      anchors.left: description.left
-      anchors.right: hintPanel.right
-      anchors.rightMargin: 15
+      anchors {
+        bottom: parent.bottom
+        left: parent.left
+        right: hintPanel.right
+        rightMargin: 15
+        bottomMargin: 15
+      }
       fillMode: AnimatedImage.PreserveAspectFit
-      anchors.topMargin: 8
     }
 
     QfButton {
@@ -254,9 +256,9 @@ Popup {
       text: isLast ? guide.finishText : guide.nextText
       anchors {
         bottom: parent.bottom
-        bottomMargin: 8
         right: parent.right
         rightMargin: 15
+        bottomMargin: 15
       }
       bgcolor: Theme.mainColor
       height: 32
@@ -282,8 +284,8 @@ Popup {
       anchors {
         right: nextButton.left
         bottom: parent.bottom
-        bottomMargin: 8
-        rightMargin: 14
+        bottomMargin: 15
+        rightMargin: 15
       }
       onClicked: {
         guide.index -= 1;


### PR DESCRIPTION
A bit of guides polishing, including:
- Fix next button color on dark theme (i.e., white text on main green color is barely readable)
- Fix oversized close button, and tweak its margins to sit better alongside other items
- Add font sizes for all text elements, make the title strong font (i.e. default font size + bold) and the description tip font
- Harmonize bottom margin

After the tweaks, we look like this:

![image](https://github.com/user-attachments/assets/62aaa7af-1431-4ed6-bd51-40d42bf0670d)
