### PR TITLE
Center Map on Vertex Addition When Position Locked & Off-Screen

### DIFF
--- a/src/qml/CoordinateLocator.qml
+++ b/src/qml/CoordinateLocator.qml
@@ -390,7 +390,7 @@ Item {
   function flash() {
     flashAnimation.start();
     if (positionLocked) {
-      const outOfScreen = crosshairCircle.x <= 0 || crosshairCircle.x >= mainWindow.width || crosshairCircle.y <= 0 || crosshairCircle.y >= mainWindow.height;
+      const outOfScreen = crosshairCircle.x + crosshairCircle.width <= 0 || crosshairCircle.x - crosshairCircle.width >= mainWindow.width || crosshairCircle.y + crosshairCircle.height <= 0 || crosshairCircle.y - crosshairCircle.height >= mainWindow.height;
       if (outOfScreen) {
         mapCanvas.mapSettings.setCenter(positionSource.projectedPosition, true);
       }

--- a/src/qml/CoordinateLocator.qml
+++ b/src/qml/CoordinateLocator.qml
@@ -389,6 +389,12 @@ Item {
 
   function flash() {
     flashAnimation.start();
+    if (positionLocked) {
+      const outOfScreen = crosshairCircle.x <= 0 || crosshairCircle.x >= mainWindow.width || crosshairCircle.y <= 0 || crosshairCircle.y >= mainWindow.height;
+      if (outOfScreen) {
+        mapCanvas.mapSettings.setCenter(positionSource.projectedPosition, true);
+      }
+    }
   }
 
   /** Function to get the multiplier based on the selected tolerance


### PR DESCRIPTION
**Description**:

This PR addresses a usability issue related to adding vertices when the coordinate cursor is locked and is off-screen.  (#5883 ).

**Problem:**

When the coordinate cursor is locked, new vertices should be added at the current location point. However, if the user moves the map canvas so the current location (and thus the crosshair) is no longer visible, the user receives no visual confirmation of vertex addition. This creates uncertainty as to whether the vertex has been added or not.

**Solution:**

This PR implements a solution that automatically recenters the map when a vertex is added under the described condition. Specifically:

When the positionLocked setting is enabled and a vertex is being added.

The code checks if the crosshair circle (representing the current location) is off-screen.  This is determined by the following logic:

```Js
const outOfScreen = crosshairCircle.x + crosshairCircle.width <= 0 ||
                    crosshairCircle.x - crosshairCircle.width >= mainWindow.width ||
                    crosshairCircle.y + crosshairCircle.height <= 0 ||
                    crosshairCircle.y - crosshairCircle.height >= mainWindow.height;
```
If `outOfScreen` is `true` , the map is automatically recentered to the current location using `mapCanvas.mapSettings.setCenter(positionSource.projectedPosition, true);`.

**Screen cast:**


[Screencast From 2025-02-16 23-49-34.webm](https://github.com/user-attachments/assets/eb43a8a1-299c-4d4e-b78c-624cbab18d3a)
