### PR TITLE
Positioning device refactoring

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -26,6 +26,7 @@ set(QFIELD_CORE_SRCS
     locator/gotolocatorfilter.cpp
     locator/helplocatorfilter.cpp
     locator/locatormodelsuperbridge.cpp
+    positioning/abstractgnssreceiver.cpp
     positioning/gnsspositioninformation.cpp
     positioning/internalgnssreceiver.cpp
     positioning/nmeagnssreceiver.cpp

--- a/src/core/positioning/abstractgnssreceiver.cpp
+++ b/src/core/positioning/abstractgnssreceiver.cpp
@@ -1,3 +1,19 @@
+/***************************************************************************
+ abstractgnssreceiver.cpp - AbstractGnssReceiver
+
+ ---------------------
+ begin                : October 2024
+ copyright            : (C) 2024 by Mohsen Dehghanzadeh
+ email                : mohsen@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 #include "abstractgnssreceiver.h"
 
 AbstractGnssReceiver::AbstractGnssReceiver( QObject *parent )
@@ -25,8 +41,12 @@ QString AbstractGnssReceiver::socketStateString()
 void AbstractGnssReceiver::setSocketState( const QAbstractSocket::SocketState &state )
 {
   if ( mSocketState == state )
+  {
     return;
+  }
+
   mSocketState = state;
+
   emit socketStateChanged( mSocketState );
   emit socketStateStringChanged( socketStateString() );
 }

--- a/src/core/positioning/abstractgnssreceiver.cpp
+++ b/src/core/positioning/abstractgnssreceiver.cpp
@@ -1,0 +1,32 @@
+#include "abstractgnssreceiver.h"
+
+AbstractGnssReceiver::AbstractGnssReceiver( QObject *parent )
+  : QObject( parent )
+{
+}
+
+QString AbstractGnssReceiver::socketStateString()
+{
+  switch ( mSocketState )
+  {
+    case QAbstractSocket::ConnectingState:
+    case QAbstractSocket::HostLookupState:
+      return tr( "Connecting…" );
+    case QAbstractSocket::ConnectedState:
+    case QAbstractSocket::BoundState:
+      return tr( "Successfully connected" );
+    case QAbstractSocket::UnconnectedState:
+      return tr( "Disconnected" );
+    default:
+      return tr( "Socket state %1" ).arg( static_cast<int>( socketState() ) );
+  }
+}
+
+void AbstractGnssReceiver::setSocketState( const QAbstractSocket::SocketState &state )
+{
+  if ( mSocketState == state )
+    return;
+  mSocketState = state;
+  emit socketStateChanged( mSocketState );
+  emit socketStateStringChanged( socketStateString() );
+}

--- a/src/core/positioning/abstractgnssreceiver.h
+++ b/src/core/positioning/abstractgnssreceiver.h
@@ -26,7 +26,7 @@ class AbstractGnssReceiver : public QObject
     Q_OBJECT
 
     Q_PROPERTY( GnssPositionInformation lastGnssPositionInformation READ lastGnssPositionInformation NOTIFY lastGnssPositionInformationChanged )
-    Q_PROPERTY( QAbstractSocket::SocketState socketState READ socketState WRITE setSocketState NOTIFY socketStateChanged )
+    Q_PROPERTY( QAbstractSocket::SocketState socketState READ socketState NOTIFY socketStateChanged )
     Q_PROPERTY( QString socketStateString READ socketStateString NOTIFY socketStateStringChanged )
     Q_PROPERTY( QString lastError READ lastError NOTIFY lastErrorChanged )
 
@@ -60,10 +60,9 @@ class AbstractGnssReceiver : public QObject
 
     virtual QList<QPair<QString, QVariant>> details() const { return {}; }
     virtual QAbstractSocket::SocketState socketState() const { return mSocketState; }
-
-
-  public slots:
     virtual QString socketStateString();
+
+  protected:
     void setSocketState( const QAbstractSocket::SocketState &state );
 
   signals:

--- a/src/core/positioning/abstractgnssreceiver.h
+++ b/src/core/positioning/abstractgnssreceiver.h
@@ -26,6 +26,8 @@ class AbstractGnssReceiver : public QObject
     Q_OBJECT
 
     Q_PROPERTY( GnssPositionInformation lastGnssPositionInformation READ lastGnssPositionInformation NOTIFY lastGnssPositionInformationChanged )
+    Q_PROPERTY( QAbstractSocket::SocketState socketState READ socketState WRITE setSocketState NOTIFY socketStateChanged )
+    Q_PROPERTY( QString socketStateString READ socketStateString NOTIFY socketStateStringChanged )
     Q_PROPERTY( QString lastError READ lastError NOTIFY lastErrorChanged )
 
   public:
@@ -38,8 +40,7 @@ class AbstractGnssReceiver : public QObject
     Q_DECLARE_FLAGS( Capabilities, Capability )
     Q_FLAGS( Capabilities )
 
-    explicit AbstractGnssReceiver( QObject *parent = nullptr )
-      : QObject( parent ) {}
+    explicit AbstractGnssReceiver( QObject *parent = nullptr );
     virtual ~AbstractGnssReceiver() = default;
 
     bool valid() const { return mValid; }
@@ -57,33 +58,20 @@ class AbstractGnssReceiver : public QObject
 
     Q_INVOKABLE virtual AbstractGnssReceiver::Capabilities capabilities() const { return NoCapabilities; }
 
-    virtual QList<QPair<QString, QVariant>> details() { return {}; }
+    virtual QList<QPair<QString, QVariant>> details() const { return {}; }
+    virtual QAbstractSocket::SocketState socketState() const { return mSocketState; }
+
 
   public slots:
-    virtual QAbstractSocket::SocketState socketState() { return QAbstractSocket::SocketState::UnconnectedState; }
-    virtual QString socketStateString()
-    {
-      switch ( socketState() )
-      {
-        case QAbstractSocket::ConnectingState:
-        case QAbstractSocket::HostLookupState:
-          return tr( "Connecting…" );
-        case QAbstractSocket::ConnectedState:
-        case QAbstractSocket::BoundState:
-          return tr( "Successfully connected" );
-        case QAbstractSocket::UnconnectedState:
-          return tr( "Disconnected" );
-        default:
-          return tr( "Socket state %1" ).arg( static_cast<int>( socketState() ) );
-      }
-    }
+    virtual QString socketStateString();
+    void setSocketState( const QAbstractSocket::SocketState &state );
 
   signals:
     void validChanged();
-    void lastGnssPositionInformationChanged( GnssPositionInformation &lastGnssPositionInformation );
+    void lastGnssPositionInformationChanged( const GnssPositionInformation &lastGnssPositionInformation );
     void socketStateChanged( const QAbstractSocket::SocketState socketState );
     void socketStateStringChanged( const QString &socketStateString );
-    void lastErrorChanged( QString &lastError );
+    void lastErrorChanged( const QString &lastError );
 
   private:
     friend class InternalGnssReceiver;
@@ -102,6 +90,7 @@ class AbstractGnssReceiver : public QObject
 
     bool mValid = false;
     GnssPositionInformation mLastGnssPositionInformation;
+    QAbstractSocket::SocketState mSocketState = QAbstractSocket::UnconnectedState;
     QString mLastError;
 };
 

--- a/src/core/positioning/abstractgnssreceiver.h
+++ b/src/core/positioning/abstractgnssreceiver.h
@@ -26,8 +26,6 @@ class AbstractGnssReceiver : public QObject
     Q_OBJECT
 
     Q_PROPERTY( GnssPositionInformation lastGnssPositionInformation READ lastGnssPositionInformation NOTIFY lastGnssPositionInformationChanged )
-    Q_PROPERTY( QAbstractSocket::SocketState socketState READ socketState NOTIFY socketStateChanged )
-    Q_PROPERTY( QString socketStateString READ socketStateString NOTIFY socketStateStringChanged )
     Q_PROPERTY( QString lastError READ lastError NOTIFY lastErrorChanged )
 
   public:
@@ -55,19 +53,36 @@ class AbstractGnssReceiver : public QObject
 
     GnssPositionInformation lastGnssPositionInformation() const { return mLastGnssPositionInformation; }
 
-    QAbstractSocket::SocketState socketState() const { return mSocketState; }
-    QString socketStateString() const { return mSocketStateString; }
     QString lastError() const { return mLastError; }
 
     Q_INVOKABLE virtual AbstractGnssReceiver::Capabilities capabilities() const { return NoCapabilities; }
 
     virtual QList<QPair<QString, QVariant>> details() { return {}; }
 
+  public slots:
+    virtual QAbstractSocket::SocketState socketState() { return QAbstractSocket::SocketState::UnconnectedState; }
+    virtual QString socketStateString()
+    {
+      switch ( socketState() )
+      {
+        case QAbstractSocket::ConnectingState:
+        case QAbstractSocket::HostLookupState:
+          return tr( "Connecting…" );
+        case QAbstractSocket::ConnectedState:
+        case QAbstractSocket::BoundState:
+          return tr( "Successfully connected" );
+        case QAbstractSocket::UnconnectedState:
+          return tr( "Disconnected" );
+        default:
+          return tr( "Socket state %1" ).arg( static_cast<int>( socketState() ) );
+      }
+    }
+
   signals:
     void validChanged();
     void lastGnssPositionInformationChanged( GnssPositionInformation &lastGnssPositionInformation );
-    void socketStateChanged( QAbstractSocket::SocketState socketState );
-    void socketStateStringChanged( QString &socketStateString );
+    void socketStateChanged( const QAbstractSocket::SocketState socketState );
+    void socketStateStringChanged( const QString &socketStateString );
     void lastErrorChanged( QString &lastError );
 
   private:
@@ -87,8 +102,6 @@ class AbstractGnssReceiver : public QObject
 
     bool mValid = false;
     GnssPositionInformation mLastGnssPositionInformation;
-    QAbstractSocket::SocketState mSocketState = QAbstractSocket::UnconnectedState;
-    QString mSocketStateString;
     QString mLastError;
 };
 

--- a/src/core/positioning/bluetoothreceiver.h
+++ b/src/core/positioning/bluetoothreceiver.h
@@ -34,6 +34,10 @@ class BluetoothReceiver : public NmeaGnssReceiver
     explicit BluetoothReceiver( const QString &address = QString(), QObject *parent = nullptr );
     ~BluetoothReceiver() override;
 
+  public slots:
+    QAbstractSocket::SocketState socketState() override;
+    QString socketStateString() override;
+
   private slots:
     /**
      * these functions used for repairing are only needed in the linux (not android) environment

--- a/src/core/positioning/bluetoothreceiver.h
+++ b/src/core/positioning/bluetoothreceiver.h
@@ -33,9 +33,9 @@ class BluetoothReceiver : public NmeaGnssReceiver
   public:
     explicit BluetoothReceiver( const QString &address = QString(), QObject *parent = nullptr );
     ~BluetoothReceiver() override;
+    QAbstractSocket::SocketState socketState() const override;
 
   public slots:
-    QAbstractSocket::SocketState socketState() override;
     QString socketStateString() override;
 
   private slots:
@@ -45,8 +45,6 @@ class BluetoothReceiver : public NmeaGnssReceiver
      * but meanwhile we keep them as the developer setup.
      */
     void pairingFinished( const QBluetoothAddress &address, QBluetoothLocalDevice::Pairing status );
-
-    void setSocketState( const QBluetoothSocket::SocketState socketState );
 
   private:
     void handleConnectDevice() override;

--- a/src/core/positioning/bluetoothreceiver.h
+++ b/src/core/positioning/bluetoothreceiver.h
@@ -33,7 +33,6 @@ class BluetoothReceiver : public NmeaGnssReceiver
   public:
     explicit BluetoothReceiver( const QString &address = QString(), QObject *parent = nullptr );
     ~BluetoothReceiver() override;
-    QAbstractSocket::SocketState socketState() const override;
 
   public slots:
     QString socketStateString() override;

--- a/src/core/positioning/egenioussreceiver.cpp
+++ b/src/core/positioning/egenioussreceiver.cpp
@@ -32,15 +32,6 @@ void EgenioussReceiver::handleDisconnectDevice()
   mTcpSocket->disconnectFromHost();
 }
 
-QAbstractSocket::SocketState EgenioussReceiver::socketState() const
-{
-  if ( mTcpSocket == nullptr )
-  {
-    return QAbstractSocket::UnconnectedState;
-  }
-  return mTcpSocket->state();
-}
-
 QList<QPair<QString, QVariant>> EgenioussReceiver::details() const
 {
   QList<QPair<QString, QVariant>> detailsList;

--- a/src/core/positioning/egenioussreceiver.cpp
+++ b/src/core/positioning/egenioussreceiver.cpp
@@ -28,41 +28,15 @@ void EgenioussReceiver::handleDisconnectDevice()
   mTcpSocket->disconnectFromHost();
 }
 
+QAbstractSocket::SocketState EgenioussReceiver::socketState()
+{
+  return mTcpSocket ? mTcpSocket->state() : QAbstractSocket::UnconnectedState;
+}
+
 void EgenioussReceiver::setSocketState( const QAbstractSocket::SocketState socketState )
 {
-  if ( mSocketState == socketState )
-  {
-    return;
-  }
-
-  switch ( socketState )
-  {
-    case QAbstractSocket::ConnectingState:
-    case QAbstractSocket::HostLookupState:
-    {
-      mSocketStateString = tr( "Connecting…" );
-      break;
-    }
-    case QAbstractSocket::ConnectedState:
-    case QAbstractSocket::BoundState:
-    {
-      mSocketStateString = tr( "Successfully connected" );
-      break;
-    }
-    case QAbstractSocket::UnconnectedState:
-    {
-      mSocketStateString = tr( "Disconnected" );
-      break;
-    }
-    default:
-    {
-      mSocketStateString = tr( "Socket state %1" ).arg( static_cast<int>( socketState ) );
-    }
-  }
-
-  mSocketState = socketState;
-  emit socketStateChanged( mSocketState );
-  emit socketStateStringChanged( mSocketStateString );
+  emit socketStateChanged( socketState );
+  emit socketStateStringChanged( socketStateString() );
 }
 
 QList<QPair<QString, QVariant>> EgenioussReceiver::details()
@@ -156,8 +130,8 @@ void EgenioussReceiver::handleError( QAbstractSocket::SocketError error )
       mLastError = tr( "TCP receiver error (%1)" ).arg( QMetaEnum::fromType<QAbstractSocket::SocketError>().valueToKey( error ) );
       break;
   }
-  mSocketState = QAbstractSocket::UnconnectedState;
-  mSocketStateString = mLastError;
+  setSocketState( QAbstractSocket::UnconnectedState );
+
   qInfo() << QStringLiteral( "EgenioussReceiver: Error: %1" ).arg( mLastError );
 
   emit lastErrorChanged( mLastError );

--- a/src/core/positioning/egenioussreceiver.cpp
+++ b/src/core/positioning/egenioussreceiver.cpp
@@ -1,3 +1,19 @@
+/***************************************************************************
+ egeniousseeceiver.cpp - EgenioussReceiver
+
+ ---------------------
+ begin                : October 2024
+ copyright            : (C) 2024 by Mohsen Dehghanzadeh
+ email                : mohsen@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 #include "egenioussreceiver.h"
 
 #include <QHostAddress>
@@ -9,9 +25,7 @@ EgenioussReceiver::EgenioussReceiver( QObject *parent )
 {
   connect( mTcpSocket, &QTcpSocket::readyRead, this, &EgenioussReceiver::onReadyRead );
   connect( mTcpSocket, &QTcpSocket::errorOccurred, this, &EgenioussReceiver::handleError );
-  connect( mTcpSocket, &QTcpSocket::stateChanged, this, [=]( QAbstractSocket::SocketState state ) {
-    setSocketState( state );
-  } );
+  connect( mTcpSocket, &QTcpSocket::stateChanged, this, &AbstractGnssReceiver::setSocketState );
 
   setValid( true );
 }

--- a/src/core/positioning/egenioussreceiver.h
+++ b/src/core/positioning/egenioussreceiver.h
@@ -15,7 +15,6 @@ class EgenioussReceiver : public AbstractGnssReceiver
     ~EgenioussReceiver();
 
     QList<QPair<QString, QVariant>> details() const override;
-    QAbstractSocket::SocketState socketState() const override;
 
   private:
     void handleConnectDevice() override;

--- a/src/core/positioning/egenioussreceiver.h
+++ b/src/core/positioning/egenioussreceiver.h
@@ -12,10 +12,12 @@ class EgenioussReceiver : public AbstractGnssReceiver
 
   public:
     explicit EgenioussReceiver( QObject *parent = nullptr );
+    ~EgenioussReceiver();
 
   private:
     void handleConnectDevice() override;
     void handleDisconnectDevice() override;
+    void setSocketState( const QAbstractSocket::SocketState socketState );
     QList<QPair<QString, QVariant>> details() override;
 
   private slots:
@@ -24,8 +26,6 @@ class EgenioussReceiver : public AbstractGnssReceiver
 
   private:
     void processReceivedData();
-    void connected();
-    void disconnected();
 
   private:
     QTcpSocket *mTcpSocket = nullptr;

--- a/src/core/positioning/egenioussreceiver.h
+++ b/src/core/positioning/egenioussreceiver.h
@@ -1,3 +1,19 @@
+/***************************************************************************
+ egeniousseeceiver.h - EgenioussReceiver
+
+ ---------------------
+ begin                : October 2024
+ copyright            : (C) 2024 by Mohsen Dehghanzadeh
+ email                : mohsen@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 #ifndef EGENIOUSSRECEIVER_H
 #define EGENIOUSSRECEIVER_H
 

--- a/src/core/positioning/egenioussreceiver.h
+++ b/src/core/positioning/egenioussreceiver.h
@@ -14,18 +14,16 @@ class EgenioussReceiver : public AbstractGnssReceiver
     explicit EgenioussReceiver( QObject *parent = nullptr );
     ~EgenioussReceiver();
 
-  public slots:
-    QAbstractSocket::SocketState socketState() override;
+    QList<QPair<QString, QVariant>> details() const override;
+    QAbstractSocket::SocketState socketState() const override;
 
   private:
     void handleConnectDevice() override;
     void handleDisconnectDevice() override;
-    QList<QPair<QString, QVariant>> details() override;
 
   private slots:
     void onReadyRead();
     void handleError( QAbstractSocket::SocketError error );
-    void setSocketState( const QAbstractSocket::SocketState socketState );
 
   private:
     void processReceivedData();

--- a/src/core/positioning/egenioussreceiver.h
+++ b/src/core/positioning/egenioussreceiver.h
@@ -14,15 +14,18 @@ class EgenioussReceiver : public AbstractGnssReceiver
     explicit EgenioussReceiver( QObject *parent = nullptr );
     ~EgenioussReceiver();
 
+  public slots:
+    QAbstractSocket::SocketState socketState() override;
+
   private:
     void handleConnectDevice() override;
     void handleDisconnectDevice() override;
-    void setSocketState( const QAbstractSocket::SocketState socketState );
     QList<QPair<QString, QVariant>> details() override;
 
   private slots:
     void onReadyRead();
     void handleError( QAbstractSocket::SocketError error );
+    void setSocketState( const QAbstractSocket::SocketState socketState );
 
   private:
     void processReceivedData();

--- a/src/core/positioning/internalgnssreceiver.cpp
+++ b/src/core/positioning/internalgnssreceiver.cpp
@@ -35,7 +35,7 @@ InternalGnssReceiver::InternalGnssReceiver( QObject *parent )
     connect( mGeoPositionSource.get(), &QGeoPositionInfoSource::positionUpdated, this, &InternalGnssReceiver::handlePositionUpdated );
     connect( mGeoPositionSource.get(), qOverload<QGeoPositionInfoSource::Error>( &QGeoPositionInfoSource::errorOccurred ), this, &InternalGnssReceiver::handleError );
 
-    mSocketState = QAbstractSocket::ConnectedState;
+    setSocketState( QAbstractSocket::ConnectedState );
 
     setValid( true );
   }
@@ -50,12 +50,6 @@ InternalGnssReceiver::InternalGnssReceiver( QObject *parent )
   }
 
   connect( QgsApplication::instance(), &QGuiApplication::applicationStateChanged, this, &InternalGnssReceiver::onApplicationStateChanged );
-}
-
-
-QAbstractSocket::SocketState InternalGnssReceiver::socketState()
-{
-  return mSocketState;
 }
 
 void InternalGnssReceiver::onApplicationStateChanged( Qt::ApplicationState state )

--- a/src/core/positioning/internalgnssreceiver.cpp
+++ b/src/core/positioning/internalgnssreceiver.cpp
@@ -52,6 +52,12 @@ InternalGnssReceiver::InternalGnssReceiver( QObject *parent )
   connect( QgsApplication::instance(), &QGuiApplication::applicationStateChanged, this, &InternalGnssReceiver::onApplicationStateChanged );
 }
 
+
+QAbstractSocket::SocketState InternalGnssReceiver::socketState()
+{
+  return mSocketState;
+}
+
 void InternalGnssReceiver::onApplicationStateChanged( Qt::ApplicationState state )
 {
 #ifdef Q_OS_ANDROID

--- a/src/core/positioning/internalgnssreceiver.h
+++ b/src/core/positioning/internalgnssreceiver.h
@@ -31,6 +31,9 @@ class InternalGnssReceiver : public AbstractGnssReceiver
     explicit InternalGnssReceiver( QObject *parent = nullptr );
     ~InternalGnssReceiver() override = default;
 
+  public slots:
+    QAbstractSocket::SocketState socketState() override;
+
   private slots:
 
     void onApplicationStateChanged( Qt::ApplicationState state );
@@ -57,6 +60,7 @@ class InternalGnssReceiver : public AbstractGnssReceiver
     QList<int> mSatellitesID;
     QList<QgsSatelliteInfo> mSatellitesInfo;
     bool mSatelliteInformationValid = true;
+    QAbstractSocket::SocketState mSocketState = QAbstractSocket::UnconnectedState;
 };
 
 #endif // INTERNALGNSSRECEIVER_H

--- a/src/core/positioning/internalgnssreceiver.h
+++ b/src/core/positioning/internalgnssreceiver.h
@@ -31,9 +31,6 @@ class InternalGnssReceiver : public AbstractGnssReceiver
     explicit InternalGnssReceiver( QObject *parent = nullptr );
     ~InternalGnssReceiver() override = default;
 
-  public slots:
-    QAbstractSocket::SocketState socketState() override;
-
   private slots:
 
     void onApplicationStateChanged( Qt::ApplicationState state );
@@ -60,7 +57,6 @@ class InternalGnssReceiver : public AbstractGnssReceiver
     QList<int> mSatellitesID;
     QList<QgsSatelliteInfo> mSatellitesInfo;
     bool mSatelliteInformationValid = true;
-    QAbstractSocket::SocketState mSocketState = QAbstractSocket::UnconnectedState;
 };
 
 #endif // INTERNALGNSSRECEIVER_H

--- a/src/core/positioning/nmeagnssreceiver.cpp
+++ b/src/core/positioning/nmeagnssreceiver.cpp
@@ -116,7 +116,7 @@ void NmeaGnssReceiver::handleStopLogging()
   mLogFile.close();
 }
 
-QList<QPair<QString, QVariant>> NmeaGnssReceiver::details()
+QList<QPair<QString, QVariant>> NmeaGnssReceiver::details() const
 {
   QList<QPair<QString, QVariant>> dataList;
 

--- a/src/core/positioning/nmeagnssreceiver.h
+++ b/src/core/positioning/nmeagnssreceiver.h
@@ -50,7 +50,7 @@ class NmeaGnssReceiver : public AbstractGnssReceiver
   private:
     void handleStartLogging() override;
     void handleStopLogging() override;
-    QList<QPair<QString, QVariant>> details() override;
+    QList<QPair<QString, QVariant>> details() const override;
 
     void processImuSentence( const QString &sentence );
 

--- a/src/core/positioning/serialportreceiver.cpp
+++ b/src/core/positioning/serialportreceiver.cpp
@@ -34,14 +34,19 @@ SerialPortReceiver::~SerialPortReceiver()
   mSocket = nullptr;
 }
 
+QAbstractSocket::SocketState SerialPortReceiver::socketState()
+{
+  return mSocketState;
+}
+
 void SerialPortReceiver::handleDisconnectDevice()
 {
   if ( mSocketState == QAbstractSocket::ConnectedState )
   {
     mSocket->close();
-
     mSocketState = QAbstractSocket::UnconnectedState;
     emit socketStateChanged( mSocketState );
+    emit socketStateStringChanged( socketStateString() );
   }
 }
 
@@ -59,6 +64,7 @@ void SerialPortReceiver::handleConnectDevice()
   {
     mSocketState = QAbstractSocket::ConnectedState;
     emit socketStateChanged( mSocketState );
+    emit socketStateStringChanged( socketStateString() );
   }
 }
 

--- a/src/core/positioning/serialportreceiver.cpp
+++ b/src/core/positioning/serialportreceiver.cpp
@@ -19,34 +19,27 @@
 SerialPortReceiver::SerialPortReceiver( const QString &address, QObject *parent )
   : NmeaGnssReceiver( parent )
   , mAddress( address )
-  , mSocket( new QSerialPort() )
+  , mSerialPort( new QSerialPort() )
 {
-  connect( mSocket, qOverload<QSerialPort::SerialPortError>( &QSerialPort::errorOccurred ), this, &SerialPortReceiver::handleError );
+  connect( mSerialPort, qOverload<QSerialPort::SerialPortError>( &QSerialPort::errorOccurred ), this, &SerialPortReceiver::handleError );
 
-  initNmeaConnection( mSocket );
+  initNmeaConnection( mSerialPort );
 
   setValid( !mAddress.isEmpty() );
 }
 
 SerialPortReceiver::~SerialPortReceiver()
 {
-  mSocket->deleteLater();
-  mSocket = nullptr;
-}
-
-QAbstractSocket::SocketState SerialPortReceiver::socketState()
-{
-  return mSocketState;
+  mSerialPort->deleteLater();
+  mSerialPort = nullptr;
 }
 
 void SerialPortReceiver::handleDisconnectDevice()
 {
-  if ( mSocketState == QAbstractSocket::ConnectedState )
+  if ( socketState() == QAbstractSocket::ConnectedState )
   {
-    mSocket->close();
-    mSocketState = QAbstractSocket::UnconnectedState;
-    emit socketStateChanged( mSocketState );
-    emit socketStateStringChanged( socketStateString() );
+    mSerialPort->close();
+    setSocketState( QAbstractSocket::UnconnectedState );
   }
 }
 
@@ -58,13 +51,11 @@ void SerialPortReceiver::handleConnectDevice()
   }
   qInfo() << "SerialPortReceiver: Initiating connection to port name: " << mAddress;
 
-  mSocket->setPortName( mAddress );
-  mSocket->setBaudRate( QSerialPort::Baud9600 );
-  if ( mSocket->open( QIODevice::ReadOnly ) )
+  mSerialPort->setPortName( mAddress );
+  mSerialPort->setBaudRate( QSerialPort::Baud9600 );
+  if ( mSerialPort->open( QIODevice::ReadOnly ) )
   {
-    mSocketState = QAbstractSocket::ConnectedState;
-    emit socketStateChanged( mSocketState );
-    emit socketStateStringChanged( socketStateString() );
+    setSocketState( QAbstractSocket::ConnectedState );
   }
 }
 

--- a/src/core/positioning/serialportreceiver.h
+++ b/src/core/positioning/serialportreceiver.h
@@ -33,9 +33,6 @@ class SerialPortReceiver : public NmeaGnssReceiver
     explicit SerialPortReceiver( const QString &address = QString(), QObject *parent = nullptr );
     ~SerialPortReceiver() override;
 
-  public slots:
-    QAbstractSocket::SocketState socketState() override;
-
   private:
     void handleConnectDevice() override;
     void handleDisconnectDevice() override;
@@ -43,9 +40,7 @@ class SerialPortReceiver : public NmeaGnssReceiver
 
     QString mAddress;
 
-    QSerialPort *mSocket = nullptr;
-
-    QAbstractSocket::SocketState mSocketState = QAbstractSocket::UnconnectedState;
+    QSerialPort *mSerialPort = nullptr;
 };
 
 #endif // SERIALPORTRECEIVER_H

--- a/src/core/positioning/serialportreceiver.h
+++ b/src/core/positioning/serialportreceiver.h
@@ -33,6 +33,9 @@ class SerialPortReceiver : public NmeaGnssReceiver
     explicit SerialPortReceiver( const QString &address = QString(), QObject *parent = nullptr );
     ~SerialPortReceiver() override;
 
+  public slots:
+    QAbstractSocket::SocketState socketState() override;
+
   private:
     void handleConnectDevice() override;
     void handleDisconnectDevice() override;
@@ -41,6 +44,8 @@ class SerialPortReceiver : public NmeaGnssReceiver
     QString mAddress;
 
     QSerialPort *mSocket = nullptr;
+
+    QAbstractSocket::SocketState mSocketState = QAbstractSocket::UnconnectedState;
 };
 
 #endif // SERIALPORTRECEIVER_H

--- a/src/core/positioning/tcpreceiver.h
+++ b/src/core/positioning/tcpreceiver.h
@@ -33,13 +33,10 @@ class TcpReceiver : public NmeaGnssReceiver
   public:
     explicit TcpReceiver( const QString &address = QString(), const int port = 0, QObject *parent = nullptr );
     ~TcpReceiver() override;
+    QAbstractSocket::SocketState socketState() const override;
 
   public slots:
-    QAbstractSocket::SocketState socketState() override;
     QString socketStateString() override;
-
-  private slots:
-    void setSocketState( QAbstractSocket::SocketState socketState );
 
   private:
     void handleConnectDevice() override;

--- a/src/core/positioning/tcpreceiver.h
+++ b/src/core/positioning/tcpreceiver.h
@@ -33,7 +33,6 @@ class TcpReceiver : public NmeaGnssReceiver
   public:
     explicit TcpReceiver( const QString &address = QString(), const int port = 0, QObject *parent = nullptr );
     ~TcpReceiver() override;
-    QAbstractSocket::SocketState socketState() const override;
 
   public slots:
     QString socketStateString() override;

--- a/src/core/positioning/tcpreceiver.h
+++ b/src/core/positioning/tcpreceiver.h
@@ -34,8 +34,11 @@ class TcpReceiver : public NmeaGnssReceiver
     explicit TcpReceiver( const QString &address = QString(), const int port = 0, QObject *parent = nullptr );
     ~TcpReceiver() override;
 
-  private slots:
+  public slots:
+    QAbstractSocket::SocketState socketState() override;
+    QString socketStateString() override;
 
+  private slots:
     void setSocketState( QAbstractSocket::SocketState socketState );
 
   private:

--- a/src/core/positioning/udpreceiver.h
+++ b/src/core/positioning/udpreceiver.h
@@ -34,14 +34,10 @@ class UdpReceiver : public NmeaGnssReceiver
   public:
     explicit UdpReceiver( const QString &address = QString(), const int port = 0, QObject *parent = nullptr );
     ~UdpReceiver() override;
+    QAbstractSocket::SocketState socketState() const override;
 
   public slots:
-    QAbstractSocket::SocketState socketState() override;
     QString socketStateString() override;
-
-  private slots:
-
-    void setSocketState( QAbstractSocket::SocketState socketState );
 
   private:
     void handleConnectDevice() override;

--- a/src/core/positioning/udpreceiver.h
+++ b/src/core/positioning/udpreceiver.h
@@ -34,7 +34,6 @@ class UdpReceiver : public NmeaGnssReceiver
   public:
     explicit UdpReceiver( const QString &address = QString(), const int port = 0, QObject *parent = nullptr );
     ~UdpReceiver() override;
-    QAbstractSocket::SocketState socketState() const override;
 
   public slots:
     QString socketStateString() override;

--- a/src/core/positioning/udpreceiver.h
+++ b/src/core/positioning/udpreceiver.h
@@ -35,6 +35,10 @@ class UdpReceiver : public NmeaGnssReceiver
     explicit UdpReceiver( const QString &address = QString(), const int port = 0, QObject *parent = nullptr );
     ~UdpReceiver() override;
 
+  public slots:
+    QAbstractSocket::SocketState socketState() override;
+    QString socketStateString() override;
+
   private slots:
 
     void setSocketState( QAbstractSocket::SocketState socketState );

--- a/src/qml/PositioningDeviceSettings.qml
+++ b/src/qml/PositioningDeviceSettings.qml
@@ -49,8 +49,10 @@ Popup {
         });
     } else {
       positioningDeviceTypeModel.remove(0, 1);
-      positioningDeviceModel.removeDevice("Egeniouss");
-      positioningDeviceComboBox.currentIndex = 0;
+      if (positioningDeviceModel.findIndexFromDeviceId("egeniouss:") !== -1) {
+        positioningDeviceModel.removeDevice("Egeniouss");
+        positioningDeviceComboBox.currentIndex = 0;
+      }
     }
     positioningDeviceType.model = positioningDeviceTypeModel;
   }


### PR DESCRIPTION
# PR Description
In this PR we are going to address these: 
* Refactor 1: https://github.com/opengisch/QField/pull/5637#discussion_r1767657714
* Refactor 2: https://github.com/opengisch/QField/pull/5637#discussion_r1767666659

---

#### Step 1 of Refactor 1: Instead of capturing `connected` and `disconnected` signals we can use `stateChanged` signal and simplify a bit.
This pattern is been used in: 
https://github.com/opengisch/QField/blob/3a1586f83605a886531bf996600e63063ac6ef28/src/core/positioning/bluetoothreceiver.cpp#L30
https://github.com/opengisch/QField/blob/3a1586f83605a886531bf996600e63063ac6ef28/src/core/positioning/tcpreceiver.cpp#L25
https://github.com/opengisch/QField/blob/3a1586f83605a886531bf996600e63063ac6ef28/src/core/positioning/udpreceiver.cpp#L38

--- 
#### Step 2 of Refactor 1: lets go for the bigger refactoring changing all of these.
> @domi4484: It feels a bit strange to me that subclasses of postioning device have to manage mSocketState that way. mSocketState and mSocketStateString have a quite risk to get out of sync. Wouldn't be it a cleaner interface to reimplement AbstractGnssReceiver::socketState() and socketStateString in subclasses and get rid of the variables mSocketState and mSocketStateString?