### PR TITLE
Canvas location lock improvement.

### DIFF
--- a/src/qml/MapCanvas.qml
+++ b/src/qml/MapCanvas.qml
@@ -51,6 +51,9 @@ Item {
   //! Emitted when a release happens after a long press
   signal longPressReleased(var type)
 
+  //! Emitted when a zoom action is about to occur, allowing for pre-zoom adjustments
+  signal aboutToZoom
+
   /**
    * Freezes the map canvas refreshes.
    *
@@ -441,8 +444,6 @@ Item {
     grabPermissions: PointerHandler.CanTakeOverFromHandlersOfDifferentType | PointerHandler.ApprovesTakeOverByItems
 
     onWheel: event => {
-      if (gnssButton.followActive)
-        gnssButton.followActiveSkipExtentChanged = true;
       if (event.angleDelta.y > 0) {
         zoomIn(point.position);
       } else {

--- a/src/qml/MapCanvas.qml
+++ b/src/qml/MapCanvas.qml
@@ -52,7 +52,7 @@ Item {
   signal longPressReleased(var type)
 
   //! Emitted when a zoom action is about to occur, allowing for pre-zoom adjustments
-  signal aboutToZoom
+  signal aboutToWheelZoom
 
   /**
    * Freezes the map canvas refreshes.
@@ -444,6 +444,7 @@ Item {
     grabPermissions: PointerHandler.CanTakeOverFromHandlersOfDifferentType | PointerHandler.ApprovesTakeOverByItems
 
     onWheel: event => {
+      aboutToWheelZoom();
       if (event.angleDelta.y > 0) {
         zoomIn(point.position);
       } else {

--- a/src/qml/MapCanvas.qml
+++ b/src/qml/MapCanvas.qml
@@ -441,6 +441,8 @@ Item {
     grabPermissions: PointerHandler.CanTakeOverFromHandlersOfDifferentType | PointerHandler.ApprovesTakeOverByItems
 
     onWheel: event => {
+      if (gnssButton.followActive)
+        gnssButton.followActiveSkipExtentChanged = true;
       if (event.angleDelta.y > 0) {
         zoomIn(point.position);
       } else {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -579,6 +579,11 @@ ApplicationWindow {
         }
       }
 
+      onAboutToZoom: {
+        if (gnssButton.followActive)
+          gnssButton.followActiveSkipExtentChanged = true;
+      }
+
       GridRenderer {
         id: gridDecoration
         mapSettings: mapCanvas.mapSettings

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -579,7 +579,7 @@ ApplicationWindow {
         }
       }
 
-      onAboutToZoom: {
+      onAboutToWheelZoom: {
         if (gnssButton.followActive)
           gnssButton.followActiveSkipExtentChanged = true;
       }


### PR DESCRIPTION
### PR Description:
At present, when the canvas location is locked and the user zooms in or out with a mouse, the lock will break.

### Fix: 
Using same approach in `zoomInButton` and `zoomOutButton`:
```QML
if (gnssButton.followActive)
        gnssButton.followActiveSkipExtentChanged = true;
```

### Demo: 
Now zooming in/out wont break lock.   


[Screencast from 2024-10-19 16-49-36.webm](https://github.com/user-attachments/assets/dffa4b78-986c-4f3c-8344-fe48dd094245)

