### PR TITLE
Implement a borderless window mode for QField on windows/linux/macos and add a couple of additional keyboard shortcuts

### DIFF
--- a/src/core/focusstack.cpp
+++ b/src/core/focusstack.cpp
@@ -49,3 +49,11 @@ void FocusStack::setUnfocused( QQuickItem *item )
     }
   }
 }
+
+void FocusStack::forceActiveFocusOnLastTaker() const
+{
+  if ( mStackList.isEmpty() )
+    return;
+
+  mStackList.last()->forceActiveFocus();
+}

--- a/src/core/focusstack.h
+++ b/src/core/focusstack.h
@@ -28,6 +28,7 @@ class FocusStack : public QObject
 
   public:
     Q_INVOKABLE void addFocusTaker( QQuickItem *item );
+    Q_INVOKABLE void forceActiveFocusOnLastTaker() const;
 
   private slots:
     void itemFocusChanged( bool itemActiveFocus );

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -29,10 +29,6 @@ Drawer {
     }
   }
 
-  onOpened: {
-    contentItem.forceActiveFocus();
-  }
-
   width: Math.min(300, mainWindow.width)
   height: parent.height
   edge: Qt.LeftEdge
@@ -234,18 +230,7 @@ Drawer {
           }
         }
 
-        onPositionChanged: {
-          if (checked) {
-            changeMode("digitize");
-          } else {
-            if (digitizingToolbar.rubberbandModel && digitizingToolbar.rubberbandModel.vertexCount > 1) {
-              displayToast(qsTr("Finish or dimiss the digitizing feature before toggling to browse mode"));
-              checked = !checked;
-            } else {
-              changeMode("browse");
-            }
-          }
-        }
+        onPositionChanged: mainWindow.toggleDigitizeMode()
       }
     }
 

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -781,7 +781,7 @@ Page {
 
   QfToolButton {
     id: currentProjectButton
-    visible: false
+    visible: !!qgisProject.fileName
     anchors {
       top: parent.top
       left: parent.left
@@ -799,7 +799,7 @@ Page {
 
   QfToolButton {
     id: exitButton
-    visible: false
+    visible: !!qgisProject.fileName && (Qt.platform.os === "ios" || Qt.platform.os === "android" || mainWindow.sceneBorderless)
     anchors {
       top: parent.top
       right: parent.right
@@ -918,9 +918,6 @@ Page {
 
   function adjustWelcomeScreen() {
     if (visible) {
-      const currentProjectButtonVisible = !!qgisProject.fileName;
-      currentProjectButton.visible = currentProjectButtonVisible;
-      exitButton.visible = currentProjectButtonVisible && (Qt.platform.os === "ios" || Qt.platform.os === "android");
       if (firstShown) {
         welcomeText.text = " ";
       } else {

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -781,7 +781,7 @@ Page {
 
   QfToolButton {
     id: currentProjectButton
-    visible: !!qgisProject.fileName
+    visible: qgisProject && !!qgisProject.fileName
     anchors {
       top: parent.top
       left: parent.left
@@ -799,7 +799,7 @@ Page {
 
   QfToolButton {
     id: exitButton
-    visible: !!qgisProject.fileName && (Qt.platform.os === "ios" || Qt.platform.os === "android" || mainWindow.sceneBorderless)
+    visible: qgisProject && !!qgisProject.fileName && (Qt.platform.os === "ios" || Qt.platform.os === "android" || mainWindow.sceneBorderless)
     anchors {
       top: parent.top
       right: parent.right

--- a/src/qml/imports/Theme/QfButton.qml
+++ b/src/qml/imports/Theme/QfButton.qml
@@ -23,6 +23,7 @@ Button {
   bottomInset: 2
   leftInset: 4
   rightInset: 4
+  focusPolicy: Qt.NoFocus
 
   icon.color: button.color
   font: Theme.defaultFont

--- a/src/qml/imports/Theme/QfDialog.qml
+++ b/src/qml/imports/Theme/QfDialog.qml
@@ -9,4 +9,8 @@ Dialog {
 
   x: (mainWindow.width - width) / 2
   y: (mainWindow.height - height) / 2
+
+  onClosed: {
+    focusstack.forceActiveFocusOnLastTaker();
+  }
 }

--- a/src/qml/imports/Theme/QfToolButton.qml
+++ b/src/qml/imports/Theme/QfToolButton.qml
@@ -21,6 +21,7 @@ RoundButton {
   height: 48
   implicitWidth: width
   implicitHeight: height
+  focusPolicy: Qt.NoFocus
 
   topInset: 0
   bottomInset: 0

--- a/src/qml/imports/Theme/QfToolButtonDrawer.qml
+++ b/src/qml/imports/Theme/QfToolButtonDrawer.qml
@@ -47,6 +47,7 @@ Container {
   }
   spacing: 4
   clip: true
+  focusPolicy: Qt.NoFocus
 
   Behavior on width  {
     enabled: true

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -190,6 +190,14 @@ ApplicationWindow {
     }
   }
 
+  Shortcut {
+    enabled: keyHandler.focus && stateMachine.state === "digitize"
+    sequence: "Ctrl+Space"
+    onActivated: {
+      digitizingToolbar.triggerAddVertex();
+    }
+  }
+
   //currentRubberband provides the rubberband depending on the current state (digitize or measure)
   property Rubberband currentRubberband
   property LayerObserver layerObserverAlias: layerObserver

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -139,6 +139,9 @@ ApplicationWindow {
       } else if (event.key === Qt.Key_F12) {
         if (Qt.platform.os !== "android" && Qt.platform.os !== "ios") {
           mainWindow.sceneBorderless = !mainWindow.sceneBorderless;
+          if (mainWindow.sceneBorderless) {
+            displayToast(qsTr("Borderless mode activated, use the top left and botom right corner to move and resize the window"));
+          }
         }
       }
     }
@@ -4285,6 +4288,7 @@ ApplicationWindow {
     MouseArea {
       enabled: mainWindow.sceneBorderless
       anchors.fill: parent
+      cursorShape: enabled ? Qt.DragMoveCursor : Qt.ArrowCursor
       onPressed: mouse => {
         mainWindow.startSystemMove();
       }
@@ -4302,6 +4306,7 @@ ApplicationWindow {
     MouseArea {
       enabled: mainWindow.sceneBorderless
       anchors.fill: parent
+      cursorShape: enabled ? Qt.SizeFDiagCursor : Qt.ArrowCursor
       onPressed: mouse => {
         mainWindow.startSystemResize(Qt.RightEdge | Qt.BottomEdge);
       }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -39,11 +39,12 @@ ApplicationWindow {
   id: mainWindow
   objectName: 'mainWindow'
   visible: true
-  flags: Qt.Window | Qt.WindowTitleHint | Qt.WindowSystemMenuHint | (Qt.platform.os === "ios" ? Qt.MaximizeUsingFullscreenGeometryHint : 0) | (Qt.platform.os !== "ios" && Qt.platform.os !== "android" ? Qt.WindowMinMaxButtonsHint | Qt.WindowCloseButtonHint : 0)
+  flags: Qt.Window | Qt.WindowTitleHint | Qt.WindowSystemMenuHint | (sceneBorderless ? Qt.FramelessWindowHint : 0) | (Qt.platform.os === "ios" ? Qt.MaximizeUsingFullscreenGeometryHint : 0) | (Qt.platform.os !== "ios" && Qt.platform.os !== "android" ? Qt.WindowMinMaxButtonsHint | Qt.WindowCloseButtonHint : 0)
 
   Material.theme: Theme.darkTheme ? "Dark" : "Light"
   Material.accent: Theme.mainColor
 
+  property bool sceneBorderless: false
   property double sceneTopMargin: platformUtilities.sceneMargins(mainWindow)["top"]
   property double sceneBottomMargin: platformUtilities.sceneMargins(mainWindow)["bottom"]
 
@@ -134,6 +135,10 @@ ApplicationWindow {
               mainWindow.showMaximized();
             }
           }
+        }
+      } else if (event.key === Qt.Key_F12) {
+        if (Qt.platform.os !== "android" && Qt.platform.os !== "ios") {
+          mainWindow.sceneBorderless = !mainWindow.sceneBorderless;
         }
       }
     }
@@ -4266,6 +4271,40 @@ ApplicationWindow {
     function blockGuides() {
       mapCanvasTour.blockGuide();
       settings.setValue("/QField/showMapCanvasGuide", false);
+    }
+  }
+
+  Rectangle {
+    anchors.top: parent.top
+    anchors.left: parent.left
+
+    width: 14
+    height: 14
+    color: "transparent"
+
+    MouseArea {
+      enabled: mainWindow.sceneBorderless
+      anchors.fill: parent
+      onPressed: mouse => {
+        mainWindow.startSystemMove();
+      }
+    }
+  }
+
+  Rectangle {
+    anchors.bottom: parent.bottom
+    anchors.right: parent.right
+
+    width: 14
+    height: 14
+    color: "transparent"
+
+    MouseArea {
+      enabled: mainWindow.sceneBorderless
+      anchors.fill: parent
+      onPressed: mouse => {
+        mainWindow.startSystemResize(Qt.RightEdge | Qt.BottomEdge);
+      }
     }
   }
 }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -184,7 +184,7 @@ ApplicationWindow {
 
   Shortcut {
     enabled: projectInfo.insertRights
-    sequence: "Ctrl+Insert"
+    sequence: "Ctrl++"
     onActivated: {
       mainWindow.toggleDigitizeMode();
     }


### PR DESCRIPTION
This mode is toggled using F12 on the above-mentioned platforms. It is an alternative to the fullscreen mode (toggle via F11) which provides the possibility to do nice windows arrangement, screenshots, and screencasts.

How it looks on linux:

![image](https://github.com/user-attachments/assets/39049f17-7470-4687-83cb-86eab410bf33)

The PR also adds a couple of additional keyboard shortcuts. What we have now is:
- `F11`: toggle fullscreen
- `F12`: toggle borderless mode
- `Ctrl+Plus`: toggle browse/digitize mode
- `Ctrl+M`: activate the measurement mode
- `Ctrl+O`: open the file picker to select a project/dataset to load
- `Ctrl+K`: expand/focus on the search bar
- `Ctrl+Space`: digitize vertex/point
