### PR TITLE
[Backport release-3_4] To avoid interference with snapping results when creating features using a mouse/stylus, do not reset coordinate cursor when rubber band is frozen

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -379,7 +379,9 @@ ApplicationWindow {
           } else if (geometryEditorsToolbar.editorRubberbandModel && geometryEditorsToolbar.editorRubberbandModel.vertexCount > 1) {
             coordinateLocator.sourceLocation = mapCanvas.mapSettings.coordinateToScreen(geometryEditorsToolbar.editorRubberbandModel.lastCoordinate);
           } else {
-            coordinateLocator.sourceLocation = undefined;
+            if (!digitizingToolbar.rubberbandModel.frozen) {
+              coordinateLocator.sourceLocation = undefined;
+            }
           }
         }
       }


### PR DESCRIPTION
Backport #5808
 **Authored by:** @nirvn