### PR TITLE
Use curve to digitize Polylines/Polygons

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -171,5 +171,6 @@
         <file>themes/qfield/nodpi/ic_shutdown_24dp.svg</file>
         <file>themes/qfield/nodpi/ic_egeniouss_receiver_black_24dp.svg</file>
         <file>themes/qfield/nodpi/ic_location_tracking_white_24dp.svg</file>
+        <file>themes/qfield/nodpi/ic_line_curve_24dp.svg</file>
     </qresource>
 </RCC>

--- a/images/themes/qfield/nodpi/ic_line_curve_24dp.svg
+++ b/images/themes/qfield/nodpi/ic_line_curve_24dp.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px">
+    <path
+        d="M720-160q0-116-44-218T556-556q-76-76-178-120t-218-44v-80q132 0 248.5 50.5T612-612q87 87 137.5 203.5T800-160h-80Z"
+        fill="#fff" stroke="#fff" stroke-width=".529" />
+</svg>

--- a/src/core/rubberbandmodel.cpp
+++ b/src/core/rubberbandmodel.cpp
@@ -407,7 +407,12 @@ void RubberbandModel::removeCurve()
 
 void RubberbandModel::reset()
 {
-  removeVertices( 0, vertexCount() - 1 );
+  mCompoundCurve.clear();
+  mDuringCurveDrawing = false;
+  mCompoundCurve.addVertex( mCurrentCoordinate );
+  emit verticesRemoved( 0, vertexCount() - 1 );
+  setCurrentCoordinateIndex( 0 );
+  emit vertexCountChanged();
   mFrozen = false;
   emit frozenChanged();
 }

--- a/src/core/rubberbandmodel.cpp
+++ b/src/core/rubberbandmodel.cpp
@@ -24,28 +24,38 @@ RubberbandModel::RubberbandModel( QObject *parent )
   : QObject( parent )
   , mLayer( nullptr )
 {
-  mPointList.insert( 0, QgsPoint() );
+  mCompoundCurve.addVertex( QgsPoint() );
 }
 
 int RubberbandModel::vertexCount() const
 {
-  return mPointList.size();
+  return mCompoundCurve.vertexCount( 0, 0 );
 }
 
 bool RubberbandModel::isEmpty() const
 {
-  return mPointList.isEmpty();
+  return mCompoundCurve.isEmpty();
 }
 
 QVector<QgsPoint> RubberbandModel::vertices() const
 {
-  return mPointList;
+  QgsVertexIterator vertexIterator = mCompoundCurve.curveToLine()->vertices();
+
+  // Create an empty QVector<QgsPoint>
+  QVector<QgsPoint> points;
+
+  // Iterate over the vertices and add them to the vector
+  while ( vertexIterator.hasNext() )
+  {
+    points.append( vertexIterator.next() );
+  }
+  return points;
 }
 
 QVector<QgsPoint> RubberbandModel::verticesCopy( bool skipCurrentPoint ) const
 {
   QVector<QgsPoint> points;
-  for ( const QgsPoint &pt : mPointList )
+  for ( const QgsPoint &pt : vertices() )
   {
     points << QgsPoint( pt );
   }
@@ -60,7 +70,7 @@ QgsPointSequence RubberbandModel::pointSequence( const QgsCoordinateReferenceSys
   QgsPointSequence sequence;
   QgsCoordinateTransform ct( mCrs, crs, QgsProject::instance()->transformContext() );
 
-  for ( const QgsPoint &pt : mPointList )
+  for ( const QgsPoint &pt : vertices() )
   {
     //crs transformation of XY
     QgsPointXY p1 = ct.transform( pt.x(), pt.y() );
@@ -97,7 +107,7 @@ QVector<QgsPointXY> RubberbandModel::flatPointSequence( const QgsCoordinateRefer
 
   QgsCoordinateTransform ct( mCrs, crs, QgsProject::instance()->transformContext() );
 
-  for ( const QgsPoint &pt : mPointList )
+  for ( const QgsPoint &pt : vertices() )
   {
     sequence.append( ct.transform( pt.x(), pt.y() ) );
   }
@@ -107,9 +117,10 @@ QVector<QgsPointXY> RubberbandModel::flatPointSequence( const QgsCoordinateRefer
 
 void RubberbandModel::setVertex( int index, QgsPoint coordinate )
 {
-  if ( mPointList.at( index ) != coordinate )
+  QgsVertexId id = QgsVertexId( 0, 0, index );
+  if ( mCompoundCurve.vertexAt( id ) != coordinate )
   {
-    mPointList.replace( index, coordinate );
+    mCompoundCurve.moveVertex( id, coordinate );
     emit vertexChanged( index );
   }
 }
@@ -118,7 +129,8 @@ void RubberbandModel::insertVertices( int index, int count )
 {
   for ( int i = 0; i < count; ++i )
   {
-    mPointList.insert( index, currentCoordinate() );
+    QgsVertexId id = QgsVertexId( 0, 0, index );
+    mCompoundCurve.insertVertex( id, currentCoordinate() );
   }
 
   emit verticesInserted( index, count );
@@ -127,14 +139,23 @@ void RubberbandModel::insertVertices( int index, int count )
 
 void RubberbandModel::removeVertices( int index, int count )
 {
-  if ( mPointList.size() <= 1 )
+  if ( vertexCount() <= 1 )
     return;
 
-  mPointList.remove( index, count );
-
-  if ( mCurrentCoordinateIndex >= mPointList.size() )
+  for ( int i = 0; i < count; ++i )
   {
-    setCurrentCoordinateIndex( mPointList.size() - 1 );
+    QgsVertexId id = QgsVertexId( 0, 0, index );
+    mCompoundCurve.deleteVertex( id );
+  }
+
+  if ( vertexCount() == 0 )
+  {
+    mCompoundCurve.addVertex( QgsPoint() );
+  }
+
+  if ( mCurrentCoordinateIndex >= vertexCount() )
+  {
+    setCurrentCoordinateIndex( vertexCount() - 1 );
   }
 
   emit verticesRemoved( index, count );
@@ -162,8 +183,8 @@ void RubberbandModel::setCurrentCoordinateIndex( int currentCoordinateIndex )
 QgsPoint RubberbandModel::currentPoint( const QgsCoordinateReferenceSystem &crs, Qgis::WkbType wkbType ) const
 {
   QgsCoordinateTransform ct( mCrs, crs, QgsProject::instance()->transformContext() );
-
-  QgsPoint currentPt = mPointList.at( mCurrentCoordinateIndex );
+  QgsVertexId id = QgsVertexId( 0, 0, mCurrentCoordinateIndex );
+  QgsPoint currentPt = mCompoundCurve.vertexAt( id );
   double x = currentPt.x();
   double y = currentPt.y();
   double z = QgsWkbTypes::hasZ( currentPt.wkbType() ) ? currentPt.z() : 0;
@@ -195,64 +216,66 @@ QgsPoint RubberbandModel::currentPoint( const QgsCoordinateReferenceSystem &crs,
 
 QgsPoint RubberbandModel::currentCoordinate() const
 {
-  return mPointList.value( mCurrentCoordinateIndex );
+  QgsVertexId id = QgsVertexId( 0, 0, mCurrentCoordinateIndex );
+  return mCompoundCurve.vertexAt( id );
 }
 
 QgsPoint RubberbandModel::firstCoordinate() const
 {
-  if ( mPointList.isEmpty() )
+  if ( mCompoundCurve.isEmpty() )
     return QgsPoint();
 
-  return mPointList.at( 0 );
+  QgsVertexId id = QgsVertexId( 0, 0, 0 );
+  return mCompoundCurve.vertexAt( id );
 }
 
 QgsPoint RubberbandModel::lastCoordinate() const
 {
-  if ( mPointList.isEmpty() )
+  if ( mCompoundCurve.isEmpty() )
     return QgsPoint();
-
-  return mPointList.at( mCurrentCoordinateIndex > 0 ? mCurrentCoordinateIndex - 1 : 0 );
+  QgsVertexId id = QgsVertexId( 0, 0, mCurrentCoordinateIndex > 0 ? mCurrentCoordinateIndex - 1 : 0 );
+  return mCompoundCurve.vertexAt( id );
 }
 
 QgsPoint RubberbandModel::penultimateCoordinate() const
 {
-  if ( mPointList.size() < 3 )
+  if ( mCompoundCurve.vertexCount( 0, 0 ) < 3 )
     return QgsPoint();
-
-  return mPointList.at( mCurrentCoordinateIndex > 1 ? mCurrentCoordinateIndex - 2 : 0 );
+  QgsVertexId id = QgsVertexId( 0, 0, mCurrentCoordinateIndex > 1 ? mCurrentCoordinateIndex - 2 : 0 );
+  return mCompoundCurve.vertexAt( id );
 }
 
 void RubberbandModel::setCurrentCoordinate( const QgsPoint &currentCoordinate )
 {
   // play safe, but try to find out
-  // Q_ASSERT( mPointList.count() != 0 );
-  if ( mPointList.count() == 0 )
+  if ( mCompoundCurve.isEmpty() )
     return;
 
-  if ( mPointList.at( mCurrentCoordinateIndex ) == currentCoordinate )
+  QgsVertexId id = QgsVertexId( 0, 0, mCurrentCoordinateIndex );
+  if ( mCompoundCurve.vertexAt( id ) == currentCoordinate )
     return;
 
   if ( mFrozen )
     return;
 
-  mPointList.replace( mCurrentCoordinateIndex, currentCoordinate );
+  mCompoundCurve.moveVertex( id, currentCoordinate );
 
   if ( !mLayer || QgsWkbTypes::hasM( mLayer->wkbType() ) )
   {
     if ( !std::isnan( mMeasureValue ) )
     {
-      if ( QgsWkbTypes::hasM( mPointList[mCurrentCoordinateIndex].wkbType() ) )
+      if ( QgsWkbTypes::hasM( mCompoundCurve.vertexAt( id ).wkbType() ) )
       {
-        mPointList[mCurrentCoordinateIndex].setM( mMeasureValue );
+        mCompoundCurve.vertexAt( id ).setM( mMeasureValue );
       }
       else
       {
-        mPointList[mCurrentCoordinateIndex].addMValue( mMeasureValue );
+        mCompoundCurve.vertexAt( id ).addMValue( mMeasureValue );
       }
     }
     else
     {
-      mPointList[mCurrentCoordinateIndex].dropMValue();
+      mCompoundCurve.vertexAt( id ).dropMValue();
     }
   }
 
@@ -295,7 +318,7 @@ void RubberbandModel::setMeasureValue( const double measureValue )
 void RubberbandModel::addVertex()
 {
   // Avoid double vertices accidentally
-  if ( mPointList.size() > 1 && *( mPointList.end() - 1 ) == *( mPointList.end() - 2 ) )
+  if ( mCompoundCurve.vertexCount( 0, 0 ) > 1 && currentCoordinate() == penultimateCoordinate() )
   {
     return;
   }
@@ -318,7 +341,7 @@ void RubberbandModel::removeVertex()
 
 void RubberbandModel::reset()
 {
-  removeVertices( 0, mPointList.size() - 1 );
+  removeVertices( 0, vertexCount() - 1 );
   mFrozen = false;
   emit frozenChanged();
 }
@@ -331,7 +354,7 @@ void RubberbandModel::setDataFromGeometry( QgsGeometry geometry, const QgsCoordi
   QgsCoordinateTransform ct( crs, mCrs, QgsProject::instance()->transformContext() );
   geometry.transform( ct );
 
-  mPointList.clear();
+  mCompoundCurve.clear();
   const QgsAbstractGeometry *abstractGeom = geometry.constGet();
   if ( !abstractGeom )
     return;
@@ -344,22 +367,22 @@ void RubberbandModel::setDataFromGeometry( QgsGeometry geometry, const QgsCoordi
     {
       break;
     }
-    mPointList << pt;
+    mCompoundCurve.addVertex( pt );
   }
 
   // for polygons, remove the last vertex which is a duplicate of the first vertex
   if ( geometry.type() == Qgis::GeometryType::Polygon )
   {
-    mPointList.removeLast();
+    mCompoundCurve.removeDuplicateNodes();
   }
 
   // insert the last point twice so the resutling rubberband's current coordinate property being modified (by e.g.
   // the GNSS position) will not replace the last vertex from the passed geometry
-  mPointList << mPointList.last();
+  mCompoundCurve.addVertex( mCompoundCurve.endPoint() );
 
-  mCurrentCoordinateIndex = mPointList.size() - 1;
+  mCurrentCoordinateIndex = mCompoundCurve.vertexCount( 0, 0 ) - 1;
 
-  emit verticesInserted( 0, mPointList.size() );
+  emit verticesInserted( 0, mCompoundCurve.vertexCount( 0, 0 ) );
   emit vertexCountChanged();
 }
 

--- a/src/core/rubberbandmodel.h
+++ b/src/core/rubberbandmodel.h
@@ -25,6 +25,7 @@
 #include <QVector>
 #include <qgis.h>
 #include <qgsabstractgeometry.h>
+#include <qgscircularstring.h>
 #include <qgscompoundcurve.h>
 #include <qgscoordinatereferencesystem.h>
 #include <qgsgeometry.h>
@@ -155,8 +156,20 @@ class QFIELD_CORE_EXPORT RubberbandModel : public QObject
     //! Remove the vertex at the current index
     Q_INVOKABLE void removeVertex();
 
+    //! Add a curve at the current index
+    Q_INVOKABLE void addCurve();
+
+    //! Set the middle point of the curve at the current index
+    Q_INVOKABLE void addMiddlePointCurve();
+
+    //! Remove the curve at the current index
+    Q_INVOKABLE void removeCurve();
+
     //! Reset the model, remove all vertices and restart the vertex index
     Q_INVOKABLE void reset();
+
+    //! Returns whether the rubberband model is currently drawing a curve
+    Q_INVOKABLE bool isDuringCurveDrawing() const { return mDuringCurveDrawing; }
 
     /**
      * Sets the model data to match a given \a geometry
@@ -206,6 +219,11 @@ class QFIELD_CORE_EXPORT RubberbandModel : public QObject
     QgsCoordinateReferenceSystem mCrs;
     double mMeasureValue = std::numeric_limits<double>::quiet_NaN();
     bool mFrozen = false;
+    bool mDuringCurveDrawing = false;
+
+    QgsPoint mLastStartCurvePoint;
+    QgsPoint mLastMiddleCurvePoint;
+    QgsPoint mCurrentCoordinate;
 };
 
 #endif // RUBBERBANDMODEL_H

--- a/src/core/rubberbandmodel.h
+++ b/src/core/rubberbandmodel.h
@@ -25,6 +25,7 @@
 #include <QVector>
 #include <qgis.h>
 #include <qgsabstractgeometry.h>
+#include <qgscompoundcurve.h>
 #include <qgscoordinatereferencesystem.h>
 #include <qgsgeometry.h>
 #include <qgspoint.h>
@@ -197,7 +198,7 @@ class QFIELD_CORE_EXPORT RubberbandModel : public QObject
     void measureValueChanged();
 
   private:
-    QVector<QgsPoint> mPointList;
+    QgsCompoundCurve mCompoundCurve;
     int mCurrentCoordinateIndex = 0;
     QDateTime mCurrentPositionTimestamp;
     Qgis::GeometryType mGeometryType = Qgis::GeometryType::Line;

--- a/src/qml/DigitizingToolbar.qml
+++ b/src/qml/DigitizingToolbar.qml
@@ -242,7 +242,19 @@ QfVisibilityFadingRow {
       if (Number(rubberbandModel.geometryType) === Qgis.GeometryType.Point || Number(rubberbandModel.geometryType) === Qgis.GeometryType.Null) {
         confirm();
       } else {
-        addVertex();
+        if (settings.valueBool("/QField/Digitizing/CurveEdition", false) == true) {
+          if (currentRubberband.model.isDuringCurveDrawing() == true || currentRubberband.model.vertexCount == 1) {
+            if (currentRubberband.model.vertexCount != 1) {
+              addCurve();
+            } else {
+              addVertex();
+            }
+          } else {
+            addMiddlePointCurve();
+          }
+        } else {
+          addVertex();
+        }
       }
     }
   }
@@ -279,6 +291,14 @@ QfVisibilityFadingRow {
 
   function triggerAddVertex() {
     addVertexButton.clicked();
+  }
+
+  function addCurve() {
+    rubberbandModel.addCurve();
+  }
+
+  function addMiddlePointCurve() {
+    rubberbandModel.addMiddlePointCurve();
   }
 
   function addVertex() {

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -424,6 +424,52 @@ Page {
               Layout.fillWidth: true
               Layout.leftMargin: 20
               Layout.rightMargin: 20
+              Layout.topMargin: 5
+              Layout.bottomMargin: 5
+
+              columns: 1
+              columnSpacing: 0
+              rowSpacing: 0
+
+              visible: true
+
+              Label {
+                Layout.fillWidth: true
+
+                text: qsTr('Curve tolerance')
+                font: Theme.defaultFont
+                color: Theme.mainTextColor
+                wrapMode: Text.WordWrap
+              }
+
+              QfSlider {
+                Layout.fillWidth: true
+                value: settings ? settings.value('/QField/Digitizing/CurveTolerance', 0.02) : 0.02
+                from: 0
+                to: 1
+                stepSize: 0.001
+                suffixText: " m"
+                implicitHeight: 40
+
+                onMoved: function () {
+                  settings.setValue('/QField/Digitizing/CurveTolerance', value);
+                }
+              }
+
+              Label {
+                Layout.fillWidth: true
+                text: qsTr('Maximum difference between approximation and curve')
+
+                font: Theme.tipFont
+                color: Theme.secondaryTextColor
+                wrapMode: Text.WordWrap
+              }
+            }
+
+            GridLayout {
+              Layout.fillWidth: true
+              Layout.leftMargin: 20
+              Layout.rightMargin: 20
 
               columns: 2
               columnSpacing: 0

--- a/src/qml/geometryeditors/Erase.qml
+++ b/src/qml/geometryeditors/Erase.qml
@@ -21,7 +21,19 @@ QfVisibilityFadingRow {
 
   function canvasClicked(point, type) {
     if (type === "stylus") {
-      drawPolygonToolbar.addVertex();
+      if (settings.valueBool("/QField/Digitizing/CurveEdition", false) == true) {
+        if (drawPolygonToolbar.rubberbandModel.isDuringCurveDrawing() == true || drawPolygonToolbar.rubberbandModel.vertexCount == 1) {
+          if (drawPolygonToolbar.rubberbandModel.vertexCount != 1) {
+            drawPolygonToolbar.addCurve();
+          } else {
+            drawPolygonToolbar.addVertex();
+          }
+        } else {
+          drawPolygonToolbar.addMiddlePointCurve();
+        }
+      } else {
+        drawPolygonToolbar.addVertex();
+      }
       return true;
     }
     return false;

--- a/src/qml/geometryeditors/FillRing.qml
+++ b/src/qml/geometryeditors/FillRing.qml
@@ -19,7 +19,19 @@ QfVisibilityFadingRow {
 
   function canvasClicked(point, type) {
     if (type === "stylus") {
-      drawPolygonToolbar.addVertex();
+      if (settings.valueBool("/QField/Digitizing/CurveEdition", false) == true) {
+        if (drawPolygonToolbar.rubberbandModel.isDuringCurveDrawing() == true || drawPolygonToolbar.rubberbandModel.vertexCount == 1) {
+          if (drawPolygonToolbar.rubberbandModel.vertexCount != 1) {
+            drawPolygonToolbar.addCurve();
+          } else {
+            drawPolygonToolbar.addVertex();
+          }
+        } else {
+          drawPolygonToolbar.addMiddlePointCurve();
+        }
+      } else {
+        drawPolygonToolbar.addVertex();
+      }
       return true;
     }
     return false;

--- a/src/qml/geometryeditors/Reshape.qml
+++ b/src/qml/geometryeditors/Reshape.qml
@@ -18,7 +18,19 @@ QfVisibilityFadingRow {
 
   function canvasClicked(point, type) {
     if (type === "stylus") {
-      drawPolygonToolbar.addVertex();
+      if (settings.valueBool("/QField/Digitizing/CurveEdition", false) == true) {
+        if (drawPolygonToolbar.rubberbandModel.isDuringCurveDrawing() == true || drawPolygonToolbar.rubberbandModel.vertexCount == 1) {
+          if (drawPolygonToolbar.rubberbandModel.vertexCount != 1) {
+            drawPolygonToolbar.addCurve();
+          } else {
+            drawPolygonToolbar.addVertex();
+          }
+        } else {
+          drawPolygonToolbar.addMiddlePointCurve();
+        }
+      } else {
+        drawPolygonToolbar.addVertex();
+      }
       return true;
     }
     return false;

--- a/src/qml/geometryeditors/SplitFeature.qml
+++ b/src/qml/geometryeditors/SplitFeature.qml
@@ -17,7 +17,19 @@ QfVisibilityFadingRow {
 
   function canvasClicked(point, type) {
     if (type === "stylus") {
-      drawLineToolbar.addVertex();
+      if (settings.valueBool("/QField/Digitizing/CurveEdition", false) == true) {
+        if (drawLineToolbar.rubberbandModel.isDuringCurveDrawing() == true || drawLineToolbar.rubberbandModel.vertexCount == 1) {
+          if (drawLineToolbar.rubberbandModel.vertexCount != 1) {
+            drawLineToolbar.addCurve();
+          } else {
+            drawLineToolbar.addVertex();
+          }
+        } else {
+          drawLineToolbar.addMiddlePointCurve();
+        }
+      } else {
+        drawLineToolbar.addVertex();
+      }
       return true;
     }
     return false;

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -504,7 +504,19 @@ ApplicationWindow {
               if (Number(currentRubberband.model.geometryType) === Qgis.GeometryType.Point || Number(currentRubberband.model.geometryType) === Qgis.GeometryType.Null) {
                 digitizingToolbar.confirm();
               } else {
-                digitizingToolbar.addVertex();
+                if (settings.valueBool("/QField/Digitizing/CurveEdition", false) == true) {
+                  if (currentRubberband.model.isDuringCurveDrawing() == true || currentRubberband.model.vertexCount == 1) {
+                    if (currentRubberband.model.vertexCount != 1) {
+                      digitizingToolbar.addCurve();
+                    } else {
+                      digitizingToolbar.addVertex();
+                    }
+                  } else {
+                    digitizingToolbar.addMiddlePointCurve();
+                  }
+                } else {
+                  digitizingToolbar.addVertex();
+                }
               }
             }
           } else {
@@ -1557,6 +1569,51 @@ ApplicationWindow {
                 }
               }
             }
+          }
+        }
+
+        QfToolButton {
+          id: curveEditionButton
+          width: visible ? 40 : 0
+          height: visible ? 40 : 0
+          padding: 2
+          round: true
+          visible: dashBoard.activeLayer && (dashBoard.activeLayer.geometryType() === Qgis.GeometryType.Polygon || dashBoard.activeLayer.geometryType() === Qgis.GeometryType.Line)
+          iconSource: Theme.getThemeVectorIcon("ic_line_curve_24dp")
+          iconColor: "white"
+          bgcolor: Theme.darkGray
+
+          property bool curveEdition: false
+          state: curveEdition ? "On" : "Off"
+
+          states: [
+            State {
+
+              name: "Off"
+              PropertyChanges {
+                target: curveEditionButton
+                iconColor: "white"
+                bgcolor: Theme.darkGraySemiOpaque
+              }
+            },
+            State {
+              name: "On"
+              PropertyChanges {
+                target: curveEditionButton
+                iconColor: Theme.mainColor
+                bgcolor: Theme.darkGray
+              }
+            }
+          ]
+
+          onClicked: {
+            curveEdition = !curveEdition;
+            displayToast(curveEdition ? qsTr("Curve edition turned on") : qsTr("Curve edition turned off"));
+            settings.setValue("/QField/Digitizing/CurveEdition", curveEdition);
+          }
+
+          Component.onCompleted: {
+            curveEdition = settings.valueBool("/QField/Digitizing/CurveEdition", false);
           }
         }
       }


### PR DESCRIPTION
Use curve to digitize Polylines/Polygons

![test](https://github.com/user-attachments/assets/5fbbc93e-560f-4b50-9ce8-10584049fbd4)

1. Active Curve mode during Digitization of a Polygon
2. Add a first vertex to define the center point of the arc
3. Add a second vertex to stop the arc

Precision of the final arc can be set in QField Parameters page (slider) 