### PR TITLE
Fix loss of images when merging patches against pre-existing create/patch deltas

### DIFF
--- a/src/core/deltafilewrapper.cpp
+++ b/src/core/deltafilewrapper.cpp
@@ -907,7 +907,10 @@ void DeltaFileWrapper::mergePatchDelta( const QJsonObject &delta )
       attributesCreate.insert( attributeName, tmpNewAttrs.value( attributeName ) );
     }
 
-    newCreate.insert( QStringLiteral( "geometry" ), newGeomString );
+    if ( !newGeomString.isEmpty() )
+    {
+      newCreate.insert( QStringLiteral( "geometry" ), newGeomString );
+    }
     newCreate.insert( QStringLiteral( "attributes" ), attributesCreate );
 
     QJsonObject dummyOldFileChecksums;

--- a/src/core/deltafilewrapper.cpp
+++ b/src/core/deltafilewrapper.cpp
@@ -498,7 +498,6 @@ void DeltaFileWrapper::addPatch( const QString &localLayerId, const QString &sou
       { "clientId", QFieldCloudUtils::projectSetting( mCloudProjectId, QStringLiteral( "lastLocalExportId" ) ).toString() },
     } );
 
-  const QStringList attachmentFieldsList = attachmentFieldNames( mProject, localLayerId );
   const QgsGeometry oldGeom = oldFeature.geometry();
   const QgsGeometry newGeom = newFeature.geometry();
   const QgsAttributes oldAttrs = oldFeature.attributes();
@@ -581,9 +580,6 @@ void DeltaFileWrapper::addPatch( const QString &localLayerId, const QString &sou
 
   QJsonObject tmpOldAttrs;
   QJsonObject tmpNewAttrs;
-  QJsonObject tmpOldFileChecksums;
-  QJsonObject tmpNewFileChecksums;
-
   for ( const QgsField &field : fields )
   {
     const QString name = field.name();
@@ -603,30 +599,6 @@ void DeltaFileWrapper::addPatch( const QString &localLayerId, const QString &sou
       tmpNewAttrs.insert( name, attributeToJsonValue( newVal ) );
 
       hasFeatureChanged = true;
-
-      if ( attachmentFieldsList.contains( name ) )
-      {
-        const QString homeDir = mProject->homePath();
-        const QString oldFileName = oldVal.toString();
-        const QString newFileName = newVal.toString();
-
-        // if the file name is an empty or null string, there is not much we can do
-        if ( !oldFileName.isEmpty() )
-        {
-          const QString oldFullFileName = QFileInfo( oldFileName ).isAbsolute() ? oldFileName : QStringLiteral( "%1/%2" ).arg( homeDir, oldFileName );
-          const QByteArray oldFileChecksum = FileUtils::fileChecksum( oldFullFileName, QCryptographicHash::Sha256 );
-          const QJsonValue oldFileChecksumJson = oldFileChecksum.isEmpty() ? QJsonValue::Null : QJsonValue( QString( oldFileChecksum.toHex() ) );
-          tmpOldFileChecksums.insert( oldFileName, oldFileChecksumJson );
-        }
-
-        if ( !newFileName.isEmpty() )
-        {
-          const QString newFullFileName = QFileInfo( newFileName ).isAbsolute() ? newFileName : QStringLiteral( "%1/%2" ).arg( homeDir, newFileName );
-          const QByteArray newFileChecksum = FileUtils::fileChecksum( newFullFileName, QCryptographicHash::Sha256 );
-          const QJsonValue newFileChecksumJson = newFileChecksum.isEmpty() ? QJsonValue::Null : QJsonValue( QString( newFileChecksum.toHex() ) );
-          tmpNewFileChecksums.insert( newFileName, newFileChecksumJson );
-        }
-      }
     }
     else if ( storeSnapshot )
     {
@@ -641,17 +613,20 @@ void DeltaFileWrapper::addPatch( const QString &localLayerId, const QString &sou
   if ( tmpOldAttrs.length() > 0 || tmpNewAttrs.length() > 0 )
   {
     oldData.insert( QStringLiteral( "attributes" ), tmpOldAttrs );
-    if ( tmpOldFileChecksums.length() > 0 )
-      oldData.insert( QStringLiteral( "files_sha256" ), tmpOldFileChecksums );
-
     newData.insert( QStringLiteral( "attributes" ), tmpNewAttrs );
-    if ( tmpNewFileChecksums.length() > 0 )
-      newData.insert( QStringLiteral( "files_sha256" ), tmpNewFileChecksums );
-  }
-  else
-  {
-    Q_ASSERT( tmpOldFileChecksums.isEmpty() );
-    Q_ASSERT( tmpNewFileChecksums.isEmpty() );
+
+    QJsonObject oldFileChecksums;
+    QJsonObject newFileChecksums;
+    addAttachments( localLayerId, tmpOldAttrs, tmpNewAttrs, oldFileChecksums, newFileChecksums );
+    if ( oldFileChecksums.length() > 0 )
+    {
+      oldData.insert( QStringLiteral( "files_sha256" ), oldFileChecksums );
+    }
+
+    if ( newFileChecksums.length() > 0 )
+    {
+      newData.insert( QStringLiteral( "files_sha256" ), newFileChecksums );
+    }
   }
 
   newData.insert( QStringLiteral( "is_snapshot" ), false );
@@ -662,6 +637,37 @@ void DeltaFileWrapper::addPatch( const QString &localLayerId, const QString &sou
   appendDelta( delta );
 }
 
+void DeltaFileWrapper::addAttachments( const QString &localLayerId, const QJsonObject &oldAttrs, const QJsonObject &newAttrs, QJsonObject &oldFileChecksums, QJsonObject &newFileChecksums )
+{
+  const QStringList attachmentFieldsList = attachmentFieldNames( mProject, localLayerId );
+  const QStringList newAttrNames = newAttrs.keys();
+  for ( const QString &name : newAttrNames )
+  {
+    if ( attachmentFieldsList.contains( name ) )
+    {
+      const QString homeDir = mProject->homePath();
+      const QString oldFileName = oldAttrs.value( name ).toString();
+      const QString newFileName = newAttrs.value( name ).toString();
+
+      // if the file name is an empty or null string, there is not much we can do
+      if ( !oldFileName.isEmpty() )
+      {
+        const QString oldFullFileName = QFileInfo( oldFileName ).isAbsolute() ? oldFileName : QStringLiteral( "%1/%2" ).arg( homeDir, oldFileName );
+        const QByteArray oldFileChecksum = FileUtils::fileChecksum( oldFullFileName, QCryptographicHash::Sha256 );
+        const QJsonValue oldFileChecksumJson = oldFileChecksum.isEmpty() ? QJsonValue::Null : QJsonValue( QString( oldFileChecksum.toHex() ) );
+        oldFileChecksums.insert( oldFileName, oldFileChecksumJson );
+      }
+
+      if ( !newFileName.isEmpty() )
+      {
+        const QString newFullFileName = QFileInfo( newFileName ).isAbsolute() ? newFileName : QStringLiteral( "%1/%2" ).arg( homeDir, newFileName );
+        const QByteArray newFileChecksum = FileUtils::fileChecksum( newFullFileName, QCryptographicHash::Sha256 );
+        const QJsonValue newFileChecksumJson = newFileChecksum.isEmpty() ? QJsonValue::Null : QJsonValue( QString( newFileChecksum.toHex() ) );
+        newFileChecksums.insert( newFileName, newFileChecksumJson );
+      }
+    }
+  }
+}
 
 void DeltaFileWrapper::addDelete( const QString &localLayerId, const QString &sourceLayerId, const QString &localPkAttrName, const QString &sourcePkAttrName, const QgsFeature &oldFeature )
 {
@@ -736,12 +742,10 @@ void DeltaFileWrapper::addCreate( const QString &localLayerId, const QString &so
       { "exportId", QFieldCloudUtils::projectSetting( mCloudProjectId, QStringLiteral( "lastExportId" ) ).toString() },
       { "clientId", QFieldCloudUtils::projectSetting( mCloudProjectId, QStringLiteral( "lastLocalExportId" ) ).toString() },
     } );
-  const QStringList attachmentFieldsList = attachmentFieldNames( mProject, localLayerId );
   const QgsAttributes newAttrs = newFeature.attributes();
   const QgsFields newFields = newFeature.fields();
   QJsonObject newData( { { "geometry", geometryToJsonValue( newFeature.geometry() ) } } );
   QJsonObject tmpNewAttrs;
-  QJsonObject tmpNewFileChecksums;
 
   for ( int idx = 0; idx < newAttrs.count(); ++idx )
   {
@@ -774,30 +778,20 @@ void DeltaFileWrapper::addCreate( const QString &localLayerId, const QString &so
     }
 
     tmpNewAttrs.insert( name, attributeToJsonValue( newVal ) );
-
-    if ( attachmentFieldsList.contains( name ) )
-    {
-      const QString newFileName = newVal.toString();
-      const QString newFullFileName = QFileInfo( newFileName ).isAbsolute() ? newFileName : QStringLiteral( "%1/%2" ).arg( mProject->homePath(), newFileName );
-      const QByteArray newFileChecksum = FileUtils::fileChecksum( newFullFileName, QCryptographicHash::Sha256 );
-      const QJsonValue newFileChecksumJson = newFileChecksum.isEmpty() ? QJsonValue::Null : QJsonValue( QString( newFileChecksum.toHex() ) );
-
-      tmpNewFileChecksums.insert( newFileName, newFileChecksumJson );
-    }
   }
 
   if ( tmpNewAttrs.length() > 0 )
   {
     newData.insert( QStringLiteral( "attributes" ), tmpNewAttrs );
 
-    if ( tmpNewFileChecksums.length() > 0 )
+    const QJsonObject dummyOldAttrs;
+    QJsonObject dummyOldFileChecksums;
+    QJsonObject newFileChecksums;
+    addAttachments( localLayerId, dummyOldAttrs, tmpNewAttrs, dummyOldFileChecksums, newFileChecksums );
+    if ( newFileChecksums.length() > 0 )
     {
-      newData.insert( QStringLiteral( "files_sha256" ), tmpNewFileChecksums );
+      newData.insert( QStringLiteral( "files_sha256" ), newFileChecksums );
     }
-  }
-  else
-  {
-    Q_ASSERT( tmpNewFileChecksums.isEmpty() );
   }
 
   delta.insert( QStringLiteral( "new" ), newData );
@@ -871,7 +865,7 @@ void DeltaFileWrapper::mergePatchDelta( const QJsonObject &delta )
   QJsonObject tmpNewAttrs;
   if ( newData.contains( QStringLiteral( "geometry" ) ) )
   {
-    newGeomString = oldData.value( QStringLiteral( "geometry" ) ).toString();
+    newGeomString = newData.value( QStringLiteral( "geometry" ) ).toString();
   }
   if ( newData.contains( QStringLiteral( "attributes" ) ) )
   {
@@ -909,8 +903,18 @@ void DeltaFileWrapper::mergePatchDelta( const QJsonObject &delta )
       attributesCreate.insert( attributeName, tmpNewAttrs.value( attributeName ) );
     }
 
-    newCreate.insert( QStringLiteral( "attributes" ), newGeomString );
+    newCreate.insert( QStringLiteral( "geometry" ), newGeomString );
     newCreate.insert( QStringLiteral( "attributes" ), attributesCreate );
+
+    const QJsonObject dummyOldAttrs;
+    QJsonObject dummyOldFileChecksums;
+    QJsonObject newFileChecksums;
+    addAttachments( localLayerId, dummyOldAttrs, attributesCreate, dummyOldFileChecksums, newFileChecksums );
+    if ( !newFileChecksums.isEmpty() )
+    {
+      newCreate.insert( QStringLiteral( "files_sha256" ), newFileChecksums );
+    }
+
     deltaCreate.insert( QStringLiteral( "new" ), newCreate );
     deltaCreate.insert( QStringLiteral( "sourcePk" ), delta.value( QStringLiteral( "sourcePk" ) ) );
 
@@ -957,6 +961,18 @@ void DeltaFileWrapper::mergePatchDelta( const QJsonObject &delta )
           }
           existingOldData.insert( "attributes", existingOldAttributes );
           existingNewData.insert( "attributes", existingNewAttributes );
+
+          QJsonObject oldFileChecksums;
+          QJsonObject newFileChecksums;
+          addAttachments( localLayerId, existingOldAttributes, existingNewAttributes, oldFileChecksums, newFileChecksums );
+          if ( !oldFileChecksums.isEmpty() )
+          {
+            existingOldData.insert( "files_sha256", oldFileChecksums );
+          }
+          if ( !newFileChecksums.isEmpty() )
+          {
+            existingNewData.insert( "files_sha256", newFileChecksums );
+          }
         }
         existingDelta.insert( "old", existingOldData );
         existingDelta.insert( "new", existingNewData );

--- a/src/core/deltafilewrapper.cpp
+++ b/src/core/deltafilewrapper.cpp
@@ -610,20 +610,20 @@ void DeltaFileWrapper::addPatch( const QString &localLayerId, const QString &sou
   if ( !hasFeatureChanged )
     return;
 
-  if ( tmpOldAttrs.length() > 0 || tmpNewAttrs.length() > 0 )
+  if ( !tmpOldAttrs.isEmpty() || !tmpNewAttrs.isEmpty() )
   {
     oldData.insert( QStringLiteral( "attributes" ), tmpOldAttrs );
     newData.insert( QStringLiteral( "attributes" ), tmpNewAttrs );
 
     QJsonObject oldFileChecksums;
     QJsonObject newFileChecksums;
-    addAttachments( localLayerId, tmpOldAttrs, tmpNewAttrs, oldFileChecksums, newFileChecksums );
-    if ( oldFileChecksums.length() > 0 )
+    std::tie( newFileChecksums, oldFileChecksums ) = addAttachments( localLayerId, tmpNewAttrs, tmpOldAttrs );
+    if ( !oldFileChecksums.isEmpty() )
     {
       oldData.insert( QStringLiteral( "files_sha256" ), oldFileChecksums );
     }
 
-    if ( newFileChecksums.length() > 0 )
+    if ( !newFileChecksums.isEmpty() )
     {
       newData.insert( QStringLiteral( "files_sha256" ), newFileChecksums );
     }
@@ -637,8 +637,11 @@ void DeltaFileWrapper::addPatch( const QString &localLayerId, const QString &sou
   appendDelta( delta );
 }
 
-void DeltaFileWrapper::addAttachments( const QString &localLayerId, const QJsonObject &oldAttrs, const QJsonObject &newAttrs, QJsonObject &oldFileChecksums, QJsonObject &newFileChecksums )
+std::tuple<QJsonObject, QJsonObject> DeltaFileWrapper::addAttachments( const QString &localLayerId, const QJsonObject &newAttrs, const QJsonObject &oldAttrs )
 {
+  QJsonObject newFileChecksums;
+  QJsonObject oldFileChecksums;
+
   const QStringList attachmentFieldsList = attachmentFieldNames( mProject, localLayerId );
   const QStringList newAttrNames = newAttrs.keys();
   for ( const QString &name : newAttrNames )
@@ -667,6 +670,8 @@ void DeltaFileWrapper::addAttachments( const QString &localLayerId, const QJsonO
       }
     }
   }
+
+  return std::make_tuple( newFileChecksums, oldFileChecksums );
 }
 
 void DeltaFileWrapper::addDelete( const QString &localLayerId, const QString &sourceLayerId, const QString &localPkAttrName, const QString &sourcePkAttrName, const QgsFeature &oldFeature )
@@ -708,11 +713,11 @@ void DeltaFileWrapper::addDelete( const QString &localLayerId, const QString &so
     }
   }
 
-  if ( tmpOldAttrs.length() > 0 )
+  if ( !tmpOldAttrs.isEmpty() )
   {
     oldData.insert( QStringLiteral( "attributes" ), tmpOldAttrs );
 
-    if ( tmpOldFileChecksums.length() > 0 )
+    if ( !tmpOldFileChecksums.isEmpty() )
     {
       oldData.insert( QStringLiteral( "files_sha256" ), tmpOldFileChecksums );
     }
@@ -780,15 +785,14 @@ void DeltaFileWrapper::addCreate( const QString &localLayerId, const QString &so
     tmpNewAttrs.insert( name, attributeToJsonValue( newVal ) );
   }
 
-  if ( tmpNewAttrs.length() > 0 )
+  if ( !tmpNewAttrs.isEmpty() )
   {
     newData.insert( QStringLiteral( "attributes" ), tmpNewAttrs );
 
-    const QJsonObject dummyOldAttrs;
     QJsonObject dummyOldFileChecksums;
     QJsonObject newFileChecksums;
-    addAttachments( localLayerId, dummyOldAttrs, tmpNewAttrs, dummyOldFileChecksums, newFileChecksums );
-    if ( newFileChecksums.length() > 0 )
+    std::tie( newFileChecksums, dummyOldFileChecksums ) = addAttachments( localLayerId, tmpNewAttrs );
+    if ( !newFileChecksums.isEmpty() )
     {
       newData.insert( QStringLiteral( "files_sha256" ), newFileChecksums );
     }
@@ -906,10 +910,9 @@ void DeltaFileWrapper::mergePatchDelta( const QJsonObject &delta )
     newCreate.insert( QStringLiteral( "geometry" ), newGeomString );
     newCreate.insert( QStringLiteral( "attributes" ), attributesCreate );
 
-    const QJsonObject dummyOldAttrs;
     QJsonObject dummyOldFileChecksums;
     QJsonObject newFileChecksums;
-    addAttachments( localLayerId, dummyOldAttrs, attributesCreate, dummyOldFileChecksums, newFileChecksums );
+    std::tie( newFileChecksums, dummyOldFileChecksums ) = addAttachments( localLayerId, attributesCreate );
     if ( !newFileChecksums.isEmpty() )
     {
       newCreate.insert( QStringLiteral( "files_sha256" ), newFileChecksums );
@@ -964,7 +967,7 @@ void DeltaFileWrapper::mergePatchDelta( const QJsonObject &delta )
 
           QJsonObject oldFileChecksums;
           QJsonObject newFileChecksums;
-          addAttachments( localLayerId, existingOldAttributes, existingNewAttributes, oldFileChecksums, newFileChecksums );
+          std::tie( newFileChecksums, oldFileChecksums ) = addAttachments( localLayerId, existingNewAttributes, existingOldAttributes );
           if ( !oldFileChecksums.isEmpty() )
           {
             existingOldData.insert( "files_sha256", oldFileChecksums );

--- a/src/core/deltafilewrapper.h
+++ b/src/core/deltafilewrapper.h
@@ -378,6 +378,10 @@ class DeltaFileWrapper : public QObject
      */
     bool applyDeltasOnLayers( QHash<QString, QgsVectorLayer *> &vectorLayers, bool shouldApplyInReverse );
 
+    /**
+     * Add file checksums from relevant changed attributes.
+     */
+    void addAttachments( const QString &localLayerId, const QJsonObject &oldAttrs, const QJsonObject &newAttrs, QJsonObject &oldFileChecksums, QJsonObject &newFileChecksums );
 
     /**
      * Converts QVariant value to QJsonValue

--- a/src/core/deltafilewrapper.h
+++ b/src/core/deltafilewrapper.h
@@ -380,8 +380,9 @@ class DeltaFileWrapper : public QObject
 
     /**
      * Add file checksums from relevant changed attributes.
+     * \returns A std::tuple<QJsonObject, QJsonObject> where the first object reflects new file checksums and the second reflects old file checkums.
      */
-    void addAttachments( const QString &localLayerId, const QJsonObject &oldAttrs, const QJsonObject &newAttrs, QJsonObject &oldFileChecksums, QJsonObject &newFileChecksums );
+    std::tuple<QJsonObject, QJsonObject> addAttachments( const QString &localLayerId, const QJsonObject &newAttrs, const QJsonObject &oldAttrs = QJsonObject() );
 
     /**
      * Converts QVariant value to QJsonValue

--- a/test/test_deltafilewrapper.cpp
+++ b/test/test_deltafilewrapper.cpp
@@ -844,6 +844,164 @@ TEST_CASE( "DeltaFileWrapper" )
                                                            .toUtf8() );
     REQUIRE( QJsonDocument( getDeltasArray( dfw.toString() ) ) == expectedDoc );
 
+    // Insure that an updated attachment will be incorporated into the create patch
+    QgsFeature f2 = QgsFeature( f );
+    f2.setAttribute( QStringLiteral( "attachment" ), attachmentFileName2 );
+
+    dfw.addPatch( layer->id(), layer->id(), QStringLiteral( "fid" ), QStringLiteral( "fid" ), f, f2, false );
+
+    expectedDoc = QJsonDocument::fromJson( QStringLiteral( R""""(
+        [
+          {
+            "uuid": "11111111-1111-1111-1111-111111111111",
+            "clientId": "22222222-2222-2222-2222-222222222222",
+            "exportId": "33333333-3333-3333-3333-333333333333",
+            "localLayerCrs": "EPSG:3857",
+            "localLayerId": "dummyLayerIdL1",
+            "localLayerName": "layer_name",
+            "localPk": "100",
+            "sourceLayerId": "dummyLayerIdS1",
+            "sourcePk": "100",
+            "method": "create",
+            "new": {
+              "attributes": {
+                "attachment": "%1",
+                "dbl": 3.14,
+                "fid": 100,
+                "int": 42,
+                "str": "stringy"
+              },
+              "files_sha256": {
+                "%1": "%2"
+              },
+              "geometry": "Point (25.96569999999999823 43.83559999999999945)"
+            }
+          }
+        ]
+      )"""" )
+                                             .arg( attachmentFileName2, attachmentFileChecksumSha2562 )
+                                             .toUtf8() );
+    REQUIRE( QJsonDocument( getDeltasArray( dfw.toString() ) ) == expectedDoc );
+
+    // Insure that an updated geometry will be incorporated into the create patch
+    QgsFeature f3 = QgsFeature( f2 );
+    f3.setGeometry( QgsGeometry( new QgsPoint( 5.4, 3.2 ) ) );
+
+    dfw.addPatch( layer->id(), layer->id(), QStringLiteral( "fid" ), QStringLiteral( "fid" ), f2, f3, false );
+
+    expectedDoc = QJsonDocument::fromJson( QStringLiteral( R""""(
+        [
+          {
+            "uuid": "11111111-1111-1111-1111-111111111111",
+            "clientId": "22222222-2222-2222-2222-222222222222",
+            "exportId": "33333333-3333-3333-3333-333333333333",
+            "localLayerCrs": "EPSG:3857",
+            "localLayerId": "dummyLayerIdL1",
+            "localLayerName": "layer_name",
+            "localPk": "100",
+            "sourceLayerId": "dummyLayerIdS1",
+            "sourcePk": "100",
+            "method": "create",
+            "new": {
+              "attributes": {
+                "attachment": "%1",
+                "dbl": 3.14,
+                "fid": 100,
+                "int": 42,
+                "str": "stringy"
+              },
+              "files_sha256": {
+                "%1": "%2"
+              },
+              "geometry": "Point (5.40000000000000036 3.20000000000000018)"
+            }
+          }
+        ]
+      )"""" )
+                                             .arg( attachmentFileName2, attachmentFileChecksumSha2562 )
+                                             .toUtf8() );
+    REQUIRE( QJsonDocument( getDeltasArray( dfw.toString() ) ) == expectedDoc );
+
+    // Check if creates delta of a feature with a non existant attachment (subsequently edited to have one)
+    dfw.reset();
+    f = QgsFeature( layer->fields(), 100 );
+    f.setAttribute( QStringLiteral( "fid" ), 100 );
+    f.setAttribute( QStringLiteral( "dbl" ), 3.14 );
+    f.setAttribute( QStringLiteral( "int" ), 42 );
+    f.setAttribute( QStringLiteral( "str" ), QStringLiteral( "stringy" ) );
+
+    // Check if creates delta of a feature with a geometry and existing attachment
+    f.setGeometry( QgsGeometry( new QgsPoint( 25.9657, 43.8356 ) ) );
+    dfw.addCreate( layer->id(), layer->id(), QStringLiteral( "fid" ), QStringLiteral( "fid" ), f );
+
+    expectedDoc = QJsonDocument::fromJson( QStringLiteral( R""""(
+        [
+          {
+            "uuid": "11111111-1111-1111-1111-111111111111",
+            "clientId": "22222222-2222-2222-2222-222222222222",
+            "exportId": "33333333-3333-3333-3333-333333333333",
+            "localLayerCrs": "EPSG:3857",
+            "localLayerId": "dummyLayerIdL1",
+            "localLayerName": "layer_name",
+            "localPk": "100",
+            "sourceLayerId": "dummyLayerIdS1",
+            "sourcePk": "100",
+            "method": "create",
+            "new": {
+              "attributes": {
+                "attachment": null,
+                "dbl": 3.14,
+                "fid": 100,
+                "int": 42,
+                "str": "stringy"
+              },
+              "geometry": "Point (25.96569999999999823 43.83559999999999945)"
+            }
+          }
+        ]
+      )"""" )
+                                             .toUtf8() );
+    REQUIRE( QJsonDocument( getDeltasArray( dfw.toString() ) ) == expectedDoc );
+
+    // Insure that a new attachment will be incorporated into the create patch
+    f2 = QgsFeature( f );
+    f2.setAttribute( QStringLiteral( "attachment" ), attachmentFileName2 );
+
+    dfw.addPatch( layer->id(), layer->id(), QStringLiteral( "fid" ), QStringLiteral( "fid" ), f, f2, false );
+
+    expectedDoc = QJsonDocument::fromJson( QStringLiteral( R""""(
+        [
+          {
+            "uuid": "11111111-1111-1111-1111-111111111111",
+            "clientId": "22222222-2222-2222-2222-222222222222",
+            "exportId": "33333333-3333-3333-3333-333333333333",
+            "localLayerCrs": "EPSG:3857",
+            "localLayerId": "dummyLayerIdL1",
+            "localLayerName": "layer_name",
+            "localPk": "100",
+            "sourceLayerId": "dummyLayerIdS1",
+            "sourcePk": "100",
+            "method": "create",
+            "new": {
+              "attributes": {
+                "attachment": "%1",
+                "dbl": 3.14,
+                "fid": 100,
+                "int": 42,
+                "str": "stringy"
+              },
+              "files_sha256": {
+                "%1": "%2"
+              },
+              "geometry": "Point (25.96569999999999823 43.83559999999999945)"
+            }
+          }
+        ]
+      )"""" )
+                                             .arg( attachmentFileName2, attachmentFileChecksumSha2562 )
+                                             .toUtf8() );
+    REQUIRE( QJsonDocument( getDeltasArray( dfw.toString() ) ) == expectedDoc );
+
 
     // Check if creates delta of a feature with a NULL geometry and non existant attachment.
     // NOTE this is the same as calling f clearGeometry()

--- a/test/test_deltafilewrapper.cpp
+++ b/test/test_deltafilewrapper.cpp
@@ -141,20 +141,27 @@ TEST_CASE( "DeltaFileWrapper" )
   QDir projectDir( QStringLiteral( "%1/cloud_projects/TEST_PROJECT_ID" ).arg( settingsDir.path() ) );
   QFieldCloudUtils::setLocalCloudDirectory( settingsDir.path() );
   QFile projectFile( QStringLiteral( "%1/%2" ).arg( projectDir.path(), QStringLiteral( "project.qgs" ) ) );
-  QFile attachmentFile( QStringLiteral( "%1/%2" ).arg( projectDir.path(), QStringLiteral( "attachment.jpg" ) ) );
 
   REQUIRE( projectFile.open( QIODevice::WriteOnly ) );
   REQUIRE( projectFile.flush() );
 
   project->setFileName( projectFile.fileName() );
 
+  QFile attachmentFile( QStringLiteral( "%1/%2" ).arg( projectDir.path(), QStringLiteral( "attachment.jpg" ) ) );
   const char *fileContents = "кирилица"; // SHA 256 71055d022f50027387eae32426a1857d6e2fa2d416d64753b63470db7f00f239
   REQUIRE( attachmentFile.open( QIODevice::ReadWrite ) );
   REQUIRE( attachmentFile.write( fileContents ) );
   REQUIRE( attachmentFile.flush() );
-
   QString attachmentFileName = attachmentFile.fileName();
   QString attachmentFileChecksumSha256 = FileUtils::fileChecksum( attachmentFileName, QCryptographicHash::Sha256 ).toHex();
+
+  QFile attachmentFile2( QStringLiteral( "%1/%2" ).arg( projectDir.path(), QStringLiteral( "attachment2.jpg" ) ) );
+  const char *fileContents2 = "ខ្មែរ"; // SHA 256 61fb004cdb5732d803a5685d0e708d3128979562580da9ae269336bf0eded87c
+  REQUIRE( attachmentFile2.open( QIODevice::ReadWrite ) );
+  REQUIRE( attachmentFile2.write( fileContents2 ) );
+  REQUIRE( attachmentFile2.flush() );
+  QString attachmentFileName2 = attachmentFile2.fileName();
+  QString attachmentFileChecksumSha2562 = FileUtils::fileChecksum( attachmentFileName2, QCryptographicHash::Sha256 ).toHex();
 
   std::unique_ptr<QgsVectorLayer> layer = std::make_unique<QgsVectorLayer>( QStringLiteral( "Point?crs=EPSG:3857&field=fid:integer&field=int:integer&field=dbl:double&field=str:string&field=attachment:string" ), QStringLiteral( "layer_name" ), QStringLiteral( "memory" ) );
   layer->setEditorWidgetSetup( layer->fields().indexFromName( QStringLiteral( "attachment" ) ), QgsEditorWidgetSetup( QStringLiteral( "ExternalResource" ), QVariantMap() ) );
@@ -1212,10 +1219,12 @@ TEST_CASE( "DeltaFileWrapper" )
     newerFeature.setAttribute( QStringLiteral( "str" ), QStringLiteral( "modified stringy" ) );
     // test geometry change not already part of a patch to insure an old geometry is added
     newerFeature.setGeometry( QgsGeometry( new QgsPoint( 5.9657, 3.8356 ) ) );
+    // test attachment addition to make sure the file checksum is added
+    newerFeature.setAttribute( QStringLiteral( "attachment" ), attachmentFileName );
 
     dfw.addPatch( layer->id(), layer->id(), QStringLiteral( "fid" ), QStringLiteral( "fid" ), newFeature, newerFeature, false );
 
-    expectedDoc = QJsonDocument::fromJson( R""""(
+    expectedDoc = QJsonDocument::fromJson( QStringLiteral( R""""(
         [
             {
                 "clientId": "22222222-2222-2222-2222-222222222222",
@@ -1227,14 +1236,19 @@ TEST_CASE( "DeltaFileWrapper" )
                 "method": "patch",
                 "new": {
                     "attributes": {
+                        "attachment": "%1",
                         "int": 5,
                         "str": "modified stringy"
+                    },
+                    "files_sha256": {
+                      "%1": "%2"
                     },
                     "geometry": "Point (5.9657 3.8355999999999999)",
                     "is_snapshot": false
                 },
                 "old": {
                     "attributes": {
+                        "attachment": null,
                         "int": 42,
                         "str": "stringy"
                     },
@@ -1246,16 +1260,20 @@ TEST_CASE( "DeltaFileWrapper" )
                 "uuid": "11111111-1111-1111-1111-111111111111"
             }
         ]
-      )"""" );
+      )"""" )
+                                             .arg( attachmentFileName, attachmentFileChecksumSha256 )
+                                             .toUtf8() );
     REQUIRE( QJsonDocument( getDeltasArray( dfw.toString() ) ) == expectedDoc );
 
     QgsFeature newestFeature( newerFeature );
     // test geometry change already part of a patch to insure the *initial* old geometry is kept
     newestFeature.setGeometry( QgsGeometry( new QgsPoint( 0.9657, 0.8356 ) ) );
+    // test attachment addition on top of a pre-existing attachment patch to make sure the file checksum is added
+    newestFeature.setAttribute( QStringLiteral( "attachment" ), attachmentFileName2 );
 
     dfw.addPatch( layer->id(), layer->id(), QStringLiteral( "fid" ), QStringLiteral( "fid" ), newerFeature, newestFeature, false );
 
-    expectedDoc = QJsonDocument::fromJson( R""""(
+    expectedDoc = QJsonDocument::fromJson( QStringLiteral( R""""(
         [
             {
                 "clientId": "22222222-2222-2222-2222-222222222222",
@@ -1267,14 +1285,19 @@ TEST_CASE( "DeltaFileWrapper" )
                 "method": "patch",
                 "new": {
                     "attributes": {
+                        "attachment": "%1",
                         "int": 5,
                         "str": "modified stringy"
+                    },
+                    "files_sha256": {
+                      "%1": "%2"
                     },
                     "geometry": "Point (0.9657 0.83560000000000001)",
                     "is_snapshot": false
                 },
                 "old": {
                     "attributes": {
+                        "attachment": null,
                         "int": 42,
                         "str": "stringy"
                     },
@@ -1286,7 +1309,9 @@ TEST_CASE( "DeltaFileWrapper" )
                 "uuid": "11111111-1111-1111-1111-111111111111"
             }
         ]
-      )"""" );
+      )"""" )
+                                             .arg( attachmentFileName2, attachmentFileChecksumSha2562 )
+                                             .toUtf8() );
     REQUIRE( QJsonDocument( getDeltasArray( dfw.toString() ) ) == expectedDoc );
   }
 


### PR DESCRIPTION
The mysterious image loss issue has been resolved! 

Long story short, if a photo was changed/added in a follow up edit after a feature was added or already edited once _prior to pushing_, the photos would go missing as the logic to merge new patches into pre-existing create and patch deltas were not adding the necessary file checksums.

The PR fixes that. Woupidou.