### PR TITLE
Processing / measuring tool bug fix

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2139,6 +2139,12 @@ ApplicationWindow {
     homeButton.waitingForDigitizingFinish = false;
   }
 
+  function activateMeasurementMode() {
+    mainMenu.close();
+    dashBoard.close();
+    changeMode('measure');
+  }
+
   Menu {
     id: mainMenu
     title: qsTr("Main Menu")
@@ -2194,6 +2200,7 @@ ApplicationWindow {
       }
 
       QfToolButton {
+        id: measurementButton
         anchors.verticalCenter: parent.verticalCenter
         height: 48
         width: 48
@@ -2203,10 +2210,12 @@ ApplicationWindow {
         bgcolor: hovered ? parent.hoveredColor : "#00ffffff"
 
         onClicked: {
-          mainMenu.close();
-          dashBoard.close();
-          changeMode('measure');
-          highlighted = false;
+          if (featureForm.state === "ProcessingAlgorithmForm") {
+            cancelAlgorithmDialog.visible = true;
+          } else {
+            activateMeasurementMode();
+            highlighted = false;
+          }
         }
       }
 
@@ -4031,6 +4040,35 @@ ApplicationWindow {
     }
 
     standardButtons: Dialog.Yes | Dialog.No
+  }
+
+  Dialog {
+    id: cancelAlgorithmDialog
+    parent: mainWindow.contentItem
+
+    visible: false
+    modal: true
+    font: Theme.defaultFont
+
+    z: 10000 // 1000s are embedded feature forms, user a higher value to insure the dialog will always show above embedded feature forms
+    x: (mainWindow.width - width) / 2
+    y: (mainWindow.height - height) / 2
+
+    title: qsTr("Cancel algorithm")
+    Label {
+      width: parent.width
+      wrapMode: Text.WordWrap
+      text: qsTr("You are about to dismiss algorithm, proceed?")
+    }
+
+    standardButtons: Dialog.Ok | Dialog.Cancel
+    onAccepted: {
+      featureForm.state = "FeatureList";
+      activateMeasurementMode();
+    }
+    onDiscarded: {
+      cancelAlgorithmDialog.visible = false;
+    }
   }
 
   Connections {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -4054,11 +4054,11 @@ ApplicationWindow {
     x: (mainWindow.width - width) / 2
     y: (mainWindow.height - height) / 2
 
-    title: qsTr("Cancel algorithm")
+    title: qsTr("Cancel algorithm operation")
     Label {
       width: parent.width
       wrapMode: Text.WordWrap
-      text: qsTr("You are about to dismiss algorithm, proceed?")
+      text: qsTr("You are about to dismiss the ongoing algorithm operation, proceed?")
     }
 
     standardButtons: Dialog.Ok | Dialog.Cancel

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -4063,7 +4063,7 @@ ApplicationWindow {
 
     standardButtons: Dialog.Ok | Dialog.Cancel
     onAccepted: {
-      featureForm.state = "FeatureList";
+      featureForm.state = "Hidden";
       activateMeasurementMode();
     }
     onDiscarded: {


### PR DESCRIPTION
## PR Description: 
When users are in the algorithm design mode and attempt to navigate to the measurement section, the preview feature remains active, which is an unauthorized behavior. This pull request addresses and resolves that issue.

### Solution:
To prevent users from entering the measurement section while still in the algorithm design mode, we will implement a confirmation dialog. This dialog will prompt the user with the question: “Do you want to discard the algorithm to enter the measurement section?”

> If the user accepts, the algorithm will be discarded, allowing for a proper transition to the measurement section. 

This change aims to enhance user experience by ensuring that the application behaves predictably and maintains the integrity of the design process.

### Changes Made:
Added a confirmation dialog for transitioning from algorithm design to measurement.
Managed state transitions effectively based on user input.


## Before and After Demo:    


[Screencast from 2024-10-17 18-18-35.webm](https://github.com/user-attachments/assets/95e119a8-f97a-4f28-a63d-ca48e76e6087)
