### PR TITLE
When printing layouts (atlas and non-atlas ones), place them in the current project path's subfolder for easier synchronization / export

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -1251,7 +1251,7 @@ bool QgisMobileapp::print( const QString &layoutName )
   if ( !layoutToPrint || layoutToPrint->pageCollection()->pageCount() == 0 )
     return false;
 
-  const QString destination = mProject->homePath() + '/' + layoutToPrint->name() + '-' + QDateTime::currentDateTime().toString( QStringLiteral( "yyyyMMdd_hhmmss" ) ) + QStringLiteral( ".pdf" );
+  const QString destination = QStringLiteral( "%1/layouts/%2-%3.pdf" ).arg( mProject->homePath(), layoutToPrint->name(), QDateTime::currentDateTime().toString( QStringLiteral( "yyyyMMdd_hhmmss" ) ) );
 
   if ( !layoutToPrint->atlas() || !layoutToPrint->atlas()->enabled() )
   {
@@ -1322,7 +1322,7 @@ bool QgisMobileapp::printAtlasFeatures( const QString &layoutName, const QList<l
   layoutToPrint->atlas()->setFilterFeatures( true );
   layoutToPrint->atlas()->updateFeatures();
 
-  const QString destination = mProject->homePath() + '/' + layoutToPrint->name() + '-' + QDateTime::currentDateTime().toString( QStringLiteral( "yyyyMMdd_hhmmss" ) ) + QStringLiteral( ".pdf" );
+  const QString destination = QStringLiteral( "%1/layouts/%2-%3.pdf" ).arg( mProject->homePath(), layoutToPrint->name(), QDateTime::currentDateTime().toString( QStringLiteral( "yyyyMMdd_hhmmss" ) ) );
   QString finalDestination;
   const bool destinationSingleFile = layoutToPrint->customProperty( QStringLiteral( "singleFile" ), true ).toBool();
   if ( !destinationSingleFile && ids.size() == 1 )


### PR DESCRIPTION
Doing so means we'll be able to synchronize generated layout PDFs to the cloud by adding 'layouts' to the attachments directories within the project properties' QField panel:

![image](https://github.com/user-attachments/assets/bc91d0b4-a752-4702-8456-106012c9683c)

This also makes it easier to compress the whole folder and send it via email / messenger app / etc. on Android for non-cloud projects, as well as deleting them (the 3-dot menu offers a 'delete project folder' already).