### PR TITLE
Fix cloud user information context when loading a new cloud project

### DIFF
--- a/src/core/projectinfo.cpp
+++ b/src/core/projectinfo.cpp
@@ -48,7 +48,6 @@ void ProjectInfo::setFilePath( const QString &filePath )
   emit filePathChanged();
   emit stateModeChanged();
   emit activeLayerChanged();
-  emit cloudUserInformationChanged();
 }
 
 QString ProjectInfo::filePath() const
@@ -320,6 +319,11 @@ void ProjectInfo::setCloudUserInformation( const CloudUserInformation cloudUserI
   mSettings.setValue( QStringLiteral( "json" ), cloudUserInformation.toJson() );
   mSettings.endGroup();
 
+  emit cloudUserInformationChanged();
+}
+
+void ProjectInfo::restoreCloudUserInformation()
+{
   emit cloudUserInformationChanged();
 }
 

--- a/src/core/projectinfo.h
+++ b/src/core/projectinfo.h
@@ -169,6 +169,11 @@ class ProjectInfo : public QObject
      */
     void setCloudUserInformation( const CloudUserInformation cloudUserInformation );
 
+    /**
+     * Restores last saved cloud user information details attached to the current project
+     */
+    Q_INVOKABLE void restoreCloudUserInformation();
+
     //! Save an ongoing vector \a layer tracking session details
     Q_INVOKABLE void saveTracker( QgsVectorLayer *layer );
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3360,7 +3360,10 @@ ApplicationWindow {
           qfieldCloudPopup.show();
         }
         if (cloudConnection.status === QFieldCloudConnection.LoggedIn) {
+          projectInfo.cloudUserInformation = cloudConnection.userInformation;
           cloudProjectsModel.refreshProjectFileOutdatedStatus(cloudProjectId);
+        } else {
+          projectInfo.restoreCloudUserInformation();
         }
       } else {
         projectInfo.hasInsertRights = true;
@@ -3408,7 +3411,6 @@ ApplicationWindow {
     mapSettings: mapCanvas.mapSettings
     layerTree: dashBoard.layerTree
     trackingModel: trackings.model
-    cloudUserInformation: cloudConnection.userInformation
 
     property var distanceUnits: Qgis.DistanceUnit.Meters
     property var areaUnits: Qgis.AreaUnit.SquareMeters
@@ -3618,6 +3620,7 @@ ApplicationWindow {
         }
         var cloudProjectId = QFieldCloudUtils.getProjectId(qgisProject.fileName);
         if (cloudProjectId) {
+          projectInfo.cloudUserInformation = userInformation;
           cloudProjectsModel.refreshProjectFileOutdatedStatus(cloudProjectId);
         }
       }


### PR DESCRIPTION
This PR fixes missing cloud user details context for expressions when loading a new cloud project.

Long story short here, when we load a new cloud project, the cloud user information having not been saved before is simply not written, and therefore the cloud user information changed signal returns empty values.