### PR TITLE
Insure that QField toasts appear above the virtual keyboard

### DIFF
--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -12,6 +12,7 @@
   <uses-permission android:name="android.permission.CAMERA" />
   <uses-permission android:name="android.permission.RECORD_AUDIO" />
   <uses-permission android:name="android.permission.FLASHLIGHT" />
+  <uses-permission android:name="android.permission.VIBRATE" />
   <uses-permission android:name="android.permission.WAKE_LOCK" />
   <uses-permission android:name="android.permission.NFC" />
   <uses-permission android:name="android.permission.BLUETOOTH"

--- a/src/qml/Toast.qml
+++ b/src/qml/Toast.qml
@@ -7,9 +7,17 @@ Popup {
 
   property string type: 'info'
   property int edgeSpacing: 52
+  property real virtualKeyboardHeight: {
+    const top = Qt.inputMethod.keyboardRectangle.top / Screen.devicePixelRatio;
+    if (top > 0) {
+      const height = Qt.inputMethod.keyboardRectangle.height / Screen.devicePixelRatio;
+      return height - (top + height - mainWindow.height);
+    }
+    return 0;
+  }
 
   x: edgeSpacing
-  y: parent.height - 112
+  y: mainWindow.height - 112 - virtualKeyboardHeight
   z: 10001
 
   width: mainWindow.width - edgeSpacing * 2


### PR DESCRIPTION
Very important fix considering we now have geofencing alerts, which would display _below_ the virtual keyboard prior to this PR.

Edit: PR also add missing vibration permission into the Android manifest (commit missed the original geofencing PR!).