### PR TITLE
Work around an upstream Qt crash when a relation editor combobox leads to its attribute item to be hidden

### DIFF
--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -330,10 +330,17 @@ Item {
         topMargin: mainWindow.sceneTopMargin
         bottomMargin: mainWindow.sceneTopMargin
 
+        onAboutToShow: {
+          contentItem.model = comboBox.delegateModel;
+        }
+
+        onAboutToHide: {
+          contentItem.model = null;
+        }
+
         contentItem: ListView {
           clip: true
           implicitHeight: Math.min(mainWindow.height - mainWindow.sceneTopMargin - mainWindow.sceneTopMargin, contentHeight)
-          model: comboBox.popup.visible ? comboBox.delegateModel : null
           currentIndex: comboBox.highlightedIndex
 
           section.property: featureListModel.groupField != "" ? "groupFieldValue" : ""


### PR DESCRIPTION
Fixes https://github.com/opengisch/QField/issues/5766 in a less intrusive fashion than patching QtDeclarative source code for now.

It's definitively a workaround here, but I think we can be happy with it for now.

Discussion upstream continues here: https://bugreports.qt.io/browse/QTBUG-130819
