### PR TITLE
[Backport release-3_3] Fix snapping result point reprojection when current layer has a Z/M dimension

### DIFF
--- a/src/core/utils/snappingutils.cpp
+++ b/src/core/utils/snappingutils.cpp
@@ -113,9 +113,9 @@ void SnappingUtils::snap()
   {
     const QgsFeature ft = match.layer()->getFeature( match.featureId() );
     QgsPoint snappedPoint = newPoint( ft.geometry().vertexAt( match.vertexIndex() ), vlayer->wkbType() );
-    if ( vlayer->crs() != mapSettings()->destinationCrs() )
+    if ( match.layer()->crs() != mapSettings()->destinationCrs() )
     {
-      QgsCoordinateTransform transform( vlayer->crs(), mapSettings()->destinationCrs(), QgsProject::instance()->transformContext() );
+      QgsCoordinateTransform transform( match.layer()->crs(), mapSettings()->destinationCrs(), QgsProject::instance()->transformContext() );
       try
       {
         snappedPoint.transform( transform );


### PR DESCRIPTION
Backport #5547
 **Authored by:** @nirvn