### PR TITLE
QF-1414-Download and writing data to a temporary file in QFieldCloudProjects.

### DIFF
--- a/src/core/networkreply.cpp
+++ b/src/core/networkreply.cpp
@@ -41,10 +41,7 @@ void NetworkReply::abort()
 
 QNetworkReply *NetworkReply::reply() const
 {
-  if ( mIsFinished )
-    return mReply;
-
-  return nullptr;
+  return mReply;
 }
 
 

--- a/src/core/networkreply.cpp
+++ b/src/core/networkreply.cpp
@@ -39,7 +39,7 @@ void NetworkReply::abort()
 }
 
 
-QNetworkReply *NetworkReply::reply() const
+QNetworkReply *NetworkReply::currentRawReply() const
 {
   return mReply;
 }
@@ -87,6 +87,7 @@ void NetworkReply::initiateRequest()
     case QNetworkAccessManager::UnknownOperation:
       throw QStringLiteral( "Not implemented!" );
   }
+  emit currentRawReplyChanged();
 
   mReply->ignoreSslErrors( mExpectedSslErrors );
 

--- a/src/core/networkreply.h
+++ b/src/core/networkreply.h
@@ -58,7 +58,7 @@ class NetworkReply : public QObject
 
 
     /**
-     * Get the QNetworkReply object. Do not delete it manually.
+     * Get the current `QNetworkReply` object. Note that it might get deleted even if the parent `NetworkReply` is not in case of redirect or internal retry. Do not delete it manually.
      * @return network reply
      */
     QNetworkReply *reply() const;

--- a/src/core/networkreply.h
+++ b/src/core/networkreply.h
@@ -58,7 +58,7 @@ class NetworkReply : public QObject
 
 
     /**
-     * Get the QNetworkReply object once the CloudReply is finilized. Do not delete it manually.
+     * Get the QNetworkReply object. Do not delete it manually.
      * @return network reply
      */
     QNetworkReply *reply() const;

--- a/src/core/networkreply.h
+++ b/src/core/networkreply.h
@@ -59,9 +59,9 @@ class NetworkReply : public QObject
 
     /**
      * Get the current `QNetworkReply` object. Note that it might get deleted even if the parent `NetworkReply` is not in case of redirect or internal retry. Do not delete it manually.
-     * @return network reply
+     * @return network currentRawReply
      */
-    QNetworkReply *reply() const;
+    QNetworkReply *currentRawReply() const;
 
 
     /**
@@ -144,6 +144,11 @@ class NetworkReply : public QObject
      * @param code
      */
     void temporaryErrorOccurred( QNetworkReply::NetworkError code );
+
+    /**
+     * Emitted when reply has changed.
+     */
+    void currentRawReplyChanged();
 
   private:
     /**

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -573,19 +573,19 @@ bool AndroidPlatformUtilities::checkPositioningPermissions() const
   auto r = QtAndroidPrivate::checkPermission( "android.permission.ACCESS_COARSE_LOCATION" ).result();
   if ( r == QtAndroidPrivate::Denied )
   {
-    return checkAndAcquirePermissions( QStringList() << "android.permission.ACCESS_FINE_LOCATION" );
+    return checkAndAcquirePermissions( { QStringLiteral( "android.permission.ACCESS_FINE_LOCATION" ) } );
   }
   return true;
 }
 
 bool AndroidPlatformUtilities::checkCameraPermissions() const
 {
-  return checkAndAcquirePermissions( QStringList() << "android.permission.CAMERA" );
+  return checkAndAcquirePermissions( { QStringLiteral( "android.permission.CAMERA" ) } );
 }
 
 bool AndroidPlatformUtilities::checkMicrophonePermissions() const
 {
-  return checkAndAcquirePermissions( QStringList() << "android.permission.RECORD_AUDIO" );
+  return checkAndAcquirePermissions( { QStringLiteral( "android.permission.RECORD_AUDIO" ) } );
 }
 
 bool AndroidPlatformUtilities::checkAndAcquirePermissions( QStringList permissions, bool forceAsk ) const
@@ -714,7 +714,7 @@ QVariantMap AndroidPlatformUtilities::sceneMargins( QQuickWindow *window ) const
 void AndroidPlatformUtilities::uploadPendingAttachments( QFieldCloudConnection *connection ) const
 {
   // Request notification permission
-  checkAndAcquirePermissions( QStringList() << QStringLiteral( "android.permission.POST_NOTIFICATIONS" ) );
+  checkAndAcquirePermissions( { QStringLiteral( "android.permission.POST_NOTIFICATIONS" ) } );
 
   QTimer::singleShot( 500, [connection]() {
     if ( connection )
@@ -754,13 +754,13 @@ void AndroidPlatformUtilities::vibrate( int milliseconds ) const
 
 void AndroidPlatformUtilities::requestBackgroundPositioningPermissions()
 {
-  checkAndAcquirePermissions( QStringLiteral( "android.permission.ACCESS_BACKGROUND_LOCATION" ) );
+  checkAndAcquirePermissions( { QStringLiteral( "android.permission.ACCESS_BACKGROUND_LOCATION" ) } );
 }
 
 void AndroidPlatformUtilities::startPositioningService() const
 {
   // Request notification permission
-  checkAndAcquirePermissions( QStringLiteral( "android.permission.POST_NOTIFICATIONS" ) );
+  checkAndAcquirePermissions( { QStringLiteral( "android.permission.POST_NOTIFICATIONS" ) } );
 
   qInfo() << "Launching QField positioning service...";
   QJniObject::callStaticMethod<void>( "ch/opengis/" APP_PACKAGE_NAME "/QFieldPositioningService",

--- a/src/core/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloudconnection.cpp
@@ -164,7 +164,7 @@ void QFieldCloudConnection::login()
 
   // Handle login redirect as an error state
   connect( reply, &NetworkReply::redirected, this, [=]() {
-    QNetworkReply *rawReply = reply->reply();
+    QNetworkReply *rawReply = reply->currentRawReply();
     reply->deleteLater();
     rawReply->deleteLater();
 
@@ -175,7 +175,7 @@ void QFieldCloudConnection::login()
   } );
 
   connect( reply, &NetworkReply::finished, this, [=]() {
-    QNetworkReply *rawReply = reply->reply();
+    QNetworkReply *rawReply = reply->currentRawReply();
 
     Q_ASSERT( reply->isFinished() );
     Q_ASSERT( rawReply );
@@ -334,7 +334,7 @@ NetworkReply *QFieldCloudConnection::post( const QString &endpoint, const QVaria
   mPendingRequests++;
   setState( ConnectionState::Busy );
   connect( reply, &NetworkReply::finished, this, [=]() {
-    QNetworkReply *rawReply = reply->reply();
+    QNetworkReply *rawReply = reply->currentRawReply();
     if ( --mPendingRequests == 0 )
     {
       if ( rawReply->error() != QNetworkReply::NoError )
@@ -395,7 +395,7 @@ NetworkReply *QFieldCloudConnection::get( QNetworkRequest &request, const QUrl &
   mPendingRequests++;
   setState( ConnectionState::Busy );
   connect( reply, &NetworkReply::finished, this, [=]() {
-    QNetworkReply *rawReply = reply->reply();
+    QNetworkReply *rawReply = reply->currentRawReply();
     if ( --mPendingRequests == 0 )
     {
       if ( rawReply->error() != QNetworkReply::NoError )
@@ -602,7 +602,7 @@ void QFieldCloudConnection::processPendingAttachments()
     QString projectId = it.key();
     QString fileName = it.value();
     connect( attachmentCloudReply, &NetworkReply::finished, this, [=]() {
-      QNetworkReply *attachmentReply = attachmentCloudReply->reply();
+      QNetworkReply *attachmentReply = attachmentCloudReply->currentRawReply();
       attachmentCloudReply->deleteLater();
 
       Q_ASSERT( attachmentCloudReply->isFinished() );

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -1808,14 +1808,17 @@ void QFieldCloudProjectsModel::downloadFileConnections( const QString &projectId
   } );
 
   connect( reply, &NetworkReply::downloadProgress, reply, [=]( int bytesReceived, int bytesTotal ) {
-    const QString temporaryFileName = project->downloadFileTransfers[fileName].tmpFile;
     QNetworkReply *rawReply = reply->reply();
-    QFile file( temporaryFileName );
+    if ( !rawReply )
+    {
+      return;
+    }
 
-    bool hasError = false;
+    const QString temporaryFileName = project->downloadFileTransfers[fileName].tmpFile;
+    QFile file( temporaryFileName );
     QString errorMessageDetail;
     QString errorMessage;
-
+    bool hasError = false;
 
     if ( file.open( QIODevice::WriteOnly | QIODevice::Append ) )
     {

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -1841,7 +1841,7 @@ void QFieldCloudProjectsModel::downloadFileConnections( const QString &projectId
     // check if the code above failed with error
     if ( hasError )
     {
-      logFailedDownload( project, projectId, fileName, errorMessage, errorMessageDetail );
+      logFailedDownload( project, fileName, errorMessage, errorMessageDetail );
       rawReply->abort();
       return;
     }
@@ -1905,7 +1905,7 @@ void QFieldCloudProjectsModel::downloadFileConnections( const QString &projectId
     // check if the code above failed with error
     if ( hasError )
     {
-      logFailedDownload( project, projectId, fileName, errorMessage, errorMessageDetail );
+      logFailedDownload( project, fileName, errorMessage, errorMessageDetail );
       rawReply->abort();
       return;
     }
@@ -2084,7 +2084,7 @@ void QFieldCloudProjectsModel::insertProjects( const QList<CloudProject *> &proj
   endInsertRows();
 }
 
-void QFieldCloudProjectsModel::logFailedDownload( CloudProject *project, const QString &projectId, const QString &fileName, const QString &errorMessage, const QString &errorMessageDetail )
+void QFieldCloudProjectsModel::logFailedDownload( CloudProject *project, const QString &fileName, const QString &errorMessage, const QString &errorMessageDetail )
 {
   project->downloadFilesFailed++;
 
@@ -2099,7 +2099,7 @@ void QFieldCloudProjectsModel::logFailedDownload( CloudProject *project, const Q
 
   QgsMessageLog::logMessage( QStringLiteral( "%1\n%2" ).arg( baseMessage, errorMessageDetail ) );
 
-  emit projectDownloadFinished( projectId, trimmedMessage );
+  emit projectDownloadFinished( project->id, trimmedMessage );
 }
 
 void QFieldCloudProjectsModel::loadProjects( const QJsonArray &remoteProjects, bool skipLocalProjects )

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -390,7 +390,7 @@ void QFieldCloudProjectsModel::refreshProjectFileOutdatedStatus( const QString &
       return;
     }
 
-    QNetworkReply *rawReply = reply->reply();
+    QNetworkReply *rawReply = reply->currentRawReply();
     reply->deleteLater();
 
     if ( rawReply->error() != QNetworkReply::NoError )
@@ -519,7 +519,7 @@ void QFieldCloudProjectsModel::projectRefreshData( const QString &projectId, con
     if ( !findProject( projectId ) )
       return;
 
-    QNetworkReply *rawReply = reply->reply();
+    QNetworkReply *rawReply = reply->currentRawReply();
 
     reply->deleteLater();
 
@@ -620,7 +620,7 @@ void QFieldCloudProjectsModel::projectStartJob( const QString &projectId, const 
       return;
     }
 
-    QNetworkReply *rawReply = reply->reply();
+    QNetworkReply *rawReply = reply->currentRawReply();
 
     if ( rawReply->error() != QNetworkReply::NoError )
     {
@@ -699,7 +699,7 @@ void QFieldCloudProjectsModel::projectGetJobStatus( const QString &projectId, co
       return;
     }
 
-    QNetworkReply *rawReply = reply->reply();
+    QNetworkReply *rawReply = reply->currentRawReply();
 
     if ( rawReply->error() != QNetworkReply::NoError )
     {
@@ -1005,7 +1005,7 @@ void QFieldCloudProjectsModel::projectDownload( const QString &projectId )
       return;
     }
 
-    QNetworkReply *rawReply = reply->reply();
+    QNetworkReply *rawReply = reply->currentRawReply();
 
     reply->deleteLater();
 
@@ -1379,7 +1379,7 @@ void QFieldCloudProjectsModel::projectUpload( const QString &projectId, const bo
     emit dataChanged( projectIndex, projectIndex, QVector<int>() << UploadDeltaProgressRole );
   } );
   connect( deltasCloudReply, &NetworkReply::finished, this, [=]() {
-    QNetworkReply *deltasReply = deltasCloudReply->reply();
+    QNetworkReply *deltasReply = deltasCloudReply->currentRawReply();
     deltasCloudReply->deleteLater();
 
     Q_ASSERT( deltasCloudReply->isFinished() );
@@ -1561,7 +1561,7 @@ void QFieldCloudProjectsModel::refreshProjectDeltaList( const QString &projectId
   }
 
   connect( deltaStatusReply, &NetworkReply::finished, this, [=]() {
-    QNetworkReply *rawReply = deltaStatusReply->reply();
+    QNetworkReply *rawReply = deltaStatusReply->currentRawReply();
     deltaStatusReply->deleteLater();
 
     Q_ASSERT( deltaStatusReply->isFinished() );
@@ -1591,7 +1591,7 @@ void QFieldCloudProjectsModel::projectGetDeltaStatus( const QString &projectId )
 
   project->deltaFileUploadStatusString = QString();
   connect( deltaStatusReply, &NetworkReply::finished, this, [=]() {
-    QNetworkReply *rawReply = deltaStatusReply->reply();
+    QNetworkReply *rawReply = deltaStatusReply->currentRawReply();
     deltaStatusReply->deleteLater();
 
     Q_ASSERT( deltaStatusReply->isFinished() );
@@ -1688,7 +1688,7 @@ void QFieldCloudProjectsModel::layerObserverLayerEdited( const QString &layerId 
 void QFieldCloudProjectsModel::projectListReceived()
 {
   NetworkReply *reply = qobject_cast<NetworkReply *>( sender() );
-  QNetworkReply *rawReply = reply->reply();
+  QNetworkReply *rawReply = reply->currentRawReply();
 
   Q_ASSERT( rawReply );
 
@@ -1808,7 +1808,7 @@ void QFieldCloudProjectsModel::downloadFileConnections( const QString &projectId
   } );
 
   connect( reply, &NetworkReply::downloadProgress, reply, [=]( int bytesReceived, int bytesTotal ) {
-    QNetworkReply *rawReply = reply->reply();
+    QNetworkReply *rawReply = reply->currentRawReply();
     if ( !rawReply )
     {
       return;
@@ -1872,7 +1872,7 @@ void QFieldCloudProjectsModel::downloadFileConnections( const QString &projectId
     }
 
     QVector<int> rolesChanged;
-    QNetworkReply *rawReply = reply->reply();
+    QNetworkReply *rawReply = reply->currentRawReply();
 
     Q_ASSERT( reply->isFinished() );
     Q_ASSERT( reply );

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -496,6 +496,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     void downloadFileConnections( const QString &projectId, const QString &fileName );
     void loadProjects( const QJsonArray &remoteProjects = QJsonArray(), bool skipLocalProjects = false );
     void insertProjects( const QList<CloudProject *> &projects );
+    void logFailedDownload( CloudProject *projectName, const QString &projectId, const QString &fileName, const QString &errorMessage, const QString &errorMessageDetail );
 };
 
 Q_DECLARE_METATYPE( QFieldCloudProjectsModel::ProjectStatus )

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -496,7 +496,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     void downloadFileConnections( const QString &projectId, const QString &fileName );
     void loadProjects( const QJsonArray &remoteProjects = QJsonArray(), bool skipLocalProjects = false );
     void insertProjects( const QList<CloudProject *> &projects );
-    void logFailedDownload( CloudProject *projectName, const QString &projectId, const QString &fileName, const QString &errorMessage, const QString &errorMessageDetail );
+    void logFailedDownload( CloudProject *project, const QString &fileName, const QString &errorMessage, const QString &errorMessageDetail );
 };
 
 Q_DECLARE_METATYPE( QFieldCloudProjectsModel::ProjectStatus )

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -133,7 +133,7 @@ Rectangle {
         property int distance: 0
         property bool isTracing: false
 
-        onPressed: {
+        onPressed: mouse => {
           startX = mouse.x;
           startY = mouse.y;
           lastX = mouse.x;
@@ -142,7 +142,7 @@ Rectangle {
           distance = 0;
           isTracing = true;
         }
-        onPositionChanged: {
+        onPositionChanged: mouse => {
           if (!isTracing)
             return;
           var currentVelocity = Math.abs(mouse.y - lastY);

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -175,7 +175,6 @@ Page {
           height: filterBar.defaultHeight
           width: projects.width / filterBar.count
           font: Theme.defaultFont
-          enabled: (cloudConnection.state === QFieldCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0)
           onClicked: {
             filterBar.currentIndex = index;
           }
@@ -224,20 +223,26 @@ Page {
           section.labelPositioning: ViewSection.CurrentLabelAtStart | ViewSection.InlineLabels
           section.delegate: Component {
             /* section header: layer name */
-            Rectangle {
+            Item {
               width: parent.width
-              height: 30
-              color: Theme.controlBorderColor
+              height: 32
 
-              Text {
-                anchors {
-                  horizontalCenter: parent.horizontalCenter
-                  verticalCenter: parent.verticalCenter
+              Rectangle {
+                width: parent.width
+                height: 30
+                color: Theme.controlBorderColor
+                anchors.bottom: parent.bottom
+
+                Text {
+                  anchors {
+                    horizontalCenter: parent.horizontalCenter
+                    verticalCenter: parent.verticalCenter
+                  }
+                  font.bold: true
+                  font.pointSize: Theme.resultFont.pointSize
+                  color: Theme.mainTextColor
+                  text: section
                 }
-                font.bold: true
-                font.pointSize: Theme.resultFont.pointSize
-                color: Theme.mainTextColor
-                text: section
               }
             }
           }
@@ -266,7 +271,7 @@ Page {
             property int status: Status
 
             width: parent ? parent.width : undefined
-            height: line.height
+            height: line.height + 6
             color: "transparent"
 
             ProgressBar {


### PR DESCRIPTION
**PR Description:**  
  
This PR aims to handle the download progress of a network reply by writing the downloaded data incrementally to a temporary file. The key steps include:

- **Listening to Download Progress:** We connect the `downloadProgress` signal of the `NetworkReply` to a lambda function that processes the download as it progresses.

- **File Writing:** Inside the lambda, we open the temporary file in append mode `(QIODevice::Append)` and write the data to it each time new bytes are received.

- **Error Handling:** If any error occurs while opening the file or during the write operation, we log the error and abort the network reply `(rawReply->abort())`.

- **Reading Data:** For each progress update, we read all available data from the reply using `readAll()` and write it to the file.

**Ui polish:**  
       
1. Allow changing tabs ["My Projects" / "Community"].
2. Fix invisible progressBar under headersection (layer name).
3. Fix spacing between progressBar and next item.

**Summary:**

This approach focuses on incrementally saving downloaded data to a temporary file during each progress update. It includes basic error handling and attempts to append data to the file as it is received. 