### PR TITLE
Shutdown 'unchanged files' code warnings that show up in PRs

### DIFF
--- a/src/core/trackingmodel.cpp
+++ b/src/core/trackingmodel.cpp
@@ -57,7 +57,7 @@ QModelIndex TrackingModel::parent( const QModelIndex &index ) const
 int TrackingModel::rowCount( const QModelIndex &parent ) const
 {
   Q_UNUSED( parent )
-  return mTrackers.size();
+  return static_cast<int>( mTrackers.size() );
 }
 
 int TrackingModel::columnCount( const QModelIndex &parent ) const

--- a/src/core/valuemapmodelbase.cpp
+++ b/src/core/valuemapmodelbase.cpp
@@ -37,7 +37,7 @@ void ValueMapModelBase::setMap( const QVariant &map )
   const QVariantList list = map.toList();
   if ( !list.empty() ) // QGIS 3
   {
-    beginInsertRows( QModelIndex(), 0, list.size() - 1 );
+    beginInsertRows( QModelIndex(), 0, static_cast<int>( list.size() ) - 1 );
 
     for ( const QVariant &item : list )
     {

--- a/src/core/valuemapmodelbase.cpp
+++ b/src/core/valuemapmodelbase.cpp
@@ -55,7 +55,7 @@ void ValueMapModelBase::setMap( const QVariant &map )
     const QVariantMap valueMap = map.toMap();
     if ( !valueMap.empty() )
     {
-      beginInsertRows( QModelIndex(), 0, valueMap.size() - 1 );
+      beginInsertRows( QModelIndex(), 0, static_cast<int>( valueMap.size() ) - 1 );
 
       QMapIterator<QString, QVariant> i( valueMap );
       while ( i.hasNext() )
@@ -77,7 +77,7 @@ void ValueMapModelBase::setMap( const QVariant &map )
 int ValueMapModelBase::rowCount( const QModelIndex &parent ) const
 {
   Q_UNUSED( parent )
-  return mMap.size();
+  return static_cast<int>( mMap.size() );
 }
 
 QVariant ValueMapModelBase::data( const QModelIndex &index, int role ) const

--- a/src/core/vertexmodel.cpp
+++ b/src/core/vertexmodel.cpp
@@ -302,7 +302,7 @@ void VertexModel::createCandidates()
     if ( ( r == 0 || mVertices.at( r - 1 ).ring != vertex.ring ) && mGeometryType == Qgis::GeometryType::Polygon )
     {
       Vertex lastVertex;
-      for ( int i = r + 1; i < mVertices.count(); i++ )
+      for ( qsizetype i = r + 1; i < mVertices.count(); i++ )
       {
         if ( mVertices.at( i ).ring != vertex.ring )
           break;
@@ -670,7 +670,7 @@ void VertexModel::removeCurrentVertex()
 
 void VertexModel::updateGeometry( const QgsGeometry &geometry )
 {
-  int preservedIndex = mCurrentIndex;
+  qsizetype preservedIndex = mCurrentIndex;
   setGeometry( geometry );
   //since the index is shifted after reload, we decrement
   setCurrentVertex( preservedIndex - 1 );
@@ -737,7 +737,8 @@ void VertexModel::setCurrentVertex( qsizetype newVertex, bool forceUpdate )
   if ( mCurrentIndex >= 0 && mCurrentIndex < mVertices.count() )
   {
     mVertices[mCurrentIndex].currentVertex = false;
-    emit dataChanged( index( mCurrentIndex, 0, QModelIndex() ), index( mCurrentIndex, 0, QModelIndex() ) );
+    const QModelIndex changedIndex = index( static_cast<int>( mCurrentIndex ), 0, QModelIndex() );
+    emit dataChanged( changedIndex, changedIndex );
   }
 
   if ( mVertices.count() == 0 )
@@ -762,7 +763,8 @@ void VertexModel::setCurrentVertex( qsizetype newVertex, bool forceUpdate )
   if ( mCurrentIndex >= 0 && mCurrentIndex < mVertices.count() )
   {
     mVertices[mCurrentIndex].currentVertex = true;
-    emit dataChanged( index( mCurrentIndex, 0, QModelIndex() ), index( mCurrentIndex, 0, QModelIndex() ) );
+    const QModelIndex changedIndex = index( static_cast<int>( mCurrentIndex ), 0, QModelIndex() );
+    emit dataChanged( changedIndex, changedIndex );
   }
 
   emit currentVertexIndexChanged();
@@ -781,7 +783,7 @@ void VertexModel::setCurrentVertexIndex( qsizetype currentIndex )
 
 int VertexModel::currentVertexIndex() const
 {
-  return mCurrentIndex;
+  return static_cast<int>( mCurrentIndex );
 }
 
 int VertexModel::vertexCount() const

--- a/src/core/vertexmodel.cpp
+++ b/src/core/vertexmodel.cpp
@@ -144,7 +144,7 @@ void VertexModel::undoHistory()
       {
         setCurrentVertexIndex( -1 );
         beginResetModel();
-        mVertices.insert( std::max( 0, change.index - 1 ), change.vertex );
+        mVertices.insert( std::max<long long int>( change.index - 1, 0 ), change.vertex );
         createCandidates();
         endResetModel();
         setCurrentVertexIndex( change.index );
@@ -246,7 +246,7 @@ void VertexModel::createCandidates()
                                    []( const Vertex &vertex ) { return vertex.type != ExistingVertex; } ),
                    mVertices.end() );
 
-  int r = 0;
+  qsizetype r = 0;
 
   while ( r < mVertices.count() )
   {
@@ -382,7 +382,7 @@ QModelIndex VertexModel::parent( const QModelIndex &child ) const
 int VertexModel::rowCount( const QModelIndex &parent ) const
 {
   Q_UNUSED( parent )
-  return mVertices.count();
+  return static_cast<int>( mVertices.count() );
 }
 
 int VertexModel::columnCount( const QModelIndex &parent ) const
@@ -732,7 +732,7 @@ void VertexModel::setCurrentPoint( const QgsPoint &point )
   emit geometryChanged();
 }
 
-void VertexModel::setCurrentVertex( int newVertex, bool forceUpdate )
+void VertexModel::setCurrentVertex( qsizetype newVertex, bool forceUpdate )
 {
   if ( mCurrentIndex >= 0 && mCurrentIndex < mVertices.count() )
   {
@@ -768,7 +768,7 @@ void VertexModel::setCurrentVertex( int newVertex, bool forceUpdate )
   emit currentVertexIndexChanged();
 }
 
-void VertexModel::setCurrentVertexIndex( int currentIndex )
+void VertexModel::setCurrentVertexIndex( qsizetype currentIndex )
 {
   if ( currentIndex == mCurrentIndex )
     return;
@@ -786,7 +786,7 @@ int VertexModel::currentVertexIndex() const
 
 int VertexModel::vertexCount() const
 {
-  return mVertices.count();
+  return static_cast<int>( mVertices.count() );
 }
 
 int VertexModel::ringCount() const

--- a/src/core/vertexmodel.h
+++ b/src/core/vertexmodel.h
@@ -127,14 +127,14 @@ class QFIELD_CORE_EXPORT VertexModel : public QAbstractListModel
 
     struct VertexChange
     {
-        VertexChange( VertexChangeType type, int &index, const Vertex &vertex )
+        VertexChange( VertexChangeType type, qsizetype &index, const Vertex &vertex )
           : type( type )
           , index( index )
           , vertex( vertex )
         {}
 
         VertexChangeType type = NoChange;
-        int index = -1;
+        qsizetype index = -1;
         Vertex vertex;
     };
 
@@ -253,7 +253,7 @@ class QFIELD_CORE_EXPORT VertexModel : public QAbstractListModel
 
     int currentVertexIndex() const;
 
-    void setCurrentVertexIndex( int currentIndex );
+    void setCurrentVertexIndex( qsizetype currentIndex );
 
     Vertex vertex( int row ) const;
 
@@ -330,11 +330,11 @@ class QFIELD_CORE_EXPORT VertexModel : public QAbstractListModel
      * @param newVertex the new vertex index
      * @param forceUpdate if true, it will force to update all vertices and emit signal
      */
-    void setCurrentVertex( int newVertex, bool forceUpdate = false );
+    void setCurrentVertex( qsizetype newVertex, bool forceUpdate = false );
 
     EditingMode mMode = NoEditing;
     //!
-    int mCurrentIndex = -1;
+    qsizetype mCurrentIndex = -1;
     int mRingCount = 0;
     Qgis::GeometryType mGeometryType = Qgis::GeometryType::Line;
     Qgis::WkbType mGeometryWkbType = Qgis::WkbType::Unknown;
@@ -346,7 +346,7 @@ class QFIELD_CORE_EXPORT VertexModel : public QAbstractListModel
     bool mIsHovering = false;
 
     QList<VertexChange> mHistory;
-    int mHistoryIndex = -1;
+    qsizetype mHistoryIndex = -1;
     bool mHistoryTraversing = false;
 
     friend class VertexModelTest;


### PR DESCRIPTION
Makes this section of PR files changed go away:

![image](https://github.com/user-attachments/assets/17f71bb1-851e-4ae2-80d1-a4a3f7dfd891)

It's been distracting me, and it's the right thing to do :)