### PR TITLE
Remove use of trademark wording

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -1126,7 +1126,7 @@ void QgisMobileapp::readProjectFile()
 
     if ( suffix.compare( QLatin1String( "pdf" ) ) == 0 )
     {
-      // GeoPDFs should have vector layers hidden by default
+      // Geospatial PDFs should have vector layers hidden by default
       for ( QgsMapLayer *layer : vectorLayers )
       {
         mProject->layerTreeRoot()->findLayer( layer->id() )->setItemVisibilityChecked( false );


### PR DESCRIPTION
Also aligns usage of geospatial PDF with what's been picked by gdal & QGIS.