### PR TITLE
Improve QField image geotagging UX

### DIFF
--- a/src/qml/QFieldCamera.qml
+++ b/src/qml/QFieldCamera.qml
@@ -354,7 +354,13 @@ Popup {
               onClicked: {
                 if (cameraItem.state == "PhotoCapture") {
                   captureSession.imageCapture.captureToFile(qgisProject.homePath + '/DCIM/');
-                  currentPosition = positionSource.positionInformation;
+                  if (cameraSettings.geoTagging) {
+                    if (positionSource.active) {
+                      currentPosition = positionSource.positionInformation;
+                    } else {
+                      displayToast(qsTr("Image geotagging requires positioning to be turned on"), "warning");
+                    }
+                  }
                 } else if (cameraItem.state == "VideoCapture") {
                   if (captureSession.recorder.recorderState === MediaRecorder.StoppedState) {
                     captureSession.recorder.record();
@@ -554,15 +560,13 @@ Popup {
         padding: 2
 
         iconSource: positionSource.active ? Theme.getThemeIcon("ic_geotag_24dp") : Theme.getThemeIcon("ic_geotag_missing_24dp")
-        iconColor: positionSource.active && cameraSettings.geoTagging ? Theme.mainColor : "white"
+        iconColor: cameraSettings.geoTagging ? Theme.mainColor : "white"
         bgcolor: Theme.darkGraySemiOpaque
         round: true
 
         onClicked: {
-          if (positionSource.active) {
-            cameraSettings.geoTagging = !cameraSettings.geoTagging;
-            displayToast(cameraSettings.geoTagging ? qsTr("Geotagging enabled") : qsTr("Geotagging disabled"));
-          }
+          cameraSettings.geoTagging = !cameraSettings.geoTagging;
+          displayToast(cameraSettings.geoTagging ? qsTr("Geotagging enabled") : qsTr("Geotagging disabled"));
         }
       }
 


### PR DESCRIPTION
This PR streamlines the UX of activating QField camera geotagging by avoiding a "dead" tool button when positioning is not active. 

The new behavior allows for toggling of geotagging irrespective of the positioning active state. When taking a photo, a warning message will teach users about the need for an active positioning state. This new UX is simpler, and more informative.

Based on feedback provided by @cemno here: https://github.com/opengisch/QField/issues/5532