### PR TITLE
Fix QField always forced back to first screen on launch

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -74,13 +74,21 @@ ApplicationWindow {
     property alias height: mainWindow.height
 
     property int minimumSize: Qt.platform.os !== "ios" && Qt.platform.os !== "android" ? 300 : 50
+    property string screenConfiguration: ''
 
     Component.onCompleted: {
       if (Qt.platform.os !== "ios" && Qt.platform.os !== "android") {
-        width = Math.max(width, minimumSize);
-        height = Math.max(height, minimumSize);
-        x = Math.min(x, mainWindow.screen.width - width);
-        y = Math.min(y, mainWindow.screen.height - height);
+        let currentScreensConfiguration = `${Qt.application.screens.length}`;
+        for (let screen of Qt.application.screens) {
+          currentScreensConfiguration += `:${screen.width}x${screen.height}-${screen.virtualX}-${screen.virtualY}`;
+        }
+        if (currentScreensConfiguration != screenConfiguration) {
+          screenConfiguration = currentScreensConfiguration;
+          width = Math.max(width, minimumSize);
+          height = Math.max(height, minimumSize);
+          x = Math.min(x, mainWindow.screen.width - width);
+          y = Math.min(y, mainWindow.screen.height - height);
+        }
       }
     }
   }


### PR DESCRIPTION
@m-kuhn , a long time ago, you added code in QField to avoid the application window going missing on dual monitor systems when, upon relaunch, one screen has been removed. While that's super useful, it also ends up forcing QField to be moved onto the first screen on every launch, which isn't super friendly for people who have a static dual monitor setup, or launch QField multiple times within the same dual monitor configuration.

This PR improves things by forcing the main window to fit within the first screen _only_ when the system's screens configuration has been changed from the last time QField was loaded. 

And all of a second, I can reliably launch QField onto my secondary monitor consistently! :partying_face: 