### PR TITLE
Support grid decoration

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -65,6 +65,7 @@ set(QFIELD_CORE_SRCS
     focusstack.cpp
     geometry.cpp
     geometryeditorsmodel.cpp
+    gridmodel.cpp
     identifytool.cpp
     layerobserver.cpp
     featurehistory.cpp
@@ -186,6 +187,7 @@ set(QFIELD_CORE_HDRS
     focusstack.h
     geometry.h
     geometryeditorsmodel.h
+    gridmodel.h
     identifytool.h
     layerobserver.h
     featurehistory.h

--- a/src/core/gridmodel.cpp
+++ b/src/core/gridmodel.cpp
@@ -101,7 +101,8 @@ void GridModel::update()
   mAnnotations.clear();
 
   const QgsRectangle visibleExtent = mMapSettings->visibleExtent();
-  if ( mXInterval / mMapSettings->mapUnitsPerPoint() < 3 || mYInterval / mMapSettings->mapUnitsPerPoint() < 3 )
+  double smallestScreenInterval = std::min( mXInterval / mMapSettings->mapUnitsPerPoint(), mYInterval / mMapSettings->mapUnitsPerPoint() );
+  if ( smallestScreenInterval < 10 )
   {
     if ( hadGrid )
     {
@@ -113,7 +114,7 @@ void GridModel::update()
   QList<QPointF> line;
   QPointF intersectionPoint;
 
-  if ( mDrawMarkers )
+  if ( mDrawMarkers && smallestScreenInterval > 20 )
   {
     double xPos = visibleExtent.xMinimum() - std::fmod( visibleExtent.xMinimum(), mXInterval ) + mXOffset;
     while ( xPos <= visibleExtent.xMaximum() )

--- a/src/core/gridmodel.cpp
+++ b/src/core/gridmodel.cpp
@@ -1,0 +1,159 @@
+/***************************************************************************
+  gridmodel.cpp - GridModel
+
+ ---------------------
+ begin                : 4.10.2024
+ copyright            : (C) 2024 by Mathieu Pellerin
+ email                : mathieu@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "gridmodel.h"
+
+GridModel::GridModel( QObject *parent )
+  : QObject( parent )
+{
+}
+
+void GridModel::setMapSettings( QgsQuickMapSettings *mapSettings )
+{
+  if ( mMapSettings == mapSettings )
+  {
+    return;
+  }
+
+  if ( mMapSettings )
+  {
+    disconnect( mMapSettings, &QgsQuickMapSettings::visibleExtentChanged, this, &GridModel::update );
+  }
+
+  mMapSettings = mapSettings;
+  emit mapSettingsChanged();
+
+
+  if ( mMapSettings )
+  {
+    connect( mMapSettings, &QgsQuickMapSettings::visibleExtentChanged, this, &GridModel::update );
+  }
+}
+
+void GridModel::setXInterval( double interval )
+{
+  if ( mXInterval == interval )
+    return;
+
+  mXInterval = interval;
+  emit xIntervalChanged();
+
+  update();
+}
+
+void GridModel::setYInterval( double interval )
+{
+  if ( mYInterval == interval )
+    return;
+
+  mYInterval = interval;
+  emit yIntervalChanged();
+
+  update();
+}
+
+void GridModel::setXOffset( double offset )
+{
+  if ( mXOffset == offset )
+    return;
+
+  mXOffset = offset;
+  emit xOffsetChanged();
+
+  update();
+}
+
+void GridModel::setYOffset( double offset )
+{
+  if ( mYOffset == offset )
+    return;
+
+  mYOffset = offset;
+  emit yOffsetChanged();
+
+  update();
+}
+
+void GridModel::update()
+{
+  if ( !mMapSettings )
+  {
+    return;
+  }
+
+  bool hadLines = !mLines.isEmpty();
+  mLines.clear();
+  mAnnotations.clear();
+
+  const QgsRectangle visibleExtent = mMapSettings->visibleExtent();
+  if ( mXInterval / mMapSettings->mapUnitsPerPoint() < 3 || mYInterval / mMapSettings->mapUnitsPerPoint() < 3 )
+  {
+    if ( hadLines )
+    {
+      emit linesChanged();
+      emit annotationsChanged();
+    }
+    return;
+  }
+
+  QList<QPointF> line;
+  QPointF intersectionPoint;
+
+  double xPos = visibleExtent.xMinimum() - std::fmod( visibleExtent.xMinimum(), mXInterval ) + mXOffset;
+  const QLineF topBorder( QPointF( 0, 0 ), QPointF( mMapSettings->outputSize().width(), 0 ) );
+  const QLineF bottomBorder( QPointF( 0, mMapSettings->outputSize().height() ), QPointF( mMapSettings->outputSize().width(), mMapSettings->outputSize().height() ) );
+  while ( xPos <= visibleExtent.xMaximum() )
+  {
+    const QLineF currentLine( mMapSettings->coordinateToScreen( QgsPoint( xPos, visibleExtent.yMinimum() ) ), mMapSettings->coordinateToScreen( QgsPoint( xPos, visibleExtent.yMaximum() ) ) );
+    if ( currentLine.intersects( topBorder, &intersectionPoint ) )
+    {
+      mAnnotations << GridAnnotation( GridAnnotation::Top, intersectionPoint, mLocale.toString( xPos, 'f', 0 ) );
+    }
+    if ( currentLine.intersects( bottomBorder, &intersectionPoint ) )
+    {
+      mAnnotations << GridAnnotation( GridAnnotation::Bottom, intersectionPoint, mLocale.toString( xPos, 'f', 0 ) );
+    }
+
+    line << currentLine.p1() << currentLine.p2();
+    mLines << line;
+    line.clear();
+    xPos += mXInterval;
+  }
+
+  double yPos = visibleExtent.yMinimum() - std::fmod( visibleExtent.yMinimum(), mYInterval ) + mYOffset;
+  const QLineF leftBorder( QPointF( 0, 0 ), QPointF( 0, mMapSettings->outputSize().height() ) );
+  const QLineF rightBorder( QPointF( mMapSettings->outputSize().width(), 0 ), QPointF( mMapSettings->outputSize().width(), mMapSettings->outputSize().height() ) );
+  while ( yPos <= visibleExtent.yMaximum() )
+  {
+    const QLineF currentLine( mMapSettings->coordinateToScreen( QgsPoint( visibleExtent.xMinimum(), yPos ) ), mMapSettings->coordinateToScreen( QgsPoint( visibleExtent.xMaximum(), yPos ) ) );
+    if ( currentLine.intersects( leftBorder, &intersectionPoint ) )
+    {
+      mAnnotations << GridAnnotation( GridAnnotation::Left, intersectionPoint, mLocale.toString( yPos, 'f', 0 ) );
+    }
+    if ( currentLine.intersects( rightBorder, &intersectionPoint ) )
+    {
+      mAnnotations << GridAnnotation( GridAnnotation::Right, intersectionPoint, mLocale.toString( yPos, 'f', 0 ) );
+    }
+
+    line << currentLine.p1() << currentLine.p2();
+    mLines << line;
+    line.clear();
+    yPos += mYInterval;
+  }
+
+  emit linesChanged();
+  emit annotationsChanged();
+}

--- a/src/core/gridmodel.cpp
+++ b/src/core/gridmodel.cpp
@@ -21,6 +21,30 @@ GridModel::GridModel( QObject *parent )
 {
 }
 
+void GridModel::setEnabled( bool enabled )
+{
+  if ( mEnabled == enabled )
+    return;
+
+  mEnabled = enabled;
+  emit enabledChanged();
+
+  if ( mEnabled )
+  {
+    update();
+  }
+  else
+  {
+    if ( !mLines.isEmpty() || !mMarkers.isEmpty() || !mAnnotations.isEmpty() )
+    {
+      mLines.clear();
+      mMarkers.clear();
+      mAnnotations.clear();
+      emit gridChanged();
+    }
+  }
+}
+
 void GridModel::setMapSettings( QgsQuickMapSettings *mapSettings )
 {
   if ( mMapSettings == mapSettings )
@@ -87,9 +111,75 @@ void GridModel::setYOffset( double offset )
   update();
 }
 
+void GridModel::setPrepareLines( bool prepare )
+{
+  if ( mPrepareLines == prepare )
+    return;
+
+  mPrepareLines = prepare;
+  emit prepareLinesChanged();
+
+  if ( mPrepareLines )
+  {
+    update();
+  }
+  else
+  {
+    if ( !mLines.isEmpty() )
+    {
+      mLines.clear();
+      emit gridChanged();
+    }
+  }
+}
+
+void GridModel::setPrepareMarkers( bool prepare )
+{
+  if ( mPrepareMarkers == prepare )
+    return;
+
+  mPrepareMarkers = prepare;
+  emit prepareMarkersChanged();
+
+  if ( mPrepareMarkers )
+  {
+    update();
+  }
+  else
+  {
+    if ( !mMarkers.isEmpty() )
+    {
+      mMarkers.clear();
+      emit gridChanged();
+    }
+  }
+}
+
+void GridModel::setPrepareAnnotations( bool prepare )
+{
+  if ( mPrepareAnnotations == prepare )
+    return;
+
+  mPrepareAnnotations = prepare;
+  emit prepareAnnotationsChanged();
+
+  if ( mPrepareAnnotations )
+  {
+    update();
+  }
+  else
+  {
+    if ( !mAnnotations.isEmpty() )
+    {
+      mAnnotations.clear();
+      emit gridChanged();
+    }
+  }
+}
+
 void GridModel::update()
 {
-  if ( !mMapSettings )
+  if ( !mEnabled || !mMapSettings )
   {
     return;
   }
@@ -114,7 +204,7 @@ void GridModel::update()
   QList<QPointF> line;
   QPointF intersectionPoint;
 
-  if ( mDrawMarkers && smallestScreenInterval > 20 )
+  if ( mPrepareMarkers && smallestScreenInterval > 20 )
   {
     double xPos = visibleExtent.xMinimum() - std::fmod( visibleExtent.xMinimum(), mXInterval ) + mXOffset;
     while ( xPos <= visibleExtent.xMaximum() )
@@ -129,7 +219,7 @@ void GridModel::update()
     }
   }
 
-  if ( mDrawLines || mDrawAnnotations )
+  if ( mPrepareLines || mPrepareAnnotations )
   {
     double xPos = visibleExtent.xMinimum() - std::fmod( visibleExtent.xMinimum(), mXInterval ) + mXOffset;
     const QLineF topBorder( QPointF( 0, 0 ), QPointF( mMapSettings->outputSize().width(), 0 ) );
@@ -138,7 +228,7 @@ void GridModel::update()
     {
       const QLineF currentLine( mMapSettings->coordinateToScreen( QgsPoint( xPos, visibleExtent.yMinimum() ) ), mMapSettings->coordinateToScreen( QgsPoint( xPos, visibleExtent.yMaximum() ) ) );
 
-      if ( mDrawAnnotations )
+      if ( mPrepareAnnotations )
       {
         if ( currentLine.intersects( topBorder, &intersectionPoint ) )
         {
@@ -163,7 +253,7 @@ void GridModel::update()
     {
       const QLineF currentLine( mMapSettings->coordinateToScreen( QgsPoint( visibleExtent.xMinimum(), yPos ) ), mMapSettings->coordinateToScreen( QgsPoint( visibleExtent.xMaximum(), yPos ) ) );
 
-      if ( mDrawAnnotations )
+      if ( mPrepareAnnotations )
       {
         if ( currentLine.intersects( leftBorder, &intersectionPoint ) )
         {

--- a/src/core/gridmodel.cpp
+++ b/src/core/gridmodel.cpp
@@ -192,7 +192,7 @@ void GridModel::update()
 
   const QgsRectangle visibleExtent = mMapSettings->visibleExtent();
   double smallestScreenInterval = std::min( mXInterval / mMapSettings->mapUnitsPerPoint(), mYInterval / mMapSettings->mapUnitsPerPoint() );
-  if ( smallestScreenInterval < 10 )
+  if ( smallestScreenInterval < ( mPrepareMarkers ? 20 : 10 ) )
   {
     if ( hadGrid )
     {
@@ -204,7 +204,7 @@ void GridModel::update()
   QList<QPointF> line;
   QPointF intersectionPoint;
 
-  if ( mPrepareMarkers && smallestScreenInterval > 20 )
+  if ( mPrepareMarkers )
   {
     double xPos = visibleExtent.xMinimum() - std::fmod( visibleExtent.xMinimum(), mXInterval ) + mXOffset;
     while ( xPos <= visibleExtent.xMaximum() )
@@ -232,17 +232,21 @@ void GridModel::update()
       {
         if ( currentLine.intersects( topBorder, &intersectionPoint ) )
         {
-          mAnnotations << GridAnnotation( GridAnnotation::Top, intersectionPoint, mLocale.toString( xPos, 'f', 0 ) );
+          mAnnotations << GridAnnotation( GridAnnotation::Top, intersectionPoint, xPos );
         }
         if ( currentLine.intersects( bottomBorder, &intersectionPoint ) )
         {
-          mAnnotations << GridAnnotation( GridAnnotation::Bottom, intersectionPoint, mLocale.toString( xPos, 'f', 0 ) );
+          mAnnotations << GridAnnotation( GridAnnotation::Bottom, intersectionPoint, xPos );
         }
       }
 
-      line << currentLine.p1() << currentLine.p2();
-      mLines << line;
-      line.clear();
+      if ( mPrepareLines )
+      {
+        line << currentLine.p1() << currentLine.p2();
+        mLines << line;
+        line.clear();
+      }
+
       xPos += mXInterval;
     }
 
@@ -257,17 +261,21 @@ void GridModel::update()
       {
         if ( currentLine.intersects( leftBorder, &intersectionPoint ) )
         {
-          mAnnotations << GridAnnotation( GridAnnotation::Left, intersectionPoint, mLocale.toString( yPos, 'f', 0 ) );
+          mAnnotations << GridAnnotation( GridAnnotation::Left, intersectionPoint, yPos );
         }
         if ( currentLine.intersects( rightBorder, &intersectionPoint ) )
         {
-          mAnnotations << GridAnnotation( GridAnnotation::Right, intersectionPoint, mLocale.toString( yPos, 'f', 0 ) );
+          mAnnotations << GridAnnotation( GridAnnotation::Right, intersectionPoint, yPos );
         }
       }
 
-      line << currentLine.p1() << currentLine.p2();
-      mLines << line;
-      line.clear();
+      if ( mPrepareLines )
+      {
+        line << currentLine.p1() << currentLine.p2();
+        mLines << line;
+        line.clear();
+      }
+
       yPos += mYInterval;
     }
   }

--- a/src/core/gridmodel.cpp
+++ b/src/core/gridmodel.cpp
@@ -219,11 +219,12 @@ void GridModel::update()
     }
   }
 
+  const QSizeF sceneSize = mMapSettings->outputSize() / mMapSettings->devicePixelRatio();
   if ( mPrepareLines || mPrepareAnnotations )
   {
     double xPos = visibleExtent.xMinimum() - std::fmod( visibleExtent.xMinimum(), mXInterval ) + mXOffset;
-    const QLineF topBorder( QPointF( 0, 0 ), QPointF( mMapSettings->outputSize().width(), 0 ) );
-    const QLineF bottomBorder( QPointF( 0, mMapSettings->outputSize().height() ), QPointF( mMapSettings->outputSize().width(), mMapSettings->outputSize().height() ) );
+    const QLineF topBorder( QPointF( 0, 0 ), QPointF( sceneSize.width(), 0 ) );
+    const QLineF bottomBorder( QPointF( 0, sceneSize.height() ), QPointF( sceneSize.width(), sceneSize.height() ) );
     while ( xPos <= visibleExtent.xMaximum() )
     {
       const QLineF currentLine( mMapSettings->coordinateToScreen( QgsPoint( xPos, visibleExtent.yMinimum() ) ), mMapSettings->coordinateToScreen( QgsPoint( xPos, visibleExtent.yMaximum() ) ) );
@@ -251,8 +252,8 @@ void GridModel::update()
     }
 
     double yPos = visibleExtent.yMinimum() - std::fmod( visibleExtent.yMinimum(), mYInterval ) + mYOffset;
-    const QLineF leftBorder( QPointF( 0, 0 ), QPointF( 0, mMapSettings->outputSize().height() ) );
-    const QLineF rightBorder( QPointF( mMapSettings->outputSize().width(), 0 ), QPointF( mMapSettings->outputSize().width(), mMapSettings->outputSize().height() ) );
+    const QLineF leftBorder( QPointF( 0, 0 ), QPointF( 0, sceneSize.height() ) );
+    const QLineF rightBorder( QPointF( sceneSize.width(), 0 ), QPointF( sceneSize.width(), sceneSize.height() ) );
     while ( yPos <= visibleExtent.yMaximum() )
     {
       const QLineF currentLine( mMapSettings->coordinateToScreen( QgsPoint( visibleExtent.xMinimum(), yPos ) ), mMapSettings->coordinateToScreen( QgsPoint( visibleExtent.xMaximum(), yPos ) ) );

--- a/src/core/gridmodel.h
+++ b/src/core/gridmodel.h
@@ -1,0 +1,146 @@
+/***************************************************************************
+  gridmodel.h - GridModel
+
+ ---------------------
+ begin                : 4.10.2024
+ copyright            : (C) 2024 by Mathieu Pellerin
+ email                : mathieu@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef GRIDMODEL_H
+#define GRIDMODEL_H
+
+#include "qfield_core_export.h"
+#include "qgsquickmapsettings.h"
+
+/**
+ * This model manages lists of lines or points representing a grid.
+ */
+
+class QFIELD_CORE_EXPORT GridAnnotation
+{
+    Q_GADGET
+
+    Q_PROPERTY( Positions position MEMBER position )
+    Q_PROPERTY( QPointF coordinate MEMBER coordinate )
+    Q_PROPERTY( QString label MEMBER label )
+
+  public:
+    enum Positions
+    {
+      Top,
+      Bottom,
+      Left,
+      Right,
+    };
+    Q_ENUM( Positions )
+
+    GridAnnotation( const Positions position = Top, const QPointF coordinate = QPointF(), const QString label = QString() )
+      : position( position )
+      , coordinate( coordinate )
+      , label( label )
+    {}
+
+    Positions position = Top;
+    QPointF coordinate;
+    QString label;
+};
+
+class QFIELD_CORE_EXPORT GridModel : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY( QgsQuickMapSettings *mapSettings READ mapSettings WRITE setMapSettings NOTIFY mapSettingsChanged )
+
+    Q_PROPERTY( double xInterval READ xInterval WRITE setXInterval NOTIFY xIntervalChanged )
+    Q_PROPERTY( double yInterval READ yInterval WRITE setYInterval NOTIFY yIntervalChanged )
+    Q_PROPERTY( double xOffset READ xOffset WRITE setXOffset NOTIFY xOffsetChanged )
+    Q_PROPERTY( double yOffset READ yOffset WRITE setYOffset NOTIFY yOffsetChanged )
+
+    Q_PROPERTY( QList<QList<QPointF>> lines READ lines NOTIFY linesChanged )
+    Q_PROPERTY( QList<GridAnnotation> annotations READ annotations NOTIFY annotationsChanged )
+
+  public:
+    //! Default constructor
+    explicit GridModel( QObject *parent = nullptr );
+
+    //! Returns the map settings object
+    QgsQuickMapSettings *mapSettings() const { return mMapSettings; }
+
+    //! Sets the map settings object
+    void setMapSettings( QgsQuickMapSettings *mapSettings );
+
+    //! Returns the grid X interval
+    double xInterval() const { return mXInterval; }
+
+    //! Sets the grid X interval
+    void setXInterval( double interval );
+
+    //! Returns the grid Y interval
+    double yInterval() const { return mYInterval; }
+
+    //! Sets the grid Y interval
+    void setYInterval( double interval );
+
+    //! Returns the grid X interval
+    double xOffset() const { return mXOffset; }
+
+    //! Sets the grid X interval
+    void setXOffset( double offset );
+
+    //! Returns the grid Y interval
+    double yOffset() const { return mYOffset; }
+
+    //! Sets the grid Y interval
+    void setYOffset( double offset );
+
+    //! Returns the grid lines
+    QList<QList<QPointF>> lines() const { return mLines; }
+
+    //! Returns the grid annotations
+    QList<GridAnnotation> annotations() const { return mAnnotations; }
+
+  signals:
+    //! Emitted when the map settings object has changed
+    void mapSettingsChanged();
+
+    //! Emitted when the grid X interval has changed
+    void xIntervalChanged();
+
+    //! Emitted when the grid Y interval has changed
+    void yIntervalChanged();
+
+    //! Emitted when the grid X offset has changed
+    void xOffsetChanged();
+
+    //! Emitted when the grid Y offset has changed
+    void yOffsetChanged();
+
+    //! Emitted when the grid lines have changed
+    void linesChanged();
+
+    //! Emitted when the grid annotations have changed
+    void annotationsChanged();
+
+  private:
+    void update();
+
+    QgsQuickMapSettings *mMapSettings = nullptr;
+
+    double mXInterval = 2500.0;
+    double mYInterval = 2500.0;
+    double mXOffset = 0.0;
+    double mYOffset = 0.0;
+
+    QList<QList<QPointF>> mLines;
+    QList<GridAnnotation> mAnnotations;
+    QLocale mLocale;
+};
+Q_DECLARE_METATYPE( GridAnnotation )
+#endif // GRIDMODEL_H

--- a/src/core/gridmodel.h
+++ b/src/core/gridmodel.h
@@ -20,9 +20,8 @@
 #include "qgsquickmapsettings.h"
 
 /**
- * This model manages lists of lines or points representing a grid.
+ * Holds details for a given grid annotation.
  */
-
 class QFIELD_CORE_EXPORT GridAnnotation
 {
     Q_GADGET
@@ -52,6 +51,9 @@ class QFIELD_CORE_EXPORT GridAnnotation
     double value;
 };
 
+/**
+ * This model manages lists of lines, markers, and annotations representing a grid.
+ */
 class QFIELD_CORE_EXPORT GridModel : public QObject
 {
     Q_OBJECT

--- a/src/core/gridmodel.h
+++ b/src/core/gridmodel.h
@@ -63,8 +63,9 @@ class QFIELD_CORE_EXPORT GridModel : public QObject
     Q_PROPERTY( double xOffset READ xOffset WRITE setXOffset NOTIFY xOffsetChanged )
     Q_PROPERTY( double yOffset READ yOffset WRITE setYOffset NOTIFY yOffsetChanged )
 
-    Q_PROPERTY( QList<QList<QPointF>> lines READ lines NOTIFY linesChanged )
-    Q_PROPERTY( QList<GridAnnotation> annotations READ annotations NOTIFY annotationsChanged )
+    Q_PROPERTY( QList<QList<QPointF>> lines READ lines NOTIFY gridChanged )
+    Q_PROPERTY( QList<QPointF> markers READ markers NOTIFY gridChanged )
+    Q_PROPERTY( QList<GridAnnotation> annotations READ annotations NOTIFY gridChanged )
 
   public:
     //! Default constructor
@@ -103,6 +104,9 @@ class QFIELD_CORE_EXPORT GridModel : public QObject
     //! Returns the grid lines
     QList<QList<QPointF>> lines() const { return mLines; }
 
+    //! Returns the grid markers
+    QList<QPointF> markers() const { return mMarkers; }
+
     //! Returns the grid annotations
     QList<GridAnnotation> annotations() const { return mAnnotations; }
 
@@ -122,11 +126,8 @@ class QFIELD_CORE_EXPORT GridModel : public QObject
     //! Emitted when the grid Y offset has changed
     void yOffsetChanged();
 
-    //! Emitted when the grid lines have changed
-    void linesChanged();
-
-    //! Emitted when the grid annotations have changed
-    void annotationsChanged();
+    //! Emitted when the grid lines, markers, and/or annotations have changed
+    void gridChanged();
 
   private:
     void update();
@@ -138,8 +139,13 @@ class QFIELD_CORE_EXPORT GridModel : public QObject
     double mXOffset = 0.0;
     double mYOffset = 0.0;
 
+    bool mDrawLines = true;
     QList<QList<QPointF>> mLines;
+    bool mDrawMarkers = true;
+    QList<QPointF> mMarkers;
+    bool mDrawAnnotations = true;
     QList<GridAnnotation> mAnnotations;
+
     QLocale mLocale;
 };
 Q_DECLARE_METATYPE( GridAnnotation )

--- a/src/core/gridmodel.h
+++ b/src/core/gridmodel.h
@@ -56,6 +56,8 @@ class QFIELD_CORE_EXPORT GridModel : public QObject
 {
     Q_OBJECT
 
+    Q_PROPERTY( bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged )
+
     Q_PROPERTY( QgsQuickMapSettings *mapSettings READ mapSettings WRITE setMapSettings NOTIFY mapSettingsChanged )
 
     Q_PROPERTY( double xInterval READ xInterval WRITE setXInterval NOTIFY xIntervalChanged )
@@ -63,13 +65,22 @@ class QFIELD_CORE_EXPORT GridModel : public QObject
     Q_PROPERTY( double xOffset READ xOffset WRITE setXOffset NOTIFY xOffsetChanged )
     Q_PROPERTY( double yOffset READ yOffset WRITE setYOffset NOTIFY yOffsetChanged )
 
+    Q_PROPERTY( bool prepareLines READ prepareLines WRITE setPrepareLines NOTIFY prepareLinesChanged )
     Q_PROPERTY( QList<QList<QPointF>> lines READ lines NOTIFY gridChanged )
+    Q_PROPERTY( bool prepareMarkers READ prepareMarkers WRITE setPrepareMarkers NOTIFY prepareMarkersChanged )
     Q_PROPERTY( QList<QPointF> markers READ markers NOTIFY gridChanged )
+    Q_PROPERTY( bool prepareAnnotations READ prepareAnnotations WRITE setPrepareAnnotations NOTIFY prepareAnnotationsChanged )
     Q_PROPERTY( QList<GridAnnotation> annotations READ annotations NOTIFY gridChanged )
 
   public:
     //! Default constructor
     explicit GridModel( QObject *parent = nullptr );
+
+    //! Returns TRUE when grid elements will be prepared
+    bool enabled() const { return mEnabled; }
+
+    //! Sets whether grid elements will be prepared
+    void setEnabled( bool enabled );
 
     //! Returns the map settings object
     QgsQuickMapSettings *mapSettings() const { return mMapSettings; }
@@ -101,16 +112,37 @@ class QFIELD_CORE_EXPORT GridModel : public QObject
     //! Sets the grid Y interval
     void setYOffset( double offset );
 
+    //! Returns whether grid lines will be prepared
+    bool prepareLines() const { return mPrepareLines; }
+
+    //! Sets whether grid lines will be prepared
+    void setPrepareLines( bool prepare );
+
     //! Returns the grid lines
     QList<QList<QPointF>> lines() const { return mLines; }
 
+    //! Returns whether grid markers will be prepared
+    bool prepareMarkers() const { return mPrepareMarkers; }
+
+    //! Sets whether grid markers will be prepared
+    void setPrepareMarkers( bool prepare );
+
     //! Returns the grid markers
     QList<QPointF> markers() const { return mMarkers; }
+
+    //! Returns whether grid annotations will be prepared
+    bool prepareAnnotations() const { return mPrepareAnnotations; }
+
+    //! Sets whether grid annotations will be prepared
+    void setPrepareAnnotations( bool prepare );
 
     //! Returns the grid annotations
     QList<GridAnnotation> annotations() const { return mAnnotations; }
 
   signals:
+    //! Emitted when the grid enabled setting has changed
+    void enabledChanged();
+
     //! Emitted when the map settings object has changed
     void mapSettingsChanged();
 
@@ -126,11 +158,22 @@ class QFIELD_CORE_EXPORT GridModel : public QObject
     //! Emitted when the grid Y offset has changed
     void yOffsetChanged();
 
+    //! Emitted when grid lines preparation setting has changed
+    void prepareLinesChanged();
+
+    //! Emitted when grid markers preparation setting has changed
+    void prepareMarkersChanged();
+
+    //! Emitted when grid annotations preparation setting has changed
+    void prepareAnnotationsChanged();
+
     //! Emitted when the grid lines, markers, and/or annotations have changed
     void gridChanged();
 
   private:
     void update();
+
+    bool mEnabled = false;
 
     QgsQuickMapSettings *mMapSettings = nullptr;
 
@@ -139,11 +182,11 @@ class QFIELD_CORE_EXPORT GridModel : public QObject
     double mXOffset = 0.0;
     double mYOffset = 0.0;
 
-    bool mDrawLines = true;
+    bool mPrepareLines = true;
     QList<QList<QPointF>> mLines;
-    bool mDrawMarkers = true;
+    bool mPrepareMarkers = false;
     QList<QPointF> mMarkers;
-    bool mDrawAnnotations = true;
+    bool mPrepareAnnotations = false;
     QList<GridAnnotation> mAnnotations;
 
     QLocale mLocale;

--- a/src/core/gridmodel.h
+++ b/src/core/gridmodel.h
@@ -29,7 +29,7 @@ class QFIELD_CORE_EXPORT GridAnnotation
 
     Q_PROPERTY( Positions position MEMBER position )
     Q_PROPERTY( QPointF coordinate MEMBER coordinate )
-    Q_PROPERTY( QString label MEMBER label )
+    Q_PROPERTY( double value MEMBER value )
 
   public:
     enum Positions
@@ -41,15 +41,15 @@ class QFIELD_CORE_EXPORT GridAnnotation
     };
     Q_ENUM( Positions )
 
-    GridAnnotation( const Positions position = Top, const QPointF coordinate = QPointF(), const QString label = QString() )
+    GridAnnotation( const Positions position = Top, const QPointF coordinate = QPointF(), const double value = 0.0 )
       : position( position )
       , coordinate( coordinate )
-      , label( label )
+      , value( value )
     {}
 
     Positions position = Top;
     QPointF coordinate;
-    QString label;
+    double value;
 };
 
 class QFIELD_CORE_EXPORT GridModel : public QObject
@@ -182,7 +182,7 @@ class QFIELD_CORE_EXPORT GridModel : public QObject
     double mXOffset = 0.0;
     double mYOffset = 0.0;
 
-    bool mPrepareLines = true;
+    bool mPrepareLines = false;
     QList<QList<QPointF>> mLines;
     bool mPrepareMarkers = false;
     QList<QPointF> mMarkers;

--- a/src/core/projectinfo.h
+++ b/src/core/projectinfo.h
@@ -194,6 +194,9 @@ class ProjectInfo : public QObject
     //! Retrieves configuration of the image decoration
     Q_INVOKABLE QVariantMap getImageDecorationConfiguration();
 
+    //! Retrieves configuration of the grid decoration
+    Q_INVOKABLE QVariantMap getGridDecorationConfiguration();
+
     //! Retrieves the default active layer for a given map theme
     Q_INVOKABLE QgsMapLayer *getDefaultActiveLayerForMapTheme( const QString &mapTheme );
 

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -65,6 +65,7 @@
 #include "geometryeditorsmodel.h"
 #include "geometryutils.h"
 #include "gnsspositioninformation.h"
+#include "gridmodel.h"
 #include "identifytool.h"
 #include "layerobserver.h"
 #include "layerresolver.h"
@@ -446,6 +447,8 @@ void QgisMobileapp::initDeclarative( QQmlEngine *engine )
   qmlRegisterType<ProjectInfo>( "org.qfield", 1, 0, "ProjectInfo" );
   qmlRegisterType<ProjectSource>( "org.qfield", 1, 0, "ProjectSource" );
   qmlRegisterType<ViewStatus>( "org.qfield", 1, 0, "ViewStatus" );
+  qmlRegisterType<GridModel>( "org.qfield", 1, 0, "GridModel" );
+  qmlRegisterUncreatableType<GridAnnotation>( "org.qfield", 1, 0, "GridAnnotation", "" );
 
   qmlRegisterType<Geofencer>( "org.qfield", 1, 0, "Geofencer" );
   qmlRegisterType<DigitizingLogger>( "org.qfield", 1, 0, "DigitizingLogger" );

--- a/src/qml/GridRenderer.qml
+++ b/src/qml/GridRenderer.qml
@@ -20,29 +20,25 @@ Item {
   GridModel {
     id: gridModel
 
+    onLinesChanged: {
+      let svgPath = "";
+      for (const line of lines) {
+        svgPath += "M " + (line[0].x) + " " + (line[0].y) + " L " + (line[1].x) + " " + (line[1].y) + " ";
+      }
+      lineSvgPath.path = svgPath;
+    }
+
     onMarkersChanged: {
       let svgPath = "";
-      for (const marker of gridModel.markers) {
+      for (const marker of markers) {
         svgPath += "M " + (marker.x) + " " + (marker.y - 5) + " L " + (marker.x) + " " + (marker.y + 5) + " " + "M " + (marker.x - 5) + " " + (marker.y) + " L " + (marker.x + 5) + " " + (marker.y) + " ";
       }
       markerSvgPath.path = svgPath;
     }
   }
 
-  Instantiator {
-    id: lineInstantiator
-    asynchronous: true
-    model: gridModel.lines
-    onModelChanged: linesPath.pathElements = []
-    onObjectAdded: (index, object) => linesPath.pathElements.push(object)
-
-    PathPolyline {
-      path: modelData
-    }
-  }
-
   Shape {
-    id: lines
+    id: linesContainer
     visible: gridModel.lines.length > 0
     anchors.fill: parent
 
@@ -54,11 +50,16 @@ Item {
       fillColor: "transparent"
       joinStyle: ShapePath.RoundJoin
       capStyle: ShapePath.RoundCap
+
+      PathSvg {
+        id: lineSvgPath
+        path: ""
+      }
     }
   }
 
   Shape {
-    id: markers
+    id: markersContainer
     visible: gridModel.markers.length > 0
     anchors.fill: parent
 
@@ -79,7 +80,7 @@ Item {
   }
 
   Repeater {
-    id: annotations
+    id: annotationsContainer
     model: gridModel.annotations
 
     Rectangle {
@@ -92,6 +93,7 @@ Item {
       color: lineColor
 
       Text {
+        id: annotation
         anchors.top: modelData.position === GridAnnotation.Top ? parent.bottom : undefined
         anchors.bottom: modelData.position === GridAnnotation.Bottom ? parent.top : undefined
         anchors.left: modelData.position === GridAnnotation.Left ? parent.right : undefined

--- a/src/qml/GridRenderer.qml
+++ b/src/qml/GridRenderer.qml
@@ -21,8 +21,9 @@ Item {
   property color markerColor: "#000000"
 
   property alias prepareAnnotations: gridModel.prepareAnnotations
+  property int annotationPrecision: 0
   property color annotationColor: "#000000"
-  property bool hasAnnotationOutline: false
+  property bool annotationHasOutline: false
   property color annotationOutlineColor: "#ffffff"
 
   GridModel {
@@ -111,10 +112,10 @@ Item {
 
         font: Theme.tinyFont
         color: annotationColor
-        style: hasAnnotationOutline ? Text.Outline : Text.Normal
+        style: annotationHasOutline ? Text.Outline : Text.Normal
         styleColor: annotationOutlineColor
 
-        text: modelData.label
+        text: Number(modelData.value).toLocaleString(Qt.locale(), 'f', annotationPrecision)
       }
     }
   }

--- a/src/qml/GridRenderer.qml
+++ b/src/qml/GridRenderer.qml
@@ -6,6 +6,7 @@ import Theme
 Item {
   id: gridRenderer
 
+  property alias enabled: gridModel.enabled
   property alias mapSettings: gridModel.mapSettings
 
   property alias xInterval: gridModel.xInterval
@@ -13,9 +14,16 @@ Item {
   property alias xOffset: gridModel.xOffset
   property alias yOffset: gridModel.yOffset
 
+  property alias prepareLines: gridModel.prepareLines
   property color lineColor: "#000000"
+
+  property alias prepareMarkers: gridModel.prepareMarkers
   property color markerColor: "#000000"
+
+  property alias prepareAnnotations: gridModel.prepareAnnotations
   property color annotationColor: "#000000"
+  property bool hasAnnotationOutline: false
+  property color annotationOutlineColor: "#ffffff"
 
   GridModel {
     id: gridModel
@@ -103,8 +111,8 @@ Item {
 
         font: Theme.tinyFont
         color: annotationColor
-        style: Text.Outline
-        styleColor: "#ffffff"
+        style: hasAnnotationOutline ? Text.Outline : Text.Normal
+        styleColor: annotationOutlineColor
 
         text: modelData.label
       }

--- a/src/qml/GridRenderer.qml
+++ b/src/qml/GridRenderer.qml
@@ -1,0 +1,82 @@
+import QtQuick
+import QtQuick.Shapes
+import org.qfield
+import Theme
+
+Item {
+  id: gridRenderer
+
+  property alias mapSettings: gridModel.mapSettings
+
+  property alias xInterval: gridModel.xInterval
+  property alias yInterval: gridModel.yInterval
+  property alias xOffset: gridModel.xOffset
+  property alias yOffset: gridModel.yOffset
+
+  property color lineColor: "#000000"
+  property color annotationColor: "#000000"
+
+  GridModel {
+    id: gridModel
+  }
+
+  Instantiator {
+    id: lineInstantiator
+    asynchronous: true
+    model: gridModel.lines
+    onModelChanged: linesPath.pathElements = []
+    onObjectAdded: (index, object) => linesPath.pathElements.push(object)
+
+    PathPolyline {
+      path: modelData
+    }
+  }
+
+  Shape {
+    id: lines
+    visible: gridModel.lines.length > 0
+    anchors.fill: parent
+
+    ShapePath {
+      id: linesPath
+      strokeColor: lineColor
+      strokeWidth: 1
+      strokeStyle: ShapePath.SolidLine
+      fillColor: "transparent"
+      joinStyle: ShapePath.RoundJoin
+      capStyle: ShapePath.RoundCap
+    }
+  }
+
+  Repeater {
+    id: annotations
+    model: gridModel.annotations
+
+    Rectangle {
+      x: modelData.coordinate.x - width / 2
+      y: modelData.coordinate.y - height / 2
+
+      width: 4
+      height: 4
+      radius: width / 2
+
+      color: lineColor
+
+      Text {
+        anchors.top: modelData.position === GridAnnotation.Top ? parent.bottom : undefined
+        anchors.bottom: modelData.position === GridAnnotation.Bottom ? parent.top : undefined
+        anchors.left: modelData.position === GridAnnotation.Left ? parent.right : undefined
+        anchors.right: modelData.position === GridAnnotation.Right ? parent.left : undefined
+        anchors.horizontalCenter: modelData.position === GridAnnotation.Top || modelData.position === GridAnnotation.Bottom ? parent.horizontalCenter : undefined
+        anchors.verticalCenter: modelData.position === GridAnnotation.Left || modelData.position === GridAnnotation.Right ? parent.verticalCenter : undefined
+
+        font: Theme.tinyFont
+        color: annotationColor
+        style: Text.Outline
+        styleColor: "#ffffff"
+
+        text: modelData.label
+      }
+    }
+  }
+}

--- a/src/qml/GridRenderer.qml
+++ b/src/qml/GridRenderer.qml
@@ -22,10 +22,8 @@ Item {
 
     onMarkersChanged: {
       let svgPath = "";
-      if (gridModel.markers.length > 0 && gridModel.markers.length < 2000) {
-        for (const marker of gridModel.markers) {
-          svgPath += "M " + (marker.x) + " " + (marker.y - 5) + " L " + (marker.x) + " " + (marker.y + 5) + " " + "M " + (marker.x - 5) + " " + (marker.y) + " L " + (marker.x + 5) + " " + (marker.y) + " ";
-        }
+      for (const marker of gridModel.markers) {
+        svgPath += "M " + (marker.x) + " " + (marker.y - 5) + " L " + (marker.x) + " " + (marker.y + 5) + " " + "M " + (marker.x - 5) + " " + (marker.y) + " L " + (marker.x + 5) + " " + (marker.y) + " ";
       }
       markerSvgPath.path = svgPath;
     }

--- a/src/qml/GridRenderer.qml
+++ b/src/qml/GridRenderer.qml
@@ -14,10 +14,21 @@ Item {
   property alias yOffset: gridModel.yOffset
 
   property color lineColor: "#000000"
+  property color markerColor: "#000000"
   property color annotationColor: "#000000"
 
   GridModel {
     id: gridModel
+
+    onMarkersChanged: {
+      let svgPath = "";
+      if (gridModel.markers.length > 0 && gridModel.markers.length < 2000) {
+        for (const marker of gridModel.markers) {
+          svgPath += "M " + (marker.x) + " " + (marker.y - 5) + " L " + (marker.x) + " " + (marker.y + 5) + " " + "M " + (marker.x - 5) + " " + (marker.y) + " L " + (marker.x + 5) + " " + (marker.y) + " ";
+        }
+      }
+      markerSvgPath.path = svgPath;
+    }
   }
 
   Instantiator {
@@ -48,6 +59,27 @@ Item {
     }
   }
 
+  Shape {
+    id: markers
+    visible: gridModel.markers.length > 0
+    anchors.fill: parent
+
+    ShapePath {
+      id: markerPath
+      strokeColor: markerColor
+      strokeWidth: 2
+      strokeStyle: ShapePath.SolidLine
+      fillColor: "transparent"
+      joinStyle: ShapePath.RoundJoin
+      capStyle: ShapePath.RoundCap
+
+      PathSvg {
+        id: markerSvgPath
+        path: ""
+      }
+    }
+  }
+
   Repeater {
     id: annotations
     model: gridModel.annotations
@@ -56,9 +88,8 @@ Item {
       x: modelData.coordinate.x - width / 2
       y: modelData.coordinate.y - height / 2
 
-      width: 4
-      height: 4
-      radius: width / 2
+      width: 1
+      height: 1
 
       color: lineColor
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -580,6 +580,7 @@ ApplicationWindow {
       }
 
       GridRenderer {
+        id: gridDecoration
         mapSettings: mapCanvas.mapSettings
       }
     }
@@ -3394,6 +3395,16 @@ ApplicationWindow {
       imageDecoration.source = imageDecorationConfiguration["source"];
       imageDecoration.fillColor = imageDecorationConfiguration["fillColor"];
       imageDecoration.strokeColor = imageDecorationConfiguration["strokeColor"];
+      let gridDecorationConfiguration = projectInfo.getGridDecorationConfiguration();
+      gridDecoration.enabled = gridDecorationConfiguration["hasLines"] || gridDecorationConfiguration["hasMarkers"];
+      gridDecoration.prepareLines = gridDecorationConfiguration["hasLines"];
+      gridDecoration.lineColor = gridDecorationConfiguration["lineColor"];
+      gridDecoration.prepareMarkers = gridDecorationConfiguration["hasMarkers"];
+      gridDecoration.markerColor = gridDecorationConfiguration["markerColor"];
+      gridDecoration.prepareAnnotations = gridDecorationConfiguration["hasAnnotations"];
+      gridDecoration.annotationColor = gridDecorationConfiguration["annotationColor"];
+      gridDecoration.hasAnnotationOutline = gridDecorationConfiguration["hasAnnotationOutline"];
+      gridDecoration.annotationOutlineColor = gridDecorationConfiguration["annotationOutlineColor"];
       recentProjectListModel.reloadModel();
       const cloudProjectId = QFieldCloudUtils.getProjectId(qgisProject.fileName);
       cloudProjectsModel.currentProjectId = cloudProjectId;

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3373,7 +3373,7 @@ ApplicationWindow {
       dashBoard.activeLayer = activeLayer;
       drawingTemplateModel.projectFilePath = path;
       mapCanvasBackground.color = mapCanvas.mapSettings.backgroundColor;
-      let titleDecorationConfiguration = projectInfo.getTitleDecorationConfiguration();
+      const titleDecorationConfiguration = projectInfo.getTitleDecorationConfiguration();
       titleDecoration.color = titleDecorationConfiguration["color"];
       titleDecoration.style = titleDecorationConfiguration["hasOutline"] === true ? Text.Outline : Text.Normal;
       titleDecoration.styleColor = titleDecorationConfiguration["outlineColor"];
@@ -3382,7 +3382,7 @@ ApplicationWindow {
       if (!titleDecoration.isExpressionTemplate) {
         titleDecoration.text = titleDecorationConfiguration["text"];
       }
-      let copyrightDecorationConfiguration = projectInfo.getCopyrightDecorationConfiguration();
+      const copyrightDecorationConfiguration = projectInfo.getCopyrightDecorationConfiguration();
       copyrightDecoration.color = copyrightDecorationConfiguration["color"];
       copyrightDecoration.style = copyrightDecorationConfiguration["hasOutline"] === true ? Text.Outline : Text.Normal;
       copyrightDecoration.styleColor = copyrightDecorationConfiguration["outlineColor"];
@@ -3391,20 +3391,22 @@ ApplicationWindow {
       if (!titleDecoration.isExpressionTemplate) {
         copyrightDecoration.text = copyrightDecorationConfiguration["text"];
       }
-      let imageDecorationConfiguration = projectInfo.getImageDecorationConfiguration();
+      const imageDecorationConfiguration = projectInfo.getImageDecorationConfiguration();
       imageDecoration.source = imageDecorationConfiguration["source"];
       imageDecoration.fillColor = imageDecorationConfiguration["fillColor"];
       imageDecoration.strokeColor = imageDecorationConfiguration["strokeColor"];
-      let gridDecorationConfiguration = projectInfo.getGridDecorationConfiguration();
-      gridDecoration.enabled = gridDecorationConfiguration["hasLines"] || gridDecorationConfiguration["hasMarkers"];
+      const gridDecorationConfiguration = projectInfo.getGridDecorationConfiguration();
+      gridDecoration.enabled = false;
       gridDecoration.prepareLines = gridDecorationConfiguration["hasLines"];
       gridDecoration.lineColor = gridDecorationConfiguration["lineColor"];
       gridDecoration.prepareMarkers = gridDecorationConfiguration["hasMarkers"];
       gridDecoration.markerColor = gridDecorationConfiguration["markerColor"];
       gridDecoration.prepareAnnotations = gridDecorationConfiguration["hasAnnotations"];
+      gridDecoration.annotationPrecision = gridDecorationConfiguration["annotationPrecision"];
       gridDecoration.annotationColor = gridDecorationConfiguration["annotationColor"];
-      gridDecoration.hasAnnotationOutline = gridDecorationConfiguration["hasAnnotationOutline"];
+      gridDecoration.annotationHasOutline = gridDecorationConfiguration["annotationHasOutline"];
       gridDecoration.annotationOutlineColor = gridDecorationConfiguration["annotationOutlineColor"];
+      gridDecoration.enabled = gridDecorationConfiguration["hasLines"] || gridDecorationConfiguration["hasMarkers"];
       recentProjectListModel.reloadModel();
       const cloudProjectId = QFieldCloudUtils.getProjectId(qgisProject.fileName);
       cloudProjectsModel.currentProjectId = cloudProjectId;

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -578,6 +578,10 @@ ApplicationWindow {
           overlayFeatureFormDrawer.closePolicy = Popup.CloseOnEscape | Popup.CloseOnPressOutside;
         }
       }
+
+      GridRenderer {
+        mapSettings: mapCanvas.mapSettings
+      }
     }
 
     /**************************************************

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -16,6 +16,7 @@
         <file>ElevationProfile.qml</file>
         <file>FeatureForm.qml</file>
         <file>FeatureListForm.qml</file>
+        <file>GridRenderer.qml</file>
         <file>LinePolygon.qml</file>
         <file>LocationMarker.qml</file>
         <file>MapCanvas.qml</file>


### PR DESCRIPTION
This pull request adds grid decoration functionality to QField:

https://github.com/user-attachments/assets/97097ce5-0815-425b-8dfb-6f7244fd1bb7

QField will enable the grid based on the currently opened project's grid decoration settings, which is configured when preparing a project in QGIS. Implementation note: as with other decorations implemented in QField, we do not do a 1-to-1 implementation; in this case, we will take the line or maker color defined in QGIS but we will render the line and marker style our own way (namely non-dashed lines and cross markers).

![image](https://github.com/user-attachments/assets/d3ef824e-63fc-4cb6-a211-0e237e661c34)

Quite interestingly, relying on QML Shape rendering ended up being _much faster_ than relying on a QQuickPaintedItem and doing the rendering completely on the C++ side of things. That was surprising to me, and serves as a good reminder that QML scenes have excellent rendering speeds!

Sample project showcasing grid:

[grid_Sample_project.zip](https://github.com/user-attachments/files/17268029/grid_Sample_project.zip)
