### PR TITLE
Better QFieldCloud account's empty project list message

### DIFF
--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -407,12 +407,14 @@ Page {
 
           Label {
             anchors.fill: parent
-            horizontalAlignment: Qt.AlignHCenter
-            verticalAlignment: Qt.AlignVCenter
-            visible: parent.count == 0
-            text: table.refreshing ? qsTr("Refreshing projects list") : qsTr("No projects found")
-            font: Theme.strongTipFont
-            color: Theme.secondaryTextColor
+            anchors.margins: 20
+            visible: parent.count == 0 && filterBar.currentIndex === 0
+            text: table.refreshing ? qsTr("Refreshing projects list") : qsTr("No cloud projects found. To get started, %1read the documentation%2.").arg("<a href=\"https://docs.qfield.org/get-started/tutorials/get-started-qfc/\">").arg("</a>")
+            font: Theme.defaultFont
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+            onLinkActivated: Qt.openUrlExternally(link)
           }
 
           MouseArea {


### PR DESCRIPTION
Before, a brand new cloud user would see an unhelpful "no projects found" when first logging into their cloud account using QField.

This PR tries to do better by offering a link to our QFieldCloud getting started documentation page:

![Screenshot from 2024-08-16 16-24-46](https://github.com/user-attachments/assets/9f7cab20-195f-4ab0-831c-be67d9230977)
