### PR TITLE
Add missing translations for tabbar on QFieldCloudScreen

### DIFF
--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -167,7 +167,7 @@ Page {
 
       QfTabBar {
         id: filterBar
-        model: ["My Projects", "Community"]
+        model: [qsTr("My Projects"), qsTR("Community")]
         Layout.fillWidth: true
         Layout.preferredHeight: defaultHeight
         delegate: TabButton {

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -167,7 +167,7 @@ Page {
 
       QfTabBar {
         id: filterBar
-        model: [qsTr("My Projects"), qsTR("Community")]
+        model: [qsTr("My Projects"), qsTr("Community")]
         Layout.fillWidth: true
         Layout.preferredHeight: defaultHeight
         delegate: TabButton {


### PR DESCRIPTION
On the project selection screen when opening QField, the tab switch with My projects and community was not translated.

In this PR is the (one-line) change necessary to get this also correctly translated in the app.