### PR TITLE
Rework pg_service.conf handling to support SSL keys authentication

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -201,6 +201,60 @@ int main( int argc, char **argv )
     delete[] newPaths;
   }
 
+#if defined( Q_OS_ANDROID ) || defined( Q_OS_IOS )
+  for ( const QString &dataDir : dataDirs )
+  {
+    const QFileInfo pgServiceFileInfo( QStringLiteral( "%1/pg_service.conf" ).arg( dataDir ) );
+    if ( pgServiceFileInfo.exists() && pgServiceFileInfo.isReadable() )
+    {
+      const QString systemLocalDataPath = platformUtils->systemLocalDataLocation( QString() );
+
+      QFile pgServiceFile( QStringLiteral( "%1/pg_service.conf" ).arg( dataDir ) );
+      pgServiceFile.open( QFile::ReadOnly | QFile::Text );
+      QTextStream textStream( &pgServiceFile );
+      QString psServiceFileContent = textStream.readAll();
+      pgServiceFile.close();
+
+      const QStringList keys = QStringList() << QStringLiteral( "sslrootcert" ) << QStringLiteral( "sslcert" ) << QStringLiteral( "sslkey" );
+      for ( const QString &key : keys )
+      {
+        const QRegularExpression rx( QStringLiteral( "%1=(.*)" ).arg( key ) );
+        QRegularExpressionMatchIterator matchIt = rx.globalMatch( psServiceFileContent );
+        while ( matchIt.hasNext() )
+        {
+          const QRegularExpressionMatch match = matchIt.next();
+          const QString fileName = match.captured( 1 ).trimmed();
+
+          // Check if the file is relative to the pg_service.conf, in which case copy to user-owned location, use absolute path, and change permissions
+          const QString filePath = QStringLiteral( "%1/%2" ).arg( dataDir, fileName );
+          const QFileInfo fileInfo( filePath );
+          if ( QFileInfo::exists( filePath ) )
+          {
+            const QString newFilePath = QStringLiteral( "%1/%2" ).arg( systemLocalDataPath, fileName );
+            if ( QFileInfo::exists( newFilePath ) )
+            {
+              QFile newFile( newFilePath );
+              newFile.remove();
+            }
+            QFile::copy( filePath, newFilePath );
+            QFile::setPermissions( newFilePath, QFileDevice::ReadOwner | QFileDevice::WriteOwner );
+            psServiceFileContent.replace( QStringLiteral( "%1=%2" ).arg( key, match.captured( 1 ) ), QStringLiteral( "%1=%2" ).arg( key, newFilePath ) );
+          }
+        }
+      }
+
+      const QString localPgServiceFileName = QStringLiteral( "%1/pg_service.conf" ).arg( systemLocalDataPath );
+      QFile localPgServiceFile( localPgServiceFileName );
+      localPgServiceFile.open( QFile::WriteOnly );
+      localPgServiceFile.write( psServiceFileContent.toUtf8() );
+      localPgServiceFile.close();
+
+      setenv( "PGSYSCONFDIR", systemLocalDataPath.toUtf8(), true );
+      break;
+    }
+  }
+#endif
+
 #if WITH_SENTRY
   sentry_wrapper::install_message_handler();
 #endif

--- a/src/core/platforms/platformutilities.cpp
+++ b/src/core/platforms/platformutilities.cpp
@@ -140,7 +140,7 @@ QString PlatformUtilities::systemSharedDataLocation() const
 
 QString PlatformUtilities::systemLocalDataLocation( const QString &subDir ) const
 {
-  return QStandardPaths::writableLocation( QStandardPaths::AppDataLocation ) + '/' + subDir;
+  return QStandardPaths::writableLocation( QStandardPaths::AppDataLocation ) + ( !subDir.isEmpty() ? '/' + subDir : QString() );
 }
 
 bool PlatformUtilities::hasQgsProject() const

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -92,7 +92,7 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
      *          this includes local qfieldcloud data or sample projects.
      *          A \a subDir is appended to the path.
      */
-    virtual QString systemLocalDataLocation( const QString &subDir ) const;
+    virtual QString systemLocalDataLocation( const QString &subDir = QString() ) const;
 
     /**
      * Returns TRUE is a project file has been provided and should be opened at launch.

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -287,18 +287,6 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
 
   if ( !dataDirs.isEmpty() )
   {
-#if defined( Q_OS_ANDROID ) || defined( Q_OS_IOS )
-    for ( const QString &dataDir : dataDirs )
-    {
-      QFileInfo pgServiceFile( QStringLiteral( "%1/pg_service.conf" ).arg( dataDir ) );
-      if ( pgServiceFile.exists() && pgServiceFile.isReadable() )
-      {
-        setenv( "PGSYSCONFDIR", dataDir.toUtf8(), true );
-        break;
-      }
-    }
-#endif
-
     QgsApplication::instance()->authManager()->setPasswordHelperEnabled( false );
     QgsApplication::instance()->authManager()->setMasterPassword( QString( "qfield" ) );
     // import authentication method configurations


### PR DESCRIPTION
This PR reworks the way we handle the presence of a pg_service.conf in the QField data directory (i.e. on Android <storage root>/Android/data/ch.opengis.qfield/files/QField) to allow for immediate and future improvements.

The big change: instead of having postgres consume that service configuration file (most often drag and dropped via USB cable), QField will copy its content into a new pg_service.conf file living within the QField app's writable system directory. By doing this, we unlock the ability by QField to modify that pg_service.conf file at will (think QFieldCloud-provided services being written into that file when successfully logging into QFC).

Back to the present, the new handling is meant to unlock support for SSL keys authentication through the following logic:
- when a pg_service.conf file is detected, QField will scan for three keys: sslrootcert, sslcert, and sslkey;
- for each key, QField will capture the value and look for its associated file using the value as _a relative file path_ to pg_services.conf;
- when a file is found, QField will copy the file into the above-mentioned app's writable system directory and will tweak its access permission to satisfy postgres / openssl; 
- QField will then modify the pg_services.conf content for the services to point to the newly copied files. 

This method allows us to support SSL authentication on Android in a way that allows for the users to share the same pg_services.conf content across desktop and Android.