### PR TITLE
Prevent crashes when opening a feature form containing a blob attribute

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -484,10 +484,10 @@ void AttributeFormModelBase::buildForm( QgsAttributeEditorContainer *container, 
           continue;
 
         QgsField field = mLayer->fields().at( fieldIndex );
+        const QgsEditorWidgetSetup setup = findBest( fieldIndex );
 
         item->setData( mLayer->attributeDisplayName( fieldIndex ), AttributeFormModel::Name );
-        item->setData( !mLayer->editFormConfig().readOnly( fieldIndex ), AttributeFormModel::AttributeEditable );
-        const QgsEditorWidgetSetup setup = findBest( fieldIndex );
+        item->setData( !mLayer->editFormConfig().readOnly( fieldIndex ) && setup.type() != QStringLiteral( "Binary" ), AttributeFormModel::AttributeEditable );
         item->setData( setup.type(), AttributeFormModel::EditorWidget );
         item->setData( setup.config(), AttributeFormModel::EditorWidgetConfig );
         item->setData( mFeatureModel->rememberedAttributes().at( fieldIndex ) ? Qt::Checked : Qt::Unchecked, AttributeFormModel::RememberValue );
@@ -1041,6 +1041,11 @@ QgsEditorWidgetSetup AttributeFormModelBase::findBest( const int fieldIndex )
     {
       // on numeric types, take "Range"
       return QgsEditorWidgetSetup( QStringLiteral( "Range" ), QVariantMap() );
+    }
+    else if ( field.typeName() == QStringLiteral( "Binary" ) )
+    {
+      // on blob type, take "Binary"
+      return QgsEditorWidgetSetup( QStringLiteral( "Binary" ), QVariantMap() );
     }
   }
 

--- a/src/qml/editorwidgets/Binary.qml
+++ b/src/qml/editorwidgets/Binary.qml
@@ -1,0 +1,33 @@
+import QtQuick
+import QtQuick.Controls
+import org.qfield
+import Theme
+
+EditorWidgetBase {
+  id: binaryItem
+
+  height: childrenRect.height
+
+  Label {
+    id: binaryValue
+    topPadding: 10
+    bottomPadding: 10
+    anchors.left: parent.left
+    anchors.right: parent.right
+    font: Theme.defaultFont
+    color: Theme.mainTextColor
+    opacity: 0.45
+    wrapMode: Text.Wrap
+
+    text: qsTr('(Blob)')
+  }
+
+  Rectangle {
+    anchors.left: parent.left
+    anchors.right: parent.right
+    y: binaryValue.height - height - binaryValue.bottomPadding / 2
+    implicitWidth: 120
+    height: 1
+    color: Theme.accentLightColor
+  }
+}

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -48,6 +48,7 @@
         <file>VariableEditor.qml</file>
         <file>WelcomeScreen.qml</file>
         <file>editorwidgets/EditorWidgetBase.qml</file>
+        <file>editorwidgets/Binary.qml</file>
         <file>editorwidgets/CheckBox.qml</file>
         <file>editorwidgets/DateTime.qml</file>
         <file>editorwidgets/ExternalResource.qml</file>


### PR DESCRIPTION
Fixes the crash raised in https://github.com/opengisch/QField/issues/5668 . That will leave us with one day implementing blob support if it gets funded.