### PR TITLE
translate server side error messages.

### DIFF
--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -81,7 +81,7 @@ QString QFieldCloudUtils::userFriendlyErrorString( const QString &errorString )
 {
   QString resultErrorString = errorString.startsWith( "[QF/" ) ? tr( "A server error has occured, please try again." ) : tr( "A network error has occured, please try again." );
 
-  if ( errorString.contains( ERROR_CODE_OVER_QUOTA ) )
+  if ( errorString.contains( errorCodeOverQuota ) )
   {
     resultErrorString = tr( "Your account's available storage is full." );
   }
@@ -93,7 +93,7 @@ QString QFieldCloudUtils::documentationFromErrorString( const QString &errorStri
 {
   QString linkToDocumentation;
 
-  if ( errorString.contains( ERROR_CODE_OVER_QUOTA ) )
+  if ( errorString.contains( errorCodeOverQuota ) )
   {
     linkToDocumentation = "https://docs.qfield.org/get-started/storage-qfc/";
   }

--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -95,7 +95,7 @@ QString QFieldCloudUtils::documentationFromErrorString( const QString &errorStri
 
   if ( errorString.contains( errorCodeOverQuota ) )
   {
-    linkToDocumentation = "https://docs.qfield.org/get-started/storage-qfc/";
+    linkToDocumentation = "https://docs.qfield.org/get-started/storage-qfc/#add-qfieldcloud-storage";
   }
 
   return linkToDocumentation;

--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -77,6 +77,34 @@ const QString QFieldCloudUtils::getProjectId( const QString &fileName )
   return QString();
 }
 
+const QString QFieldCloudUtils::userFriendlyErrorString( const QString &errorMessage )
+{
+  QString resultErrorMessage = errorMessage.startsWith( "[QF/" ) ? tr( "A server error has occured, please try again." ) : tr( "A network error has occured, please try again." );
+
+  const QString OVER_QUOTA( "over_quota" );
+
+  if ( errorMessage.contains( OVER_QUOTA ) )
+  {
+    resultErrorMessage = "Your account's available storage is full.";
+  }
+
+  return resultErrorMessage;
+}
+
+const QString QFieldCloudUtils::documentationFromErrorString( const QString &errorMessage )
+{
+  QString linkToDocumentation;
+
+  const QString OVER_QUOTA( "over_quota" );
+
+  if ( errorMessage.contains( OVER_QUOTA ) )
+  {
+    linkToDocumentation = "https://docs.qfield.org/get-started/storage-qfc/";
+  }
+
+  return linkToDocumentation;
+}
+
 void QFieldCloudUtils::setProjectSetting( const QString &projectId, const QString &setting, const QVariant &value )
 {
   thread_local QgsSettings settings;

--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -77,7 +77,7 @@ const QString QFieldCloudUtils::getProjectId( const QString &fileName )
   return QString();
 }
 
-const QString QFieldCloudUtils::userFriendlyErrorString( const QString &errorMessage )
+QString QFieldCloudUtils::userFriendlyErrorString( const QString &errorMessage )
 {
   QString resultErrorMessage = errorMessage.startsWith( "[QF/" ) ? tr( "A server error has occured, please try again." ) : tr( "A network error has occured, please try again." );
 
@@ -91,7 +91,7 @@ const QString QFieldCloudUtils::userFriendlyErrorString( const QString &errorMes
   return resultErrorMessage;
 }
 
-const QString QFieldCloudUtils::documentationFromErrorString( const QString &errorMessage )
+QString QFieldCloudUtils::documentationFromErrorString( const QString &errorMessage )
 {
   QString linkToDocumentation;
 

--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -77,27 +77,23 @@ const QString QFieldCloudUtils::getProjectId( const QString &fileName )
   return QString();
 }
 
-QString QFieldCloudUtils::userFriendlyErrorString( const QString &errorMessage )
+QString QFieldCloudUtils::userFriendlyErrorString( const QString &errorString )
 {
-  QString resultErrorMessage = errorMessage.startsWith( "[QF/" ) ? tr( "A server error has occured, please try again." ) : tr( "A network error has occured, please try again." );
+  QString resultErrorString = errorString.startsWith( "[QF/" ) ? tr( "A server error has occured, please try again." ) : tr( "A network error has occured, please try again." );
 
-  const QString OVER_QUOTA( "over_quota" );
-
-  if ( errorMessage.contains( OVER_QUOTA ) )
+  if ( errorString.contains( ERROR_CODE_OVER_QUOTA ) )
   {
-    resultErrorMessage = tr( "Your account's available storage is full." );
+    resultErrorString = tr( "Your account's available storage is full." );
   }
 
-  return resultErrorMessage;
+  return resultErrorString;
 }
 
-QString QFieldCloudUtils::documentationFromErrorString( const QString &errorMessage )
+QString QFieldCloudUtils::documentationFromErrorString( const QString &errorString )
 {
   QString linkToDocumentation;
 
-  const QString OVER_QUOTA( "over_quota" );
-
-  if ( errorMessage.contains( OVER_QUOTA ) )
+  if ( errorString.contains( ERROR_CODE_OVER_QUOTA ) )
   {
     linkToDocumentation = "https://docs.qfield.org/get-started/storage-qfc/";
   }

--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -85,7 +85,7 @@ const QString QFieldCloudUtils::userFriendlyErrorString( const QString &errorMes
 
   if ( errorMessage.contains( OVER_QUOTA ) )
   {
-    resultErrorMessage = "Your account's available storage is full.";
+    resultErrorMessage = tr( "Your account's available storage is full." );
   }
 
   return resultErrorMessage;

--- a/src/core/utils/qfieldcloudutils.h
+++ b/src/core/utils/qfieldcloudutils.h
@@ -105,7 +105,7 @@ class QFieldCloudUtils : public QObject
      * @param errorMessage reveiced error message
      * @return const QString
      */
-    Q_INVOKABLE static const QString userFriendlyErrorString( const QString &errorMessage );
+    Q_INVOKABLE static QString userFriendlyErrorString( const QString &errorMessage );
 
     /**
      * Returns link to documentation page related to error message.
@@ -113,7 +113,7 @@ class QFieldCloudUtils : public QObject
      * @param errorMessage reveiced error message
      * @return const QString
      */
-    Q_INVOKABLE static const QString documentationFromErrorString( const QString &errorMessage );
+    Q_INVOKABLE static QString documentationFromErrorString( const QString &errorMessage );
 
     //! Sets a \a setting to a given \a value for project with given \a projectId to the permanent storage.
     static void setProjectSetting( const QString &projectId, const QString &setting, const QVariant &value );

--- a/src/core/utils/qfieldcloudutils.h
+++ b/src/core/utils/qfieldcloudutils.h
@@ -99,6 +99,22 @@ class QFieldCloudUtils : public QObject
      */
     Q_INVOKABLE static const QString getProjectId( const QString &fileName );
 
+    /**
+     * Returns user-friendly message.
+     *
+     * @param errorMessage reveiced error message
+     * @return const QString
+     */
+    Q_INVOKABLE static const QString userFriendlyErrorString( const QString &errorMessage );
+
+    /**
+     * Returns link to documentation page related to error message.
+     *
+     * @param errorMessage reveiced error message
+     * @return const QString
+     */
+    Q_INVOKABLE static const QString documentationFromErrorString( const QString &errorMessage );
+
     //! Sets a \a setting to a given \a value for project with given \a projectId to the permanent storage.
     static void setProjectSetting( const QString &projectId, const QString &setting, const QVariant &value );
 

--- a/src/core/utils/qfieldcloudutils.h
+++ b/src/core/utils/qfieldcloudutils.h
@@ -16,9 +16,12 @@
 #ifndef QFIELDCLOUDUTILS_H
 #define QFIELDCLOUDUTILS_H
 
+#define ERROR_CODE_OVER_QUOTA QString( "over_quota" )
+
 #include <qfieldcloudprojectsmodel.h>
 #include <qgsmaplayer.h>
 #include <qgsproject.h>
+
 
 class QString;
 class QFieldCloudProjectsModel;
@@ -100,20 +103,20 @@ class QFieldCloudUtils : public QObject
     Q_INVOKABLE static const QString getProjectId( const QString &fileName );
 
     /**
-     * Returns user-friendly message.
+     * Returns a user-friendly error message.
      *
-     * @param errorMessage reveiced error message
-     * @return const QString
+     * @param errorString the error string to be processed.
+     * @return A user-friendly error message that will be displayed to the user, translated based on received error code.
      */
-    Q_INVOKABLE static QString userFriendlyErrorString( const QString &errorMessage );
+    Q_INVOKABLE static QString userFriendlyErrorString( const QString &errorString );
 
     /**
-     * Returns link to documentation page related to error message.
+     * Returns a documentation page hyperlink related to the provided error string.
      *
-     * @param errorMessage reveiced error message
-     * @return const QString
+     * @param errorString the error string to be processed
+     * @return The hyperlink to the documentation page related to the provided error code, or an empty string if no match is found.
      */
-    Q_INVOKABLE static QString documentationFromErrorString( const QString &errorMessage );
+    Q_INVOKABLE static QString documentationFromErrorString( const QString &errorString );
 
     //! Sets a \a setting to a given \a value for project with given \a projectId to the permanent storage.
     static void setProjectSetting( const QString &projectId, const QString &setting, const QVariant &value );

--- a/src/core/utils/qfieldcloudutils.h
+++ b/src/core/utils/qfieldcloudutils.h
@@ -16,8 +16,6 @@
 #ifndef QFIELDCLOUDUTILS_H
 #define QFIELDCLOUDUTILS_H
 
-#define ERROR_CODE_OVER_QUOTA QString( "over_quota" )
-
 #include <qfieldcloudprojectsmodel.h>
 #include <qgsmaplayer.h>
 #include <qgsproject.h>
@@ -132,6 +130,9 @@ class QFieldCloudUtils : public QObject
 
     //! Adds removes a \a fileName for a given \a projectId to the pending attachments list
     static void removePendingAttachment( const QString &projectId, const QString &fileName );
+
+  private:
+    static inline const QString errorCodeOverQuota { QStringLiteral( "over_quota" ) };
 };
 
 #endif // QFIELDCLOUDUTILS_H

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -301,17 +301,9 @@ Popup {
           detailsColor: Theme.secondaryTextColor
           font: Theme.tipFont
 
-          titleText: detailsText.startsWith('[QF/') ? qsTr('A server error has occured, please try again.') : qsTr('A network error has occured, please try again.')
+          externalLink: QFieldCloudUtils.documentationFromErrorString(detailsText)
+          titleText: QFieldCloudUtils.userFriendlyErrorString(detailsText)
           detailsText: ''
-
-          function humanizeError(errorString) {
-            if (errorString.includes("Network Error")) {
-              errorString = "Network Error";
-            } else if (errorString.includes("Quota Error")) {
-              errorString = "Quota Error";
-            }
-            return errorString;
-          }
 
           Connections {
             target: iface
@@ -327,14 +319,14 @@ Popup {
             function onPushFinished(projectId, hasError, errorString) {
               transferError.hasError = hasError;
               if (transferError.visible) {
-                transferError.detailsText = transferError.humanizeError(errorString);
+                transferError.detailsText = errorString;
               }
             }
 
             function onProjectDownloaded(projectId, projectName, hasError, errorString) {
               transferError.hasError = hasError;
               if (transferError.visible) {
-                transferError.detailsText = transferError.humanizeError(errorString);
+                transferError.detailsText = errorString;
               }
               const projectData = cloudProjectsModel.getProjectData(projectId);
               if (projectData.PackagedLayerErrors.length !== 0) {

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -304,6 +304,15 @@ Popup {
           titleText: detailsText.startsWith('[QF/') ? qsTr('A server error has occured, please try again.') : qsTr('A network error has occured, please try again.')
           detailsText: ''
 
+          function humanizeError(errorString) {
+            if (errorString.includes("Network Error")) {
+              errorString = "Network Error";
+            } else if (errorString.includes("Quota Error")) {
+              errorString = "Quota Error";
+            }
+            return errorString;
+          }
+
           Connections {
             target: iface
 
@@ -318,14 +327,14 @@ Popup {
             function onPushFinished(projectId, hasError, errorString) {
               transferError.hasError = hasError;
               if (transferError.visible) {
-                transferError.detailsText = errorString;
+                transferError.detailsText = transferError.humanizeError(errorString);
               }
             }
 
             function onProjectDownloaded(projectId, projectName, hasError, errorString) {
               transferError.hasError = hasError;
               if (transferError.visible) {
-                transferError.detailsText = errorString;
+                transferError.detailsText = transferError.humanizeError(errorString);
               }
               const projectData = cloudProjectsModel.getProjectData(projectId);
               if (projectData.PackagedLayerErrors.length !== 0) {

--- a/src/qml/imports/Theme/QfCollapsibleMessage.qml
+++ b/src/qml/imports/Theme/QfCollapsibleMessage.qml
@@ -6,6 +6,7 @@ import Theme 1.0
 
 Item {
   property bool collapsed: true
+  property string externalLink: ""
   property alias color: titleText.color
   property alias detailsColor: detailsText.color
   property alias font: titleText.font
@@ -26,7 +27,6 @@ Item {
   Rectangle {
     id: background
     anchors.fill: parent
-
     color: "transparent"
     border.color: titleText.color
     border.width: 1
@@ -36,28 +36,47 @@ Item {
 
   Text {
     id: titleText
-
     width: parent.width - 5
     anchors.top: parent.top
     anchors.left: parent.left
-    padding: 5
+    leftPadding: 8
+    topPadding: 10
+    bottomPadding: 10
     clip: true
-
     font: Theme.defaultFont
     color: "black"
-
-    horizontalAlignment: Text.AlignHCenter
+    horizontalAlignment: Text.AlignLeft
     wrapMode: Text.WordWrap
+  }
+
+  ToolButton {
+    id: externalLinkButton
+    z: mainMouseArea.z + 1
+    visible: externalLink !== ''
+    flat: false
+    text: "?"
+    anchors.verticalCenter: titleText.verticalCenter
+    anchors.right: parent.right
+    anchors.rightMargin: 4
+    highlighted: true
+    Material.accent: Theme.mainBackgroundColor
+    font.bold: true
+    onClicked: {
+      Qt.openUrlExternally(externalLink);
+    }
+    background: Rectangle {
+      implicitWidth: 30
+      implicitHeight: 30
+      color: titleText.color
+      radius: background.radius
+    }
   }
 
   Rectangle {
     id: separator
-
-    width: parent.width - 24
+    width: parent.width - 36
     anchors.top: titleText.bottom
-    anchors.left: parent.left
-    anchors.leftMargin: 12
-
+    anchors.horizontalCenter: parent.horizontalCenter
     height: 1
     color: titleText.color
     opacity: 0.25
@@ -65,27 +84,25 @@ Item {
 
   Text {
     id: detailsText
-
     width: parent.width - 5
     anchors.top: separator.bottom
-    anchors.left: parent.left
-    padding: 5
+    anchors.right: externalLinkButton.left
+    anchors.left: titleText.left
+    leftPadding: 8
+    topPadding: 10
+    bottomPadding: 10
     clip: true
-
     font.pointSize: titleText.font.pointSize / 1.5
     font.weight: titleText.font.weight
     font.italic: titleText.font.italic
     font.family: titleText.font.family
-
     color: titleText.color
-
-    horizontalAlignment: Text.AlignHCenter
     wrapMode: Text.WordWrap
   }
 
   MouseArea {
+    id: mainMouseArea
     anchors.fill: parent
-
     onClicked: {
       parent.collapsed = !parent.collapsed;
     }


### PR DESCRIPTION
This pull request introduces a new function, which takes a server-side error message and returns a user-friendly version. The function simplifies and clarifies complex error messages, making it easier for users to understand what went wrong and how to fix it.

**Key Features:**
- Translates technical error messages into user-friendly messages
- Provides clear and concise explanations of complex errors

**Benefits:**
- Increased customer satisfaction by providing clear explanations of what went wrong
- Reduced support requests by making it easier for users to troubleshoot issues on their own

**Related:**
https://github.com/opengisch/QField/discussions/5493

**New Look:**   
   
![image](https://github.com/user-attachments/assets/d37d466f-12fd-4773-b6be-51dd1fd15dc7)
  
   

![image](https://github.com/user-attachments/assets/821bdbad-e0c5-42ad-9d30-0900f2dd09ff)
