### PR TITLE
Fix value relation filter breaking after changing attribute value(s), improve relation editor widget handling of multiline feature display names

### DIFF
--- a/src/core/featurelistmodel.cpp
+++ b/src/core/featurelistmodel.cpp
@@ -514,7 +514,9 @@ void FeatureListModel::setCurrentFormFeature( const QgsFeature &feature )
   mCurrentFormFeature = feature;
 
   if ( !mFilterExpression.isEmpty() && QgsValueRelationFieldFormatter::expressionRequiresFormScope( mFilterExpression ) )
+  {
     reloadLayer();
+  }
 
   emit currentFormFeatureChanged();
 }

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -170,8 +170,4 @@ EditorWidgetBase {
       }
     }
   }
-
-  function siblingValueChanged(field, feature) {
-    listModel.currentFormFeature = feature;
-  }
 }

--- a/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
@@ -13,7 +13,7 @@ import ".."
 EditorWidgetBase {
   id: relationEditor
 
-  property int itemHeight: 40
+  property int itemHeight: 48
 
   // because no additional addEntry item on readOnly (isEnabled false)
   height: listView.contentHeight + (isEnabled ? addEntry.height : 0)
@@ -250,27 +250,31 @@ EditorWidgetBase {
           Image {
             id: featureImage
             source: ImagePath ? UrlUtils.fromString(ImagePath) : Theme.getThemeVectorIcon("ic_photo_notavailable_black_24dp")
-            width: parent.height
-            height: parent.height
+            anchors.verticalCenter: parent.verticalCenter
+            width: 48
+            height: 48
             fillMode: Image.PreserveAspectFit
             visible: !!ImagePath
           }
 
           Text {
             id: featureText
+            anchors.verticalCenter: parent.verticalCenter
+            width: parent.width - 8 - (featureImage.visible ? featureImage.width : 0) - viewButton.width - moveDownButton.width - moveUpButton.width - deleteButton.width
+            topPadding: 5
+            bottomPadding: 5
             font: Theme.defaultFont
             color: !isEnabled ? Theme.mainTextDisabledColor : Theme.mainTextColor
             text: Description || model.displayString
-            verticalAlignment: Text.AlignVCenter
-            padding: 4
             elide: Text.ElideRight
-            width: parent.width - 8 - (featureImage.visible ? featureImage.width : 0) - viewButton.width - moveDownButton.width - moveUpButton.width - deleteButton.width
+            wrapMode: Text.WordWrap
           }
 
           QfToolButton {
             id: viewButton
-            width: 40
-            height: 40
+            anchors.verticalCenter: parent.verticalCenter
+            width: 48
+            height: 48
 
             round: false
             iconSource: isEnabled ? Theme.getThemeVectorIcon('ic_edit_attributes_white_24dp') : Theme.getThemeVectorIcon('ic_baseline-list_white_24dp')
@@ -290,9 +294,10 @@ EditorWidgetBase {
 
           QfToolButton {
             id: moveDownButton
+            anchors.verticalCenter: parent.verticalCenter
             visible: isEnabled
-            width: visible ? 40 : 0
-            height: 40
+            width: visible ? 48 : 0
+            height: 48
             opacity: (index === listView.count - 1) ? 0.3 : 1
 
             round: false
@@ -310,9 +315,10 @@ EditorWidgetBase {
 
           QfToolButton {
             id: moveUpButton
+            anchors.verticalCenter: parent.verticalCenter
             visible: isEnabled
-            width: visible ? 40 : 0
-            height: 40
+            width: visible ? 48 : 0
+            height: 48
             opacity: (index === 0) ? 0.3 : 1
 
             round: false
@@ -330,9 +336,10 @@ EditorWidgetBase {
 
           QfToolButton {
             id: deleteButton
+            anchors.verticalCenter: parent.verticalCenter
             visible: isEnabled
-            width: visible ? 40 : 0
-            height: 40
+            width: visible ? 48 : 0
+            height: 48
 
             round: false
             iconSource: Theme.getThemeVectorIcon('ic_delete_forever_white_24dp')

--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -12,7 +12,7 @@ import ".."
 EditorWidgetBase {
   id: relationEditor
 
-  property int itemHeight: 40
+  property int itemHeight: 48
   property int bottomMargin: 10
   property int maximumVisibleItems: 4
 
@@ -229,16 +229,20 @@ EditorWidgetBase {
           id: featureText
           anchors.verticalCenter: parent.verticalCenter
           width: parent.width - viewButton.width - deleteButton.width
+          topPadding: 5
+          bottomPadding: 5
           font: Theme.defaultFont
           color: !isEnabled ? Theme.mainTextDisabledColor : Theme.mainTextColor
           elide: Text.ElideRight
+          wrapMode: Text.WordWrap
           text: nmRelationId ? model.nmDisplayString : model.displayString
         }
 
         QfToolButton {
           id: viewButton
-          width: 40
-          height: 40
+          anchors.verticalCenter: parent.verticalCenter
+          width: 48
+          height: 48
 
           round: false
           iconSource: isEnabled ? Theme.getThemeVectorIcon('ic_edit_attributes_white_24dp') : Theme.getThemeVectorIcon('ic_baseline-list_white_24dp')
@@ -257,9 +261,10 @@ EditorWidgetBase {
 
         QfToolButton {
           id: deleteButton
+          anchors.verticalCenter: parent.verticalCenter
           visible: isEnabled && isButtonEnabled('DeleteChildFeature')
-          width: visible ? 40 : 0
-          height: 40
+          width: visible ? 48 : 0
+          height: 48
 
           round: false
           iconSource: Theme.getThemeVectorIcon('ic_delete_forever_white_24dp')


### PR DESCRIPTION
The value relation's feature list model had its current feature form binding broken when a feature attribute value was changed. This PR fixes that.

In addition, I've fixed multi-line handling within our relation editor widget, which was until now glitching.

Before:
![image](https://github.com/user-attachments/assets/e028b352-6deb-417e-882a-59cf4755cfa2)

PR:
![image](https://github.com/user-attachments/assets/8883311c-be31-4fec-b460-bdf61a2ab2e3)

