### PR TITLE
QML locator filter framework for QField plugin

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -25,6 +25,7 @@ set(QFIELD_CORE_SRCS
     locator/finlandlocatorfilter.cpp
     locator/gotolocatorfilter.cpp
     locator/helplocatorfilter.cpp
+    locator/qfieldlocatorfilter.cpp
     locator/locatormodelsuperbridge.cpp
     positioning/abstractgnssreceiver.cpp
     positioning/gnsspositioninformation.cpp
@@ -146,6 +147,7 @@ set(QFIELD_CORE_HDRS
     locator/finlandlocatorfilter.h
     locator/gotolocatorfilter.h
     locator/helplocatorfilter.h
+    locator/qfieldlocatorfilter.h
     locator/locatormodelsuperbridge.h
     positioning/abstractgnssreceiver.h
     positioning/gnsspositioninformation.h

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -20,6 +20,7 @@
 
 #include <QObject>
 #include <QPointF>
+#include <QQmlComponent>
 #include <QStandardItemModel>
 
 class QgisMobileapp;

--- a/src/core/locator/activelayerfeatureslocatorfilter.cpp
+++ b/src/core/locator/activelayerfeatureslocatorfilter.cpp
@@ -238,10 +238,10 @@ void ActiveLayerFeaturesLocatorFilter::fetchResults( const QString &string, cons
       result.userData = QVariantList() << f.id() << mLayerId;
 #endif
       result.score = static_cast<double>( searchString.length() ) / result.displayString.size();
-      result.actions << QgsLocatorResult::ResultAction( OpenForm, tr( "Open form" ), QStringLiteral( "ic_baseline-list_white_24dp" ) );
+      result.actions << QgsLocatorResult::ResultAction( OpenForm, tr( "Open form" ), QStringLiteral( "qrc:/themes/qfield/nodpi/ic_baseline-list_white_24dp.svg" ) );
       if ( mLayerIsSpatial )
       {
-        result.actions << QgsLocatorResult::ResultAction( Navigation, tr( "Set feature as destination" ), QStringLiteral( "ic_navigation_flag_purple_24dp" ) );
+        result.actions << QgsLocatorResult::ResultAction( Navigation, tr( "Set feature as destination" ), QStringLiteral( "qrc:/themes/qfield/nodpi/ic_navigation_flag_purple_24dp.svg" ) );
       }
 
       emit resultFetched( result );
@@ -296,10 +296,10 @@ void ActiveLayerFeaturesLocatorFilter::fetchResults( const QString &string, cons
     result.userData = QVariantList() << f.id() << mLayerId;
 #endif
     result.score = static_cast<double>( searchString.length() ) / result.displayString.size();
-    result.actions << QgsLocatorResult::ResultAction( OpenForm, tr( "Open form" ), QStringLiteral( "ic_baseline-list_white_24dp" ) );
+    result.actions << QgsLocatorResult::ResultAction( OpenForm, tr( "Open form" ), QStringLiteral( "qrc:/themes/qfield/nodpi/ic_baseline-list_white_24dp.svg" ) );
     if ( mLayerIsSpatial )
     {
-      result.actions << QgsLocatorResult::ResultAction( Navigation, tr( "Set feature as destination" ), QStringLiteral( "ic_navigation_flag_purple_24dp" ) );
+      result.actions << QgsLocatorResult::ResultAction( Navigation, tr( "Set feature as destination" ), QStringLiteral( "qrc:/themes/qfield/nodpi/ic_navigation_flag_purple_24dp.svg" ) );
     }
 
     emit resultFetched( result );

--- a/src/core/locator/featureslocatorfilter.cpp
+++ b/src/core/locator/featureslocatorfilter.cpp
@@ -121,10 +121,10 @@ void FeaturesLocatorFilter::fetchResults( const QString &string, const QgsLocato
 #endif
       result.icon = preparedLayer->layerIcon;
       result.score = static_cast<double>( string.length() ) / result.displayString.size();
-      result.actions << QgsLocatorResult::ResultAction( OpenForm, tr( "Open form" ), QStringLiteral( "ic_baseline-list_white_24dp" ) );
+      result.actions << QgsLocatorResult::ResultAction( OpenForm, tr( "Open form" ), QStringLiteral( "qrc:/themes/qfield/nodpi/ic_baseline-list_white_24dp.svg" ) );
       if ( preparedLayer->layerGeometryType != Qgis::GeometryType::Null && preparedLayer->layerGeometryType != Qgis::GeometryType::Unknown )
       {
-        result.actions << QgsLocatorResult::ResultAction( Navigation, tr( "Set feature as destination" ), QStringLiteral( "ic_navigation_flag_purple_24dp" ) );
+        result.actions << QgsLocatorResult::ResultAction( Navigation, tr( "Set feature as destination" ), QStringLiteral( "qrc:/themes/qfield/nodpi/ic_navigation_flag_purple_24dp.svg" ) );
       }
 
       emit resultFetched( result );

--- a/src/core/locator/locatormodelsuperbridge.cpp
+++ b/src/core/locator/locatormodelsuperbridge.cpp
@@ -55,6 +55,11 @@ void LocatorModelSuperBridge::registerQFieldLocatorFilter( QFieldLocatorFilter *
   locator()->registerFilter( filter );
 }
 
+void LocatorModelSuperBridge::deregisterQFieldLocatorFilter( QFieldLocatorFilter *filter )
+{
+  locator()->deregisterFilter( filter );
+}
+
 Navigation *LocatorModelSuperBridge::navigation() const
 {
   return mNavigation;

--- a/src/core/locator/locatormodelsuperbridge.cpp
+++ b/src/core/locator/locatormodelsuperbridge.cpp
@@ -53,11 +53,13 @@ LocatorModelSuperBridge::LocatorModelSuperBridge( QObject *parent )
 void LocatorModelSuperBridge::registerQFieldLocatorFilter( QFieldLocatorFilter *filter )
 {
   locator()->registerFilter( filter );
+  emit locatorFiltersChanged();
 }
 
 void LocatorModelSuperBridge::deregisterQFieldLocatorFilter( QFieldLocatorFilter *filter )
 {
   locator()->deregisterFilter( filter );
+  emit locatorFiltersChanged();
 }
 
 Navigation *LocatorModelSuperBridge::navigation() const
@@ -410,13 +412,25 @@ LocatorModelSuperBridge *LocatorFiltersModel::locatorModelSuperBridge() const
   return mLocatorModelSuperBridge;
 }
 
+void LocatorFiltersModel::locatorFiltersChanged()
+{
+  emit beginResetModel();
+  emit endResetModel();
+}
+
 void LocatorFiltersModel::setLocatorModelSuperBridge( LocatorModelSuperBridge *locatorModelSuperBridge )
 {
   if ( mLocatorModelSuperBridge == locatorModelSuperBridge )
     return;
 
+  if ( mLocatorModelSuperBridge )
+  {
+    disconnect( mLocatorModelSuperBridge, &LocatorModelSuperBridge::locatorFiltersChanged, this, &LocatorFiltersModel::locatorFiltersChanged );
+  }
   emit beginResetModel();
   mLocatorModelSuperBridge = locatorModelSuperBridge;
   emit locatorModelSuperBridgeChanged();
   emit endResetModel();
+
+  connect( mLocatorModelSuperBridge, &LocatorModelSuperBridge::locatorFiltersChanged, this, &LocatorFiltersModel::locatorFiltersChanged );
 }

--- a/src/core/locator/locatormodelsuperbridge.cpp
+++ b/src/core/locator/locatormodelsuperbridge.cpp
@@ -26,6 +26,7 @@
 #include "helplocatorfilter.h"
 #include "locatormodelsuperbridge.h"
 #include "peliasgeocoder.h"
+#include "qfieldlocatorfilter.h"
 #include "qgsquickmapsettings.h"
 
 #include <QStandardItem>
@@ -47,6 +48,11 @@ LocatorModelSuperBridge::LocatorModelSuperBridge( QObject *parent )
   // Finnish's Digitransit geocoder (disabled until API access can be sorted)
   //mFinlandGeocoder = new PeliasGeocoder( QStringLiteral( "https://api.digitransit.fi/geocoding/v1/search" ) );
   //locator()->registerFilter( new FinlandLocatorFilter( mFinlandGeocoder, this ) );
+}
+
+void LocatorModelSuperBridge::registerQFieldLocatorFilter( QFieldLocatorFilter *filter )
+{
+  locator()->registerFilter( filter );
 }
 
 Navigation *LocatorModelSuperBridge::navigation() const

--- a/src/core/locator/locatormodelsuperbridge.h
+++ b/src/core/locator/locatormodelsuperbridge.h
@@ -28,6 +28,7 @@ class QgsQuickMapSettings;
 class FeatureListExtentController;
 class PeliasGeocoder;
 class GnssPositionInformation;
+class QFieldLocatorFilter;
 class QgsLocator;
 
 /**
@@ -135,6 +136,8 @@ class LocatorModelSuperBridge : public QgsLocatorModelBridge
      * string will be returned.
      */
     Q_INVOKABLE QString getPrefixFromSearchString( const QString &string );
+
+    Q_INVOKABLE void registerQFieldLocatorFilter( QFieldLocatorFilter *filter );
 
     void emitMessage( const QString &text );
 

--- a/src/core/locator/locatormodelsuperbridge.h
+++ b/src/core/locator/locatormodelsuperbridge.h
@@ -159,6 +159,7 @@ class LocatorModelSuperBridge : public QgsLocatorModelBridge
     void messageEmitted( const QString &text );
     void keepScaleChanged();
     void searchTextChangeRequested( const QString &text );
+    void locatorFiltersChanged();
 
   public slots:
     Q_INVOKABLE void triggerResultAtRow( const int row, const int id = -1 );
@@ -210,8 +211,10 @@ class LocatorFiltersModel : public QAbstractListModel
     Q_INVOKABLE void setGeocoderLocatorFiltersDefaulByPosition( const GnssPositionInformation &position );
 
   signals:
-
     void locatorModelSuperBridgeChanged();
+
+  private slots:
+    void locatorFiltersChanged();
 
   private:
     LocatorModelSuperBridge *mLocatorModelSuperBridge = nullptr;

--- a/src/core/locator/locatormodelsuperbridge.h
+++ b/src/core/locator/locatormodelsuperbridge.h
@@ -137,7 +137,15 @@ class LocatorModelSuperBridge : public QgsLocatorModelBridge
      */
     Q_INVOKABLE QString getPrefixFromSearchString( const QString &string );
 
+    /**
+     * Registers a given \a filter with the locator.
+     */
     Q_INVOKABLE void registerQFieldLocatorFilter( QFieldLocatorFilter *filter );
+
+    /**
+     * Deregisters a given \a filter with the locator.
+     */
+    Q_INVOKABLE void deregisterQFieldLocatorFilter( QFieldLocatorFilter *filter );
 
     void emitMessage( const QString &text );
 

--- a/src/core/locator/qfieldlocatorfilter.cpp
+++ b/src/core/locator/qfieldlocatorfilter.cpp
@@ -1,0 +1,124 @@
+/***************************************************************************
+  qfieldlocatorfilter.cpp
+
+ ---------------------
+  Date                 : November 2024
+  Copyright            : (C) 2024 by Mathieu Pellerin
+  Email                : mathieu at opengis dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qfieldlocatorfilter.h"
+
+#include <QEventLoop>
+#include <QQmlContext>
+#include <QQmlEngine>
+#include <qgsfeedback.h>
+
+QFieldLocatorFilter::QFieldLocatorFilter( QObject *parent )
+  : QgsLocatorFilter( parent )
+{
+  setUseWithoutPrefix( false );
+}
+
+QFieldLocatorFilter *QFieldLocatorFilter::clone() const
+{
+  QFieldLocatorFilter *filter = new QFieldLocatorFilter();
+  filter->setName( mName );
+  filter->setDisplayName( mDisplayName );
+  filter->setPrefix( mPrefix );
+  filter->setComponentUrl( mComponentUrl );
+  filter->setLocatorBridge( mLocatorBridge );
+  return filter;
+}
+
+void QFieldLocatorFilter::setComponentUrl( const QString &componentUrl )
+{
+  if ( mComponentUrl == componentUrl )
+    return;
+
+  mComponentUrl = componentUrl;
+  emit componentUrlChanged();
+}
+
+void QFieldLocatorFilter::setLocatorBridge( LocatorModelSuperBridge *locatorBridge )
+{
+  if ( mLocatorBridge == locatorBridge )
+    return;
+
+  mLocatorBridge = locatorBridge;
+  emit locatorBridgeChanged();
+}
+
+void QFieldLocatorFilter::setName( const QString &name )
+{
+  if ( mName == name )
+    return;
+
+  mName = name;
+  emit nameChanged();
+}
+
+void QFieldLocatorFilter::setDisplayName( const QString &displayName )
+{
+  if ( mDisplayName == displayName )
+    return;
+
+  mDisplayName = displayName;
+  emit displayNameChanged();
+}
+
+void QFieldLocatorFilter::setPrefix( const QString &prefix )
+{
+  if ( mPrefix == prefix )
+    return;
+
+  mPrefix = prefix;
+  emit prefixChanged();
+}
+
+void QFieldLocatorFilter::fetchResultsEnded()
+{
+  mFetchResultsEnded = true;
+}
+
+void QFieldLocatorFilter::fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback )
+{
+  if ( mComponentUrl.isEmpty() )
+    return;
+
+  QQmlEngine engine;
+  QQmlComponent component( &engine );
+  component.loadUrl( mComponentUrl );
+  QObject *object = component.create();
+  if ( object )
+  {
+    mFetchResultsEnded = false;
+    connect( object, SIGNAL( fetchResultsEnded() ), this, SLOT( fetchResultsEnded() ) );
+
+    QEventLoop loop;
+    connect( object, SIGNAL( fetchResultsEnded() ), &loop, SLOT( quit() ) );
+    connect( feedback, &QgsFeedback::canceled, &loop, &QEventLoop::quit );
+
+    QMetaObject::invokeMethod( object, QStringLiteral( "fetchResults" ).toStdString().c_str(), QVariant( string ), QVariant::fromValue<QgsLocatorContext>( context ) );
+    if ( !mFetchResultsEnded )
+    {
+      loop.exec();
+    }
+    object->deleteLater();
+  }
+}
+
+void QFieldLocatorFilter::triggerResult( const QgsLocatorResult &result )
+{
+}
+
+void QFieldLocatorFilter::triggerResultFromAction( const QgsLocatorResult &result, const int actionId )
+{
+}

--- a/src/core/locator/qfieldlocatorfilter.cpp
+++ b/src/core/locator/qfieldlocatorfilter.cpp
@@ -116,6 +116,12 @@ void QFieldLocatorFilter::prepareResult( const QVariant &details )
   result.score = detailsMap.value( QStringLiteral( "score" ), 0.5 ).toDouble();
   result.group = detailsMap.value( QStringLiteral( "group" ), QString() ).toString();
   result.groupScore = detailsMap.value( QStringLiteral( "groupScore" ), 0.5 ).toDouble();
+  const QVariantList actions = detailsMap.value( QStringLiteral( "actions" ) ).toList();
+  for ( const QVariant action : actions )
+  {
+    const QVariantMap actionMap = action.toMap();
+    result.actions << QgsLocatorResult::ResultAction( actionMap.value( "id", 0 ).toInt(), actionMap.value( "name", QString() ).toString(), actionMap.value( "icon", QString() ).toString() );
+  }
   emit resultFetched( result );
 }
 
@@ -155,4 +161,5 @@ void QFieldLocatorFilter::triggerResult( const QgsLocatorResult &result )
 
 void QFieldLocatorFilter::triggerResultFromAction( const QgsLocatorResult &result, const int actionId )
 {
+  QMetaObject::invokeMethod( this, QStringLiteral( "triggerResultFromAction" ).toStdString().c_str(), QVariant::fromValue<QgsLocatorResult>( result ), QVariant( actionId ) );
 }

--- a/src/core/locator/qfieldlocatorfilter.cpp
+++ b/src/core/locator/qfieldlocatorfilter.cpp
@@ -96,6 +96,19 @@ void QFieldLocatorFilter::fetchResultsEnded()
   mFetchResultsEnded = true;
 }
 
+void QFieldLocatorFilter::prepareResult( QVariant details )
+{
+  QVariantMap detailsMap = details.toMap();
+  QgsLocatorResult result;
+  result.userData() = detailsMap.value( QStringLiteral( "userData" ) );
+  result.displayString = detailsMap.value( QStringLiteral( "displayString" ), QString() ).toString();
+  result.description = detailsMap.value( QStringLiteral( "description" ), QString() ).toString();
+  result.score = detailsMap.value( QStringLiteral( "score" ), 0.5 ).toDouble();
+  result.group = detailsMap.value( QStringLiteral( "group" ), QString() ).toString();
+  result.groupScore = detailsMap.value( QStringLiteral( "groupScore" ), 0.5 ).toDouble();
+  emit resultFetched( result );
+}
+
 void QFieldLocatorFilter::fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback )
 {
   if ( mSource.isEmpty() )
@@ -108,6 +121,7 @@ void QFieldLocatorFilter::fetchResults( const QString &string, const QgsLocatorC
   if ( object )
   {
     mFetchResultsEnded = false;
+    connect( object, SIGNAL( prepareResult( QVariant ) ), this, SLOT( prepareResult( QVariant ) ) );
     connect( object, SIGNAL( fetchResultsEnded() ), this, SLOT( fetchResultsEnded() ) );
 
     QEventLoop loop;
@@ -125,6 +139,7 @@ void QFieldLocatorFilter::fetchResults( const QString &string, const QgsLocatorC
 
 void QFieldLocatorFilter::triggerResult( const QgsLocatorResult &result )
 {
+  QMetaObject::invokeMethod( this, QStringLiteral( "triggerResult" ).toStdString().c_str(), QVariant::fromValue<QgsLocatorResult>( result ) );
 }
 
 void QFieldLocatorFilter::triggerResultFromAction( const QgsLocatorResult &result, const int actionId )

--- a/src/core/locator/qfieldlocatorfilter.cpp
+++ b/src/core/locator/qfieldlocatorfilter.cpp
@@ -131,6 +131,7 @@ void QFieldLocatorFilter::fetchResults( const QString &string, const QgsLocatorC
   if ( object )
   {
     mFetchResultsEnded = false;
+    // These SIGNAL() SLOT() macros are needed, it is the only connect syntax that will work with signals declared within the QML environment itself
     connect( object, SIGNAL( prepareResult( QVariant ) ), this, SLOT( prepareResult( QVariant ) ) );
     connect( object, SIGNAL( fetchResultsEnded() ), this, SLOT( fetchResultsEnded() ) );
 

--- a/src/core/locator/qfieldlocatorfilter.cpp
+++ b/src/core/locator/qfieldlocatorfilter.cpp
@@ -34,9 +34,19 @@ QFieldLocatorFilter *QFieldLocatorFilter::clone() const
   filter->setName( mName );
   filter->setDisplayName( mDisplayName );
   filter->setPrefix( mPrefix );
+  filter->setParameters( mParameters );
   filter->setSource( mSource );
   filter->setLocatorBridge( mLocatorBridge );
   return filter;
+}
+
+void QFieldLocatorFilter::setParameters( const QVariantMap &parameters )
+{
+  if ( mParameters == parameters )
+    return;
+
+  mParameters = parameters;
+  emit parametersChanged();
 }
 
 void QFieldLocatorFilter::setSource( const QUrl &source )
@@ -128,7 +138,7 @@ void QFieldLocatorFilter::fetchResults( const QString &string, const QgsLocatorC
     connect( object, SIGNAL( fetchResultsEnded() ), &loop, SLOT( quit() ) );
     connect( feedback, &QgsFeedback::canceled, &loop, &QEventLoop::quit );
 
-    QMetaObject::invokeMethod( object, QStringLiteral( "fetchResults" ).toStdString().c_str(), QVariant( string ), QVariant::fromValue<QgsLocatorContext>( context ) );
+    QMetaObject::invokeMethod( object, QStringLiteral( "fetchResults" ).toStdString().c_str(), QVariant( string ), QVariant::fromValue<QgsLocatorContext>( context ), QVariant::fromValue( mParameters ) );
     if ( !mFetchResultsEnded )
     {
       loop.exec();

--- a/src/core/locator/qfieldlocatorfilter.cpp
+++ b/src/core/locator/qfieldlocatorfilter.cpp
@@ -33,18 +33,19 @@ QFieldLocatorFilter *QFieldLocatorFilter::clone() const
   filter->setName( mName );
   filter->setDisplayName( mDisplayName );
   filter->setPrefix( mPrefix );
-  filter->setComponentUrl( mComponentUrl );
+  filter->setSource( mSource );
   filter->setLocatorBridge( mLocatorBridge );
   return filter;
 }
 
-void QFieldLocatorFilter::setComponentUrl( const QString &componentUrl )
+void QFieldLocatorFilter::setSource( const QUrl &source )
 {
-  if ( mComponentUrl == componentUrl )
+  if ( mSource.toString( QUrl::RemoveQuery ) == source.toString( QUrl::RemoveQuery ) )
     return;
 
-  mComponentUrl = componentUrl;
-  emit componentUrlChanged();
+  mSource = source;
+  mSource.setQuery( QStringLiteral( "t=%1" ).arg( QDateTime::currentSecsSinceEpoch() ) );
+  emit sourceChanged();
 }
 
 void QFieldLocatorFilter::setLocatorBridge( LocatorModelSuperBridge *locatorBridge )
@@ -90,12 +91,12 @@ void QFieldLocatorFilter::fetchResultsEnded()
 
 void QFieldLocatorFilter::fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback )
 {
-  if ( mComponentUrl.isEmpty() )
+  if ( mSource.isEmpty() )
     return;
 
   QQmlEngine engine;
   QQmlComponent component( &engine );
-  component.loadUrl( mComponentUrl );
+  component.loadUrl( mSource );
   QObject *object = component.create();
   if ( object )
   {

--- a/src/core/locator/qfieldlocatorfilter.cpp
+++ b/src/core/locator/qfieldlocatorfilter.cpp
@@ -31,6 +31,7 @@ QFieldLocatorFilter::QFieldLocatorFilter( QObject *parent )
 QFieldLocatorFilter *QFieldLocatorFilter::clone() const
 {
   QFieldLocatorFilter *filter = new QFieldLocatorFilter();
+  filter->setFetchResultsDelay( fetchResultsDelay() );
   filter->setName( mName );
   filter->setDisplayName( mDisplayName );
   filter->setPrefix( mPrefix );
@@ -72,6 +73,15 @@ void QFieldLocatorFilter::setLocatorBridge( LocatorModelSuperBridge *locatorBrid
 
   mLocatorBridge = locatorBridge;
   emit locatorBridgeChanged();
+}
+
+void QFieldLocatorFilter::setDelay( int delay )
+{
+  if ( fetchResultsDelay() == delay )
+    return;
+
+  setFetchResultsDelay( delay );
+  emit delayChanged();
 }
 
 void QFieldLocatorFilter::setName( const QString &name )

--- a/src/core/locator/qfieldlocatorfilter.cpp
+++ b/src/core/locator/qfieldlocatorfilter.cpp
@@ -19,6 +19,7 @@
 #include <QEventLoop>
 #include <QQmlContext>
 #include <QQmlEngine>
+#include <QUrlQuery>
 #include <qgsfeedback.h>
 
 QFieldLocatorFilter::QFieldLocatorFilter( QObject *parent )
@@ -40,11 +41,17 @@ QFieldLocatorFilter *QFieldLocatorFilter::clone() const
 
 void QFieldLocatorFilter::setSource( const QUrl &source )
 {
-  if ( mSource.toString( QUrl::RemoveQuery ) == source.toString( QUrl::RemoveQuery ) )
+  if ( mSource.path() == source.path() )
     return;
 
   mSource = source;
-  mSource.setQuery( QStringLiteral( "t=%1" ).arg( QDateTime::currentSecsSinceEpoch() ) );
+  QUrlQuery query( mSource );
+  if ( !query.hasQueryItem( "t" ) )
+  {
+    // Bypass caching to insure updated QML content is reloaded when the plugin is loaded
+    query.addQueryItem( QStringLiteral( "t" ), QStringLiteral( "t=%1" ).arg( QDateTime::currentSecsSinceEpoch() ) );
+    mSource.setQuery( query );
+  }
   emit sourceChanged();
 }
 

--- a/src/core/locator/qfieldlocatorfilter.cpp
+++ b/src/core/locator/qfieldlocatorfilter.cpp
@@ -117,10 +117,10 @@ void QFieldLocatorFilter::prepareResult( const QVariant &details )
   result.group = detailsMap.value( QStringLiteral( "group" ), QString() ).toString();
   result.groupScore = detailsMap.value( QStringLiteral( "groupScore" ), 0.5 ).toDouble();
   const QVariantList actions = detailsMap.value( QStringLiteral( "actions" ) ).toList();
-  for ( const QVariant action : actions )
+  for ( const QVariant &action : actions )
   {
     const QVariantMap actionMap = action.toMap();
-    result.actions << QgsLocatorResult::ResultAction( actionMap.value( "id", 0 ).toInt(), actionMap.value( "name", QString() ).toString(), actionMap.value( "icon", QString() ).toString() );
+    result.actions << QgsLocatorResult::ResultAction( actionMap.value( QStringLiteral( "id" ), 0 ).toInt(), actionMap.value( QStringLiteral( "name" ), QString() ).toString(), actionMap.value( QStringLiteral( "icon" ), QString() ).toString() );
   }
   emit resultFetched( result );
 }

--- a/src/core/locator/qfieldlocatorfilter.cpp
+++ b/src/core/locator/qfieldlocatorfilter.cpp
@@ -96,11 +96,11 @@ void QFieldLocatorFilter::fetchResultsEnded()
   mFetchResultsEnded = true;
 }
 
-void QFieldLocatorFilter::prepareResult( QVariant details )
+void QFieldLocatorFilter::prepareResult( const QVariant &details )
 {
-  QVariantMap detailsMap = details.toMap();
+  const QVariantMap detailsMap = details.toMap();
   QgsLocatorResult result;
-  result.userData() = detailsMap.value( QStringLiteral( "userData" ) );
+  result.setUserData( detailsMap.value( QStringLiteral( "userData" ) ) );
   result.displayString = detailsMap.value( QStringLiteral( "displayString" ), QString() ).toString();
   result.description = detailsMap.value( QStringLiteral( "description" ), QString() ).toString();
   result.score = detailsMap.value( QStringLiteral( "score" ), 0.5 ).toDouble();

--- a/src/core/locator/qfieldlocatorfilter.h
+++ b/src/core/locator/qfieldlocatorfilter.h
@@ -75,7 +75,7 @@ class QFieldLocatorFilter : public QgsLocatorFilter
 
   private slots:
     void fetchResultsEnded();
-    void prepareResult( QVariant details );
+    void prepareResult( const QVariant &details );
 
   private:
     QString mName;

--- a/src/core/locator/qfieldlocatorfilter.h
+++ b/src/core/locator/qfieldlocatorfilter.h
@@ -46,38 +46,91 @@ class QFieldLocatorFilter : public QgsLocatorFilter
 
   public:
     explicit QFieldLocatorFilter( QObject *parent = nullptr );
+
+    //! Clone the locator filter
     QFieldLocatorFilter *clone() const override;
 
+    //! \copydoc QgsLocatorFilter::name
     QString name() const override { return mName; }
+
+    /**
+     * Sets the unique name of the filter. This should be an untranslated string identifying the filter.
+     */
     void setName( const QString &name );
 
+    //! \copydoc QgsLocatorFilter::displayName
     QString displayName() const override { return mDisplayName; }
+
+    /**
+     * Sets a translated, user-friendly name for the filter.
+     */
     void setDisplayName( const QString &displayName );
 
+    //! \copydoc QgsLocatorFilter::prefix
     QString prefix() const override { return mPrefix; }
+
+    /**
+     * Sets the search prefix character(s) for this filter. Prefix a search
+     * with these characters will restrict the locator search to only include
+     * results from this filter.
+     * \note The prefix must be >= 3 characters otherwise it will be ignored.
+     */
     void setPrefix( const QString &prefix );
 
+    /**
+     * Returns the source QML file which will process the locator filter results.
+     */
     QUrl source() const { return mSource; }
+
+    /**
+     * Setsthe source QML file which will process the locator filter results.
+     */
     void setSource( const QUrl &source );
 
+    /**
+     * Returns additional locator filter parameters which will possed onto the source QML
+     * that will process the locator filter results.
+     */
     QVariantMap parameters() const { return mParameters; }
+
+    /**
+     * Sets additional locator filter parameters which will possed onto the source QML
+     * that will process the locator filter results.
+     */
     void setParameters( const QVariantMap &parameters );
 
+    /**
+     * Returns the locator bridge object.
+     */
     LocatorModelSuperBridge *locatorBridge() const { return mLocatorBridge; }
+
+    /**
+     * Sets the locator bridge object.
+     */
     void setLocatorBridge( LocatorModelSuperBridge *locatorBridge );
 
     Priority priority() const override { return Medium; }
-
     void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) override;
     void triggerResult( const QgsLocatorResult &result ) override;
     void triggerResultFromAction( const QgsLocatorResult &result, const int actionId ) override;
 
   signals:
+    //! Emitted when the name has changed
     void nameChanged();
+
+    //! Emitted when the display name has changed
     void displayNameChanged();
+
+    //! Emitted when the prefix has changed
     void prefixChanged();
+
+    //! Emitted when the parameters object has changed
     void parametersChanged();
+
+    //! Emitted when the source has changed
     void sourceChanged();
+
+    //! Emitted when the locator bridge has changed
     void locatorBridgeChanged();
 
   private slots:

--- a/src/core/locator/qfieldlocatorfilter.h
+++ b/src/core/locator/qfieldlocatorfilter.h
@@ -38,7 +38,10 @@ class QFieldLocatorFilter : public QgsLocatorFilter
     Q_PROPERTY( QString name READ name WRITE setName NOTIFY nameChanged )
     Q_PROPERTY( QString displayName READ displayName WRITE setDisplayName NOTIFY displayNameChanged )
     Q_PROPERTY( QString prefix READ prefix WRITE setPrefix NOTIFY prefixChanged )
+
+    Q_PROPERTY( QVariantMap parameters READ parameters WRITE setParameters NOTIFY parametersChanged )
     Q_PROPERTY( QUrl source READ source WRITE setSource NOTIFY sourceChanged )
+
     Q_PROPERTY( LocatorModelSuperBridge *locatorBridge READ locatorBridge WRITE setLocatorBridge NOTIFY locatorBridgeChanged )
 
   public:
@@ -57,6 +60,9 @@ class QFieldLocatorFilter : public QgsLocatorFilter
     QUrl source() const { return mSource; }
     void setSource( const QUrl &source );
 
+    QVariantMap parameters() const { return mParameters; }
+    void setParameters( const QVariantMap &parameters );
+
     LocatorModelSuperBridge *locatorBridge() const { return mLocatorBridge; }
     void setLocatorBridge( LocatorModelSuperBridge *locatorBridge );
 
@@ -70,6 +76,7 @@ class QFieldLocatorFilter : public QgsLocatorFilter
     void nameChanged();
     void displayNameChanged();
     void prefixChanged();
+    void parametersChanged();
     void sourceChanged();
     void locatorBridgeChanged();
 
@@ -84,6 +91,7 @@ class QFieldLocatorFilter : public QgsLocatorFilter
 
     bool mFetchResultsEnded = false;
 
+    QVariantMap mParameters;
     QUrl mSource;
 
     LocatorModelSuperBridge *mLocatorBridge = nullptr;

--- a/src/core/locator/qfieldlocatorfilter.h
+++ b/src/core/locator/qfieldlocatorfilter.h
@@ -38,7 +38,7 @@ class QFieldLocatorFilter : public QgsLocatorFilter
     Q_PROPERTY( QString name READ name WRITE setName NOTIFY nameChanged )
     Q_PROPERTY( QString displayName READ displayName WRITE setDisplayName NOTIFY displayNameChanged )
     Q_PROPERTY( QString prefix READ prefix WRITE setPrefix NOTIFY prefixChanged )
-    Q_PROPERTY( QString componentUrl READ componentUrl WRITE setComponentUrl NOTIFY componentUrlChanged )
+    Q_PROPERTY( QUrl source READ source WRITE setSource NOTIFY sourceChanged )
     Q_PROPERTY( LocatorModelSuperBridge *locatorBridge READ locatorBridge WRITE setLocatorBridge NOTIFY locatorBridgeChanged )
 
   public:
@@ -54,8 +54,8 @@ class QFieldLocatorFilter : public QgsLocatorFilter
     QString prefix() const override { return mPrefix; }
     void setPrefix( const QString &prefix );
 
-    QString componentUrl() const { return mComponentUrl; }
-    void setComponentUrl( const QString &componentUrl );
+    QUrl source() const { return mSource; }
+    void setSource( const QUrl &source );
 
     LocatorModelSuperBridge *locatorBridge() const { return mLocatorBridge; }
     void setLocatorBridge( LocatorModelSuperBridge *locatorBridge );
@@ -70,7 +70,7 @@ class QFieldLocatorFilter : public QgsLocatorFilter
     void nameChanged();
     void displayNameChanged();
     void prefixChanged();
-    void componentUrlChanged();
+    void sourceChanged();
     void locatorBridgeChanged();
 
   private slots:
@@ -83,7 +83,7 @@ class QFieldLocatorFilter : public QgsLocatorFilter
 
     bool mFetchResultsEnded = false;
 
-    QString mComponentUrl;
+    QUrl mSource;
 
     LocatorModelSuperBridge *mLocatorBridge = nullptr;
 };

--- a/src/core/locator/qfieldlocatorfilter.h
+++ b/src/core/locator/qfieldlocatorfilter.h
@@ -35,6 +35,7 @@ class QFieldLocatorFilter : public QgsLocatorFilter
 {
     Q_OBJECT
 
+    Q_PROPERTY( int delay READ delay WRITE setDelay NOTIFY delayChanged )
     Q_PROPERTY( QString name READ name WRITE setName NOTIFY nameChanged )
     Q_PROPERTY( QString displayName READ displayName WRITE setDisplayName NOTIFY displayNameChanged )
     Q_PROPERTY( QString prefix READ prefix WRITE setPrefix NOTIFY prefixChanged )
@@ -49,6 +50,12 @@ class QFieldLocatorFilter : public QgsLocatorFilter
 
     //! Clone the locator filter
     QFieldLocatorFilter *clone() const override;
+
+    //! Returns the delay before which the fetching of results is triggered
+    int delay() const { return fetchResultsDelay(); }
+
+    //! Sets the delay before which the fetching of results is triggered
+    void setDelay( int delay );
 
     //! \copydoc QgsLocatorFilter::name
     QString name() const override { return mName; }
@@ -115,6 +122,9 @@ class QFieldLocatorFilter : public QgsLocatorFilter
     void triggerResultFromAction( const QgsLocatorResult &result, const int actionId ) override;
 
   signals:
+    //! Emitted when the fetch result delay has changed
+    void delayChanged();
+
     //! Emitted when the name has changed
     void nameChanged();
 

--- a/src/core/locator/qfieldlocatorfilter.h
+++ b/src/core/locator/qfieldlocatorfilter.h
@@ -1,0 +1,91 @@
+/***************************************************************************
+  qfieldlocatorfilter.h
+
+ ---------------------
+  Date                 : November 2024
+  Copyright            : (C) 2024 by Mathieu Pellerin
+  Email                : mathieu at opengis dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef QFIELDLOCATORFILTER_H
+#define QFIELDLOCATORFILTER_H
+
+#include "locatormodelsuperbridge.h"
+
+#include <QObject>
+#include <QQmlComponent>
+#include <qgslocatorfilter.h>
+
+
+class LocatorModelSuperBridge;
+
+/**
+ * QFieldLocatorFilter is a locator filter item for QField plugins to integrate with
+ * locator searches.
+ */
+class QFieldLocatorFilter : public QgsLocatorFilter
+{
+    Q_OBJECT
+
+    Q_PROPERTY( QString name READ name WRITE setName NOTIFY nameChanged )
+    Q_PROPERTY( QString displayName READ displayName WRITE setDisplayName NOTIFY displayNameChanged )
+    Q_PROPERTY( QString prefix READ prefix WRITE setPrefix NOTIFY prefixChanged )
+    Q_PROPERTY( QString componentUrl READ componentUrl WRITE setComponentUrl NOTIFY componentUrlChanged )
+    Q_PROPERTY( LocatorModelSuperBridge *locatorBridge READ locatorBridge WRITE setLocatorBridge NOTIFY locatorBridgeChanged )
+
+  public:
+    explicit QFieldLocatorFilter( QObject *parent = nullptr );
+    QFieldLocatorFilter *clone() const override;
+
+    QString name() const override { return mName; }
+    void setName( const QString &name );
+
+    QString displayName() const override { return mDisplayName; }
+    void setDisplayName( const QString &displayName );
+
+    QString prefix() const override { return mPrefix; }
+    void setPrefix( const QString &prefix );
+
+    QString componentUrl() const { return mComponentUrl; }
+    void setComponentUrl( const QString &componentUrl );
+
+    LocatorModelSuperBridge *locatorBridge() const { return mLocatorBridge; }
+    void setLocatorBridge( LocatorModelSuperBridge *locatorBridge );
+
+    Priority priority() const override { return Medium; }
+
+    void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) override;
+    void triggerResult( const QgsLocatorResult &result ) override;
+    void triggerResultFromAction( const QgsLocatorResult &result, const int actionId ) override;
+
+  signals:
+    void nameChanged();
+    void displayNameChanged();
+    void prefixChanged();
+    void componentUrlChanged();
+    void locatorBridgeChanged();
+
+  private slots:
+    void fetchResultsEnded();
+
+  private:
+    QString mName;
+    QString mDisplayName;
+    QString mPrefix;
+
+    bool mFetchResultsEnded = false;
+
+    QString mComponentUrl;
+
+    LocatorModelSuperBridge *mLocatorBridge = nullptr;
+};
+
+#endif // QFIELDLOCATORFILTER_H

--- a/src/core/locator/qfieldlocatorfilter.h
+++ b/src/core/locator/qfieldlocatorfilter.h
@@ -75,6 +75,7 @@ class QFieldLocatorFilter : public QgsLocatorFilter
 
   private slots:
     void fetchResultsEnded();
+    void prepareResult( QVariant details );
 
   private:
     QString mName;

--- a/src/core/pluginmanager.cpp
+++ b/src/core/pluginmanager.cpp
@@ -80,7 +80,12 @@ void PluginManager::loadPlugin( const QString &pluginPath, const QString &plugin
     }
     return;
   }
-  QObject *object = component.create( mEngine->rootContext() );
+
+  QFileInfo fi( pluginPath );
+  QVariantMap properties;
+  properties["pluginFolder"] = fi.absolutePath() + QDir::separator();
+  QObject *object = component.createWithInitialProperties( properties, mEngine->rootContext() );
+
   mLoadedPlugins.insert( pluginPath, QPointer<QObject>( object ) );
 
   if ( !pluginUuid.isEmpty() )

--- a/src/core/pluginmanager.cpp
+++ b/src/core/pluginmanager.cpp
@@ -81,11 +81,7 @@ void PluginManager::loadPlugin( const QString &pluginPath, const QString &plugin
     return;
   }
 
-  QFileInfo fi( pluginPath );
-  QVariantMap properties;
-  properties["pluginFolder"] = fi.absolutePath() + QDir::separator();
-  QObject *object = component.createWithInitialProperties( properties, mEngine->rootContext() );
-
+  QObject *object = component.create( mEngine->rootContext() );
   mLoadedPlugins.insert( pluginPath, QPointer<QObject>( object ) );
 
   if ( !pluginUuid.isEmpty() )

--- a/src/core/pluginmanager.h
+++ b/src/core/pluginmanager.h
@@ -20,6 +20,7 @@
 #include <QObject>
 #include <QQmlEngine>
 
+
 /**
  * \ingroup core
  */

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -103,6 +103,7 @@
 #include "qfieldcloudconnection.h"
 #include "qfieldcloudprojectsmodel.h"
 #include "qfieldcloudutils.h"
+#include "qfieldlocatorfilter.h"
 #include "qgismobileapp.h"
 #include "qgsgeometrywrapper.h"
 #include "qgsproviderregistry.h"
@@ -160,6 +161,7 @@
 #include <qgslayoutpagecollection.h>
 #include <qgslocalizeddatapathregistry.h>
 #include <qgslocator.h>
+#include <qgslocatorcontext.h>
 #include <qgslocatormodel.h>
 #include <qgsmaplayer.h>
 #include <qgsmaplayerstyle.h>
@@ -521,6 +523,9 @@ void QgisMobileapp::initDeclarative( QQmlEngine *engine )
   qmlRegisterType<ProcessingAlgorithm>( "org.qfield", 1, 0, "ProcessingAlgorithm" );
   qmlRegisterType<ProcessingAlgorithmParametersModel>( "org.qfield", 1, 0, "ProcessingAlgorithmParametersModel" );
   qmlRegisterType<ProcessingAlgorithmsModel>( "org.qfield", 1, 0, "ProcessingAlgorithmsModel" );
+
+  qmlRegisterType<QgsLocatorContext>( "org.qgis", 1, 0, "QgsLocatorContext" );
+  qmlRegisterType<QFieldLocatorFilter>( "org.qfield", 1, 0, "QFieldLocatorFilter" );
 
   REGISTER_SINGLETON( "org.qfield", ExpressionContextUtils, "ExpressionContextUtils" );
   REGISTER_SINGLETON( "org.qfield", GeometryEditorsModel, "GeometryEditorsModelSingleton" );

--- a/src/core/qgsquick/qgsquickmapsettings.h
+++ b/src/core/qgsquick/qgsquickmapsettings.h
@@ -154,7 +154,7 @@ class QFIELD_CORE_EXPORT QgsQuickMapSettings : public QObject
     QgsRectangle extent() const;
 
     //! \copydoc QgsMapSettings::setExtent()
-    void setExtent( const QgsRectangle &extent, bool handleMargins = false );
+    Q_INVOKABLE void setExtent( const QgsRectangle &extent, bool handleMargins = false );
 
     //! \copydoc QgsQuickMapSettings::project
     void setProject( QgsProject *project );

--- a/src/core/utils/coordinatereferencesystemutils.h
+++ b/src/core/utils/coordinatereferencesystemutils.h
@@ -32,6 +32,9 @@ class QFIELD_CORE_EXPORT CoordinateReferenceSystemUtils : public QObject
   public:
     explicit CoordinateReferenceSystemUtils( QObject *parent = nullptr );
 
+    //! Returns an CRS matching the provided \a definition.
+    static Q_INVOKABLE QgsCoordinateReferenceSystem fromDescription( const QString &definition ) { return QgsCoordinateReferenceSystem( definition ); }
+
     //! Returns an EPGS:4326 WGS84 CRS
     static Q_INVOKABLE QgsCoordinateReferenceSystem wgs84Crs() { return QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ); }
 

--- a/src/core/utils/featureutils.cpp
+++ b/src/core/utils/featureutils.cpp
@@ -18,6 +18,7 @@
 #include "qgsquickmapsettings.h"
 
 #include <qgsexpressioncontextutils.h>
+#include <qgsjsonutils.h>
 #include <qgsproject.h>
 #include <qgsvectorlayer.h>
 #include <qgsvectorlayerutils.h>
@@ -94,4 +95,10 @@ QgsRectangle FeatureUtils::extent( QgsQuickMapSettings *mapSettings, QgsVectorLa
   }
 
   return QgsRectangle();
+}
+
+QList<QgsFeature> FeatureUtils::featuresFromJsonString( const QString &string )
+{
+  const QgsFields fields = QgsJsonUtils::stringToFields( string );
+  return QgsJsonUtils::stringToFeatureList( string, fields );
 }

--- a/src/core/utils/featureutils.h
+++ b/src/core/utils/featureutils.h
@@ -59,6 +59,12 @@ class QFIELD_CORE_EXPORT FeatureUtils : public QObject
      * \returns a QgsRectangle extent
      */
     static Q_INVOKABLE QgsRectangle extent( QgsQuickMapSettings *mapSettings, QgsVectorLayer *layer, const QgsFeature &feature );
+
+    /**
+     * Returns a list of features while attempting to parse a GeoJSON \a string. If the string could not
+     * be parsed, an enmpty list will be returned.
+     */
+    static Q_INVOKABLE QList<QgsFeature> featuresFromJsonString( const QString &string );
 };
 
 #endif // FEATUREUTILS_H

--- a/src/core/utils/geometryutils.cpp
+++ b/src/core/utils/geometryutils.cpp
@@ -206,6 +206,16 @@ QgsPoint GeometryUtils::reprojectPointToWgs84( const QgsPoint &point, const QgsC
                    point.isMeasure() ? point.m() : std::numeric_limits<double>::quiet_NaN() );
 }
 
+QgsPoint GeometryUtils::centroid( const QgsGeometry &geometry )
+{
+  const QgsGeometry centroid = geometry.centroid();
+  if ( !centroid.isEmpty() )
+  {
+    return QgsPoint( *static_cast<const QgsPoint *>( centroid.constGet() ) );
+  }
+  return QgsPoint();
+}
+
 QgsPoint GeometryUtils::reprojectPoint( const QgsPoint &point, const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs )
 {
   if ( sourceCrs == destinationCrs )
@@ -228,6 +238,26 @@ QgsPoint GeometryUtils::reprojectPoint( const QgsPoint &point, const QgsCoordina
                    point.is3D() ? point.z() : std::numeric_limits<double>::quiet_NaN(),
                    point.isMeasure() ? point.m() : std::numeric_limits<double>::quiet_NaN() );
 }
+
+QgsRectangle GeometryUtils::reprojectRectangle( const QgsRectangle &rectangle, const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs )
+{
+  if ( sourceCrs == destinationCrs )
+    return rectangle;
+
+  const QgsCoordinateTransform ct( sourceCrs, destinationCrs, QgsProject::instance() );
+  QgsRectangle reprojectedRectangle;
+  try
+  {
+    reprojectedRectangle = ct.transform( rectangle );
+  }
+  catch ( QgsCsException & )
+  {
+    return QgsRectangle();
+  }
+
+  return reprojectedRectangle;
+}
+
 QgsGeometry GeometryUtils::createGeometryFromWkt( const QString &wkt )
 {
   return QgsGeometry::fromWkt( wkt );

--- a/src/core/utils/geometryutils.h
+++ b/src/core/utils/geometryutils.h
@@ -103,8 +103,17 @@ class QFIELD_CORE_EXPORT GeometryUtils : public QObject
     //! Creates a point from \a x and \a y.
     static Q_INVOKABLE QgsPoint point( double x, double y ) { return QgsPoint( x, y ); }
 
+    //! Creates a centroid point from a given \a geometry.
+    static Q_INVOKABLE QgsPoint centroid( const QgsGeometry &geometry );
+
     //! Creates a geometry from a WKT string.
     static Q_INVOKABLE QgsGeometry createGeometryFromWkt( const QString &wkt );
+
+    //! Returns the bounding box of a given \a geometry.
+    static Q_INVOKABLE QgsRectangle boundingBox( const QgsGeometry &geometry ) { return geometry.boundingBox(); }
+
+    //! Returns a reprojected \a rectangle from the stated \a sourceCrs to a \a destinationCrs.
+    static Q_INVOKABLE QgsRectangle reprojectRectangle( const QgsRectangle &rectangle, const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs );
 };
 
 #endif // GEOMETRYUTILS_H

--- a/src/qml/LocatorItem.qml
+++ b/src/qml/LocatorItem.qml
@@ -221,14 +221,14 @@ Item {
         color: "transparent"
       }
       inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
-      onTextChanged: {
+      onDisplayTextChanged: {
         locatorItem.state = "on";
         searchTermHandled = false;
         searchTermChanged(searchField.displayText);
         if (!searchTermHandled) {
-          locatorBridge.performSearch(searchField.text);
+          locatorBridge.performSearch(searchField.displayText);
         }
-        if (searchField.displayText == 'f ' && dashBoard.activeLayer == undefined) {
+        if (searchField.displayText === 'f ' && dashBoard.activeLayer == undefined) {
           displayToast(qsTr('To search features within the active layer, select a vector layer through the legend.'));
         }
       }

--- a/src/qml/LocatorItem.qml
+++ b/src/qml/LocatorItem.qml
@@ -516,7 +516,7 @@ Item {
               padding: 0
               bgcolor: "transparent"
 
-              iconSource: Theme.getThemeVectorIcon(IconPath)
+              iconSource: IconPath
 
               onClicked: {
                 locatorItem.state = "off";

--- a/src/qml/LocatorItem.qml
+++ b/src/qml/LocatorItem.qml
@@ -504,7 +504,7 @@ Item {
           anchors.right: parent.right
           anchors.verticalCenter: parent.verticalCenter
           height: 32
-          anchors.rightMargin: 1
+          anchors.rightMargin: 5
 
           Repeater {
             model: locatorBridge.contextMenuActionsModel(index)

--- a/src/qml/LocatorItem.qml
+++ b/src/qml/LocatorItem.qml
@@ -221,12 +221,12 @@ Item {
         color: "transparent"
       }
       inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
-      onDisplayTextChanged: {
+      onTextChanged: {
         locatorItem.state = "on";
         searchTermHandled = false;
         searchTermChanged(searchField.displayText);
         if (!searchTermHandled) {
-          locatorBridge.performSearch(searchField.displayText);
+          locatorBridge.performSearch(searchField.text);
         }
         if (searchField.displayText == 'f ' && dashBoard.activeLayer == undefined) {
           displayToast(qsTr('To search features within the active layer, select a vector layer through the legend.'));

--- a/src/qml/LocatorSettings.qml
+++ b/src/qml/LocatorSettings.qml
@@ -96,7 +96,7 @@ Popup {
               indicator.implicitHeight: 24
               indicator.implicitWidth: 24
               checked: Default ? true : false
-              onCheckedChanged: Default = checked
+              onClicked: Default = checked
             }
           }
         }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -83,6 +83,7 @@ ApplicationWindow {
 
   LocatorModelSuperBridge {
     id: locatorBridge
+    objectName: "locatorBridge"
 
     activeLayer: dashBoard.activeLayer
     bookmarks: bookmarkModel

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -729,6 +729,8 @@ ApplicationWindow {
 
     Navigation {
       id: navigation
+      objectName: "navigation"
+
       mapSettings: mapCanvas.mapSettings
       location: positionSource.active ? positionSource.projectedPosition : GeometryUtils.emptyPoint()
 

--- a/vcpkg/ports/qgis/locatorcontext.patch
+++ b/vcpkg/ports/qgis/locatorcontext.patch
@@ -1,0 +1,17 @@
+diff --git a/src/core/locator/qgslocatorcontext.h b/src/core/locator/qgslocatorcontext.h
+index 6f19dc35ecc..325e6cc1be2 100644
+--- a/src/core/locator/qgslocatorcontext.h
++++ b/src/core/locator/qgslocatorcontext.h
+@@ -30,6 +30,12 @@
+  */
+ class CORE_EXPORT QgsLocatorContext
+ {
++    Q_GADGET
++
++    Q_PROPERTY( QgsRectangle targetExtent MEMBER targetExtent )
++    Q_PROPERTY( QgsCoordinateReferenceSystem targetExtentCrs MEMBER targetExtentCrs )
++    Q_PROPERTY( bool usingPrefix MEMBER usingPrefix )
++
+   public:
+ 
+     QgsLocatorContext() = default;

--- a/vcpkg/ports/qgis/locatorcontext.patch
+++ b/vcpkg/ports/qgis/locatorcontext.patch
@@ -15,3 +15,23 @@ index 6f19dc35ecc..325e6cc1be2 100644
    public:
  
      QgsLocatorContext() = default;
+diff --git a/src/core/locator/qgslocatorfilter.h b/src/core/locator/qgslocatorfilter.h
+index f560ae36c08..1657d39d2e6 100644
+--- a/src/core/locator/qgslocatorfilter.h
++++ b/src/core/locator/qgslocatorfilter.h
+@@ -36,6 +36,15 @@ class QgsLocatorFilter;
+  */
+ class CORE_EXPORT QgsLocatorResult
+ {
++    Q_GADGET
++
++    Q_PROPERTY( QVariant userData READ userData WRITE setUserData )
++    Q_PROPERTY( QString displayString MEMBER displayString )
++    Q_PROPERTY( QString description MEMBER description )
++    Q_PROPERTY( double score MEMBER score )
++    Q_PROPERTY( QString group MEMBER group )
++    Q_PROPERTY( double groupScore MEMBER groupScore )
++
+   public:
+ 
+     QgsLocatorResult() = default;

--- a/vcpkg/ports/qgis/locatorcontext.patch
+++ b/vcpkg/ports/qgis/locatorcontext.patch
@@ -2,7 +2,7 @@ diff --git a/src/core/locator/qgslocatorcontext.h b/src/core/locator/qgslocatorc
 index 6f19dc35ecc..325e6cc1be2 100644
 --- a/src/core/locator/qgslocatorcontext.h
 +++ b/src/core/locator/qgslocatorcontext.h
-@@ -30,6 +30,12 @@
+@@ -30,6 +30,13 @@
   */
  class CORE_EXPORT QgsLocatorContext
  {
@@ -10,6 +10,7 @@ index 6f19dc35ecc..325e6cc1be2 100644
 +
 +    Q_PROPERTY( QgsRectangle targetExtent MEMBER targetExtent )
 +    Q_PROPERTY( QgsCoordinateReferenceSystem targetExtentCrs MEMBER targetExtentCrs )
++    Q_PROPERTY( QgsCoordinateTransformContext transformContext MEMBER transformContext )
 +    Q_PROPERTY( bool usingPrefix MEMBER usingPrefix )
 +
    public:
@@ -35,3 +36,34 @@ index f560ae36c08..1657d39d2e6 100644
    public:
  
      QgsLocatorResult() = default;
+diff --git a/src/core/proj/qgscoordinatetransformcontext.cpp b/src/core/proj/qgscoordinatetransformcontext.cpp
+index f61b4079204..4a4dfc8eea6 100644
+--- a/src/core/proj/qgscoordinatetransformcontext.cpp
++++ b/src/core/proj/qgscoordinatetransformcontext.cpp
+@@ -65,6 +65,11 @@ bool QgsCoordinateTransformContext::operator==( const QgsCoordinateTransformCont
+   return equal;
+ }
+ 
++bool QgsCoordinateTransformContext::operator!=( const QgsCoordinateTransformContext &rhs ) const
++{
++  return !( *this == rhs );
++}
++
+ void QgsCoordinateTransformContext::clear()
+ {
+   d.detach();
+diff --git a/src/core/proj/qgscoordinatetransformcontext.h b/src/core/proj/qgscoordinatetransformcontext.h
+index 7f62c7b6e1b..7779a0e0366 100644
+--- a/src/core/proj/qgscoordinatetransformcontext.h
++++ b/src/core/proj/qgscoordinatetransformcontext.h
+@@ -67,7 +67,8 @@ class CORE_EXPORT QgsCoordinateTransformContext
+     QgsCoordinateTransformContext( const QgsCoordinateTransformContext &rhs );
+     QgsCoordinateTransformContext &operator=( const QgsCoordinateTransformContext &rhs ) SIP_SKIP;
+ 
+-    bool operator==( const QgsCoordinateTransformContext &rhs ) const ;
++    bool operator==( const QgsCoordinateTransformContext &rhs ) const;
++    bool operator!=( const QgsCoordinateTransformContext &rhs ) const;
+ 
+     /**
+      * Clears all stored transform information from the context.
+

--- a/vcpkg/ports/qgis/portfile.cmake
+++ b/vcpkg/ports/qgis/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_from_github(
         include-qthread.patch
         processing.patch # Needed to avoid link issue with tinygltf (ATM embedded into QGIS) and _GEOSQueryCallback defined multiple times
         meshoptimizer.patch
+        locatorcontext.patch # Remove when upgrading to QGIS 3.42
 )
 
 file(REMOVE ${SOURCE_PATH}/cmake/FindGDAL.cmake)

--- a/vcpkg/ports/qgis/portfile.cmake
+++ b/vcpkg/ports/qgis/portfile.cmake
@@ -17,7 +17,7 @@ vcpkg_from_github(
         include-qthread.patch
         processing.patch # Needed to avoid link issue with tinygltf (ATM embedded into QGIS) and _GEOSQueryCallback defined multiple times
         meshoptimizer.patch
-        locatorcontext.patch # Remove when upgrading to QGIS 3.42
+        locatorcontext.patch # Remove when upgrading to QGIS 3.42  
 )
 
 file(REMOVE ${SOURCE_PATH}/cmake/FindGDAL.cmake)

--- a/vcpkg/ports/qgis/portfile.cmake
+++ b/vcpkg/ports/qgis/portfile.cmake
@@ -18,6 +18,7 @@ vcpkg_from_github(
         processing.patch # Needed to avoid link issue with tinygltf (ATM embedded into QGIS) and _GEOSQueryCallback defined multiple times
         meshoptimizer.patch
         locatorcontext.patch # Remove when upgrading to QGIS 3.42  
+        rectangle.patch # Remove when upgrading to QGIS 3.42
 )
 
 file(REMOVE ${SOURCE_PATH}/cmake/FindGDAL.cmake)

--- a/vcpkg/ports/qgis/rectangle.patch
+++ b/vcpkg/ports/qgis/rectangle.patch
@@ -1,0 +1,62 @@
+diff --git a/src/core/geometry/qgsrectangle.h b/src/core/geometry/qgsrectangle.h
+index 81500f6c70d..ec335968a2f 100644
+--- a/src/core/geometry/qgsrectangle.h
++++ b/src/core/geometry/qgsrectangle.h
+@@ -40,6 +40,20 @@ class QgsBox3D;
+  */
+ class CORE_EXPORT QgsRectangle
+ {
++    Q_GADGET
++
++    Q_PROPERTY( double xMinimum READ xMinimum WRITE setXMinimum )
++    Q_PROPERTY( double xMaximum READ xMaximum WRITE setXMaximum )
++    Q_PROPERTY( double yMinimum READ yMinimum WRITE setYMinimum )
++    Q_PROPERTY( double yMaximum READ yMaximum WRITE setYMaximum )
++    Q_PROPERTY( double width READ width )
++    Q_PROPERTY( double height READ height )
++    Q_PROPERTY( double area READ area )
++    Q_PROPERTY( double perimeter READ perimeter )
++    Q_PROPERTY( QgsPointXY center READ center )
++    Q_PROPERTY( bool isEmpty READ isEmpty )
++    Q_PROPERTY( bool isNull READ isNull )
++
+   public:
+ 
+     //! Constructor for a null rectangle
+@@ -518,12 +532,12 @@ class CORE_EXPORT QgsRectangle
+     /**
+      * Returns a string representation of the rectangle in WKT format.
+      */
+-    QString asWktCoordinates() const;
++    Q_INVOKABLE QString asWktCoordinates() const;
+ 
+     /**
+      * Returns a string representation of the rectangle as a WKT Polygon.
+      */
+-    QString asWktPolygon() const;
++    Q_INVOKABLE QString asWktPolygon() const;
+ 
+     /**
+      * Returns a QRectF with same coordinates as the rectangle.
+@@ -538,7 +552,7 @@ class CORE_EXPORT QgsRectangle
+      * Coordinates will be truncated to the specified precision.
+      * If the specified precision is less than 0, a suitable minimum precision is used.
+      */
+-    QString toString( int precision = 16 ) const;
++    Q_INVOKABLE QString toString( int precision = 16 ) const;
+ 
+     /**
+      * Returns the rectangle as a polygon.
+diff --git a/src/core/geometry/qgsreferencedgeometry.h b/src/core/geometry/qgsreferencedgeometry.h
+index 1a4544b37de..e16e5a54c65 100644
+--- a/src/core/geometry/qgsreferencedgeometry.h
++++ b/src/core/geometry/qgsreferencedgeometry.h
+@@ -70,6 +70,8 @@ class CORE_EXPORT QgsReferencedGeometryBase
+  */
+ class CORE_EXPORT QgsReferencedRectangle : public QgsRectangle, public QgsReferencedGeometryBase
+ {
++    Q_GADGET
++
+   public:
+ 
+     /**


### PR DESCRIPTION
_Much wisdom gained from these lines of code._

The PR adds a framework that allows for plugin authors to integrate into the search bar through a QML-driven locator filter.

Here's a sample plugin registering a QML locator filter being declared:

```qml
Item {
  id: plugin

  Component.onCompleted: {
    locatorBridge.registerQFieldLocatorFilter(testLocatorFilter);
  }

  QFieldLocatorFilter {
    id: testLocatorFilter

    name: "testlocator"
    displayName: "test locator!!!"
    prefix: "123"

    source: Qt.resolvedUrl('testlocator.qml')
    
    function triggerResult(result) {
      console.log(result)
    }
  }
}
```

The QFieldLocatorFilter item *lives in the same thread and context* as QField's mainWindow, and therefore can access the map canvas et al within the `triggerResult` function.

Notice the source property of QFieldLocatorFilter. This is a sidecar QML component file that lives next to the main plugin QML (i.e. main.qml for app-wide plugins and my_project_file_name.qml for project plugins). That component must be declared in its own file as everything in there will be happening in a separate QML engine altogether, in a separate thread.

~~Also notice the use of a new property named `pluginFolder`. This was added so plugins can load extra resource from their folder. To make use of it, simply declare a property var pluginFolder at the root of your plugin root Item {}.~~ Note the use Qt.resolveUrl('my_file.qml') to resolve relative paths against the source file of the QML being loaded for the source property.

Moving on, here's a sample example of the source file (named testlocator.qml in the example above):

```qml
Item {
  signal prepareResult(var details)
  signal fetchResultsEnded()
  
  Timer {
    id: timer
    interval: 2000
    running: false
    repeat: false
    
    onTriggered: {
      let details = {
        "userData": GeometryUtils.point(0, 0),
        "displayString": "My title",
        "description": "My description...",
        "score": 0.5,
        "group": "My group",
        "groupScore": 0.5
      };
      prepareResult(details);
      fetchResultsEnded();
    }
  }
  
  function fetchResults(string, context) {
    timer.start();
  }
}
```

The use of the Timer here is merely to demonstrate how asynchronous result gathering happens. First, the function fetchResults(string, context) will be called. *If the results can be computed right away*, simply emit prepareResult(details) as many time as you want, and end the function by emitting fetchResultEnded(). However, it the very likely scenario the result fetching is waiting for some data (e.g. waiting for the response of an xmlhttprequest), the locator filter itself will wait until the fetchResultEnded() is emitted.

When all is done and understood, you'll get a beautiful integration:

[Screencast](https://github.com/user-attachments/assets/63ae86c2-b59c-4a7f-ae73-1c39ee2bafe8)

Here's a sample plugin that adds a GeoMapFish service into the search bar:

[qfield-geomapfish-locator-v1.1.zip](https://github.com/user-attachments/files/17893072/qfield-geomapfish-locator-v1.1.zip)

Another sample plugin that adds OSM nominatim service into the search bar:

[qfield-nominatim-locator-v1.1.zip](https://github.com/user-attachments/files/17910619/qfield-nominatim-locator-v1.1.zip)

The framework also allows for plugins to add secondary actions to results. For example here, the search result has a secondary option to use the result geometry as destination:

[0001-0220.webm](https://github.com/user-attachments/assets/020ee185-1e8c-4d9a-937b-da025e35a41a)


