### PR TITLE
Fix geometry digitizing step missing when adding a relationship parent via the relation combobox

### DIFF
--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -614,9 +614,11 @@ Item {
       visible: enabled && allowAddFeature && relation !== undefined && relation.isValid
 
       onClicked: {
-        embeddedPopup.state = 'Add';
-        embeddedPopup.currentLayer = relationCombobox.relation ? relationCombobox.relation.referencedLayer : null;
-        embeddedPopup.open();
+        if (relationCombobox.relation.referencedLayer.geometryType() !== Qgis.GeometryType.Null) {
+          requestGeometry(relationCombobox, relationCombobox.relation.referencedLayer);
+          return;
+        }
+        showAddFeaturePopup();
       }
     }
 
@@ -645,5 +647,18 @@ Item {
         comboBox.currentIndex = index;
       }
     }
+  }
+
+  function requestedGeometryReceived(geometry) {
+    showAddFeaturePopup(geometry);
+  }
+
+  function showAddFeaturePopup(geometry) {
+    embeddedPopup.state = 'Add';
+    embeddedPopup.currentLayer = relationCombobox.relation ? relationCombobox.relation.referencedLayer : null;
+    if (geometry !== undefined) {
+      embeddedPopup.applyGeometry(geometry);
+    }
+    embeddedPopup.open();
   }
 }

--- a/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
@@ -77,16 +77,14 @@ EditorWidgetBase {
       Text {
         visible: isEnabled
         color: Theme.secondaryTextColor
-        text: isEnabled && !constraintsHardValid ? qsTr('Ensure contraints') : ''
+        text: isEnabled && !constraintsHardValid ? qsTr('Ensure contraints are met') : ''
         anchors {
           leftMargin: 10
           left: parent.left
           right: addButtonRow.left
           verticalCenter: parent.verticalCenter
         }
-        font.bold: true
-        font.italic: true
-        font.pointSize: Theme.tipFont.pointSize
+        font: Theme.tipFont
       }
 
       Row {
@@ -106,7 +104,7 @@ EditorWidgetBase {
 
           round: false
           iconSource: Theme.getThemeVectorIcon('ic_add_white_24dp')
-          bgcolor: parent.enabled ? nmRelationId ? 'blue' : 'black' : 'grey'
+          bgcolor: parent.enabled ? 'black' : 'grey'
         }
       }
 

--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -87,16 +87,14 @@ EditorWidgetBase {
         Text {
           visible: isEnabled
           color: Theme.secondaryTextColor
-          text: isEnabled && !constraintsHardValid ? qsTr('Ensure contraints') : ''
+          text: isEnabled && !constraintsHardValid ? qsTr('Ensure contraints are met') : ''
           anchors {
             leftMargin: 10
             left: parent.left
             right: addButtonRow.left
             verticalCenter: parent.verticalCenter
           }
-          font.bold: true
-          font.italic: true
-          font.pointSize: Theme.tipFont.pointSize
+          font: Theme.tipFont
         }
 
         Row {
@@ -116,7 +114,7 @@ EditorWidgetBase {
 
             round: false
             iconSource: Theme.getThemeVectorIcon('ic_add_white_24dp')
-            bgcolor: parent.enabled ? nmRelationId ? 'blue' : 'black' : 'grey'
+            bgcolor: parent.enabled ? 'black' : 'grey'
           }
         }
 


### PR DESCRIPTION
This PR fixes https://github.com/opengisch/QField/issues/5662 whereas the bits required to digitize a geometry when adding a parent / child feature in a relationship was missing from the relation combobox item.