### PR TITLE
Fix crash when a value relation editor widget has its filter updated

### DIFF
--- a/vcpkg/ports/qtdeclarative/listviewsectioncrash.patch
+++ b/vcpkg/ports/qtdeclarative/listviewsectioncrash.patch
@@ -1,0 +1,14 @@
+diff --git a/src/quick/items/qquicklistview.cpp b/src/quick/items/qquicklistview.cpp
+index 54b1157881..9f757ed5ee 100644
+--- a/src/quick/items/qquicklistview.cpp
++++ b/src/quick/items/qquicklistview.cpp
+@@ -1080,7 +1080,8 @@ QQuickItem * QQuickListViewPrivate::getSectionItem(const QString &section)
+         sectionCache[i] = nullptr;
+         sectionItem->setVisible(true);
+         QQmlContext *context = QQmlEngine::contextForObject(sectionItem)->parentContext();
+-        setSectionHelper(context, sectionItem, section);
++        if (context)
++            setSectionHelper(context, sectionItem, section);
+     } else {
+         QQmlComponent* delegate = sectionCriteria->delegate();
+         const bool reuseExistingContext = delegate->isBound();

--- a/vcpkg/ports/qtdeclarative/portfile.cmake
+++ b/vcpkg/ports/qtdeclarative/portfile.cmake
@@ -1,0 +1,37 @@
+set(SCRIPT_PATH "${CURRENT_INSTALLED_DIR}/share/qtbase")
+include("${SCRIPT_PATH}/qt_install_submodule.cmake")
+
+vcpkg_buildpath_length_warning(44)
+
+set(${PORT}_PATCHES
+        listviewsectioncrash.patch
+)
+
+ set(TOOL_NAMES 
+        qml
+        qmlcachegen
+        qmleasing
+        qmlformat
+        qmlimportscanner
+        qmllint
+        qmlplugindump
+        qmlpreview
+        qmlprofiler
+        qmlscene
+        qmltestrunner
+        qmltime
+        qmltyperegistrar
+        qmldom
+        qmltc
+        qmlls
+        qmljsrootgen
+        svgtoqml
+    )
+
+qt_install_submodule(PATCHES    ${${PORT}_PATCHES}
+                     TOOL_NAMES ${TOOL_NAMES}
+                     CONFIGURE_OPTIONS
+                      -DCMAKE_DISABLE_FIND_PACKAGE_LTTngUST:BOOL=ON
+                     CONFIGURE_OPTIONS_RELEASE
+                     CONFIGURE_OPTIONS_DEBUG
+                    )

--- a/vcpkg/ports/qtdeclarative/vcpkg.json
+++ b/vcpkg/ports/qtdeclarative/vcpkg.json
@@ -1,0 +1,28 @@
+{
+  "name": "qtdeclarative",
+  "version": "6.7.3",
+  "description": "Qt Declarative (Quick 2)",
+  "homepage": "https://www.qt.io/",
+  "license": null,
+  "dependencies": [
+    {
+      "name": "qtbase",
+      "default-features": false,
+      "features": [
+        "network",
+        "testlib"
+      ]
+    },
+    {
+      "name": "qtdeclarative",
+      "host": true,
+      "default-features": false
+    },
+    "qtlanguageserver",
+    {
+      "name": "qtshadertools",
+      "default-features": false
+    },
+    "qtsvg"
+  ]
+}


### PR DESCRIPTION
Fixes https://github.com/opengisch/QField/issues/5766 . Note that while I've confirmed locally the crash is gone, I'm not sure I'm fixing the symptom (vs. merely patching a problem). In any case, I've opened a report with this patch upstream, we'll hopefully get feedback and a proper fix there. 

