### PR TITLE
Refactor the About screen to show the QGIS and GDAL/OGR versions

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -27,6 +27,7 @@
 #include "cpl_conv.h"
 #include "cpl_string.h"
 #include "cpl_vsi.h"
+#include "gdal_version.h"
 
 #ifdef WITH_BLUETOOTH
 #include "bluetoothdevicemodel.h"
@@ -557,6 +558,8 @@ void QgisMobileapp::initDeclarative( QQmlEngine *engine )
 
   // Register some globally available variables
   engine->rootContext()->setContextProperty( "qVersion", qVersion() );
+  engine->rootContext()->setContextProperty( "qgisVersion", Qgis::version() );
+  engine->rootContext()->setContextProperty( "gdalVersion", GDAL_RELEASE_NAME );
   engine->rootContext()->setContextProperty( "withNfc", QVariant( NearFieldReader::isSupported() ) );
   engine->rootContext()->setContextProperty( "systemFontPointSize", PlatformUtilities::instance()->systemFontPointSize() );
   engine->rootContext()->setContextProperty( "mouseDoubleClickInterval", QApplication::styleHints()->mouseDoubleClickInterval() );

--- a/src/qml/About.qml
+++ b/src/qml/About.qml
@@ -74,10 +74,15 @@ Item {
             color: Theme.light
             textFormat: Text.RichText
             text: {
-              var links = '<a href="https://github.com/opengisch/QField/commit/' + gitRev + '">' + gitRev.substr(0, 6) + '</a>';
-              if (appVersion && appVersion !== '1.0.0')
+              let links = '<a href="https://github.com/opengisch/QField/commit/' + gitRev + '">' + gitRev.substr(0, 6) + '</a>';
+              if (appVersion && appVersion !== '1.0.0') {
                 links += ' <a href="https://github.com/opengisch/QField/releases/tag/' + appVersion + '">' + appVersion + '</a>';
-              return "QField<br>" + appVersionStr + " (" + links + ")<br>Qt " + qVersion;
+              }
+              // the `qgisVersion` has the format `<int>.<int>.<int>-<any text>`, so we get everything before the first `-`
+              const qgisVersionWithoutName = qgisVersion.split("-", 1)[0];
+              const dependencies = [["QGIS", qgisVersionWithoutName], ["GDAL/OGR", gdalVersion], ["Qt", qVersion]];
+              const dependenciesStr = dependencies.map(pair => pair.join(" ")).join(" | ");
+              return "QField<br>" + appVersionStr + " (" + links + ")<br>" + dependenciesStr;
             }
             onLinkActivated: link => Qt.openUrlExternally(link)
           }


### PR DESCRIPTION
Also small refactor on the `Label.text` implementation to bring it to the latest best practices in JavaScript:
- `var` -> `const`
- braces around `if`s

| before | after |
|-|-|
| ![image](https://github.com/user-attachments/assets/1a3a2589-2c52-44c5-b986-a87edfbaca08) | ![image](https://github.com/user-attachments/assets/b2ae4cf2-8c78-4fa1-8b4c-5177f7eb23bd) |


