### PR TITLE
Fix crash occuring when the internal receiver is request permission while immediately replaced with external receiver on launch

### DIFF
--- a/src/core/positioning/internalgnssreceiver.cpp
+++ b/src/core/positioning/internalgnssreceiver.cpp
@@ -104,7 +104,7 @@ void InternalGnssReceiver::handleConnectDevice()
     Qt::PermissionStatus permissionStatus = qApp->checkPermission( locationPermission );
     if ( permissionStatus == Qt::PermissionStatus::Undetermined )
     {
-      qApp->requestPermission( locationPermission, [=]( const QPermission &permission ) {
+      qApp->requestPermission( locationPermission, this, [=]( const QPermission &permission ) {
         if ( permission.status() == Qt::PermissionStatus::Granted )
         {
           mPermissionChecked = true;


### PR DESCRIPTION
Corner scenario, but still important to fix on 3.4