### PR TITLE
Fix image attachments rotation issues after drawing on them

### DIFF
--- a/src/core/drawingcanvas.cpp
+++ b/src/core/drawingcanvas.cpp
@@ -110,6 +110,12 @@ QString DrawingCanvas::save() const
       image.save( path, "jpg", 88 );
       for ( const QString &key : metadata.keys() )
       {
+        if ( key == QLatin1String( "Exif.Image.Orientation" ) )
+        {
+          // The rotation transform already happened when we loaded the image, skip the tag
+          continue;
+        }
+
         QgsExifTools::tagImage( path, key, metadata[key] );
       }
       return path;


### PR DESCRIPTION
This PR fixes https://github.com/opengisch/QField/issues/6010 -- we were adding Exif orientation tag to a modified image that was already rotated by the drawing canvas.