### PR TITLE
[Backport release-3_4] Work around an upstream Qt crash when a relation editor combobox leads to its attribute item to be hidden

### DIFF
--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -327,10 +327,17 @@ Item {
         topMargin: mainWindow.sceneTopMargin
         bottomMargin: mainWindow.sceneTopMargin
 
+        onAboutToShow: {
+          contentItem.model = comboBox.delegateModel;
+        }
+
+        onAboutToHide: {
+          contentItem.model = null;
+        }
+
         contentItem: ListView {
           clip: true
           implicitHeight: Math.min(mainWindow.height - mainWindow.sceneTopMargin - mainWindow.sceneTopMargin, contentHeight)
-          model: comboBox.popup.visible ? comboBox.delegateModel : null
           currentIndex: comboBox.highlightedIndex
 
           section.property: featureListModel.groupField != "" ? "groupFieldValue" : ""


### PR DESCRIPTION
Backport #5800
 **Authored by:** @nirvn