### PR TITLE
UI followup to have the improved dashboard behave better on tiny, minuscule screens

### DIFF
--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -358,23 +358,26 @@ Drawer {
     color: Theme.darkTheme ? Theme.mainBackgroundColorSemiOpaque : Theme.lightestGray
 
     Item {
-      height: 48
       width: parent.width
+      height: 48
       anchors.bottom: parent.bottom
       anchors.bottomMargin: mainWindow.sceneBottomMargin
 
       MenuItem {
         id: homeButton
+        width: parent.width - modeSwitch.width
+        height: 48
         icon.source: Theme.getThemeVectorIcon("ic_home_black_24dp")
         text: "Return home"
+
         onClicked: returnHome()
       }
 
       Switch {
         id: modeSwitch
         visible: projectInfo.insertRights
-        height: 56
-        width: (56 + 36)
+        width: 56 + 36
+        height: 48
         anchors.right: parent.right
         anchors.verticalCenter: parent.verticalCenter
         indicator: Rectangle {

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -138,18 +138,6 @@ Drawer {
           }
 
           QfToolButton {
-            text: qsTr("Project Folder")
-            anchors.verticalCenter: parent.verticalCenter
-            font: Theme.defaultFont
-            iconSource: Theme.getThemeVectorIcon("ic_project_folder_black_24dp")
-            iconColor: Theme.mainOverlayColor
-            round: true
-            onClicked: {
-              projectFolderClicked();
-            }
-          }
-
-          QfToolButton {
             id: cloudButton
             anchors.verticalCenter: parent.verticalCenter
             iconSource: {
@@ -214,9 +202,22 @@ Drawer {
               }
               running: cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Downloading || cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Uploading
               loops: Animation.Infinite
+
               onStopped: {
                 cloudButton.opacity = 1;
               }
+            }
+          }
+
+          QfToolButton {
+            text: qsTr("Project Folder")
+            anchors.verticalCenter: parent.verticalCenter
+            font: Theme.defaultFont
+            iconSource: Theme.getThemeVectorIcon("ic_project_folder_black_24dp")
+            iconColor: Theme.mainOverlayColor
+            round: true
+            onClicked: {
+              projectFolderClicked();
             }
           }
         }

--- a/src/qml/imports/Theme/QfScrollBar.qml
+++ b/src/qml/imports/Theme/QfScrollBar.qml
@@ -7,6 +7,7 @@ T.ScrollBar {
   id: control
 
   property color color: Theme.mainColor
+  property color backgroundColor: Theme.scrollBarBackgroundColor
   property real _maxSize: 8
   property real _minSize: 4
 
@@ -17,7 +18,7 @@ T.ScrollBar {
   background: Rectangle {
     id: background
     radius: _minSize
-    color: Theme.scrollBarBackgroundColor
+    color: control.backgroundColor
     opacity: {
       if (vertical) {
         return handle.width === _maxSize;
@@ -39,7 +40,7 @@ T.ScrollBar {
     Rectangle {
       id: handle
       width: vertical ? _minSize : parent.width
-      height: Math.max(10, horizontal ? _minSize : parent.height)
+      height: horizontal ? _minSize : Math.max(10, parent.height)
       color: control.color
       anchors {
         right: vertical ? parent.right : undefined
@@ -56,7 +57,7 @@ T.ScrollBar {
         PropertyChanges {
           target: handle
           width: vertical ? _maxSize : parent.width
-          height: Math.max(10, horizontal ? _maxSize : parent.height)
+          height: horizontal ? _maxSize : Math.max(10, parent.height)
         }
       },
       State {
@@ -65,7 +66,7 @@ T.ScrollBar {
         PropertyChanges {
           target: handle
           width: vertical ? _minSize : parent.width
-          height: Math.max(10, horizontal ? _minSize : parent.height)
+          height: horizontal ? _minSize : Math.max(10, parent.height)
         }
       }
     ]

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2305,9 +2305,10 @@ ApplicationWindow {
   DashBoard {
     id: dashBoard
     objectName: "dashBoard"
+
     allowActiveLayerChange: !digitizingToolbar.isDigitizing
+    allowInteractive: !welcomeScreen.visible && !qfieldSettings.visible && !qfieldCloudScreen.visible && !qfieldLocalDataPickerScreen.visible && !codeReader.visible && !screenLocker.enabled
     mapSettings: mapCanvas.mapSettings
-    interactive: !welcomeScreen.visible && !qfieldSettings.visible && !qfieldCloudScreen.visible && !qfieldLocalDataPickerScreen.visible && !codeReader.visible && !screenLocker.enabled
 
     Component.onCompleted: focusstack.addFocusTaker(this)
 


### PR DESCRIPTION
Screencast:

https://github.com/user-attachments/assets/41538308-fed7-49d5-bf49-a7f649c0adcd

Improvements are as follow:
- The return home label gets '...' when it can't fit in the available space
- The top row of buttons now has the back/close button and 3-dot menu button always anchored to left and right edges, with the remaining button contained within a flickable item so nano screens can have access to all content
- The cloud button has been relocated to insure that has visual priority over the project folder button
