### PR TITLE
Editable project variables.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           build_dir: "build"
           lgtm_comment_body: ''
-          clang_tidy_checks: '-*,performance-*,bugprone-*,clang-analyzer-*,mpi-*,-bugprone-narrowing-conversions,-clang-analyzer-optin.core.EnumCastOutOfRange,-performance-enum-size'
+          clang_tidy_checks: '-*,performance-*,bugprone-*,clang-analyzer-*,mpi-*,-bugprone-narrowing-conversions,-bugprone-easily-swappable-parameters,-clang-analyzer-optin.core.EnumCastOutOfRange,-performance-enum-size'
 
       - name: Package
         run: |

--- a/src/core/expressionvariablemodel.cpp
+++ b/src/core/expressionvariablemodel.cpp
@@ -83,7 +83,7 @@ void ExpressionVariableModel::save()
     const QString itemName = currentItem->data( VariableName ).toString();
     const QString itemValue = currentItem->data( VariableValue ).toString();
 
-    if ( currentItem->isEditable() && itemScope == VariableScope::ApplicationScope )
+    if ( currentItem->isEditable() && itemScope == VariableScope::GlobalScope )
     {
       QgsExpressionContextUtils::setGlobalVariable( itemName, itemValue );
     }
@@ -112,7 +112,7 @@ void ExpressionVariableModel::reloadVariables()
       if ( QString::compare( varValue.toString(), QStringLiteral( "Not available" ) ) == 0 )
         varValue = QVariant( QT_TR_NOOP( "Not Available" ) );
 
-      addVariable( VariableScope::ApplicationScope, varName, varValue.toString(), false );
+      addVariable( VariableScope::GlobalScope, varName, varValue.toString(), false );
     }
   }
   // Second add custom variables
@@ -120,7 +120,7 @@ void ExpressionVariableModel::reloadVariables()
   {
     if ( !scope->isReadOnly( varName ) )
     {
-      addVariable( VariableScope::ApplicationScope, varName, scope->variable( varName ).toString() );
+      addVariable( VariableScope::GlobalScope, varName, scope->variable( varName ).toString() );
     }
   }
   // Finally add readonly project variables

--- a/src/core/expressionvariablemodel.cpp
+++ b/src/core/expressionvariablemodel.cpp
@@ -76,17 +76,22 @@ void ExpressionVariableModel::removeVariable( VariableScope scope, const QString
 
 void ExpressionVariableModel::save()
 {
-  QVariantMap variables;
   for ( int i = 0; i < rowCount(); ++i )
   {
-    const VariableScope itemScope = item( i )->data( VariableScopeRole ).value<VariableScope>();
-    if ( item( i )->isEditable() && itemScope == VariableScope::ApplicationScope )
+    const QStandardItem *currentItem = item( i );
+    const VariableScope itemScope = currentItem->data( VariableScopeRole ).value<VariableScope>();
+    const QString itemName = currentItem->data( VariableName ).toString();
+    const QString itemValue = currentItem->data( VariableValue ).toString();
+
+    if ( currentItem->isEditable() && itemScope == VariableScope::ApplicationScope )
     {
-      variables.insert( item( i )->data( VariableName ).toString(), item( i )->data( VariableValue ) );
+      QgsExpressionContextUtils::setGlobalVariable( itemName, itemValue );
+    }
+    else if ( itemScope == VariableScope::ProjectScope )
+    {
+      ExpressionContextUtils::setProjectVariable( mCurrentProject, itemName, itemValue );
     }
   }
-
-  QgsExpressionContextUtils::setGlobalVariables( variables );
 }
 
 void ExpressionVariableModel::reloadVariables()

--- a/src/core/expressionvariablemodel.cpp
+++ b/src/core/expressionvariablemodel.cpp
@@ -62,9 +62,9 @@ void ExpressionVariableModel::removeVariable( VariableScope scope, const QString
 {
   for ( int i = 0; i < rowCount(); ++i )
   {
-    QStandardItem *rowItem = item( i );
-    QString variableName = rowItem->data( VariableName ).toString();
-    VariableScope variableScope = rowItem->data( VariableScopeRole ).value<VariableScope>();
+    const QStandardItem *rowItem = item( i );
+    const QString variableName = rowItem->data( VariableName ).toString();
+    const VariableScope variableScope = rowItem->data( VariableScopeRole ).value<VariableScope>();
 
     if ( variableName == name && variableScope == scope )
     {
@@ -79,7 +79,8 @@ void ExpressionVariableModel::save()
   QVariantMap variables;
   for ( int i = 0; i < rowCount(); ++i )
   {
-    if ( item( i )->isEditable() )
+    const VariableScope itemScope = item( i )->data( VariableScopeRole ).value<VariableScope>();
+    if ( item( i )->isEditable() && itemScope == VariableScope::ApplicationScope )
     {
       variables.insert( item( i )->data( VariableName ).toString(), item( i )->data( VariableValue ) );
     }
@@ -114,16 +115,17 @@ void ExpressionVariableModel::reloadVariables()
   {
     if ( !scope->isReadOnly( varName ) )
     {
-      addVariable( VariableScope::ApplicationScope, varName, scope->variable( varName ).toString(), true );
+      addVariable( VariableScope::ApplicationScope, varName, scope->variable( varName ).toString() );
     }
   }
   // Finally add readonly project variables
   QVariantMap projectVariables = ExpressionContextUtils::projectVariables( mCurrentProject );
-  for ( const QString &varName : projectVariables.keys() )
+  const QStringList projectVariableKeys = projectVariables.keys();
+  for ( const QString &varName : projectVariableKeys )
   {
     QVariant varValue = projectVariables.value( varName ).toString();
 
-    addVariable( VariableScope::ProjectScope, varName, varValue.toString(), false );
+    addVariable( VariableScope::ProjectScope, varName, varValue.toString() );
   }
 }
 

--- a/src/core/expressionvariablemodel.h
+++ b/src/core/expressionvariablemodel.h
@@ -36,7 +36,7 @@ class ExpressionVariableModel : public QStandardItemModel
 
     enum class VariableScope
     {
-      ApplicationScope,
+      GlobalScope,
       ProjectScope
     };
 

--- a/src/core/expressionvariablemodel.h
+++ b/src/core/expressionvariablemodel.h
@@ -44,7 +44,7 @@ class ExpressionVariableModel : public QStandardItemModel
 
     bool setData( const QModelIndex &index, const QVariant &value, int role ) override;
 
-    Q_INVOKABLE int addVariable( VariableScope scope, const QString &name, const QString &value, bool editable );
+    Q_INVOKABLE int addVariable( VariableScope scope, const QString &name, const QString &value, bool editable = true );
 
     Q_INVOKABLE void removeVariable( VariableScope scope, const QString &name );
 

--- a/src/core/expressionvariablemodel.h
+++ b/src/core/expressionvariablemodel.h
@@ -44,7 +44,7 @@ class ExpressionVariableModel : public QStandardItemModel
 
     bool setData( const QModelIndex &index, const QVariant &value, int role ) override;
 
-    Q_INVOKABLE int addVariable( VariableScope scope, const QString &name, const QString &value );
+    Q_INVOKABLE int addVariable( VariableScope scope, const QString &name, const QString &value, bool editable );
 
     Q_INVOKABLE void removeVariable( VariableScope scope, const QString &name );
 

--- a/src/core/expressionvariablemodel.h
+++ b/src/core/expressionvariablemodel.h
@@ -40,6 +40,8 @@ class ExpressionVariableModel : public QStandardItemModel
       ProjectScope
     };
 
+    Q_ENUM( VariableScope )
+
     explicit ExpressionVariableModel( QObject *parent = nullptr );
 
     bool setData( const QModelIndex &index, const QVariant &value, int role ) override;

--- a/src/qml/VariableEditor.qml
+++ b/src/qml/VariableEditor.qml
@@ -46,7 +46,7 @@ ColumnLayout {
         color: "transparent"
 
         property var itemRow: index
-        property bool canDelete: VariableEditable && VariableScope == 0 // application scope
+        property bool canDelete: VariableEditable && VariableScope == ExpressionVariableModel.GlobalScope
 
         function forceFocusOnVariableName() {
           variableNameText.forceActiveFocus();
@@ -156,8 +156,7 @@ ColumnLayout {
     text: qsTr("Add a new variable")
 
     onClicked: {
-      let applicationScope = 0;
-      let insertionPosition = table.model.addVariable(applicationScope, "new_variable", "");
+      let insertionPosition = table.model.addVariable(ExpressionVariableModel.GlobalScope, "new_variable", "");
       table.positionViewAtIndex(insertionPosition, ListView.Contain);
       table.itemAtIndex(insertionPosition).forceFocusOnVariableName();
     }

--- a/src/qml/VariableEditor.qml
+++ b/src/qml/VariableEditor.qml
@@ -157,7 +157,7 @@ ColumnLayout {
 
     onClicked: {
       let applicationScope = 0;
-      let insertionPosition = table.model.addVariable(applicationScope, "new_variable", "", true);
+      let insertionPosition = table.model.addVariable(applicationScope, "new_variable", "");
       table.positionViewAtIndex(insertionPosition, ListView.Contain);
       table.itemAtIndex(insertionPosition).forceFocusOnVariableName();
     }

--- a/src/qml/VariableEditor.qml
+++ b/src/qml/VariableEditor.qml
@@ -46,7 +46,7 @@ ColumnLayout {
         color: "transparent"
 
         property var itemRow: index
-        property bool canDelete: VariableEditable
+        property bool canDelete: VariableEditable && VariableScope == 0 // application scope
 
         function forceFocusOnVariableName() {
           variableNameText.forceActiveFocus();
@@ -157,7 +157,7 @@ ColumnLayout {
 
     onClicked: {
       let applicationScope = 0;
-      let insertionPosition = table.model.addVariable(applicationScope, "new_variable", "");
+      let insertionPosition = table.model.addVariable(applicationScope, "new_variable", "", true);
       table.positionViewAtIndex(insertionPosition, ListView.Contain);
       table.itemAtIndex(insertionPosition).forceFocusOnVariableName();
     }


### PR DESCRIPTION
### Description

This PR represents the second step in revamping the variables page within the settings. As you know in [**This PR**](https://github.com/opengisch/QField/pull/5577), we introduced project variables to the existing list, which previously only displayed application-wide (global) variables.

In this step, we've made it possible to edit project variables (_but unremovable_). The changes will remain effective throughout the session, but once the project is closed and reopened, the values will revert to their original settings.

**Stay tuned:** 

for step three, where we will focus on enhancing the visual design! :)


**Demo:**    
   
You can see editable but unremovable project variables here: 
  

![image](https://github.com/user-attachments/assets/4620d4b3-9fb2-4475-b6b8-cd0519afa21b)
