### PR TITLE
Fix handling of autogenerated fid in feature form, adjust default NDK following github Ubuntu 22.04 image update

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -78,8 +78,11 @@ jobs:
         run: |
           echo "JAVA_HOME=${JAVA_HOME_17_X64}" >> $GITHUB_ENV
           echo "ANDROID_NDK_VERSION=25.2.9519653" >> $GITHUB_ENV
+          echo "ANDROID_NDK=/usr/local/lib/android/sdk/ndk/25.2.9519653" >> $GITHUB_ENV
+          echo "ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk/25.2.9519653" >> $GITHUB_ENV
+          echo "ANDROID_NDK_ROOT=/usr/local/lib/android/sdk/ndk/25.2.9519653" >> $GITHUB_ENV
           echo "ANDROID_BUILD_TOOLS_VERSION=33.0.0" >> $GITHUB_ENV
-          echo "ndk.dir=$ANDROID_NDK_HOME" >> local.properties
+          echo "ndk.dir=/usr/local/lib/android/sdk/ndk/25.2.9519653" >> local.properties
           ALL_FILES_ACCESS=${{ matrix.all_files_access }} ./scripts/ci/env_gh.sh
 
           BUILD_ROOT="/home/runner"

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -79,11 +79,19 @@ EditorWidgetBase {
     }
 
     onTextChanged: {
-      if (field.isNumeric) {
-        let value = parseFloat(text);
-        valueChangeRequested(value, isNaN(value));
+      if (text !== '') {
+        if (field.isNumeric) {
+          let value = parseFloat(text);
+          // Only trigger value change for valid numerical values to insure we do not
+          // interfere with 'Autogenerate' value
+          if (!isNaN(value)) {
+            valueChangeRequested(value, false);
+          }
+        } else {
+          valueChangeRequested(text, false);
+        }
       } else {
-        valueChangeRequested(text, text === '');
+        valueChangeRequested(text, true);
       }
     }
   }


### PR DESCRIPTION
This PR fixes https://github.com/opengisch/QField/issues/5502 , a regression which slipped in 3.3.7. It's a bad one, I think we should push 3.3.9 ASAP.

To that end, this PR fixes Android CI following an Ubuntu 22.04 image update which changed the default Android NDK to r27 (see https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20240730.2).