### PR TITLE
Add condition to ruby install in Windows action

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -182,6 +182,7 @@ jobs:
           overwrite: true
 
       - name: 💎 Setup ruby
+        if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v')
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2' # Not needed with a .ruby-version file


### PR DESCRIPTION
Within the Windows build workflow, Ruby is installed as one of the last steps. It is installed to facilitate the S3 upload and debug symbol upload. These steps however contains conditions, and are only executed when a release is created.

Herby a PR to add also the same condition to the Ruby setup. The task itself takes just 30 seconds in the workflow, but still it is every time 30 seconds in a workflow that takes already significant time to run.