### PR TITLE
Improve feature attribute transfer by allowing copying _some_ expression-driven attributes

### DIFF
--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -684,9 +684,10 @@ bool FeatureModel::updateAttributesFromFeature( const QgsFeature &feature )
         continue;
       }
 
-      // Do not paste values for attributes that have default values
-      if ( !mFeature.fields()[idx].defaultValueDefinition().expression().isEmpty() )
+      const QgsField field = mFeature.fields()[idx];
+      if ( !field.defaultValueDefinition().expression().isEmpty() && !field.defaultValueDefinition().applyOnUpdate() )
       {
+        // Skip attributes that have default value set only once on feature creation to avoid overriding generated UUIDs
         continue;
       }
 


### PR DESCRIPTION
When we initially released this functionality, we turned out to be a bit too rigid on our handling of expression-driven attribute. 

This PR relaxes things a bit by applying the prohibition on transfer of attribute values on attributes with default value expression to those that _don't_ update their value on feature updates. The updated logic continues to protect users from overwriting UUID / unique value / timestamp attributes  that would have been generated _once_ on feature creation while allowing for expression-drive attributes set to refresh on feature update to have values transferred.