### PR TITLE
Implement a QFieldCloud server combobox to ease multi-server environments

### DIFF
--- a/src/core/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloudconnection.cpp
@@ -90,6 +90,20 @@ QString QFieldCloudConnection::defaultUrl()
   return QStringLiteral( "https://app.qfield.cloud" );
 }
 
+QStringList QFieldCloudConnection::urls() const
+{
+  QStringList savedUrls = QSettings().value( QStringLiteral( "/QFieldCloud/urls" ) ).toStringList();
+  if ( !savedUrls.contains( defaultUrl() ) )
+  {
+    savedUrls.prepend( defaultUrl() );
+  }
+  if ( !savedUrls.contains( mUrl ) )
+  {
+    savedUrls << mUrl;
+  }
+  return savedUrls;
+}
+
 QString QFieldCloudConnection::username() const
 {
   return mUsername;
@@ -218,8 +232,9 @@ void QFieldCloudConnection::login()
       setToken( token );
     }
 
+    QSettings settings;
     mUsername = resp.value( QStringLiteral( "username" ) ).toString();
-    QSettings().setValue( "/QFieldCloud/username", mUsername );
+    settings.setValue( QStringLiteral( "/QFieldCloud/username" ), mUsername );
     emit usernameChanged();
 
     mAvatarUrl = resp.value( QStringLiteral( "avatar_url" ) ).toString();
@@ -227,6 +242,13 @@ void QFieldCloudConnection::login()
     mUserInformation = CloudUserInformation( mUsername, resp.value( QStringLiteral( "email" ) ).toString() );
     emit userInformationChanged();
 
+    QStringList savedUrls = settings.value( QStringLiteral( "/QFieldCloud/urls" ), QStringList() << defaultUrl() ).toStringList();
+    if ( !savedUrls.contains( mUrl ) )
+    {
+      savedUrls << mUrl;
+      settings.setValue( QStringLiteral( "/QFieldCloud/urls" ), savedUrls );
+      emit urlsChanged();
+    }
     setStatus( ConnectionStatus::LoggedIn );
   } );
 }

--- a/src/core/qfieldcloudconnection.h
+++ b/src/core/qfieldcloudconnection.h
@@ -73,6 +73,7 @@ class QFieldCloudConnection : public QObject
     Q_PROPERTY( QString avatarUrl READ avatarUrl NOTIFY avatarUrlChanged )
     Q_PROPERTY( QString url READ url WRITE setUrl NOTIFY urlChanged )
     Q_PROPERTY( QString defaultUrl READ defaultUrl CONSTANT )
+    Q_PROPERTY( QStringList urls READ urls NOTIFY urlsChanged )
 
     Q_PROPERTY( ConnectionStatus status READ status NOTIFY statusChanged )
     Q_PROPERTY( ConnectionState state READ state NOTIFY stateChanged )
@@ -99,6 +100,11 @@ class QFieldCloudConnection : public QObject
      * Default server connection URL, pointing to the production server.
      */
     static QString defaultUrl();
+
+    /**
+     * Returns the connections URLs successfully logged in in the past.
+     */
+    Q_INVOKABLE QStringList urls() const;
 
     QString username() const;
     void setUsername( const QString &username );
@@ -162,6 +168,7 @@ class QFieldCloudConnection : public QObject
     void passwordChanged();
     void avatarUrlChanged();
     void urlChanged();
+    void urlsChanged();
     void statusChanged();
     void stateChanged();
     void tokenChanged();


### PR DESCRIPTION
Looks:

![image](https://github.com/user-attachments/assets/366f3454-5d7b-4005-a56a-7d01a3e24a28)

This added combobox functionality makes it much easier to switch back and forth from the default QFieldCloud server (https://apps.qfield.cloud) and custom server(s). No need to remember the exact URL, just pick it from the history of URLs :partying_face: 

This also aligns QField to QFieldSync where we've had a combobox for a long time:

![image](https://github.com/user-attachments/assets/be08bce7-e95b-421b-beaf-7a673799a5b3)
