### PR TITLE
Improvements to theme color handling, allow customizing appearance colors

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -82,7 +82,6 @@
         <file>themes/qfield/nodpi/ic_cloud_project_localonly_48dp.svg</file>
         <file>themes/qfield/nodpi/ic_geotag_white_24dp.svg</file>
         <file>themes/qfield/nodpi/ic_geotag_missing_white_24dp.svg</file>
-        <file>themes/qfield/nodpi/ic_compass_arrow_24dp.svg</file>
         <file>themes/qfield/nodpi/ic_chevron_left_white_24dp.svg</file>
         <file>themes/qfield/nodpi/ic_chevron_right_white_24dp.svg</file>
         <file>themes/qfield/nodpi/ic_fullscreen_white_24dp.svg</file>

--- a/src/qml/BusyOverlay.qml
+++ b/src/qml/BusyOverlay.qml
@@ -108,7 +108,7 @@ Rectangle {
     anchors.top: busyIndicator.bottom
     anchors.topMargin: 10
     anchors.horizontalCenter: parent.horizontalCenter
-    color: Theme.darkGraySemiOpaque
+    color: Theme.toolButtonBackgroundSemiOpaqueColor
     radius: 4
 
     width: busyMessage.width
@@ -123,7 +123,7 @@ Rectangle {
       anchors.centerIn: parent
       horizontalAlignment: Text.AlignHCenter
       font: Theme.tipFont
-      color: "white"
+      color: Theme.toolButtonColor
       text: ''
       wrapMode: Text.WordWrap
     }

--- a/src/qml/CodeReader.qml
+++ b/src/qml/CodeReader.qml
@@ -389,8 +389,8 @@ Popup {
           anchors.horizontalCenter: parent.horizontalCenter
           round: true
           iconSource: Theme.getThemeVectorIcon('ic_flashlight_white_48dp')
-          iconColor: "white"
-          bgcolor: Theme.darkGraySemiOpaque
+          iconColor: Theme.toolButtonColor
+          bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
 
           visible: settings.cameraActive && cameraLoader.active && cameraLoader.item.camera.isTorchModeSupported(Camera.TorchOn)
           state: cameraLoader.active && cameraLoader.item.camera.torchMode === Camera.TorchOn ? "On" : "Off"
@@ -399,8 +399,8 @@ Popup {
               name: "Off"
               PropertyChanges {
                 target: flashlightButton
-                iconColor: "white"
-                bgcolor: Theme.darkGraySemiOpaque
+                iconColor: Theme.toolButtonColor
+                bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
               }
             },
             State {
@@ -408,7 +408,7 @@ Popup {
               PropertyChanges {
                 target: flashlightButton
                 iconColor: Theme.mainColor
-                bgcolor: Theme.darkGray
+                bgcolor: Theme.toolButtonBackgroundColor
               }
             }
           ]
@@ -430,8 +430,8 @@ Popup {
           anchors.rightMargin: 10
           round: true
           iconSource: Theme.getThemeVectorIcon('ic_qr_code_black_24dp')
-          iconColor: "white"
-          bgcolor: Theme.darkGraySemiOpaque
+          iconColor: Theme.toolButtonColor
+          bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
 
           visible: withNfc
           state: settings.cameraActive ? "On" : "Off"
@@ -440,7 +440,7 @@ Popup {
               name: "Off"
               PropertyChanges {
                 target: cameraButton
-                bgcolor: Theme.darkGraySemiOpaque
+                bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
               }
             },
             State {
@@ -448,7 +448,7 @@ Popup {
               PropertyChanges {
                 target: cameraButton
                 iconColor: Theme.mainColor
-                bgcolor: Theme.darkGray
+                bgcolor: Theme.toolButtonBackgroundColor
               }
             }
           ]
@@ -466,8 +466,8 @@ Popup {
           anchors.leftMargin: 10
           round: true
           iconSource: Theme.getThemeVectorIcon('ic_nfc_code_black_24dp')
-          iconColor: "white"
-          bgcolor: Theme.darkGraySemiOpaque
+          iconColor: Theme.toolButtonColor
+          bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
 
           visible: withNfc
           state: settings.nearfieldActive ? "On" : "Off"
@@ -476,7 +476,7 @@ Popup {
               name: "Off"
               PropertyChanges {
                 target: nearfieldButton
-                bgcolor: Theme.darkGraySemiOpaque
+                bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
               }
             },
             State {
@@ -484,7 +484,7 @@ Popup {
               PropertyChanges {
                 target: nearfieldButton
                 iconColor: Theme.mainColor
-                bgcolor: Theme.darkGray
+                bgcolor: Theme.toolButtonBackgroundColor
               }
             }
           ]
@@ -516,7 +516,7 @@ Popup {
           opacity: enabled ? 1 : 0.2
           Layout.alignment: Qt.AlignVCenter
           iconSource: Theme.getThemeVectorIcon('ic_check_white_24dp')
-          iconColor: enabled ? "white" : Theme.mainTextColor
+          iconColor: enabled ? Theme.toolButtonColor : Theme.toolButtonBackgroundSemiOpaqueColor
           bgcolor: enabled ? Theme.mainColor : "transparent"
           round: true
 

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -87,6 +87,7 @@ Drawer {
           id: closeButton
           anchors.verticalCenter: parent.verticalCenter
           iconSource: Theme.getThemeVectorIcon('ic_arrow_left_white_24dp')
+          iconColor: Theme.mainOverlayColor
           bgcolor: "transparent"
           onClicked: close()
         }
@@ -95,6 +96,7 @@ Drawer {
           id: settingsButton
           anchors.verticalCenter: parent.verticalCenter
           iconSource: Theme.getThemeVectorIcon('ic_settings_white_24dp')
+          iconColor: Theme.mainOverlayColor
           bgcolor: "transparent"
           onClicked: showMenu()
         }
@@ -126,6 +128,13 @@ Drawer {
               }
             } else {
               return Theme.getThemeVectorIcon('ic_cloud_24dp');
+            }
+            iconColor: {
+              if (iconSource == Theme.getThemeVectorIcon('ic_cloud_24dp')) {
+                return Theme.mainOverlayColor;
+              } else {
+                return "transparent";
+              }
             }
           }
           bgcolor: "transparent"
@@ -207,7 +216,7 @@ Drawer {
             height: 36
             radius: 4
             color: Theme.mainColor
-            border.color: "white"
+            border.color: Theme.mainOverlayColor
             Image {
               width: 28
               height: 28

--- a/src/qml/DigitizingToolbar.qml
+++ b/src/qml/DigitizingToolbar.qml
@@ -133,9 +133,10 @@ QfVisibilityFadingRow {
   QfToolButton {
     id: removeVertexButton
     iconSource: Theme.getThemeVectorIcon("ic_remove_vertex_white_24dp")
+    iconColor: Theme.toolButtonColor
     visible: rubberbandModel && rubberbandModel.vertexCount > 1
     round: true
-    bgcolor: Theme.darkGray
+    bgcolor: Theme.toolButtonBackgroundColor
 
     onPressed: {
       removeVertex();
@@ -156,17 +157,17 @@ QfVisibilityFadingRow {
     enabled: !screenHovering
     bgcolor: {
       if (!enabled) {
-        Theme.darkGraySemiOpaque;
+        Theme.toolButtonBackgroundSemiOpaqueColor;
       } else if (!showConfirmButton) {
-        Theme.darkGray;
+        Theme.toolButtonBackgroundColor;
       } else if (Number(rubberbandModel ? rubberbandModel.geometryType : 0) === Qgis.GeometryType.Point || Number(rubberbandModel.geometryType) === Qgis.GeometryType.Null) {
         Theme.mainColor;
       } else {
-        Theme.darkGray;
+        Theme.toolButtonBackgroundColor;
       }
     }
     iconSource: Theme.getThemeVectorIcon("ic_add_vertex_white_24dp")
-    iconColor: enabled ? "white" : Theme.darkGraySemiOpaque
+    iconColor: enabled ? Theme.toolButtonColor : Theme.toolButtonBackgroundSemiOpaqueColor
 
     property bool lastAdditionAveraged: false
     property bool averagedPositionPressAndHeld: false

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -783,6 +783,7 @@ Page {
         clip: true
 
         iconSource: Theme.getThemeVectorIcon("ic_check_white_24dp")
+        iconColor: Theme.mainOverlayColor
         opacity: model.constraintsHardValid ? 1.0 : 0.3
 
         onClicked: {
@@ -804,7 +805,7 @@ Page {
         objectName: "titleLabel"
 
         font: Theme.strongFont
-        color: Theme.light
+        color: Theme.mainOverlayColor
 
         text: {
           const featureModel = model.featureModel;
@@ -838,6 +839,7 @@ Page {
         visible: !setupOnly
 
         iconSource: form.state === 'Add' ? Theme.getThemeVectorIcon('ic_delete_forever_white_24dp') : Theme.getThemeVectorIcon('ic_close_white_24dp')
+        iconColor: Theme.mainOverlayColor
 
         onClicked: {
           Qt.inputMethod.hide();
@@ -850,6 +852,7 @@ Page {
       }
     }
   }
+
   QfDialog {
     id: cancelDialog
     parent: mainWindow.contentItem

--- a/src/qml/GeometryEditorsToolbar.qml
+++ b/src/qml/GeometryEditorsToolbar.qml
@@ -167,7 +167,7 @@ QfVisibilityFadingRow {
   QfToolButton {
     id: activeToolButton
     iconSource: Theme.getThemeVectorIcon("ic_ellipsis_black_24dp")
-    iconColor: "white"
+    iconColor: Theme.toolButtonColor
     round: true
     visible: !selectorRow.stateVisible && !(toolbarRow.item && toolbarRow.item.stateVisible && toolbarRow.item.blocking)
     bgcolor: Theme.mainColor

--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -101,7 +101,7 @@ ListView {
             width: height
             anchors.centerIn: parent
             iconSource: Theme.getThemeVectorIcon('ic_legend_collapsed_state_24dp')
-            iconColor: isSelectedLayer ? "white" : Theme.mainTextColor
+            iconColor: isSelectedLayer ? Theme.mainOverlayColor : Theme.mainTextColor
             bgcolor: "transparent"
             visible: HasChildren
             enabled: HasChildren
@@ -147,7 +147,7 @@ ListView {
             opacity: Visible ? 1 : 0.25
             anchors.centerIn: parent
             iconSource: !Visible ? Theme.getThemeVectorIcon('ic_hide_green_48dp') : Theme.getThemeVectorIcon('ic_show_green_48dp')
-            iconColor: isSelectedLayer ? "white" : Theme.mainTextColor
+            iconColor: isSelectedLayer ? Theme.mainOverlayColor : Theme.mainTextColor
             bgcolor: "transparent"
             visible: HasSpatialExtent
             enabled: (allowActiveLayerChange || (projectInfo.activeLayer != VectorLayerPointer))
@@ -225,7 +225,7 @@ ListView {
           opacity: Visible ? 1 : 0.25
           color: {
             if (isSelectedLayer)
-              return Theme.light;
+              return Theme.mainOverlayColor;
             else if (IsValid)
               return Theme.mainTextColor;
             else

--- a/src/qml/LocatorItem.qml
+++ b/src/qml/LocatorItem.qml
@@ -303,8 +303,9 @@ Item {
     }
 
     iconSource: Theme.getThemeVectorIcon("ic_baseline_search_white")
-    round: true
+    iconColor: Theme.mainOverlayColor
     bgcolor: Theme.mainColor
+    round: true
 
     onClicked: {
       locatorItem.state = locatorItem.state == "off" ? "on" : "off";

--- a/src/qml/LocatorItem.qml
+++ b/src/qml/LocatorItem.qml
@@ -478,7 +478,7 @@ Item {
             text: isFilterName ? ResultFilterName : typeof (model.Text) == 'string' ? model.Text.trim() : ''
             font.bold: false
             font.pointSize: Theme.resultFont.pointSize
-            color: isFilterName ? "white" : Theme.mainTextColor
+            color: isFilterName ? Theme.mainOverlayColor : Theme.mainTextColor
             elide: Text.ElideRight
             horizontalAlignment: isGroup ? Text.AlignHCenter : Text.AlignLeft
           }

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -98,7 +98,7 @@ Rectangle {
       // Insure that the text is always visually centered by using the same left and right margi
       property double balancedMargin: Math.max((saveButton.visible ? saveButton.width : 0) + (previousButton.visible ? previousButton.width : 0) + (nextButton.visible ? nextButton.width : 0) + (multiClearButton.visible ? multiClearButton.width : 0), (cancelButton.visible ? cancelButton.width : 0) + (editButton.visible ? editButton.width : 0) + (editGeomButton.visible ? editGeomButton.width : 0) + (multiEditButton.visible ? multiEditButton.width : 0) + (menuButton.visible ? menuButton.width : 0))
       font: Theme.strongFont
-      color: Theme.light
+      color: Theme.mainOverlayColor
       anchors.left: parent.left
       anchors.right: parent.right
       anchors.top: parent.top
@@ -185,6 +185,7 @@ Rectangle {
     clip: true
 
     iconSource: Theme.getThemeVectorIcon("ic_chevron_right_white_24dp")
+    iconColor: Theme.mainOverlayColor
 
     enabled: (toolBar.state == "Navigation")
 
@@ -217,6 +218,7 @@ Rectangle {
     clip: true
 
     iconSource: toolBar.state == "Navigation" ? Theme.getThemeVectorIcon("ic_chevron_left_white_24dp") : Theme.getThemeVectorIcon("ic_arrow_left_white_24dp")
+    iconColor: Theme.mainOverlayColor
 
     enabled: toolBar.state != "Edit" && !toolBar.multiSelection
 
@@ -249,6 +251,8 @@ Rectangle {
     clip: true
 
     iconSource: Theme.getThemeVectorIcon("ic_check_white_24dp")
+    iconColor: Theme.mainOverlayColor
+
     opacity: featureForm.model.constraintsHardValid ? 1.0 : 0.3
     onClicked: {
       if (toolBar.state == "ProcessingLaunch") {
@@ -281,6 +285,7 @@ Rectangle {
     clip: true
 
     iconSource: Theme.getThemeVectorIcon("ic_clear_white_24dp")
+    iconColor: Theme.mainOverlayColor
 
     onClicked: {
       toolBar.cancel();
@@ -305,6 +310,7 @@ Rectangle {
     anchors.topMargin: toolBar.topMargin
 
     iconSource: Theme.getThemeVectorIcon("ic_edit_geometry_white_24dp")
+    iconColor: Theme.mainOverlayColor
 
     width: visible ? 48 : 0
     height: 48
@@ -346,6 +352,7 @@ Rectangle {
     clip: true
 
     iconSource: Theme.getThemeVectorIcon("ic_edit_attributes_white_24dp")
+    iconColor: Theme.mainOverlayColor
 
     onClicked: {
       toolBar.editAttributesButtonClicked();
@@ -386,7 +393,7 @@ Rectangle {
     clip: true
 
     iconSource: Theme.getThemeVectorIcon("ic_dot_menu_black_24dp")
-    iconColor: "white"
+    iconColor: Theme.mainOverlayColor
 
     onClicked: {
       if (toolBar.state == "Indication") {
@@ -416,6 +423,7 @@ Rectangle {
     clip: true
 
     iconSource: Theme.getThemeVectorIcon("ic_clear_white_24dp")
+    iconColor: Theme.mainOverlayColor
 
     enabled: (toolBar.multiSelection && toolBar.model)
 
@@ -440,7 +448,7 @@ Rectangle {
     height: 48
     verticalAlignment: Text.AlignVCenter
     font: Theme.strongFont
-    color: Theme.light
+    color: Theme.mainOverlayColor
 
     text: model.selectedFeatures.length < 100 ? model.selectedFeatures.length : '99+'
 
@@ -460,6 +468,7 @@ Rectangle {
     clip: true
 
     iconSource: Theme.getThemeVectorIcon("ic_edit_attributes_white_24dp")
+    iconColor: Theme.mainOverlayColor
 
     enabled: toolBar.model && toolBar.model.canEditAttributesSelection && toolBar.model.selectedCount > 1 && projectInfo.editRights
 

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -773,7 +773,7 @@ Rectangle {
       text: qsTr('Rotate Feature')
       icon.source: Theme.getThemeVectorIcon("ic_rotate_white_24dp")
       // allow only rotation for line or polygon or multipoint
-      enabled: ((projectInfo.editRights || editButton.isCreatedCloudFeature) && (!selection.focusedLayer || !featureForm.model.featureModel.geometryLocked)) && (selection.focusedLayer.geometryType() == 0 || selection.focusedLayer.geometryType() == 1 || selection.focusedLayer.geometryType() == 2)
+      enabled: ((projectInfo.editRights || editButton.isCreatedCloudFeature) && (!selection.focusedLayer || !featureForm.model.featureModel.geometryLocked)) && (selection.focusedLayer !== null && (selection.focusedLayer.geometryType() === 0 || selection.focusedLayer.geometryType() === 1 || selection.focusedLayer.geometryType() === 2))
       visible: enabled
 
       font: Theme.defaultFont

--- a/src/qml/QFieldAudioRecorder.qml
+++ b/src/qml/QFieldAudioRecorder.qml
@@ -291,7 +291,7 @@ Popup {
           opacity: enabled ? 1 : 0.2
           Layout.alignment: Qt.AlignVCenter
           iconSource: Theme.getThemeVectorIcon('ic_check_white_24dp')
-          iconColor: enabled ? "white" : Theme.mainTextColor
+          iconColor: enabled ? Theme.toolButtonColor : Theme.toolButtonBackgroundSemiOpaqueColor
           bgcolor: enabled ? Theme.mainColor : "transparent"
           round: true
 

--- a/src/qml/QFieldCamera.qml
+++ b/src/qml/QFieldCamera.qml
@@ -368,6 +368,7 @@ Popup {
               round: true
               roundborder: true
               iconSource: cameraItem.state == "PhotoPreview" || cameraItem.state == "VideoPreview" ? Theme.getThemeVectorIcon("ic_check_white_24dp") : ''
+              iconColor: Theme.toolButtonColor
               bgcolor: cameraItem.state == "PhotoPreview" || cameraItem.state == "VideoPreview" ? Theme.mainColor : cameraItem.state == "VideoCapture" ? "red" : "white"
 
               onClicked: {
@@ -413,8 +414,8 @@ Popup {
             x: cameraItem.isPortraitMode ? (parent.width / 4) - (width / 2) : (parent.width - width) / 2
             y: cameraItem.isPortraitMode ? (parent.height - height) / 2 : (parent.height / 4) * 3 - (height / 2)
 
-            iconColor: "white"
-            bgcolor: Theme.darkGraySemiOpaque
+            iconColor: Theme.toolButtonColor
+            bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
             round: true
 
             text: camera.zoomFactor.toFixed(1) + 'X'
@@ -444,8 +445,8 @@ Popup {
                 return '';
               }
             }
-            iconColor: "white"
-            bgcolor: Qt.hsla(Theme.darkGray.hslHue, Theme.darkGray.hslSaturation, Theme.darkGray.hslLightness, 0.5)
+            iconColor: Theme.toolButtonColor
+            bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
             round: true
 
             onClicked: {
@@ -485,7 +486,7 @@ Popup {
                   return '00:00:01';
                 }
               }
-              color: 'white'
+              color: "white"
             }
 
             FontMetrics {
@@ -506,8 +507,8 @@ Popup {
       anchors.topMargin: mainWindow.sceneTopMargin + 4
 
       iconSource: Theme.getThemeVectorIcon("ic_chevron_left_white_24dp")
-      iconColor: "white"
-      bgcolor: Qt.hsla(Theme.darkGray.hslHue, Theme.darkGray.hslSaturation, Theme.darkGray.hslLightness, 0.5)
+      iconColor: Theme.toolButtonColor
+      bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
       round: true
 
       onClicked: {
@@ -534,8 +535,8 @@ Popup {
       anchors.topMargin: 4
 
       iconSource: Theme.getThemeVectorIcon("ic_camera_settings_black_24dp")
-      iconColor: "white"
-      bgcolor: Theme.darkGraySemiOpaque
+      iconColor: Theme.toolButtonColor
+      bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
       spacing: 4
       collapsed: false
 
@@ -548,8 +549,8 @@ Popup {
         padding: 2
 
         iconSource: Theme.getThemeVectorIcon("ic_camera_switch_black_24dp")
-        iconColor: "white"
-        bgcolor: Theme.darkGraySemiOpaque
+        iconColor: Theme.toolButtonColor
+        bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
         round: true
 
         onClicked: {
@@ -566,8 +567,8 @@ Popup {
         padding: 2
 
         iconSource: Theme.getThemeVectorIcon("ic_camera_resolution_black_24dp")
-        iconColor: "white"
-        bgcolor: Theme.darkGraySemiOpaque
+        iconColor: Theme.toolButtonColor
+        bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
         round: true
 
         onClicked: {
@@ -583,8 +584,8 @@ Popup {
         padding: 2
 
         iconSource: Theme.getThemeVectorIcon("ic_text_black_24dp")
-        iconColor: cameraSettings.stamping ? Theme.mainColor : "white"
-        bgcolor: Theme.darkGraySemiOpaque
+        iconColor: cameraSettings.stamping ? Theme.mainColor : Theme.toolButtonColor
+        bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
         round: true
 
         onClicked: {
@@ -601,8 +602,8 @@ Popup {
         padding: 2
 
         iconSource: positionSource.active ? Theme.getThemeVectorIcon("ic_geotag_white_24dp") : Theme.getThemeVectorIcon("ic_geotag_missing_white_24dp")
-        iconColor: cameraSettings.geoTagging ? Theme.mainColor : "white"
-        bgcolor: Theme.darkGraySemiOpaque
+        iconColor: cameraSettings.geoTagging ? Theme.mainColor : Theme.toolButtonColor
+        bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
         round: true
 
         onClicked: {
@@ -619,8 +620,8 @@ Popup {
         padding: 2
 
         iconSource: Theme.getThemeVectorIcon("ic_3x3_grid_white_24dp")
-        iconColor: cameraSettings.showGrid ? Theme.mainColor : "white"
-        bgcolor: Theme.darkGraySemiOpaque
+        iconColor: cameraSettings.showGrid ? Theme.mainColor : Theme.toolButtonColor
+        bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
         round: true
 
         onClicked: {

--- a/src/qml/QFieldSketcher.qml
+++ b/src/qml/QFieldSketcher.qml
@@ -287,8 +287,8 @@ Popup {
       anchors.topMargin: mainWindow.sceneTopMargin + 5
 
       iconSource: Theme.getThemeVectorIcon("ic_chevron_left_white_24dp")
-      iconColor: "white"
-      bgcolor: Theme.darkGraySemiOpaque
+      iconColor: Theme.toolButtonColor
+      bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
       round: true
 
       onClicked: {
@@ -307,8 +307,8 @@ Popup {
       anchors.topMargin: mainWindow.sceneTopMargin + 5
 
       iconSource: Theme.getThemeVectorIcon("ic_undo_black_24dp")
-      iconColor: "white"
-      bgcolor: Theme.darkGraySemiOpaque
+      iconColor: Theme.toolButtonColor
+      bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
       round: true
 
       onClicked: {
@@ -326,8 +326,8 @@ Popup {
       anchors.topMargin: mainWindow.sceneTopMargin + 5
 
       iconSource: Theme.getThemeVectorIcon("ic_check_white_24dp")
-      iconColor: "white"
-      bgcolor: drawingCanvas.isDirty ? Theme.mainColor : Theme.darkGraySemiOpaque
+      iconColor: Theme.toolButtonColor
+      bgcolor: drawingCanvas.isDirty ? Theme.mainColor : Theme.toolButtonBackgroundSemiOpaqueColor
       round: true
 
       onClicked: {

--- a/src/qml/ScaleBar.qml
+++ b/src/qml/ScaleBar.qml
@@ -26,9 +26,9 @@ Item {
     anchors.horizontalCenter: bar.horizontalCenter
     anchors.left: undefined
     font: Theme.defaultFont
-    color: Theme.darkGray
+    color: Theme.toolButtonBackgroundColor
     style: Text.Outline
-    styleColor: "#CCFFFFFF"
+    styleColor: Qt.hsla(Theme.toolButtonColor.hslHue, Theme.toolButtonColor.hslSaturation, Theme.toolButtonColor.hslLightness, 0.8)
 
     states: State {
       name: "narrow"
@@ -52,7 +52,7 @@ Item {
 
     ShapePath {
       strokeWidth: barLine.strokeWidth + 1.5
-      strokeColor: "#CCFFFFFF"
+      strokeColor: Qt.hsla(Theme.toolButtonColor.hslHue, Theme.toolButtonColor.hslSaturation, Theme.toolButtonColor.hslLightness, 0.8)
       fillColor: "transparent"
       startX: 0
       startY: 0
@@ -74,7 +74,7 @@ Item {
     ShapePath {
       id: barLine
       strokeWidth: scaleBar.lineWidth
-      strokeColor: "#000000"
+      strokeColor: Theme.toolButtonBackgroundColor
       fillColor: "transparent"
       startX: 0
       startY: 0

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -114,11 +114,11 @@ Page {
             gradient: Gradient {
               GradientStop {
                 position: 0.0
-                color: "#4480cc28"
+                color: Qt.hsla(Theme.mainColor.hslHue, Theme.mainColor.hslSaturation, Theme.mainColor.hslLightness, 0.26)
               }
               GradientStop {
                 position: 0.88
-                color: "#0580cc28"
+                color: Qt.hsla(Theme.mainColor.hslHue, Theme.mainColor.hslSaturation, Theme.mainColor.hslLightness, 0.02)
               }
             }
 
@@ -167,11 +167,11 @@ Page {
             gradient: Gradient {
               GradientStop {
                 position: 0.0
-                color: "#4480cc28"
+                color: Qt.hsla(Theme.mainColor.hslHue, Theme.mainColor.hslSaturation, Theme.mainColor.hslLightness, 0.26)
               }
               GradientStop {
                 position: 0.88
-                color: "#0580cc28"
+                color: Qt.hsla(Theme.mainColor.hslHue, Theme.mainColor.hslSaturation, Theme.mainColor.hslLightness, 0.02)
               }
             }
 
@@ -198,6 +198,7 @@ Page {
               Layout.bottomMargin: 10
               QfToolButton {
                 iconSource: Theme.getThemeVectorIcon('ic_dissatisfied_white_24dp')
+                iconColor: Theme.mainOverlayColor
                 bgcolor: Theme.mainColor
                 round: true
 
@@ -207,6 +208,7 @@ Page {
               }
               QfToolButton {
                 iconSource: Theme.getThemeVectorIcon('ic_satisfied_white_24dp')
+                iconColor: Theme.mainOverlayColor
                 bgcolor: Theme.mainColor
                 round: true
 
@@ -229,11 +231,11 @@ Page {
             gradient: Gradient {
               GradientStop {
                 position: 0.0
-                color: "#4480cc28"
+                color: Qt.hsla(Theme.mainColor.hslHue, Theme.mainColor.hslSaturation, Theme.mainColor.hslLightness, 0.26)
               }
               GradientStop {
                 position: 0.88
-                color: "#0580cc28"
+                color: Qt.hsla(Theme.mainColor.hslHue, Theme.mainColor.hslSaturation, Theme.mainColor.hslLightness, 0.02)
               }
             }
 
@@ -311,11 +313,11 @@ Page {
             gradient: Gradient {
               GradientStop {
                 position: 0.0
-                color: "#4480cc28"
+                color: Qt.hsla(Theme.mainColor.hslHue, Theme.mainColor.hslSaturation, Theme.mainColor.hslLightness, 0.26)
               }
               GradientStop {
                 position: 0.88
-                color: "#0580cc28"
+                color: Qt.hsla(Theme.mainColor.hslHue, Theme.mainColor.hslSaturation, Theme.mainColor.hslLightness, 0.02)
               }
             }
 
@@ -346,11 +348,11 @@ Page {
             gradient: Gradient {
               GradientStop {
                 position: 0.0
-                color: "#4480cc28"
+                color: Qt.hsla(Theme.mainColor.hslHue, Theme.mainColor.hslSaturation, Theme.mainColor.hslLightness, 0.26)
               }
               GradientStop {
                 position: 0.88
-                color: "#0580cc28"
+                color: Qt.hsla(Theme.mainColor.hslHue, Theme.mainColor.hslSaturation, Theme.mainColor.hslLightness, 0.02)
               }
             }
 

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -327,8 +327,8 @@ EditorWidgetBase {
 
       round: true
       iconSource: Theme.getThemeVectorIcon("ic_freehand_white_24dp")
-      iconColor: "white"
-      bgcolor: Theme.darkGraySemiOpaque
+      iconColor: Theme.toolButtonColor
+      bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
 
       onClicked: {
         sketcherConnection.enabled = true;

--- a/src/qml/geometryeditors/Erase.qml
+++ b/src/qml/geometryeditors/Erase.qml
@@ -114,10 +114,10 @@ QfVisibilityFadingRow {
     property int sizeLarge: 12
 
     iconSource: eraseToolbar.size == sizeSmall ? Theme.getThemeVectorIcon("ic_size_small_white_24dp") : eraseToolbar.size == sizeMedium ? Theme.getThemeVectorIcon("ic_size_medium_white_24dp") : Theme.getThemeVectorIcon("ic_size_large_white_24dp")
-    iconColor: "white"
+    iconColor: Theme.toolButtonColor
     round: true
     visible: true
-    bgcolor: Theme.darkGray
+    bgcolor: Theme.toolButtonBackgroundColor
 
     onClicked: {
       if (eraseToolbar.size == sizeSmall) {

--- a/src/qml/geometryeditors/VertexEditor.qml
+++ b/src/qml/geometryeditors/VertexEditor.qml
@@ -63,10 +63,10 @@ QfVisibilityFadingRow {
   QfToolButton {
     id: undoButton
     iconSource: Theme.getThemeVectorIcon("ic_undo_black_24dp")
-    iconColor: "white"
+    iconColor: Theme.toolButtonColor
     round: true
     visible: featureModel && featureModel.vertexModel.canUndo
-    bgcolor: Theme.darkGray
+    bgcolor: Theme.toolButtonBackgroundColor
     onClicked: {
       featureModel.vertexModel.undoHistory();
       mapSettings.setCenter(featureModel.vertexModel.currentPoint, true);
@@ -78,7 +78,7 @@ QfVisibilityFadingRow {
     iconSource: Theme.getThemeVectorIcon("ic_clear_white_24dp")
     round: true
     visible: featureModel && featureModel.vertexModel.dirty && !qfieldSettings.autoSave
-    bgcolor: "#900000"
+    bgcolor: Theme.darkRed
     onClicked: {
       digitizingLogger.clearCoordinates();
       cancel();
@@ -89,9 +89,10 @@ QfVisibilityFadingRow {
   QfToolButton {
     id: applyButton
     iconSource: Theme.getThemeVectorIcon("ic_check_white_24dp")
+    iconColor: Theme.toolButtonColor
     round: true
     visible: featureModel && featureModel.vertexModel.dirty
-    bgcolor: !qfieldSettings.autoSave ? Theme.mainColor : Theme.darkGray
+    bgcolor: !qfieldSettings.autoSave ? Theme.mainColor : Theme.toolButtonBackgroundColor
 
     onClicked: {
       if (vertexEditorToolbar.currentVertexModified)
@@ -105,9 +106,10 @@ QfVisibilityFadingRow {
   QfToolButton {
     id: removeVertexButton
     iconSource: Theme.getThemeVectorIcon("ic_remove_vertex_white_24dp")
+    iconColor: Theme.toolButtonColor
     round: true
     visible: featureModel && featureModel.vertexModel.canRemoveVertex
-    bgcolor: Theme.darkGray
+    bgcolor: Theme.toolButtonBackgroundColor
 
     onClicked: {
       if (featureModel.vertexModel.canRemoveVertex) {
@@ -126,7 +128,7 @@ QfVisibilityFadingRow {
     enabled: !screenHovering && featureModel && featureModel.vertexModel.canAddVertex && featureModel.vertexModel.editingMode !== VertexModel.AddVertex
     bgcolor: enabled ? Theme.darkGray : Theme.darkGraySemiOpaque
     iconSource: Theme.getThemeVectorIcon("ic_add_vertex_white_24dp")
-    iconColor: enabled ? "white" : Theme.darkGraySemiOpaque
+    iconColor: enabled ? Theme.toolButtonColor : Theme.toolButtonBackgroundSemiOpaqueColor
 
     onClicked: {
       applyChanges(qfieldSettings.autoSave);
@@ -148,9 +150,9 @@ QfVisibilityFadingRow {
     round: true
     enabled: !screenHovering
     visible: featureModel && (featureModel.vertexModel.canAddVertex || featureModel.vertexModel.editingMode === VertexModel.AddVertex)
-    bgcolor: enabled && featureModel && featureModel.vertexModel.canPreviousVertex ? Theme.darkGray : Theme.darkGraySemiOpaque
+    bgcolor: enabled && featureModel && featureModel.vertexModel.canPreviousVertex ? Theme.toolButtonBackgroundColor : Theme.toolButtonBackgroundSemiOpaqueColor
     iconSource: Theme.getThemeVectorIcon("ic_chevron_left_white_24dp")
-    iconColor: enabled && featureModel && featureModel.vertexModel.canNextVertex ? "white" : Theme.darkGraySemiOpaque
+    iconColor: enabled && featureModel && featureModel.vertexModel.canNextVertex ? Theme.toolButtonColor : Theme.toolButtonBackgroundSemiOpaqueColor
 
     onClicked: {
       if (vertexEditorToolbar.currentVertexModified) {
@@ -168,7 +170,7 @@ QfVisibilityFadingRow {
     visible: featureModel && (featureModel.vertexModel.canAddVertex || featureModel.vertexModel.editingMode === VertexModel.AddVertex)
     bgcolor: enabled && featureModel && featureModel.vertexModel.canNextVertex ? Theme.darkGray : Theme.darkGraySemiOpaque
     iconSource: Theme.getThemeVectorIcon("ic_chevron_right_white_24dp")
-    iconColor: enabled && featureModel && featureModel.vertexModel.canNextVertex ? "white" : Theme.darkGraySemiOpaque
+    iconColor: enabled && featureModel && featureModel.vertexModel.canNextVertex ? Theme.toolButtonColor : Theme.toolButtonBackgroundSemiOpaqueColor
 
     onClicked: {
       if (vertexEditorToolbar.currentVertexModified) {

--- a/src/qml/imports/Theme/QfButton.qml
+++ b/src/qml/imports/Theme/QfButton.qml
@@ -8,7 +8,7 @@ Button {
   id: button
 
   property color bgcolor: Theme.mainColor
-  property color color: button.enabled ? Theme.controlBackgroundColor : Theme.mainTextDisabledColor
+  property color color: button.enabled ? Theme.buttonTextColor : Theme.mainTextDisabledColor
   property alias radius: backgroundRectangle.radius
   property alias borderColor: backgroundRectangle.border.color
   property bool dropdown: false

--- a/src/qml/imports/Theme/QfCalendarPanel.qml
+++ b/src/qml/imports/Theme/QfCalendarPanel.qml
@@ -252,7 +252,7 @@ Popup {
               font.pointSize: Theme.tipFont.pointSize
               font.bold: parent.isSelectedDate ? true : false
               font.underline: parent.isNow ? true : false
-              color: parent.isSelectedDate ? "white" : Theme.mainTextColor
+              color: parent.isSelectedDate ? Theme.mainOverlayColor : Theme.mainTextColor
             }
           }
 

--- a/src/qml/imports/Theme/QfCloseButton.qml
+++ b/src/qml/imports/Theme/QfCloseButton.qml
@@ -18,7 +18,7 @@ ToolButton {
   background: Rectangle {
     width: parent.width
     height: 48
-    color: '#80000000'
+    color: Theme.toolButtonBackgroundSemiOpaqueColor
     radius: height / 2
 
     QfToolButton {
@@ -29,8 +29,8 @@ ToolButton {
       enabled: false
       round: true
       iconSource: button.toolImage
-      iconColor: "white"
-      bgcolor: Theme.darkGray
+      iconColor: Theme.toolButtonColor
+      bgcolor: Theme.toolButtonBackgroundColor
     }
 
     Ripple {
@@ -57,7 +57,7 @@ ToolButton {
       anchors.verticalCenter: parent.verticalCenter
       verticalAlignment: Text.AlignVCenter
       text: button.toolText
-      color: Theme.light
+      color: Theme.toolButtonColor
       font: Theme.strongFont
     }
 

--- a/src/qml/imports/Theme/QfPageHeader.qml
+++ b/src/qml/imports/Theme/QfPageHeader.qml
@@ -106,7 +106,7 @@ ToolBar {
       Layout.alignment: Qt.AlignTop | Qt.AlignLeft
       clip: true
       iconSource: Theme.getThemeVectorIcon('ic_arrow_left_white_24dp')
-      iconColor: backgroundFill ? Theme.light : Theme.mainTextColor
+      iconColor: backgroundFill ? Theme.mainOverlayColor : Theme.mainTextColor
 
       onClicked: {
         back();
@@ -120,7 +120,7 @@ ToolBar {
       Layout.alignment: Qt.AlignTop | Qt.AlignLeft
       clip: true
       iconSource: Theme.getThemeVectorIcon('ic_check_white_24dp')
-      iconColor: backgroundFill ? Theme.light : Theme.mainTextColor
+      iconColor: backgroundFill ? Theme.mainOverlayColor : Theme.mainTextColor
 
       onClicked: {
         apply();
@@ -133,7 +133,7 @@ ToolBar {
       leftPadding: !showApplyButton && showCancelButton ? 48 : 0
       rightPadding: (showApplyButton || showBackButton) && !showCancelButton ? 48 : 0
       font: Theme.strongFont
-      color: backgroundFill ? Theme.light : Theme.mainColor
+      color: backgroundFill ? Theme.mainOverlayColor : Theme.mainColor
       elide: Label.ElideRight
       horizontalAlignment: Qt.AlignHCenter
       verticalAlignment: Qt.AlignVCenter
@@ -146,7 +146,7 @@ ToolBar {
       Layout.alignment: Qt.AlignTop | Qt.AlignRight
       clip: true
       iconSource: Theme.getThemeVectorIcon('ic_close_white_24dp')
-      iconColor: backgroundFill ? Theme.light : Theme.mainTextColor
+      iconColor: backgroundFill ? Theme.mainOverlayColor : Theme.mainTextColor
 
       onClicked: {
         cancel();

--- a/src/qml/imports/Theme/Theme.qml
+++ b/src/qml/imports/Theme/Theme.qml
@@ -5,66 +5,70 @@ import QtQuick.Controls.Material
 QtObject {
   property bool darkTheme: false
 
+  property color mainColor: "#80cc28"
+
   property color mainBackgroundColor: darkTheme ? "#303030" : "#fafafa"
   property color mainBackgroundColorSemiOpaque: darkTheme ? "#bb303030" : "#bbfafafa"
 
   property color mainTextColor: darkTheme ? "#EEEEEE" : "#000000"
-  readonly property color mainTextDisabledColor: darkTheme ? "#73EEEEEE" : "#73000000"
-  readonly property color mainColor: "#80cc28"
+  property color mainTextDisabledColor: darkTheme ? "#73EEEEEE" : "#73000000"
+  property color secondaryTextColor: darkTheme ? "#AAAAAA" : "#999999"
 
-  readonly property color secondaryTextColor: darkTheme ? "#AAAAAA" : "#999999"
+  property color controlBackgroundColor: darkTheme ? "#202020" : "#ffffff"
+  property color controlBackgroundAlternateColor: darkTheme ? "#202020" : "#e6e6e6" // used by feature form editor widgets
+  property color controlBackgroundDisabledColor: "#33555555"
+  property color controlBorderColor: darkTheme ? "#404040" : "#e6e6e6"
 
-  readonly property color controlBackgroundColor: darkTheme ? "#202020" : "#ffffff"
-  readonly property color controlBackgroundAlternateColor: darkTheme ? "#202020" : "#e6e6e6" // used by feature form editor widgets
-  readonly property color controlBackgroundDisabledColor: "#33555555"
-  readonly property color controlBorderColor: darkTheme ? "#404040" : "#e6e6e6"
+  property color toolButtonColor: "#ffffff"
+  property color toolButtonBackgroundColor: darkGray
+  property color toolButtonBackgroundSemiOpaqueColor: darkGraySemiOpaque
 
-  readonly property color darkRed: "#c0392b"
-  readonly property color darkGray: "#212121"
-  readonly property color darkGraySemiOpaque: "#4D212121"
-  readonly property color gray: "#888888"
-  readonly property color lightGray: "#dddddd"
-  readonly property color lightestGray: "#eeeeee"
-  readonly property color light: "#ffffff"
-  readonly property color hyperlinkBlue: '#0000EE'
+  property color darkRed: "#c0392b"
+  property color darkGray: "#212121"
+  property color darkGraySemiOpaque: "#4D212121"
+  property color gray: "#888888"
+  property color lightGray: "#dddddd"
+  property color lightestGray: "#eeeeee"
+  property color light: "#ffffff"
+  property color hyperlinkBlue: '#0000EE'
 
-  readonly property color errorColor: darkTheme ? "#df3422" : "#c0392b"
-  readonly property color warningColor: "orange"
-  readonly property color cloudColor: "#4c6dac"
+  property color errorColor: darkTheme ? "#df3422" : "#c0392b"
+  property color warningColor: "orange"
+  property color cloudColor: "#4c6dac"
 
-  readonly property color positionColor: "#64b5f6"
-  readonly property color positionColorSemiOpaque: "#3364b5f6"
-  readonly property color positionBackgroundColor: "#3364b5f6"
-  readonly property color darkPositionColor: "#2374b5"
-  readonly property color darkPositionColorSemiOpaque: "#882374b5"
+  property color positionColor: "#64b5f6"
+  property color positionColorSemiOpaque: "#3364b5f6"
+  property color positionBackgroundColor: "#3364b5f6"
+  property color darkPositionColor: "#2374b5"
+  property color darkPositionColorSemiOpaque: "#882374b5"
 
-  readonly property color accuracyBad: "#c0392b"
-  readonly property color accuracyTolerated: "orange"
-  readonly property color accuracyExcellent: "#80cc28"
+  property color accuracyBad: "#c0392b"
+  property color accuracyTolerated: "orange"
+  property color accuracyExcellent: "#80cc28"
 
-  readonly property color navigationColor: "#984ea3"
-  readonly property color navigationColorSemiOpaque: "#99984ea3"
-  readonly property color navigationBackgroundColor: "#33984ea3"
+  property color navigationColor: "#984ea3"
+  property color navigationColorSemiOpaque: "#99984ea3"
+  property color navigationBackgroundColor: "#33984ea3"
 
-  readonly property color sensorBackgroundColor: "#33999999"
+  property color sensorBackgroundColor: "#33999999"
 
-  readonly property color bookmarkDefault: "#80cc28"
-  readonly property color bookmarkOrange: "orange"
-  readonly property color bookmarkRed: "#c0392b"
-  readonly property color bookmarkBlue: "#64b5f6"
+  property color bookmarkDefault: "#80cc28"
+  property color bookmarkOrange: "orange"
+  property color bookmarkRed: "#c0392b"
+  property color bookmarkBlue: "#64b5f6"
 
-  readonly property color vertexColor: "#FF0000"
-  readonly property color vertexColorSemiOpaque: "#40FF0000"
-  readonly property color vertexSelectedColor: "#0000FF"
-  readonly property color vertexSelectedColorSemiOpaque: "#200000FF"
-  readonly property color vertexNewColor: "#4CAF50"
-  readonly property color vertexNewColorSemiOpaque: "#404CAF50"
+  property color vertexColor: "#FF0000"
+  property color vertexColorSemiOpaque: "#40FF0000"
+  property color vertexSelectedColor: "#0000FF"
+  property color vertexSelectedColorSemiOpaque: "#200000FF"
+  property color vertexNewColor: "#4CAF50"
+  property color vertexNewColorSemiOpaque: "#404CAF50"
 
-  readonly property color processingPreview: '#99000000'
-  readonly property color scrollBarBackgroundColor: darkTheme ? mainBackgroundColorSemiOpaque : "#aaffffff"
+  property color processingPreview: '#99000000'
+  property color scrollBarBackgroundColor: darkTheme ? mainBackgroundColorSemiOpaque : "#aaffffff"
 
-  readonly property color accentColor: '#4CAF50'
-  readonly property color accentLightColor: '#994CAF50'
+  property color accentColor: '#4CAF50'
+  property color accentLightColor: '#994CAF50'
 
   property real fontScale: 1.0
 

--- a/src/qml/imports/Theme/Theme.qml
+++ b/src/qml/imports/Theme/Theme.qml
@@ -3,28 +3,76 @@ import QtQuick
 import QtQuick.Controls.Material
 
 QtObject {
+  id: object
+
+  property var darkThemeColors: {
+    "mainColor": "#80cc28",
+    "mainOverlayColor": "#ffffff",
+    "accentColor": "#4CAF50",
+    "accentLightColor": "#994CAF50",
+    "mainBackgroundColor": "#303030",
+    "mainBackgroundColorSemiOpaque": "#bb303030",
+    "mainTextColor": "#EEEEEE",
+    "mainTextDisabledColor": "#73EEEEEE",
+    "secondaryTextColor": "#AAAAAA",
+    "controlBackgroundColor": "#202020",
+    "controlBackgroundAlternateColor": "#202020",
+    "controlBackgroundDisabledColor": "#33555555",
+    "controlBorderColor": "#404040",
+    "buttonTextColor": "#202020",
+    "toolButtonColor": "#ffffff",
+    "toolButtonBackgroundColor": Theme.darkGray,
+    "toolButtonBackgroundSemiOpaqueColor": Theme.darkGraySemiOpaque,
+    "scrollBarBackgroundColor": "#bb303030"
+  }
+
+  property var lightThemeColors: {
+    "mainColor": "#80cc28",
+    "mainOverlayColor": "#ffffff",
+    "accentColor": "#4CAF50",
+    "accentLightColor": "#994CAF50",
+    "mainBackgroundColor": "#fafafa",
+    "mainBackgroundColorSemiOpaque": "#bbfafafa",
+    "mainTextColor": "#000000",
+    "mainTextDisabledColor": "#73000000",
+    "secondaryTextColor": "#999999",
+    "controlBackgroundColor": "#ffffff",
+    "controlBackgroundAlternateColor": "#e6e6e6",
+    "controlBackgroundDisabledColor": "#33555555",
+    "controlBorderColor": "#e6e6e6",
+    "buttonTextColor": "#ffffff",
+    "toolButtonColor": "#ffffff",
+    "toolButtonBackgroundColor": Theme.darkGray,
+    "toolButtonBackgroundSemiOpaqueColor": Theme.darkGraySemiOpaque,
+    "scrollBarBackgroundColor": "#aaffffff"
+  }
+
   property bool darkTheme: false
 
   property color mainColor: "#80cc28"
   property color mainOverlayColor: "#ffffff"
+  property color accentColor: "#4CAF50"
+  property color accentLightColor: "#994CAF50"
 
-  property color mainBackgroundColor: darkTheme ? "#303030" : "#fafafa"
-  property color mainBackgroundColorSemiOpaque: darkTheme ? "#bb303030" : "#bbfafafa"
+  property color mainBackgroundColor: "#fafafa"
+  property color mainBackgroundColorSemiOpaque: "#bbfafafa"
+  property color mainTextColor: "#000000"
+  property color mainTextDisabledColor: "#73000000"
 
-  property color mainTextColor: darkTheme ? "#EEEEEE" : "#000000"
-  property color mainTextDisabledColor: darkTheme ? "#73EEEEEE" : "#73000000"
-  property color secondaryTextColor: darkTheme ? "#AAAAAA" : "#999999"
+  property color secondaryTextColor: "#999999"
 
-  property color controlBackgroundColor: darkTheme ? "#202020" : "#ffffff"
-  property color controlBackgroundAlternateColor: darkTheme ? "#202020" : "#e6e6e6" // used by feature form editor widgets
+  property color controlBackgroundColor: "#ffffff"
+  property color controlBackgroundAlternateColor: "#e6e6e6"
   property color controlBackgroundDisabledColor: "#33555555"
-  property color controlBorderColor: darkTheme ? "#404040" : "#e6e6e6"
+  property color controlBorderColor: "#e6e6e6"
 
-  property color buttonTextColor: darkTheme ? "#202020" : "#ffffff"
+  property color buttonTextColor: "#ffffff"
 
   property color toolButtonColor: "#ffffff"
-  property color toolButtonBackgroundColor: darkGray
-  property color toolButtonBackgroundSemiOpaqueColor: darkGraySemiOpaque
+  property color toolButtonBackgroundColor: Theme.darkGray
+  property color toolButtonBackgroundSemiOpaqueColor: Theme.darkGraySemiOpaque
+
+  property color scrollBarBackgroundColor: "#aaffffff"
 
   property color darkRed: "#c0392b"
   property color darkGray: "#212121"
@@ -33,7 +81,6 @@ QtObject {
   property color lightGray: "#dddddd"
   property color lightestGray: "#eeeeee"
   property color light: "#ffffff"
-  property color hyperlinkBlue: '#0000EE'
 
   property color errorColor: darkTheme ? "#df3422" : "#c0392b"
   property color warningColor: "orange"
@@ -68,10 +115,6 @@ QtObject {
   property color vertexNewColorSemiOpaque: "#404CAF50"
 
   property color processingPreview: '#99000000'
-  property color scrollBarBackgroundColor: darkTheme ? mainBackgroundColorSemiOpaque : "#aaffffff"
-
-  property color accentColor: '#4CAF50'
-  property color accentLightColor: '#994CAF50'
 
   property real fontScale: 1.0
 
@@ -155,18 +198,29 @@ QtObject {
     return styles;
   }
 
-  function applyAppearance() {
-    var appearance = settings ? settings.value('appearance', 'system') : undefined;
+  function applyColors(colors) {
+    const names = Object.keys(colors);
+    for (const name of names) {
+      if (object.hasOwnProperty(name)) {
+        object[name] = colors[name];
+      }
+    }
+  }
+
+  function applyAppearance(colors, baseAppearance) {
+    const appearance = baseAppearance !== undefined ? baseAppearance : settings ? settings.value('appearance', 'system') : undefined;
     if (appearance === undefined || appearance === 'system') {
       darkTheme = platformUtilities.isSystemDarkTheme();
-    } else if (appearance === 'light') {
-      darkTheme = false;
-    } else if (appearance === 'dark') {
-      darkTheme = true;
+    } else {
+      darkTheme = appearance === 'dark';
     }
     Material.theme = darkTheme ? "Dark" : "Light";
+    applyColors(darkTheme ? Theme.darkThemeColors : Theme.lightThemeColors);
     mainBackgroundColor = Material.backgroundColor;
     mainTextColor = Material.foreground;
+    if (colors !== undefined) {
+      applyColors(colors);
+    }
   }
 
   function applyFontScale() {

--- a/src/qml/imports/Theme/Theme.qml
+++ b/src/qml/imports/Theme/Theme.qml
@@ -6,6 +6,7 @@ QtObject {
   property bool darkTheme: false
 
   property color mainColor: "#80cc28"
+  property color mainOverlayColor: "#ffffff"
 
   property color mainBackgroundColor: darkTheme ? "#303030" : "#fafafa"
   property color mainBackgroundColorSemiOpaque: darkTheme ? "#bb303030" : "#bbfafafa"
@@ -18,6 +19,8 @@ QtObject {
   property color controlBackgroundAlternateColor: darkTheme ? "#202020" : "#e6e6e6" // used by feature form editor widgets
   property color controlBackgroundDisabledColor: "#33555555"
   property color controlBorderColor: darkTheme ? "#404040" : "#e6e6e6"
+
+  property color buttonTextColor: darkTheme ? "#202020" : "#ffffff"
 
   property color toolButtonColor: "#ffffff"
   property color toolButtonBackgroundColor: darkGray

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -19,6 +19,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Controls.Material
 import QtQuick.Effects
+import QtQuick.Shapes
 import QtQuick.Window
 import QtQml
 import QtSensors
@@ -1194,7 +1195,64 @@ ApplicationWindow {
       anchors.bottomMargin: 54
       round: true
       bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
-      iconSource: Theme.getThemeVectorIcon('ic_compass_arrow_24dp')
+
+      Shape {
+        width: compassArrow.width
+        height: compassArrow.height
+
+        ShapePath {
+          strokeWidth: 3
+          strokeColor: "transparent"
+          strokeStyle: ShapePath.SolidLine
+          fillColor: Theme.mainColor
+          joinStyle: ShapePath.MiterJoin
+          startX: compassArrow.width / 2
+          startY: 8
+          PathLine {
+            x: compassArrow.width / 2 + 6
+            y: compassArrow.height / 2
+          }
+          PathLine {
+            x: compassArrow.width / 2
+            y: compassArrow.height / 2 - 2
+          }
+          PathLine {
+            x: compassArrow.width / 2 - 6
+            y: compassArrow.height / 2
+          }
+          PathLine {
+            x: compassArrow.width / 2
+            y: 8
+          }
+        }
+
+        ShapePath {
+          strokeWidth: 3
+          strokeColor: "transparent"
+          strokeStyle: ShapePath.SolidLine
+          fillColor: Theme.toolButtonColor
+          joinStyle: ShapePath.MiterJoin
+          startX: compassArrow.width / 2
+          startY: compassArrow.height - 8
+          PathLine {
+            x: compassArrow.width / 2 + 6
+            y: compassArrow.height / 2
+          }
+          PathLine {
+            x: compassArrow.width / 2
+            y: compassArrow.height / 2 + 2
+          }
+          PathLine {
+            x: compassArrow.width / 2 - 6
+            y: compassArrow.height / 2
+          }
+          PathLine {
+            x: compassArrow.width / 2
+            y: compassArrow.height - 8
+          }
+        }
+      }
+
       onClicked: mapCanvas.mapSettings.rotation = 0
     }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1193,7 +1193,7 @@ ApplicationWindow {
       anchors.leftMargin: 4
       anchors.bottomMargin: 54
       round: true
-      bgcolor: Theme.darkGraySemiOpaque
+      bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
       iconSource: Theme.getThemeVectorIcon('ic_compass_arrow_24dp')
       onClicked: mapCanvas.mapSettings.rotation = 0
     }
@@ -1244,8 +1244,9 @@ ApplicationWindow {
         round: true
         anchors.right: parent.right
 
-        bgcolor: Theme.darkGray
+        bgcolor: Theme.toolButtonBackgroundColor
         iconSource: Theme.getThemeVectorIcon("ic_add_white_24dp")
+        iconColor: Theme.toolButtonColor
 
         width: 36
         height: 36
@@ -1261,8 +1262,9 @@ ApplicationWindow {
         round: true
         anchors.right: parent.right
 
-        bgcolor: Theme.darkGray
+        bgcolor: Theme.toolButtonBackgroundColor
         iconSource: Theme.getThemeVectorIcon("ic_remove_white_24dp")
+        iconColor: Theme.toolButtonColor
 
         width: 36
         height: 36
@@ -1379,9 +1381,9 @@ ApplicationWindow {
         name: "digitizingDrawer"
         size: 48
         round: true
-        bgcolor: Theme.darkGray
+        bgcolor: Theme.toolButtonBackgroundColor
         iconSource: Theme.getThemeVectorIcon('ic_digitizing_settings_black_24dp')
-        iconColor: "white"
+        iconColor: Theme.toolButtonColor
         spacing: 4
         visible: stateMachine.state === "digitize" && dashBoard.activeLayer && dashBoard.activeLayer.isValid && (dashBoard.activeLayer.geometryType() === Qgis.GeometryType.Polygon || dashBoard.activeLayer.geometryType() === Qgis.GeometryType.Line || dashBoard.activeLayer.geometryType() === Qgis.GeometryType.Point)
 
@@ -1393,8 +1395,8 @@ ApplicationWindow {
           round: true
           state: qgisProject && qgisProject.snappingConfig.enabled ? "On" : "Off"
           iconSource: Theme.getThemeVectorIcon("ic_snapping_white_24dp")
-          iconColor: "white"
-          bgcolor: Theme.darkGray
+          iconColor: Theme.toolButtonColor
+          bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
 
           states: [
             State {
@@ -1402,8 +1404,8 @@ ApplicationWindow {
               name: "Off"
               PropertyChanges {
                 target: snappingButton
-                iconColor: "white"
-                bgcolor: Theme.darkGraySemiOpaque
+                iconColor: Theme.toolButtonColor
+                bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
               }
             },
             State {
@@ -1411,7 +1413,7 @@ ApplicationWindow {
               PropertyChanges {
                 target: snappingButton
                 iconColor: Theme.mainColor
-                bgcolor: Theme.darkGray
+                bgcolor: Theme.toolButtonBackgroundColor
               }
             }
           ]
@@ -1433,8 +1435,8 @@ ApplicationWindow {
           round: true
           state: qgisProject && qgisProject.topologicalEditing ? "On" : "Off"
           iconSource: Theme.getThemeVectorIcon("ic_topology_white_24dp")
-          iconColor: "white"
-          bgcolor: Theme.darkGray
+          iconColor: Theme.toolButtonColor
+          bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
 
           states: [
             State {
@@ -1442,8 +1444,8 @@ ApplicationWindow {
               name: "Off"
               PropertyChanges {
                 target: topologyButton
-                iconColor: "white"
-                bgcolor: Theme.darkGraySemiOpaque
+                iconColor: Theme.toolButtonColor
+                bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
               }
             },
             State {
@@ -1451,7 +1453,7 @@ ApplicationWindow {
               PropertyChanges {
                 target: topologyButton
                 iconColor: Theme.mainColor
-                bgcolor: Theme.darkGray
+                bgcolor: Theme.toolButtonBackgroundColor
               }
             }
           ]
@@ -1470,8 +1472,8 @@ ApplicationWindow {
           round: true
           visible: hoverHandler.hasBeenHovered && !(positionSource.active && positioningSettings.positioningCoordinateLock) && stateMachine.state === "digitize" && ((digitizingToolbar.geometryRequested && digitizingToolbar.geometryRequestedLayer && digitizingToolbar.geometryRequestedLayer.isValid && (digitizingToolbar.geometryRequestedLayer.geometryType() === Qgis.GeometryType.Polygon || digitizingToolbar.geometryRequestedLayer.geometryType() === Qgis.GeometryType.Line)) || (!digitizingToolbar.geometryRequested && dashBoard.activeLayer && dashBoard.activeLayer.isValid && (dashBoard.activeLayer.geometryType() === Qgis.GeometryType.Polygon || dashBoard.activeLayer.geometryType() === Qgis.GeometryType.Line)))
           iconSource: Theme.getThemeVectorIcon("ic_freehand_white_24dp")
-          iconColor: "white"
-          bgcolor: Theme.darkGray
+          iconColor: Theme.toolButtonColor
+          bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
 
           property bool freehandDigitizing: false
           state: freehandDigitizing ? "On" : "Off"
@@ -1481,8 +1483,8 @@ ApplicationWindow {
               name: "Off"
               PropertyChanges {
                 target: freehandButton
-                iconColor: "white"
-                bgcolor: Theme.darkGraySemiOpaque
+                iconColor: Theme.toolButtonColor
+                bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
               }
             },
             State {
@@ -1490,7 +1492,7 @@ ApplicationWindow {
               PropertyChanges {
                 target: freehandButton
                 iconColor: Theme.mainColor
-                bgcolor: Theme.darkGray
+                bgcolor: Theme.toolButtonBackgroundColor
               }
             }
           ]
@@ -1517,8 +1519,8 @@ ApplicationWindow {
           round: true
           visible: dashBoard.activeLayer && (dashBoard.activeLayer.geometryType() === Qgis.GeometryType.Polygon || dashBoard.activeLayer.geometryType() === Qgis.GeometryType.Line)
           iconSource: Theme.getThemeVectorIcon("ic_common_angle_white_24dp")
-          iconColor: "white"
-          bgcolor: Theme.darkGray
+          iconColor: Theme.toolButtonColor
+          bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
 
           property bool isSnapToCommonAngleEnabled: false
           property bool isSnapToCommonAngleRelative: true
@@ -1531,8 +1533,8 @@ ApplicationWindow {
               name: "Off"
               PropertyChanges {
                 target: snapToCommonAngleButton
-                iconColor: "white"
-                bgcolor: Theme.darkGraySemiOpaque
+                iconColor: Theme.toolButtonColor
+                bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
               }
             },
             State {
@@ -1540,7 +1542,7 @@ ApplicationWindow {
               PropertyChanges {
                 target: snapToCommonAngleButton
                 iconColor: Theme.mainColor
-                bgcolor: Theme.darkGray
+                bgcolor: Theme.toolButtonBackgroundColor
               }
             }
           ]
@@ -1620,8 +1622,8 @@ ApplicationWindow {
         round: true
         visible: stateMachine.state === 'measure'
         iconSource: Theme.getThemeVectorIcon("ic_elevation_white_24dp")
-
-        bgcolor: Theme.darkGray
+        iconColor: Theme.toolButtonColor
+        bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
 
         property bool elevationProfileActive: false
         state: elevationProfileActive ? "On" : "Off"
@@ -1631,16 +1633,16 @@ ApplicationWindow {
             name: "Off"
             PropertyChanges {
               target: elevationProfileButton
-              iconSource: Theme.getThemeVectorIcon("ic_elevation_white_24dp")
-              bgcolor: Theme.darkGraySemiOpaque
+              iconColor: Theme.toolButtonColor
+              bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
             }
           },
           State {
             name: "On"
             PropertyChanges {
               target: elevationProfileButton
-              iconSource: Theme.getThemeVectorIcon("ic_elevation_green_24dp")
-              bgcolor: Theme.darkGray
+              iconColor: Theme.mainColor
+              bgcolor: Theme.toolButtonBackgroundColor
             }
           }
         ]
@@ -1690,8 +1692,8 @@ ApplicationWindow {
 
         property bool isFollowLocationActive: positionSource.active && gnssButton.followActive && followIncludeDestination
         iconSource: Theme.getThemeVectorIcon("ic_navigation_flag_purple_24dp")
-        iconColor: isFollowLocationActive ? "white" : Theme.navigationColor
-        bgcolor: isFollowLocationActive ? Theme.navigationColor : Theme.darkGray
+        iconColor: isFollowLocationActive ? Theme.toolButtonColor : Theme.navigationColor
+        bgcolor: isFollowLocationActive ? Theme.navigationColor : Theme.toolButtonBackgroundColor
 
         /*
         / When set to true, when the map follows the device's current position, the extent
@@ -1733,7 +1735,8 @@ ApplicationWindow {
             PropertyChanges {
               target: gnssLockButton
               iconSource: Theme.getThemeVectorIcon("ic_location_locked_white_24dp")
-              bgcolor: Theme.darkGraySemiOpaque
+              iconColor: Theme.toolButtonColor
+              bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
             }
           },
           State {
@@ -1742,7 +1745,7 @@ ApplicationWindow {
               target: gnssLockButton
               iconSource: Theme.getThemeVectorIcon("ic_location_locked_active_white_24dp")
               iconColor: Theme.positionColor
-              bgcolor: Theme.darkGray
+              bgcolor: Theme.toolButtonBackgroundColor
             }
           }
         ]
@@ -1816,7 +1819,8 @@ ApplicationWindow {
             PropertyChanges {
               target: gnssButton
               iconSource: Theme.getThemeVectorIcon("ic_location_disabled_white_24dp")
-              bgcolor: Theme.darkGraySemiOpaque
+              iconColor: Theme.toolButtonColor
+              bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
             }
           },
           State {
@@ -1824,8 +1828,8 @@ ApplicationWindow {
             PropertyChanges {
               target: gnssButton
               iconSource: trackings.count > 0 ? Theme.getThemeVectorIcon("ic_location_tracking_white_24dp") : positionSource.positionInformation && positionSource.positionInformation.latitudeValid ? Theme.getThemeVectorIcon("ic_location_valid_white_24dp") : Theme.getThemeVectorIcon("ic_location_white_24dp")
-              iconColor: followActive ? "white" : Theme.positionColor
-              bgcolor: followActive ? Theme.positionColor : Theme.darkGray
+              iconColor: followActive ? Theme.toolButtonColor : Theme.positionColor
+              bgcolor: followActive ? Theme.positionColor : Theme.toolButtonBackgroundColor
             }
           }
         ]
@@ -1903,7 +1907,7 @@ ApplicationWindow {
           radius: width / 2
 
           border.width: 1.5
-          border.color: 'white'
+          border.color: "white"
 
           visible: positioningSettings.accuracyIndicator && gnssButton.state === "On"
           color: !positionSource.positionInformation || !positionSource.positionInformation.haccValid || positionSource.positionInformation.hacc > positioningSettings.accuracyBad ? Theme.accuracyBad : positionSource.positionInformation.hacc > positioningSettings.accuracyExcellent ? Theme.accuracyTolerated : Theme.accuracyExcellent


### PR DESCRIPTION
This gets rid of a bunch of "white" (or non-declared) color in favor of Theme color properties.  The PR also declares a new set of properties for tool buttons to make it semantically easier to read / modify.

The PR also adds a main [color] overlay color (i.e. the color we can use as overlay to the main color). This is mostly QField green navigation bar's text + buttons (which were hard-coded as "white"), or selected items' text.

Finally, the PR allows for customizing individual (or all) appearance colors. I.e., say hello to color scheme plugins.