### PR TITLE
Fix snapping result point reprojection when current layer has a Z/M dimension

### DIFF
--- a/src/core/utils/snappingutils.cpp
+++ b/src/core/utils/snappingutils.cpp
@@ -112,9 +112,9 @@ void SnappingUtils::snap()
   {
     const QgsFeature ft = match.layer()->getFeature( match.featureId() );
     QgsPoint snappedPoint = newPoint( ft.geometry().vertexAt( match.vertexIndex() ), vlayer->wkbType() );
-    if ( vlayer->crs() != mapSettings()->destinationCrs() )
+    if ( match.layer()->crs() != mapSettings()->destinationCrs() )
     {
-      QgsCoordinateTransform transform( vlayer->crs(), mapSettings()->destinationCrs(), QgsProject::instance()->transformContext() );
+      QgsCoordinateTransform transform( match.layer()->crs(), mapSettings()->destinationCrs(), QgsProject::instance()->transformContext() );
       try
       {
         snappedPoint.transform( transform );


### PR DESCRIPTION
Fixes issue raised in this discussion (https://github.com/opengisch/QField/discussions/5546). 

@DrawQuick , in 15 minutes or so you will find test APKs in this pull request to test that the disappearing coordinate cursor disappearing issue has been fixed. Thanks for the report.