### PR TITLE
Do not enable snapping to angle when cursor locked to position, improve code to avoid referencing to parent item

### DIFF
--- a/src/qml/CoordinateLocator.qml
+++ b/src/qml/CoordinateLocator.qml
@@ -28,6 +28,13 @@ Item {
   property int averagedPositionCount: 0
 
   /**
+   * Snapping-related information
+   */
+  property bool snapToCommonAngles: false
+  property bool snappingIsRelative: false
+  property real snappingAngleDegrees: 45.0
+
+  /**
    * Overrides any possibility for the user to modify the coordinate.
    * There will be no user interaction or snapping if this is set to a QgsPoint.
    * Set this to `undefined` to revert to the user and snapping controlled behavior.
@@ -62,23 +69,23 @@ Item {
     inputCoordinate: {
       // Get the current crosshair location in screen coordinates. If `undefined`, then we use the center of the screen as input point.
       const location = sourceLocation === undefined ? Qt.point(locator.width / 2, locator.height / 2) : sourceLocation;
-      if (snapToCommonAngleButton.isSnapToCommonAngleEnabled) {
+      if (!locator.positionLocked && locator.snapToCommonAngles) {
         let backwardCommonAngleInDegrees = undefined;
         let backwardCoords = {};
         let backwardPoint = undefined;
-        backwardCommonAngleInDegrees = getCommonAngleInDegrees(location, locator.rubberbandModel, snapToCommonAngleButton.snapToCommonAngleDegrees, snapToCommonAngleButton.isSnapToCommonAngleRelative);
+        backwardCommonAngleInDegrees = getCommonAngleInDegrees(location, locator.rubberbandModel, locator.snappingAngleDegrees, locator.snappingIsRelative);
         if (backwardCommonAngleInDegrees !== undefined) {
-          backwardPoint = snapPointToCommonAngle(location, locator.rubberbandModel, backwardCommonAngleInDegrees, snapToCommonAngleButton.isSnapToCommonAngleRelative);
-          backwardCoords = calculateSnapToAngleLineEndCoords(backwardPoint, backwardCommonAngleInDegrees, snapToCommonAngleButton.isSnapToCommonAngleRelative, 1000);
+          backwardPoint = snapPointToCommonAngle(location, locator.rubberbandModel, backwardCommonAngleInDegrees, locator.snappingIsRelative);
+          backwardCoords = calculateSnapToAngleLineEndCoords(backwardPoint, backwardCommonAngleInDegrees, locator.snappingIsRelative, 1000);
         }
         let forwardCommonAngleInDegrees = undefined;
         let forwardCoords = {};
         let forwardPoint = undefined;
         if (locator.rubberbandModel && locator.rubberbandModel.vertexCount >= 4) {
-          forwardCommonAngleInDegrees = getCommonAngleInDegrees(location, locator.rubberbandModel, snapToCommonAngleButton.snapToCommonAngleDegrees, snapToCommonAngleButton.isSnapToCommonAngleRelative, true);
+          forwardCommonAngleInDegrees = getCommonAngleInDegrees(location, locator.rubberbandModel, locator.snappingAngleDegrees, locator.snappingIsRelative, true);
           if (forwardCommonAngleInDegrees !== undefined) {
-            forwardPoint = snapPointToCommonAngle(location, locator.rubberbandModel, forwardCommonAngleInDegrees, snapToCommonAngleButton.isSnapToCommonAngleRelative, true);
-            forwardCoords = calculateSnapToAngleLineEndCoords(forwardPoint, forwardCommonAngleInDegrees, snapToCommonAngleButton.isSnapToCommonAngleRelative, 1000, -1);
+            forwardPoint = snapPointToCommonAngle(location, locator.rubberbandModel, forwardCommonAngleInDegrees, locator.snappingIsRelative, true);
+            forwardCoords = calculateSnapToAngleLineEndCoords(forwardPoint, forwardCommonAngleInDegrees, locator.snappingIsRelative, 1000, -1);
           }
         }
         snappingLinesModel.setProperty(0, "beginCoordX", backwardCoords.x1 || 0);

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1580,11 +1580,7 @@ ApplicationWindow {
           iconColor: Theme.toolButtonColor
           bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
 
-          property bool isSnapToCommonAngleEnabled: false
-          property bool isSnapToCommonAngleRelative: true
-          property int snapToCommonAngleDegrees: 45
-
-          state: isSnapToCommonAngleEnabled ? "On" : "Off"
+          state: coordinateLocator.snapToCommonAngles ? "On" : "Off"
 
           states: [
             State {
@@ -1606,9 +1602,9 @@ ApplicationWindow {
           ]
 
           onClicked: {
-            isSnapToCommonAngleEnabled = !isSnapToCommonAngleEnabled;
-            settings.setValue("/QField/Digitizing/SnapToCommonAngleIsEnabled", isSnapToCommonAngleEnabled);
-            displayToast(isSnapToCommonAngleEnabled ? qsTr("Snap to %1° angle turned on").arg(snapToCommonAngleDegrees) : qsTr("Snap to common angle turned off"));
+            coordinateLocator.snapToCommonAngles = !coordinateLocator.snapToCommonAngles;
+            settings.setValue("/QField/Digitizing/SnapToCommonAngleIsEnabled", coordinateLocator.snapToCommonAngles);
+            displayToast(coordinateLocator.snapToCommonAngles ? qsTr("Snap to %1° angle turned on").arg(coordinateLocator.snappingAngleDegrees) : qsTr("Snap to common angle turned off"));
           }
 
           onPressAndHold: {
@@ -1616,9 +1612,9 @@ ApplicationWindow {
           }
 
           Component.onCompleted: {
-            isSnapToCommonAngleEnabled = settings.valueBool("/QField/Digitizing/SnapToCommonAngleIsEnabled", false);
-            isSnapToCommonAngleRelative = settings.valueBool("/QField/Digitizing/SnapToCommonAngleIsRelative", true);
-            snapToCommonAngleDegrees = settings.valueInt("/QField/Digitizing/SnapToCommonAngleDegrees", snapToCommonAngleDegrees);
+            coordinateLocator.snapToCommonAngles = settings.valueBool("/QField/Digitizing/SnapToCommonAngleIsEnabled", false);
+            coordinateLocator.snappingIsRelative = settings.valueBool("/QField/Digitizing/SnapToCommonAngleIsRelative", true);
+            coordinateLocator.snappingAngleDegrees = settings.valueInt("/QField/Digitizing/SnapToCommonAngleDegrees", 45);
           }
 
           Menu {
@@ -1631,11 +1627,11 @@ ApplicationWindow {
               leftPadding: Theme.menuItemCheckLeftPadding
 
               checkable: true
-              checked: snapToCommonAngleButton.isSnapToCommonAngleRelative
+              checked: coordinateLocator.snappingIsRelative
 
               onTriggered: {
-                snapToCommonAngleButton.isSnapToCommonAngleRelative = checked;
-                settings.setValue("/QField/Digitizing/SnapToCommonAngleIsRelative", snapToCommonAngleButton.isSnapToCommonAngleRelative);
+                coordinateLocator.snappingIsRelative = checked;
+                settings.setValue("/QField/Digitizing/SnapToCommonAngleIsRelative", coordinateLocator.snappingIsRelative);
               }
             }
 
@@ -1656,16 +1652,16 @@ ApplicationWindow {
                 leftPadding: Theme.menuItemCheckLeftPadding
 
                 checkable: true
-                checked: modelData === snapToCommonAngleButton.snapToCommonAngleDegrees
-                enabled: modelData !== snapToCommonAngleButton.snapToCommonAngleDegrees
+                checked: modelData === coordinateLocator.snappingAngleDegrees
+                enabled: modelData !== coordinateLocator.snappingAngleDegrees
 
                 onTriggered: {
                   if (!checked) {
                     return;
                   }
-                  snapToCommonAngleButton.isSnapToCommonAngleEnabled = true;
-                  snapToCommonAngleButton.snapToCommonAngleDegrees = modelData;
-                  settings.setValue("/QField/Digitizing/SnapToCommonAngleDegrees", snapToCommonAngleButton.snapToCommonAngleDegrees);
+                  coordinateLocator.snapToCommonAngles = true;
+                  coordinateLocator.snappingAngleDegrees = modelData;
+                  settings.setValue("/QField/Digitizing/SnapToCommonAngleDegrees", coordinateLocator.snappingAngleDegrees);
                   displayToast(qsTr("Snap to %1° angle turned on").arg(modelData));
                   snapToCommonAngleMenu.close();
                 }


### PR DESCRIPTION
This PR fixes https://github.com/opengisch/QField/issues/5882

@suricactus , thanks for the report. I've also taken the opportunity to update the code to avoid referencing to the snapToCommonAngleButton item. That created an assumption it is always present in the parent scene, which makes it harder to test items in isolation afterwards.