### PR TITLE
Add sentry patch for XCode 16 support

### DIFF
--- a/vcpkg/ports/sentry-cocoa/exception.patch
+++ b/vcpkg/ports/sentry-cocoa/exception.patch
@@ -1,0 +1,12 @@
+diff --git a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.cpp b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.cpp
+index 51996c2f4c..7ab3a473a7 100644
+--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.cpp
++++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.cpp
+@@ -39,6 +39,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <typeinfo>
++#include <exception>
+
+ #define STACKTRACE_BUFFER_LENGTH 30
+ #define DESCRIPTION_BUFFER_LENGTH 1000

--- a/vcpkg/ports/sentry-cocoa/portfile.cmake
+++ b/vcpkg/ports/sentry-cocoa/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
       stdint.patch
       ucontext64.patch
+      exception.patch
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})


### PR DESCRIPTION
Missed a fix I had local which I didn't proposed here yet in a PR, related to XCode / iOS builds.

When using XCode 16, the build always fails due to an issue with the Sentry package. I checked if it was feasible to update the package, but as still version 7 of the package was used, and the fix only existed in 8 I decided to only apply the patch. Maybe in a future version the Sentry package can be updated, but I assume there is a reason why this hasn't been done yet?

The issue / PR from Sentry that describes the issue and why it is resolved is over here: https://github.com/getsentry/sentry-cocoa/pull/4051