### PR TITLE
Additonal functionalities surrounding the code reader and geometry highlighter for plugins

### DIFF
--- a/src/core/locator/activelayerfeatureslocatorfilter.cpp
+++ b/src/core/locator/activelayerfeatureslocatorfilter.cpp
@@ -436,8 +436,8 @@ void ActiveLayerFeaturesLocatorFilter::triggerResultFromAction( const QgsLocator
             mLocatorBridge->mapSettings()->setExtent( r, true );
           }
 
-          mLocatorBridge->locatorHighlightGeometry()->setProperty( "qgsGeometry", geom );
-          mLocatorBridge->locatorHighlightGeometry()->setProperty( "crs", layer->crs() );
+          mLocatorBridge->geometryHighlighter()->setProperty( "qgsGeometry", geom );
+          mLocatorBridge->geometryHighlighter()->setProperty( "crs", layer->crs() );
           break;
         }
       }

--- a/src/core/locator/bookmarklocatorfilter.cpp
+++ b/src/core/locator/bookmarklocatorfilter.cpp
@@ -77,6 +77,6 @@ void BookmarkLocatorFilter::triggerResultFromAction( const QgsLocatorResult &res
   mLocatorBridge->bookmarks()->setExtentFromBookmark( mLocatorBridge->bookmarks()->index( row, 0 ) );
 
   QgsGeometry geom( mLocatorBridge->bookmarks()->data( mLocatorBridge->bookmarks()->index( row, 0 ), BookmarkModel::BookmarkPoint ).value<QgsGeometry>() );
-  mLocatorBridge->locatorHighlightGeometry()->setProperty( "qgsGeometry", geom );
-  mLocatorBridge->locatorHighlightGeometry()->setProperty( "crs", mLocatorBridge->mapSettings()->mapSettings().destinationCrs() );
+  mLocatorBridge->geometryHighlighter()->setProperty( "qgsGeometry", geom );
+  mLocatorBridge->geometryHighlighter()->setProperty( "crs", mLocatorBridge->mapSettings()->mapSettings().destinationCrs() );
 }

--- a/src/core/locator/featureslocatorfilter.cpp
+++ b/src/core/locator/featureslocatorfilter.cpp
@@ -241,7 +241,7 @@ void FeaturesLocatorFilter::triggerResultFromAction( const QgsLocatorResult &res
       mLocatorBridge->mapSettings()->setExtent( r, true );
 
 
-    mLocatorBridge->locatorHighlightGeometry()->setProperty( "qgsGeometry", geom );
-    mLocatorBridge->locatorHighlightGeometry()->setProperty( "crs", layer->crs() );
+    mLocatorBridge->geometryHighlighter()->setProperty( "qgsGeometry", geom );
+    mLocatorBridge->geometryHighlighter()->setProperty( "crs", layer->crs() );
   }
 }

--- a/src/core/locator/finlandlocatorfilter.cpp
+++ b/src/core/locator/finlandlocatorfilter.cpp
@@ -61,6 +61,6 @@ void FinlandLocatorFilter::handleGeocodeResult( const QgsGeocoderResult &result 
 
   mLocatorBridge->mapSettings()->setCenter( transformedGeometry.centroid().vertexAt( 0 ), true );
 
-  mLocatorBridge->locatorHighlightGeometry()->setProperty( "qgsGeometry", result.geometry() );
-  mLocatorBridge->locatorHighlightGeometry()->setProperty( "crs", result.crs() );
+  mLocatorBridge->geometryHighlighter()->setProperty( "qgsGeometry", result.geometry() );
+  mLocatorBridge->geometryHighlighter()->setProperty( "crs", result.crs() );
 }

--- a/src/core/locator/gotolocatorfilter.cpp
+++ b/src/core/locator/gotolocatorfilter.cpp
@@ -206,7 +206,7 @@ void GotoLocatorFilter::triggerResultFromAction( const QgsLocatorResult &result,
   {
     mLocatorBridge->mapSettings()->setCenter( geom.vertexAt( 0 ), true );
 
-    mLocatorBridge->locatorHighlightGeometry()->setProperty( "qgsGeometry", geom );
-    mLocatorBridge->locatorHighlightGeometry()->setProperty( "crs", mLocatorBridge->mapSettings()->mapSettings().destinationCrs() );
+    mLocatorBridge->geometryHighlighter()->setProperty( "qgsGeometry", geom );
+    mLocatorBridge->geometryHighlighter()->setProperty( "crs", mLocatorBridge->mapSettings()->mapSettings().destinationCrs() );
   }
 }

--- a/src/core/locator/locatormodelsuperbridge.cpp
+++ b/src/core/locator/locatormodelsuperbridge.cpp
@@ -113,18 +113,18 @@ void LocatorModelSuperBridge::setMapSettings( QgsQuickMapSettings *mapSettings )
   emit mapSettingsChanged();
 }
 
-QObject *LocatorModelSuperBridge::locatorHighlightGeometry() const
+QObject *LocatorModelSuperBridge::geometryHighlighter() const
 {
-  return mLocatorHighlightGeometry;
+  return mGeometryHighlighter;
 }
 
-void LocatorModelSuperBridge::setLocatorHighlightGeometry( QObject *locatorHighlightGeometry )
+void LocatorModelSuperBridge::setGeometryHighlighter( QObject *geometryHighlighter )
 {
-  if ( locatorHighlightGeometry == mLocatorHighlightGeometry )
+  if ( mGeometryHighlighter == geometryHighlighter )
     return;
 
-  mLocatorHighlightGeometry = locatorHighlightGeometry;
-  emit locatorHighlightGeometryChanged();
+  mGeometryHighlighter = geometryHighlighter;
+  emit geometryHighlighterChanged();
 }
 
 FeatureListExtentController *LocatorModelSuperBridge::featureListController() const

--- a/src/core/locator/locatormodelsuperbridge.h
+++ b/src/core/locator/locatormodelsuperbridge.h
@@ -63,7 +63,7 @@ class LocatorModelSuperBridge : public QgsLocatorModelBridge
     //! The current project's map settings
     Q_PROPERTY( QgsQuickMapSettings *mapSettings READ mapSettings WRITE setMapSettings NOTIFY mapSettingsChanged )
     //! The locator highlight geometry object through which locator actions can highhlight features
-    Q_PROPERTY( QObject *locatorHighlightGeometry READ locatorHighlightGeometry WRITE setLocatorHighlightGeometry NOTIFY locatorHighlightGeometryChanged )
+    Q_PROPERTY( QObject *geometryHighlighter READ geometryHighlighter WRITE setGeometryHighlighter NOTIFY geometryHighlighterChanged )
     //! The feature list extent controller
     Q_PROPERTY( FeatureListExtentController *featureListController READ featureListController WRITE setFeatureListController NOTIFY featureListControllerChanged )
     //! The current project's active layer
@@ -94,10 +94,10 @@ class LocatorModelSuperBridge : public QgsLocatorModelBridge
     //! \copydoc LocatorModelSuperBridge::navigation
     void setNavigation( Navigation *navigation );
 
-    //! \copydoc LocatorModelSuperBridge::locatorHighlightGeometry
-    QObject *locatorHighlightGeometry() const;
-    //! \copydoc LocatorModelSuperBridge::locatorHighlightGeometry
-    void setLocatorHighlightGeometry( QObject *locatorHighlightGeometry );
+    //! \copydoc LocatorModelSuperBridge::geometryHighlighter
+    QObject *geometryHighlighter() const;
+    //! \copydoc LocatorModelSuperBridge::geometryHighlighter
+    void setGeometryHighlighter( QObject *geometryHighlighter );
 
     //! \copydoc LocatorModelSuperBridge::featureListController
     FeatureListExtentController *featureListController() const;
@@ -158,7 +158,7 @@ class LocatorModelSuperBridge : public QgsLocatorModelBridge
     void mapSettingsChanged();
     void bookmarksChanged();
     void navigationChanged();
-    void locatorHighlightGeometryChanged();
+    void geometryHighlighterChanged();
     void featureListControllerChanged();
     void activeLayerChanged();
     void messageEmitted( const QString &text );
@@ -172,7 +172,7 @@ class LocatorModelSuperBridge : public QgsLocatorModelBridge
 
   private:
     QgsQuickMapSettings *mMapSettings = nullptr;
-    QObject *mLocatorHighlightGeometry = nullptr;
+    QObject *mGeometryHighlighter = nullptr;
     FeatureListExtentController *mFeatureListController = nullptr;
     QPointer<QgsMapLayer> mActiveLayer;
     bool mKeepScale = false;

--- a/src/qml/CodeReader.qml
+++ b/src/qml/CodeReader.qml
@@ -13,7 +13,10 @@ import Theme
 Popup {
   id: codeReader
 
+  //! Emitted when a QR code or NFC tag has been decoded/received
   signal decoded(var string)
+  //! Emitted when a QR code or NFC tag has been accepted
+  signal accepted(var string)
 
   property string decodedString: ''
   property var barcodeRequestedItem: undefined //<! when a feature form is requesting a bardcode, this will be set to attribute editor widget which triggered the request
@@ -70,6 +73,7 @@ Popup {
       if (decodedString !== '') {
         codeReader.decodedString = decodedString;
         decodedFlashAnimation.start();
+        decoded(decodedString);
       }
     }
   }
@@ -525,7 +529,7 @@ Popup {
               codeReader.barcodeRequestedItem.requestedBarcodeReceived(codeReader.decodedString);
               codeReader.barcodeRequestedItem = undefined;
             } else {
-              codeReader.decoded(codeReader.decodedString);
+              codeReader.accepted(codeReader.decodedString);
             }
             codeReader.close();
           }

--- a/src/qml/LocatorItem.qml
+++ b/src/qml/LocatorItem.qml
@@ -181,7 +181,7 @@ Item {
     target: codeReader
     enabled: false
 
-    function onDecoded(string) {
+    function onAccepted(string) {
       var prefix = locatorBridge.getPrefixFromSearchString(searchField.text);
       searchField.text = prefix !== '' ? prefix + ' ' + string : string;
     }

--- a/src/qml/editorwidgets/RelationReference.qml
+++ b/src/qml/editorwidgets/RelationReference.qml
@@ -72,8 +72,8 @@ EditorWidgetBase {
     onClicked: {
       if (listModel.currentLayer !== undefined) {
         var feature = listModel.getFeatureFromKeyValue(relationReference.currentKeyValue);
-        locatorHighlightItem.geometryWrapper.qgsGeometry = feature.geometry;
-        locatorHighlightItem.geometryWrapper.crs = listModel.currentLayer.crs;
+        geometryHighlighter.geometryWrapper.qgsGeometry = feature.geometry;
+        geometryHighlighter.geometryWrapper.crs = listModel.currentLayer.crs;
         mapCanvas.mapSettings.extent = FeatureUtils.extent(mapCanvas.mapSettings, listModel.currentLayer, feature);
       }
     }

--- a/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
@@ -197,8 +197,8 @@ EditorWidgetBase {
 
       onClicked: {
         if (orderedRelationModel.relation.referencingLayer !== undefined) {
-          locatorHighlightItem.geometryWrapper.qgsGeometry = nmRelationId ? model.nmReferencingFeature.geometry : model.referencingFeature.geometry;
-          locatorHighlightItem.geometryWrapper.crs = orderedRelationModel.relation.referencingLayer.crs;
+          geometryHighlighter.geometryWrapper.qgsGeometry = nmRelationId ? model.nmReferencingFeature.geometry : model.referencingFeature.geometry;
+          geometryHighlighter.geometryWrapper.crs = orderedRelationModel.relation.referencingLayer.crs;
           mapCanvas.mapSettings.extent = FeatureUtils.extent(mapCanvas.mapSettings, orderedRelationModel.relation.referencingLayer, nmRelationId ? model.nmReferencingFeature : model.referencingFeature);
         }
       }

--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -211,8 +211,8 @@ EditorWidgetBase {
 
         onClicked: {
           if (relationEditorModel.relation.referencingLayer !== undefined) {
-            locatorHighlightItem.geometryWrapper.qgsGeometry = nmRelationId ? model.nmReferencingFeature.geometry : model.referencingFeature.geometry;
-            locatorHighlightItem.geometryWrapper.crs = relationEditorModel.relation.referencingLayer.crs;
+            geometryHighlighter.geometryWrapper.qgsGeometry = nmRelationId ? model.nmReferencingFeature.geometry : model.referencingFeature.geometry;
+            geometryHighlighter.geometryWrapper.crs = relationEditorModel.relation.referencingLayer.crs;
             mapCanvas.mapSettings.extent = FeatureUtils.extent(mapCanvas.mapSettings, relationEditorModel.relation.referencingLayer, nmRelationId ? model.nmReferencingFeature : model.referencingFeature);
           }
         }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -102,7 +102,7 @@ ApplicationWindow {
     featureListController: featureForm.extentController
     mapSettings: mapCanvas.mapSettings
     navigation: navigation
-    locatorHighlightGeometry: locatorHighlightItem.geometryWrapper
+    geometryHighlighter: geometryHighlighter.geometryWrapper
     keepScale: qfieldSettings.locatorKeepScale
 
     onMessageEmitted: {
@@ -987,7 +987,8 @@ ApplicationWindow {
 
     /* Highlight features identified by locator or relation editor widgets */
     GeometryHighlighter {
-      id: locatorHighlightItem
+      id: geometryHighlighter
+      objectName: "geometryHighlighter"
     }
 
     MapToScreen {


### PR DESCRIPTION
Practically speaking, the PR is there for a client's plugin to be able to react to captured QR/NFC codes without having to manually accept the decoded string.

Since this now happens without confirmation, we need a way to provide some more visual feedback in the form of geometry highlight. This wasn't available to plugins until this PR, and it's a nice and simple functionality that many people will appreciate.