### PR TITLE
Tracker optimisation focus 

### DIFF
--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -822,7 +822,7 @@ bool FeatureModel::create()
 
   if ( mBatchMode )
   {
-    isSuccess = mLayer->addFeature( mFeature );
+    isSuccess = mLayer->addFeature( mFeature, QgsFeatureSink::FastInsert );
     if ( isSuccess )
     {
       mFeature.setId( createdFeatureId );

--- a/src/core/layertreemapcanvasbridge.cpp
+++ b/src/core/layertreemapcanvasbridge.cpp
@@ -166,6 +166,27 @@ void LayerTreeMapCanvasBridge::layerInTrackingChanged( QgsVectorLayer *layer, bo
   if ( layer )
   {
     QgsLayerTreeLayer *nodeLayer = mRoot->findLayer( layer->id() );
+    if ( layer->geometryType() == Qgis::GeometryType::Point )
+    {
+      // Disable feature count while tracking to avoid needless CPU cycles wasted updating a collapsed legend
+      if ( tracking )
+      {
+        QVariant showFeatureCountValue = nodeLayer->customProperty( QStringLiteral( "showFeatureCount" ) );
+        if ( showFeatureCountValue.isValid() && showFeatureCountValue.toInt() != 0 )
+        {
+          nodeLayer->setCustomProperty( QStringLiteral( "showFeatureCount" ), 0 );
+          nodeLayer->setCustomProperty( QStringLiteral( "previousShowFeatureCount" ), showFeatureCountValue );
+        }
+      }
+      else
+      {
+        QVariant previousShowFeatureCount = nodeLayer->customProperty( QStringLiteral( "previousShowFeatureCount" ) );
+        if ( previousShowFeatureCount.isValid() )
+        {
+          nodeLayer->setCustomProperty( QStringLiteral( "showFeatureCount" ), previousShowFeatureCount );
+        }
+      }
+    }
     mModel->setLayerInTracking( nodeLayer, tracking );
   }
 }

--- a/src/core/rubberbandshape.h
+++ b/src/core/rubberbandshape.h
@@ -35,6 +35,8 @@ class RubberbandShape : public QQuickItem
 {
     Q_OBJECT
 
+    Q_PROPERTY( bool freeze READ freeze WRITE setFreeze NOTIFY freezeChanged )
+
     Q_PROPERTY( RubberbandModel *model READ model WRITE setModel NOTIFY modelChanged )
     Q_PROPERTY( VertexModel *vertexModel READ vertexModel WRITE setVertexModel NOTIFY vertexModelChanged )
     Q_PROPERTY( QgsQuickMapSettings *mapSettings READ mapSettings WRITE setMapSettings NOTIFY mapSettingsChanged )
@@ -66,6 +68,11 @@ class RubberbandShape : public QQuickItem
     QgsQuickMapSettings *mapSettings() const;
     void setMapSettings( QgsQuickMapSettings *mapSettings );
 
+    //! \copydoc freeze
+    bool freeze() const;
+    //! \copydoc freeze
+    void setFreeze( bool freeze );
+
     //! \copydoc color
     QColor color() const;
     //! \copydoc color
@@ -96,6 +103,8 @@ class RubberbandShape : public QQuickItem
     void modelChanged();
     void vertexModelChanged();
     void mapSettingsChanged();
+    //! \copydoc freeze
+    void freezeChanged();
     //! \copydoc color
     void colorChanged();
     //! \copydoc outlineColor
@@ -121,6 +130,7 @@ class RubberbandShape : public QQuickItem
     RubberbandModel *mRubberbandModel = nullptr;
     VertexModel *mVertexModel = nullptr;
     QgsQuickMapSettings *mMapSettings = nullptr;
+    bool mFreeze = false;
     bool mDirty = false;
     QColor mColor = QColor( 192, 57, 43, 150 );
     QColor mOutlineColor = QColor( 255, 255, 255, 100 );

--- a/src/core/rubberbandshape.h
+++ b/src/core/rubberbandshape.h
@@ -35,6 +35,7 @@ class RubberbandShape : public QQuickItem
 {
     Q_OBJECT
 
+    //! When set to TRUE, changes to the linked rubber band or vertex model as well as map settings will be ignored and the rubber band shape data will be left untouched
     Q_PROPERTY( bool freeze READ freeze WRITE setFreeze NOTIFY freezeChanged )
 
     Q_PROPERTY( RubberbandModel *model READ model WRITE setModel NOTIFY modelChanged )

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -310,42 +310,46 @@ void Tracker::processPositionInformation( const GnssPositionInformation &positio
 
   mLastDevicePositionTimestamp = positionInformation.utcDateTime();
 
+  double measureValue = 0.0;
   switch ( mMeasureType )
   {
     case Tracker::SecondsSinceStart:
-      mRubberbandModel->setMeasureValue( positionInformation.utcDateTime().toSecsSinceEpoch() - mStartPositionTimestamp.toSecsSinceEpoch() );
+      measureValue = positionInformation.utcDateTime().toSecsSinceEpoch() - mStartPositionTimestamp.toSecsSinceEpoch();
       break;
     case Tracker::Timestamp:
-      mRubberbandModel->setMeasureValue( positionInformation.utcDateTime().toSecsSinceEpoch() );
+      measureValue = positionInformation.utcDateTime().toSecsSinceEpoch();
       break;
     case Tracker::GroundSpeed:
-      mRubberbandModel->setMeasureValue( positionInformation.speed() );
+      measureValue = positionInformation.speed();
       break;
     case Tracker::Bearing:
-      mRubberbandModel->setMeasureValue( positionInformation.direction() );
+      measureValue = positionInformation.direction();
       break;
     case Tracker::HorizontalAccuracy:
-      mRubberbandModel->setMeasureValue( positionInformation.hacc() );
+      measureValue = positionInformation.hacc();
       break;
     case Tracker::VerticalAccuracy:
-      mRubberbandModel->setMeasureValue( positionInformation.vacc() );
+      measureValue = positionInformation.vacc();
       break;
     case Tracker::PDOP:
-      mRubberbandModel->setMeasureValue( positionInformation.pdop() );
+      measureValue = positionInformation.pdop();
       break;
     case Tracker::HDOP:
-      mRubberbandModel->setMeasureValue( positionInformation.hdop() );
+      measureValue = positionInformation.hdop();
       break;
     case Tracker::VDOP:
-      mRubberbandModel->setMeasureValue( positionInformation.vdop() );
+      measureValue = positionInformation.vdop();
       break;
   }
 
+  whileBlocking( mRubberbandModel )->setMeasureValue( measureValue );
   mRubberbandModel->setCurrentCoordinate( projectedPosition );
 }
 
 void Tracker::replayPositionInformationList( const QList<GnssPositionInformation> &positionInformationList, QgsQuickCoordinateTransformer *coordinateTransformer )
 {
+  const qint64 startTime = QDateTime::currentMSecsSinceEpoch();
+
   bool wasActive = false;
   if ( mIsActive )
   {
@@ -390,6 +394,11 @@ void Tracker::replayPositionInformationList( const QList<GnssPositionInformation
   {
     start();
   }
+
+  const qint64 endTime = QDateTime::currentMSecsSinceEpoch();
+  qDebug() << "---";
+  qDebug() << ( endTime - startTime ) << "ms";
+  qDebug() << "---";
 }
 
 void Tracker::rubberbandModelVertexCountChanged()

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -350,13 +350,6 @@ void Tracker::replayPositionInformationList( const QList<GnssPositionInformation
 {
   const qint64 startTime = QDateTime::currentMSecsSinceEpoch();
 
-  bool wasActive = false;
-  if ( mIsActive )
-  {
-    wasActive = true;
-    stop();
-  }
-
   mIsReplaying = true;
   emit isReplayingChanged();
 
@@ -396,13 +389,25 @@ void Tracker::replayPositionInformationList( const QList<GnssPositionInformation
   mIsReplaying = false;
   emit isReplayingChanged();
 
-  if ( wasActive )
+  if ( mIsSuspended )
   {
+    mIsSuspended = false;
+    emit isSuspendedChanged();
     start();
   }
 
   const qint64 endTime = QDateTime::currentMSecsSinceEpoch();
   qInfo() << QStringLiteral( "Tracker position information replay duration: %1ms" ).arg( endTime - startTime );
+}
+
+void Tracker::suspendUntilReplay()
+{
+  if ( mIsActive )
+  {
+    mIsSuspended = true;
+    emit isSuspendedChanged();
+    stop();
+  }
 }
 
 void Tracker::rubberbandModelVertexCountChanged()

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -402,9 +402,7 @@ void Tracker::replayPositionInformationList( const QList<GnssPositionInformation
   }
 
   const qint64 endTime = QDateTime::currentMSecsSinceEpoch();
-  qDebug() << "---";
-  qDebug() << ( endTime - startTime ) << "ms";
-  qDebug() << "---";
+  qInfo() << QStringLiteral( "Tracker position information replay duration: %1ms" ).arg( endTime - startTime );
 }
 
 void Tracker::rubberbandModelVertexCountChanged()

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -361,16 +361,22 @@ void Tracker::replayPositionInformationList( const QList<GnssPositionInformation
   emit isReplayingChanged();
 
   const Qgis::GeometryType geometryType = mRubberbandModel->geometryType();
-  mFeatureModel->setBatchMode( geometryType == Qgis::GeometryType::Point );
+  const bool isPointGeometry = geometryType == Qgis::GeometryType::Point;
+  mFeatureModel->setBatchMode( isPointGeometry );
+
   connect( mRubberbandModel, &RubberbandModel::currentCoordinateChanged, this, &Tracker::positionReceived );
   for ( const GnssPositionInformation &positionInformation : positionInformationList )
   {
+    if ( isPointGeometry )
+    {
+      mFeatureModel->setPositionInformation( positionInformation );
+    }
     processPositionInformation( positionInformation,
                                 coordinateTransformer ? coordinateTransformer->transformPosition( QgsPoint( positionInformation.longitude(), positionInformation.latitude(), positionInformation.elevation() ) ) : QgsPoint() );
   }
   disconnect( mRubberbandModel, &RubberbandModel::currentCoordinateChanged, this, &Tracker::positionReceived );
-  mFeatureModel->setBatchMode( false );
 
+  mFeatureModel->setBatchMode( false );
   const int vertexCount = mRubberbandModel->vertexCount();
   if ( ( geometryType == Qgis::GeometryType::Line && vertexCount > 2 ) || ( geometryType == Qgis::GeometryType::Polygon && vertexCount > 3 ) )
   {

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -35,6 +35,7 @@ class Tracker : public QObject
     Q_OBJECT
 
     Q_PROPERTY( bool isActive READ isActive NOTIFY isActiveChanged )
+    Q_PROPERTY( bool isSuspended READ isSuspended NOTIFY isSuspendedChanged )
     Q_PROPERTY( bool isReplaying READ isReplaying NOTIFY isReplayingChanged )
 
     Q_PROPERTY( bool visible READ visible WRITE setVisible NOTIFY visibleChanged )
@@ -134,6 +135,9 @@ class Tracker : public QObject
     //! Returns whether the tracker has been started
     bool isActive() const { return mIsActive; }
 
+    //! Returns whether the track has been suspended
+    bool isSuspended() const { return mIsSuspended; }
+
     //! Returns whether the tracker is replaying positions
     bool isReplaying() const { return mIsReplaying; }
 
@@ -148,8 +152,11 @@ class Tracker : public QObject
     //! Replays a list of position information taking into account the tracker settings
     void replayPositionInformationList( const QList<GnssPositionInformation> &positionInformationList, QgsQuickCoordinateTransformer *coordinateTransformer = nullptr );
 
+    void suspendUntilReplay();
+
   signals:
     void isActiveChanged();
+    void isSuspendedChanged();
     void isReplayingChanged();
     void visibleChanged();
     void vectorLayerChanged();
@@ -177,6 +184,7 @@ class Tracker : public QObject
     void trackPosition();
 
     bool mIsActive = false;
+    bool mIsSuspended = false;
     bool mIsReplaying = false;
 
     RubberbandModel *mRubberbandModel = nullptr;

--- a/src/core/trackingmodel.cpp
+++ b/src/core/trackingmodel.cpp
@@ -169,9 +169,21 @@ void TrackingModel::replayPositionInformationList( const QList<GnssPositionInfor
   for ( int i = 0; i < mTrackers.size(); i++ )
   {
     Tracker *tracker = mTrackers[i];
-    if ( tracker->isActive() )
+    if ( tracker->isSuspended() )
     {
       tracker->replayPositionInformationList( positionInformationList, coordinateTransformer );
+    }
+  }
+}
+
+void TrackingModel::suspendUntilReplay()
+{
+  for ( int i = 0; i < mTrackers.size(); i++ )
+  {
+    Tracker *tracker = mTrackers[i];
+    if ( tracker->isActive() )
+    {
+      tracker->suspendUntilReplay();
     }
   }
 }

--- a/src/core/trackingmodel.h
+++ b/src/core/trackingmodel.h
@@ -71,6 +71,8 @@ class TrackingModel : public QAbstractItemModel
     //! Replays a list of position information for all active trackers
     Q_INVOKABLE void replayPositionInformationList( const QList<GnssPositionInformation> &positionInformationList, QgsQuickCoordinateTransformer *coordinateTransformer = nullptr );
 
+    Q_INVOKABLE void suspendUntilReplay();
+
     void reset();
 
     /**

--- a/src/qml/TrackingSession.qml
+++ b/src/qml/TrackingSession.qml
@@ -23,8 +23,10 @@ Item {
     enabled: tracker.isActive
 
     function onPositionInformationChanged() {
-      featureModel.positionInformation = positionSource.positionInformation;
-      tracker.processPositionInformation(positionSource.positionInformation, positionSource.projectedPosition);
+      if (!positionSource.backgroundMode) {
+        featureModel.positionInformation = positionSource.positionInformation;
+        tracker.processPositionInformation(positionSource.positionInformation, positionSource.projectedPosition);
+      }
     }
   }
 

--- a/src/qml/TrackingSession.qml
+++ b/src/qml/TrackingSession.qml
@@ -23,10 +23,8 @@ Item {
     enabled: tracker.isActive
 
     function onPositionInformationChanged() {
-      if (!positionSource.backgroundMode) {
-        featureModel.positionInformation = positionSource.positionInformation;
-        tracker.processPositionInformation(positionSource.positionInformation, positionSource.projectedPosition);
-      }
+      featureModel.positionInformation = positionSource.positionInformation;
+      tracker.processPositionInformation(positionSource.positionInformation, positionSource.projectedPosition);
     }
   }
 

--- a/src/qml/TrackingSession.qml
+++ b/src/qml/TrackingSession.qml
@@ -48,6 +48,7 @@ Item {
   Rubberband {
     id: rubberband
     visible: tracker.visible
+    freeze: tracker.isReplaying
 
     color: Qt.rgba(Math.min(0.75, Math.random()), Math.min(0.75, Math.random()), Math.min(0.75, Math.random()), 0.6)
     geometryType: Qgis.GeometryType.Line

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -352,7 +352,6 @@ ApplicationWindow {
 
     onBackgroundModeChanged: {
       if (!backgroundMode) {
-        console.log('qqq onBackgroundModeChanged');
         mapCanvasMap.freeze('trackerreplay');
         let list = positionSource.getBackgroundPositionInformation();
         // Qt bug weirdly returns an empty list on first invokation to source, call twice to insure we've got the actual list

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -351,14 +351,31 @@ ApplicationWindow {
     }
 
     onBackgroundModeChanged: {
-      if (!backgroundMode) {
-        mapCanvasMap.freeze('trackerreplay');
-        let list = positionSource.getBackgroundPositionInformation();
-        // Qt bug weirdly returns an empty list on first invokation to source, call twice to insure we've got the actual list
-        list = positionSource.getBackgroundPositionInformation();
-        trackingModel.replayPositionInformationList(list, coordinateTransformer);
-        mapCanvasMap.unfreeze('trackerreplay');
+      if (trackings.count > 0) {
+        if (backgroundMode) {
+          trackingModel.suspendUntilReplay();
+        } else {
+          busyOverlay.text = qsTr("Replaying collected positions, hold on");
+          busyOverlay.state = "visible";
+          replayTimer.restart();
+        }
       }
+    }
+  }
+
+  Timer {
+    id: replayTimer
+
+    interval: 250
+    repeat: false
+    onTriggered: {
+      mapCanvasMap.freeze('trackerreplay');
+      let list = positionSource.getBackgroundPositionInformation();
+      // Qt bug weirdly returns an empty list on first invokation to source, call twice to insure we've got the actual list
+      list = positionSource.getBackgroundPositionInformation();
+      trackingModel.replayPositionInformationList(list, positionSource.coordinateTransformer);
+      mapCanvasMap.unfreeze('trackerreplay');
+      busyOverlay.state = "hidden";
     }
   }
 


### PR DESCRIPTION
This PR implements a number of strategies to optimize tracking playback when returning from a long period of time when QField was set in the background or the phone was locked.

For line and polygon layers, this makes replaying hours of captured positions near instantaneous. 

For point layers, the speed is significantly improved, yet as every position will lead to a completely new feature being added (inc. unique value checks, default value expression calculation, etc), the time required to playback the position can take longer. To that end, we now have a busy indicator overlay to tell the user an ongoing operation is happening. 

Overall, it makes using background tracking for long period of time much, much more efficient.