### PR TITLE
Improve logic and handling of of attachments upload to QFieldCloud

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           build_dir: "build"
           lgtm_comment_body: ''
-          clang_tidy_checks: '-*,performance-*,bugprone-*,clang-analyzer-*,mpi-*'
+          clang_tidy_checks: '-*,performance-*,bugprone-*,clang-analyzer-*,mpi-*,-bugprone-narrowing-conversions'
 
       - name: Package
         run: |

--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -3,6 +3,7 @@
 
   <!-- The permissions are specified manually. This way we do not request the microphone permissions which would be pulled in
        as dependent permissions because of qt multimedia. -->
+  <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/src/core/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloudconnection.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "appinterface.h"
 #include "qfield.h"
 #include "qfieldcloudconnection.h"
 #include "qfieldcloudutils.h"
@@ -595,6 +596,20 @@ void QFieldCloudConnection::processPendingAttachments()
       }
       else
       {
+        const int httpCode = attachmentReply->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
+        if ( httpCode != 201 )
+        {
+          qInfo() << QStringLiteral( "Attachment project ID: %1" ).arg( projectId );
+          qInfo() << QStringLiteral( "Attachment file name: %1" ).arg( fileName );
+          qInfo() << QStringLiteral( "Attachment reply HTTP status code: %1" ).arg( httpCode );
+          for ( const QByteArray &header : attachmentReply->rawHeaderList() )
+          {
+            qInfo() << QStringLiteral( "Attachment reply header: %1 => %2" ).arg( header ).arg( attachmentReply->rawHeader( header ) );
+          }
+          qInfo() << QStringLiteral( "Attachment reply content: %1" ).arg( attachmentReply->readAll() );
+          AppInterface::instance()->sendLog( QStringLiteral( "QFieldCloud file upload HTTP code oddity!" ), QString() );
+        }
+
         QFieldCloudUtils::removePendingAttachment( projectId, fileName );
         mUploadPendingCount--;
         mUploadFailingCount = 0;

--- a/src/core/qfieldcloudconnection.h
+++ b/src/core/qfieldcloudconnection.h
@@ -176,6 +176,7 @@ class QFieldCloudConnection : public QObject
     void setState( ConnectionState state );
     void setToken( const QByteArray &token );
     void invalidateToken();
+    void processPendingAttachments();
 
     QString mUrl;
 
@@ -190,8 +191,8 @@ class QFieldCloudConnection : public QObject
 
     int mPendingRequests = 0;
 
-    bool mUploadingAttachments = false;
-    int mUploadCount = 0;
+    int mUploadPendingCount = 0;
+    int mUploadFailingCount = 0;
 
     void setClientHeaders( QNetworkRequest &request );
 };

--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -115,6 +115,11 @@ const QVariant QFieldCloudUtils::projectSetting( const QString &projectId, const
   return settings.value( QStringLiteral( "%1/%2" ).arg( projectPrefix, setting ), defaultValue );
 }
 
+bool QFieldCloudUtils::hasPendingAttachments()
+{
+  return !QFieldCloudUtils::getPendingAttachments().isEmpty();
+}
+
 const QMultiMap<QString, QString> QFieldCloudUtils::getPendingAttachments()
 {
   QMultiMap<QString, QString> files;

--- a/src/core/utils/qfieldcloudutils.h
+++ b/src/core/utils/qfieldcloudutils.h
@@ -122,6 +122,9 @@ class QFieldCloudUtils : public QObject
     //! Gets a \a setting value for project with given \a projectId from the permanent storage. Return \a defaultValue if not present.
     static const QVariant projectSetting( const QString &projectId, const QString &setting, const QVariant &defaultValue = QVariant() );
 
+    //! Returns TRUE if pending attachments are detected.
+    Q_INVOKABLE static bool hasPendingAttachments();
+
     //! Returns the list of attachments that have not yet been uploaded to the cloud.
     static const QMultiMap<QString, QString> getPendingAttachments();
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3612,8 +3612,10 @@ ApplicationWindow {
         displayToast(qsTr('Connecting...'));
       } else if (cloudConnection.status === QFieldCloudConnection.LoggedIn) {
         displayToast(qsTr('Signed in'));
-        // Go ahead and upload pending attachments in the background
-        platformUtilities.uploadPendingAttachments(cloudConnection);
+        if (QFieldCloudUtils.hasPendingAttachments()) {
+          // Go ahead and upload pending attachments in the background
+          platformUtilities.uploadPendingAttachments(cloudConnection);
+        }
         var cloudProjectId = QFieldCloudUtils.getProjectId(qgisProject.fileName);
         if (cloudProjectId) {
           cloudProjectsModel.refreshProjectFileOutdatedStatus(cloudProjectId);
@@ -3642,9 +3644,10 @@ ApplicationWindow {
         return;
       }
       displayToast(qsTr("Changes successfully pushed to QFieldCloud"));
-
-      // Go ahead and upload pending attachments in the background
-      platformUtilities.uploadPendingAttachments(cloudConnection);
+      if (QFieldCloudUtils.hasPendingAttachments()) {
+        // Go ahead and upload pending attachments in the background
+        platformUtilities.uploadPendingAttachments(cloudConnection);
+      }
     }
 
     onWarning: displayToast(message)


### PR DESCRIPTION
Prior to this PR, if you had 20 attachments added prior to pushing changes, QField would try to upload those 20 attachments _simultaneously_ in parallel. On slow internet connections, this would lead to _really slow_ simultaneous transfers. In turn, it could well have resulted in QField never able to successfully upload most of its queue prior to the app being shutdown or put in background on platforms but Android. The PR improves things there by having the files uploaded sequentially one by one.

Furthermore, a failed attachment upload caused by a momentary server/network error was never retried _on the spot_,. It was merely left in the queue to try again the next time users would push changes. While this wasn't causing data loss, I think we still should retry a failed upload a few times prior to relegating it to much later. This PR does that by allowing for 4 consecutive failures, upon which QField will bail out of uploading the queue until the next user-triggered push.

The PR also fixes a bad never-ending loop: when the code detected a non-existent attachment, it wasn't incrementing the iterator, resulting in ∞.