### PR TITLE
Avoid needless save when adding a child to a parent that is already part of its dataset

### DIFF
--- a/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
@@ -131,7 +131,7 @@ EditorWidgetBase {
         repeat: false
 
         onTriggered: {
-          let saved = save();
+          let saved = form.state === 'Add' ? save() : true;
           if (ProjectUtils.transactionMode(qgisProject) !== Qgis.TransactionMode.Disabled) {
             // When a transaction mode is enabled, we must fallback to saving the parent feature to have provider-side issues
             if (!saved) {
@@ -375,6 +375,14 @@ EditorWidgetBase {
     }
   }
 
+  BusyIndicator {
+    id: busyIndicator
+    anchors.centerIn: parent
+    width: 36
+    height: 36
+    running: orderedRelationModel.isLoading
+  }
+
   Dialog {
     id: deleteDialog
     parent: mainWindow.contentItem
@@ -412,14 +420,6 @@ EditorWidgetBase {
     onRejected: {
       visible = false;
     }
-  }
-
-  BusyIndicator {
-    id: busyIndicator
-    anchors.centerIn: parent
-    width: 36
-    height: 36
-    running: orderedRelationModel.isLoading
   }
 
   EmbeddedFeatureForm {

--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -141,7 +141,7 @@ EditorWidgetBase {
           repeat: false
 
           onTriggered: {
-            let saved = save();
+            let saved = form.state === 'Add' ? save() : true;
             if (ProjectUtils.transactionMode(qgisProject) !== Qgis.TransactionMode.Disabled) {
               // When a transaction mode is enabled, we must fallback to saving the parent feature to have provider-side issues
               if (!saved) {
@@ -174,6 +174,14 @@ EditorWidgetBase {
           }
         }
       }
+    }
+
+    BusyIndicator {
+      id: busyIndicator
+      anchors.centerIn: parent
+      width: 36
+      height: 36
+      running: relationEditorModel.isLoading
     }
   }
 
@@ -318,14 +326,6 @@ EditorWidgetBase {
     onRejected: {
       visible = false;
     }
-  }
-
-  BusyIndicator {
-    id: busyIndicator
-    anchors.centerIn: parent
-    width: 36
-    height: 36
-    running: relationEditorModel.isLoading
   }
 
   EmbeddedFeatureForm {


### PR DESCRIPTION
Unconditionally calling save() of a parent feature when adding children can be needlessly costly on online datasets, let's only do it when we absolutely need it (i.e. when a parent feature isn't created yet).