### PR TITLE
Add a UX for plugins to register a configuration dialog within the plugin manager popup

### DIFF
--- a/src/core/pluginmanager.cpp
+++ b/src/core/pluginmanager.cpp
@@ -322,9 +322,26 @@ void PluginManager::disableAppPlugin( const QString &uuid )
   }
 }
 
+void PluginManager::configureAppPlugin( const QString &uuid )
+{
+  callPluginMethod( uuid, QStringLiteral( "configure" ) );
+}
+
 bool PluginManager::isAppPluginEnabled( const QString &uuid ) const
 {
   return mAvailableAppPlugins.contains( uuid ) && mLoadedPlugins.contains( mAvailableAppPlugins[uuid].path() );
+}
+
+bool PluginManager::isAppPluginConfigurable( const QString &uuid ) const
+{
+  if ( mAvailableAppPlugins.contains( uuid ) && mLoadedPlugins.contains( mAvailableAppPlugins[uuid].path() ) )
+  {
+    const char *normalizedSignature = QMetaObject::normalizedSignature( "configure()" );
+    const int idx = mLoadedPlugins[mAvailableAppPlugins[uuid].path()]->metaObject()->indexOfSlot( normalizedSignature );
+    return idx >= 0;
+  }
+
+  return false;
 }
 
 void PluginManager::installFromUrl( const QString &url )
@@ -470,7 +487,7 @@ QString PluginManager::findProjectPlugin( const QString &projectPath )
   return QString();
 }
 
-void PluginManager::callPluginMethod( const QString &uuid, const QString &methodName )
+void PluginManager::callPluginMethod( const QString &uuid, const QString &methodName ) const
 {
   if ( !mAvailableAppPlugins.contains( uuid ) )
   {

--- a/src/core/pluginmanager.h
+++ b/src/core/pluginmanager.h
@@ -98,7 +98,10 @@ class PluginManager : public QObject
 
     Q_INVOKABLE void enableAppPlugin( const QString &uuid );
     Q_INVOKABLE void disableAppPlugin( const QString &uuid );
+    Q_INVOKABLE void configureAppPlugin( const QString &uuid );
+
     Q_INVOKABLE bool isAppPluginEnabled( const QString &uuid ) const;
+    Q_INVOKABLE bool isAppPluginConfigurable( const QString &uuid ) const;
 
     void refreshAppPlugins();
     void restoreAppPlugins();
@@ -122,7 +125,7 @@ class PluginManager : public QObject
 
   private slots:
     void handleWarnings( const QList<QQmlError> &warnings );
-    void callPluginMethod( const QString &uuid, const QString &methodName );
+    void callPluginMethod( const QString &uuid, const QString &methodName ) const;
 
   private:
     QQmlEngine *mEngine = nullptr;

--- a/src/qml/PluginManagerSettings.qml
+++ b/src/qml/PluginManagerSettings.qml
@@ -81,7 +81,7 @@ Popup {
             anchors.leftMargin: 20
             anchors.rightMargin: 20
 
-            columns: 2
+            columns: 3
             columnSpacing: 0
             rowSpacing: 2
 
@@ -117,6 +117,19 @@ Popup {
               }
             }
 
+            QfToolButton {
+              id: configureEnabledPlugin
+              Layout.preferredWidth: enabled ? 48 : 0
+              enabled: Configurable
+
+              iconSource: Theme.getThemeVectorIcon("ic_tune_white_24dp")
+              iconColor: Theme.mainTextColor
+
+              onClicked: {
+                pluginManager.configureAppPlugin(Uuid);
+              }
+            }
+
             QfSwitch {
               id: toggleEnabledPlugin
               Layout.preferredWidth: implicitContentWidth
@@ -133,6 +146,7 @@ Popup {
             }
 
             ColumnLayout {
+              Layout.columnSpan: 2
               Layout.fillWidth: true
 
               Label {
@@ -370,6 +384,7 @@ Popup {
       for (let i = 0; i < pluginsList.model.count; i++) {
         if (pluginsList.model.get(i).Uuid === uuid) {
           pluginsList.model.get(i).Enabled = true;
+          pluginsList.model.get(i).Configurable = pluginManager.isAppPluginConfigurable(uuid);
         }
       }
     }
@@ -378,6 +393,7 @@ Popup {
       for (let i = 0; i < pluginsList.model.count; i++) {
         if (pluginsList.model.get(i).Uuid === uuid) {
           pluginsList.model.get(i).Enabled = false;
+          pluginsList.model.get(i).Configurable = false;
         }
       }
     }
@@ -390,9 +406,11 @@ Popup {
   function refreshAppPluginsList() {
     pluginsList.model.clear();
     for (const plugin of pluginManager.availableAppPlugins) {
+      const isEnabled = pluginManager.isAppPluginEnabled(plugin.uuid);
       pluginsList.model.append({
           "Uuid": plugin.uuid,
-          "Enabled": pluginManager.isAppPluginEnabled(plugin.uuid),
+          "Enabled": isEnabled,
+          "Configurable": isEnabled && pluginManager.isAppPluginConfigurable(plugin.uuid),
           "Name": plugin.name,
           "Description": plugin.description,
           "Author": plugin.author,


### PR DESCRIPTION
Until now, plugins wanting to offer a configuration dialog had to rely on adding a button _somewhere_ in QField, which creates clutter for no real reason when configuration is a once in a blue moon.

To remedy to the situation, this PR empowers plugin authors into adding a mechanism to trigger a configuration dialog. When loading a plugin, the plugin manager will now check for a `function configure() {}` declaration in the root item of the plugin in main.qml.

Screencast:

https://github.com/user-attachments/assets/c7f6297b-4754-44bf-b0ca-1ae8b8f0c95b

@mbernasocchi , as discussed. We can now have a clutter-free Ask AI! :)
