### PR TITLE
Fix import URL eating tons of memory on large file downloads

### DIFF
--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -387,6 +387,7 @@ void AppInterface::importUrl( const QString &url )
       }
     }
 
+    // cppcheck-suppress nullPointer
     tmpFile->remove();
     emit importEnded();
   } );


### PR DESCRIPTION
This PR introduces the use of a temporary file to progressively save data as a file is being downloaded during the import URL process. 

This should prevent QField from crashed caused by running out of memory when downloading large files in this process.