### PR TITLE
Insure that search bar reacts to partial text entered by all virtual keyboards

### DIFF
--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -69,7 +69,7 @@ Item {
 
     onOpened: {
       if (searchableText.typedFilter != '') {
-        searchBar.searchTerm = searchableText.typedFilter;
+        searchBar.setSearchTerm(searchableText.typedFilter);
       }
       if (resultsList.contentHeight > resultsList.height) {
         searchBar.focusOnTextField();
@@ -99,7 +99,7 @@ Item {
         height: childrenRect.height
 
         onSearchTermChanged: {
-          featureListModel.searchTerm = searchTerm;
+          featureListModel.setSearchTerm(searchTerm);
         }
 
         onReturnPressed: {

--- a/src/qml/imports/Theme/QfSearchBar.qml
+++ b/src/qml/imports/Theme/QfSearchBar.qml
@@ -6,7 +6,7 @@ import Theme
 Item {
   id: searchBar
 
-  property alias searchTerm: searchField.text
+  property alias searchTerm: searchField.displayText
   property string placeHolderText: qsTr("Search")
 
   signal returnPressed
@@ -69,6 +69,10 @@ Item {
 
   function focusOnTextField() {
     searchField.forceActiveFocus();
+  }
+
+  function setSearchTerm(term) {
+    searchField.text = term;
   }
 
   function clear() {


### PR DESCRIPTION
On some virtual keyboards, a textfield's text property isn't update when typing a word (with e.g. auto completion on). The fix is to use displayText.

Fixes https://github.com/opengisch/QField/issues/5682 .