### PR TITLE
[Backport release-3_5] Only ignore SSL errors on non qfield.cloud endpoints

### DIFF
--- a/src/core/networkreply.cpp
+++ b/src/core/networkreply.cpp
@@ -103,7 +103,10 @@ void NetworkReply::initiateRequest()
     for ( const QSslError &error : errors )
       qDebug() << "SSL: " << error;
 
-    mReply->ignoreSslErrors( errors );
+    if ( !mRequest.url().host().endsWith( QStringLiteral( ".qfield.cloud" ) ) )
+    {
+      mReply->ignoreSslErrors( errors );
+    }
   } );
 }
 


### PR DESCRIPTION
Backport #6015
 **Authored by:** @nirvn