### PR TITLE
Autopublish to ms store

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - release-**
-      - ms-store-publish
   pull_request:
   release:
     types: ['published']
@@ -189,6 +188,7 @@ jobs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - name: 🍺 Deploy
+        # if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v')
         env:
           S3_BUCKET: qfieldapks
           S3_REGION: ch-dk-2
@@ -210,6 +210,8 @@ jobs:
     name: deploy (ms store)
     runs-on: windows-2022
 
+    # if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v')
+
     needs: build
 
     steps:
@@ -228,6 +230,7 @@ jobs:
         uses: microsoft/store-submission@v1
         with:
           command: update
+          # See documentation here https://learn.microsoft.com/en-us/windows/apps/publish/store-submission-api#update-current-draft-submission-metadata-api
           product-update: '{"packages":[{"packageUrl":"https://sos-ch-dk-2.exo.io/qfieldapks/releases/${{ needs.build.outputs.artifact_name }}","languages":["en"],"architectures":["X64"],"isSilentInstall":true}]}'
 
       - name: Publish Submission

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,8 +20,8 @@ jobs:
     name: build (windows)
     runs-on: windows-2022
 
-  outputs:
-    artifact_name: ${{ steps.package.outputs.artifact_name }}
+    outputs:
+      artifact_name: ${{ steps.package.outputs.artifact_name }}
 
     steps:
       - name: 🐣 Checkout

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - release-**
+      - ms-store-publish
   pull_request:
   release:
     types: ['published']
@@ -181,37 +182,15 @@ jobs:
           ruby-version: '3.2' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
-#      - name: 🍺 Deploy
-#        env:
-#          S3_BUCKET: qfieldapks
-#          S3_REGION: ch-dk-2
-#          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY}}
-#          S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY}}
-#        run: |
-#          bundle exec fastlane windows upload_s3 exe:${{ env.ARTIFACT_PATHNAME }}
-#
-#      - name: Configure Store Credentials
-#        uses: microsoft/store-submission@v1
-#        with:
-#          command: configure
-#          type: win32
-#          seller-id: ${{ secrets.MICROSOFT_STORE_SELLER_ID }}
-#          product-id: ${{ secrets.MICROSOFT_STORE_PRODUCT_ID }}
-#          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-#          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-#          client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
-#
-#      - name: Update Draft Submission
-#        uses: microsoft/store-submission@v1
-#        with:
-#          command: update
-#          product-update: '{"packages":[{"packageUrl":"https://cdn.contoso.us/prod/5.10.1.4420/ContosoIgniteInstallerFull.msi","languages":["en"],"architectures":["X64"],"isSilentInstall":true}]}'
-#
-#      - name: Publish Submission
-#        uses: microsoft/store-submission@v1
-#        with:
-#          command: publish
-#
+      - name: 🍺 Deploy
+        env:
+          S3_BUCKET: qfieldapks
+          S3_REGION: ch-dk-2
+          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY}}
+          S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY}}
+        run: |
+          bundle exec fastlane windows upload_s3 exe:${{ env.ARTIFACT_PATHNAME }}
+
       - name: 📮 Upload debug symbols
         if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v') && env.ARTIFACT_NAME != null
         env:
@@ -220,3 +199,30 @@ jobs:
           SENTRY_PROJECT_SLUG: qfield
         run: |
           bundle exec fastlane run sentry_debug_files_upload path:${{ env.CMAKE_BUILD_DIR }}
+
+  deploy:
+    name: deploy (ms store)
+    runs-on: windows-2022
+
+    steps:
+      - name: Configure Store Credentials
+        uses: microsoft/store-submission@v1
+        with:
+          command: configure
+          type: win32
+          seller-id: ${{ secrets.MICROSOFT_STORE_SELLER_ID }}
+          product-id: ${{ secrets.MICROSOFT_STORE_PRODUCT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+
+      - name: Update Draft Submission
+        uses: microsoft/store-submission@v1
+        with:
+          command: update
+          product-update: '{"packages":[{"packageUrl":"https://sos-ch-dk-2.exo.io/qfieldapks/releases/qfield-v3.4.5-windows-x64.exe","languages":["en"],"architectures":["X64"],"isSilentInstall":true}]}'
+
+      - name: Publish Submission
+        uses: microsoft/store-submission@v1
+        with:
+          command: publish

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -187,8 +187,8 @@ jobs:
           ruby-version: '3.2' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
-      - name: 🍺 Deploy
-        # if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v')
+      - name: 🍺 Upload to S3
+        if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v')
         env:
           S3_BUCKET: qfieldapks
           S3_REGION: ch-dk-2
@@ -210,7 +210,7 @@ jobs:
     name: deploy (ms store)
     runs-on: windows-2022
 
-    # if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v')
 
     needs: build
 
@@ -231,7 +231,7 @@ jobs:
         with:
           command: update
           # See documentation here https://learn.microsoft.com/en-us/windows/apps/publish/store-submission-api#update-current-draft-submission-metadata-api
-          product-update: '{"packages":[{"packageUrl":"https://sos-ch-dk-2.exo.io/qfieldapks/releases/${{ needs.build.outputs.artifact_name }}","languages":["en"],"architectures":["X64"],"isSilentInstall":true}]}'
+          product-update: '{"packages":[{"packageUrl":"https://sos-ch-dk-2.exo.io/qfieldapks/releases/files/${{ needs.build.outputs.artifact_name }}","languages":["en"],"architectures":["X64"],"isSilentInstall":true}]}'
 
       - name: Publish Submission
         uses: microsoft/store-submission@v1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,6 +20,9 @@ jobs:
     name: build (windows)
     runs-on: windows-2022
 
+  outputs:
+    artifact_name: ${{ steps.package.outputs.artifact_name }}
+
     steps:
       - name: 🐣 Checkout
         uses: actions/checkout@v4
@@ -120,6 +123,7 @@ jobs:
           ctest --output-on-failure -C ${{ env.BUILD_TYPE }} -E qmltest
 
       - name: Package
+        id: package
         shell: bash
         run: |
           cmake --build  "${{ env.CMAKE_BUILD_DIR }}" --target bundle --config ${{ env.BUILD_TYPE }} -j1
@@ -127,6 +131,8 @@ jobs:
           ARTIFACT_NAME=$(basename $ARTIFACT_PATHNAME)
           echo "ARTIFACT_PATHNAME=${ARTIFACT_PATHNAME}" >> $GITHUB_ENV
           echo "ARTIFACT_NAME=qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-windows-x64.exe" >> $GITHUB_ENV
+
+          echo "artifact_name=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: 📑 Upload logs
         uses: actions/upload-artifact@v4
@@ -204,6 +210,8 @@ jobs:
     name: deploy (ms store)
     runs-on: windows-2022
 
+    needs: build
+
     steps:
       - name: Configure Store Credentials
         uses: microsoft/store-submission@v1
@@ -220,7 +228,7 @@ jobs:
         uses: microsoft/store-submission@v1
         with:
           command: update
-          product-update: '{"packages":[{"packageUrl":"https://sos-ch-dk-2.exo.io/qfieldapks/releases/qfield-v3.4.5-windows-x64.exe","languages":["en"],"architectures":["X64"],"isSilentInstall":true}]}'
+          product-update: '{"packages":[{"packageUrl":"https://sos-ch-dk-2.exo.io/qfieldapks/releases/${{ needs.build.outputs.artifact_name }}","languages":["en"],"architectures":["X64"],"isSilentInstall":true}]}'
 
       - name: Publish Submission
         uses: microsoft/store-submission@v1

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,8 +2,6 @@ platform :windows do
   lane :upload_s3 do |options|
     exe = options[:exe]
 
-    setup_ci if is_ci
-
     aws_s3(
       files: [exe],
       endpoint: "https://sos-ch-dk-2.exo.io",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -7,7 +7,7 @@ platform :windows do
     aws_s3(
       files: [exe],
       endpoint: "https://sos-ch-dk-2.exo.io",
-      app_directory: "ci-builds/ios/#{ENV['CI_PACKAGE_FILE_SUFFIX']}"
+      app_directory: "releases"
     )
   end
 end


### PR DESCRIPTION
This automatically pushes releases to S3 and creates an update on the ms store.
This reduces manual maintenance work.

Risk: when we republish too quickly (<3d), it will fail because "there's already an update in progress". We might be able to cancel an update, not yet done.

Room for improvement: add more languages, a link to release notes, ...