### PR TITLE
What is causing our AppImage to die?

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -57,14 +57,6 @@
       "default-features": false
     },
     {
-      "name": "qtbase",
-      "default-features": false,
-      "features": [
-        "gles3"
-      ],
-      "platform": "!windows & !osx & !android"
-    },
-    {
       "name": "qtcharts",
       "features": [
         "qml"

--- a/vcpkg/ports/qgis/vcpkg.json
+++ b/vcpkg/ports/qgis/vcpkg.json
@@ -70,6 +70,10 @@
           "name": "gles2",
           "platform": "android"
         },
+        {
+          "name": "gles3",
+          "platform": "ios"
+        },
         "gui",
         "harfbuzz",
         "jpeg",


### PR DESCRIPTION
Small picture lesson learned: AppImage environment doesn't like gles3.

Big picture lesson learned here is: local vcpkg-based Linux builds != Linux AppImage. One successfully executing does not mean the other will. 