### PR TITLE
When loading a project with pending authentication requests, do not set an active layer to avoid potential crash

### DIFF
--- a/src/core/qfieldappauthrequesthandler.h
+++ b/src/core/qfieldappauthrequesthandler.h
@@ -38,6 +38,8 @@ class QFieldAppAuthRequestHandler : public QObject, public QgsCredentials, publi
 {
     Q_OBJECT
 
+    Q_PROPERTY( bool hasPendingAuthRequest READ hasPendingAuthRequest NOTIFY hasPendingAuthRequestChanged )
+
   public:
     QFieldAppAuthRequestHandler();
 
@@ -58,12 +60,16 @@ class QFieldAppAuthRequestHandler : public QObject, public QgsCredentials, publi
     //! abort an ongoing external browser authentication request
     Q_INVOKABLE void abortAuthBrowser();
 
+    //! returns the number of pending authentication requests
+    bool hasPendingAuthRequest() const;
+
   signals:
     void showLoginDialog( const QString &realm, const QString &title );
     void loginDialogClosed( const QString &realm, const bool canceled );
     void reloadEverything();
     void showLoginBrowser( const QString &url );
     void hideLoginBrowser();
+    void hasPendingAuthRequestChanged();
 
   protected:
     bool request( const QString &realm, QString &username, QString &password, const QString &message = QString() ) override;
@@ -95,6 +101,7 @@ class QFieldAppAuthRequestHandler : public QObject, public QgsCredentials, publi
     };
 
     QList<RealmEntry> mRealms;
+    bool mBrowserAuthenticationOngoing = false;
 };
 
 #endif // QFIELDAPPAUTHREQUESTHANDLER_H

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3342,6 +3342,11 @@ ApplicationWindow {
     }
 
     function onLoadProjectTriggered(path, name) {
+      messageLogModel.suppress({
+          "WFS": [""],
+          "WMS": [""],
+          "PostGIS": ["fe_sendauth: no password supplied"]
+        });
       qfieldLocalDataPickerScreen.visible = false;
       qfieldLocalDataPickerScreen.focus = false;
       welcomeScreen.visible = false;
@@ -3360,6 +3365,17 @@ ApplicationWindow {
     function onLoadProjectEnded(path, name) {
       mapCanvasMap.unfreeze('projectload');
       busyOverlay.state = "hidden";
+      dashBoard.layerTree.unfreeze(true);
+      if (qfieldAuthRequestHandler.hasPendingAuthRequest) {
+        qfieldAuthRequestHandler.handleLayerLogins();
+      } else {
+        // project in need of handling layer credentials
+        messageLogModel.unsuppress({
+            "WFS": [],
+            "WMS": [],
+            "PostGIS": []
+          });
+      }
       projectInfo.filePath = path;
       stateMachine.state = projectInfo.stateMode;
       platformUtilities.setHandleVolumeKeys(qfieldSettings.digitizingVolumeKeys && stateMachine.state != 'browse');
@@ -3370,7 +3386,10 @@ ApplicationWindow {
           activeLayer = defaultActiveLayer;
         }
       }
-      dashBoard.activeLayer = activeLayer;
+      if (!qfieldAuthRequestHandler.hasPendingAuthRequest) {
+        // only set active layer when not handling layer credentials
+        dashBoard.activeLayer = activeLayer;
+      }
       drawingTemplateModel.projectFilePath = path;
       mapCanvasBackground.color = mapCanvas.mapSettings.backgroundColor;
       const titleDecorationConfiguration = projectInfo.getTitleDecorationConfiguration();
@@ -3447,7 +3466,7 @@ ApplicationWindow {
         projectInfo.hasInsertRights = true;
         projectInfo.hasEditRights = true;
       }
-      if (stateMachine.state === "digitize") {
+      if (stateMachine.state === "digitize" && !qfieldAuthRequestHandler.hasPendingAuthRequest) {
         dashBoard.ensureEditableLayerSelected();
       }
       var distanceString = iface.readProjectEntry("Measurement", "/DistanceUnits", "");
@@ -3535,29 +3554,6 @@ ApplicationWindow {
 
   Item {
     id: layerLogin
-
-    Connections {
-      target: iface
-      function onLoadProjectTriggered(path) {
-        messageLogModel.suppress({
-            "WFS": [""],
-            "WMS": [""],
-            "PostGIS": ["fe_sendauth: no password supplied"]
-          });
-      }
-
-      function onLoadProjectEnded() {
-        dashBoard.layerTree.unfreeze(true);
-        if (!qfieldAuthRequestHandler.handleLayerLogins()) {
-          //project loaded without more layer handling needed
-          messageLogModel.unsuppress({
-              "WFS": [],
-              "WMS": [],
-              "PostGIS": []
-            });
-        }
-      }
-    }
 
     Connections {
       target: qfieldAuthRequestHandler


### PR DESCRIPTION
The goal of this change is to avoid having QField focus on a layer, triggering a feature form rebuild that might be halted halfway due to authentication being submitted and QField then force reloading the project.

On top of saving a few CPU cycles, it has the potential to avoid obscure threading crashes.