### PR TITLE
Fix sketching over image attachments sometimes not working

### DIFF
--- a/src/core/platforms/platformutilities.cpp
+++ b/src/core/platforms/platformutilities.cpp
@@ -183,14 +183,27 @@ bool PlatformUtilities::rmFile( const QString &filename ) const
   return file.remove( filename );
 }
 
-bool PlatformUtilities::renameFile( const QString &filename, const QString &newname ) const
+bool PlatformUtilities::renameFile( const QString &oldFilePath, const QString &newFilePath, bool overwrite ) const
 {
-  QFileInfo fi( newname );
-  QDir dir( fi.absolutePath() );
-  dir.mkpath( fi.absolutePath() );
+  QFileInfo oldFi( oldFilePath );
+  QFileInfo newFi( newFilePath );
+  if ( oldFi.absoluteFilePath() == newFi.absoluteFilePath() )
+  {
+    return true;
+  }
 
-  QFile file( filename );
-  return file.rename( newname );
+  // Insure the path exists
+  QDir dir( newFi.absolutePath() );
+  dir.mkpath( newFi.absolutePath() );
+
+  // If the renamed file exists, overwrite
+  if ( newFi.exists() && overwrite )
+  {
+    QFile newfile( newFilePath );
+    newfile.remove();
+  }
+
+  return QFile::rename( oldFilePath, newFilePath );
 }
 
 QString PlatformUtilities::applicationDirectory() const

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -116,7 +116,7 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
     // TODO: move these functions to fileutils. Make sure to adjust any qml code relying on this.
     Q_INVOKABLE bool createDir( const QString &path, const QString &dirname ) const;
     Q_INVOKABLE bool rmFile( const QString &filename ) const;
-    Q_INVOKABLE bool renameFile( const QString &filename, const QString &newname ) const;
+    Q_INVOKABLE bool renameFile( const QString &oldFilePath, const QString &newFilePath, bool overwrite = true ) const;
 
 
     /**

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -347,6 +347,10 @@ EditorWidgetBase {
         filepath = filepath.replace('{filename}', FileUtils.fileName(path));
         filepath = filepath.replace('{extension}', FileUtils.fileSuffix(path));
         platformUtilities.renameFile(path, prefixToRelativePath + filepath);
+
+        // In order to insure an edited image gets refreshed in the feature form, reset the source
+        image.source = '';
+        image.source = UrlUtils.fromString(prefixToRelativePath + filepath);
         valueChangeRequested(filepath, false);
         enabled = false;
       }


### PR DESCRIPTION
This is a relatively serious fix here as it was leading to failed saving of sketches over images, or even attempts at overwriting an image attachment for a given feature _provided the expression-driven filename resulted in the same filename as the previous one being replace_.