### PR TITLE
Implement Multi-Selection for Local Data Picker Screen

### DIFF
--- a/src/core/localfilesmodel.cpp
+++ b/src/core/localfilesmodel.cpp
@@ -316,7 +316,7 @@ QVariant LocalFilesModel::data( const QModelIndex &index, int role ) const
   if ( index.row() >= mItems.size() || index.row() < 0 )
     return QVariant();
 
-  const Item item = mItems[index.row()];
+  const Item &item = mItems[index.row()];
 
   switch ( static_cast<Role>( role ) )
   {
@@ -376,4 +376,14 @@ void LocalFilesModel::setChecked( const int &mIdx, const bool &checked )
     emit inSelectionModeChanged();
     emit dataChanged( index( 0, 0, QModelIndex() ), index( mItems.size() - 1, 0, QModelIndex() ), { ItemCheckedRole } );
   }
+}
+
+void LocalFilesModel::clearSelection()
+{
+  for ( Item &item : mItems )
+  {
+    item.checked = false;
+  }
+  emit inSelectionModeChanged();
+  emit dataChanged( index( 0, 0, QModelIndex() ), index( mItems.size() - 1, 0, QModelIndex() ), { ItemCheckedRole } );
 }

--- a/src/core/localfilesmodel.cpp
+++ b/src/core/localfilesmodel.cpp
@@ -61,6 +61,7 @@ QHash<int, QByteArray> LocalFilesModel::roleNames() const
   roles[ItemHasThumbnailRole] = "ItemHasThumbnail";
   roles[ItemIsFavoriteRole] = "ItemIsFavorite";
   roles[ItemHasWebdavConfigurationRole] = "ItemHasWebdavConfiguration";
+  roles[ItemCheckedRole] = "ItemChecked";
   return roles;
 }
 
@@ -315,38 +316,61 @@ QVariant LocalFilesModel::data( const QModelIndex &index, int role ) const
   if ( index.row() >= mItems.size() || index.row() < 0 )
     return QVariant();
 
+  const Item item = mItems[index.row()];
+
   switch ( static_cast<Role>( role ) )
   {
     case ItemMetaTypeRole:
-      return mItems[index.row()].metaType;
+      return item.metaType;
 
     case ItemTypeRole:
-      return mItems[index.row()].type;
+      return item.type;
 
     case ItemTitleRole:
-      return mItems[index.row()].title;
+      return item.title;
 
     case ItemFormatRole:
-      return mItems[index.row()].format;
+      return item.format;
 
     case ItemPathRole:
-      return mItems[index.row()].path;
+      return item.path;
 
     case ItemSizeRole:
-      return mItems[index.row()].size;
+      return item.size;
 
     case ItemHasThumbnailRole:
-      return mItems[index.row()].size < 25000000
-             && SUPPORTED_DATASET_THUMBNAIL.contains( mItems[index.row()].format );
+      return item.size < 25000000 && SUPPORTED_DATASET_THUMBNAIL.contains( item.format );
 
     case ItemIsFavoriteRole:
-      return mFavorites.contains( mItems[index.row()].path );
+      return mFavorites.contains( item.path );
 
     case ItemHasWebdavConfigurationRole:
-    {
-      return WebdavConnection::hasWebdavConfiguration( mItems[index.row()].path );
-    }
+      return WebdavConnection::hasWebdavConfiguration( item.path );
+
+    case ItemCheckedRole:
+      return item.checked;
   }
 
   return QVariant();
+}
+
+bool LocalFilesModel::inSelectionMode()
+{
+  for ( const Item &item : mItems )
+  {
+    if ( item.checked )
+      return true;
+  }
+  return false;
+}
+
+void LocalFilesModel::setChecked( const int &mIdx, const bool &checked )
+{
+  if ( mItems[mIdx].checked != checked )
+  {
+    mItems[mIdx].checked = checked;
+
+    emit inSelectionModeChanged();
+    emit dataChanged( index( 0, 0, QModelIndex() ), index( mItems.size() - 1, 0, QModelIndex() ), { ItemCheckedRole } );
+  }
 }

--- a/src/core/localfilesmodel.cpp
+++ b/src/core/localfilesmodel.cpp
@@ -359,12 +359,7 @@ bool LocalFilesModel::inSelectionMode()
   if ( currentTitle() == QStringLiteral( "Home" ) )
     return false;
 
-  for ( const Item &item : mItems )
-  {
-    if ( item.checked )
-      return true;
-  }
-  return false;
+  return std::any_of( mItems.begin(), mItems.end(), []( const Item &item ) { return item.checked; } );
 }
 
 void LocalFilesModel::setChecked( const int &mIdx, const bool &checked )

--- a/src/core/localfilesmodel.cpp
+++ b/src/core/localfilesmodel.cpp
@@ -356,6 +356,9 @@ QVariant LocalFilesModel::data( const QModelIndex &index, int role ) const
 
 bool LocalFilesModel::inSelectionMode()
 {
+  if ( currentTitle() == QStringLiteral( "Home" ) )
+    return false;
+
   for ( const Item &item : mItems )
   {
     if ( item.checked )

--- a/src/core/localfilesmodel.h
+++ b/src/core/localfilesmodel.h
@@ -142,6 +142,9 @@ class LocalFilesModel : public QAbstractListModel
     //! Set checked state of an item in list
     Q_INVOKABLE void setChecked( const int &mIdx, const bool &checked );
 
+    //! Set checked state of all items to false
+    Q_INVOKABLE void clearSelection();
+
   signals:
 
     void currentPathChanged();

--- a/src/core/localfilesmodel.h
+++ b/src/core/localfilesmodel.h
@@ -29,6 +29,7 @@ class LocalFilesModel : public QAbstractListModel
     Q_PROPERTY( QString currentPath READ currentPath WRITE setCurrentPath NOTIFY currentPathChanged )
     Q_PROPERTY( int currentDepth READ currentDepth NOTIFY currentPathChanged )
     Q_PROPERTY( bool isDeletedAllowedInCurrentPath READ isDeletedAllowedInCurrentPath NOTIFY currentPathChanged )
+    Q_PROPERTY( bool inSelectionMode READ inSelectionMode NOTIFY inSelectionModeChanged )
 
   public:
     enum ItemMetaType
@@ -57,13 +58,14 @@ class LocalFilesModel : public QAbstractListModel
     {
         Item() = default;
 
-        Item( ItemMetaType metaType, ItemType type, const QString &title, const QString &format, const QString &path, qint64 size = 0 )
+        Item( ItemMetaType metaType, ItemType type, const QString &title, const QString &format, const QString &path, qint64 size = 0, const bool checked = false )
           : metaType( metaType )
           , type( type )
           , title( title )
           , format( format )
           , path( path )
           , size( size )
+          , checked( checked )
         {}
 
         ItemMetaType metaType = ItemMetaType::Folder;
@@ -72,6 +74,7 @@ class LocalFilesModel : public QAbstractListModel
         QString format;
         QString path;
         qint64 size = 0;
+        bool checked;
     };
 
     enum Role
@@ -85,6 +88,7 @@ class LocalFilesModel : public QAbstractListModel
       ItemHasThumbnailRole,
       ItemIsFavoriteRole,
       ItemHasWebdavConfigurationRole,
+      ItemCheckedRole,
     };
     Q_ENUM( Role )
 
@@ -132,9 +136,17 @@ class LocalFilesModel : public QAbstractListModel
     //! Walks the navigation history back up on step
     Q_INVOKABLE void moveUp();
 
+    //! Returns whether list is in multi-selection mode or not
+    bool inSelectionMode();
+
+    //! Set checked state of an item in list
+    Q_INVOKABLE void setChecked( const int &mIdx, const bool &checked );
+
   signals:
 
     void currentPathChanged();
+
+    void inSelectionModeChanged();
 
   private:
     void reloadModel();

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -32,8 +32,13 @@ Page {
     showApplyButton: false
     showCancelButton: false
     showMenuButton: localFilesModel.inSelectionMode
+    backAsCancel: localFilesModel.inSelectionMode
 
     topMargin: mainWindow.sceneTopMargin
+
+    onCancel: {
+      localFilesModel.clearSelection();
+    }
 
     onBack: {
       if (table.model.currentDepth > 1) {

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -254,7 +254,7 @@ Page {
               }
             }
             QfToolButton {
-              visible: itemMenuVisible
+              visible: itemMenuVisible && !localFilesModel.inSelectionMode
               round: true
               opacity: 0.5
 

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -31,6 +31,7 @@ Page {
     showBackButton: true
     showApplyButton: false
     showCancelButton: false
+    showMenuButton: localFilesModel.inSelectionMode
 
     topMargin: mainWindow.sceneTopMargin
 

--- a/src/qml/imports/Theme/QfPageHeader.qml
+++ b/src/qml/imports/Theme/QfPageHeader.qml
@@ -12,6 +12,7 @@ ToolBar {
   property alias showBackButton: backButton.visible
   property alias showApplyButton: applyButton.visible
   property alias showCancelButton: cancelButton.visible
+  property alias showMenuButton: menuButton.visible
 
   property alias busyIndicatorState: busyIndicator.state
   property alias busyIndicatorValue: busyIndicator.value
@@ -24,6 +25,7 @@ ToolBar {
   signal apply
   signal back
   signal finished
+  signal openMenu
 
   anchors {
     top: parent.top
@@ -131,7 +133,7 @@ ToolBar {
     Label {
       id: titleLabel
       leftPadding: !showApplyButton && showCancelButton ? 48 : 0
-      rightPadding: (showApplyButton || showBackButton) && !showCancelButton ? 48 : 0
+      rightPadding: (showApplyButton || showBackButton) && !showCancelButton && !showMenuButton ? 48 : 0
       font: Theme.strongFont
       color: backgroundFill ? Theme.mainOverlayColor : Theme.mainColor
       elide: Label.ElideRight
@@ -151,6 +153,21 @@ ToolBar {
       onClicked: {
         cancel();
         finished();
+      }
+    }
+
+    QfToolButton {
+      id: menuButton
+
+      Layout.alignment: Qt.AlignTop | Qt.AlignRight
+      clip: true
+      visible: false
+
+      iconSource: Theme.getThemeVectorIcon("ic_dot_menu_black_24dp")
+      iconColor: Theme.mainOverlayColor
+
+      onClicked: {
+        openMenu();
       }
     }
   }

--- a/src/qml/imports/Theme/QfPageHeader.qml
+++ b/src/qml/imports/Theme/QfPageHeader.qml
@@ -8,6 +8,7 @@ ToolBar {
   property alias title: titleLabel.text
 
   property bool backgroundFill: true
+  property bool backAsCancel: false
 
   property alias showBackButton: backButton.visible
   property alias showApplyButton: applyButton.visible
@@ -107,11 +108,15 @@ ToolBar {
 
       Layout.alignment: Qt.AlignTop | Qt.AlignLeft
       clip: true
-      iconSource: Theme.getThemeVectorIcon('ic_arrow_left_white_24dp')
+      iconSource: backAsCancel ? Theme.getThemeVectorIcon('ic_close_white_24dp') : Theme.getThemeVectorIcon('ic_arrow_left_white_24dp')
       iconColor: backgroundFill ? Theme.mainOverlayColor : Theme.mainTextColor
 
       onClicked: {
-        back();
+        if (backAsCancel) {
+          cancel();
+        } else {
+          back();
+        }
         finished();
       }
     }


### PR DESCRIPTION
**Description:**
In this PR we are implementing multi-selection functionality in the local project and dataset view.

**Changes Implemented:**
1- Selection mode triggers with **long press** on file / folder.
2- It is not possible to trigger selection mode in **root** (Home).   
3- In selection mode, **3 dot menu** for each item is invisible.  
4- In selection mode, back button will turn in to **cancel button** that clear selection.

**Main C++ Changes:**
1- Adding `inSelectionMode` Q_PROPERTY which indicates is in selection mode or not.   
2- Add `ItemCheckedRole`.
3- Add `clearSelection` function that `uncheck` selected mode for all items.  

**Screen cast:**

[Screencast From 2025-02-18 20-50-42.webm](https://github.com/user-attachments/assets/f449d458-14a3-4e86-a6a1-565499e50ebf)
