### PR TITLE
Fix legend image corruption when jumping from subtree to another with a step greater than one

### DIFF
--- a/src/core/legendimageprovider.cpp
+++ b/src/core/legendimageprovider.cpp
@@ -75,10 +75,11 @@ QPixmap LegendImageProvider::requestPixmap( const QString &id, QSize *size, cons
           legendParts.removeLast();
 
           QModelIndex nextIndex = mLayerTreeModel->sibling( index.row() + 1, 0, index );
-          if ( !nextIndex.isValid() && index.parent() != layerIndex )
+          while ( !nextIndex.isValid() && index != layerIndex )
           {
             legendParts.removeLast();
-            nextIndex = mLayerTreeModel->sibling( index.parent().row() + 1, 0, index.parent() );
+            index = index.parent();
+            nextIndex = mLayerTreeModel->sibling( index.row() + 1, 0, index );
           }
           index = nextIndex;
         }


### PR DESCRIPTION
The PR fixes #6003.