### PR TITLE
Implement remembrance into the import webdav dialog

### DIFF
--- a/src/core/webdavconnection.h
+++ b/src/core/webdavconnection.h
@@ -94,6 +94,8 @@ class WebdavConnection : public QObject
 
     Q_INVOKABLE static bool hasWebdavConfiguration( const QString &path );
 
+    Q_INVOKABLE static QVariantMap importHistory();
+
   signals:
     void urlChanged();
     void usernameChanged();

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -1230,7 +1230,7 @@ Page {
         webdavConnectionLoader.item.username = importWebdavUserInput.editText;
         webdavConnectionLoader.item.password = importWebdavPasswordInput.text;
         webdavConnectionLoader.item.storePassword = importWebdavStorePasswordCheck.checked;
-        webdavConnectionLoader.item.importPath(importWebdavPathInput.displayText, platformUtilities.applicationDirectory() + "Imported Projects/");
+        webdavConnectionLoader.item.importPath(importWebdavPathInput.displayText, platformUtilities.applicationDirectory() + "/Imported Projects/");
       }
     }
   }


### PR DESCRIPTION
This PR improves the import webdav functionality by adding a mechanism through which URLs, users, and their last imported path will be saved and restored via combo box items.

By default, opening the import webdav folder will pre-fill to the last import selection.

The PR also implements a tree view to navigate remote folders, which _greatly_ eases navigation on complex tree structures:

https://github.com/user-attachments/assets/3ee339a3-2512-4c0e-8232-167f3101ed50

