### PR TITLE
Restore Stylus Binding to CoordinateLocator

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -558,10 +558,13 @@ ApplicationWindow {
      * PointerDevice.TouchScreen was explicitly taken out of the accepted devices.
      * The timer is needed as adding additional fingers onto a device re-triggers hovered
      * changes in unpredictable order.
+     *
+     * Known issue: Switching between finger and stylus input within 500 milliseconds may break
+     * the stylus binding to the CoordinateLocator.
      */
     Timer {
       id: dummyHoverTimer
-      interval: 750
+      interval: 500
       repeat: false
 
       onTriggered: {
@@ -571,7 +574,7 @@ ApplicationWindow {
 
     HoverHandler {
       id: dummyHoverHandler
-      enabled: !qfieldSettings.mouseAsTouchScreen && !(positionSource.active && positioningSettings.positioningCoordinateLock)
+      enabled: !qfieldSettings.mouseAsTouchScreen && hoverHandler.enabled
       acceptedDevices: PointerDevice.TouchScreen
       grabPermissions: PointerHandler.TakeOverForbidden
 


### PR DESCRIPTION
**Description**

This PR addresses issue [#5296](https://github.com/opengisch/QField/issues/5296), which concerns a broken stylus binding to the coordinate locator.
The stylus binding is reliably broken by the following steps:

1.  Add a point using the stylus.
2.  Discard the point using your finger.

After this sequence, the stylus no longer functions correctly with the coordinate locator.

**Solution:**

It turned out that the `dummyHoverHandler`'s enabled property should be synchronized with the `hoverHandler` at all times.


**Known Limitation:**

There is a remaining edge case: If a user pans the map with their finger and then switches to using the stylus *within* 500 milliseconds, the stylus binding to the `CoordinateLocator` might be temporarily disrupted.  This is a known area for future improvement.
