### PR TITLE
When setting up our tracking feature, we avoid saving at all times, make relations accept that reality

### DIFF
--- a/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
@@ -131,7 +131,7 @@ EditorWidgetBase {
         repeat: false
 
         onTriggered: {
-          let saved = form.state === 'Add' ? save() : true;
+          let saved = form.state === 'Add' ? !form.setupOnly && save() : true;
           if (ProjectUtils.transactionMode(qgisProject) !== Qgis.TransactionMode.Disabled) {
             // When a transaction mode is enabled, we must fallback to saving the parent feature to have provider-side issues
             if (!saved) {

--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -141,7 +141,7 @@ EditorWidgetBase {
           repeat: false
 
           onTriggered: {
-            let saved = form.state === 'Add' ? save() : true;
+            let saved = form.state === 'Add' ? !form.setupOnly && save() : true;
             if (ProjectUtils.transactionMode(qgisProject) !== Qgis.TransactionMode.Disabled) {
               // When a transaction mode is enabled, we must fallback to saving the parent feature to have provider-side issues
               if (!saved) {


### PR DESCRIPTION
This PR fixes https://github.com/opengisch/QField/issues/5610 by insuring that the relation editor widgets respect the setupOnly feature form property. 

This means that people will be able to add a number of children prior to starting a track _as long as unique constraints on the data provider side doesn't prohibit it_.