### PR TITLE
Remove custom position code, let Qt center dialogs

### DIFF
--- a/src/qml/MessageLog.qml
+++ b/src/qml/MessageLog.qml
@@ -153,7 +153,6 @@ Page {
     id: applicationLogDialog
     title: qsTr("Send application log")
     focus: true
-    y: (mainWindow.height - height - 80) / 2
 
     onAboutToShow: {
       appliationLogInput.text = '';

--- a/src/qml/PluginManagerSettings.qml
+++ b/src/qml/PluginManagerSettings.qml
@@ -238,7 +238,6 @@ Popup {
     id: authorDetails
     title: authorName
     parent: mainWindow.contentItem
-    y: (mainWindow.height - height - 80) / 2
 
     property string authorName: ""
     property string authorHomepage: ""
@@ -286,7 +285,6 @@ Popup {
     title: "Install Plugin from URL"
     parent: mainWindow.contentItem
     focus: true
-    y: (mainWindow.height - height - 80) / 2
 
     onAboutToShow: {
       installFromUrlInput.text = '';
@@ -327,7 +325,6 @@ Popup {
     id: uninstallConfirmation
     title: "Uninstall Plugin"
     parent: mainWindow.contentItem
-    y: (mainWindow.height - height - 80) / 2
 
     property string pluginName: ""
     property string pluginUuid: ""

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -799,7 +799,6 @@ Page {
     title: qsTr("Import URL")
     focus: visible
     parent: mainWindow.contentItem
-    y: (mainWindow.height - height) / 2
 
     onAboutToShow: {
       importUrlInput.text = '';
@@ -908,7 +907,6 @@ Page {
     title: isUploadingPath ? qsTr("WebDAV upload") : qsTr("WebDAV download")
     focus: visible
     parent: mainWindow.contentItem
-    y: (mainWindow.height - height) / 2
 
     property bool isUploadingPath: false
     property string host: ""
@@ -1007,7 +1005,6 @@ Page {
     title: qsTr("Import WebDAV folder")
     focus: visible
     parent: mainWindow.contentItem
-    y: (mainWindow.height - height) / 2
 
     onAboutToShow: {
       if (webdavConnectionLoader.item) {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -4176,8 +4176,6 @@ ApplicationWindow {
     font: Theme.defaultFont
 
     z: 10000 // 1000s are embedded feature forms, user a higher value to insure the dialog will always show above embedded feature forms
-    x: (mainWindow.width - width) / 2
-    y: (mainWindow.height - height) / 2
 
     title: qsTr("Cancel algorithm operation")
     Label {


### PR DESCRIPTION
On Android, the popup that appears when long pressing on text fields is mislocated way down the screen for all of our dialog popups, including our shiny new WebDAV dialogs.

I suspect it has to do with us manually setting up the y property. We don't actually need to do that, let Qt handle placement.