### PR TITLE
Rework storage permission handling on Android to serve permission request in context

### DIFF
--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -503,7 +503,6 @@ public class QFieldActivity extends QtActivity {
             getSharedPreferences("QField", Context.MODE_PRIVATE);
         sharedPreferenceEditor = sharedPreferences.edit();
 
-        checkPermissions();
         checkAllFileAccess(); // Storage access permission handling for Android
                               // 11+
 
@@ -1242,7 +1241,7 @@ public class QFieldActivity extends QtActivity {
         });
     }
 
-    private void checkPermissions() {
+    private void checkStoragePermissions() {
         List<String> permissionsList = new ArrayList<String>();
         if (ContextCompat.checkSelfPermission(
                 QFieldActivity.this,
@@ -1282,8 +1281,8 @@ public class QFieldActivity extends QtActivity {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
             !Environment.isExternalStorageManager() &&
             !sharedPreferences.getBoolean("DontAskAllFilesPermission", false)) {
-            // if MANAGE_EXTERNAL_STORAGE permission isn't in the manifest, bail
-            // out
+            // if MANAGE_EXTERNAL_STORAGE permission isn't in the manifest,
+            // bail out
             String[] requestedPermissions;
             try {
                 PackageInfo pi = getPackageManager().getPackageInfo(
@@ -1298,6 +1297,8 @@ public class QFieldActivity extends QtActivity {
                      .contains(Manifest.permission.MANAGE_EXTERNAL_STORAGE)) {
                 return;
             }
+
+            checkStoragePermissions();
 
             AlertDialog.Builder builder =
                 new AlertDialog.Builder(this, R.style.DialogTheme);

--- a/src/core/platforms/android/androidplatformutilities.h
+++ b/src/core/platforms/android/androidplatformutilities.h
@@ -62,10 +62,10 @@ class AndroidPlatformUtilities : public PlatformUtilities
 
     ViewStatus *open( const QString &filePath, bool isEditing, QObject *parent = nullptr ) override;
 
+    void requestStoragePermission() const override;
     bool checkPositioningPermissions() const override;
     bool checkCameraPermissions() const override;
     bool checkMicrophonePermissions() const override;
-    bool checkWriteExternalStoragePermissions() const override;
 
     void setScreenLockPermission( const bool allowLock ) override;
 
@@ -86,7 +86,7 @@ class AndroidPlatformUtilities : public PlatformUtilities
 
   private:
     // separate multiple permissions using a semi-column (;)
-    bool checkAndAcquirePermissions( const QString &permissions ) const;
+    bool checkAndAcquirePermissions( QStringList permissions, bool forceAsk = false ) const;
     ResourceSource *processCameraActivity( const QString &prefix, const QString &filePath, const QString &suffix, bool isVideo, QObject *parent = nullptr );
     ResourceSource *processGalleryActivity( const QString &prefix, const QString &filePath, const QString &mimeType, QObject *parent = nullptr );
 

--- a/src/core/platforms/platformutilities.cpp
+++ b/src/core/platforms/platformutilities.cpp
@@ -373,11 +373,6 @@ bool PlatformUtilities::checkMicrophonePermissions() const
   return true;
 }
 
-bool PlatformUtilities::checkWriteExternalStoragePermissions() const
-{
-  return true;
-}
-
 void PlatformUtilities::copyTextToClipboard( const QString &string ) const
 {
   QGuiApplication::clipboard()->setText( string );

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -248,14 +248,6 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
     Q_DECL_DEPRECATED Q_INVOKABLE virtual bool checkMicrophonePermissions() const;
 
     /**
-     * Checks for permissions to write exeternal storage.
-     * If the permissions are not given, the user will be asked to grant
-     * permissions.
-     * \deprecated Since QField 3.1
-     */
-    Q_DECL_DEPRECATED Q_INVOKABLE virtual bool checkWriteExternalStoragePermissions() const;
-
-    /**
      * Sets whether the device screen is allowed to go in lock mode.
      * @param allowLock if set to FALSE, the screen will not be allowed to lock.
      */
@@ -311,12 +303,13 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
      */
     Q_INVOKABLE virtual void vibrate( int milliseconds ) const { Q_UNUSED( milliseconds ) }
 
-    static PlatformUtilities *instance();
-
+    Q_INVOKABLE virtual void requestStoragePermission() const {};
     virtual Qt::PermissionStatus checkCameraPermission() const;
     virtual void requestCameraPermission( std::function<void( Qt::PermissionStatus )> func );
     virtual Qt::PermissionStatus checkMicrophonePermission() const;
     virtual void requestMicrophonePermission( std::function<void( Qt::PermissionStatus )> func );
+
+    static PlatformUtilities *instance();
 
   signals:
     //! Emitted when a resource has been received.

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -446,6 +446,7 @@ Page {
             Layout.fillWidth: true
             text: qsTr("Open local file")
             onClicked: {
+              platformUtilities.requestStoragePermission();
               openLocalDataPicker();
             }
           }

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -314,6 +314,7 @@ EditorWidgetBase {
 
       onClicked: {
         if (FileUtils.fileExists(prefixToRelativePath + value)) {
+          platformUtilities.requestStoragePermission();
           __viewStatus = platformUtilities.open(prefixToRelativePath + value, isEnabled, this);
         }
       }
@@ -631,6 +632,7 @@ EditorWidgetBase {
 
   function attachFile() {
     Qt.inputMethod.hide();
+    platformUtilities.requestStoragePermission();
     var filepath = getResourceFilePath();
     if (documentViewer == document_AUDIO) {
       __resourceSource = platformUtilities.getFile(qgisProject.homePath + '/', filepath, PlatformUtilities.AudioFiles, this);
@@ -641,6 +643,7 @@ EditorWidgetBase {
 
   function attachGallery() {
     Qt.inputMethod.hide();
+    platformUtilities.requestStoragePermission();
     var filepath = getResourceFilePath();
     if (documentViewer == document_VIDEO) {
       __resourceSource = platformUtilities.getGalleryVideo(qgisProject.homePath + '/', filepath, this);


### PR DESCRIPTION
This PR gets rid of the last permission-request-on-launch popup when installing QField on Android: storage access. Instead of throwing an intimidating / irritating permission request when launching QField, we adopt a much better practice of asking permission when actually needed. We adopted this behavior for all other permissions, and it makes a huge difference.

In this case, we will only request permission when users have clicked on the "open local files" button from the welcome screen, or when users use the "attach picture from gallery" or "attach file" actions within the feature form's attachment editor widget.

This means someone could install QField, log into QFieldCloud, fetch and consume a project without ever being asked for this permission, _unless_ they would end up triggering an action that requires/benefits from the permission. Big UX win.

This also comes in as a micro optimization as we end up not having to check storage permission on every QField launch.

Cherry on top of this nice sundae: it makes testing QField during development slightly less irritating :)