### PR TITLE
Don't translate strings used in tests only

### DIFF
--- a/test/qml/tst_qFieldGuide.qml
+++ b/test/qml/tst_qFieldGuide.qml
@@ -46,20 +46,20 @@ TestCase {
       id: testTour
       baseRoot: dummyParent
       steps: [{
-          "title": qsTr("dummyItem1"),
-          "description": qsTr("dummyItem1 responsibility."),
+          "title": "dummyItem1",
+          "description": "dummyItem1 responsibility.",
           "target": () => [dummyItem1]
         }, {
-          "title": qsTr("dummyItem2"),
-          "description": qsTr("dummyItem2 responsibility."),
+          "title": "dummyItem2",
+          "description": "dummyItem2 responsibility.",
           "target": () => [dummyItem2]
         }, {
-          "title": qsTr("dummyItem3"),
-          "description": qsTr("dummyItem3 responsibility."),
+          "title": "dummyItem3",
+          "description": "dummyItem3 responsibility.",
           "target": () => [dummyItem3]
         }, {
-          "title": qsTr("dummyItem4"),
-          "description": qsTr("dummyItem4 responsibility."),
+          "title": "dummyItem4",
+          "description": "dummyItem4 responsibility.",
           "target": () => [dummyItem4]
         }]
     }


### PR DESCRIPTION
We can either do what I suggest in this PR, or don't upload the translation strings from the `test` dir. I think this is easier.