### PR TITLE
To avoid interference with snapping results when creating features using a mouse/stylus, do not reset coordinate cursor when rubber band is frozen

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -387,7 +387,9 @@ ApplicationWindow {
           } else if (geometryEditorsToolbar.editorRubberbandModel && geometryEditorsToolbar.editorRubberbandModel.vertexCount > 1) {
             coordinateLocator.sourceLocation = mapCanvas.mapSettings.coordinateToScreen(geometryEditorsToolbar.editorRubberbandModel.lastCoordinate);
           } else {
-            coordinateLocator.sourceLocation = undefined;
+            if (!digitizingToolbar.rubberbandModel.frozen) {
+              coordinateLocator.sourceLocation = undefined;
+            }
           }
         }
       }


### PR DESCRIPTION
This PR fixes https://github.com/opengisch/QField/issues/5661 . Long story short, when we digitize a new geometry using a mouse or stylus and we hit confirm, we would often lose snapped feature information as the coordinate cursor would reset to the screen center _prior to_ the feature form having calculated its default value. By resetting onto the middle of the screen, any snapped feature context would be lost.

It isn't really a problem when people uses fingers to interface with the interface since the cursor always stays in the middle of the screen. 