### PR TITLE
Allow for users to manually push images/PDF files to the cloud from the project folder panel

### DIFF
--- a/src/core/utils/qfieldcloudutils.h
+++ b/src/core/utils/qfieldcloudutils.h
@@ -126,7 +126,7 @@ class QFieldCloudUtils : public QObject
     static const QMultiMap<QString, QString> getPendingAttachments();
 
     //! Adds an \a fileName for a given \a projectId to the pending attachments list
-    static void addPendingAttachment( const QString &projectId, const QString &fileName );
+    Q_INVOKABLE static void addPendingAttachment( const QString &projectId, const QString &fileName );
 
     //! Adds removes a \a fileName for a given \a projectId to the pending attachments list
     static void removePendingAttachment( const QString &projectId, const QString &fileName );

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -129,7 +129,7 @@ Page {
           property string itemTitle: ItemTitle
           property string itemPath: ItemPath
           property bool itemMenuLoadable: !projectFolderView && (ItemMetaType === LocalFilesModel.Project || ItemMetaType === LocalFilesModel.Dataset)
-          property bool itemMenuVisible: (platformUtilities.capabilities & PlatformUtilities.CustomExport || platformUtilities.capabilities & PlatformUtilities.CustomSend) && (ItemMetaType === LocalFilesModel.Dataset || (ItemType === LocalFilesModel.SimpleFolder && table.model.currentPath !== 'root'))
+          property bool itemMenuVisible: ((platformUtilities.capabilities & PlatformUtilities.CustomExport || platformUtilities.capabilities & PlatformUtilities.CustomSend) && (ItemMetaType === LocalFilesModel.Dataset || (ItemType === LocalFilesModel.SimpleFolder && table.model.currentPath !== 'root'))) || (ItemMetaType === LocalFilesModel.Dataset && ItemType === LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId)
 
           width: parent ? parent.width : undefined
           height: line.height
@@ -368,6 +368,23 @@ Page {
         text: qsTr("Send to...")
         onTriggered: {
           platformUtilities.sendDatasetTo(itemMenu.itemPath);
+        }
+      }
+
+      MenuItem {
+        id: pushDatasetToCloud
+        enabled: itemMenu.itemMetaType == LocalFilesModel.Dataset && itemMenu.itemType == LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId
+        visible: enabled
+
+        font: Theme.defaultFont
+        width: parent.width
+        height: enabled ? undefined : 0
+        leftPadding: Theme.menuItemLeftPadding
+
+        text: qsTr("Push to QFieldCloud...")
+        onTriggered: {
+          QFieldCloudUtils.addPendingAttachment(cloudProjectsModel.currentProjectId, itemMenu.itemPath);
+          platformUtilities.uploadPendingAttachments(cloudConnection);
         }
       }
 

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -385,6 +385,7 @@ Page {
         onTriggered: {
           QFieldCloudUtils.addPendingAttachment(cloudProjectsModel.currentProjectId, itemMenu.itemPath);
           platformUtilities.uploadPendingAttachments(cloudConnection);
+          displayToast(qsTr("‘%1’ is being uploaded to QFieldCloud").arg(FileUtils.fileName(itemMenu.itemPath)));
         }
       }
 


### PR DESCRIPTION
This PR adds a mechanism - through the project folder panel - which allows users to push images and PDFs contained within a cloud project folder (or one of its subfolders) to the QFieldCloud server. 

The action is available through a raster image's 3-dot menu within the project folder panel:
![image](https://github.com/user-attachments/assets/e3ff0842-89f2-40aa-8f6e-ea137d6c228a)

It is enabled _only for raster files_ to prevent the world from colliding if we were to push back geopackages to the cloud, messing up with delta handling et al.

Practically speaking, this allows: a/ users to recover images that never made it into the server automatically (it shouldn't happen, but as Jurassic Park told us, life finds a way), and b/ users to send back printed layouts and atlases back onto the server.