### PR TITLE
Avoiding using QfTextField when we mix up other material controls & popup height fixes

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -232,6 +232,7 @@ int main( int argc, char **argv )
   app.installTranslator( &qfieldTranslator );
 
   qputenv( "QT_QUICK_CONTROLS_STYLE", QByteArray( "Material" ) );
+  qputenv( "QT_QUICK_CONTROLS_MATERIAL_VARIANT", QByteArray( "Dense" ) );
 
   QgisMobileapp mApp( &app );
 

--- a/src/qml/BookmarkProperties.qml
+++ b/src/qml/BookmarkProperties.qml
@@ -49,30 +49,19 @@ Popup {
 
     ColumnLayout {
       id: propertiesLayout
-      spacing: 4
+      spacing: 10
       width: parent.width
 
-      Label {
-        Layout.fillWidth: true
-        text: qsTr('Name')
-        font: Theme.defaultFont
-      }
-
-      QfTextField {
+      TextField {
         id: nameField
         Layout.fillWidth: true
         font: Theme.defaultFont
+        placeholderText: qsTr('Name')
         text: ''
 
         onTextChanged: {
           saveBookmark();
         }
-      }
-
-      Label {
-        Layout.fillWidth: true
-        text: qsTr('Color')
-        font: Theme.defaultFont
       }
 
       RowLayout {
@@ -87,9 +76,11 @@ Popup {
           saveBookmark();
         }
 
+        Item {
+          Layout.fillWidth: true
+        }
         Rectangle {
           id: defaultColor
-          Layout.alignment: Qt.AlignVCenter
           width: groupField.iconSize
           height: groupField.iconSize
           color: Theme.bookmarkDefault

--- a/src/qml/BookmarkProperties.qml
+++ b/src/qml/BookmarkProperties.qml
@@ -68,6 +68,7 @@ Popup {
         id: groupField
         spacing: 8
         Layout.fillWidth: true
+        Layout.alignment: Qt.AlignHCenter
 
         property int iconSize: 32
         property string value: ''
@@ -76,9 +77,6 @@ Popup {
           saveBookmark();
         }
 
-        Item {
-          Layout.fillWidth: true
-        }
         Rectangle {
           id: defaultColor
           width: groupField.iconSize
@@ -135,15 +133,11 @@ Popup {
             onClicked: groupField.value = 'blue'
           }
         }
-        Item {
-          Layout.fillWidth: true
-        }
       }
 
       QfButton {
         id: updateBookmarkButton
         Layout.fillWidth: true
-        Layout.topMargin: 10
         text: qsTr('Copy bookmark details')
 
         onClicked: {

--- a/src/qml/Changelog.qml
+++ b/src/qml/Changelog.qml
@@ -11,10 +11,10 @@ Popup {
   id: changelogPopup
 
   parent: mainWindow.contentItem
+  width: mainWindow.width - Theme.popupScreenEdgeMargin * 2
+  height: mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
   x: Theme.popupScreenEdgeMargin
-  y: Theme.popupScreenEdgeMargin
-  width: parent.width - Theme.popupScreenEdgeMargin * 2
-  height: parent.height - Theme.popupScreenEdgeMargin * 2
+  y: (mainWindow.height - height) / 2
   padding: 0
   modal: true
   closePolicy: Popup.CloseOnEscape

--- a/src/qml/CodeReader.qml
+++ b/src/qml/CodeReader.qml
@@ -21,7 +21,7 @@ Popup {
   property bool openedOnce: false
 
   width: popupWidth
-  height: Math.min(mainWindow.height - Theme.popupScreenEdgeMargin, popupWidth + toolBar.height + acceptButton.height)
+  height: Math.min(mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4), popupWidth + toolBar.height + acceptButton.height)
   x: (parent.width - width) / 2
   y: (parent.height - height) / 2
   z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes

--- a/src/qml/EmbeddedFeatureForm.qml
+++ b/src/qml/EmbeddedFeatureForm.qml
@@ -48,13 +48,12 @@ Popup {
   parent: mainWindow.contentItem
   closePolicy: form.state === "ReadOnly" ? Popup.CloseOnEscape : Popup.NoAutoClose // prevent accidental feature addition and editing
 
-  x: Theme.popupScreenEdgeMargin / 2
-  y: Theme.popupScreenEdgeMargin
-  z: 1000 + embeddedLevel
-
   padding: 0
-  width: parent.width - Theme.popupScreenEdgeMargin
-  height: parent.height - Theme.popupScreenEdgeMargin * 2
+  width: mainWindow.width - Theme.popupScreenEdgeMargin
+  height: mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
+  x: Theme.popupScreenEdgeMargin / 2
+  y: (mainWindow.height - height) / 2
+  z: 1000 + embeddedLevel
   modal: true
   focus: visible
 

--- a/src/qml/LayerLoginDialog.qml
+++ b/src/qml/LayerLoginDialog.qml
@@ -61,18 +61,18 @@ Page {
       }
 
       TextField {
-        id: username
+        id: usernameField
         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-        Layout.preferredWidth: parent.width / 1.3
+        Layout.preferredWidth: parent.width - showPasswordButton.width * 2
         inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhPreferLowercase
         horizontalAlignment: Text.AlignHCenter
         placeholderText: qsTr("Username")
       }
 
       TextField {
-        id: password
+        id: passwordField
         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-        Layout.preferredWidth: parent.width / 1.3
+        Layout.preferredWidth: parent.width - showPasswordButton.width * 2
         Layout.bottomMargin: 10
         echoMode: TextInput.Password
         inputMethodHints: Qt.ImhHiddenText | Qt.ImhNoPredictiveText | Qt.ImhSensitiveData | Qt.ImhNoAutoUppercase | Qt.ImhPreferLowercase
@@ -81,6 +81,29 @@ Page {
 
         Keys.onReturnPressed: _processAuth()
         Keys.onEnterPressed: _processAuth()
+
+        QfToolButton {
+          id: showPasswordButton
+
+          property var linkedField: passwordField
+          property int originalEchoMode: TextInput.Normal
+
+          visible: (!!linkedField.echoMode && linkedField.echoMode !== TextInput.Normal) || originalEchoMode !== TextInput.Normal
+          iconSource: linkedField.echoMode === TextInput.Normal ? Theme.getThemeVectorIcon('ic_hide_green_48dp') : Theme.getThemeVectorIcon('ic_show_green_48dp')
+          iconColor: Theme.mainColor
+          anchors.left: linkedField.right
+          anchors.verticalCenter: linkedField.verticalCenter
+          opacity: linkedField.text.length > 0 ? 1 : 0.25
+
+          onClicked: {
+            if (linkedField.echoMode !== TextInput.Normal) {
+              originalEchoMode = linkedField.echoMode;
+              linkedField.echoMode = TextInput.Normal;
+            } else {
+              linkedField.echoMode = originalEchoMode;
+            }
+          }
+        }
       }
 
       QfButton {
@@ -101,13 +124,13 @@ Page {
 
   onVisibleChanged: {
     if (visible) {
-      username.forceActiveFocus();
+      usernameField.forceActiveFocus();
     }
   }
 
   function _processAuth() {
-    enter(username.text, password.text);
-    username.text = '';
-    password.text = '';
+    enter(usernameField.text, passwordField.text);
+    usernameField.text = '';
+    passwordField.text = '';
   }
 }

--- a/src/qml/LayerLoginDialog.qml
+++ b/src/qml/LayerLoginDialog.qml
@@ -27,6 +27,7 @@ Page {
   Flickable {
     id: flickable
     anchors.fill: parent
+    anchors.margins: 20
     Layout.fillWidth: true
     Layout.fillHeight: true
     contentHeight: content.height
@@ -37,94 +38,55 @@ Page {
     ColumnLayout {
       id: content
       width: parent.width
-      spacing: 2
-      anchors {
-        margins: 4
-        topMargin: 52 // Leave space for the toolbar
-      }
-
-      Item {
-        // spacer item
-        height: 24
-      }
+      spacing: 10
 
       Image {
         Layout.alignment: Qt.AlignHCenter
+        Layout.topMargin: 30
+        Layout.bottomMargin: 10
         source: Theme.getThemeVectorIcon('ic_password_48dp')
         sourceSize.width: Math.min(64, parent.width / 5)
         sourceSize.height: Math.min(64, parent.width / 5)
       }
 
-      Item {
-        // spacer item
-        height: 8
-      }
-
       Text {
         text: credentialTitle
-        horizontalAlignment: Text.AlignHCenter
         Layout.fillWidth: true
+        Layout.bottomMargin: 10
+        horizontalAlignment: Text.AlignHCenter
         wrapMode: Text.WordWrap
         font: Theme.defaultFont
         color: Theme.mainTextColor
         padding: 16
       }
 
-      Item {
-        // spacer item
-        height: 35
-      }
-
-      Text {
-        id: usernamelabel
-        Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-        text: qsTr("Username")
-        font: Theme.defaultFont
-        color: Theme.mainTextColor
-      }
-
-      QfTextField {
+      TextField {
         id: username
         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-        Layout.preferredWidth: Math.max(parent.width / 2, usernamelabel.width)
+        Layout.preferredWidth: parent.width / 1.3
         inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhPreferLowercase
         horizontalAlignment: Text.AlignHCenter
+        placeholderText: qsTr("Username")
       }
 
-      Item {
-        // spacer item
-        height: 35
-      }
-
-      Text {
-        id: passwordlabel
-        Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-        text: qsTr("Password")
-        font: Theme.defaultFont
-        color: Theme.mainTextColor
-      }
-
-      QfTextField {
+      TextField {
         id: password
         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-        Layout.preferredWidth: Math.max(parent.width / 2, usernamelabel.width)
+        Layout.preferredWidth: parent.width / 1.3
+        Layout.bottomMargin: 10
         echoMode: TextInput.Password
         inputMethodHints: Qt.ImhHiddenText | Qt.ImhNoPredictiveText | Qt.ImhSensitiveData | Qt.ImhNoAutoUppercase | Qt.ImhPreferLowercase
         horizontalAlignment: Text.AlignHCenter
+        placeholderText: qsTr("Password")
 
         Keys.onReturnPressed: _processAuth()
         Keys.onEnterPressed: _processAuth()
       }
 
-      Item {
-        // spacer item
-        height: 35
-      }
-
       QfButton {
         id: submit
         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-        Layout.preferredWidth: Math.max(parent.width / 2, usernamelabel.width)
+        Layout.fillWidth: true
         text: "Submit"
         onClicked: _processAuth()
       }

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -26,6 +26,7 @@ Popup {
 
   parent: mainWindow.contentItem
   width: Math.min(childrenRect.width, mainWindow.width - Theme.popupScreenEdgeMargin)
+  height: Math.min(popupLayout.childrenRect.height + headerLayout.childrenRect.height + 20, mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4))
   x: (mainWindow.width - width) / 2
   y: (mainWindow.height - height) / 2
   padding: 0
@@ -60,8 +61,10 @@ Popup {
   Page {
     id: popupContent
     width: parent.width
-    padding: 0
+    height: parent.height
+    padding: 10
     header: RowLayout {
+      id: headerLayout
       spacing: 2
       Label {
         id: titleLabel
@@ -95,13 +98,13 @@ Popup {
     }
 
     ScrollView {
-      padding: 10
+      padding: 0
       ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
       ScrollBar.vertical: QfScrollBar {
       }
       contentWidth: popupLayout.childrenRect.width
       contentHeight: popupLayout.childrenRect.height
-      height: Math.min(popupLayout.childrenRect.height + 20, mainWindow.height - mainWindow.sceneTopMargin - mainWindow.sceneBottomMargin)
+      height: parent.height
       clip: true
 
       ColumnLayout {

--- a/src/qml/PluginManagerSettings.qml
+++ b/src/qml/PluginManagerSettings.qml
@@ -312,7 +312,7 @@ Popup {
         color: Theme.mainTextColor
       }
 
-      QfTextField {
+      TextField {
         id: installFromUrlInput
         width: installFromUrlLabel.width
       }

--- a/src/qml/PositioningDeviceSettings.qml
+++ b/src/qml/PositioningDeviceSettings.qml
@@ -15,9 +15,9 @@ Popup {
   signal apply
 
   width: mainWindow.width - Theme.popupScreenEdgeMargin * 2
-  height: mainWindow.height - Theme.popupScreenEdgeMargin * 2
+  height: mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
   x: Theme.popupScreenEdgeMargin
-  y: Theme.popupScreenEdgeMargin
+  y: (mainWindow.height - height) / 2
   padding: 0
   modal: true
   focus: visible

--- a/src/qml/PositioningDeviceSettings.qml
+++ b/src/qml/PositioningDeviceSettings.qml
@@ -108,26 +108,12 @@ Popup {
     }
 
     ColumnLayout {
-      spacing: 5
+      spacing: 10
       width: parent.width
 
       Label {
         Layout.fillWidth: true
-        text: qsTr("Name:")
-        font: Theme.defaultFont
-        wrapMode: Text.WordWrap
-      }
-
-      QfTextField {
-        id: positioningDeviceName
-        Layout.fillWidth: true
-        font: Theme.defaultFont
-        placeholderText: displayText === '' ? qsTr('Leave empty to auto-fill') : ''
-      }
-
-      Label {
-        Layout.fillWidth: true
-        text: qsTr("Connection type:")
+        text: qsTr("Connection type")
         font: Theme.defaultFont
         wrapMode: Text.WordWrap
       }
@@ -196,6 +182,20 @@ Popup {
 
           onClicked: positioningDeviceType.popup.open()
         }
+      }
+
+      TextField {
+        id: positioningDeviceName
+        Layout.fillWidth: true
+        font: Theme.defaultFont
+        placeholderText: qsTr("Name") + (displayText === '' ? qsTr(' (leave empty to auto-fill)') : '')
+      }
+
+      Label {
+        Layout.fillWidth: true
+        text: qsTr("Connection details")
+        font: Theme.defaultFont
+        wrapMode: Text.WordWrap
       }
 
       ListModel {

--- a/src/qml/PositioningDeviceSettings.qml
+++ b/src/qml/PositioningDeviceSettings.qml
@@ -19,6 +19,7 @@ Popup {
   x: Theme.popupScreenEdgeMargin
   y: Theme.popupScreenEdgeMargin
   padding: 0
+  modal: true
   focus: visible
 
   property alias name: positioningDeviceName.text

--- a/src/qml/QFieldAudioRecorder.qml
+++ b/src/qml/QFieldAudioRecorder.qml
@@ -21,7 +21,7 @@ Popup {
   property int popupWidth: Math.min(400, mainWindow.width <= mainWindow.height ? mainWindow.width - Theme.popupScreenEdgeMargin : mainWindow.height - Theme.popupScreenEdgeMargin)
 
   width: popupWidth
-  height: Math.min(mainWindow.height - Theme.popupScreenEdgeMargin, popupWidth + toolBar.height + recordButton.height)
+  height: Math.min(mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4), popupWidth + toolBar.height + recordButton.height)
   x: (parent.width - width) / 2
   y: (parent.height - height) / 2
   z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes

--- a/src/qml/QFieldCloudDeltaHistory.qml
+++ b/src/qml/QFieldCloudDeltaHistory.qml
@@ -79,7 +79,7 @@ Popup {
         leftPadding: 48
         rightPadding: 48
         width: parent.width
-        visible: !!model && model.rowCount === 0
+        visible: deltaList.count === 0
 
         text: qsTr("No changes have been pushed yet!")
         color: Theme.mainTextDisabledColor
@@ -91,7 +91,7 @@ Popup {
         id: deltaList
         Layout.fillWidth: true
         Layout.fillHeight: true
-        visible: !!model !== undefined && model.rowCount !== 0
+        visible: count !== 0
         clip: true
         ScrollBar.vertical: QfScrollBar {
         }

--- a/src/qml/QFieldCloudDeltaHistory.qml
+++ b/src/qml/QFieldCloudDeltaHistory.qml
@@ -14,12 +14,12 @@ Popup {
   property alias model: deltaList.model
 
   width: Math.min(400, mainWindow.width - Theme.popupScreenEdgeMargin * 2)
-  x: (parent.width - width) / 2
-  y: (parent.height - page.height) / 2
+  height: page.height
+  x: (mainWindow.width - width) / 2
+  y: (mainWindow.height - height) / 2
   padding: 0
 
   onOpened: function () {
-    page.height = mainWindow.height - 160 + 60;
     if (cloudProjectsModel.currentProjectId) {
       cloudProjectsModel.refreshProjectDeltaList(cloudProjectsModel.currentProjectId);
     }
@@ -32,7 +32,7 @@ Popup {
   Page {
     id: page
     width: parent.width
-    height: deltaList.height + 60
+    height: Math.min(deltaList.contentHeight + toolBar.childrenRect.height + 20, mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4))
     padding: 10
     header: ToolBar {
       id: toolBar
@@ -70,11 +70,12 @@ Popup {
       }
     }
 
-    Column {
+    ColumnLayout {
+      anchors.fill: parent
       spacing: 4
-      width: parent.width
 
       Label {
+        Layout.fillWidth: true
         leftPadding: 48
         rightPadding: 48
         width: parent.width
@@ -88,10 +89,12 @@ Popup {
 
       ListView {
         id: deltaList
-        width: parent.width
-        height: visible ? mainWindow.height - 160 : 0
-        visible: deltaList && deltaList.model !== undefined && deltaList.model.rowCount !== 0
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        visible: !!model !== undefined && model.rowCount !== 0
         clip: true
+        ScrollBar.vertical: QfScrollBar {
+        }
 
         delegate: Rectangle {
           id: rectangle

--- a/src/qml/QFieldCloudLogin.qml
+++ b/src/qml/QFieldCloudLogin.qml
@@ -130,7 +130,7 @@ Item {
     TextField {
       id: usernameField
       inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhPreferLowercase
-      Layout.preferredWidth: parent.width / 1.3
+      Layout.preferredWidth: parent.width - showPasswordButton.width * 2
       Layout.alignment: Qt.AlignHCenter
       visible: cloudConnection.status === QFieldCloudConnection.Disconnected
       enabled: visible
@@ -146,7 +146,7 @@ Item {
       id: passwordField
       echoMode: TextInput.Password
       inputMethodHints: Qt.ImhHiddenText | Qt.ImhNoPredictiveText | Qt.ImhSensitiveData | Qt.ImhNoAutoUppercase | Qt.ImhPreferLowercase
-      Layout.preferredWidth: parent.width / 1.3
+      Layout.preferredWidth: parent.width - showPasswordButton.width * 2
       Layout.alignment: Qt.AlignHCenter
       Layout.bottomMargin: 10
       visible: cloudConnection.status === QFieldCloudConnection.Disconnected
@@ -156,6 +156,29 @@ Item {
       placeholderText: qsTr("Password")
 
       Keys.onReturnPressed: loginFormSumbitHandler()
+
+      QfToolButton {
+        id: showPasswordButton
+
+        property var linkedField: passwordField
+        property int originalEchoMode: TextInput.Normal
+
+        visible: (!!linkedField.echoMode && linkedField.echoMode !== TextInput.Normal) || originalEchoMode !== TextInput.Normal
+        iconSource: linkedField.echoMode === TextInput.Normal ? Theme.getThemeVectorIcon('ic_hide_green_48dp') : Theme.getThemeVectorIcon('ic_show_green_48dp')
+        iconColor: Theme.mainColor
+        anchors.left: linkedField.right
+        anchors.verticalCenter: linkedField.verticalCenter
+        opacity: linkedField.text.length > 0 ? 1 : 0.25
+
+        onClicked: {
+          if (linkedField.echoMode !== TextInput.Normal) {
+            originalEchoMode = linkedField.echoMode;
+            linkedField.echoMode = TextInput.Normal;
+          } else {
+            linkedField.echoMode = originalEchoMode;
+          }
+        }
+      }
     }
 
     FontMetrics {

--- a/src/qml/QFieldCloudLogin.qml
+++ b/src/qml/QFieldCloudLogin.qml
@@ -25,7 +25,6 @@ Item {
     Image {
       id: logo
       Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
-      Layout.bottomMargin: 10
       fillMode: Image.PreserveAspectFit
       smooth: true
       source: "qrc:/images/qfieldcloud_logo.svg"
@@ -36,6 +35,17 @@ Item {
         anchors.fill: parent
         onDoubleClicked: toggleServerUrlEditing()
       }
+    }
+
+    Text {
+      Layout.fillWidth: true
+      Layout.bottomMargin: 10
+      horizontalAlignment: Text.AlignHCenter
+      font.pointSize: Theme.titleFont.pointSize
+      font.bold: true
+      color: Theme.cloudColor
+      wrapMode: Text.WordWrap
+      text: qsTr("QFieldCloud")
     }
 
     Text {
@@ -77,7 +87,7 @@ Item {
       text: qsTr("Server URL\n(Leave empty to use the default server)")
       horizontalAlignment: Text.AlignHCenter
       font: Theme.defaultFont
-      color: 'gray'
+      color: Theme.secondaryTextColor
       wrapMode: Text.WordWrap
     }
 

--- a/src/qml/QFieldCloudLogin.qml
+++ b/src/qml/QFieldCloudLogin.qml
@@ -15,27 +15,17 @@ Item {
 
   height: connectionSettings.childrenRect.height
 
-  Image {
-    id: sourceImg
-    fillMode: Image.Stretch
-    width: parent.width
-    height: 200
-    smooth: true
-    opacity: 1
-    source: "qrc:/images/qfieldcloud_background.svg"
-    sourceSize.width: 1024
-    sourceSize.height: 1024
-  }
-
   ColumnLayout {
     id: connectionSettings
     width: parent.width
     Layout.minimumHeight: (logo.height + fontMetrics.height * 9) * 2
-    spacing: 6
+    Layout.bottomMargin: 10
+    spacing: 10
 
     Image {
       id: logo
       Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
+      Layout.bottomMargin: 10
       fillMode: Image.PreserveAspectFit
       smooth: true
       source: "qrc:/images/qfieldcloud_logo.svg"
@@ -51,6 +41,7 @@ Item {
     Text {
       id: loginFeedbackLabel
       Layout.fillWidth: true
+      Layout.bottomMargin: 10
       visible: false
       text: qsTr("Failed to sign in")
       horizontalAlignment: Text.AlignHCenter
@@ -94,6 +85,7 @@ Item {
       id: serverUrlComboBox
       Layout.preferredWidth: parent.width / 1.3
       Layout.alignment: Qt.AlignHCenter
+      Layout.bottomMargin: 10
       visible: cloudConnection.status === QFieldCloudConnection.Disconnected && (prefixUrlWithProtocol(cloudConnection.url) !== cloudConnection.defaultUrl || isServerUrlEditingActive)
       enabled: visible
       font: Theme.defaultFont
@@ -116,12 +108,10 @@ Item {
         serverUrlField.text = displayText;
       }
 
-      contentItem: QfTextField {
+      contentItem: TextField {
         id: serverUrlField
 
         inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhPreferLowercase
-        Layout.preferredWidth: parent.width / 1.3
-        Layout.alignment: Qt.AlignHCenter
         visible: cloudConnection.status === QFieldCloudConnection.Disconnected
         enabled: visible
         font: Theme.defaultFont
@@ -130,24 +120,14 @@ Item {
 
         onTextChanged: text = text.replace(/\s+/g, '')
         Keys.onReturnPressed: loginFormSumbitHandler()
-      }
 
-      background: Rectangle {
-        color: "transparent"
+        background: Rectangle {
+          color: "transparent"
+        }
       }
     }
 
-    Text {
-      id: usernamelabel
-      Layout.fillWidth: true
-      visible: cloudConnection.status === QFieldCloudConnection.Disconnected
-      text: qsTr("Username or email")
-      horizontalAlignment: Text.AlignHCenter
-      font: Theme.defaultFont
-      color: Theme.mainTextColor
-    }
-
-    QfTextField {
+    TextField {
       id: usernameField
       inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhPreferLowercase
       Layout.preferredWidth: parent.width / 1.3
@@ -156,31 +136,24 @@ Item {
       enabled: visible
       font: Theme.defaultFont
       horizontalAlignment: Text.AlignHCenter
+      placeholderText: qsTr("Username or email")
 
       onTextChanged: text = text.replace(/\s+/g, '')
       Keys.onReturnPressed: loginFormSumbitHandler()
     }
 
-    Text {
-      id: passwordlabel
-      Layout.fillWidth: true
-      visible: cloudConnection.status === QFieldCloudConnection.Disconnected
-      text: qsTr("Password")
-      horizontalAlignment: Text.AlignHCenter
-      font: Theme.defaultFont
-      color: Theme.mainTextColor
-    }
-
-    QfTextField {
+    TextField {
       id: passwordField
       echoMode: TextInput.Password
       inputMethodHints: Qt.ImhHiddenText | Qt.ImhNoPredictiveText | Qt.ImhSensitiveData | Qt.ImhNoAutoUppercase | Qt.ImhPreferLowercase
       Layout.preferredWidth: parent.width / 1.3
       Layout.alignment: Qt.AlignHCenter
+      Layout.bottomMargin: 10
       visible: cloudConnection.status === QFieldCloudConnection.Disconnected
       enabled: visible
       font: Theme.defaultFont
       horizontalAlignment: Text.AlignHCenter
+      placeholderText: qsTr("Password")
 
       Keys.onReturnPressed: loginFormSumbitHandler()
     }
@@ -192,6 +165,7 @@ Item {
 
     QfButton {
       Layout.fillWidth: true
+      Layout.bottomMargin: 10
       text: cloudConnection.status == QFieldCloudConnection.LoggedIn ? qsTr("Sign out") : cloudConnection.status == QFieldCloudConnection.Connecting ? qsTr("Signing in, please wait") : qsTr("Sign in")
       enabled: cloudConnection.status != QFieldCloudConnection.Connecting
 

--- a/src/qml/QFieldCloudPackageLayersFeedback.qml
+++ b/src/qml/QFieldCloudPackageLayersFeedback.qml
@@ -8,13 +8,14 @@ import Theme
  * \ingroup qml
  */
 QfDialog {
-  parent: mainWindow.contentItem
-
   property int selectedCount: 0
   property bool isDeleted: false
   property alias packagedLayersListViewModel: packagedLayersListView.model
 
-  width: mainWindow.width - 20
+  parent: mainWindow.contentItem
+  width: mainWindow.width - Theme.popupScreenEdgeMargin * 2
+  height: Math.min(300 + packagedLayersListView.contentHeight, mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4))
+
   title: qsTr("QFieldCloud had troubles packaging your project")
 
   ColumnLayout {
@@ -32,8 +33,9 @@ QfDialog {
       model: []
 
       Layout.fillWidth: true
+      Layout.fillHeight: true
       Layout.topMargin: 10
-      Layout.preferredHeight: Math.min(childrenRect.height, 300)
+      Layout.preferredHeight: contentHeight
 
       delegate: Text {
         width: parent.width

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -798,7 +798,8 @@ Page {
     id: importUrlDialog
     title: qsTr("Import URL")
     focus: visible
-    y: (mainWindow.height - height - 80) / 2
+    parent: mainWindow.contentItem
+    y: (mainWindow.height - height) / 2
 
     onAboutToShow: {
       importUrlInput.text = '';
@@ -905,8 +906,9 @@ Page {
   QfDialog {
     id: downloadUploadWebdavDialog
     title: isUploadingPath ? qsTr("WebDAV upload") : qsTr("WebDAV download")
-    focus: true
-    y: (mainWindow.height - height - 80) / 2
+    focus: visible
+    parent: mainWindow.contentItem
+    y: (mainWindow.height - height) / 2
 
     property bool isUploadingPath: false
     property string host: ""
@@ -1004,7 +1006,8 @@ Page {
     id: importWebdavDialog
     title: qsTr("Import WebDAV folder")
     focus: visible
-    y: (mainWindow.height - height - 80) / 2
+    parent: mainWindow.contentItem
+    y: (mainWindow.height - height) / 2
 
     onAboutToShow: {
       if (webdavConnectionLoader.item) {

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -824,7 +824,7 @@ Page {
         color: Theme.mainTextColor
       }
 
-      QfTextField {
+      TextField {
         id: importUrlInput
         width: importUrlLabel.width
       }

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -60,11 +60,11 @@ Item {
     id: searchFeaturePopup
 
     parent: mainWindow.contentItem
+    width: mainWindow.width - Theme.popupScreenEdgeMargin * 2
+    height: mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
     x: Theme.popupScreenEdgeMargin
-    y: Theme.popupScreenEdgeMargin
+    y: (mainWindow.height - height) / 2
     z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes
-    width: parent.width - Theme.popupScreenEdgeMargin * 2
-    height: parent.height - Theme.popupScreenEdgeMargin * 2
     padding: 0
     modal: true
     closePolicy: Popup.CloseOnEscape

--- a/src/qml/TcpDeviceChooser.qml
+++ b/src/qml/TcpDeviceChooser.qml
@@ -33,34 +33,22 @@ Item {
     width: parent.width
     columns: 1
     columnSpacing: 0
-    rowSpacing: 5
+    rowSpacing: 10
 
-    Label {
-      Layout.fillWidth: true
-      text: qsTr("Address:")
-      font: Theme.defaultFont
-      wrapMode: Text.WordWrap
-    }
-
-    QfTextField {
+    TextField {
       id: tcpDeviceAddress
       Layout.fillWidth: true
       font: Theme.defaultFont
+      placeholderText: qsTr("IP address")
       text: '127.0.0.1'
       inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhPreferLowercase
     }
 
-    Label {
-      Layout.fillWidth: true
-      text: qsTr("Port:")
-      font: Theme.defaultFont
-      wrapMode: Text.WordWrap
-    }
-
-    QfTextField {
+    TextField {
       id: tcpDevicePort
       Layout.fillWidth: true
       font: Theme.defaultFont
+      placeholderText: qsTr("Port")
       text: '9000'
       inputMethodHints: Qt.ImhFormattedNumbersOnly
     }

--- a/src/qml/TrackerSettings.qml
+++ b/src/qml/TrackerSettings.qml
@@ -10,13 +10,13 @@ import Theme
  */
 Popup {
   id: trackInformationPopup
-  parent: mainWindow.contentItem
 
-  x: Theme.popupScreenEdgeMargin / 2
-  y: Theme.popupScreenEdgeMargin
+  parent: mainWindow.contentItem
   padding: 0
-  width: parent.width - Theme.popupScreenEdgeMargin
-  height: parent.height - Theme.popupScreenEdgeMargin * 2
+  width: mainWindow.width - Theme.popupScreenEdgeMargin
+  height: mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
+  x: Theme.popupScreenEdgeMargin / 2
+  y: (mainWindow.height - height) / 2
   modal: true
   closePolicy: Popup.NoAutoClose
 

--- a/src/qml/UdpDeviceChooser.qml
+++ b/src/qml/UdpDeviceChooser.qml
@@ -35,32 +35,20 @@ Item {
     columnSpacing: 0
     rowSpacing: 5
 
-    Label {
-      Layout.fillWidth: true
-      text: qsTr("Address:")
-      font: Theme.defaultFont
-      wrapMode: Text.WordWrap
-    }
-
-    QfTextField {
+    TextField {
       id: udpDeviceAddress
       Layout.fillWidth: true
       font: Theme.defaultFont
+      placeholderText: qsTr("Address")
       text: '127.0.0.1'
       inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhPreferLowercase
     }
 
-    Label {
-      Layout.fillWidth: true
-      text: qsTr("Port:")
-      font: Theme.defaultFont
-      wrapMode: Text.WordWrap
-    }
-
-    QfTextField {
+    TextField {
       id: udpDevicePort
       Layout.fillWidth: true
       font: Theme.defaultFont
+      placeholderText: qsTr("Port")
       text: '11111'
       inputMethodHints: Qt.ImhFormattedNumbersOnly
     }

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -135,6 +135,7 @@ Page {
 
             Text {
               Layout.margins: 6
+              Layout.topMargin: 12
               Layout.maximumWidth: feedbackView.width - 12
               text: qsTr("We're sorry to hear that. Click on the button below to comment or seek support.")
               font: Theme.defaultFont
@@ -147,9 +148,12 @@ Page {
               spacing: 6
               Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
               Layout.bottomMargin: 10
+
               QfButton {
-                leftPadding: 20
-                rightPadding: 20
+                topPadding: 8
+                bottomPadding: 8
+                leftPadding: 10
+                rightPadding: 10
 
                 text: qsTr("Reach out")
                 icon.source: Theme.getThemeVectorIcon('ic_create_white_24dp')
@@ -188,6 +192,7 @@ Page {
 
             Text {
               Layout.margins: 6
+              Layout.topMargin: 12
               Layout.maximumWidth: feedbackView.width - 12
               text: qsTr("Hey there, how do you like your experience with QField so far?")
               font: Theme.defaultFont
@@ -252,6 +257,7 @@ Page {
 
             Text {
               Layout.margins: 6
+              Layout.topMargin: 12
               Layout.maximumWidth: feedbackView.width - 12
               text: qsTr("That's great! We'd love for you to click on the button below and leave a review.")
               font: Theme.defaultFont
@@ -266,8 +272,10 @@ Page {
               Layout.margins: 6
               Layout.bottomMargin: 10
               QfButton {
-                leftPadding: 20
-                rightPadding: 20
+                topPadding: 8
+                bottomPadding: 8
+                leftPadding: 10
+                rightPadding: 10
 
                 text: qsTr("Rate us")
                 icon.source: Theme.getThemeVectorIcon('ic_star_white_24dp')
@@ -334,6 +342,7 @@ Page {
 
             Text {
               Layout.margins: 6
+              Layout.topMargin: 12
               Layout.maximumWidth: collectionView.width - 12
               text: qsTr("Anonymized metrics collection has been disabled. You can re-enable through the settings panel.")
               font: Theme.defaultFont
@@ -369,6 +378,7 @@ Page {
 
             Text {
               Layout.margins: 6
+              Layout.topMargin: 12
               Layout.maximumWidth: collectionView.width - 12
               text: qsTr("To improve stability for everyone, QField collects and sends anonymized metrics.")
               font: Theme.defaultFont
@@ -382,6 +392,11 @@ Page {
               Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
               Layout.bottomMargin: 10
               QfButton {
+                topPadding: 8
+                bottomPadding: 8
+                leftPadding: 10
+                rightPadding: 10
+
                 text: qsTr('I agree')
 
                 onClicked: {
@@ -391,6 +406,11 @@ Page {
               }
 
               QfButton {
+                topPadding: 8
+                bottomPadding: 8
+                leftPadding: 10
+                rightPadding: 10
+
                 text: qsTr('I prefer not')
                 bgcolor: "transparent"
                 color: Theme.mainColor

--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -244,11 +244,11 @@ EditorWidgetBase {
       id: searchFeaturePopup
 
       parent: mainWindow.contentItem
+      width: mainWindow.width - Theme.popupScreenEdgeMargin * 2
+      height: mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
       x: Theme.popupScreenEdgeMargin
-      y: Theme.popupScreenEdgeMargin
+      y: (mainWindow.height - height) / 2
       z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes
-      width: parent.width - Theme.popupScreenEdgeMargin * 2
-      height: parent.height - Theme.popupScreenEdgeMargin * 2
       padding: 0
       modal: true
       closePolicy: Popup.CloseOnEscape

--- a/src/qml/imports/Theme/QfButton.qml
+++ b/src/qml/imports/Theme/QfButton.qml
@@ -15,12 +15,11 @@ Button {
 
   signal dropdownClicked
 
-  topPadding: 8
-  bottomPadding: 8
-  leftPadding: 8
-  rightPadding: dropdown ? 40 : 8
-  topInset: 2
-  bottomInset: 2
+  verticalPadding: Material.buttonVerticalPadding
+  leftPadding: Math.max((dropdown ? 40 : 0), Material.buttonLeftPadding(flat, hasIcon && (display !== AbstractButton.TextOnly)))
+  rightPadding: Math.max((dropdown ? 40 : 0), Material.buttonRightPadding(flat, hasIcon && (display !== AbstractButton.TextOnly), (text !== "") && (display !== AbstractButton.IconOnly)))
+  topInset: 0
+  bottomInset: 0
   leftInset: 4
   rightInset: 4
   focusPolicy: Qt.NoFocus
@@ -52,11 +51,6 @@ Button {
     spacing: parent.spacing
     mirrored: parent.mirrored
     display: parent.display
-
-    topPadding: 2
-    bottomPadding: 2
-    leftPadding: 0
-    rightPadding: 0
 
     icon: parent.icon
     color: button.color

--- a/src/qml/imports/Theme/QfButton.qml
+++ b/src/qml/imports/Theme/QfButton.qml
@@ -18,8 +18,8 @@ Button {
   verticalPadding: Material.buttonVerticalPadding
   leftPadding: Math.max((dropdown ? 40 : 0), Material.buttonLeftPadding(flat, hasIcon && (display !== AbstractButton.TextOnly)))
   rightPadding: Math.max((dropdown ? 40 : 0), Material.buttonRightPadding(flat, hasIcon && (display !== AbstractButton.TextOnly), (text !== "") && (display !== AbstractButton.IconOnly)))
-  topInset: 0
-  bottomInset: 0
+  topInset: 2
+  bottomInset: 2
   leftInset: 4
   rightInset: 4
   focusPolicy: Qt.NoFocus

--- a/src/qml/imports/Theme/QfTextField.qml
+++ b/src/qml/imports/Theme/QfTextField.qml
@@ -24,12 +24,6 @@ TextField {
     }
   }
 
-  onFocusChanged: {
-    if (focus) {
-      Qt.inputMethod.show();
-    }
-  }
-
   QfToolButton {
     id: showPasswordButton
     property int originalEchoMode: TextInput.Normal

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3966,10 +3966,6 @@ ApplicationWindow {
   QFieldCloudPackageLayersFeedback {
     id: cloudPackageLayersFeedback
     visible: false
-    parent: Overlay.overlay
-
-    width: parent.width
-    height: parent.height
   }
 
   QFieldLocalDataPickerScreen {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3796,10 +3796,10 @@ ApplicationWindow {
     Popup {
       id: loginDialogPopup
       parent: Overlay.overlay
-      x: Theme.popupScreenEdgeMargin
-      y: Theme.popupScreenEdgeMargin
       width: parent.width - Theme.popupScreenEdgeMargin * 2
-      height: parent.height - Theme.popupScreenEdgeMargin * 2
+      height: parent.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
+      x: Theme.popupScreenEdgeMargin
+      y: (mainWindow.height - height) / 2
       padding: 0
       modal: true
       closePolicy: Popup.CloseOnEscape


### PR DESCRIPTION
This PR improves the looks of a couple of dialogs as well as positioning device settings popup by moving away from QfTextField (still used in the feature form and a few other places) in favor of the default Material TextField implementation.

Beyond sitting better alongside Material ComboBox items, It comes with a couple of nice improvements:
- slightly bigger hit area
- nicer reactive appearance to mouse hovering
- allows us to replace some labels with placeholder text, providing a more modern UI/UX

I came to realize this was needed for us while developing the WebDAV stuff, and I just can't unsee this now.

E.g.:

![Screenshot From 2025-01-29 17-38-16](https://github.com/user-attachments/assets/329bd615-ffc8-4ae9-a96d-0f214182437c)

![Screenshot From 2025-01-29 17-38-24](https://github.com/user-attachments/assets/8d17d337-f6f1-41ff-96df-d04a0e6c61a0)
