### PR TITLE
Implement a iface function for plugins to add actions to the new dashboard actions toolbar

### DIFF
--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -68,6 +68,20 @@ void AppInterface::addItemToCanvasActionsToolbar( QQuickItem *item ) const
   }
 }
 
+void AppInterface::addItemToDashboardActionsToolbar( QQuickItem *item ) const
+{
+  if ( !mApp->rootObjects().isEmpty() )
+  {
+    QQuickItem *toolbar = mApp->rootObjects().at( 0 )->findChild<QQuickItem *>( QStringLiteral( "dashboardActionsToolbar" ) );
+    item->setParentItem( toolbar );
+  }
+}
+
+void AppInterface::addItemToMainMenuActionsToolbar( QQuickItem *item ) const
+{
+  addItemToDashboardActionsToolbar( item );
+}
+
 QObject *AppInterface::mainWindow() const
 {
   if ( !mApp->rootObjects().isEmpty() )

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -110,9 +110,21 @@ class AppInterface : public QObject
     Q_INVOKABLE void addItemToPluginsToolbar( QQuickItem *item ) const;
 
     /**
-     * Adds an \a item in the main menu action toolbar container
+     * Adds an \a item in the map canvas menu's action toolbar container
      */
     Q_INVOKABLE void addItemToCanvasActionsToolbar( QQuickItem *item ) const;
+
+    /**
+     * Adds an \a item in the dashboard's action toolbar container
+     */
+    Q_INVOKABLE void addItemToDashboardActionsToolbar( QQuickItem *item ) const;
+
+    /**
+     * Adds an \a item in the dashboard's action toolbar container
+     * \note This function is deprecated and will be removed in the future, use
+     * the addItemToDashboardActionsToolbar function instead
+     */
+    Q_INVOKABLE void addItemToMainMenuActionsToolbar( QQuickItem *item ) const;
 
     /**
      * Returns the main window.

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -67,7 +67,7 @@ Drawer {
     anchors.fill: parent
 
     Rectangle {
-      height: mainWindow.sceneTopMargin + Math.max(buttonsRow.height, buttonsRow.childrenRect.height)
+      height: mainWindow.sceneTopMargin + Math.max(buttonsRow.height + 8, buttonsRow.childrenRect.height)
       Layout.fillWidth: true
       Layout.preferredHeight: height
 
@@ -88,7 +88,8 @@ Drawer {
         anchors.left: closeButton.right
         anchors.right: menuButton.left
         anchors.top: parent.top
-        anchors.topMargin: mainWindow.sceneTopMargin
+        anchors.topMargin: mainWindow.sceneTopMargin + 4
+        anchors.bottomMargin: 4
         height: buttonsRow.height
         contentWidth: buttonsRow.width
         contentHeight: buttonsRow.height
@@ -105,8 +106,8 @@ Drawer {
 
         Row {
           id: buttonsRow
-          anchors.topMargin: mainWindow.sceneTopMargin
-          height: 56
+          objectName: "dashboardActionsToolbar"
+          height: 48
           spacing: 1
 
           QfToolButton {


### PR DESCRIPTION
Screenshot time, look at the beautiful Ask AI button here:

![image](https://github.com/user-attachments/assets/87a65818-3a05-4829-927c-080c8a42ea0a)

As seen above, the PR allows for plugins to gently place themselves into the new dashboard actions toolbar. I've also resurrected the iface.addItemToMainMenuActionsToolbar() function as a deprecated method that now stands as an alias to addItemToDashboardActionsToolbar(). While plugins are still in their first year of existence, I guess it's not bad to avoid outright breaking things :)