### PR TITLE
Expression template support for title and copyright decorations

### DIFF
--- a/src/core/expressionevaluator.cpp
+++ b/src/core/expressionevaluator.cpp
@@ -15,8 +15,10 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "expressioncontextutils.h"
 #include "expressionevaluator.h"
-#include "qgsexpressioncontextutils.h"
+
+#include <qgsexpressioncontextutils.h>
 
 ExpressionEvaluator::ExpressionEvaluator( QObject *parent )
   : QObject( parent )
@@ -77,6 +79,18 @@ void ExpressionEvaluator::setMapSettings( QgsQuickMapSettings *mapSettings )
   emit mapSettingsChanged();
 }
 
+void ExpressionEvaluator::setPositionInformation( const GnssPositionInformation &positionInformation )
+{
+  mPositionInformation = positionInformation;
+  emit positionInformationChanged();
+}
+
+void ExpressionEvaluator::setCloudUserInformation( const CloudUserInformation &cloudUserInformation )
+{
+  mCloudUserInformation = cloudUserInformation;
+  emit cloudUserInformationChanged();
+}
+
 QVariant ExpressionEvaluator::evaluate()
 {
   if ( mExpressionText.isEmpty() )
@@ -84,6 +98,15 @@ QVariant ExpressionEvaluator::evaluate()
 
   QgsExpressionContext expressionContext;
   expressionContext << QgsExpressionContextUtils::globalScope();
+
+  if ( mPositionInformation.isValid() )
+  {
+    expressionContext << ExpressionContextUtils::positionScope( mPositionInformation, false );
+  }
+  if ( !mCloudUserInformation.username.isEmpty() )
+  {
+    expressionContext << ExpressionContextUtils::cloudUserScope( mCloudUserInformation );
+  }
   if ( mMapSettings )
   {
     expressionContext << QgsExpressionContextUtils::mapSettingsScope( mMapSettings->mapSettings() );

--- a/src/core/expressionevaluator.cpp
+++ b/src/core/expressionevaluator.cpp
@@ -17,44 +17,101 @@
 
 #include "expressionevaluator.h"
 #include "qgsexpressioncontextutils.h"
-#include "qgsproject.h"
 
 ExpressionEvaluator::ExpressionEvaluator( QObject *parent )
   : QObject( parent )
 {
 }
 
+void ExpressionEvaluator::setMode( Mode mode )
+{
+  if ( mMode == mode )
+    return;
+
+  mMode = mode;
+  emit modeChanged();
+}
+
 void ExpressionEvaluator::setExpressionText( const QString &expressionText )
 {
+  if ( mExpressionText == expressionText )
+    return;
+
   mExpressionText = expressionText;
-  emit expressionTextChanged( mExpressionText );
+  emit expressionTextChanged();
 }
 
 void ExpressionEvaluator::setFeature( const QgsFeature &feature )
 {
+  if ( mFeature == feature )
+    return;
+
   mFeature = feature;
-  emit featureChanged( mFeature );
+  emit featureChanged();
 }
 
 void ExpressionEvaluator::setLayer( QgsMapLayer *layer )
 {
+  if ( mLayer == layer )
+    return;
+
   mLayer = layer;
-  emit layerChanged( mLayer );
+  emit layerChanged();
+}
+
+void ExpressionEvaluator::setProject( QgsProject *project )
+{
+  if ( mProject == project )
+    return;
+
+  mProject = project;
+  emit projectChanged();
+}
+
+void ExpressionEvaluator::setMapSettings( QgsQuickMapSettings *mapSettings )
+{
+  if ( mMapSettings == mapSettings )
+    return;
+
+  mMapSettings = mapSettings;
+  emit mapSettingsChanged();
 }
 
 QVariant ExpressionEvaluator::evaluate()
 {
-  if ( !mFeature.isValid() || !mLayer || mExpressionText.isEmpty() )
+  if ( mExpressionText.isEmpty() )
     return QString();
 
-  QgsExpression exp( mExpressionText );
   QgsExpressionContext expressionContext;
-  expressionContext.setFeature( mFeature );
-  expressionContext << QgsExpressionContextUtils::globalScope()
-                    << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
-                    << QgsExpressionContextUtils::layerScope( mLayer );
+  expressionContext << QgsExpressionContextUtils::globalScope();
+  if ( mMapSettings )
+  {
+    expressionContext << QgsExpressionContextUtils::mapSettingsScope( mMapSettings->mapSettings() );
+  }
+  if ( mProject )
+  {
+    expressionContext << QgsExpressionContextUtils::projectScope( mProject );
+  }
+  if ( mLayer )
+  {
+    expressionContext << QgsExpressionContextUtils::layerScope( mLayer );
+  }
+  if ( mFeature.isValid() )
+  {
+    expressionContext.setFeature( mFeature );
+  }
 
-  exp.prepare( &expressionContext );
-  QVariant value = exp.evaluate( &expressionContext );
+  QVariant value;
+  if ( mMode == ExpressionMode )
+  {
+    QgsExpression expression( mExpressionText );
+    expression.prepare( &expressionContext );
+    value = expression.evaluate( &expressionContext );
+  }
+  else
+  {
+    value = QgsExpression::replaceExpressionText( mExpressionText, &expressionContext );
+  }
+
   return value.toString();
 }

--- a/src/core/expressionevaluator.h
+++ b/src/core/expressionevaluator.h
@@ -18,41 +18,75 @@
 #ifndef EXPRESSIONEVALUATOR_H
 #define EXPRESSIONEVALUATOR_H
 
+#include "qgsquickmapsettings.h"
+
 #include <QObject>
 #include <qgsexpression.h>
 #include <qgsexpressioncontext.h>
 #include <qgsmaplayer.h>
+#include <qgsproject.h>
 
 class ExpressionEvaluator : public QObject
 {
     Q_OBJECT
 
+    Q_PROPERTY( Mode mode READ mode WRITE setMode NOTIFY modeChanged )
+
     Q_PROPERTY( QString expressionText READ expressionText WRITE setExpressionText NOTIFY expressionTextChanged )
+
     Q_PROPERTY( QgsFeature feature READ feature WRITE setFeature NOTIFY featureChanged )
     Q_PROPERTY( QgsMapLayer *layer READ layer WRITE setLayer NOTIFY layerChanged )
+    Q_PROPERTY( QgsProject *project READ project WRITE setProject NOTIFY projectChanged )
+    Q_PROPERTY( QgsProject *project READ project WRITE setProject NOTIFY projectChanged )
+    Q_PROPERTY( QgsQuickMapSettings *mapSettings READ mapSettings WRITE setMapSettings NOTIFY mapSettingsChanged )
 
   public:
+    enum Mode
+    {
+      ExpressionMode,
+      ExpressionTemplateMode
+    };
+    Q_ENUM( Mode )
+
     explicit ExpressionEvaluator( QObject *parent = nullptr );
 
-    QString expressionText() { return mExpressionText; }
-    QgsFeature feature() { return mFeature; }
-    QgsMapLayer *layer() { return mLayer; }
+    Mode mode() const { return mMode; }
+    void setMode( Mode mode );
 
+    QString expressionText() { return mExpressionText; }
     void setExpressionText( const QString &expressionText );
+
+    QgsFeature feature() const { return mFeature; }
     void setFeature( const QgsFeature &feature );
+
+    QgsMapLayer *layer() const { return mLayer; }
     void setLayer( QgsMapLayer *layer );
+
+    QgsProject *project() const { return mProject; }
+    void setProject( QgsProject *project );
+
+    QgsQuickMapSettings *mapSettings() const { return mMapSettings; }
+    void setMapSettings( QgsQuickMapSettings *mapSettings );
 
     //! Returns the evaluated string value
     Q_INVOKABLE QVariant evaluate();
 
   signals:
-    void layerChanged( QgsMapLayer *layer );
-    void expressionTextChanged( QString expressionText );
-    void featureChanged( QgsFeature feature );
+    void modeChanged();
+    void expressionTextChanged();
+    void featureChanged();
+    void layerChanged();
+    void projectChanged();
+    void mapSettingsChanged();
 
   private:
+    Mode mMode = ExpressionMode;
+
     QString mExpressionText;
+
     QgsFeature mFeature;
     QgsMapLayer *mLayer = nullptr;
+    QgsProject *mProject = nullptr;
+    QgsQuickMapSettings *mMapSettings = nullptr;
 };
 #endif // EXPRESSIONEVALUATOR_H

--- a/src/core/expressionevaluator.h
+++ b/src/core/expressionevaluator.h
@@ -28,6 +28,11 @@
 #include <qgsmaplayer.h>
 #include <qgsproject.h>
 
+
+/**
+ * @brief The ExpressionEvaluator class enables evaluation of expression
+ * strings and expression templates.
+ */
 class ExpressionEvaluator : public QObject
 {
     Q_OBJECT
@@ -45,40 +50,65 @@ class ExpressionEvaluator : public QObject
     Q_PROPERTY( CloudUserInformation cloudUserInformation READ cloudUserInformation WRITE setCloudUserInformation NOTIFY cloudUserInformationChanged )
 
   public:
+    //! Expression evaluator modes
     enum Mode
     {
-      ExpressionMode,
-      ExpressionTemplateMode
+      ExpressionMode,         //!< Handle expression text as expression strings
+      ExpressionTemplateMode, //!< Handle expression text as expression templates
     };
     Q_ENUM( Mode )
 
     explicit ExpressionEvaluator( QObject *parent = nullptr );
 
+    //! Returns the expression evaluator mode
     Mode mode() const { return mMode; }
+
+    //! Sets the expression evaluator \a mode
     void setMode( Mode mode );
 
+    //! Returns the expression text used when evaluating
     QString expressionText() { return mExpressionText; }
+
+    //! Sets the expression text used when evaluating
     void setExpressionText( const QString &expressionText );
 
+    //! Returns the feature attached to the expression context
     QgsFeature feature() const { return mFeature; }
+
+    //! Sets the feature attached to the expression context
     void setFeature( const QgsFeature &feature );
 
+    //! Returns the map layer attached to the expression context
     QgsMapLayer *layer() const { return mLayer; }
+
+    //! Sets the map layer attached to the expression context
     void setLayer( QgsMapLayer *layer );
 
+    //! Returns the project attached to the expression context
     QgsProject *project() const { return mProject; }
+
+    //! Sets the project attached to the expression context
     void setProject( QgsProject *project );
 
+    //! Returns the map settings attached to the expression context
     QgsQuickMapSettings *mapSettings() const { return mMapSettings; }
+
+    //! Sets the map settings attached to the expression context
     void setMapSettings( QgsQuickMapSettings *mapSettings );
 
+    //! Returns the position information attached to the expression context
     GnssPositionInformation positionInformation() const { return mPositionInformation; }
+
+    //! Sets the position information attached to the expression context
     void setPositionInformation( const GnssPositionInformation &positionInformation );
 
+    //! Returns the cloud user information attached to the expression context
     CloudUserInformation cloudUserInformation() const { return mCloudUserInformation; }
+
+    //! Sets the cloud user information attached to the expression context
     void setCloudUserInformation( const CloudUserInformation &cloudUserInformation );
 
-    //! Returns the evaluated string value
+    //! Returns the evaluated expression text value
     Q_INVOKABLE QVariant evaluate();
 
   signals:

--- a/src/core/expressionevaluator.h
+++ b/src/core/expressionevaluator.h
@@ -18,6 +18,8 @@
 #ifndef EXPRESSIONEVALUATOR_H
 #define EXPRESSIONEVALUATOR_H
 
+#include "gnsspositioninformation.h"
+#include "qfieldcloudutils.h"
 #include "qgsquickmapsettings.h"
 
 #include <QObject>
@@ -39,6 +41,8 @@ class ExpressionEvaluator : public QObject
     Q_PROPERTY( QgsProject *project READ project WRITE setProject NOTIFY projectChanged )
     Q_PROPERTY( QgsProject *project READ project WRITE setProject NOTIFY projectChanged )
     Q_PROPERTY( QgsQuickMapSettings *mapSettings READ mapSettings WRITE setMapSettings NOTIFY mapSettingsChanged )
+    Q_PROPERTY( GnssPositionInformation positionInformation READ positionInformation WRITE setPositionInformation NOTIFY positionInformationChanged )
+    Q_PROPERTY( CloudUserInformation cloudUserInformation READ cloudUserInformation WRITE setCloudUserInformation NOTIFY cloudUserInformationChanged )
 
   public:
     enum Mode
@@ -68,6 +72,12 @@ class ExpressionEvaluator : public QObject
     QgsQuickMapSettings *mapSettings() const { return mMapSettings; }
     void setMapSettings( QgsQuickMapSettings *mapSettings );
 
+    GnssPositionInformation positionInformation() const { return mPositionInformation; }
+    void setPositionInformation( const GnssPositionInformation &positionInformation );
+
+    CloudUserInformation cloudUserInformation() const { return mCloudUserInformation; }
+    void setCloudUserInformation( const CloudUserInformation &cloudUserInformation );
+
     //! Returns the evaluated string value
     Q_INVOKABLE QVariant evaluate();
 
@@ -78,6 +88,8 @@ class ExpressionEvaluator : public QObject
     void layerChanged();
     void projectChanged();
     void mapSettingsChanged();
+    void positionInformationChanged();
+    void cloudUserInformationChanged();
 
   private:
     Mode mMode = ExpressionMode;
@@ -88,5 +100,7 @@ class ExpressionEvaluator : public QObject
     QgsMapLayer *mLayer = nullptr;
     QgsProject *mProject = nullptr;
     QgsQuickMapSettings *mMapSettings = nullptr;
+    GnssPositionInformation mPositionInformation;
+    CloudUserInformation mCloudUserInformation;
 };
 #endif // EXPRESSIONEVALUATOR_H

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -16,6 +16,7 @@ EditorWidgetBase {
 
   ExpressionEvaluator {
     id: rootPathEvaluator
+    project: qgisProject
   }
   property string prefixToRelativePath: {
     if (qgisProject == undefined)
@@ -111,6 +112,7 @@ EditorWidgetBase {
     id: expressionEvaluator
     feature: currentFeature
     layer: currentLayer
+    project: qgisProject
     expressionText: {
       var value;
       if (currentLayer && currentLayer.customProperty('QFieldSync/attachment_naming') !== undefined) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -95,5 +95,6 @@ ADD_CATCH2_TEST(digitizingloggertest test_digitizinglogger.cpp FALSE)
 ADD_CATCH2_TEST(attributeformmodeltest test_attributeformmodel.cpp FALSE)
 ADD_CATCH2_TEST(orderedrelationmodeltest test_orderedrelationmodel.cpp FALSE)
 ADD_CATCH2_TEST(referencingfeaturelistmodeltest test_referencingfeaturelistmodel.cpp FALSE)
+ADD_CATCH2_TEST(expressionevaluatortest test_expressionevaluator.cpp TRUE)
 
 ADD_QFIELD_QML_TEST(qmltest test_qml.cpp)

--- a/test/test_expressionevaluator.cpp
+++ b/test/test_expressionevaluator.cpp
@@ -1,0 +1,82 @@
+/***************************************************************************
+                        test_expressionevaluator.h
+                        --------------------
+  begin                : Aug 2024
+  copyright            : (C) 2024 by Mathieu Pellerin
+  email                : mathieu at opengis dot ch
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "catch2.h"
+#include "expressionevaluator.h"
+#include "positioningutils.h"
+
+#include <QTemporaryFile>
+#include <qgsvectorlayer.h>
+
+TEST_CASE( "ExpressionEvaluator" )
+{
+  ExpressionEvaluator evaluator;
+
+  QgsProject project;
+  project.setTitle( QStringLiteral( "QField rocks!" ) );
+  evaluator.setProject( &project );
+
+  QgsVectorLayer layer( QStringLiteral( "Point?crs=EPSG:4326&field=test_field:string(255,0)" ), QStringLiteral( "test" ), QStringLiteral( "memory" ) );
+  QgsFeature feature( layer.fields() );
+  feature.setAttribute( QStringLiteral( "test_field" ), QStringLiteral( "success" ) );
+  evaluator.setLayer( &layer );
+  evaluator.setFeature( feature );
+
+  GnssPositionInformation positionInformation = PositioningUtils::createGnssPositionInformation( 1.234, 1.234, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, QDateTime(), QStringLiteral( "test" ) );
+  evaluator.setPositionInformation( positionInformation );
+
+  CloudUserInformation cloudUserInformation( QStringLiteral( "nyuki" ), QStringLiteral( "nyuki@opengis.ch" ) );
+  evaluator.setCloudUserInformation( cloudUserInformation );
+
+  SECTION( "Expression mode" )
+  {
+    evaluator.setMode( ExpressionEvaluator::ExpressionMode );
+    evaluator.setExpressionText( "10 + 10" );
+    REQUIRE( evaluator.evaluate() == QStringLiteral( "20" ) );
+
+    evaluator.setExpressionText( QStringLiteral( "@project_title" ) );
+    REQUIRE( evaluator.evaluate() == QStringLiteral( "QField rocks!" ) );
+
+    evaluator.setExpressionText( QStringLiteral( "\"test_field\"" ) );
+    REQUIRE( evaluator.evaluate() == QStringLiteral( "success" ) );
+
+    evaluator.setExpressionText( QStringLiteral( "x(@gnss_coordinate)" ) );
+    REQUIRE( evaluator.evaluate() == QStringLiteral( "1.234" ) );
+
+    evaluator.setExpressionText( QStringLiteral( "@cloud_username || ' - ' || @cloud_useremail" ) );
+    REQUIRE( evaluator.evaluate() == QStringLiteral( "nyuki - nyuki@opengis.ch" ) );
+  }
+
+  SECTION( "Expression template mode" )
+  {
+    evaluator.setMode( ExpressionEvaluator::ExpressionTemplateMode );
+    evaluator.setExpressionText( QStringLiteral( "Result: [%10 + 10%]" ) );
+    REQUIRE( evaluator.evaluate() == QStringLiteral( "Result: 20" ) );
+
+    evaluator.setExpressionText( QStringLiteral( "[%@project_title%] What a title!" ) );
+    REQUIRE( evaluator.evaluate() == QStringLiteral( "QField rocks! What a title!" ) );
+
+    evaluator.setExpressionText( QStringLiteral( "This is [% \"test_field\" %]ful" ) );
+    REQUIRE( evaluator.evaluate() == QStringLiteral( "This is successful" ) );
+
+    evaluator.setExpressionText( QStringLiteral( "[%x(@gnss_coordinate)%]" ) );
+    REQUIRE( evaluator.evaluate() == QStringLiteral( "1.234" ) );
+
+    evaluator.setExpressionText( QStringLiteral( "User: [%@cloud_username%]\nEmail: [%@cloud_useremail%]" ) );
+    REQUIRE( evaluator.evaluate() == QStringLiteral( "User: nyuki\nEmail: nyuki@opengis.ch" ) );
+  }
+}


### PR DESCRIPTION
The PR improves our expression evaluator class through the following changes:

- avoid a QgsProject::instance() use in favor of a property
- add a map settings property to unlock map canvas scoping
- allow for expressions to run without the presence of a layer or feature 
- add an expression template mode (i.e. resolving a 'my field value is [% "MY_FIELD" %]')

This aimed at fixing QField not handling expression templates in title and copyright decorators. Without further due, here are expression template within decorations:

https://github.com/user-attachments/assets/7e06a791-0dca-4ad8-b218-e5ec840ded02

The title decoration relies on a @project_title variable:

```
[%@project_title%]
```

The copyright decoration here relies both on the map canvas context (showing the map scale) as well as the positioning context (showing the lat / lon). 

```
lat: [%format_number(y(@gnss_coordinate), 8)%] / lon: [%format_number(x(@gnss_coordinate), 8)%]
scale: [%format('1:%1', round(@map_scale))%]
```

The possibility to use positioning variables opens some interesting doors, such as a much leaner way to display positioning details when needed.