### PR TITLE
Relation editor widget's print child feature atlas layout to PDF

### DIFF
--- a/src/qml/editorwidgets/RelationEditorBase.qml
+++ b/src/qml/editorwidgets/RelationEditorBase.qml
@@ -1,14 +1,9 @@
 import QtQuick
 import QtQuick.Controls
-import QtQml.Models
-import QtQuick.Layouts
-import QtQuick.Controls.Material
-import QtQuick.Controls.Material.impl
 import org.qfield
 import org.qgis
 import Theme
-import "../.."
-import ".."
+import "../"
 
 EditorWidgetBase {
   id: relationEditorBase
@@ -60,7 +55,7 @@ EditorWidgetBase {
       anchors.bottom: parent.bottom
       height: itemHeight
       width: parent.width
-      visible: isButtonEnabled('AddChildFeature')
+      visible: isActionEnabled('AddChildFeature')
 
       focus: true
 
@@ -219,7 +214,53 @@ EditorWidgetBase {
     }
   }
 
-  function isButtonEnabled(buttonType) {
+  property Menu childMenu: Menu {
+    id: childMenu
+    title: qsTr("Child Menu")
+    z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes
+
+    property int entryReferencingFeatureId: -1
+    property string entryDisplayString: ""
+    property int entryNmReferencedFeatureId: -1
+    property string entryNmReferencedFeatureDisplayMessage: ""
+
+    width: {
+      let result = 50;
+      let padding = 0;
+      for (var i = 0; i < count; ++i) {
+        let item = itemAt(i);
+        result = Math.max(item.contentItem.implicitWidth, result);
+        padding = Math.max(item.leftPadding + item.rightPadding, padding);
+      }
+      return mainWindow.width > 0 ? Math.min(result + padding, mainWindow.width - 20) : result + padding;
+    }
+
+    topMargin: mainWindow.sceneTopMargin
+    bottomMargin: mainWindow.sceneBottomMargin
+
+    MenuItem {
+      id: deleteChildItem
+      enabled: isEnabled
+      visible: isActionEnabled('DeleteChildFeature')
+
+      font: Theme.defaultFont
+      width: parent.width
+      height: visible ? 48 : 0
+      leftPadding: Theme.menuItemLeftPadding
+      icon.source: Theme.getThemeVectorIcon("ic_delete_forever_white_24dp")
+
+      text: qsTr("Delete Child Feature")
+      onTriggered: {
+        deleteDialog.referencingFeatureId = childMenu.entryReferencingFeatureId;
+        deleteDialog.referencingFeatureDisplayMessage = childMenu.entryDisplayString;
+        deleteDialog.nmReferencedFeatureId = childMenu.entryNmReferencedFeatureId;
+        deleteDialog.nmReferencedFeatureDisplayMessage = childMenu.entryNmReferencedFeatureDisplayMessage;
+        deleteDialog.visible = true;
+      }
+    }
+  }
+
+  function isActionEnabled(buttonType) {
     const buttons = relationEditorWidgetConfig.buttons;
     if (buttons === undefined)
       return true;

--- a/src/qml/editorwidgets/RelationEditorBase.qml
+++ b/src/qml/editorwidgets/RelationEditorBase.qml
@@ -1,0 +1,252 @@
+import QtQuick
+import QtQuick.Controls
+import QtQml.Models
+import QtQuick.Layouts
+import QtQuick.Controls.Material
+import QtQuick.Controls.Material.impl
+import org.qfield
+import org.qgis
+import Theme
+import "../.."
+import ".."
+
+EditorWidgetBase {
+  id: relationEditorBase
+
+  property var relationEditorModel: undefined
+  property alias listView: listView
+
+  property int itemHeight: 48
+  property int bottomMargin: 10
+  property int maximumVisibleItems: 4
+
+  Component.onCompleted: {
+    if (currentLayer && currentLayer.customProperty('QFieldSync/relationship_maximum_visible') !== undefined) {
+      var value = JSON.parse(currentLayer.customProperty('QFieldSync/relationship_maximum_visible'))[relationId];
+      maximumVisibleItems = value !== undefined ? value : 4;
+    } else {
+      maximumVisibleItems = 4;
+    }
+  }
+
+  // because no additional addEntry item on readOnly (isEnabled false)
+  height: listView.contentHeight + (isEnabled ? addEntry.height : 0) + 10
+  enabled: true
+
+  Rectangle {
+    anchors.top: parent.top
+    anchors.bottom: parent.bottom
+    anchors.bottomMargin: relationEditorBase.bottomMargin
+    width: parent.width
+    color: "transparent"
+    border.color: Theme.controlBorderColor
+    border.width: 1
+    clip: true
+
+    ListView {
+      id: listView
+      width: parent.width
+      height: maximumVisibleItems > 0 ? Math.min(maximumVisibleItems * itemHeight, listView.count * itemHeight) + (listView.count > maximumVisibleItems ? itemHeight / 2 : 0) : listView.count * itemHeight
+      focus: true
+      clip: true
+      highlightRangeMode: ListView.ApplyRange
+      ScrollBar.vertical: QfScrollBar {
+      }
+    }
+
+    Item {
+      id: addEntry
+      anchors.bottom: parent.bottom
+      height: itemHeight
+      width: parent.width
+      visible: isButtonEnabled('AddChildFeature')
+
+      focus: true
+
+      Rectangle {
+        anchors.fill: parent
+        color: Theme.controlBorderColor
+        visible: isEnabled
+
+        Text {
+          visible: isEnabled
+          color: Theme.secondaryTextColor
+          text: isEnabled && !constraintsHardValid ? qsTr('Ensure contraints are met') : ''
+          anchors {
+            leftMargin: 10
+            left: parent.left
+            right: addButtonRow.left
+            verticalCenter: parent.verticalCenter
+          }
+          font: Theme.tipFont
+        }
+
+        Row {
+          id: addButtonRow
+          anchors {
+            top: parent.top
+            right: parent.right
+            rightMargin: 10
+          }
+          height: parent.height
+
+          QfToolButton {
+            id: addButton
+            width: parent.height
+            height: parent.height
+            enabled: constraintsHardValid
+
+            round: false
+            iconSource: Theme.getThemeVectorIcon('ic_add_white_24dp')
+            bgcolor: parent.enabled ? 'black' : 'grey'
+          }
+        }
+
+        BusyIndicator {
+          id: addingIndicator
+          anchors {
+            top: parent.top
+            right: parent.right
+            rightMargin: 10
+          }
+          width: parent.height
+          height: parent.height
+          running: false
+        }
+
+        Timer {
+          id: addingTimer
+
+          property string printName: ''
+
+          interval: 50
+          repeat: false
+
+          onTriggered: {
+            let saved = form.state === 'Add' ? !form.setupOnly && save() : true;
+            if (ProjectUtils.transactionMode(qgisProject) !== Qgis.TransactionMode.Disabled) {
+              // When a transaction mode is enabled, we must fallback to saving the parent feature to have provider-side issues
+              if (!saved) {
+                addingIndicator.running = false;
+                displayToast(qsTr('Cannot add child feature: insure the parent feature meets all constraints and can be saved'), 'warning');
+                return;
+              }
+            }
+
+            //this has to be checked after buffering because the primary could be a value that has been created on creating featurer (e.g. fid)
+            if (relationEditorModel.parentPrimariesAvailable) {
+              displayToast(qsTr('Adding child feature in layer %1').arg(relationEditorModel.relation.referencingLayer.name));
+              if (relationEditorModel.relation.referencingLayer.geometryType() !== Qgis.GeometryType.Null) {
+                requestGeometry(relationEditor, relationEditorModel.relation.referencingLayer);
+                return;
+              }
+              showAddFeaturePopup();
+            } else {
+              addingIndicator.running = false;
+              displayToast(qsTr('Cannot add child feature: attribute value linking parent and children is not set'), 'warning');
+            }
+          }
+        }
+
+        MouseArea {
+          anchors.fill: parent
+          onClicked: {
+            addingIndicator.running = true;
+            addingTimer.restart();
+          }
+        }
+      }
+    }
+
+    BusyIndicator {
+      id: busyIndicator
+      anchors.centerIn: parent
+      width: 36
+      height: 36
+      running: relationEditorModel.isLoading
+    }
+  }
+
+  property QfDialog deleteDialog: QfDialog {
+    id: deleteDialog
+    parent: mainWindow.contentItem
+
+    property int referencingFeatureId
+    property string referencingFeatureDisplayMessage
+    property string referencingLayerName: relationEditorModel.relation.referencingLayer ? relationEditorModel.relation.referencingLayer.name : ''
+    property int nmReferencedFeatureId
+    property string nmReferencedFeatureDisplayMessage
+    property string nmReferencedLayerName: relationEditorModel.nmRelation.referencedLayer ? relationEditorModel.nmRelation.referencedLayer.name : ''
+    property string nmReferencingLayerName
+
+    z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature forms
+    title: nmRelationId ? qsTr('Unlink feature %1 (%2) of %3').arg(nmReferencedFeatureDisplayMessage).arg(nmReferencedFeatureId).arg(nmReferencedLayerName) : qsTr('Delete feature %1 (%2) on %3').arg(referencingFeatureDisplayMessage).arg(referencingFeatureId).arg(referencingLayerName)
+    Label {
+      width: parent.width
+      wrapMode: Text.WordWrap
+      text: nmRelationId ? qsTr('Should the feature <b>%1 (%2)</b> of layer <b>%3</b> be unlinked?<br><i>(The connection will be deleted on layer <b>%4</b>)</i>').arg(deleteDialog.nmReferencedFeatureDisplayMessage).arg(deleteDialog.nmReferencedFeatureId).arg(deleteDialog.nmReferencedLayerName).arg(deleteDialog.referencingLayerName) : qsTr('Should the feature <b>%1 (%2)</b> on layer <b>%3</b> be deleted?').arg(deleteDialog.referencingFeatureDisplayMessage).arg(deleteDialog.referencingFeatureId).arg(deleteDialog.referencingLayerName)
+    }
+    onAccepted: {
+      if (!relationEditorModel || !relationEditorModel.deleteFeature(referencingFeatureId)) {
+        displayToast(qsTr("Failed to delete referencing feature"), 'error');
+      }
+      visible = false;
+    }
+    onRejected: {
+      visible = false;
+    }
+  }
+
+  property EmbeddedFeatureForm embeddedPopup: EmbeddedFeatureForm {
+    embeddedLevel: form.embeddedLevel + 1
+    digitizingToolbar: form.digitizingToolbar
+    codeReader: form.codeReader
+
+    onFeatureCancelled: {
+      if (autoSave) {
+        relationEditorModel.reload();
+      }
+    }
+
+    onFeatureSaved: id => {
+      relationEditorModel.featureFocus = id;
+      relationEditorModel.reload();
+    }
+
+    onOpened: {
+      addingIndicator.running = false;
+    }
+  }
+
+  function isButtonEnabled(buttonType) {
+    const buttons = relationEditorWidgetConfig.buttons;
+    if (buttons === undefined)
+      return true;
+    if (buttons === 'NoButton')
+      return false;
+    if (buttons === 'AllButtons')
+      return true;
+    if (buttons.split('|').indexOf(buttonType) >= 0)
+      return true;
+    return false;
+  }
+
+  function requestedGeometryReceived(geometry) {
+    showAddFeaturePopup(geometry);
+  }
+
+  function showAddFeaturePopup(geometry) {
+    embeddedPopup.state = 'Add';
+    embeddedPopup.currentLayer = relationEditorModel.relation.referencingLayer;
+    embeddedPopup.linkedParentFeature = relationEditorModel.feature;
+    embeddedPopup.linkedRelation = relationEditorModel.relation;
+    if (relationEditorModel.orderingField) {
+      embeddedPopup.linkedRelationOrderingField = relationEditorModel.orderingField;
+    }
+    if (geometry !== undefined) {
+      embeddedPopup.applyGeometry(geometry);
+    }
+    embeddedPopup.open();
+    embeddedPopup.attributeFormModel.applyParentDefaultValues();
+  }
+}

--- a/src/qml/editorwidgets/RelationEditorBase.qml
+++ b/src/qml/editorwidgets/RelationEditorBase.qml
@@ -176,12 +176,15 @@ EditorWidgetBase {
     property string nmReferencingLayerName
 
     z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature forms
-    title: nmRelationId ? qsTr('Unlink feature %1 (%2) of %3').arg(nmReferencedFeatureDisplayMessage).arg(nmReferencedFeatureId).arg(nmReferencedLayerName) : qsTr('Delete feature %1 (%2) on %3').arg(referencingFeatureDisplayMessage).arg(referencingFeatureId).arg(referencingLayerName)
+    title: nmRelationId ? qsTr('Unlink Feature') : qsTr('Delete Feature')
+
     Label {
       width: parent.width
       wrapMode: Text.WordWrap
       text: nmRelationId ? qsTr('Should the feature <b>%1 (%2)</b> of layer <b>%3</b> be unlinked?<br><i>(The connection will be deleted on layer <b>%4</b>)</i>').arg(deleteDialog.nmReferencedFeatureDisplayMessage).arg(deleteDialog.nmReferencedFeatureId).arg(deleteDialog.nmReferencedLayerName).arg(deleteDialog.referencingLayerName) : qsTr('Should the feature <b>%1 (%2)</b> on layer <b>%3</b> be deleted?').arg(deleteDialog.referencingFeatureDisplayMessage).arg(deleteDialog.referencingFeatureId).arg(deleteDialog.referencingLayerName)
+      font: Theme.defaultFont
     }
+
     onAccepted: {
       if (!relationEditorModel || !relationEditorModel.deleteFeature(referencingFeatureId)) {
         displayToast(qsTr("Failed to delete referencing feature"), 'error');
@@ -290,7 +293,7 @@ EditorWidgetBase {
       onTriggered: {
         deleteDialog.referencingFeatureId = childMenu.entryReferencingFeature.id;
         deleteDialog.referencingFeatureDisplayMessage = childMenu.entryDisplayString;
-        deleteDialog.nmReferencedFeatureId = childMenu.entryNmReferencedFeature.id;
+        deleteDialog.nmReferencedFeatureId = childMenu.entryNmReferencedFeature !== undefined ? childMenu.entryNmReferencedFeature.id : 0;
         deleteDialog.nmReferencedFeatureDisplayMessage = childMenu.entryNmReferencedFeatureDisplayMessage;
         deleteDialog.visible = true;
       }

--- a/src/qml/editorwidgets/RelationEditorBase.qml
+++ b/src/qml/editorwidgets/RelationEditorBase.qml
@@ -19,6 +19,7 @@ EditorWidgetBase {
   property int itemHeight: 48
   property int bottomMargin: 10
   property int maximumVisibleItems: 4
+  property bool showAllItems: false
 
   Component.onCompleted: {
     if (currentLayer && currentLayer.customProperty('QFieldSync/relationship_maximum_visible') !== undefined) {
@@ -46,7 +47,7 @@ EditorWidgetBase {
     ListView {
       id: listView
       width: parent.width
-      height: maximumVisibleItems > 0 ? Math.min(maximumVisibleItems * itemHeight, listView.count * itemHeight) + (listView.count > maximumVisibleItems ? itemHeight / 2 : 0) : listView.count * itemHeight
+      height: !showAllItems && maximumVisibleItems > 0 ? Math.min(maximumVisibleItems * itemHeight, listView.count * itemHeight) + (listView.count > maximumVisibleItems ? itemHeight / 2 : 0) : listView.count * itemHeight
       focus: true
       clip: true
       highlightRangeMode: ListView.ApplyRange

--- a/src/qml/editorwidgets/RelationEditorBase.qml
+++ b/src/qml/editorwidgets/RelationEditorBase.qml
@@ -30,10 +30,8 @@ EditorWidgetBase {
   enabled: true
 
   Rectangle {
-    anchors.top: parent.top
-    anchors.bottom: parent.bottom
+    anchors.fill: parent
     anchors.bottomMargin: relationEditorBase.bottomMargin
-    width: parent.width
     color: "transparent"
     border.color: Theme.controlBorderColor
     border.width: 1

--- a/src/qml/editorwidgets/RelationEditorBase.qml
+++ b/src/qml/editorwidgets/RelationEditorBase.qml
@@ -300,6 +300,8 @@ EditorWidgetBase {
     }
   }
 
+  // The loader is used to defer the cost involved in atlas-related item / model generation until the
+  // menu is opened in order to avoid extra cost when opening a feature form
   Loader {
     id: atlasMenuLoader
     enabled: false

--- a/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
@@ -13,15 +13,17 @@ import ".."
 RelationEditorBase {
   id: relationEditor
 
+  showAllItems: true
+
   relationEditorModel: OrderedRelationModel {
     //containing the current (parent) feature, the relation to the children
     //and the relation from the children to the other parent (if it's nm and cardinality is set)
     id: orderedRelationModel
     currentRelationId: relationId
     feature: currentFeature
-    orderingField: relationEditorWidgetConfig['ordering_field']
-    imagePath: relationEditorWidgetConfig['image_path']
-    description: relationEditorWidgetConfig['description']
+    orderingField: relationEditorWidgetConfig['ordering_field'] || ""
+    imagePath: relationEditorWidgetConfig['image_path'] || ""
+    description: relationEditorWidgetConfig['description'] || ""
 
     property int featureFocus: -1
 
@@ -49,9 +51,9 @@ RelationEditorBase {
 
       anchors.left: parent ? parent.left : undefined
       anchors.right: parent ? parent.right : undefined
-      height: content.height
+      height: listitem.height
 
-      drag.target: held ? content : undefined
+      drag.target: held ? listitem : undefined
       drag.axis: Drag.YAxis
 
       onPressAndHold: {
@@ -78,20 +80,20 @@ RelationEditorBase {
       }
 
       Rectangle {
-        id: content
+        id: listitem
         anchors {
           horizontalCenter: parent.horizontalCenter
           verticalCenter: parent.verticalCenter
         }
         width: dragArea.width
-        height: row.implicitHeight + 4
+        height: row.implicitHeight
 
         Ripple {
           clip: true
           width: parent.width
           height: parent.height
           pressed: dragArea.pressed
-          anchor: content
+          anchor: listitem
           active: dragArea.pressed
           color: Material.rippleColor
         }
@@ -108,7 +110,7 @@ RelationEditorBase {
           when: dragArea.held
 
           AnchorChanges {
-            target: content
+            target: listitem
             anchors.horizontalCenter: undefined
             anchors.verticalCenter: undefined
           }
@@ -117,9 +119,9 @@ RelationEditorBase {
         Row {
           id: row
           anchors.fill: parent
-          anchors.margins: 2
-
-          height: Math.max(itemHeight, featureText.height)
+          anchors.rightMargin: 10
+          anchors.leftMargin: 10
+          height: listitem.height
 
           Image {
             id: featureImage
@@ -134,14 +136,14 @@ RelationEditorBase {
           Text {
             id: featureText
             anchors.verticalCenter: parent.verticalCenter
-            width: parent.width - 8 - (featureImage.visible ? featureImage.width : 0) - viewButton.width - moveDownButton.width - moveUpButton.width - deleteButton.width
+            width: parent.width - (featureImage.visible ? featureImage.width : 0) - viewButton.width - moveDownButton.width - moveUpButton.width - deleteButton.width
             topPadding: 5
             bottomPadding: 5
             font: Theme.defaultFont
             color: !isEnabled ? Theme.mainTextDisabledColor : Theme.mainTextColor
-            text: Description || model.displayString
             elide: Text.ElideRight
             wrapMode: Text.WordWrap
+            text: Description || model.displayString
           }
 
           QfToolButton {
@@ -243,12 +245,12 @@ RelationEditorBase {
         anchors.fill: parent
         anchors.margins: 10
 
-        onEntered: {
+        onEntered: drag => {
           if (dragArea.indexFrom === -1) {
             dragArea.indexFrom = drag.source.DelegateModel.itemsIndex;
           }
           dragArea.indexTo = dragArea.DelegateModel.itemsIndex;
-          visualModel.items.move(drag.source.DelegateModel.itemsIndex, dragArea.DelegateModel.itemsIndex);
+          listView.model.items.move(drag.source.DelegateModel.itemsIndex, dragArea.DelegateModel.itemsIndex);
         }
       }
     }

--- a/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
@@ -223,9 +223,9 @@ RelationEditorBase {
 
             onClicked: {
               //var gc = mapToItem(mainWindow, 0, 0);
-              childMenu.entryReferencingFeatureId = model.referencingFeature.id;
+              childMenu.entryReferencingFeature = model.referencingFeature;
               childMenu.entryDisplayString = model.displayString;
-              childMenu.entryNmReferencedFeatureId = nmRelationId ? model.model.nmReferencedFeature.id : 0;
+              childMenu.entryNmReferencedFeature = nmRelationId ? model.model.nmReferencedFeature : undefined;
               childMenu.entryNmReferencedFeatureDisplayMessage = nmRelationId ? model.nmDisplayString : '';
               childMenu.popup(menuButton.x, menuButton.y);
             }

--- a/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
@@ -136,7 +136,7 @@ RelationEditorBase {
           Text {
             id: featureText
             anchors.verticalCenter: parent.verticalCenter
-            width: parent.width - (featureImage.visible ? featureImage.width : 0) - viewButton.width - moveDownButton.width - moveUpButton.width - deleteButton.width
+            width: parent.width - (featureImage.visible ? featureImage.width : 0) - viewButton.width - moveDownButton.width - moveUpButton.width - menuButton.width
             topPadding: 5
             bottomPadding: 5
             font: Theme.defaultFont
@@ -211,23 +211,23 @@ RelationEditorBase {
           }
 
           QfToolButton {
-            id: deleteButton
+            id: menuButton
             anchors.verticalCenter: parent.verticalCenter
-            visible: isEnabled
-            width: visible ? 48 : 0
+            width: 48
             height: 48
 
             round: false
-            iconSource: Theme.getThemeVectorIcon('ic_delete_forever_white_24dp')
+            iconSource: Theme.getThemeVectorIcon("ic_dot_menu_black_24dp")
             iconColor: Theme.mainTextColor
             bgcolor: 'transparent'
 
             onClicked: {
-              deleteDialog.referencingFeatureId = model.referencingFeature.id;
-              deleteDialog.referencingFeatureDisplayMessage = model.displayString;
-              deleteDialog.nmReferencedFeatureId = nmRelationId ? model.model.nmReferencedFeature.id : 0;
-              deleteDialog.nmReferencedFeatureDisplayMessage = nmRelationId ? model.nmDisplayString : '';
-              deleteDialog.visible = true;
+              //var gc = mapToItem(mainWindow, 0, 0);
+              childMenu.entryReferencingFeatureId = model.referencingFeature.id;
+              childMenu.entryDisplayString = model.displayString;
+              childMenu.entryNmReferencedFeatureId = nmRelationId ? model.model.nmReferencedFeature.id : 0;
+              childMenu.entryNmReferencedFeatureDisplayMessage = nmRelationId ? model.nmDisplayString : '';
+              childMenu.popup(menuButton.x, menuButton.y);
             }
           }
         }

--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -9,27 +9,10 @@ import Theme
 import "../.."
 import ".."
 
-EditorWidgetBase {
+RelationEditorBase {
   id: relationEditor
 
-  property int itemHeight: 48
-  property int bottomMargin: 10
-  property int maximumVisibleItems: 4
-
-  Component.onCompleted: {
-    if (currentLayer && currentLayer.customProperty('QFieldSync/relationship_maximum_visible') !== undefined) {
-      var value = JSON.parse(currentLayer.customProperty('QFieldSync/relationship_maximum_visible'))[relationId];
-      maximumVisibleItems = value !== undefined ? value : 4;
-    } else {
-      maximumVisibleItems = 4;
-    }
-  }
-
-  // because no additional addEntry item on readOnly (isEnabled false)
-  height: (isEnabled ? referencingFeatureListView.height + itemHeight : Math.max(referencingFeatureListView.height, itemHeight)) + relationEditor.bottomMargin
-  enabled: true
-
-  ReferencingFeatureListModel {
+  relationEditorModel: ReferencingFeatureListModel {
     //containing the current (parent) feature, the relation to the children
     //and the relation from the children to the other parent (if it's nm and cardinality is set)
     //if cardinality is not set, the nmRelationId is empty
@@ -47,140 +30,9 @@ EditorWidgetBase {
     }
   }
 
-  Rectangle {
-    anchors.top: parent.top
-    anchors.bottom: parent.bottom
-    anchors.bottomMargin: relationEditor.bottomMargin
-    width: parent.width
-    color: "transparent"
-    border.color: Theme.controlBorderColor
-    border.width: 1
-    clip: true
-
-    ListView {
-      id: referencingFeatureListView
-      model: relationEditorModel
-      width: parent.width
-      height: maximumVisibleItems > 0 ? Math.min(maximumVisibleItems * itemHeight, referencingFeatureListView.count * itemHeight) + (referencingFeatureListView.count > maximumVisibleItems ? itemHeight / 2 : 0) : referencingFeatureListView.count * itemHeight
-      delegate: referencingFeatureDelegate
-      focus: true
-      clip: true
-      highlightRangeMode: ListView.ApplyRange
-      ScrollBar.vertical: QfScrollBar {
-      }
-    }
-
-    Item {
-      id: addEntry
-      anchors.bottom: parent.bottom
-      height: itemHeight
-      width: parent.width
-      visible: isButtonEnabled('AddChildFeature')
-
-      focus: true
-
-      Rectangle {
-        anchors.fill: parent
-        color: Theme.controlBorderColor
-        visible: isEnabled
-
-        Text {
-          visible: isEnabled
-          color: Theme.secondaryTextColor
-          text: isEnabled && !constraintsHardValid ? qsTr('Ensure contraints are met') : ''
-          anchors {
-            leftMargin: 10
-            left: parent.left
-            right: addButtonRow.left
-            verticalCenter: parent.verticalCenter
-          }
-          font: Theme.tipFont
-        }
-
-        Row {
-          id: addButtonRow
-          anchors {
-            top: parent.top
-            right: parent.right
-            rightMargin: 10
-          }
-          height: parent.height
-
-          QfToolButton {
-            id: addButton
-            width: parent.height
-            height: parent.height
-            enabled: constraintsHardValid
-
-            round: false
-            iconSource: Theme.getThemeVectorIcon('ic_add_white_24dp')
-            bgcolor: parent.enabled ? 'black' : 'grey'
-          }
-        }
-
-        BusyIndicator {
-          id: addingIndicator
-          anchors {
-            top: parent.top
-            right: parent.right
-            rightMargin: 10
-          }
-          width: parent.height
-          height: parent.height
-          running: false
-        }
-
-        Timer {
-          id: addingTimer
-
-          property string printName: ''
-
-          interval: 50
-          repeat: false
-
-          onTriggered: {
-            let saved = form.state === 'Add' ? !form.setupOnly && save() : true;
-            if (ProjectUtils.transactionMode(qgisProject) !== Qgis.TransactionMode.Disabled) {
-              // When a transaction mode is enabled, we must fallback to saving the parent feature to have provider-side issues
-              if (!saved) {
-                addingIndicator.running = false;
-                displayToast(qsTr('Cannot add child feature: insure the parent feature meets all constraints and can be saved'), 'warning');
-                return;
-              }
-            }
-
-            //this has to be checked after buffering because the primary could be a value that has been created on creating featurer (e.g. fid)
-            if (relationEditorModel.parentPrimariesAvailable) {
-              displayToast(qsTr('Adding child feature in layer %1').arg(relationEditorModel.relation.referencingLayer.name));
-              if (relationEditorModel.relation.referencingLayer.geometryType() !== Qgis.GeometryType.Null) {
-                requestGeometry(relationEditor, relationEditorModel.relation.referencingLayer);
-                return;
-              }
-              showAddFeaturePopup();
-            } else {
-              addingIndicator.running = false;
-              displayToast(qsTr('Cannot add child feature: attribute value linking parent and children is not set'), 'warning');
-            }
-          }
-        }
-
-        MouseArea {
-          anchors.fill: parent
-          onClicked: {
-            addingIndicator.running = true;
-            addingTimer.restart();
-          }
-        }
-      }
-    }
-
-    BusyIndicator {
-      id: busyIndicator
-      anchors.centerIn: parent
-      width: 36
-      height: 36
-      running: relationEditorModel.isLoading
-    }
+  listView.model: DelegateModel {
+    model: relationEditorModel
+    delegate: referencingFeatureDelegate
   }
 
   Component {
@@ -290,86 +142,5 @@ EditorWidgetBase {
         width: parent.width
       }
     }
-  }
-
-  QfDialog {
-    id: deleteDialog
-    parent: mainWindow.contentItem
-
-    property int referencingFeatureId
-    property string referencingFeatureDisplayMessage
-    property string referencingLayerName: relationEditorModel.relation.referencingLayer ? relationEditorModel.relation.referencingLayer.name : ''
-    property int nmReferencedFeatureId
-    property string nmReferencedFeatureDisplayMessage
-    property string nmReferencedLayerName: relationEditorModel.nmRelation.referencedLayer ? relationEditorModel.nmRelation.referencedLayer.name : ''
-    property string nmReferencingLayerName
-
-    z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature forms
-    title: nmRelationId ? qsTr('Unlink feature %1 (%2) of %3').arg(nmReferencedFeatureDisplayMessage).arg(nmReferencedFeatureId).arg(nmReferencedLayerName) : qsTr('Delete feature %1 (%2) on %3').arg(referencingFeatureDisplayMessage).arg(referencingFeatureId).arg(referencingLayerName)
-    Label {
-      width: parent.width
-      wrapMode: Text.WordWrap
-      text: nmRelationId ? qsTr('Should the feature <b>%1 (%2)</b> of layer <b>%3</b> be unlinked?<br><i>(The connection will be deleted on layer <b>%4</b>)</i>').arg(deleteDialog.nmReferencedFeatureDisplayMessage).arg(deleteDialog.nmReferencedFeatureId).arg(deleteDialog.nmReferencedLayerName).arg(deleteDialog.referencingLayerName) : qsTr('Should the feature <b>%1 (%2)</b> on layer <b>%3</b> be deleted?').arg(deleteDialog.referencingFeatureDisplayMessage).arg(deleteDialog.referencingFeatureId).arg(deleteDialog.referencingLayerName)
-    }
-    onAccepted: {
-      if (!referencingFeatureListView.model.deleteFeature(referencingFeatureId)) {
-        displayToast(qsTr("Failed to delete referencing feature"), 'error');
-      }
-      visible = false;
-    }
-    onRejected: {
-      visible = false;
-    }
-  }
-
-  EmbeddedFeatureForm {
-    id: embeddedPopup
-
-    embeddedLevel: form.embeddedLevel + 1
-    digitizingToolbar: form.digitizingToolbar
-    codeReader: form.codeReader
-
-    onFeatureCancelled: {
-      if (autoSave)
-        relationEditorModel.reload();
-    }
-
-    onFeatureSaved: id => {
-      relationEditorModel.featureFocus = id;
-      relationEditorModel.reload();
-    }
-
-    onOpened: {
-      addingIndicator.running = false;
-    }
-  }
-
-  function isButtonEnabled(buttonType) {
-    const buttons = relationEditorWidgetConfig.buttons;
-    if (buttons === undefined)
-      return true;
-    if (buttons === 'NoButton')
-      return false;
-    if (buttons === 'AllButtons')
-      return true;
-    if (buttons.split('|').indexOf(buttonType) >= 0)
-      return true;
-    return false;
-  }
-
-  function requestedGeometryReceived(geometry) {
-    showAddFeaturePopup(geometry);
-  }
-
-  function showAddFeaturePopup(geometry) {
-    embeddedPopup.state = 'Add';
-    embeddedPopup.currentLayer = relationEditorModel.relation.referencingLayer;
-    embeddedPopup.linkedParentFeature = relationEditorModel.feature;
-    embeddedPopup.linkedRelation = relationEditorModel.relation;
-    if (geometry !== undefined) {
-      embeddedPopup.applyGeometry(geometry);
-    }
-    embeddedPopup.open();
-    embeddedPopup.attributeFormModel.applyParentDefaultValues();
   }
 }

--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -80,7 +80,7 @@ RelationEditorBase {
         Text {
           id: featureText
           anchors.verticalCenter: parent.verticalCenter
-          width: parent.width - viewButton.width - deleteButton.width
+          width: parent.width - viewButton.width - menuButton.width
           topPadding: 5
           bottomPadding: 5
           font: Theme.defaultFont
@@ -112,23 +112,23 @@ RelationEditorBase {
         }
 
         QfToolButton {
-          id: deleteButton
+          id: menuButton
           anchors.verticalCenter: parent.verticalCenter
-          visible: isEnabled && isButtonEnabled('DeleteChildFeature')
-          width: visible ? 48 : 0
+          width: 48
           height: 48
 
           round: false
-          iconSource: Theme.getThemeVectorIcon('ic_delete_forever_white_24dp')
+          iconSource: Theme.getThemeVectorIcon("ic_dot_menu_black_24dp")
           iconColor: Theme.mainTextColor
           bgcolor: 'transparent'
 
           onClicked: {
-            deleteDialog.referencingFeatureId = model.referencingFeature.id;
-            deleteDialog.referencingFeatureDisplayMessage = model.displayString;
-            deleteDialog.nmReferencedFeatureId = nmRelationId ? model.model.nmReferencedFeature.id : 0;
-            deleteDialog.nmReferencedFeatureDisplayMessage = nmRelationId ? model.nmDisplayString : '';
-            deleteDialog.visible = true;
+            //var gc = mapToItem(mainWindow, 0, 0);
+            childMenu.entryReferencingFeatureId = model.referencingFeature.id;
+            childMenu.entryDisplayString = model.displayString;
+            childMenu.entryNmReferencedFeatureId = nmRelationId ? model.model.nmReferencedFeature.id : 0;
+            childMenu.entryNmReferencedFeatureDisplayMessage = nmRelationId ? model.nmDisplayString : '';
+            childMenu.popup(menuButton.x, menuButton.y);
           }
         }
       }

--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -124,9 +124,9 @@ RelationEditorBase {
 
           onClicked: {
             //var gc = mapToItem(mainWindow, 0, 0);
-            childMenu.entryReferencingFeatureId = model.referencingFeature.id;
+            childMenu.entryReferencingFeature = model.referencingFeature;
             childMenu.entryDisplayString = model.displayString;
-            childMenu.entryNmReferencedFeatureId = nmRelationId ? model.model.nmReferencedFeature.id : 0;
+            childMenu.entryNmReferencedFeature = nmRelationId ? model.model.nmReferencedFeature : undefined;
             childMenu.entryNmReferencedFeatureDisplayMessage = nmRelationId ? model.nmDisplayString : '';
             childMenu.popup(menuButton.x, menuButton.y);
           }

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -60,6 +60,7 @@
         <file>editorwidgets/Range.qml</file>
         <file>editorwidgets/ValueMap.qml</file>
         <file>editorwidgets/UuidGenerator.qml</file>
+        <file>editorwidgets/RelationEditorBase.qml</file>
         <file>editorwidgets/RelationReference.qml</file>
         <file>editorwidgets/relationeditors/relation_editor.qml</file>
         <file>editorwidgets/relationeditors/ordered_relation_editor.qml</file>


### PR DESCRIPTION
This PR adds the possibility to print an atlas PDF tied to children of a parent within the parent feature form through the addition of actions within the relation editor widget's list. Here's how it looks like:

![Screenshot From 2025-02-22 16-48-42](https://github.com/user-attachments/assets/6325ce0a-a173-4a5f-9fd6-6a19b3a53981)

As the screenshot shows, the work here led to the delete button being relocated _into_ the 3-dot menu. Since it has become far less easy to accidentally tap on the delete button, it's now enabled all the time (irrespective of the feature form's editing state), just like we can delete the parent through its feature form all the time.

For good taste, I've also added a copy feature attributes to clipboard action. Interesting possibilities ahead of us! Thanks to Vevey for supporting this development. 

Note that I've taken the time to de-duplicate _tons_ of code shared across the relation editor and the ordered relation editor items. This makes the maintenance of these two sub types much easier as most fixes won't have to be applied in two different locations. 