### PR TITLE
Harmonize handling of QField's (multi)value relation editor widget with that of QGIS

### DIFF
--- a/src/core/featurechecklistmodel.cpp
+++ b/src/core/featurechecklistmodel.cpp
@@ -61,8 +61,6 @@ QHash<int, QByteArray> FeatureCheckListModel::roleNames() const
 
 QVariant FeatureCheckListModel::attributeValue() const
 {
-  QVariant value;
-
   QVariantList vl;
   //store as QVariantList because the field type supports data structure
   for ( const QString &s : std::as_const( mCheckedEntries ) )
@@ -83,23 +81,26 @@ QVariant FeatureCheckListModel::attributeValue() const
     }
   }
 
-  if ( mAllowMulti )
+  QVariant value;
+  if ( !vl.isEmpty() )
   {
-    if ( mAttributeField.type() == QMetaType::QVariantMap || mAttributeField.type() == QMetaType::QVariantList || mAttributeField.type() == QMetaType::QStringList )
+    if ( mAllowMulti )
     {
-      value = vl;
+      if ( mAttributeField.type() == QMetaType::QVariantMap || mAttributeField.type() == QMetaType::QVariantList || mAttributeField.type() == QMetaType::QStringList )
+      {
+        value = vl;
+      }
+      else
+      {
+        //make string
+        value = QgsPostgresStringUtils::buildArray( vl );
+      }
     }
     else
     {
-      //make string
-      value = QgsPostgresStringUtils::buildArray( vl );
+      value = vl.first();
     }
   }
-  else
-  {
-    value = vl.first();
-  }
-
   return value;
 }
 

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -42,7 +42,7 @@ EditorWidgetBase {
     attributeValue: value !== undefined ? value : ""
 
     onListUpdated: {
-      valueChangeRequested(attributeValue, false);
+      valueChangeRequested(attributeValue, attributeValue === "");
     }
   }
 


### PR DESCRIPTION
PR fixes https://github.com/opengisch/QField/issues/5539 , and aligns QField's behavior with that of QGIS by returning null when no value is checked .