### PR TITLE
Background tracking support

### DIFF
--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -278,7 +278,7 @@
     <meta-data android:name="io.sentry.environment" android:value="@SENTRY_ENV@" />
     <meta-data android:name="io.sentry.auto-init" android:value="false" />
 
-    <service android:process=":qt" android:name="ch.opengis.@APP_PACKAGE_NAME@.QFieldCloudService">
+    <service android:process=":qt_service" android:name="ch.opengis.@APP_PACKAGE_NAME@.QFieldCloudService">
       <meta-data android:name="android.app.arguments" android:value="--cloudservice"/>
       <meta-data android:name="android.app.lib_name" android:value="@string/lib_name"/>
       <meta-data android:name="android.app.repository" android:value="default"/>

--- a/platform/android/res/values/strings.xml
+++ b/platform/android/res/values/strings.xml
@@ -65,4 +65,7 @@
     <string name="import_operation_unsupported">Your device does not support this import operation.</string>
     <string name="export_operation_unsupported">Your device does not support this export operation.</string>
     <string name="processing_message">Processing…</string>
+    <string name="positioning_title">Positioning</string>
+    <string name="positioning_running">Positioning service running</string>
+    <string name="copy_to_clipboard">Copy to clipboard</string>
 </resources>

--- a/platform/android/src/ch/opengis/qfield/QFieldCloudService.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldCloudService.java
@@ -93,7 +93,7 @@ public class QFieldCloudService extends QtService {
             new Notification.Builder(this)
                 .setSmallIcon(R.drawable.qfield_logo)
                 .setWhen(System.currentTimeMillis())
-                .setContentTitle("QField")
+                .setContentTitle("QFieldCloud")
                 .setContentText(getString(R.string.upload_pending_attachments))
                 .setProgress(0, 0, true);
 

--- a/platform/android/src/ch/opengis/qfield/QFieldPositioningService.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldPositioningService.java
@@ -34,6 +34,7 @@ package ch.opengis.qfield;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ServiceInfo;
@@ -155,12 +156,16 @@ public class QFieldPositioningService extends QtService {
     }
 
     public void showNotification(String contentText) {
+        PendingIntent contentIntent = PendingIntent.getActivity(
+            this, 0, new Intent(this, QFieldActivity.class),
+            PendingIntent.FLAG_MUTABLE);
         Notification.Builder builder = new Notification.Builder(this)
                                            .setSmallIcon(R.drawable.qfield_logo)
                                            .setWhen(System.currentTimeMillis())
                                            .setOngoing(true)
                                            .setContentTitle("QField")
-                                           .setContentText(contentText);
+                                           .setContentText(contentText)
+                                           .setContentIntent(contentIntent);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             builder.setChannelId(CHANNEL_ID);

--- a/platform/android/src/ch/opengis/qfield/QFieldPositioningService.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldPositioningService.java
@@ -132,7 +132,7 @@ public class QFieldPositioningService extends QtService {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             notificationChannel = new NotificationChannel(
                 CHANNEL_ID, "QField", NotificationManager.IMPORTANCE_DEFAULT);
-            notificationChannel.setDescription("QField positioning");
+            notificationChannel.setDescription("QField Positioning");
             notificationChannel.setImportance(
                 NotificationManager.IMPORTANCE_LOW);
             notificationChannel.enableLights(false);
@@ -145,8 +145,8 @@ public class QFieldPositioningService extends QtService {
                 .setSmallIcon(R.drawable.qfield_logo)
                 .setWhen(System.currentTimeMillis())
                 .setOngoing(true)
-                .setContentTitle("QField")
-                .setContentText("Positioning service running");
+                .setContentTitle(getString(R.string.positioning_title))
+                .setContentText(getString(R.string.positioning_running));
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             builder.setChannelId(CHANNEL_ID);
@@ -171,13 +171,14 @@ public class QFieldPositioningService extends QtService {
             this, 0, new Intent(this, QFieldActivity.class),
             PendingIntent.FLAG_MUTABLE);
 
-        Notification.Builder builder = new Notification.Builder(this)
-                                           .setSmallIcon(R.drawable.qfield_logo)
-                                           .setWhen(System.currentTimeMillis())
-                                           .setOngoing(true)
-                                           .setContentTitle("QField")
-                                           .setContentText(contentText)
-                                           .setContentIntent(contentIntent);
+        Notification.Builder builder =
+            new Notification.Builder(this)
+                .setSmallIcon(R.drawable.qfield_logo)
+                .setWhen(System.currentTimeMillis())
+                .setOngoing(true)
+                .setContentTitle(getString(R.string.positioning_title))
+                .setContentText(contentText)
+                .setContentIntent(contentIntent);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             builder.setChannelId(CHANNEL_ID);
@@ -189,7 +190,8 @@ public class QFieldPositioningService extends QtService {
             copyIntent.putExtra("content", contentText);
             PendingIntent copyPendingIntent = PendingIntent.getService(
                 this, 0, copyIntent, PendingIntent.FLAG_MUTABLE);
-            builder.addAction(0, "Copy to clipboard", copyPendingIntent);
+            builder.addAction(0, getString(R.string.copy_to_clipboard),
+                              copyPendingIntent);
         }
 
         Notification notification = builder.build();

--- a/platform/android/src/ch/opengis/qfield/QFieldPositioningService.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldPositioningService.java
@@ -94,7 +94,7 @@ public class QFieldPositioningService extends QtService {
 
         if (getInstance() != null) {
             Log.v("QFieldPositioningService",
-                  "service already running, aborting.");
+                  "service already running, aborting onCreate.");
             stopSelf();
             return;
         }
@@ -105,6 +105,7 @@ public class QFieldPositioningService extends QtService {
         Log.v("QFieldPositioningService", "onDestroy triggered");
         notificationManager.cancel(NOTIFICATION_ID);
         super.onDestroy();
+        instance = null;
     }
 
     @Override
@@ -120,7 +121,8 @@ public class QFieldPositioningService extends QtService {
 
         int ret = super.onStartCommand(intent, flags, startId);
         if (instance != null) {
-            stopSelf();
+            Log.v("QFieldPositioningService",
+                  "service already running, aborting onStartCommand.");
             return START_NOT_STICKY;
         }
 

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -886,7 +886,7 @@ bool FeatureModel::create()
               QgsFeature childFeature;
               while ( it.nextFeature( childFeature ) )
               {
-                for ( const QgsRelation::FieldPair fieldPair : fieldPairs )
+                for ( const QgsRelation::FieldPair &fieldPair : fieldPairs )
                 {
                   childFeature.setAttribute( fieldPair.referencingField(), feat.attribute( fieldPair.referencedField() ) );
                 }

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -52,6 +52,7 @@ class FeatureModel : public QAbstractListModel
     Q_PROPERTY( bool positionLocked READ positionLocked WRITE setPositionLocked NOTIFY positionLockedChanged )
     Q_PROPERTY( CloudUserInformation cloudUserInformation READ cloudUserInformation WRITE setCloudUserInformation NOTIFY cloudUserInformationChanged )
     Q_PROPERTY( QgsProject *project READ project WRITE setProject NOTIFY projectChanged )
+    Q_PROPERTY( bool batchMode READ batchMode WRITE setBatchMode NOTIFY batchModeChanged )
 
   public:
     //! keeping the information what attributes are remembered and the last edited feature
@@ -271,6 +272,18 @@ class FeatureModel : public QAbstractListModel
 
     QgsExpressionContext createExpressionContext() const;
 
+    /**
+     * Returns TRUE if the feature model is in batch mode. When enabled, the vector layer
+     * will remain in editing mode until batch mode is disabled.
+     */
+    bool batchMode() const { return mBatchMode; }
+
+    /**
+     * Toggles the feature model batch mode. When enabled, the vector layer
+     * will remain in editing mode until batch mode is disabled.
+     */
+    void setBatchMode( bool batchMode );
+
   public slots:
     void applyGeometry();
     void removeLayer( QObject *layer );
@@ -297,6 +310,7 @@ class FeatureModel : public QAbstractListModel
     void positionLockedChanged();
     void projectChanged();
     void cloudUserInformationChanged();
+    void batchModeChanged();
 
     void warning( const QString &text );
 
@@ -331,6 +345,7 @@ class FeatureModel : public QAbstractListModel
     QgsProject *mProject = nullptr;
     QString mTempName;
     bool mPositionLocked = false;
+    bool mBatchMode = false;
 };
 
 #endif // FEATUREMODEL_H

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -383,6 +383,25 @@ void Positioning::setBackgroundMode( bool backgroundMode )
   emit backgroundModeChanged();
 }
 
+QList<GnssPositionInformation> Positioning::getBackgroundPositionInformation() const
+{
+  QList<GnssPositionInformation> positionInformationList;
+
+  if ( mPositioningSourceReplica )
+  {
+    QRemoteObjectPendingCall call;
+    QMetaObject::invokeMethod( mPositioningSourceReplica.data(), "getBackgroundPositionInformation", Qt::DirectConnection, Q_RETURN_ARG( QRemoteObjectPendingCall, call ) );
+    call.waitForFinished();
+    const QVariantList list = call.returnValue().toList();
+    for ( const QVariant &item : list )
+    {
+      positionInformationList << item.value<GnssPositionInformation>();
+    }
+  }
+
+  return std::move( positionInformationList );
+}
+
 PositioningSource::ElevationCorrectionMode Positioning::elevationCorrectionMode() const
 {
   return static_cast<PositioningSource::ElevationCorrectionMode>( ( mPositioningSourceReplica ? mPositioningSourceReplica->property( "elevationCorrectionMode" ) : mPropertiesToSync.value( "elevationCorrectionMode", static_cast<int>( PositioningSource::ElevationCorrectionMode::None ) ) ).toInt() );

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -43,8 +43,6 @@ Positioning::Positioning( QObject *parent )
     QFile::remove( PositioningSource::backgroundFilePath );
     mPropertiesToSync["backgroundMode"] = false;
   }
-
-  connect( QgsApplication::instance(), &QGuiApplication::applicationStateChanged, this, &Positioning::onApplicationStateChanged );
 }
 
 void Positioning::setupSource()
@@ -69,7 +67,6 @@ void Positioning::setupSource()
 
   mPositioningSourceReplica.reset( mNode.acquireDynamic( "PositioningSource" ) );
   mPositioningSourceReplica->waitForSource();
-
   const QList<QString> properties = mPropertiesToSync.keys();
   for ( const QString &property : properties )
   {
@@ -93,6 +90,8 @@ void Positioning::setupSource()
 
   connect( this, SIGNAL( triggerConnectDevice() ), mPositioningSourceReplica.data(), SLOT( triggerConnectDevice() ) );
   connect( this, SIGNAL( triggerDisconnectDevice() ), mPositioningSourceReplica.data(), SLOT( triggerDisconnectDevice() ) );
+
+  connect( QgsApplication::instance(), &QGuiApplication::applicationStateChanged, this, &Positioning::onApplicationStateChanged );
 }
 
 bool Positioning::isSourceAvailable() const
@@ -105,16 +104,10 @@ void Positioning::onApplicationStateChanged( Qt::ApplicationState state )
 #ifdef Q_OS_ANDROID
   // Google Play policy only allows for background access if it's explicitly stated and justified
   // Not stopping on Activity::onPause is detected as violation
-  if ( !mPositioningSourceReplica )
-    return;
-
   if ( !mPositioningSource )
   {
     // Service path
-    if ( mPositioningSourceReplica )
-    {
-      setBackgroundMode( state != Qt::ApplicationState::ApplicationActive );
-    }
+    setBackgroundMode( state != Qt::ApplicationState::ApplicationActive );
   }
   else
   {

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -14,13 +14,17 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "platformutilities.h"
 #include "positioning.h"
 #include "positioningutils.h"
 #include "tcpreceiver.h"
 #include "udpreceiver.h"
 #ifdef WITH_SERIALPORT
 #include "serialportreceiver.h"
+#endif
+
+#if defined( Q_OS_ANDROID )
+#include "platformutilities.h"
+#include "qfield_android.h"
 #endif
 
 #include <QFile>
@@ -49,7 +53,7 @@ void Positioning::setupSource()
 
 #if defined( Q_OS_ANDROID )
   PlatformUtilities::instance()->startPositioningService();
-  mNode.connectToNode( QUrl( QStringLiteral( "localabstract:replica" ) ) );
+  mNode.connectToNode( QUrl( QStringLiteral( "localabstract:" APP_PACKAGE_NAME "replica" ) ) );
   positioningService = true;
 #endif
 

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -218,17 +218,23 @@ class Positioning : public QObject
     void setLogging( bool logging );
 
     /**
-     * Returns TRUE if the background mode is active.
+     * Returns TRUE if the background mode is active. When activated, position information details
+     * will not be signaled but instead saved to disk until deactivated.
+     * \see getBackgroundPositionInformation()
      */
     bool backgroundMode() const;
 
     /**
-     * Sets whether the background mode is active.
+     * Sets whether the background mode is active. When activated, position information details
+     * will not be signaled but instead saved to disk until deactivated.
+     * \see getBackgroundPositionInformation()
      */
     void setBackgroundMode( bool backgroundMode );
 
     /**
-     * Returns a list of position information collected while background mode is turned on.
+     * Returns a list of position information collected while background mode is active.
+     * \see backgroundMode()
+     * \see setBackgroundMode()
      */
     Q_INVOKABLE QList<GnssPositionInformation> getBackgroundPositionInformation() const;
 

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -281,7 +281,7 @@ class Positioning : public QObject
     QgsQuickCoordinateTransformer *mCoordinateTransformer = nullptr;
     QgsPoint mSourcePosition;
     QgsPoint mProjectedPosition;
-    double mProjectedHorizontalAccuracy;
+    double mProjectedHorizontalAccuracy = 0.0;
     virtual QList<QPair<QString, QVariant>> details() const { return {}; }
 
     bool mInternalPermissionChecked = false;

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -265,6 +265,8 @@ class Positioning : public QObject
 
   private:
     void setupSource();
+    bool isSourceAvailable() const;
+
     double adjustOrientation( double orientation ) const;
 
     bool mValid = true;

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -227,6 +227,11 @@ class Positioning : public QObject
      */
     void setBackgroundMode( bool backgroundMode );
 
+    /**
+     * Returns a list of position information collected while background mode is turned on.
+     */
+    Q_INVOKABLE QList<GnssPositionInformation> getBackgroundPositionInformation() const;
+
   signals:
     void activeChanged();
     void validChanged();

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -51,8 +51,8 @@ class Positioning : public QObject
     Q_PROPERTY( GnssPositionInformation positionInformation READ positionInformation NOTIFY positionInformationChanged )
 
     Q_PROPERTY( QgsPoint sourcePosition READ sourcePosition NOTIFY positionInformationChanged )
-    Q_PROPERTY( QgsPoint projectedPosition READ projectedPosition NOTIFY projectedPositionChanged )
-    Q_PROPERTY( double projectedHorizontalAccuracy READ projectedHorizontalAccuracy NOTIFY projectedPositionChanged )
+    Q_PROPERTY( QgsPoint projectedPosition READ projectedPosition NOTIFY positionInformationChanged )
+    Q_PROPERTY( double projectedHorizontalAccuracy READ projectedHorizontalAccuracy NOTIFY positionInformationChanged )
 
     Q_PROPERTY( bool averagedPosition READ averagedPosition WRITE setAveragedPosition NOTIFY averagedPositionChanged )
     Q_PROPERTY( int averagedPositionCount READ averagedPositionCount NOTIFY averagedPositionCountChanged )
@@ -255,7 +255,6 @@ class Positioning : public QObject
 
   private slots:
     void onApplicationStateChanged( Qt::ApplicationState state );
-    void projectedPositionTransformed();
     void processGnssPositionInformation();
 
   private:

--- a/src/core/positioning/positioningsource.cpp
+++ b/src/core/positioning/positioningsource.cpp
@@ -150,7 +150,35 @@ void PositioningSource::setBackgroundMode( bool backgroundMode )
 
   mBackgroundMode = backgroundMode;
 
+  if ( mBackgroundMode )
+  {
+    QFile file( QStringLiteral( "%1.information" ).arg( backgroundFilePath ) );
+    file.open( QFile::WriteOnly );
+    file.close();
+  }
+
   emit backgroundModeChanged();
+}
+
+QList<GnssPositionInformation> PositioningSource::getBackgroundPositionInformation() const
+{
+  QList<GnssPositionInformation> positionInformationList;
+
+  QFile file( QStringLiteral( "%1.information" ).arg( backgroundFilePath ) );
+  if ( file.exists() )
+  {
+    file.open( QFile::ReadOnly );
+    QDataStream stream( &file );
+    while ( !stream.atEnd() )
+    {
+      GnssPositionInformation positionInformation;
+      stream >> positionInformation;
+      positionInformationList << positionInformation;
+    }
+    file.close();
+  }
+
+  return std::move( positionInformationList );
 }
 
 void PositioningSource::setElevationCorrectionMode( ElevationCorrectionMode elevationCorrectionMode )
@@ -297,6 +325,14 @@ void PositioningSource::lastGnssPositionInformationChanged( const GnssPositionIn
     {
       emit averagedPositionCountChanged();
     }
+  }
+  else
+  {
+    QFile file( QStringLiteral( "%1.information" ).arg( backgroundFilePath ) );
+    file.open( QFile::Append );
+    QDataStream stream( &file );
+    stream << mPositionInformation;
+    file.close();
   }
 }
 

--- a/src/core/positioning/positioningsource.cpp
+++ b/src/core/positioning/positioningsource.cpp
@@ -145,7 +145,6 @@ void PositioningSource::setLogging( bool logging )
 
 void PositioningSource::setBackgroundMode( bool backgroundMode )
 {
-  qDebug() << "sss setBackgroundMode " << ( backgroundMode ? "true" : "false" );
   if ( mBackgroundMode == backgroundMode )
     return;
 
@@ -165,7 +164,6 @@ void PositioningSource::setBackgroundMode( bool backgroundMode )
 
 QList<GnssPositionInformation> PositioningSource::getBackgroundPositionInformation() const
 {
-  qDebug() << "sss getBackgroundPositionInformation";
   QList<GnssPositionInformation> positionInformationList;
 
   QFile file( QStringLiteral( "%1.information" ).arg( backgroundFilePath ) );
@@ -181,7 +179,6 @@ QList<GnssPositionInformation> PositioningSource::getBackgroundPositionInformati
     }
     file.close();
   }
-  qDebug() << "sss collected positions " << positionInformationList.size();
 
   return std::move( positionInformationList );
 }
@@ -333,7 +330,6 @@ void PositioningSource::lastGnssPositionInformationChanged( const GnssPositionIn
   }
   else
   {
-    qDebug() << "sss writing to information file";
     QFile file( QStringLiteral( "%1.information" ).arg( backgroundFilePath ) );
     file.open( QFile::Append );
     QDataStream stream( &file );

--- a/src/core/positioning/positioningsource.cpp
+++ b/src/core/positioning/positioningsource.cpp
@@ -152,9 +152,11 @@ void PositioningSource::setBackgroundMode( bool backgroundMode )
 
   if ( mBackgroundMode )
   {
-    QFile file( QStringLiteral( "%1.information" ).arg( backgroundFilePath ) );
-    file.open( QFile::Truncate );
-    file.close();
+    if ( QFile::exists( QStringLiteral( "%1.information" ).arg( backgroundFilePath ) ) )
+    {
+      // Remove previously collected position information
+      QFile::remove( QStringLiteral( "%1.information" ).arg( backgroundFilePath ) );
+    }
   }
 
   emit backgroundModeChanged();

--- a/src/core/positioning/positioningsource.cpp
+++ b/src/core/positioning/positioningsource.cpp
@@ -293,7 +293,7 @@ void PositioningSource::lastGnssPositionInformationChanged( const GnssPositionIn
                                                      lastGnssPositionInformation.vdop(),
                                                      lastGnssPositionInformation.hacc(),
                                                      lastGnssPositionInformation.vacc(),
-                                                     lastGnssPositionInformation.utcDateTime(),
+                                                     lastGnssPositionInformation.utcDateTime().isValid() ? lastGnssPositionInformation.utcDateTime() : QDateTime::currentDateTimeUtc(),
                                                      lastGnssPositionInformation.fixMode(),
                                                      lastGnssPositionInformation.fixType(),
                                                      lastGnssPositionInformation.quality(),

--- a/src/core/positioning/positioningsource.cpp
+++ b/src/core/positioning/positioningsource.cpp
@@ -153,7 +153,7 @@ void PositioningSource::setBackgroundMode( bool backgroundMode )
   if ( mBackgroundMode )
   {
     QFile file( QStringLiteral( "%1.information" ).arg( backgroundFilePath ) );
-    file.open( QFile::WriteOnly );
+    file.open( QFile::Truncate );
     file.close();
   }
 

--- a/src/core/positioning/positioningsource.cpp
+++ b/src/core/positioning/positioningsource.cpp
@@ -145,6 +145,7 @@ void PositioningSource::setLogging( bool logging )
 
 void PositioningSource::setBackgroundMode( bool backgroundMode )
 {
+  qDebug() << "sss setBackgroundMode " << ( backgroundMode ? "true" : "false" );
   if ( mBackgroundMode == backgroundMode )
     return;
 
@@ -164,6 +165,7 @@ void PositioningSource::setBackgroundMode( bool backgroundMode )
 
 QList<GnssPositionInformation> PositioningSource::getBackgroundPositionInformation() const
 {
+  qDebug() << "sss getBackgroundPositionInformation";
   QList<GnssPositionInformation> positionInformationList;
 
   QFile file( QStringLiteral( "%1.information" ).arg( backgroundFilePath ) );
@@ -179,6 +181,7 @@ QList<GnssPositionInformation> PositioningSource::getBackgroundPositionInformati
     }
     file.close();
   }
+  qDebug() << "sss collected positions " << positionInformationList.size();
 
   return std::move( positionInformationList );
 }
@@ -330,6 +333,7 @@ void PositioningSource::lastGnssPositionInformationChanged( const GnssPositionIn
   }
   else
   {
+    qDebug() << "sss writing to information file";
     QFile file( QStringLiteral( "%1.information" ).arg( backgroundFilePath ) );
     file.open( QFile::Append );
     QDataStream stream( &file );

--- a/src/core/positioning/positioningsource.h
+++ b/src/core/positioning/positioningsource.h
@@ -197,17 +197,23 @@ class PositioningSource : public QObject
     void setLogging( bool logging );
 
     /**
-     * Returns TRUE if the background mode is active.
+     * Returns TRUE if the background mode is active. When activated, position information details
+     * will not be signaled but instead saved to disk until deactivated.
+     * \see getBackgroundPositionInformation()
      */
     bool backgroundMode() const { return mBackgroundMode; }
 
     /**
-     * Sets whether the background mode is active.
+     * Sets whether the background mode is active. When activated, position information details
+     * will not be signaled but instead saved to disk until deactivated.
+     * \see getBackgroundPositionInformation()
      */
     void setBackgroundMode( bool backgroundMode );
 
     /**
-     * Returns a list of position information collected while background mode is turned on.
+     * Returns a list of position information collected while background mode is active.
+     * \see backgroundMode()
+     * \see setBackgroundMode()
      */
     Q_INVOKABLE QList<GnssPositionInformation> getBackgroundPositionInformation() const;
 

--- a/src/core/positioning/positioningsource.h
+++ b/src/core/positioning/positioningsource.h
@@ -206,6 +206,11 @@ class PositioningSource : public QObject
      */
     void setBackgroundMode( bool backgroundMode );
 
+    /**
+     * Returns a list of position information collected while background mode is turned on.
+     */
+    Q_INVOKABLE QList<GnssPositionInformation> getBackgroundPositionInformation() const;
+
     static QString backgroundFilePath;
 
   signals:

--- a/src/core/projectinfo.cpp
+++ b/src/core/projectinfo.cpp
@@ -152,24 +152,25 @@ QModelIndex ProjectInfo::restoreTracker( QgsVectorLayer *layer )
     return QModelIndex();
 
   QModelIndex index = mTrackingModel->createTracker( layer );
+  Tracker *tracker = mTrackingModel->data( index, TrackingModel::TrackerPointer ).value<Tracker *>();
 
   mSettings.beginGroup( QStringLiteral( "/qgis/projectInfo/trackers/%1" ).arg( layer->id() ) );
-  mTrackingModel->setData( index, mSettings.value( "minimumDistance", 0 ).toDouble(), TrackingModel::MinimumDistance );
-  mTrackingModel->setData( index, mSettings.value( "timeInterval", 0 ).toDouble(), TrackingModel::TimeInterval );
-  mTrackingModel->setData( index, mSettings.value( "sensorCapture", false ).toBool(), TrackingModel::SensorCapture );
-  mTrackingModel->setData( index, mSettings.value( "conjunction", false ).toBool(), TrackingModel::Conjunction );
-  mTrackingModel->setData( index, mSettings.value( "maximumDistance", 0 ).toDouble(), TrackingModel::MaximumDistance );
-  mTrackingModel->setData( index, static_cast<Tracker::MeasureType>( mSettings.value( "measureType", 0 ).toInt() ), TrackingModel::MeasureType );
-  mTrackingModel->setData( index, mSettings.value( "visible", true ).toBool(), TrackingModel::Visible );
+  tracker->setTimeInterval( mSettings.value( "timeInterval", 0 ).toInt() );
+  tracker->setMinimumDistance( mSettings.value( "minimumDistance", 0 ).toDouble() );
+  tracker->setMaximumDistance( mSettings.value( "maximumDistance", 0 ).toDouble() );
+  tracker->setSensorCapture( mSettings.value( "sensorCapture", false ).toBool() );
+  tracker->setConjunction( mSettings.value( "conjunction", false ).toBool() );
+  tracker->setMeasureType( static_cast<Tracker::MeasureType>( mSettings.value( "measureType", 0 ).toInt() ) );
+  tracker->setVisible( mSettings.value( "visible", true ).toBool() );
   const QgsFeatureId fid = mSettings.value( "featureId", FID_NULL ).toLongLong();
   if ( fid >= 0 )
   {
     QgsFeature feature = layer->getFeature( fid );
-    mTrackingModel->setData( index, QVariant::fromValue<QgsFeature>( feature ), TrackingModel::Feature );
+    tracker->setFeature( feature );
   }
   else
   {
-    mTrackingModel->setData( index, QVariant::fromValue<QgsFeature>( QgsFeature( layer->fields() ) ), TrackingModel::Feature );
+    tracker->setFeature( QgsFeature( layer->fields() ) );
   }
   mSettings.endGroup();
 

--- a/src/core/qgsquick/qgsquickcoordinatetransformer.cpp
+++ b/src/core/qgsquick/qgsquickcoordinatetransformer.cpp
@@ -107,7 +107,7 @@ QgsCoordinateTransformContext QgsQuickCoordinateTransformer::transformContext() 
   return mCoordinateTransform.context();
 }
 
-QgsPoint QgsQuickCoordinateTransformer::transformPosition( const QgsPoint &position )
+QgsPoint QgsQuickCoordinateTransformer::transformPosition( const QgsPoint &position ) const
 {
   return processPosition( position );
 }
@@ -118,7 +118,7 @@ void QgsQuickCoordinateTransformer::updatePosition()
   emit projectedPositionChanged();
 }
 
-QgsPoint QgsQuickCoordinateTransformer::processPosition( const QgsPoint &position )
+QgsPoint QgsQuickCoordinateTransformer::processPosition( const QgsPoint &position ) const
 {
   double x = position.x();
   double y = position.y();

--- a/src/core/qgsquick/qgsquickcoordinatetransformer.h
+++ b/src/core/qgsquick/qgsquickcoordinatetransformer.h
@@ -125,7 +125,7 @@ class QgsQuickCoordinateTransformer : public QObject
     //!\copydoc QgsQuickCoordinateTransformer::verticalGrid
     void setVerticalGrid( const QString &grid );
 
-    Q_INVOKABLE QgsPoint transformPosition( const QgsPoint &position );
+    Q_INVOKABLE QgsPoint transformPosition( const QgsPoint &position ) const;
 
   signals:
     //!\copydoc QgsQuickCoordinateTransformer::projectedPosition
@@ -156,7 +156,7 @@ class QgsQuickCoordinateTransformer : public QObject
 
   private:
     void updatePosition();
-    QgsPoint processPosition( const QgsPoint &position );
+    QgsPoint processPosition( const QgsPoint &position ) const;
 
     QgsPoint mProjectedPosition;
     QgsPoint mSourcePosition;

--- a/src/core/qgsquick/qgsquickcoordinatetransformer.h
+++ b/src/core/qgsquick/qgsquickcoordinatetransformer.h
@@ -125,6 +125,8 @@ class QgsQuickCoordinateTransformer : public QObject
     //!\copydoc QgsQuickCoordinateTransformer::verticalGrid
     void setVerticalGrid( const QString &grid );
 
+    Q_INVOKABLE QgsPoint transformPosition( const QgsPoint &position );
+
   signals:
     //!\copydoc QgsQuickCoordinateTransformer::projectedPosition
     void projectedPositionChanged();
@@ -154,6 +156,7 @@ class QgsQuickCoordinateTransformer : public QObject
 
   private:
     void updatePosition();
+    QgsPoint processPosition( const QgsPoint &position );
 
     QgsPoint mProjectedPosition;
     QgsPoint mSourcePosition;

--- a/src/core/rubberbandmodel.cpp
+++ b/src/core/rubberbandmodel.cpp
@@ -319,6 +319,8 @@ void RubberbandModel::removeVertex()
 void RubberbandModel::reset()
 {
   removeVertices( 0, mPointList.size() - 1 );
+  mPointList.replace( 0, QgsPoint() );
+
   mFrozen = false;
   emit frozenChanged();
 }

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -222,9 +222,6 @@ void Tracker::positionReceived()
   if ( !qgsDoubleNear( mTimeInterval, 0.0 ) )
   {
     mTimeIntervalFulfilled = ( mLastDevicePositionTimestamp.toMSecsSinceEpoch() - mLastVertexPositionTimestamp.toMSecsSinceEpoch() ) >= mTimeInterval * 1000;
-    qDebug() << mLastDevicePositionTimestamp;
-    qDebug() << mTimeInterval;
-    qDebug() << ( mLastDevicePositionTimestamp.toMSecsSinceEpoch() - mLastVertexPositionTimestamp.toMSecsSinceEpoch() );
 
     if ( !mConjunction && mTimeIntervalFulfilled )
     {
@@ -346,7 +343,6 @@ void Tracker::processPositionInformation( const GnssPositionInformation &positio
 
 void Tracker::replayPositionInformationList( const QList<GnssPositionInformation> &positionInformationList, QgsQuickCoordinateTransformer *coordinateTransformer )
 {
-  qDebug() << "ttt replayPositionInformationList with count " << positionInformationList.size();
   bool wasActive = false;
   if ( mIsActive )
   {

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -346,6 +346,7 @@ void Tracker::processPositionInformation( const GnssPositionInformation &positio
 
 void Tracker::replayPositionInformationList( const QList<GnssPositionInformation> &positionInformationList, QgsQuickCoordinateTransformer *coordinateTransformer )
 {
+  qDebug() << "ttt replayPositionInformationList with count " << positionInformationList.size();
   bool wasActive = false;
   if ( mIsActive )
   {

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -101,12 +101,12 @@ void Tracker::setFeature( const QgsFeature &feature )
   emit featureChanged();
 }
 
-void Tracker::setTimeInterval( double interval )
+void Tracker::setTimeInterval( double timeInterval )
 {
-  if ( mTimeInterval == interval )
+  if ( mTimeInterval == timeInterval )
     return;
 
-  mTimeInterval = interval;
+  mTimeInterval = timeInterval;
   emit timeIntervalChanged();
 }
 

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -356,7 +356,8 @@ void Tracker::replayPositionInformationList( const QList<GnssPositionInformation
   mIsReplaying = true;
   emit isReplayingChanged();
 
-  mFeatureModel->setBatchMode( true );
+  const Qgis::GeometryType geometryType = mRubberbandModel->geometryType();
+  mFeatureModel->setBatchMode( geometryType == Qgis::GeometryType::Point );
   connect( mRubberbandModel, &RubberbandModel::currentCoordinateChanged, this, &Tracker::positionReceived );
   for ( const GnssPositionInformation &positionInformation : positionInformationList )
   {
@@ -366,7 +367,6 @@ void Tracker::replayPositionInformationList( const QList<GnssPositionInformation
   disconnect( mRubberbandModel, &RubberbandModel::currentCoordinateChanged, this, &Tracker::positionReceived );
   mFeatureModel->setBatchMode( false );
 
-  const Qgis::GeometryType geometryType = mRubberbandModel->geometryType();
   const int vertexCount = mRubberbandModel->vertexCount();
   if ( ( geometryType == Qgis::GeometryType::Line && vertexCount > 2 ) || ( geometryType == Qgis::GeometryType::Polygon && vertexCount > 3 ) )
   {

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -246,13 +246,8 @@ void Tracker::sensorDataReceived()
   }
 }
 
-void Tracker::start( bool resetRubberbandModel )
+void Tracker::start()
 {
-  if ( resetRubberbandModel )
-  {
-    mRubberbandModel->reset();
-  }
-
   mIsActive = true;
   emit isActiveChanged();
 
@@ -401,7 +396,7 @@ void Tracker::replayPositionInformationList( const QList<GnssPositionInformation
 
   if ( wasActive )
   {
-    start( false );
+    start();
   }
 }
 

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -356,6 +356,7 @@ void Tracker::replayPositionInformationList( const QList<GnssPositionInformation
   mIsReplaying = true;
   emit isReplayingChanged();
 
+  mFeatureModel->setBatchMode( true );
   connect( mRubberbandModel, &RubberbandModel::currentCoordinateChanged, this, &Tracker::positionReceived );
   for ( const GnssPositionInformation &positionInformation : positionInformationList )
   {
@@ -363,6 +364,7 @@ void Tracker::replayPositionInformationList( const QList<GnssPositionInformation
                                 coordinateTransformer ? coordinateTransformer->transformPosition( QgsPoint( positionInformation.longitude(), positionInformation.latitude(), positionInformation.elevation() ) ) : QgsPoint() );
   }
   disconnect( mRubberbandModel, &RubberbandModel::currentCoordinateChanged, this, &Tracker::positionReceived );
+  mFeatureModel->setBatchMode( false );
 
   const Qgis::GeometryType geometryType = mRubberbandModel->geometryType();
   const int vertexCount = mRubberbandModel->vertexCount();

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -133,7 +133,7 @@ class Tracker : public QObject
     //! Returns whether the tracker is replaying positions
     bool isReplaying() const { return mIsReplaying; }
 
-    void start( bool resetRubberbandModel = true );
+    void start();
     void stop();
 
     Q_INVOKABLE void processPositionInformation( const GnssPositionInformation &positionInformation, const QgsPoint &projectedPosition );

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -71,10 +71,14 @@ class Tracker : public QObject
 
     explicit Tracker( QgsVectorLayer *vectorLayer );
 
+    //! Returns the rubber band model used to generate the track geometry
     RubberbandModel *rubberbandModel() const;
+    //! Sets the rubber band model used to generate the track geometry
     void setRubberbandModel( RubberbandModel *rubberbandModel );
 
+    //! Returns the feature model used to generate the track attributes
     FeatureModel *featureModel() const;
+    //! Sets the feature model used to generate the track attributes
     void setFeatureModel( FeatureModel *featureModel );
 
     //! Returns the minimum time interval constraint between each tracked point
@@ -133,10 +137,15 @@ class Tracker : public QObject
     //! Returns whether the tracker is replaying positions
     bool isReplaying() const { return mIsReplaying; }
 
+    //! Starts tracking
     void start();
+    //! Stops tracking
     void stop();
 
+    //! Process the given position information and projected position passed onto the tracker
     Q_INVOKABLE void processPositionInformation( const GnssPositionInformation &positionInformation, const QgsPoint &projectedPosition );
+
+    //! Replays a list of position information taking into account the tracker settings
     void replayPositionInformationList( const QList<GnssPositionInformation> &positionInformationList, QgsQuickCoordinateTransformer *coordinateTransformer = nullptr );
 
   signals:

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -138,7 +138,7 @@ class Tracker : public QObject
     bool isReplaying() const { return mIsReplaying; }
 
     //! Starts tracking
-    void start();
+    void start( const GnssPositionInformation &positionInformation = GnssPositionInformation(), const QgsPoint &projectedPosition = QgsPoint() );
     //! Stops tracking
     void stop();
 
@@ -170,7 +170,6 @@ class Tracker : public QObject
 
   private slots:
     void positionReceived();
-    void timeReceived();
     void sensorDataReceived();
     void rubberbandModelVertexCountChanged();
 
@@ -183,7 +182,6 @@ class Tracker : public QObject
     RubberbandModel *mRubberbandModel = nullptr;
     FeatureModel *mFeatureModel = nullptr;
 
-    QTimer mTimer;
     double mTimeInterval = 0.0;
     double mMinimumDistance = 0.0;
     double mMaximumDistance = 0.0;
@@ -202,6 +200,8 @@ class Tracker : public QObject
     bool mVisible = true;
 
     QDateTime mStartPositionTimestamp;
+    QDateTime mLastDevicePositionTimestamp;
+    QDateTime mLastVertexPositionTimestamp;
 
     MeasureType mMeasureType = Tracker::SecondsSinceStart;
 };

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -35,8 +35,22 @@ class Tracker : public QObject
     Q_OBJECT
 
     Q_PROPERTY( bool isActive READ isActive NOTIFY isActiveChanged )
+    Q_PROPERTY( bool isReplaying READ isReplaying NOTIFY isReplayingChanged )
+
+    Q_PROPERTY( bool visible READ visible WRITE setVisible NOTIFY visibleChanged )
+
+    Q_PROPERTY( QgsVectorLayer *vectorLayer READ vectorLayer WRITE setVectorLayer NOTIFY vectorLayerChanged )
+    Q_PROPERTY( QgsFeature feature READ feature WRITE setFeature NOTIFY featureChanged )
+
     Q_PROPERTY( RubberbandModel *rubberbandModel READ rubberbandModel WRITE setRubberbandModel NOTIFY rubberbandModelChanged )
     Q_PROPERTY( FeatureModel *featureModel READ featureModel WRITE setFeatureModel NOTIFY featureModelChanged )
+
+    Q_PROPERTY( double timeInterval READ timeInterval WRITE setTimeInterval NOTIFY timeIntervalChanged )
+    Q_PROPERTY( double minimumDistance READ minimumDistance WRITE setMinimumDistance NOTIFY minimumDistanceChanged )
+    Q_PROPERTY( double maximumDistance READ maximumDistance WRITE setMaximumDistance NOTIFY maximumDistanceChanged )
+    Q_PROPERTY( bool sensorCapture READ sensorCapture WRITE setSensorCapture NOTIFY sensorCaptureChanged )
+    Q_PROPERTY( bool conjunction READ conjunction WRITE setConjunction NOTIFY conjunctionChanged )
+    Q_PROPERTY( MeasureType measureType READ measureType WRITE setMeasureType NOTIFY measureTypeChanged )
 
     Q_PROPERTY( QDateTime startPositionTimestamp READ startPositionTimestamp WRITE setStartPositionTimestamp NOTIFY startPositionTimestampChanged )
 
@@ -55,7 +69,7 @@ class Tracker : public QObject
     };
     Q_ENUM( MeasureType )
 
-    explicit Tracker( QgsVectorLayer *layer );
+    explicit Tracker( QgsVectorLayer *vectorLayer );
 
     RubberbandModel *rubberbandModel() const;
     void setRubberbandModel( RubberbandModel *rubberbandModel );
@@ -66,27 +80,27 @@ class Tracker : public QObject
     //! Returns the minimum time interval constraint between each tracked point
     double timeInterval() const { return mTimeInterval; }
     //! Sets the minimum time interval constraint between each tracked point
-    void setTimeInterval( const double timeInterval ) { mTimeInterval = timeInterval; }
+    void setTimeInterval( double timeInterval );
 
     //! Returns the minimum distance constraint between each tracked point
     double minimumDistance() const { return mMinimumDistance; }
     //! Sets the minimum distance constraint between each tracked point
-    void setMinimumDistance( const double minimumDistance ) { mMinimumDistance = minimumDistance; };
+    void setMinimumDistance( double minimumDistance );
 
     //! Returns the maximum distance tolerated beyond which a position will be considered errenous
     double maximumDistance() const { return mMaximumDistance; }
     //! Sets the maximum distance tolerated beyond which a position will be considered errenous
-    void setMaximumDistance( const double maximumDistance ) { mMaximumDistance = maximumDistance; };
+    void setMaximumDistance( double maximumDistance );
 
     //! Returns if TRUE, newly captured sensor data is needed between each tracked point
     bool sensorCapture() const { return mSensorCapture; }
     //! Sets whether newly captured sensor data is needed between each tracked point
-    void setSensorCapture( const bool capture ) { mSensorCapture = capture; }
+    void setSensorCapture( bool capture );
 
     //! Returns TRUE if all constraints need to be fulfilled between each tracked point
     bool conjunction() const { return mConjunction; }
     //! Sets where all constraints need to be fulfilled between each tracked point
-    void setConjunction( const bool conjunction ) { mConjunction = conjunction; }
+    void setConjunction( bool conjunction );
 
     //! Returns the timestamp of the first recorded point
     QDateTime startPositionTimestamp() const { return mStartPositionTimestamp; }
@@ -94,9 +108,9 @@ class Tracker : public QObject
     void setStartPositionTimestamp( const QDateTime &startPositionTimestamp ) { mStartPositionTimestamp = startPositionTimestamp; }
 
     //! Returns the current layer
-    QgsVectorLayer *layer() const { return mLayer.data(); }
+    QgsVectorLayer *vectorLayer() const { return mVectorLayer.data(); }
     //! Sets the current layer
-    void setLayer( QgsVectorLayer *layer ) { mLayer = layer; }
+    void setVectorLayer( QgsVectorLayer *vectorLayer );
 
     //! Returns the created feature
     QgsFeature feature() const;
@@ -106,27 +120,42 @@ class Tracker : public QObject
     //! Returns TRUE if the tracker rubberband is visible
     bool visible() const { return mVisible; }
     //! Sets whether the tracker rubberband is visible
-    void setVisible( const bool visible ) { mVisible = visible; }
+    void setVisible( bool visible );
 
     //! Returns the measure type used with the tracker geometry's M dimension when available
     MeasureType measureType() const { return mMeasureType; }
     //! Sets the measure type used with the tracker geometry's M dimension when available
-    void setMeasureType( MeasureType type ) { mMeasureType = type; }
+    void setMeasureType( MeasureType type );
 
     //! Returns whether the tracker has been started
     bool isActive() const { return mIsActive; }
 
-    void start();
-    void stop( bool resetRubberbandModel = true );
+    //! Returns whether the tracker is replaying positions
+    bool isReplaying() const { return mIsReplaying; }
+
+    void start( bool resetRubberbandModel = true );
+    void stop();
 
     Q_INVOKABLE void processPositionInformation( const GnssPositionInformation &positionInformation, const QgsPoint &projectedPosition );
     void replayPositionInformationList( const QList<GnssPositionInformation> &positionInformationList, QgsQuickCoordinateTransformer *coordinateTransformer = nullptr );
 
   signals:
     void isActiveChanged();
+    void isReplayingChanged();
+    void visibleChanged();
+    void vectorLayerChanged();
     void rubberbandModelChanged();
     void featureModelChanged();
+
+    void timeIntervalChanged();
+    void minimumDistanceChanged();
+    void maximumDistanceChanged();
+    void sensorCaptureChanged();
+    void conjunctionChanged();
+    void measureTypeChanged();
+
     void featureCreated();
+    void featureChanged();
 
     void startPositionTimestampChanged();
 
@@ -140,7 +169,7 @@ class Tracker : public QObject
     void trackPosition();
 
     bool mIsActive = false;
-    bool mReplaying = false;
+    bool mIsReplaying = false;
 
     RubberbandModel *mRubberbandModel = nullptr;
     FeatureModel *mFeatureModel = nullptr;
@@ -158,7 +187,7 @@ class Tracker : public QObject
     bool mSensorCaptureFulfilled = false;
     bool mSkipPositionReceived = false;
 
-    QPointer<QgsVectorLayer> mLayer;
+    QPointer<QgsVectorLayer> mVectorLayer;
     QgsFeature mFeature;
 
     bool mVisible = true;

--- a/src/core/trackingmodel.cpp
+++ b/src/core/trackingmodel.cpp
@@ -14,8 +14,6 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "featuremodel.h"
-#include "rubberbandmodel.h"
 #include "trackingmodel.h"
 
 #include <qgsproject.h>
@@ -37,19 +35,6 @@ QHash<int, QByteArray> TrackingModel::roleNames() const
 
   roles[DisplayString] = "displayString";
   roles[TrackerPointer] = "tracker";
-  roles[VectorLayer] = "vectorLayer";
-  roles[TimeInterval] = "timeInterval";
-  roles[MinimumDistance] = "minimumDistance";
-  roles[MaximumDistance] = "maximumDistance";
-  roles[Conjunction] = "conjunction";
-  roles[Feature] = "feature";
-  roles[RubberbandModelPointer] = "rubberbandModel";
-  roles[FeatureModelPointer] = "featureModel";
-  roles[Visible] = "visible";
-  roles[StartPositionTimestamp] = "startPositionTimestamp";
-  roles[MeasureType] = "measureType";
-  roles[SensorCapture] = "sensorCapture";
-  roles[IsActive] = "isActive";
 
   return roles;
 }
@@ -90,35 +75,9 @@ QVariant TrackingModel::data( const QModelIndex &index, int role ) const
   switch ( role )
   {
     case DisplayString:
-      return QString( "Tracker on layer %1" ).arg( tracker->layer()->name() );
+      return QString( "Tracker on layer %1" ).arg( tracker->vectorLayer()->name() );
     case TrackerPointer:
       return QVariant::fromValue<Tracker *>( tracker );
-    case VectorLayer:
-      return QVariant::fromValue<QgsVectorLayer *>( tracker->layer() );
-    case Feature:
-      return QVariant::fromValue<QgsFeature>( tracker->feature() );
-    case Visible:
-      return tracker->visible();
-    case StartPositionTimestamp:
-      return tracker->startPositionTimestamp();
-    case TimeInterval:
-      return tracker->timeInterval();
-    case MinimumDistance:
-      return tracker->minimumDistance();
-    case Conjunction:
-      return tracker->conjunction();
-    case RubberbandModelPointer:
-      return QVariant::fromValue<RubberbandModel *>( tracker->rubberbandModel() );
-    case FeatureModelPointer:
-      return QVariant::fromValue<FeatureModel *>( tracker->featureModel() );
-    case MeasureType:
-      return tracker->measureType();
-    case SensorCapture:
-      return tracker->sensorCapture();
-    case MaximumDistance:
-      return tracker->maximumDistance();
-    case IsActive:
-      return tracker->isActive();
     default:
       return QVariant();
   }
@@ -126,48 +85,7 @@ QVariant TrackingModel::data( const QModelIndex &index, int role ) const
 
 bool TrackingModel::setData( const QModelIndex &index, const QVariant &value, int role )
 {
-  if ( index.row() < 0 || index.row() >= mTrackers.size() )
-    return false;
-
-  Tracker *tracker = mTrackers[index.row()];
-  switch ( role )
-  {
-    case Feature:
-      tracker->setFeature( value.value<QgsFeature>() );
-      break;
-    case Visible:
-      tracker->setVisible( value.toBool() );
-      break;
-    case TimeInterval:
-      tracker->setTimeInterval( value.toDouble() );
-      break;
-    case MinimumDistance:
-      tracker->setMinimumDistance( value.toDouble() );
-      break;
-    case Conjunction:
-      tracker->setConjunction( value.toBool() );
-      break;
-    case RubberbandModelPointer:
-      tracker->setRubberbandModel( value.value<RubberbandModel *>() );
-      break;
-    case FeatureModelPointer:
-      tracker->setFeatureModel( value.value<FeatureModel *>() );
-      break;
-    case MeasureType:
-      tracker->setMeasureType( static_cast<Tracker::MeasureType>( value.toInt() ) );
-      break;
-    case SensorCapture:
-      tracker->setSensorCapture( value.toBool() );
-      break;
-    case MaximumDistance:
-      tracker->setMaximumDistance( value.toDouble() );
-      break;
-    case TrackerPointer:
-    default:
-      return false;
-  }
-  emit dataChanged( index, index, QVector<int>() << role );
-  return true;
+  return false;
 }
 
 bool TrackingModel::featureInTracking( QgsVectorLayer *layer, const QgsFeatureId featureId )
@@ -223,27 +141,27 @@ QModelIndex TrackingModel::createTracker( QgsVectorLayer *layer )
 
 void TrackingModel::startTracker( QgsVectorLayer *layer )
 {
-  int listIndex = trackerIterator( layer ) - mTrackers.constBegin();
-  mTrackers[listIndex]->start();
-
-  QModelIndex idx = index( listIndex, 0 );
-  emit dataChanged( idx, idx, QVector<int>() << TrackingModel::IsActive );
-  emit layerInTrackingChanged( layer, true );
+  const int idx = trackerIterator( layer ) - mTrackers.constBegin();
+  if ( idx >= 0 )
+  {
+    mTrackers[idx]->start();
+    emit layerInTrackingChanged( layer, true );
+  }
 }
 
 void TrackingModel::stopTracker( QgsVectorLayer *layer )
 {
-  int listIndex = trackerIterator( layer ) - mTrackers.constBegin();
-  mTrackers[listIndex]->stop();
+  const int idx = trackerIterator( layer ) - mTrackers.constBegin();
+  if ( idx >= 0 )
+  {
+    mTrackers[idx]->stop();
 
-  QModelIndex idx = index( listIndex, 0 );
-  emit dataChanged( idx, idx, QVector<int>() << TrackingModel::IsActive );
-
-  beginRemoveRows( QModelIndex(), listIndex, listIndex );
-  delete mTrackers.takeAt( listIndex );
-  endRemoveRows();
-
-  emit layerInTrackingChanged( layer, false );
+    beginRemoveRows( QModelIndex(), idx, idx );
+    Tracker *tracker = mTrackers.takeAt( idx );
+    endRemoveRows();
+    delete tracker;
+    emit layerInTrackingChanged( layer, false );
+  }
 }
 
 void TrackingModel::replayPositionInformationList( const QList<GnssPositionInformation> &positionInformationList, QgsQuickCoordinateTransformer *coordinateTransformer )
@@ -262,8 +180,8 @@ void TrackingModel::setTrackerVisibility( QgsVectorLayer *layer, bool visible )
 {
   if ( trackerIterator( layer ) != mTrackers.constEnd() )
   {
-    int listIndex = trackerIterator( layer ) - mTrackers.constBegin();
-    setData( index( listIndex, 0, QModelIndex() ), visible, Visible );
+    const int idx = trackerIterator( layer ) - mTrackers.constBegin();
+    mTrackers[idx]->setVisible( visible );
   }
 }
 

--- a/src/core/trackingmodel.cpp
+++ b/src/core/trackingmodel.cpp
@@ -139,12 +139,12 @@ QModelIndex TrackingModel::createTracker( QgsVectorLayer *layer )
   return index( mTrackers.size() - 1, 0 );
 }
 
-void TrackingModel::startTracker( QgsVectorLayer *layer )
+void TrackingModel::startTracker( QgsVectorLayer *layer, const GnssPositionInformation &positionInformation, const QgsPoint &projectedPosition )
 {
   const int idx = trackerIterator( layer ) - mTrackers.constBegin();
   if ( idx >= 0 )
   {
-    mTrackers[idx]->start();
+    mTrackers[idx]->start( positionInformation, projectedPosition );
     emit layerInTrackingChanged( layer, true );
   }
 }

--- a/src/core/trackingmodel.h
+++ b/src/core/trackingmodel.h
@@ -54,7 +54,7 @@ class TrackingModel : public QAbstractItemModel
     //! Creates a tracking session for the provided vector \a layer.
     Q_INVOKABLE QModelIndex createTracker( QgsVectorLayer *layer );
     //! Starts tracking for the provided vector \a layer provided it has a tracking session created.
-    Q_INVOKABLE void startTracker( QgsVectorLayer *layer );
+    Q_INVOKABLE void startTracker( QgsVectorLayer *layer, const GnssPositionInformation &positionInformation = GnssPositionInformation(), const QgsPoint &projectedPosition = QgsPoint() );
     //! Stops the tracking session of the provided vector \a layer.
     Q_INVOKABLE void stopTracker( QgsVectorLayer *layer );
     //! Sets whether the tracking session rubber band is \a visible.

--- a/src/core/trackingmodel.h
+++ b/src/core/trackingmodel.h
@@ -57,8 +57,6 @@ class TrackingModel : public QAbstractItemModel
     Q_INVOKABLE void startTracker( QgsVectorLayer *layer );
     //! Stops the tracking session of the provided vector \a layer.
     Q_INVOKABLE void stopTracker( QgsVectorLayer *layer );
-    //! Stops the tracking session of the provided vector \a layer.
-    Q_INVOKABLE void replayPositionInformationList( const QList<GnssPositionInformation> &positionInformationList, QgsQuickCoordinateTransformer *coordinateTransformer = nullptr );
     //! Sets whether the tracking session rubber band is \a visible.
     Q_INVOKABLE void setTrackerVisibility( QgsVectorLayer *layer, bool visible );
     //! Returns TRUE if the \a featureId is attached to a vector \a layer tracking session.
@@ -69,6 +67,9 @@ class TrackingModel : public QAbstractItemModel
     Q_INVOKABLE bool layerInTracking( QgsVectorLayer *layer );
     //! Returns the tracker for the vector \a layer if a tracking session is present, otherwise returns NULLPTR.
     Tracker *trackerForLayer( QgsVectorLayer *layer );
+
+    //! Replays a list of position information for all active trackers
+    Q_INVOKABLE void replayPositionInformationList( const QList<GnssPositionInformation> &positionInformationList, QgsQuickCoordinateTransformer *coordinateTransformer = nullptr );
 
     void reset();
 

--- a/src/core/trackingmodel.h
+++ b/src/core/trackingmodel.h
@@ -38,20 +38,7 @@ class TrackingModel : public QAbstractItemModel
     enum TrackingRoles
     {
       DisplayString = Qt::UserRole,
-      TrackerPointer,         //! tracker object
-      VectorLayer,            //! layer in the current tracking session
-      RubberbandModelPointer, //! rubber band model used in the current tracking session
-      FeatureModelPointer,    //! feature model used in the current tracking session
-      TimeInterval,           //! minimum time interval constraint between each tracked point
-      MinimumDistance,        //! minimum distance constraint between each tracked point
-      Conjunction,            //! if TRUE, all constraints needs to be fulfilled before tracking a point
-      Visible,                //! if TRUE, the tracking session rubberband is visible
-      Feature,                //! feature in the current tracking session
-      StartPositionTimestamp, //! timestamp when the current tracking session started
-      MeasureType,            //! measurement type used to set the measure value
-      SensorCapture,          //! if TRUE, newly captured sensor data constraint will be required between each tracked point
-      MaximumDistance,        //! maximum distance tolerated beyond which a position will be considered errenous
-      IsActive,               //! if TRUE, the tracker has been started
+      TrackerPointer,
     };
 
     QHash<int, QByteArray> roleNames() const override;
@@ -103,7 +90,7 @@ class TrackingModel : public QAbstractItemModel
     QList<Tracker *> mTrackers;
     QList<Tracker *>::const_iterator trackerIterator( QgsVectorLayer *layer )
     {
-      return std::find_if( mTrackers.constBegin(), mTrackers.constEnd(), [layer]( const Tracker *tracker ) { return tracker->layer() == layer; } );
+      return std::find_if( mTrackers.constBegin(), mTrackers.constEnd(), [layer]( const Tracker *tracker ) { return tracker->vectorLayer() == layer; } );
     }
 };
 

--- a/src/core/trackingmodel.h
+++ b/src/core/trackingmodel.h
@@ -20,6 +20,7 @@
 
 #include <QAbstractItemModel>
 
+class QgsQuickCoordinateTransformer;
 class RubberbandModel;
 class Track;
 
@@ -37,8 +38,10 @@ class TrackingModel : public QAbstractItemModel
     enum TrackingRoles
     {
       DisplayString = Qt::UserRole,
+      TrackerPointer,         //! tracker object
       VectorLayer,            //! layer in the current tracking session
-      RubberModel,            //! rubberbandmodel used in the current tracking session
+      RubberbandModelPointer, //! rubber band model used in the current tracking session
+      FeatureModelPointer,    //! feature model used in the current tracking session
       TimeInterval,           //! minimum time interval constraint between each tracked point
       MinimumDistance,        //! minimum distance constraint between each tracked point
       Conjunction,            //! if TRUE, all constraints needs to be fulfilled before tracking a point
@@ -67,6 +70,8 @@ class TrackingModel : public QAbstractItemModel
     Q_INVOKABLE void startTracker( QgsVectorLayer *layer );
     //! Stops the tracking session of the provided vector \a layer.
     Q_INVOKABLE void stopTracker( QgsVectorLayer *layer );
+    //! Stops the tracking session of the provided vector \a layer.
+    Q_INVOKABLE void replayPositionInformationList( const QList<GnssPositionInformation> &positionInformationList, QgsQuickCoordinateTransformer *coordinateTransformer = nullptr );
     //! Sets whether the tracking session rubber band is \a visible.
     Q_INVOKABLE void setTrackerVisibility( QgsVectorLayer *layer, bool visible );
     //! Returns TRUE if the \a featureId is attached to a vector \a layer tracking session.

--- a/src/core/utils/geometryutils.h
+++ b/src/core/utils/geometryutils.h
@@ -100,8 +100,8 @@ class QFIELD_CORE_EXPORT GeometryUtils : public QObject
     //! Returns an empty (i.e. null) point.
     static Q_INVOKABLE QgsPoint emptyPoint() { return QgsPoint(); }
 
-    //! Creates a point from \a x and \a y.
-    static Q_INVOKABLE QgsPoint point( double x, double y ) { return QgsPoint( x, y ); }
+    //! Creates a point from \a x and \a y with optional \a z and \a values
+    static Q_INVOKABLE QgsPoint point( double x, double y, double z = std::numeric_limits<double>::quiet_NaN(), double m = std::numeric_limits<double>::quiet_NaN() ) { return QgsPoint( x, y, z, m ); }
 
     //! Creates a centroid point from a given \a geometry.
     static Q_INVOKABLE QgsPoint centroid( const QgsGeometry &geometry );

--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -247,7 +247,9 @@ ListView {
           icon.color: Theme.mainTextColor
 
           onClicked: {
-            displayToast(qsTr('This layer is is currently tracking the device position.'));
+            displayToast(qsTr('This layer is is currently tracking positions.'), 'info', qsTr('Stop'), function () {
+                trackingModel.stopTracker(VectorLayerPointer);
+              });
           }
 
           SequentialAnimation on bgcolor  {

--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -248,7 +248,10 @@ ListView {
 
           onClicked: {
             displayToast(qsTr('This layer is is currently tracking positions.'), 'info', qsTr('Stop'), function () {
-                trackingModel.stopTracker(VectorLayerPointer);
+                if (trackingModel.layerInTracking(VectorLayerPointer)) {
+                  trackingModel.stopTracker(VectorLayerPointer);
+                  displayToast(qsTr('Track on layer %1 stopped').arg(VectorLayerPointer.name));
+                }
               });
           }
 

--- a/src/qml/TrackerSettings.qml
+++ b/src/qml/TrackerSettings.qml
@@ -20,57 +20,57 @@ Popup {
   modal: true
   closePolicy: Popup.NoAutoClose
 
-  property var trackerModelItem: undefined
+  property var tracker: undefined
 
   Connections {
     target: trackingModel
 
     function onTrackingSetupRequested(trackerIndex, skipSettings) {
-      trackerModelItem = trackings.itemAt(trackerIndex.row).trackerModelItem;
+      tracker = trackings.itemAt(trackerIndex.row).tracker;
       if (!skipSettings) {
         trackerSettings.open();
         trackerSettings.focus = true;
       } else {
         featureModel.resetAttributes();
         featureModel.applyGeometry();
-        trackerModelItem.feature = featureModel.feature;
+        tracker.feature = featureModel.feature;
         if (embeddedAttributeFormModel.rowCount() > 0 && !featureModel.suppressFeatureForm()) {
           embeddedFeatureForm.active = true;
         } else {
-          trackingModel.startTracker(trackerModelItem.vectorLayer);
-          displayToast(qsTr('Track on layer %1 started').arg(trackerModelItem.vectorLayer.name));
+          trackingModel.startTracker(tracker.vectorLayer);
+          displayToast(qsTr('Track on layer %1 started').arg(tracker.vectorLayer.name));
           if (featureModel.currentLayer.geometryType === Qgis.GeometryType.Point) {
             projectInfo.saveTracker(featureModel.currentLayer);
           }
-          trackerModelItem = undefined;
+          tracker = undefined;
         }
       }
     }
   }
 
-  onTrackerModelItemChanged: {
-    if (trackerModelItem != undefined) {
-      featureModel.currentLayer = trackerModelItem.vectorLayer;
-      timeInterval.checked = trackerModelItem.timeInterval > 0;
-      timeIntervalValue.text = trackerModelItem.timeInterval > 0 ? trackerModelItem.timeInterval : positioningSettings.trackerTimeInterval;
-      minimumDistance.checked = trackerModelItem.minimumDistance > 0;
-      minimumDistanceValue.text = trackerModelItem.minimumDistance > 0 ? trackerModelItem.minimumDistance : positioningSettings.trackerMinimumDistance;
-      erroneousDistanceSafeguard.checked = trackerModelItem.maximumDistance > 0;
-      erroneousDistanceValue.text = trackerModelItem.maximumDistance > 0 ? trackerModelItem.maximumDistance : positioningSettings.trackerErroneousDistance;
-      sensorCapture.checked = trackerModelItem.sensorCapture;
-      allConstraints.checked = trackerModelItem.conjunction && (timeInterval.checked + minimumDistance.checked + sensorCapture.checked) > 1;
-      measureComboBox.currentIndex = trackerModelItem.measureType;
-      resumeTrackingButton.visible = trackerModelItem.feature.id >= 0;
+  onTrackerChanged: {
+    if (tracker != undefined) {
+      featureModel.currentLayer = tracker.vectorLayer;
+      timeInterval.checked = tracker.timeInterval > 0;
+      timeIntervalValue.text = tracker.timeInterval > 0 ? tracker.timeInterval : positioningSettings.trackerTimeInterval;
+      minimumDistance.checked = tracker.minimumDistance > 0;
+      minimumDistanceValue.text = tracker.minimumDistance > 0 ? tracker.minimumDistance : positioningSettings.trackerMinimumDistance;
+      erroneousDistanceSafeguard.checked = tracker.maximumDistance > 0;
+      erroneousDistanceValue.text = tracker.maximumDistance > 0 ? tracker.maximumDistance : positioningSettings.trackerErroneousDistance;
+      sensorCapture.checked = tracker.sensorCapture;
+      allConstraints.checked = tracker.conjunction && (timeInterval.checked + minimumDistance.checked + sensorCapture.checked) > 1;
+      measureComboBox.currentIndex = tracker.measureType;
+      resumeTrackingButton.visible = tracker.feature.id >= 0;
     }
   }
 
   function applySettings() {
-    trackerModelItem.timeInterval = timeIntervalValue.text.length == 0 || !timeInterval.checked ? 0.0 : timeIntervalValue.text;
-    trackerModelItem.minimumDistance = minimumDistanceValue.text.length == 0 || !minimumDistance.checked ? 0.0 : minimumDistanceValue.text;
-    trackerModelItem.maximumDistance = erroneousDistanceValue.text.length == 0 || !erroneousDistanceSafeguard.checked ? 0.0 : erroneousDistanceValue.text;
-    trackerModelItem.sensorCapture = sensorCapture.checked;
-    trackerModelItem.conjunction = (timeInterval.checked + minimumDistance.checked + sensorCapture.checked) > 1 && allConstraints.checked;
-    trackerModelItem.measureType = measureComboBox.currentIndex;
+    tracker.timeInterval = timeIntervalValue.text.length == 0 || !timeInterval.checked ? 0.0 : timeIntervalValue.text;
+    tracker.minimumDistance = minimumDistanceValue.text.length == 0 || !minimumDistance.checked ? 0.0 : minimumDistanceValue.text;
+    tracker.maximumDistance = erroneousDistanceValue.text.length == 0 || !erroneousDistanceSafeguard.checked ? 0.0 : erroneousDistanceValue.text;
+    tracker.sensorCapture = sensorCapture.checked;
+    tracker.conjunction = (timeInterval.checked + minimumDistance.checked + sensorCapture.checked) > 1 && allConstraints.checked;
+    tracker.measureType = measureComboBox.currentIndex;
   }
 
   Page {
@@ -78,15 +78,15 @@ Popup {
     anchors.fill: parent
 
     header: QfPageHeader {
-      title: trackerModelItem !== undefined && trackerModelItem.vectorLayer ? qsTr("Tracking: %1").arg(trackerModelItem.vectorLayer.name) : qsTr("Tracking")
+      title: tracker !== undefined && tracker.vectorLayer ? qsTr("Tracking: %1").arg(tracker.vectorLayer.name) : qsTr("Tracking")
 
       showApplyButton: false
       showCancelButton: false
       showBackButton: true
 
       onBack: {
-        if (trackerModelItem != undefined) {
-          trackingModel.stopTracker(trackerModelItem.vectorLayer);
+        if (tracker != undefined) {
+          trackingModel.stopTracker(tracker.vectorLayer);
         }
         close();
       }
@@ -479,16 +479,16 @@ Popup {
           applySettings();
           featureModel.resetAttributes();
           featureModel.applyGeometry();
-          trackerModelItem.feature = featureModel.feature;
+          tracker.feature = featureModel.feature;
           if (embeddedAttributeFormModel.rowCount() > 0 && !featureModel.suppressFeatureForm()) {
             embeddedFeatureForm.active = true;
           } else {
-            trackingModel.startTracker(trackerModelItem.vectorLayer);
-            displayToast(qsTr('Track on layer %1 started').arg(trackerModelItem.vectorLayer.name));
+            trackingModel.startTracker(tracker.vectorLayer);
+            displayToast(qsTr('Track on layer %1 started').arg(tracker.vectorLayer.name));
             if (featureModel.currentLayer.geometryType === Qgis.GeometryType.Point) {
               projectInfo.saveTracker(featureModel.currentLayer);
             }
-            trackerModelItem = undefined;
+            tracker = undefined;
             trackerSettings.close();
           }
         }
@@ -508,8 +508,8 @@ Popup {
 
         onClicked: {
           applySettings();
-          trackingModel.startTracker(trackerModelItem.vectorLayer);
-          displayToast(qsTr('Track on layer %1 started').arg(trackerModelItem.vectorLayer.name));
+          trackingModel.startTracker(tracker.vectorLayer);
+          displayToast(qsTr('Track on layer %1 started').arg(tracker.vectorLayer.name));
           projectInfo.saveTracker(featureModel.currentLayer);
           trackerSettings.close();
         }
@@ -574,15 +574,15 @@ Popup {
         state: 'Add'
 
         onTemporaryStored: {
-          trackerModelItem.feature = featureModel.feature;
+          tracker.feature = featureModel.feature;
           embeddedFeatureFormPopup.close();
           embeddedFeatureForm.active = false;
-          trackingModel.startTracker(trackerModelItem.vectorLayer);
-          displayToast(qsTr('Track on layer %1 started').arg(trackerModelItem.vectorLayer.name));
+          trackingModel.startTracker(tracker.vectorLayer);
+          displayToast(qsTr('Track on layer %1 started').arg(tracker.vectorLayer.name));
           if (featureModel.currentLayer.geometryType === Qgis.GeometryType.Point) {
             projectInfo.saveTracker(featureModel.currentLayer);
           }
-          trackerModelItem = undefined;
+          tracker = undefined;
           trackerSettings.close();
         }
 
@@ -590,8 +590,8 @@ Popup {
           embeddedFeatureFormPopup.close();
           embeddedFeatureForm.active = false;
           embeddedFeatureForm.focus = false;
-          trackingModel.stopTracker(trackerModelItem.vectorLayer);
-          trackerModelItem = undefined;
+          trackingModel.stopTracker(tracker.vectorLayer);
+          tracker = undefined;
           trackerSettings.close();
         }
       }

--- a/src/qml/TrackerSettings.qml
+++ b/src/qml/TrackerSettings.qml
@@ -20,57 +20,57 @@ Popup {
   modal: true
   closePolicy: Popup.NoAutoClose
 
-  property var tracker: undefined
+  property var trackerModelItem: undefined
 
   Connections {
     target: trackingModel
 
     function onTrackingSetupRequested(trackerIndex, skipSettings) {
-      tracker = trackings.itemAt(trackerIndex.row).tracker;
+      trackerModelItem = trackings.itemAt(trackerIndex.row).trackerModelItem;
       if (!skipSettings) {
         trackerSettings.open();
         trackerSettings.focus = true;
       } else {
         featureModel.resetAttributes();
         featureModel.applyGeometry();
-        tracker.feature = featureModel.feature;
+        trackerModelItem.feature = featureModel.feature;
         if (embeddedAttributeFormModel.rowCount() > 0 && !featureModel.suppressFeatureForm()) {
           embeddedFeatureForm.active = true;
         } else {
-          trackingModel.startTracker(tracker.vectorLayer);
-          displayToast(qsTr('Track on layer %1 started').arg(tracker.vectorLayer.name));
+          trackingModel.startTracker(trackerModelItem.vectorLayer);
+          displayToast(qsTr('Track on layer %1 started').arg(trackerModelItem.vectorLayer.name));
           if (featureModel.currentLayer.geometryType === Qgis.GeometryType.Point) {
             projectInfo.saveTracker(featureModel.currentLayer);
           }
-          tracker = undefined;
+          trackerModelItem = undefined;
         }
       }
     }
   }
 
-  onTrackerChanged: {
-    if (tracker != undefined) {
-      featureModel.currentLayer = tracker.vectorLayer;
-      timeInterval.checked = tracker.timeInterval > 0;
-      timeIntervalValue.text = tracker.timeInterval > 0 ? tracker.timeInterval : positioningSettings.trackerTimeInterval;
-      minimumDistance.checked = tracker.minimumDistance > 0;
-      minimumDistanceValue.text = tracker.minimumDistance > 0 ? tracker.minimumDistance : positioningSettings.trackerMinimumDistance;
-      erroneousDistanceSafeguard.checked = tracker.maximumDistance > 0;
-      erroneousDistanceValue.text = tracker.maximumDistance > 0 ? tracker.maximumDistance : positioningSettings.trackerErroneousDistance;
-      sensorCapture.checked = tracker.sensorCapture;
-      allConstraints.checked = tracker.conjunction && (timeInterval.checked + minimumDistance.checked + sensorCapture.checked) > 1;
-      measureComboBox.currentIndex = tracker.measureType;
-      resumeTrackingButton.visible = tracker.feature.id >= 0;
+  onTrackerModelItemChanged: {
+    if (trackerModelItem != undefined) {
+      featureModel.currentLayer = trackerModelItem.vectorLayer;
+      timeInterval.checked = trackerModelItem.timeInterval > 0;
+      timeIntervalValue.text = trackerModelItem.timeInterval > 0 ? trackerModelItem.timeInterval : positioningSettings.trackerTimeInterval;
+      minimumDistance.checked = trackerModelItem.minimumDistance > 0;
+      minimumDistanceValue.text = trackerModelItem.minimumDistance > 0 ? trackerModelItem.minimumDistance : positioningSettings.trackerMinimumDistance;
+      erroneousDistanceSafeguard.checked = trackerModelItem.maximumDistance > 0;
+      erroneousDistanceValue.text = trackerModelItem.maximumDistance > 0 ? trackerModelItem.maximumDistance : positioningSettings.trackerErroneousDistance;
+      sensorCapture.checked = trackerModelItem.sensorCapture;
+      allConstraints.checked = trackerModelItem.conjunction && (timeInterval.checked + minimumDistance.checked + sensorCapture.checked) > 1;
+      measureComboBox.currentIndex = trackerModelItem.measureType;
+      resumeTrackingButton.visible = trackerModelItem.feature.id >= 0;
     }
   }
 
   function applySettings() {
-    tracker.timeInterval = timeIntervalValue.text.length == 0 || !timeInterval.checked ? 0.0 : timeIntervalValue.text;
-    tracker.minimumDistance = minimumDistanceValue.text.length == 0 || !minimumDistance.checked ? 0.0 : minimumDistanceValue.text;
-    tracker.maximumDistance = erroneousDistanceValue.text.length == 0 || !erroneousDistanceSafeguard.checked ? 0.0 : erroneousDistanceValue.text;
-    tracker.sensorCapture = sensorCapture.checked;
-    tracker.conjunction = (timeInterval.checked + minimumDistance.checked + sensorCapture.checked) > 1 && allConstraints.checked;
-    tracker.measureType = measureComboBox.currentIndex;
+    trackerModelItem.timeInterval = timeIntervalValue.text.length == 0 || !timeInterval.checked ? 0.0 : timeIntervalValue.text;
+    trackerModelItem.minimumDistance = minimumDistanceValue.text.length == 0 || !minimumDistance.checked ? 0.0 : minimumDistanceValue.text;
+    trackerModelItem.maximumDistance = erroneousDistanceValue.text.length == 0 || !erroneousDistanceSafeguard.checked ? 0.0 : erroneousDistanceValue.text;
+    trackerModelItem.sensorCapture = sensorCapture.checked;
+    trackerModelItem.conjunction = (timeInterval.checked + minimumDistance.checked + sensorCapture.checked) > 1 && allConstraints.checked;
+    trackerModelItem.measureType = measureComboBox.currentIndex;
   }
 
   Page {
@@ -78,15 +78,15 @@ Popup {
     anchors.fill: parent
 
     header: QfPageHeader {
-      title: tracker !== undefined && tracker.vectorLayer ? qsTr("Tracking: %1").arg(tracker.vectorLayer.name) : qsTr("Tracking")
+      title: trackerModelItem !== undefined && trackerModelItem.vectorLayer ? qsTr("Tracking: %1").arg(trackerModelItem.vectorLayer.name) : qsTr("Tracking")
 
       showApplyButton: false
       showCancelButton: false
       showBackButton: true
 
       onBack: {
-        if (tracker != undefined) {
-          trackingModel.stopTracker(tracker.vectorLayer);
+        if (trackerModelItem != undefined) {
+          trackingModel.stopTracker(trackerModelItem.vectorLayer);
         }
         close();
       }
@@ -479,16 +479,16 @@ Popup {
           applySettings();
           featureModel.resetAttributes();
           featureModel.applyGeometry();
-          tracker.feature = featureModel.feature;
+          trackerModelItem.feature = featureModel.feature;
           if (embeddedAttributeFormModel.rowCount() > 0 && !featureModel.suppressFeatureForm()) {
             embeddedFeatureForm.active = true;
           } else {
-            trackingModel.startTracker(tracker.vectorLayer);
-            displayToast(qsTr('Track on layer %1 started').arg(tracker.vectorLayer.name));
+            trackingModel.startTracker(trackerModelItem.vectorLayer);
+            displayToast(qsTr('Track on layer %1 started').arg(trackerModelItem.vectorLayer.name));
             if (featureModel.currentLayer.geometryType === Qgis.GeometryType.Point) {
               projectInfo.saveTracker(featureModel.currentLayer);
             }
-            tracker = undefined;
+            trackerModelItem = undefined;
             trackerSettings.close();
           }
         }
@@ -508,8 +508,8 @@ Popup {
 
         onClicked: {
           applySettings();
-          trackingModel.startTracker(tracker.vectorLayer);
-          displayToast(qsTr('Track on layer %1 started').arg(tracker.vectorLayer.name));
+          trackingModel.startTracker(trackerModelItem.vectorLayer);
+          displayToast(qsTr('Track on layer %1 started').arg(trackerModelItem.vectorLayer.name));
           projectInfo.saveTracker(featureModel.currentLayer);
           trackerSettings.close();
         }
@@ -574,15 +574,15 @@ Popup {
         state: 'Add'
 
         onTemporaryStored: {
-          tracker.feature = featureModel.feature;
+          trackerModelItem.feature = featureModel.feature;
           embeddedFeatureFormPopup.close();
           embeddedFeatureForm.active = false;
-          trackingModel.startTracker(tracker.vectorLayer);
-          displayToast(qsTr('Track on layer %1 started').arg(tracker.vectorLayer.name));
+          trackingModel.startTracker(trackerModelItem.vectorLayer);
+          displayToast(qsTr('Track on layer %1 started').arg(trackerModelItem.vectorLayer.name));
           if (featureModel.currentLayer.geometryType === Qgis.GeometryType.Point) {
             projectInfo.saveTracker(featureModel.currentLayer);
           }
-          tracker = undefined;
+          trackerModelItem = undefined;
           trackerSettings.close();
         }
 
@@ -590,8 +590,8 @@ Popup {
           embeddedFeatureFormPopup.close();
           embeddedFeatureForm.active = false;
           embeddedFeatureForm.focus = false;
-          trackingModel.stopTracker(tracker.vectorLayer);
-          tracker = undefined;
+          trackingModel.stopTracker(trackerModelItem.vectorLayer);
+          trackerModelItem = undefined;
           trackerSettings.close();
         }
       }

--- a/src/qml/TrackerSettings.qml
+++ b/src/qml/TrackerSettings.qml
@@ -37,7 +37,7 @@ Popup {
         if (embeddedAttributeFormModel.rowCount() > 0 && !featureModel.suppressFeatureForm()) {
           embeddedFeatureForm.active = true;
         } else {
-          trackingModel.startTracker(tracker.vectorLayer);
+          trackingModel.startTracker(tracker.vectorLayer, positionSource.positionInformation, positionSource.projectedPosition);
           displayToast(qsTr('Track on layer %1 started').arg(tracker.vectorLayer.name));
           if (featureModel.currentLayer.geometryType === Qgis.GeometryType.Point) {
             projectInfo.saveTracker(featureModel.currentLayer);
@@ -483,7 +483,7 @@ Popup {
           if (embeddedAttributeFormModel.rowCount() > 0 && !featureModel.suppressFeatureForm()) {
             embeddedFeatureForm.active = true;
           } else {
-            trackingModel.startTracker(tracker.vectorLayer);
+            trackingModel.startTracker(tracker.vectorLayer, positionSource.positionInformation, positionSource.projectedPosition);
             displayToast(qsTr('Track on layer %1 started').arg(tracker.vectorLayer.name));
             if (featureModel.currentLayer.geometryType === Qgis.GeometryType.Point) {
               projectInfo.saveTracker(featureModel.currentLayer);
@@ -508,7 +508,7 @@ Popup {
 
         onClicked: {
           applySettings();
-          trackingModel.startTracker(tracker.vectorLayer);
+          trackingModel.startTracker(tracker.vectorLayer, positionSource.positionInformation, positionSource.projectedPosition);
           displayToast(qsTr('Track on layer %1 started').arg(tracker.vectorLayer.name));
           projectInfo.saveTracker(featureModel.currentLayer);
           trackerSettings.close();
@@ -577,7 +577,7 @@ Popup {
           tracker.feature = featureModel.feature;
           embeddedFeatureFormPopup.close();
           embeddedFeatureForm.active = false;
-          trackingModel.startTracker(tracker.vectorLayer);
+          trackingModel.startTracker(tracker.vectorLayer, positionSource.positionInformation, positionSource.projectedPosition);
           displayToast(qsTr('Track on layer %1 started').arg(tracker.vectorLayer.name));
           if (featureModel.currentLayer.geometryType === Qgis.GeometryType.Point) {
             projectInfo.saveTracker(featureModel.currentLayer);

--- a/src/qml/TrackingSession.qml
+++ b/src/qml/TrackingSession.qml
@@ -11,7 +11,6 @@ import Theme
 Item {
   id: trackingSession
 
-  property var trackerModelItem: model
   property var tracker: model.tracker
 
   Component.onCompleted: {
@@ -21,11 +20,10 @@ Item {
 
   Connections {
     target: positionSource
+    enabled: tracker.isActive
 
     function onPositionInformationChanged() {
-      if (tracker.isActive) {
-        tracker.processPositionInformation(positionSource.positionInformation, positionSource.projectedPosition);
-      }
+      tracker.processPositionInformation(positionSource.positionInformation, positionSource.projectedPosition);
     }
   }
 
@@ -42,13 +40,13 @@ Item {
   RubberbandModel {
     id: rubberbandModel
     frozen: false
-    vectorLayer: trackerModelItem.vectorLayer
+    vectorLayer: tracker.vectorLayer
     crs: mapCanvas.mapSettings.destinationCrs
   }
 
   Rubberband {
     id: rubberband
-    visible: trackerModelItem.visible
+    visible: tracker.visible
 
     color: Qt.rgba(Math.min(0.75, Math.random()), Math.min(0.75, Math.random()), Math.min(0.75, Math.random()), 0.6)
     geometryType: Qgis.GeometryType.Line
@@ -60,11 +58,11 @@ Item {
   FeatureModel {
     id: featureModel
     project: qgisProject
-    currentLayer: trackerModelItem.vectorLayer
-    feature: trackerModelItem.feature
+    currentLayer: tracker.vectorLayer
+    feature: tracker.feature
 
     onFeatureChanged: {
-      if (!tracker.isActive) {
+      if (!tracker.isActive && !tracker.isReplaying) {
         updateRubberband();
       }
     }
@@ -72,7 +70,7 @@ Item {
     geometry: Geometry {
       id: featureModelGeometry
       rubberbandModel: rubberbandModel
-      vectorLayer: trackerModelItem.vectorLayer
+      vectorLayer: tracker.vectorLayer
     }
 
     positionInformation: coordinateLocator.positionInformation

--- a/src/qml/TrackingSession.qml
+++ b/src/qml/TrackingSession.qml
@@ -23,6 +23,7 @@ Item {
     enabled: tracker.isActive
 
     function onPositionInformationChanged() {
+      featureModel.positionInformation = positionSource.positionInformation;
       tracker.processPositionInformation(positionSource.positionInformation, positionSource.projectedPosition);
     }
   }
@@ -73,7 +74,6 @@ Item {
       vectorLayer: tracker.vectorLayer
     }
 
-    positionInformation: coordinateLocator.positionInformation
     positionLocked: true
     cloudUserInformation: projectInfo.cloudUserInformation
   }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -344,7 +344,9 @@ ApplicationWindow {
 
     onBackgroundModeChanged: {
       if (!backgroundMode) {
+        mapCanvasMap.freeze('trackerreplay');
         trackingModel.replayPositionInformationList(positionSource.getBackgroundPositionInformation(), coordinateTransformer);
+        mapCanvasMap.unfreeze('trackerreplay');
       }
     }
   }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -341,6 +341,12 @@ ApplicationWindow {
     onDeviceLastErrorChanged: {
       displayToast(qsTr('Positioning device error: %1').arg(positionSource.deviceLastError), 'error');
     }
+
+    onBackgroundModeChanged: {
+      if (!backgroundMode) {
+        trackingModel.replayPositionInformationList(positionSource.getBackgroundPositionInformation(), coordinateTransformer);
+      }
+    }
   }
 
   PositioningSettings {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -346,8 +346,9 @@ ApplicationWindow {
       if (!backgroundMode) {
         console.log('qqq onBackgroundModeChanged');
         mapCanvasMap.freeze('trackerreplay');
-        const list = positionSource.getBackgroundPositionInformation();
-        console.log('qqq collected positions  ' + list.length);
+        let list = positionSource.getBackgroundPositionInformation();
+        // Qt bug weirdly returns an empty list on first invokation to source, call twice to insure we've got the actual list
+        list = positionSource.getBackgroundPositionInformation();
         trackingModel.replayPositionInformationList(list, coordinateTransformer);
         mapCanvasMap.unfreeze('trackerreplay');
       }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -344,8 +344,11 @@ ApplicationWindow {
 
     onBackgroundModeChanged: {
       if (!backgroundMode) {
+        console.log('qqq onBackgroundModeChanged');
         mapCanvasMap.freeze('trackerreplay');
-        trackingModel.replayPositionInformationList(positionSource.getBackgroundPositionInformation(), coordinateTransformer);
+        const list = positionSource.getBackgroundPositionInformation();
+        console.log('qqq collected positions  ' + list.length);
+        trackingModel.replayPositionInformationList(list, coordinateTransformer);
         mapCanvasMap.unfreeze('trackerreplay');
       }
     }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1907,16 +1907,6 @@ ApplicationWindow {
 
         anchors.right: parent.right
 
-        onIconSourceChanged: {
-          if (state === "On") {
-            if (positionSource.positionInformation && positionSource.positionInformation.latitudeValid) {
-              displayToast(qsTr("Received position"));
-            } else {
-              displayToast(qsTr("Searching for position"));
-            }
-          }
-        }
-
         /*
         / When set to true, the map will follow the device's current position; the map
         / will stop following the position whe the user manually drag the map.

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -323,7 +323,7 @@ ApplicationWindow {
     antennaHeight: positioningSettings.antennaHeightActivated ? positioningSettings.antennaHeight : 0
     logging: positioningSettings.logging
 
-    onProjectedPositionChanged: {
+    onPositionInformationChanged: {
       if (active) {
         bearingTrueNorth = PositioningUtils.bearingTrueNorth(positionSource.projectedPosition, mapCanvas.mapSettings.destinationCrs);
         if (gnssButton.followActive) {

--- a/src/service/qfieldpositioningservice.cpp
+++ b/src/service/qfieldpositioningservice.cpp
@@ -63,7 +63,8 @@ void QFieldPositioningService::triggerShowNotification()
   QJniObject message = QJniObject::fromString( tr( "Latitude %1 | Longitude %2 | Altitude %3 | Orientation %4" ).arg( QLocale::system().toString( pos.latitude(), 'f', 7 ), QLocale::system().toString( pos.longitude(), 'f', 7 ), QLocale::system().toString( pos.elevation(), 'f', 3 ), QLocale::system().toString( mPositioningSource->orientation(), 'f', 1 ) ) );
   QJniObject::callStaticMethod<void>( "ch/opengis/" APP_PACKAGE_NAME "/QFieldPositioningService",
                                       "triggerShowNotification",
-                                      message.object<jstring>() );
+                                      message.object<jstring>(),
+                                      true );
 }
 
 void QFieldPositioningService::triggerCloseNotification()
@@ -71,7 +72,8 @@ void QFieldPositioningService::triggerCloseNotification()
   QJniObject message = QJniObject::fromString( tr( "Positioning service running" ) );
   QJniObject::callStaticMethod<void>( "ch/opengis/" APP_PACKAGE_NAME "/QFieldPositioningService",
                                       "triggerShowNotification",
-                                      message.object<jstring>() );
+                                      message.object<jstring>(),
+                                      false );
 }
 
 QFieldPositioningService::~QFieldPositioningService()

--- a/src/service/qfieldpositioningservice.cpp
+++ b/src/service/qfieldpositioningservice.cpp
@@ -28,6 +28,8 @@
 QFieldPositioningService::QFieldPositioningService( int &argc, char **argv )
   : QAndroidService( argc, argv )
 {
+  qRegisterMetaType<GnssPositionInformation>( "GnssPositionInformation" );
+
   mPositioningSource = new PositioningSource( this );
   mHost.setHostUrl( QUrl( QStringLiteral( "localabstract:replica" ) ) );
   mHost.enableRemoting( mPositioningSource, "PositioningSource" );

--- a/src/service/qfieldpositioningservice.cpp
+++ b/src/service/qfieldpositioningservice.cpp
@@ -76,19 +76,15 @@ QFieldPositioningService::QFieldPositioningService( int &argc, char **argv )
     }
   } );
 }
-}
 
 void QFieldPositioningService::triggerShowNotification()
 {
-  if ( mPositioningSource->positionInformation()->active() )
-  {
-    const GnssPositionInformation pos = mPositioningSource->positionInformation();
-    QJniObject message = QJniObject::fromString( tr( "Latitude %1 | Longitude %2 | Altitude %3 | Orientation %4" ).arg( QLocale::system().toString( pos.latitude(), 'f', 7 ), QLocale::system().toString( pos.longitude(), 'f', 7 ), QLocale::system().toString( pos.elevation(), 'f', 3 ), QLocale::system().toString( mPositioningSource->orientation(), 'f', 1 ) ) );
-    QJniObject::callStaticMethod<void>( "ch/opengis/" APP_PACKAGE_NAME "/QFieldPositioningService",
-                                        "triggerShowNotification",
-                                        message.object<jstring>(),
-                                        true );
-  }
+  const GnssPositionInformation pos = mPositioningSource->positionInformation();
+  QJniObject message = QJniObject::fromString( tr( "Latitude %1 | Longitude %2 | Altitude %3 m | Speed %4 m/s | Direction %5°" ).arg( QLocale::system().toString( pos.latitude(), 'f', 7 ), QLocale::system().toString( pos.longitude(), 'f', 7 ), QLocale::system().toString( pos.elevation(), 'f', 3 ), QLocale::system().toString( pos.speed(), 'f', 1 ), QLocale::system().toString( pos.direction(), 'f', 1 ) ) );
+  QJniObject::callStaticMethod<void>( "ch/opengis/" APP_PACKAGE_NAME "/QFieldPositioningService",
+                                      "triggerShowNotification",
+                                      message.object<jstring>(),
+                                      true );
 }
 
 void QFieldPositioningService::triggerReturnNotification()

--- a/src/service/qfieldpositioningservice.cpp
+++ b/src/service/qfieldpositioningservice.cpp
@@ -31,7 +31,7 @@ QFieldPositioningService::QFieldPositioningService( int &argc, char **argv )
   qRegisterMetaType<GnssPositionInformation>( "GnssPositionInformation" );
 
   mPositioningSource = new PositioningSource( this );
-  mHost.setHostUrl( QUrl( QStringLiteral( "localabstract:replica" ) ) );
+  mHost.setHostUrl( QUrl( QStringLiteral( "localabstract:" APP_PACKAGE_NAME "replica" ) ) );
   mHost.enableRemoting( mPositioningSource, "PositioningSource" );
 
   mNotificationTimer.setInterval( 1000 );

--- a/src/service/qfieldpositioningservice.h
+++ b/src/service/qfieldpositioningservice.h
@@ -36,7 +36,7 @@ class QFIELD_SERVICE_EXPORT QFieldPositioningService : public QAndroidService
 
   private slots:
     void triggerShowNotification();
-    void triggerCloseNotification();
+    void triggerReturnNotification();
 
   private:
     PositioningSource *mPositioningSource = nullptr;


### PR DESCRIPTION
This PR implements background tracking support in QField :partying_face: 

Implementation notes:
- Users must return to the QField app for the collected positions while QField was suspended to be saved into the vector layer tracks. This is a requirement to insure features will get proper expression context et al and avoid serious issues with vector layers co-existing in multiple processes.
- The improvements fix an interesting out-of-sync situation where the position information was not necessarily matching the projected position (which is used to add vertices to the track feature).

Plenty of code refactoring has happened, hope it doesn't make it too much harder to review this.