### PR TITLE
Use visibility signal as driver for focus stack focus

### DIFF
--- a/src/core/focusstack.cpp
+++ b/src/core/focusstack.cpp
@@ -17,8 +17,8 @@
 
 void FocusStack::addFocusTaker( QObject *object )
 {
-  QVariant visible = object->property( "visible" );
-  QVariant opened = object->property( "opened" );
+  const QVariant visible = object->property( "visible" );
+  const QVariant opened = object->property( "opened" );
   if ( opened.isValid() )
   {
     connect( object, SIGNAL( opened() ), this, SLOT( popupOpened() ) );
@@ -26,7 +26,11 @@ void FocusStack::addFocusTaker( QObject *object )
   }
   else if ( visible.isValid() )
   {
-    connect( object, SIGNAL( activeFocusChanged( bool ) ), this, SLOT( itemFocusChanged( bool ) ) );
+    connect( object, SIGNAL( visibleChanged() ), this, SLOT( visibleChanged() ) );
+    if ( visible.toBool() )
+    {
+      mStackList.append( object );
+    }
   }
 }
 
@@ -40,9 +44,10 @@ void FocusStack::popupClosed()
   setUnfocused( sender() );
 }
 
-void FocusStack::itemFocusChanged( bool itemActiveFocus )
+void FocusStack::visibleChanged()
 {
-  if ( itemActiveFocus )
+  const QVariant visible = sender()->property( "visible" );
+  if ( visible.toBool() )
   {
     setFocused( sender() );
   }
@@ -60,8 +65,8 @@ void FocusStack::setFocused( QObject *object )
 
 void FocusStack::setUnfocused( QObject *object )
 {
-  QVariant visible = object->property( "visible" );
-  QVariant opened = object->property( "opened" );
+  const QVariant visible = object->property( "visible" );
+  const QVariant opened = object->property( "opened" );
   if ( opened.isValid() )
   {
     if ( !opened.toBool() )

--- a/src/core/focusstack.h
+++ b/src/core/focusstack.h
@@ -31,7 +31,7 @@ class FocusStack : public QObject
     Q_INVOKABLE void forceActiveFocusOnLastTaker() const;
 
   private slots:
-    void itemFocusChanged( bool itemActiveFocus );
+    void visibleChanged();
     void popupOpened();
     void popupClosed();
 


### PR DESCRIPTION
After further debugging, using itemFocusChanged signal is really not ideal (e.g., it throws constant interference when focusing on feature form items!). Instead, we can rely on the visibleChanged signal.