### PR TITLE
Remove obsolete android permissions

### DIFF
--- a/cmake/Package.cmake
+++ b/cmake/Package.cmake
@@ -76,7 +76,9 @@ if(ANDROID AND ANDROIDDEPLOYQT_EXECUTABLE)
     set(AT "@")
     set(WITH_ALL_FILES_ACCESS OFF CACHE STRING "[ANDROID] Enable All Files Access to be able to work with data anywhere on your device. If this is enabled, publishing via Google Play requires a permissions declaration and a review approval by Google.")
     if(WITH_ALL_FILES_ACCESS)
-      set(QFIELD_EXTRA_PERMISSIONS "<uses-permission android:name=\"android.permission.MANAGE_EXTERNAL_STORAGE\" />")
+      set(QFIELD_EXTRA_PERMISSIONS "<uses-permission android:name=\"android.permission.MANAGE_EXTERNAL_STORAGE\" />
+        <uses-permission android:name=\"android.permission.READ_MEDIA_IMAGES\" />
+        <uses-permission android:name=\"android.permission.READ_MEDIA_VIDEO\" />")
     endif()
     configure_file(${CMAKE_SOURCE_DIR}/platform/android/AndroidManifest.xml.in ${CMAKE_SOURCE_DIR}/platform/android/AndroidManifest.xml @ONLY)
     configure_file(${CMAKE_SOURCE_DIR}/platform/android/generated.xml.in ${CMAKE_SOURCE_DIR}/platform/android/generated.xml @ONLY)

--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -26,9 +26,9 @@
       />
   <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
   <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-  <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+      android:maxSdkVersion="29"
+      />
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
       android:maxSdkVersion="28"
       />

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -549,17 +549,10 @@ void AndroidPlatformUtilities::requestStoragePermission() const
 {
   if ( !QSettings().value( QStringLiteral( "QField/storagePermissionChecked" ), false ).toBool() )
   {
-    const int sdkVersion = QCoreApplication::instance()->nativeInterface<QNativeInterface::QAndroidApplication>()->sdkVersion();
-
     QStringList permissions;
     permissions << "android.permission.READ_EXTERNAL_STORAGE"
                 << "android.permission.WRITE_EXTERNAL_STORAGE"
                 << "android.permission.ACCESS_MEDIA_LOCATION";
-    if ( sdkVersion >= 33 )
-    {
-      permissions << "android.permission.READ_MEDIA_IMAGES"
-                  << "android.permission.READ_MEDIA_VIDEO";
-    }
 
     checkAndAcquirePermissions( permissions, true );
     QSettings().setValue( QStringLiteral( "QField/storagePermissionChecked" ), true );


### PR DESCRIPTION
We rely on Android file/photo/video pickers these days.