### PR TITLE
What's new for new users is not a great experience

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3829,11 +3829,16 @@ ApplicationWindow {
   Changelog {
     id: changelogPopup
     objectName: 'changelogPopup'
-
     parent: Overlay.overlay
 
-    property var expireDate: new Date(2038, 1, 19)
-    visible: settings && settings.value("/QField/ChangelogVersion", "") !== appVersion && expireDate > new Date()
+    Component.onCompleted: {
+      const changelogVersion = settings.value("/QField/ChangelogVersion", "");
+      if (changelogVersion === "") {
+        settings.setValue("/QField/ChangelogVersion", appVersion);
+      } else if (changelogVersion !== appVersion) {
+        open();
+      }
+    }
   }
 
   Toast {


### PR DESCRIPTION
For new users, every single thing is new :)

Removing the changelog will leave space for some first-use introduction UI if we want to in the future.