### PR TITLE
Avoid infinite sort loop when gathering feature lists for the value relation editor widget

### DIFF
--- a/src/core/featurelistmodel.cpp
+++ b/src/core/featurelistmodel.cpp
@@ -398,16 +398,14 @@ void FeatureListModel::processFeatureList()
   if ( mOrderByValue || !mGroupField.isEmpty() || !mSearchTerm.isEmpty() )
   {
     std::sort( entries.begin(), entries.end(), [=]( const Entry &entry1, const Entry &entry2 ) {
-      if ( entry1.key.isNull() )
+      if ( entry1.key.isNull() && !entry2.key.isNull() )
         return true;
 
-      if ( entry2.key.isNull() )
+      if ( !entry1.key.isNull() && entry2.key.isNull() )
         return false;
 
       if ( !mGroupField.isEmpty() && entry1.group != entry2.group )
-      {
         return entry1.group < entry2.group;
-      }
 
       if ( !mSearchTerm.isEmpty() )
       {


### PR DESCRIPTION
Fixes https://github.com/opengisch/QField/issues/5859 , super happy about this one, I was seeing it often on sentry.

Big thanks to @Hikuritamete for having taken the time to answer questions and provide additional information which led to this fix.