### PR TITLE
Positioning service support on Android

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Download sentry libs
         run: |
           mkdir /tmp/sentry-android-ndk
-          wget https://repo1.maven.org/maven2/io/sentry/sentry-android-ndk/7.14.0/sentry-android-ndk-7.14.0.aar -O /tmp/sentry.zip
+          wget https://repo1.maven.org/maven2/io/sentry/sentry-android-ndk/7.19.1/sentry-android-ndk-7.19.1.aar -O /tmp/sentry.zip
           unzip /tmp/sentry.zip -d /tmp/sentry-android-ndk
 
       - name: 🌱 Install dependencies and generate project files

--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -4,6 +4,8 @@
   <!-- The permissions are specified manually. This way we do not request the microphone permissions which would be pulled in
        as dependent permissions because of qt multimedia. -->
   <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
@@ -293,7 +295,7 @@
       <meta-data android:name="android.app.background_running" android:value="true"/>
     </service>
 
-    <service android:process=":qt" android:name="ch.opengis.@APP_PACKAGE_NAME@.QFieldPositioningService">
+    <service android:process=":qt" android:name="ch.opengis.@APP_PACKAGE_NAME@.QFieldPositioningService" android:foregroundServiceType="location">
       <meta-data android:name="android.app.arguments" android:value="--positioningservice"/>
       <meta-data android:name="android.app.lib_name" android:value="@string/lib_name"/>
       <meta-data android:name="android.app.repository" android:value="default"/>

--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -7,7 +7,8 @@
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-  <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" tools:node="remove" />
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+  <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
   <uses-permission android:name="android.permission.CAMERA" />
   <uses-permission android:name="android.permission.RECORD_AUDIO" />

--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -276,7 +276,24 @@
     <meta-data android:name="io.sentry.auto-init" android:value="false" />
 
     <service android:process=":qt" android:name="ch.opengis.@APP_PACKAGE_NAME@.QFieldCloudService">
-      <meta-data android:name="android.app.arguments" android:value="--service"/>
+      <meta-data android:name="android.app.arguments" android:value="--cloudservice"/>
+      <meta-data android:name="android.app.lib_name" android:value="@string/lib_name"/>
+      <meta-data android:name="android.app.repository" android:value="default"/>
+      <meta-data android:name="android.app.qt_libs_resource_id" android:resource="@array/qt_libs"/>
+      <meta-data android:name="android.app.bundled_libs_resource_id" android:resource="@array/bundled_libs"/>
+      <meta-data android:name="android.app.bundle_local_qt_libs" android:value="-- %%BUNDLE_LOCAL_QT_LIBS%% --"/>
+      <meta-data android:name="android.app.use_local_qt_libs" android:value="-- %%USE_LOCAL_QT_LIBS%% --"/>
+      <meta-data android:name="android.app.libs_prefix" android:value="/data/local/tmp/qt/"/>
+      <meta-data android:name="android.app.load_local_libs_resource_id" android:resource="@array/load_local_libs"/>
+      <meta-data android:name="android.app.load_local_libs" android:value="-- %%INSERT_LOCAL_LIBS%% --"/>
+      <meta-data android:name="android.app.load_local_jars" android:value="-- %%INSERT_LOCAL_JARS%% --"/>
+      <meta-data android:name="android.app.static_init_classes" android:value="-- %%INSERT_INIT_CLASSES%% --"/>
+
+      <meta-data android:name="android.app.background_running" android:value="true"/>
+    </service>
+
+    <service android:process=":qt" android:name="ch.opengis.@APP_PACKAGE_NAME@.QFieldPositioningService">
+      <meta-data android:name="android.app.arguments" android:value="--positioningservice"/>
       <meta-data android:name="android.app.lib_name" android:value="@string/lib_name"/>
       <meta-data android:name="android.app.repository" android:value="default"/>
       <meta-data android:name="android.app.qt_libs_resource_id" android:resource="@array/qt_libs"/>

--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -10,7 +10,7 @@
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-  <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+  <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" tools:node="remove" />
   <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
   <uses-permission android:name="android.permission.CAMERA" />
   <uses-permission android:name="android.permission.RECORD_AUDIO" />

--- a/platform/android/build.gradle.in
+++ b/platform/android/build.gradle.in
@@ -109,5 +109,5 @@ android {
 
 // Add Sentry's SDK as a dependency.
 dependencies {
-    implementation 'io.sentry:sentry-android:7.14.0'
+    implementation 'io.sentry:sentry-android:7.19.1'
 }

--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -3,7 +3,6 @@
  * getExternalFilesDir() before starting QtActivity this can be used to perform
  * actions before QtActivity takes over.
  * @author  Marco Bernasocchi - <marco@opengis.ch>
- * @version 0.5
  */
 /*
  Copyright (c) 2011, Marco Bernasocchi <marco@opengis.ch>

--- a/platform/android/src/ch/opengis/qfield/QFieldCloudService.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldCloudService.java
@@ -1,7 +1,6 @@
 /**
  * QFieldCloudService.java
  * @author  Mathieu Pellerin - <mathieu@opengis.ch>
- * @version 0.5
  */
 /*
  Copyright (c) 2021, Mathieu Pellerin <mathieu@opengis.ch>

--- a/platform/android/src/ch/opengis/qfield/QFieldCloudService.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldCloudService.java
@@ -94,9 +94,8 @@ public class QFieldCloudService extends QtService {
             new Notification.Builder(this)
                 .setSmallIcon(R.drawable.qfield_logo)
                 .setWhen(System.currentTimeMillis())
-                .setContentTitle("QFieldCloud")
-                .setContentText(getString(R.string.upload_pending_attachments))
-                .setProgress(0, 0, true);
+                .setContentTitle("QField")
+                .setContentText("Positioning serviced launched!");
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             builder.setChannelId(CHANNEL_ID);

--- a/platform/android/src/ch/opengis/qfield/QFieldCloudService.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldCloudService.java
@@ -95,7 +95,8 @@ public class QFieldCloudService extends QtService {
                 .setSmallIcon(R.drawable.qfield_logo)
                 .setWhen(System.currentTimeMillis())
                 .setContentTitle("QField")
-                .setContentText("Positioning serviced launched!");
+                .setContentText(getString(R.string.upload_pending_attachments))
+                .setProgress(0, 0, true);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             builder.setChannelId(CHANNEL_ID);

--- a/platform/android/src/ch/opengis/qfield/QFieldPositioningService.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldPositioningService.java
@@ -1,7 +1,6 @@
 /**
  * QFieldPositioningService.java
  * @author  Mathieu Pellerin - <mathieu@opengis.ch>
- * @version 0.5
  */
 /*
  Copyright (c) 2024, Mathieu Pellerin <mathieu@opengis.ch>

--- a/platform/android/src/ch/opengis/qfield/QFieldPositioningService.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldPositioningService.java
@@ -66,12 +66,21 @@ public class QFieldPositioningService extends QtService {
         context.stopService(intent);
     }
 
-    public static void sendNotification(String message) {
+    public static void triggerShowNotification(String message) {
         if (getInstance() != null) {
             getInstance().showNotification(message);
         } else {
             Log.v("QFieldPositioningService",
-                  "Sending message failed, no instance available.");
+                  "Showing message failed, no instance available.");
+        }
+    }
+
+    public static void triggerCloseNotification() {
+        if (getInstance() != null) {
+            getInstance().closeNotification();
+        } else {
+            Log.v("QFieldPositioningService",
+                  "Closing message failed, no instance available.");
         }
     }
 
@@ -127,7 +136,7 @@ public class QFieldPositioningService extends QtService {
                 .setWhen(System.currentTimeMillis())
                 .setOngoing(true)
                 .setContentTitle("QField")
-                .setContentText("Positioning service started");
+                .setContentText("Positioning service running");
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             builder.setChannelId(CHANNEL_ID);
@@ -159,5 +168,9 @@ public class QFieldPositioningService extends QtService {
 
         Notification notification = builder.build();
         notificationManager.notify(NOTIFICATION_ID, notification);
+    }
+
+    public void closeNotification() {
+        notificationManager.cancel(NOTIFICATION_ID);
     }
 }

--- a/platform/android/src/ch/opengis/qfield/QFieldPositioningService.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldPositioningService.java
@@ -1,0 +1,106 @@
+/**
+ * QFieldPositioningService.java
+ * @author  Mathieu Pellerin - <mathieu@opengis.ch>
+ * @version 0.5
+ */
+/*
+ Copyright (c) 2024, Mathieu Pellerin <mathieu@opengis.ch>
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * Neither the name of the  Marco Bernasocchi <marco@opengis.ch> nor the
+ names of its contributors may be used to endorse or promote products
+ derived from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY Marco Bernasocchi <marco@opengis.ch> ''AS IS'' AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL Marco Bernasocchi <marco@opengis.ch> BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package ch.opengis.qfield;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.util.Log;
+import org.qtproject.qt.android.bindings.QtService;
+
+public class QFieldPositioningService extends QtService {
+
+    private NotificationManager notificationManager;
+    private NotificationChannel notificationChannel;
+
+    private final String CHANNEL_ID = "qfield_service_02";
+    private final int NOTIFICATION_ID = 102;
+
+    public static void startQFieldPositioningService(Context context) {
+        Log.v("QFieldPositioningService", "Starting QFieldPositioningService");
+        Intent intent = new Intent(context, QFieldPositioningService.class);
+        context.startService(intent);
+    }
+
+    @Override
+    public void onCreate() {
+        Log.v("QFieldPositioningService", "onCreate triggered");
+        super.onCreate();
+
+        notificationManager =
+            (NotificationManager)getSystemService(NOTIFICATION_SERVICE);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            notificationChannel = new NotificationChannel(
+                CHANNEL_ID, "QField", NotificationManager.IMPORTANCE_DEFAULT);
+            notificationChannel.setDescription("QField positioning");
+            notificationChannel.enableLights(false);
+            notificationChannel.enableVibration(false);
+            notificationManager.createNotificationChannel(notificationChannel);
+        }
+    }
+
+    @Override
+    public void onDestroy() {
+        Log.v("QFieldPositioningService", "onDestroy triggered");
+        notificationManager.cancel(NOTIFICATION_ID);
+        super.onDestroy();
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        int ret = super.onStartCommand(intent, flags, startId);
+        showNotification();
+        return ret;
+    }
+
+    private void showNotification() {
+        Notification.Builder builder =
+            new Notification.Builder(this)
+                .setSmallIcon(R.drawable.qfield_logo)
+                .setWhen(System.currentTimeMillis())
+                .setContentTitle("QField")
+                .setContentText(getString(R.string.upload_pending_attachments))
+                .setProgress(0, 0, true);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            builder.setChannelId(CHANNEL_ID);
+        }
+
+        Notification notification = builder.build();
+        notificationManager.notify(NOTIFICATION_ID, notification);
+    }
+}

--- a/platform/android/src/ch/opengis/qfield/QFieldPositioningService.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldPositioningService.java
@@ -94,6 +94,7 @@ public class QFieldPositioningService extends QtService {
             new Notification.Builder(this)
                 .setSmallIcon(R.drawable.qfield_logo)
                 .setWhen(System.currentTimeMillis())
+                .setOngoing(true)
                 .setContentTitle("QField")
                 .setContentText("Positioning serviced launched!");
 

--- a/platform/android/src/ch/opengis/qfield/QFieldPositioningService.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldPositioningService.java
@@ -82,19 +82,20 @@ public class QFieldPositioningService extends QtService {
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
+        Log.v("QFieldPositioningService", "onStartCommand triggered");
         int ret = super.onStartCommand(intent, flags, startId);
         showNotification();
         return ret;
     }
 
     private void showNotification() {
+        Log.v("QFieldPositioningService", "showNotification triggered");
         Notification.Builder builder =
             new Notification.Builder(this)
                 .setSmallIcon(R.drawable.qfield_logo)
                 .setWhen(System.currentTimeMillis())
                 .setContentTitle("QField")
-                .setContentText(getString(R.string.upload_pending_attachments))
-                .setProgress(0, 0, true);
+                .setContentText("Positioning serviced launched!");
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             builder.setChannelId(CHANNEL_ID);

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -84,7 +84,7 @@ int main( int argc, char **argv )
       QCoreApplication::setOrganizationDomain( "opengis.ch" );
       QCoreApplication::setApplicationName( qfield::appName );
 
-      // For now the service only deals with background attachment uploads;
+      // This service only deals with background attachment uploads;
       // it will terminate once all uploads are done
       QFieldCloudService app( argc, argv );
       return 0;

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -84,17 +84,17 @@ int main( int argc, char **argv )
       QCoreApplication::setOrganizationDomain( "opengis.ch" );
       QCoreApplication::setApplicationName( qfield::appName );
 
-      // For now the service only deals with background attachment uploads and will terminate once all uploads are done
+      // For now the service only deals with background attachment uploads;
+      // it will terminate once all uploads are done
       QFieldCloudService app( argc, argv );
       return 0;
     }
-    else if ( strcmp( argv[1], "--cloudservice" ) == 0 )
+    else if ( strcmp( argv[1], "--positioningservice" ) == 0 )
     {
       QCoreApplication::setOrganizationName( "OPENGIS.ch" );
       QCoreApplication::setOrganizationDomain( "opengis.ch" );
       QCoreApplication::setApplicationName( qfield::appName );
 
-      // For now the service only deals with background attachment uploads and will terminate once all uploads are done
       QFieldPositioningService app( argc, argv );
       return app.exec();
     }

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -25,6 +25,7 @@
 
 #if defined( Q_OS_ANDROID )
 #include "qfieldcloudservice.h"
+#include "qfieldpositioningservice.h"
 #endif
 
 #include <qgsapplication.h>
@@ -74,18 +75,31 @@ void initGraphics()
 
 int main( int argc, char **argv )
 {
-  if ( argc > 1 && strcmp( argv[1], "--service" ) == 0 )
-  {
-    QCoreApplication::setOrganizationName( "OPENGIS.ch" );
-    QCoreApplication::setOrganizationDomain( "opengis.ch" );
-    QCoreApplication::setApplicationName( qfield::appName );
-
 #if defined( Q_OS_ANDROID )
-    // For now the service only deals with background attachment uploads and will terminate once all uploads are done
-    QFieldCloudService app( argc, argv );
-#endif
-    return 0;
+  if ( argc > 1 )
+  {
+    if ( strcmp( argv[1], "--cloudservice" ) == 0 )
+    {
+      QCoreApplication::setOrganizationName( "OPENGIS.ch" );
+      QCoreApplication::setOrganizationDomain( "opengis.ch" );
+      QCoreApplication::setApplicationName( qfield::appName );
+
+      // For now the service only deals with background attachment uploads and will terminate once all uploads are done
+      QFieldCloudService app( argc, argv );
+      return 0;
+    }
+    else if ( strcmp( argv[1], "--cloudservice" ) == 0 )
+    {
+      QCoreApplication::setOrganizationName( "OPENGIS.ch" );
+      QCoreApplication::setOrganizationDomain( "opengis.ch" );
+      QCoreApplication::setApplicationName( qfield::appName );
+
+      // For now the service only deals with background attachment uploads and will terminate once all uploads are done
+      QFieldPositioningService app( argc, argv );
+      return app.exec();
+    }
   }
+#endif
 
   initGraphics();
 

--- a/src/core/locator/helplocatorfilter.cpp
+++ b/src/core/locator/helplocatorfilter.cpp
@@ -147,6 +147,5 @@ void HelpLocatorFilter::triggerResult( const QgsLocatorResult &result )
 void HelpLocatorFilter::triggerResultFromAction( const QgsLocatorResult &result, const int )
 {
   const QString url = result.userData().toString();
-  qDebug() << url;
   QDesktopServices::openUrl( url );
 }

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -755,7 +755,7 @@ void AndroidPlatformUtilities::vibrate( int milliseconds ) const
 void AndroidPlatformUtilities::startPositioningService() const
 {
   // Request notification permission
-  checkAndAcquirePermissions( QStringLiteral( "android.permission.POST_NOTIFICATIONS" ) );
+  checkAndAcquirePermissions( QStringLiteral( "android.permission.POST_NOTIFICATIONS;android.permission.ACCESS_FINE_LOCATION;android.permission.ACCESS_COARSE_LOCATION;android.permission.ACCESS_BACKGROUND_LOCATION" ) );
 
   qInfo() << "Launching QField positioning service...";
   QJniObject::callStaticMethod<void>( "ch/opengis/" APP_PACKAGE_NAME "/QFieldPositioningService",

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -764,6 +764,15 @@ void AndroidPlatformUtilities::startPositioningService() const
                                       qtAndroidContext().object() );
 }
 
+void AndroidPlatformUtilities::stopPositioningService() const
+{
+  qInfo() << "Terminating QField positioning service...";
+  QJniObject::callStaticMethod<void>( "ch/opengis/" APP_PACKAGE_NAME "/QFieldPositioningService",
+                                      "stopQFieldPositioningService",
+                                      "(Landroid/content/Context;)V",
+                                      qtAndroidContext().object() );
+}
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -752,10 +752,15 @@ void AndroidPlatformUtilities::vibrate( int milliseconds ) const
   }
 }
 
+void AndroidPlatformUtilities::requestBackgroundPositioningPermissions()
+{
+  checkAndAcquirePermissions( QStringLiteral( "android.permission.ACCESS_BACKGROUND_LOCATION" ) );
+}
+
 void AndroidPlatformUtilities::startPositioningService() const
 {
   // Request notification permission
-  checkAndAcquirePermissions( QStringLiteral( "android.permission.POST_NOTIFICATIONS;android.permission.ACCESS_FINE_LOCATION;android.permission.ACCESS_COARSE_LOCATION;android.permission.ACCESS_BACKGROUND_LOCATION" ) );
+  checkAndAcquirePermissions( QStringLiteral( "android.permission.POST_NOTIFICATIONS" ) );
 
   qInfo() << "Launching QField positioning service...";
   QJniObject::callStaticMethod<void>( "ch/opengis/" APP_PACKAGE_NAME "/QFieldPositioningService",

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -719,7 +719,7 @@ void AndroidPlatformUtilities::uploadPendingAttachments( QFieldCloudConnection *
   QTimer::singleShot( 500, [connection]() {
     if ( connection )
     {
-      qInfo() << "Launching QFieldCloud service from main...";
+      qInfo() << "Launching QFieldCloud service...";
       QJniObject::callStaticMethod<void>( "ch/opengis/" APP_PACKAGE_NAME "/QFieldCloudService",
                                           "startQFieldCloudService",
                                           "(Landroid/content/Context;)V",
@@ -750,6 +750,18 @@ void AndroidPlatformUtilities::vibrate( int milliseconds ) const
       }
     } );
   }
+}
+
+void AndroidPlatformUtilities::startPositioningService() const
+{
+  // Request notification permission
+  checkAndAcquirePermissions( QStringLiteral( "android.permission.POST_NOTIFICATIONS" ) );
+
+  qInfo() << "Launching QField positioning service...";
+  QJniObject::callStaticMethod<void>( "ch/opengis/" APP_PACKAGE_NAME "/QFieldPositioningService",
+                                      "startQFieldPositioningService",
+                                      "(Landroid/content/Context;)V",
+                                      qtAndroidContext().object() );
 }
 
 #ifdef __cplusplus

--- a/src/core/platforms/android/androidplatformutilities.h
+++ b/src/core/platforms/android/androidplatformutilities.h
@@ -87,6 +87,8 @@ class AndroidPlatformUtilities : public PlatformUtilities
     void startPositioningService() const override;
     void stopPositioningService() const override;
 
+    void requestBackgroundPositioningPermissions() override;
+
   private:
     // separate multiple permissions using a semi-column (;)
     bool checkAndAcquirePermissions( QStringList permissions, bool forceAsk = false ) const;

--- a/src/core/platforms/android/androidplatformutilities.h
+++ b/src/core/platforms/android/androidplatformutilities.h
@@ -85,6 +85,7 @@ class AndroidPlatformUtilities : public PlatformUtilities
     void vibrate( int milliseconds ) const override;
 
     void startPositioningService() const override;
+    void stopPositioningService() const override;
 
   private:
     // separate multiple permissions using a semi-column (;)

--- a/src/core/platforms/android/androidplatformutilities.h
+++ b/src/core/platforms/android/androidplatformutilities.h
@@ -84,6 +84,8 @@ class AndroidPlatformUtilities : public PlatformUtilities
 
     void vibrate( int milliseconds ) const override;
 
+    void startPositioningService() const override;
+
   private:
     // separate multiple permissions using a semi-column (;)
     bool checkAndAcquirePermissions( QStringList permissions, bool forceAsk = false ) const;

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -319,6 +319,7 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
     virtual void requestCameraPermission( std::function<void( Qt::PermissionStatus )> func );
     virtual Qt::PermissionStatus checkMicrophonePermission() const;
     virtual void requestMicrophonePermission( std::function<void( Qt::PermissionStatus )> func );
+    virtual void requestBackgroundPositioningPermissions() {};
 
     static PlatformUtilities *instance();
 

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -309,6 +309,11 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
      */
     virtual void startPositioningService() const {}
 
+    /**
+     * Starts a positioning service on supported platforms.
+     */
+    virtual void stopPositioningService() const {}
+
     Q_INVOKABLE virtual void requestStoragePermission() const {};
     virtual Qt::PermissionStatus checkCameraPermission() const;
     virtual void requestCameraPermission( std::function<void( Qt::PermissionStatus )> func );

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -303,6 +303,12 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
      */
     Q_INVOKABLE virtual void vibrate( int milliseconds ) const { Q_UNUSED( milliseconds ) }
 
+
+    /**
+     * Starts a positioning service on supported platforms.
+     */
+    virtual void startPositioningService() const {}
+
     Q_INVOKABLE virtual void requestStoragePermission() const {};
     virtual Qt::PermissionStatus checkCameraPermission() const;
     virtual void requestCameraPermission( std::function<void( Qt::PermissionStatus )> func );

--- a/src/core/positioning/abstractgnssreceiver.h
+++ b/src/core/positioning/abstractgnssreceiver.h
@@ -54,7 +54,7 @@ class AbstractGnssReceiver : public QObject
 
     QString lastError() const { return mLastError; }
 
-    virtual QList<QPair<QString, QVariant>> details() const { return {}; }
+    virtual GnssPositionDetails details() const { return {}; }
     virtual QAbstractSocket::SocketState socketState() const { return mSocketState; }
     virtual QString socketStateString();
 

--- a/src/core/positioning/abstractgnssreceiver.h
+++ b/src/core/positioning/abstractgnssreceiver.h
@@ -54,6 +54,9 @@ class AbstractGnssReceiver : public QObject
 
     QString lastError() const { return mLastError; }
 
+    /**
+     * Returns extra details (such as hdop, vdop, pdop) provided by the positioning device.
+     */
     virtual GnssPositionDetails details() const { return {}; }
     virtual QAbstractSocket::SocketState socketState() const { return mSocketState; }
     virtual QString socketStateString();

--- a/src/core/positioning/bluetoothreceiver.cpp
+++ b/src/core/positioning/bluetoothreceiver.cpp
@@ -18,7 +18,6 @@
 
 #include <QDebug>
 #include <QGuiApplication>
-#include <QPermissions>
 
 
 BluetoothReceiver::BluetoothReceiver( const QString &address, QObject *parent )
@@ -103,37 +102,6 @@ void BluetoothReceiver::handleDisconnectDevice()
 
 void BluetoothReceiver::handleConnectDevice()
 {
-  if ( !mPermissionChecked )
-  {
-    QBluetoothPermission bluetoothPermission;
-    bluetoothPermission.setCommunicationModes( QBluetoothPermission::Access );
-    Qt::PermissionStatus permissionStatus = qApp->checkPermission( bluetoothPermission );
-    if ( permissionStatus == Qt::PermissionStatus::Undetermined )
-    {
-      qApp->requestPermission( bluetoothPermission, this, [=]( const QPermission &permission ) {
-        if ( permission.status() == Qt::PermissionStatus::Granted )
-        {
-          mPermissionChecked = true;
-          handleConnectDevice();
-        }
-        else
-        {
-          setValid( false );
-          mLastError = tr( "Bluetooth permission denied" );
-          emit lastErrorChanged( mLastError );
-        }
-      } );
-      return;
-    }
-    else if ( permissionStatus == Qt::PermissionStatus::Denied )
-    {
-      setValid( false );
-      mLastError = tr( "Bluetooth permission denied" );
-      emit lastErrorChanged( mLastError );
-      return;
-    }
-  }
-
   if ( mAddress.isEmpty() )
   {
     return;

--- a/src/core/positioning/bluetoothreceiver.h
+++ b/src/core/positioning/bluetoothreceiver.h
@@ -56,8 +56,6 @@ class BluetoothReceiver : public NmeaGnssReceiver
     //! Used to wait for previous connection to finish disconnecting
     void doConnectDevice();
 
-    bool mPermissionChecked = false;
-
     QString mAddress;
 
     std::unique_ptr<QBluetoothLocalDevice> mLocalDevice;

--- a/src/core/positioning/egenioussreceiver.cpp
+++ b/src/core/positioning/egenioussreceiver.cpp
@@ -49,16 +49,16 @@ void EgenioussReceiver::handleDisconnectDevice()
   mTcpSocket->disconnectFromHost();
 }
 
-QList<QPair<QString, QVariant>> EgenioussReceiver::details() const
+GnssPositionDetails EgenioussReceiver::details() const
 {
-  QList<QPair<QString, QVariant>> detailsList;
+  GnssPositionDetails detailsList;
 
   if ( mPayload.isEmpty() )
   {
     return detailsList;
   }
 
-  detailsList.append( qMakePair( "q", mPayload.value( "q" ).toDouble() ) );
+  detailsList.append( "q", mPayload.value( "q" ).toDouble() );
 
   return detailsList;
 }

--- a/src/core/positioning/egenioussreceiver.h
+++ b/src/core/positioning/egenioussreceiver.h
@@ -33,7 +33,7 @@ class EgenioussReceiver : public AbstractGnssReceiver
     explicit EgenioussReceiver( QObject *parent = nullptr );
     ~EgenioussReceiver();
 
-    QList<QPair<QString, QVariant>> details() const override;
+    GnssPositionDetails details() const override;
 
     static QLatin1String identifier;
 

--- a/src/core/positioning/gnsspositioninformation.cpp
+++ b/src/core/positioning/gnsspositioninformation.cpp
@@ -169,6 +169,17 @@ QString GnssPositionInformation::fixStatusDescription() const
   return QString( QMetaEnum::fromType<FixStatus>().valueToKey( fixStatus() ) );
 }
 
+QDataStream &operator<<( QDataStream &stream, const GnssPositionDetails &positionDetails )
+{
+  return stream << positionDetails.mNames << positionDetails.mValues;
+}
+
+//cppcheck-suppress constParameter
+QDataStream &operator>>( QDataStream &stream, GnssPositionDetails &positionDetails )
+{
+  return stream >> positionDetails.mNames >> positionDetails.mValues;
+}
+
 QDataStream &operator<<( QDataStream &stream, const GnssPositionInformation &position )
 {
   return stream << position.mLatitude << position.mLongitude << position.mElevation << position.mSpeed << position.mDirection

--- a/src/core/positioning/gnsspositioninformation.h
+++ b/src/core/positioning/gnsspositioninformation.h
@@ -338,6 +338,35 @@ class GnssPositionInformation
 
 Q_DECLARE_METATYPE( GnssPositionInformation )
 
+class GnssPositionDetails
+{
+    Q_GADGET
+
+  public:
+    GnssPositionDetails() {};
+
+    void append( const QString &name, const QVariant &value )
+    {
+      mNames << name;
+      mValues << value;
+    }
+
+    QList<QString> names() const { return mNames; }
+    QList<QVariant> values() const { return mValues; }
+
+  private:
+    QList<QString> mNames;
+    QList<QVariant> mValues;
+
+    friend QDataStream &operator<<( QDataStream &stream, const GnssPositionDetails &position );
+    friend QDataStream &operator>>( QDataStream &stream, GnssPositionDetails &position );
+};
+
+Q_DECLARE_METATYPE( GnssPositionDetails )
+
+QDataStream &operator<<( QDataStream &stream, const GnssPositionDetails &positioningDetail );
+QDataStream &operator>>( QDataStream &stream, GnssPositionDetails &positioningDetail );
+
 QDataStream &operator<<( QDataStream &stream, const GnssPositionInformation &position );
 QDataStream &operator>>( QDataStream &stream, GnssPositionInformation &position );
 

--- a/src/core/positioning/gnsspositioninformation.h
+++ b/src/core/positioning/gnsspositioninformation.h
@@ -364,8 +364,8 @@ class GnssPositionDetails
 
 Q_DECLARE_METATYPE( GnssPositionDetails )
 
-QDataStream &operator<<( QDataStream &stream, const GnssPositionDetails &positioningDetail );
-QDataStream &operator>>( QDataStream &stream, GnssPositionDetails &positioningDetail );
+QDataStream &operator<<( QDataStream &stream, const GnssPositionDetails &positionDetails );
+QDataStream &operator>>( QDataStream &stream, GnssPositionDetails &positionDetails );
 
 QDataStream &operator<<( QDataStream &stream, const GnssPositionInformation &position );
 QDataStream &operator>>( QDataStream &stream, GnssPositionInformation &position );

--- a/src/core/positioning/internalgnssreceiver.cpp
+++ b/src/core/positioning/internalgnssreceiver.cpp
@@ -48,7 +48,6 @@ InternalGnssReceiver::InternalGnssReceiver( QObject *parent )
 
 void InternalGnssReceiver::handleDisconnectDevice()
 {
-  qDebug() << "XXX handleDisconnectDevice";
   if ( mGeoPositionSource )
   {
     mGeoPositionSource->stopUpdates();
@@ -64,7 +63,6 @@ void InternalGnssReceiver::handleDisconnectDevice()
 
 void InternalGnssReceiver::handleConnectDevice()
 {
-  qDebug() << "XXX handleConnectDevice";
   if ( mGeoPositionSource )
   {
     mGeoPositionSource->startUpdates();
@@ -78,12 +76,10 @@ void InternalGnssReceiver::handleConnectDevice()
 
 void InternalGnssReceiver::handlePositionUpdated( const QGeoPositionInfo &positionInfo )
 {
-  qDebug() << "XXX handlePositionUpdated";
   if ( mLastGnssPositionValid && !positionInfo.coordinate().isValid() )
   {
     return;
   }
-  qDebug() << "coordinate is valid";
 
   bool updatePositionInformation = false;
 

--- a/src/core/positioning/internalgnssreceiver.cpp
+++ b/src/core/positioning/internalgnssreceiver.cpp
@@ -48,6 +48,7 @@ InternalGnssReceiver::InternalGnssReceiver( QObject *parent )
 
 void InternalGnssReceiver::handleDisconnectDevice()
 {
+  qDebug() << "XXX handleDisconnectDevice";
   if ( mGeoPositionSource )
   {
     mGeoPositionSource->stopUpdates();
@@ -63,6 +64,7 @@ void InternalGnssReceiver::handleDisconnectDevice()
 
 void InternalGnssReceiver::handleConnectDevice()
 {
+  qDebug() << "XXX handleConnectDevice";
   if ( mGeoPositionSource )
   {
     mGeoPositionSource->startUpdates();
@@ -76,10 +78,12 @@ void InternalGnssReceiver::handleConnectDevice()
 
 void InternalGnssReceiver::handlePositionUpdated( const QGeoPositionInfo &positionInfo )
 {
+  qDebug() << "XXX handlePositionUpdated";
   if ( mLastGnssPositionValid && !positionInfo.coordinate().isValid() )
   {
     return;
   }
+  qDebug() << "coordinate is valid";
 
   bool updatePositionInformation = false;
 

--- a/src/core/positioning/internalgnssreceiver.cpp
+++ b/src/core/positioning/internalgnssreceiver.cpp
@@ -17,9 +17,6 @@
 #include "internalgnssreceiver.h"
 #include "positioningsource.h"
 
-#include <QGuiApplication>
-#include <QPermissions>
-
 
 InternalGnssReceiver::InternalGnssReceiver( QObject *parent )
   : AbstractGnssReceiver( parent )
@@ -66,37 +63,6 @@ void InternalGnssReceiver::handleDisconnectDevice()
 
 void InternalGnssReceiver::handleConnectDevice()
 {
-  if ( !mPermissionChecked )
-  {
-    QLocationPermission locationPermission;
-    locationPermission.setAccuracy( QLocationPermission::Precise );
-    Qt::PermissionStatus permissionStatus = qApp->checkPermission( locationPermission );
-    if ( permissionStatus == Qt::PermissionStatus::Undetermined )
-    {
-      qApp->requestPermission( locationPermission, this, [=]( const QPermission &permission ) {
-        if ( permission.status() == Qt::PermissionStatus::Granted )
-        {
-          mPermissionChecked = true;
-          handleConnectDevice();
-        }
-        else
-        {
-          setValid( false );
-          mLastError = tr( "Location permission denied" );
-          emit lastErrorChanged( mLastError );
-        }
-      } );
-      return;
-    }
-    else if ( permissionStatus == Qt::PermissionStatus::Denied )
-    {
-      setValid( false );
-      mLastError = tr( "Location permission denied" );
-      emit lastErrorChanged( mLastError );
-      return;
-    }
-  }
-
   if ( mGeoPositionSource )
   {
     mGeoPositionSource->startUpdates();

--- a/src/core/positioning/internalgnssreceiver.h
+++ b/src/core/positioning/internalgnssreceiver.h
@@ -47,8 +47,6 @@ class InternalGnssReceiver : public AbstractGnssReceiver
     void handleConnectDevice() override;
     void handleDisconnectDevice() override;
 
-    bool mPermissionChecked = false;
-
     std::unique_ptr<QGeoPositionInfoSource> mGeoPositionSource;
     std::unique_ptr<QGeoSatelliteInfoSource> mGeoSatelliteSource;
     bool mActive = false;

--- a/src/core/positioning/nmeagnssreceiver.cpp
+++ b/src/core/positioning/nmeagnssreceiver.cpp
@@ -115,17 +115,15 @@ void NmeaGnssReceiver::handleStopLogging()
   mLogFile.close();
 }
 
-QList<QPair<QString, QVariant>> NmeaGnssReceiver::details() const
+GnssPositionDetails NmeaGnssReceiver::details() const
 {
-  QList<QPair<QString, QVariant>> dataList;
-
-  dataList.append( qMakePair( "PDOP", QLocale::system().toString( mLastGnssPositionInformation.pdop(), 'f', 1 ) ) );
-  dataList.append( qMakePair( "HDOP", QLocale::system().toString( mLastGnssPositionInformation.hdop(), 'f', 1 ) ) );
-  dataList.append( qMakePair( "VDOP", QLocale::system().toString( mLastGnssPositionInformation.vdop(), 'f', 1 ) ) );
-  dataList.append( qMakePair( "Valid", mLastGnssPositionInformation.isValid() ? "True" : "False" ) );
-  dataList.append( qMakePair( "Fix", mLastGnssPositionInformation.fixStatusDescription() ) );
-  dataList.append( qMakePair( "Quality", mLastGnssPositionInformation.qualityDescription() ) );
-
+  GnssPositionDetails dataList;
+  dataList.append( "PDOP", QLocale::system().toString( mLastGnssPositionInformation.pdop(), 'f', 1 ) );
+  dataList.append( "HDOP", QLocale::system().toString( mLastGnssPositionInformation.hdop(), 'f', 1 ) );
+  dataList.append( "VDOP", QLocale::system().toString( mLastGnssPositionInformation.vdop(), 'f', 1 ) );
+  dataList.append( "Valid", mLastGnssPositionInformation.isValid() ? "True" : "False" );
+  dataList.append( "Fix", mLastGnssPositionInformation.fixStatusDescription() );
+  dataList.append( "Quality", mLastGnssPositionInformation.qualityDescription() );
   return dataList;
 }
 

--- a/src/core/positioning/nmeagnssreceiver.h
+++ b/src/core/positioning/nmeagnssreceiver.h
@@ -49,7 +49,7 @@ class NmeaGnssReceiver : public AbstractGnssReceiver
   private:
     void handleStartLogging() override;
     void handleStopLogging() override;
-    QList<QPair<QString, QVariant>> details() const override;
+    GnssPositionDetails details() const override;
 
     void processImuSentence( const QString &sentence );
 

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -45,10 +45,6 @@ Positioning::Positioning( QObject *parent )
 #endif
 
   mPositioningSourceReplica.reset( mNode.acquireDynamic( "PositioningSource" ) );
-  connect( mPositioningSourceReplica.data(), &QRemoteObjectDynamicReplica::stateChanged, this, [=]( QRemoteObjectReplica::State state, QRemoteObjectReplica::State oldState ) {
-    qDebug() << "xxx old state: " << oldState;
-    qDebug() << "xxx new state: " << state;
-  } );
   mPositioningSourceReplica->waitForSource();
 
   connect( mPositioningSourceReplica.data(), SIGNAL( activeChanged() ), this, SIGNAL( activeChanged() ) );
@@ -97,20 +93,6 @@ void Positioning::onApplicationStateChanged( Qt::ApplicationState state )
   //#endif
 }
 
-void Positioning::processValid()
-{
-  qDebug() << "Processing validChanged signal";
-  qDebug() << ( mPositioningSourceReplica->property( "valid" ).toBool() ? "returning valid" : "returning *not* valid" );
-  emit validChanged();
-}
-
-void Positioning::processActive()
-{
-  qDebug() << "Processing activeChanged signal";
-  qDebug() << ( mPositioningSourceReplica->property( "active" ).toBool() ? "returning active" : "returning *not* active" );
-  emit activeChanged();
-}
-
 bool Positioning::active() const
 {
   return mPositioningSourceReplica->property( "active" ).toBool();
@@ -118,8 +100,6 @@ bool Positioning::active() const
 
 void Positioning::setActive( bool active )
 {
-  qDebug() << "Setting active from replica!";
-
   if ( !mPermissionChecked )
   {
     QLocationPermission locationPermission;
@@ -130,7 +110,6 @@ void Positioning::setActive( bool active )
     Qt::PermissionStatus permissionStatus = qApp->checkPermission( locationPermission );
     if ( permissionStatus == Qt::PermissionStatus::Undetermined )
     {
-      qDebug() << "undetermined...";
       qApp->requestPermission( locationPermission, this, [=]( const QPermission &permission ) {
         if ( permission.status() == Qt::PermissionStatus::Granted )
         {
@@ -146,7 +125,6 @@ void Positioning::setActive( bool active )
     }
     else if ( permissionStatus == Qt::PermissionStatus::Denied )
     {
-      qDebug() << "denied?!?...";
       setValid( false );
       return;
     }
@@ -323,7 +301,6 @@ double Positioning::projectedHorizontalAccuracy() const
 
 void Positioning::processGnssPositionInformation()
 {
-  qDebug() << "Processing processGnssPositionInformation!";
   mPositionInformation = mPositioningSourceReplica->property( "positionInformation" ).value<GnssPositionInformation>();
 
   if ( mPositionInformation.isValid() )

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -32,14 +32,15 @@ Positioning::Positioning( QObject *parent )
 {
 #if defined( Q_OS_ANDROID )
   PlatformUtilities::instance()->startPositioningService();
+  mNode.connectToNode( QUrl( QStringLiteral( "localabstract:replica" ) ) );
 #else
   // Non-service path, we are both the host and the node
   mPositioningSource = new PositioningSource( this );
   mHost.setHostUrl( QUrl( QStringLiteral( "local:replica" ) ) );
   mHost.enableRemoting( mPositioningSource, "PositioningSource" );
+  mNode.connectToNode( QUrl( QStringLiteral( "local:replica" ) ) );
 #endif
 
-  mNode.connectToNode( QUrl( QStringLiteral( "local:replica" ) ) );
   mPositioningSourceReplica.reset( mNode.acquireDynamic( "PositioningSource" ) );
   mPositioningSourceReplica->waitForSource();
 

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -54,6 +54,7 @@ void Positioning::setupSource()
   }
 #endif
 
+  //cppcheck-suppress knownConditionTrueFalse
   if ( !positioningService )
   {
     // Non-service path, we are both the host and the node

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -131,7 +131,7 @@ void Positioning::setActive( bool active )
   if ( devId.isEmpty() )
   {
     // Handle internal receiver permission
-    if ( !mPermissionChecked )
+    if ( !mInternalPermissionChecked )
     {
       QLocationPermission locationPermission;
       locationPermission.setAccuracy( QLocationPermission::Precise );
@@ -145,7 +145,7 @@ void Positioning::setActive( bool active )
 #if defined( Q_OS_ANDROID )
             PlatformUtilities::instance()->requestBackgroundPositioningPermissions();
 #endif
-            mPermissionChecked = true;
+            mInternalPermissionChecked = true;
             setActive( true );
           }
           else
@@ -160,6 +160,7 @@ void Positioning::setActive( bool active )
         setValid( false );
         return;
       }
+      mInternalPermissionChecked = true;
     }
   }
   else
@@ -177,7 +178,7 @@ void Positioning::setActive( bool active )
 #endif
     else
     {
-      if ( !mPermissionChecked )
+      if ( !mBluetoothPermissionChecked )
       {
         QBluetoothPermission bluetoothPermission;
         bluetoothPermission.setCommunicationModes( QBluetoothPermission::Access );
@@ -187,7 +188,7 @@ void Positioning::setActive( bool active )
           qApp->requestPermission( bluetoothPermission, this, [=]( const QPermission &permission ) {
             if ( permission.status() == Qt::PermissionStatus::Granted )
             {
-              mPermissionChecked = true;
+              mBluetoothPermissionChecked = true;
               setActive( true );
             }
             else
@@ -202,6 +203,7 @@ void Positioning::setActive( bool active )
           setValid( false );
           return;
         }
+        mBluetoothPermissionChecked = true;
       }
     }
   }

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -51,8 +51,8 @@ Positioning::Positioning( QObject *parent )
   } );
   mPositioningSourceReplica->waitForSource();
 
-  connect( mPositioningSourceReplica.data(), SIGNAL( activeChanged() ), this, SLOT( processActive() ) );
-  connect( mPositioningSourceReplica.data(), SIGNAL( validChanged() ), this, SLOT( processValid() ) );
+  connect( mPositioningSourceReplica.data(), SIGNAL( activeChanged() ), this, SIGNAL( activeChanged() ) );
+  connect( mPositioningSourceReplica.data(), SIGNAL( validChanged() ), this, SIGNAL( validChanged() ) );
   connect( mPositioningSourceReplica.data(), SIGNAL( deviceIdChanged() ), this, SIGNAL( deviceIdChanged() ) );
   connect( mPositioningSourceReplica.data(), SIGNAL( deviceLastErrorChanged() ), this, SIGNAL( deviceLastErrorChanged() ) );
   connect( mPositioningSourceReplica.data(), SIGNAL( deviceSocketStateChanged() ), this, SIGNAL( deviceSocketStateChanged() ) );
@@ -63,6 +63,7 @@ Positioning::Positioning( QObject *parent )
   connect( mPositioningSourceReplica.data(), SIGNAL( antennaHeightChanged() ), this, SIGNAL( antennaHeightChanged() ) );
   connect( mPositioningSourceReplica.data(), SIGNAL( orientationChanged() ), this, SIGNAL( orientationChanged() ) );
   connect( mPositioningSourceReplica.data(), SIGNAL( loggingChanged() ), this, SIGNAL( loggingChanged() ) );
+
   connect( mPositioningSourceReplica.data(), SIGNAL( positionInformationChanged() ), this, SLOT( processGnssPositionInformation() ) );
 
   connect( this, SIGNAL( triggerConnectDevice() ), mPositioningSourceReplica.data(), SLOT( triggerConnectDevice() ) );
@@ -174,15 +175,10 @@ void Positioning::setDeviceId( const QString &id )
   mPositioningSourceReplica->setProperty( "deviceId", id );
 }
 
-QList<QPair<QString, QVariant>> Positioning::deviceDetails() const
+GnssPositionDetails Positioning::deviceDetails() const
 {
-  const QVariantList list = mPositioningSourceReplica->property( "deviceDetails" ).toList();
-  QList<QPair<QString, QVariant>> details;
-  for ( const QVariant &item : list )
-  {
-    details << item.value<QPair<QString, QVariant>>();
-  }
-  return details;
+  GnssPositionDetails list = mPositioningSourceReplica->property( "deviceDetails" ).value<GnssPositionDetails>();
+  return list;
 }
 
 QString Positioning::deviceLastError() const

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -86,7 +86,7 @@ void Positioning::setupSource()
   connect( this, SIGNAL( triggerDisconnectDevice() ), mPositioningSourceReplica.data(), SLOT( triggerDisconnectDevice() ) );
 
   const QList<QString> properties = mPropertiesToSync.keys();
-  for ( const QString property : properties )
+  for ( const QString &property : properties )
   {
     mPositioningSourceReplica->setProperty( property.toLatin1(), mPropertiesToSync[property] );
   }

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -163,7 +163,14 @@ void Positioning::setActive( bool active )
     setupSource();
   }
 
-  mPositioningSourceReplica->setProperty( "active", active );
+  if ( mPositioningSourceReplica->property( "active" ).toBool() != active )
+  {
+    mPositioningSourceReplica->setProperty( "active", active );
+  }
+  else
+  {
+    emit activeChanged();
+  }
 }
 
 bool Positioning::valid() const
@@ -180,6 +187,7 @@ void Positioning::setValid( bool valid )
   else
   {
     mValid = valid;
+    emit validChanged();
   }
 }
 
@@ -264,6 +272,7 @@ void Positioning::setAveragedPosition( bool averaged )
   else
   {
     mPropertiesToSync["averagedPosition"] = averaged;
+    emit averagedPositionChanged();
   }
 }
 
@@ -281,6 +290,7 @@ void Positioning::setLogging( bool logging )
   else
   {
     mPropertiesToSync["logging"] = logging;
+    emit loggingChanged();
   }
 }
 
@@ -298,6 +308,7 @@ void Positioning::setElevationCorrectionMode( PositioningSource::ElevationCorrec
   else
   {
     mPropertiesToSync["elevationCorrectionMode"] = static_cast<int>( elevationCorrectionMode );
+    emit elevationCorrectionModeChanged();
   }
 }
 
@@ -315,6 +326,7 @@ void Positioning::setAntennaHeight( double antennaHeight )
   else
   {
     mPropertiesToSync["antennaHeight"] = antennaHeight;
+    emit antennaHeightChanged();
   }
 }
 

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -47,17 +47,9 @@ void Positioning::setupSource()
   bool positioningService = false;
 
 #if defined( Q_OS_ANDROID )
-  QLocationPermission backgroundLocationPermission;
-  backgroundLocationPermission.setAccuracy( QLocationPermission::Precise );
-  backgroundLocationPermission.setAvailability( QLocationPermission::Always );
-  Qt::PermissionStatus permissionStatus = qApp->checkPermission( backgroundLocationPermission );
-
-  if ( permissionStatus == Qt::PermissionStatus::Granted )
-  {
-    PlatformUtilities::instance()->startPositioningService();
-    mNode.connectToNode( QUrl( QStringLiteral( "localabstract:replica" ) ) );
-    positioningService = true;
-  }
+  PlatformUtilities::instance()->startPositioningService();
+  mNode.connectToNode( QUrl( QStringLiteral( "localabstract:replica" ) ) );
+  positioningService = true;
 #endif
 
   //cppcheck-suppress knownConditionTrueFalse
@@ -161,9 +153,6 @@ void Positioning::setActive( bool active )
         qApp->requestPermission( locationPermission, this, [=]( const QPermission &permission ) {
           if ( permission.status() == Qt::PermissionStatus::Granted )
           {
-#if defined( Q_OS_ANDROID )
-            PlatformUtilities::instance()->requestBackgroundPositioningPermissions();
-#endif
             mInternalPermissionChecked = true;
             setActive( true );
           }

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -98,7 +98,8 @@ void Positioning::onApplicationStateChanged( Qt::ApplicationState state )
   // Google Play policy only allows for background access if it's explicitly stated and justified
   // Not stopping on Activity::onPause is detected as violation
   const bool isActive = active();
-  if ( isActive && mPositioningSource )
+  qDebug() << "???" << state;
+  if ( mPositioningSource && isActive )
   {
     switch ( state )
     {

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -98,7 +98,6 @@ void Positioning::onApplicationStateChanged( Qt::ApplicationState state )
   // Google Play policy only allows for background access if it's explicitly stated and justified
   // Not stopping on Activity::onPause is detected as violation
   const bool isActive = active();
-  qDebug() << "???" << state;
   if ( mPositioningSource && isActive )
   {
     switch ( state )

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -167,17 +167,13 @@ void Positioning::setActive( bool active )
   else
   {
     // Handle external receiver permission
-    if ( devId.startsWith( TcpReceiver::identifier + ":" ) || devId.startsWith( UdpReceiver::identifier + ":" ) )
-    {
-      // No permission required
-    }
+    if (
+      !devId.startsWith( TcpReceiver::identifier + ":" )
+      && !devId.startsWith( UdpReceiver::identifier + ":" )
 #ifdef WITH_SERIALPORT
-    else if ( devId.startsWith( SerialPortReceiver::identifier + ":" ) )
-    {
-      // No permission required
-    }
+      && !devId.startsWith( SerialPortReceiver::identifier + ":" )
 #endif
-    else
+    )
     {
       if ( !mBluetoothPermissionChecked )
       {

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -14,6 +14,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "platformutilities.h"
 #include "positioning.h"
 #include "positioningutils.h"
 #include "tcpreceiver.h"
@@ -29,10 +30,14 @@
 Positioning::Positioning( QObject *parent )
   : QObject( parent )
 {
+#if defined( Q_OS_ANDROID )
+  PlatformUtilities::instance()->startPositioningService();
+#else
   // Non-service path, we are both the host and the node
   mPositioningSource = new PositioningSource( this );
   mHost.setHostUrl( QUrl( QStringLiteral( "local:replica" ) ) );
   mHost.enableRemoting( mPositioningSource, "PositioningSource" );
+#endif
 
   mNode.connectToNode( QUrl( QStringLiteral( "local:replica" ) ) );
   mPositioningSourceReplica.reset( mNode.acquireDynamic( "PositioningSource" ) );

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -238,6 +238,8 @@ class Positioning : public QObject
     void onApplicationStateChanged( Qt::ApplicationState state );
     void projectedPositionTransformed();
     void processGnssPositionInformation();
+    void processActive();
+    void processValid();
 
   private:
     double adjustOrientation( double orientation ) const;
@@ -254,6 +256,8 @@ class Positioning : public QObject
     QgsPoint mProjectedPosition;
     double mProjectedHorizontalAccuracy;
     virtual QList<QPair<QString, QVariant>> details() const { return {}; }
+
+    bool mPermissionChecked = false;
 };
 
 #endif // POSITIONING_H

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -240,7 +240,10 @@ class Positioning : public QObject
     void processGnssPositionInformation();
 
   private:
+    void setupSource();
     double adjustOrientation( double orientation ) const;
+
+    bool mValid = true;
 
     PositioningSource *mPositioningSource = nullptr;
     QRemoteObjectHost mHost;
@@ -256,6 +259,8 @@ class Positioning : public QObject
     virtual QList<QPair<QString, QVariant>> details() const { return {}; }
 
     bool mPermissionChecked = false;
+
+    QVariantMap mPropertiesToSync;
 };
 
 #endif // POSITIONING_H

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -99,7 +99,7 @@ class Positioning : public QObject
     /**
      * Returns extra details (such as hdop, vdop, pdop) provided by the positioning device.
      */
-    QList<QPair<QString, QVariant>> deviceDetails() const;
+    GnssPositionDetails deviceDetails() const;
 
     /**
      * Returns positioning device's last error string.

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -64,6 +64,8 @@ class Positioning : public QObject
 
     Q_PROPERTY( bool logging READ logging WRITE setLogging NOTIFY loggingChanged )
 
+    Q_PROPERTY( bool backgroundMode READ backgroundMode WRITE setBackgroundMode NOTIFY backgroundModeChanged )
+
   public:
     explicit Positioning( QObject *parent = nullptr );
     virtual ~Positioning() = default;
@@ -215,6 +217,16 @@ class Positioning : public QObject
      */
     void setLogging( bool logging );
 
+    /**
+     * Returns TRUE if the background mode is active.
+     */
+    bool backgroundMode() const;
+
+    /**
+     * Sets whether the background mode is active.
+     */
+    void setBackgroundMode( bool backgroundMode );
+
   signals:
     void activeChanged();
     void validChanged();
@@ -231,6 +243,8 @@ class Positioning : public QObject
     void antennaHeightChanged();
     void orientationChanged();
     void loggingChanged();
+    void backgroundModeChanged();
+
     void triggerConnectDevice();
     void triggerDisconnectDevice();
 
@@ -260,6 +274,8 @@ class Positioning : public QObject
 
     bool mInternalPermissionChecked = false;
     bool mBluetoothPermissionChecked = false;
+
+    bool mBackgroundMode = false;
 
     QVariantMap mPropertiesToSync;
 };

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -258,7 +258,8 @@ class Positioning : public QObject
     double mProjectedHorizontalAccuracy;
     virtual QList<QPair<QString, QVariant>> details() const { return {}; }
 
-    bool mPermissionChecked = false;
+    bool mInternalPermissionChecked = false;
+    bool mBluetoothPermissionChecked = false;
 
     QVariantMap mPropertiesToSync;
 };

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -238,8 +238,6 @@ class Positioning : public QObject
     void onApplicationStateChanged( Qt::ApplicationState state );
     void projectedPositionTransformed();
     void processGnssPositionInformation();
-    void processActive();
-    void processValid();
 
   private:
     double adjustOrientation( double orientation ) const;

--- a/src/core/positioning/positioninginformationmodel.cpp
+++ b/src/core/positioning/positioninginformationmodel.cpp
@@ -20,7 +20,9 @@ void PositioningInformationModel::refreshData()
 
   const double distanceUnitFactor = QgsUnitTypes::fromUnitToUnitFactor( Qgis::DistanceUnit::Meters, distanceUnits() );
   const QString distanceUnitAbbreviation = QgsUnitTypes::toAbbreviatedString( distanceUnits() );
-  const QList<QPair<QString, QVariant>> deviceDetails = mPositioningSource->deviceDetails();
+  const GnssPositionDetails deviceDetails = mPositioningSource->deviceDetails();
+  const QList<QString> detailNames = deviceDetails.names();
+  const QList<QVariant> detailValues = deviceDetails.values();
 
   updateCoordinates();
 
@@ -34,12 +36,9 @@ void PositioningInformationModel::refreshData()
   updateInfo( tr( "H. Accuracy" ), hAccuracy );
   updateInfo( tr( "V. Accuracy" ), vAccuracy );
 
-  for ( int i = 0; i < deviceDetails.size(); ++i )
+  for ( int i = 0; i < detailNames.size(); ++i )
   {
-    const QString key = deviceDetails[i].first;
-    const QVariant value = deviceDetails[i].second;
-
-    updateInfo( key, value );
+    updateInfo( detailNames[i], detailValues[i] );
   }
 }
 

--- a/src/core/positioning/positioningsource.cpp
+++ b/src/core/positioning/positioningsource.cpp
@@ -42,7 +42,6 @@ PositioningSource::PositioningSource( QObject *parent )
 
 void PositioningSource::setActive( bool active )
 {
-  qDebug() << "Setting active within source!";
   if ( mActive == active )
     return;
 
@@ -50,15 +49,12 @@ void PositioningSource::setActive( bool active )
 
   if ( mActive )
   {
-    qDebug() << "Activating!";
     if ( !mReceiver )
     {
-      qDebug() << "Setting up device!";
       setupDevice();
     }
     else
     {
-      qDebug() << "Connecting to pre-existing device!";
       mReceiver->connectDevice();
     }
     if ( !QSensor::sensorsForType( QCompass::sensorType ).isEmpty() )
@@ -79,7 +75,6 @@ void PositioningSource::setActive( bool active )
     emit orientationChanged();
   }
 
-  qDebug() << "Emitting active!";
   emit activeChanged();
 }
 
@@ -181,7 +176,6 @@ void PositioningSource::setupDevice()
 
   if ( mDeviceId.isEmpty() )
   {
-    qDebug() << "new internal receiver";
     mReceiver = new InternalGnssReceiver( this );
   }
   else
@@ -236,7 +230,6 @@ void PositioningSource::setupDevice()
 
   if ( mActive )
   {
-    qDebug() << "connecting to device";
     mReceiver->connectDevice();
   }
 

--- a/src/core/positioning/positioningsource.cpp
+++ b/src/core/positioning/positioningsource.cpp
@@ -27,6 +27,9 @@
 #include "tcpreceiver.h"
 #include "udpreceiver.h"
 
+#include <QStandardPaths>
+
+QString PositioningSource::backgroundFilePath = QStringLiteral( "%1/positioning.background" ).arg( QStandardPaths::writableLocation( QStandardPaths::AppDataLocation ) );
 
 PositioningSource::PositioningSource( QObject *parent )
   : QObject( parent )
@@ -138,6 +141,16 @@ void PositioningSource::setLogging( bool logging )
   }
 
   emit loggingChanged();
+}
+
+void PositioningSource::setBackgroundMode( bool backgroundMode )
+{
+  if ( mBackgroundMode == backgroundMode )
+    return;
+
+  mBackgroundMode = backgroundMode;
+
+  emit backgroundModeChanged();
 }
 
 void PositioningSource::setElevationCorrectionMode( ElevationCorrectionMode elevationCorrectionMode )

--- a/src/core/positioning/positioningsource.cpp
+++ b/src/core/positioning/positioningsource.cpp
@@ -290,10 +290,13 @@ void PositioningSource::lastGnssPositionInformationChanged( const GnssPositionIn
     mPositionInformation = positionInformation;
   }
 
-  emit positionInformationChanged();
-  if ( mAveragedPosition )
+  if ( !mBackgroundMode )
   {
-    emit averagedPositionCountChanged();
+    emit positionInformationChanged();
+    if ( mAveragedPosition )
+    {
+      emit averagedPositionCountChanged();
+    }
   }
 }
 
@@ -311,7 +314,10 @@ void PositioningSource::processCompassReading()
     if ( mOrientation != orientation )
     {
       mOrientation = orientation;
-      emit orientationChanged();
+      if ( !mBackgroundMode )
+      {
+        emit orientationChanged();
+      }
     }
   }
 }

--- a/src/core/positioning/positioningsource.cpp
+++ b/src/core/positioning/positioningsource.cpp
@@ -42,6 +42,7 @@ PositioningSource::PositioningSource( QObject *parent )
 
 void PositioningSource::setActive( bool active )
 {
+  qDebug() << "Setting active within source!";
   if ( mActive == active )
     return;
 
@@ -49,11 +50,17 @@ void PositioningSource::setActive( bool active )
 
   if ( mActive )
   {
+    qDebug() << "Activating!";
     if ( !mReceiver )
     {
+      qDebug() << "Setting up device!";
       setupDevice();
     }
-    mReceiver->connectDevice();
+    else
+    {
+      qDebug() << "Connecting to pre-existing device!";
+      mReceiver->connectDevice();
+    }
     if ( !QSensor::sensorsForType( QCompass::sensorType ).isEmpty() )
     {
       mCompass.setActive( true );
@@ -72,6 +79,7 @@ void PositioningSource::setActive( bool active )
     emit orientationChanged();
   }
 
+  qDebug() << "Emitting active!";
   emit activeChanged();
 }
 
@@ -173,6 +181,7 @@ void PositioningSource::setupDevice()
 
   if ( mDeviceId.isEmpty() )
   {
+    qDebug() << "new internal receiver";
     mReceiver = new InternalGnssReceiver( this );
   }
   else
@@ -227,6 +236,7 @@ void PositioningSource::setupDevice()
 
   if ( mActive )
   {
+    qDebug() << "connecting to device";
     mReceiver->connectDevice();
   }
 

--- a/src/core/positioning/positioningsource.h
+++ b/src/core/positioning/positioningsource.h
@@ -24,8 +24,6 @@
 #include <QObject>
 #include <QTimer>
 
-typedef QList<QPair<QString, QVariant>> DetailPairs;
-
 /**
  * This class connects to GNSS devices (internal or bluetooth NMEA) and provides
  * positioning details.
@@ -39,7 +37,7 @@ class PositioningSource : public QObject
     Q_PROPERTY( bool valid READ valid NOTIFY validChanged )
 
     Q_PROPERTY( QString deviceId READ deviceId WRITE setDeviceId NOTIFY deviceIdChanged )
-    Q_PROPERTY( DetailPairs deviceDetails READ deviceDetails NOTIFY positionInformationChanged )
+    Q_PROPERTY( GnssPositionDetails deviceDetails READ deviceDetails NOTIFY positionInformationChanged )
     Q_PROPERTY( QString deviceLastError READ deviceLastError NOTIFY deviceLastErrorChanged )
     Q_PROPERTY( QAbstractSocket::SocketState deviceSocketState READ deviceSocketState NOTIFY deviceSocketStateChanged )
     Q_PROPERTY( QString deviceSocketStateString READ deviceSocketStateString NOTIFY deviceSocketStateStringChanged )
@@ -115,7 +113,7 @@ class PositioningSource : public QObject
     /**
      * Returns extra details (such as hdop, vdop, pdop) provided by the positioning device.
      */
-    QList<QPair<QString, QVariant>> deviceDetails() const { return mReceiver ? mReceiver->details() : QList<QPair<QString, QVariant>>(); }
+    GnssPositionDetails deviceDetails() const { return mReceiver ? mReceiver->details() : GnssPositionDetails(); }
 
     /**
      * Returns positioning device's last error string.

--- a/src/core/positioning/positioningsource.h
+++ b/src/core/positioning/positioningsource.h
@@ -54,6 +54,8 @@ class PositioningSource : public QObject
 
     Q_PROPERTY( bool logging READ logging WRITE setLogging NOTIFY loggingChanged )
 
+    Q_PROPERTY( bool backgroundMode READ backgroundMode WRITE setBackgroundMode NOTIFY backgroundModeChanged )
+
   public:
     /**
      * Elevation correction modes
@@ -95,7 +97,7 @@ class PositioningSource : public QObject
      * Returns the current positioning device \a id used to fetch position information.
      * \see setDevice
      */
-    QString deviceId() const { return mDeviceId; }
+    Q_INVOKABLE QString deviceId() const { return mDeviceId; }
 
     /**
      * Sets the positioning device \a id used to fetch position information.
@@ -194,6 +196,18 @@ class PositioningSource : public QObject
      */
     void setLogging( bool logging );
 
+    /**
+     * Returns TRUE if the background mode is active.
+     */
+    bool backgroundMode() const { return mBackgroundMode; }
+
+    /**
+     * Sets whether the background mode is active.
+     */
+    void setBackgroundMode( bool backgroundMode );
+
+    static QString backgroundFilePath;
+
   signals:
     void activeChanged();
     void validChanged();
@@ -209,6 +223,7 @@ class PositioningSource : public QObject
     void antennaHeightChanged();
     void orientationChanged();
     void loggingChanged();
+    void backgroundModeChanged();
 
   public slots:
 
@@ -237,6 +252,8 @@ class PositioningSource : public QObject
     double mAntennaHeight = 0.0;
 
     bool mLogging = false;
+
+    bool mBackgroundMode = false;
 
     AbstractGnssReceiver *mReceiver = nullptr;
 

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -1453,6 +1453,8 @@ void QgisMobileapp::saveProjectPreviewImage()
 
 QgisMobileapp::~QgisMobileapp()
 {
+  PlatformUtilities::instance()->stopPositioningService();
+
   saveProjectPreviewImage();
 
   mPluginManager->unloadPlugins();

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -519,6 +519,7 @@ void QgisMobileapp::initDeclarative( QQmlEngine *engine )
   qmlRegisterUncreatableType<AbstractGnssReceiver>( "org.qfield", 1, 0, "AbstractGnssReceiver", "" );
   qmlRegisterUncreatableType<Tracker>( "org.qfield", 1, 0, "Tracker", "" );
   qRegisterMetaType<GnssPositionInformation>( "GnssPositionInformation" );
+  qRegisterMetaType<GnssPositionDetails>( "GnssPositionDetails" );
   qRegisterMetaType<PluginInformation>( "PluginInformation" );
 
   qmlRegisterType<ProcessingAlgorithm>( "org.qfield", 1, 0, "ProcessingAlgorithm" );

--- a/src/core/qgsquick/qgsquickelevationprofilecanvas.cpp
+++ b/src/core/qgsquick/qgsquickelevationprofilecanvas.cpp
@@ -672,7 +672,6 @@ void QgsQuickElevationProfileCanvas::zoomFullInRatio()
   const QgsDoubleRange zRange = mCurrentJob->zRange();
   double xLength = mProfileCurve.get()->length();
   double yLength = zRange.upper() - zRange.lower();
-  qDebug() << yLength;
   if ( yLength < 0.0 )
   {
     // invalid range, e.g. no features found in plot!
@@ -689,11 +688,8 @@ void QgsQuickElevationProfileCanvas::zoomFullInRatio()
     double xInRatioLength = yLength * mPlotItem->size().width() / mPlotItem->size().height();
     if ( yInRatioLength > yLength )
     {
-      qDebug() << "yInRatioLength";
       mPlotItem->setYMinimum( zRange.lower() - ( yInRatioLength / 2 ) );
-      qDebug() << mPlotItem->yMinimum();
       mPlotItem->setYMaximum( zRange.upper() + ( yInRatioLength / 2 ) );
-      qDebug() << mPlotItem->yMaximum();
 
       mPlotItem->setXMinimum( 0 );
       // just 2% margin to max distance -- any more is overkill and wasted space
@@ -701,13 +697,10 @@ void QgsQuickElevationProfileCanvas::zoomFullInRatio()
     }
     else
     {
-      qDebug() << "xInRatioLength";
       // add 5% margin to height range
       const double margin = yLength * 0.05;
       mPlotItem->setYMinimum( zRange.lower() - margin );
-      qDebug() << mPlotItem->yMinimum();
       mPlotItem->setYMaximum( zRange.upper() + margin );
-      qDebug() << mPlotItem->yMaximum();
 
       mPlotItem->setXMinimum( 0 - ( xInRatioLength / 2 ) );
       mPlotItem->setXMaximum( xLength + ( xInRatioLength / 2 ) );

--- a/src/service/CMakeLists.txt
+++ b/src/service/CMakeLists.txt
@@ -1,5 +1,5 @@
-set(QFIELD_SERVICE_SRCS qfieldcloudservice.cpp)
-set(QFIELD_SERVICE_HDRS qfieldcloudservice.h)
+set(QFIELD_SERVICE_SRCS qfieldcloudservice.cpp qfieldpositioningservice.cpp)
+set(QFIELD_SERVICE_HDRS qfieldcloudservice.h qfieldpositioningservice.h)
 
 add_library(qfield_service STATIC ${QFIELD_SERVICE_SRCS} ${QFIELD_SERVICE_HDRS})
 

--- a/src/service/qfieldpositioningservice.cpp
+++ b/src/service/qfieldpositioningservice.cpp
@@ -48,7 +48,7 @@ QFieldPositioningService::QFieldPositioningService( int &argc, char **argv )
 
   connect( &mNotificationTimer, &QTimer::timeout, this, [=] {
     const GnssPositionInformation pos = mPositioningSource->positionInformation();
-    QJniObject message = QJniObject::fromString( QStringLiteral( "Latitude %1 | Longitude %2 | Altitude %3" ).arg( QLocale::system().toString( pos.latitude(), 'f', 7 ), QLocale::system().toString( pos.longitude(), 'f', 7 ), QLocale::system().toString( pos.elevation(), 'f', 3 ) ) );
+    QJniObject message = QJniObject::fromString( QStringLiteral( "Latitude %1 | Longitude %2 | Altitude %3 | Orientation %4" ).arg( QLocale::system().toString( pos.latitude(), 'f', 7 ), QLocale::system().toString( pos.longitude(), 'f', 7 ), QLocale::system().toString( pos.elevation(), 'f', 3 ), QLocale::system().toString( mPositioningSource->orientation(), 'f', 1 ) ) );
     QJniObject::callStaticMethod<void>( "ch/opengis/" APP_PACKAGE_NAME "/QFieldPositioningService",
                                         "sendNotification",
                                         message.object<jstring>() );

--- a/src/service/qfieldpositioningservice.cpp
+++ b/src/service/qfieldpositioningservice.cpp
@@ -18,6 +18,8 @@
 #include "qfield_android.h"
 #include "qfieldpositioningservice.h"
 
+#include <QQmlEngine>
+
 QFieldPositioningService::QFieldPositioningService( int &argc, char **argv )
   : QAndroidService( argc, argv )
 {

--- a/src/service/qfieldpositioningservice.cpp
+++ b/src/service/qfieldpositioningservice.cpp
@@ -14,14 +14,16 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "positioningsource.h"
 #include "qfield_android.h"
 #include "qfieldpositioningservice.h"
-
 
 QFieldPositioningService::QFieldPositioningService( int &argc, char **argv )
   : QAndroidService( argc, argv )
 {
-  return exec();
+  mPositioningSource = new PositioningSource( this );
+  mHost.setHostUrl( QUrl( QStringLiteral( "local:replica" ) ) );
+  mHost.enableRemoting( mPositioningSource, "PositioningSource" );
 }
 
 QFieldPositioningService::~QFieldPositioningService()

--- a/src/service/qfieldpositioningservice.cpp
+++ b/src/service/qfieldpositioningservice.cpp
@@ -18,14 +18,41 @@
 #include "qfield_android.h"
 #include "qfieldpositioningservice.h"
 
+#include <QJniObject>
+#include <QLocale>
 #include <QQmlEngine>
+#include <QtCore/private/qandroidextras_p.h>
+
 
 QFieldPositioningService::QFieldPositioningService( int &argc, char **argv )
   : QAndroidService( argc, argv )
 {
+  qDebug() << "XXX!!!XXX";
   mPositioningSource = new PositioningSource( this );
   mHost.setHostUrl( QUrl( QStringLiteral( "localabstract:replica" ) ) );
   mHost.enableRemoting( mPositioningSource, "PositioningSource" );
+
+  mNotificationTimer.setInterval( 2500 );
+  mNotificationTimer.setSingleShot( false );
+
+  connect( mPositioningSource, &PositioningSource::activeChanged, this, [=] {
+    if ( mPositioningSource->active() )
+    {
+      mNotificationTimer.start();
+    }
+    else
+    {
+      mNotificationTimer.stop();
+    }
+  } );
+
+  connect( &mNotificationTimer, &QTimer::timeout, this, [=] {
+    const GnssPositionInformation pos = mPositioningSource->positionInformation();
+    QJniObject message = QJniObject::fromString( QStringLiteral( "Latitude %1 | Longitude %2 | Altitude %3" ).arg( QLocale::system().toString( pos.latitude(), 'f', 7 ), QLocale::system().toString( pos.longitude(), 'f', 7 ), QLocale::system().toString( pos.elevation(), 'f', 3 ) ) );
+    QJniObject::callStaticMethod<void>( "ch/opengis/" APP_PACKAGE_NAME "/QFieldPositioningService",
+                                        "sendNotification",
+                                        message.object<jstring>() );
+  } );
 }
 
 QFieldPositioningService::~QFieldPositioningService()

--- a/src/service/qfieldpositioningservice.cpp
+++ b/src/service/qfieldpositioningservice.cpp
@@ -22,7 +22,7 @@ QFieldPositioningService::QFieldPositioningService( int &argc, char **argv )
   : QAndroidService( argc, argv )
 {
   mPositioningSource = new PositioningSource( this );
-  mHost.setHostUrl( QUrl( QStringLiteral( "local:replica" ) ) );
+  mHost.setHostUrl( QUrl( QStringLiteral( "localabstract:replica" ) ) );
   mHost.enableRemoting( mPositioningSource, "PositioningSource" );
 }
 

--- a/src/service/qfieldpositioningservice.cpp
+++ b/src/service/qfieldpositioningservice.cpp
@@ -1,9 +1,9 @@
 /***************************************************************************
-  qFieldcloudservice.h - QFieldCloudService
+  qFieldpositioningservice.cpp - QFieldPositioningService
 
  ---------------------
- begin                : 04.12.2022
- copyright            : (C) 2022 by Mathieu Pellerin
+ begin                : 21.12.2024
+ copyright            : (C) 2024 by Mathieu Pellerin
  email                : mathieu at opengis dot ch
  ***************************************************************************
  *                                                                         *
@@ -13,21 +13,17 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
-#ifndef QFIELDCLOUDSERVICE_H
-#define QFIELDCLOUDSERVICE_H
 
-#include "qfield_service_export.h"
+#include "qfield_android.h"
+#include "qfieldpositioningservice.h"
 
-#include <QtCore/private/qandroidextras_p.h>
-#include <QtGlobal>
 
-class QFIELD_SERVICE_EXPORT QFieldCloudService : public QAndroidService
+QFieldPositioningService::QFieldPositioningService( int &argc, char **argv )
+  : QAndroidService( argc, argv )
 {
-    Q_OBJECT
+  return exec();
+}
 
-  public:
-    QFieldCloudService( int &argc, char **argv );
-    ~QFieldCloudService() override;
-};
-
-#endif // QFIELDCLOUDSERVICE_H
+QFieldPositioningService::~QFieldPositioningService()
+{
+}

--- a/src/service/qfieldpositioningservice.h
+++ b/src/service/qfieldpositioningservice.h
@@ -34,6 +34,10 @@ class QFIELD_SERVICE_EXPORT QFieldPositioningService : public QAndroidService
     QFieldPositioningService( int &argc, char **argv );
     ~QFieldPositioningService() override;
 
+  private slots:
+    void triggerShowNotification();
+    void triggerCloseNotification();
+
   private:
     PositioningSource *mPositioningSource = nullptr;
     QRemoteObjectHost mHost;

--- a/src/service/qfieldpositioningservice.h
+++ b/src/service/qfieldpositioningservice.h
@@ -20,6 +20,7 @@
 #include "qfield_service_export.h"
 
 #include <QRemoteObjectHost>
+#include <QTimer>
 #include <QtCore/private/qandroidextras_p.h>
 #include <QtGlobal>
 
@@ -36,6 +37,8 @@ class QFIELD_SERVICE_EXPORT QFieldPositioningService : public QAndroidService
   private:
     PositioningSource *mPositioningSource = nullptr;
     QRemoteObjectHost mHost;
+
+    QTimer mNotificationTimer;
 };
 
 #endif // QFIELDPOSITIONINGSERVICE_H

--- a/src/service/qfieldpositioningservice.h
+++ b/src/service/qfieldpositioningservice.h
@@ -1,9 +1,9 @@
 /***************************************************************************
-  qFieldcloudservice.h - QFieldCloudService
+  qFieldpositioningservice.h - QFieldPositioningService
 
  ---------------------
- begin                : 04.12.2022
- copyright            : (C) 2022 by Mathieu Pellerin
+ begin                : 21.12.2024
+ copyright            : (C) 2024 by Mathieu Pellerin
  email                : mathieu at opengis dot ch
  ***************************************************************************
  *                                                                         *
@@ -13,21 +13,21 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
-#ifndef QFIELDCLOUDSERVICE_H
-#define QFIELDCLOUDSERVICE_H
+#ifndef QFIELDPOSITIONINGSERVICE_H
+#define QFIELDPOSITIONINGSERVICE_H
 
 #include "qfield_service_export.h"
 
 #include <QtCore/private/qandroidextras_p.h>
 #include <QtGlobal>
 
-class QFIELD_SERVICE_EXPORT QFieldCloudService : public QAndroidService
+class QFIELD_SERVICE_EXPORT QFieldPositioningService : public QAndroidService
 {
     Q_OBJECT
 
   public:
-    QFieldCloudService( int &argc, char **argv );
-    ~QFieldCloudService() override;
+    QFieldPositioningService( int &argc, char **argv );
+    ~QFieldPositioningService() override;
 };
 
-#endif // QFIELDCLOUDSERVICE_H
+#endif // QFIELDPOSITIONINGSERVICE_H

--- a/src/service/qfieldpositioningservice.h
+++ b/src/service/qfieldpositioningservice.h
@@ -16,10 +16,14 @@
 #ifndef QFIELDPOSITIONINGSERVICE_H
 #define QFIELDPOSITIONINGSERVICE_H
 
+#include "positioningsource.h"
 #include "qfield_service_export.h"
 
+#include <QRemoteObjectHost>
 #include <QtCore/private/qandroidextras_p.h>
 #include <QtGlobal>
+
+class PositioningSource;
 
 class QFIELD_SERVICE_EXPORT QFieldPositioningService : public QAndroidService
 {
@@ -28,6 +32,10 @@ class QFIELD_SERVICE_EXPORT QFieldPositioningService : public QAndroidService
   public:
     QFieldPositioningService( int &argc, char **argv );
     ~QFieldPositioningService() override;
+
+  private:
+    PositioningSource *mPositioningSource = nullptr;
+    QRemoteObjectHost mHost;
 };
 
 #endif // QFIELDPOSITIONINGSERVICE_H

--- a/vcpkg/ports/qtpositioning/devendor-poly2tri.patch
+++ b/vcpkg/ports/qtpositioning/devendor-poly2tri.patch
@@ -1,0 +1,37 @@
+diff --color -Naur a/src/3rdparty/clip2tri/CMakeLists.txt b/src/3rdparty/clip2tri/CMakeLists.txt
+--- a/src/3rdparty/clip2tri/CMakeLists.txt	2023-05-13 16:59:42.377052155 +0200
++++ b/src/3rdparty/clip2tri/CMakeLists.txt	2023-05-13 23:05:44.950379088 +0200
+@@ -4,6 +4,7 @@
+ ## Bundled_Clip2Tri Generic Library:
+ #####################################################################
+ 
++find_package(poly2tri)
+ qt_internal_add_3rdparty_library(Bundled_Clip2Tri
+     QMAKE_LIB_NAME _clip2tri
+     STATIC
+@@ -13,11 +14,12 @@
+         clip2tri.cpp clip2tri.h
+     INCLUDE_DIRECTORIES
+         ../clipper
+-        ../poly2tri
+     LIBRARIES
+         Qt::Bundled_Clipper # special case
+-        Qt::Bundled_Poly2Tri # special case
++        poly2tri::poly2tri
+ )
++target_link_libraries(Bundled_Clip2Tri PRIVATE poly2tri::poly2tri)
++set_target_properties(poly2tri::poly2tri PROPERTIES INTERFACE_QT_PACKAGE_NAME poly2tri)
+ qt_disable_warnings(Bundled_Clip2Tri)
+ qt_set_symbol_visibility_hidden(Bundled_Clip2Tri)
+ 
+diff --color -Naur a/src/CMakeLists.txt b/src/CMakeLists.txt
+--- a/src/CMakeLists.txt	2023-05-13 16:59:42.379052157 +0200
++++ b/src/CMakeLists.txt	2023-05-13 17:00:19.256085781 +0200
+@@ -2,7 +2,6 @@
+ # SPDX-License-Identifier: BSD-3-Clause
+ 
+ # special case begin
+-add_subdirectory(3rdparty/poly2tri)
+ add_subdirectory(3rdparty/clipper)
+ add_subdirectory(3rdparty/clip2tri)
+ add_subdirectory(positioning)

--- a/vcpkg/ports/qtpositioning/foregroundservice.patch
+++ b/vcpkg/ports/qtpositioning/foregroundservice.patch
@@ -1,0 +1,15 @@
+diff --git a/src/plugins/position/android/src/jnipositioning.cpp b/src/plugins/position/android/src/jnipositioning.cpp
+index 2b2919f..bc42c2e 100644
+--- a/src/plugins/position/android/src/jnipositioning.cpp
++++ b/src/plugins/position/android/src/jnipositioning.cpp
+@@ -589,10 +589,6 @@ namespace AndroidPositioning {
+     {
+         QLocationPermission permission;
+ 
+-        // The needed permission depends on whether we run as a service or as an activity
+-        if (!QNativeInterface::QAndroidApplication::isActivityContext())
+-            permission.setAvailability(QLocationPermission::Always); // background location
+-
+         bool permitted = false;
+         if (accuracy & AccuracyType::Precise) {
+             permission.setAccuracy(QLocationPermission::Precise);

--- a/vcpkg/ports/qtpositioning/portfile.cmake
+++ b/vcpkg/ports/qtpositioning/portfile.cmake
@@ -1,0 +1,25 @@
+set(SCRIPT_PATH "${CURRENT_INSTALLED_DIR}/share/qtbase")
+include("${SCRIPT_PATH}/qt_install_submodule.cmake")
+
+set(${PORT}_PATCHES
+    devendor-poly2tri.patch
+    foregroundservice.patch)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+FEATURES
+    "qml"           CMAKE_REQUIRE_FIND_PACKAGE_Qt6Quick
+INVERTED_FEATURES
+    "qml"           CMAKE_DISABLE_FIND_PACKAGE_Qt6Quick
+)
+
+list(APPEND FEATURE_OPTIONS "-DCMAKE_DISABLE_FIND_PACKAGE_Gypsy=ON"
+                            "-DCMAKE_DISABLE_FIND_PACKAGE_Gconf=ON"
+)
+
+
+
+qt_install_submodule(PATCHES    ${${PORT}_PATCHES}
+                     CONFIGURE_OPTIONS ${FEATURE_OPTIONS}
+                     CONFIGURE_OPTIONS_RELEASE
+                     CONFIGURE_OPTIONS_DEBUG
+                    )

--- a/vcpkg/ports/qtpositioning/vcpkg.json
+++ b/vcpkg/ports/qtpositioning/vcpkg.json
@@ -1,0 +1,30 @@
+{
+  "name": "qtpositioning",
+  "version": "6.8.1",
+  "description": "The Qt Positioning API provides positioning information via QML and C++ interfaces.",
+  "homepage": "https://www.qt.io/",
+  "license": null,
+  "dependencies": [
+    "jhasse-poly2tri",
+    {
+      "name": "qtbase",
+      "default-features": false
+    },
+    {
+      "name": "qtserialport",
+      "default-features": false,
+      "platform": "!ios"
+    }
+  ],
+  "features": {
+    "qml": {
+      "description": "Build QML imports",
+      "dependencies": [
+        {
+          "name": "qtdeclarative",
+          "default-features": false
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
A nice milestone to be crossing here: we're getting a brand new background positioning service on Android for Christmas.

The implementation allows for both a positioning service as well as a fallback to in-app positioning when users do not give us the right to always access position. This way, we will always find ourselves respecting their explicit permission desires.

Qt's documentation on Android Service is *minimal* at best. One thing I was not completely sure about is whether Qt (or Android) takes care of avoiding duplicate service launches. However, after much testing and debugging, I've confirmed that our positioning service is ever only launched _once_ even after manually killing the main app and re-launching it.

Another note: these services will live on beyond QField's lifespan. In our case, it could mean position being gathered in the background forever. The way I've dealt with this scenario is to shut down the service when users are explicitly quitting QField (i.e. either via the exit button on the home screen or via hitting the back key twice).

Finally, ATM, the QField service will add a notification that shows the current latitude, longitude, and altitude. It's there in part to debug the functionality, but I kind of like it, like _a lot_ :) In another part of the work ahead, I'll make the notification appear _only_ when QField is put in the background. That'll make it an actually useful notification.