### PR TITLE
Upload multiple files to webDav or QFC

### DIFF
--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -1350,7 +1350,7 @@ void QFieldCloudProjectsModel::projectUpload( const QString &projectId, const bo
     const long long fileSize = fileInfo.size();
 
     // ? should we also check the checksums of the files being uploaded? they are available at deltaFile->attachmentFileNames()->values()
-    QFieldCloudUtils::addPendingAttachment( project->id, absoluteFilePath );
+    QFieldCloudUtils::addPendingAttachments( project->id, { absoluteFilePath } );
   }
 
   QString deltaFileToUpload = deltaFileWrapper->toFileForUpload();

--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -150,19 +150,22 @@ const QMultiMap<QString, QString> QFieldCloudUtils::getPendingAttachments()
   return std::move( files );
 }
 
-void QFieldCloudUtils::addPendingAttachment( const QString &projectId, const QString &fileName )
+void QFieldCloudUtils::addPendingAttachments( const QString &projectId, const QStringList &fileNames )
 {
   QLockFile attachmentsLock( QStringLiteral( "%1/attachments.lock" ).arg( QFieldCloudUtils::localCloudDirectory() ) );
   if ( attachmentsLock.tryLock( 10000 ) )
   {
-    QStringList values = QStringList() << projectId << fileName;
-
     QFile attachmentsFile( QStringLiteral( "%1/attachments.csv" ).arg( QFieldCloudUtils::localCloudDirectory() ) );
     attachmentsFile.open( QFile::Append | QFile::Text );
     QTextStream attachmentsStream( &attachmentsFile );
     QFileInfo fi( attachmentsFile );
-    attachmentsStream << StringUtils::stringListToCsv( values )
-                      << Qt::endl;
+
+    for ( const QString &fileName : fileNames )
+    {
+      QStringList values = QStringList() << projectId << fileName;
+      attachmentsStream << StringUtils::stringListToCsv( values )
+                        << Qt::endl;
+    }
     attachmentsFile.close();
   }
 }

--- a/src/core/utils/qfieldcloudutils.h
+++ b/src/core/utils/qfieldcloudutils.h
@@ -134,8 +134,8 @@ class QFieldCloudUtils : public QObject
     //! Returns the list of attachments that have not yet been uploaded to the cloud.
     static const QMultiMap<QString, QString> getPendingAttachments();
 
-    //! Adds an \a fileName for a given \a projectId to the pending attachments list
-    Q_INVOKABLE static void addPendingAttachment( const QString &projectId, const QString &fileName );
+    //! Adds an array of \a fileNames for a given \a projectId to the pending attachments list
+    Q_INVOKABLE static void addPendingAttachments( const QString &projectId, const QStringList &fileNames );
 
     //! Adds removes a \a fileName for a given \a projectId to the pending attachments list
     static void removePendingAttachment( const QString &projectId, const QString &fileName );

--- a/src/core/webdavconnection.cpp
+++ b/src/core/webdavconnection.cpp
@@ -700,7 +700,7 @@ void WebdavConnection::uploadPaths( const QStringList &localPaths )
         }
       }
     }
-    else if ( webdavConfigurationExists && !webdavJson.isEmpty() )
+    else if ( !webdavJson.isEmpty() )
     {
       QString newRemotePath = webdavConfiguration["remote_path"].toString();
       if ( !remoteChildrenPath.isEmpty() )
@@ -710,7 +710,7 @@ void WebdavConnection::uploadPaths( const QStringList &localPaths )
       mProcessRemotePath = getCommonPath( newRemotePath, mProcessRemotePath );
     }
 
-    if ( webdavConfigurationExists && !webdavJson.isEmpty() )
+    if ( !webdavJson.isEmpty() )
     {
       if ( fi.isDir() )
       {
@@ -748,7 +748,7 @@ QString WebdavConnection::getCommonPath( const QString &addressA, const QString 
 {
   const QStringList pathComponentsA = addressA.split( "/" );
   const QStringList pathComponentsB = addressB.split( "/" );
-  const int minLength = qMin( pathComponentsA.size(), pathComponentsB.size() );
+  const int minLength = std::min( pathComponentsA.size(), pathComponentsB.size() );
 
   QString commonPath = QStringLiteral( "/" );
 

--- a/src/core/webdavconnection.cpp
+++ b/src/core/webdavconnection.cpp
@@ -326,6 +326,12 @@ void WebdavConnection::processDirParserFinished()
       }
 
       mWebdavMkDirs.clear();
+
+      if ( !remoteDirs.contains( mProcessRemotePath ) )
+      {
+        mWebdavMkDirs << mProcessRemotePath;
+      }
+
       for ( const QFileInfo &fileInfo : mLocalItems )
       {
         // Insure the path exists remotely

--- a/src/core/webdavconnection.cpp
+++ b/src/core/webdavconnection.cpp
@@ -656,11 +656,8 @@ void WebdavConnection::uploadPaths( const QStringList &localPaths )
 {
   mLocalItems.clear();
   bool webdavConfigurationExists = false;
-  QString webdavConfigurationPath = "";
-  QJsonDocument jsonDocument;
-  QFile webdavConfigurationFile;
+  QJsonDocument webdavJson;
   QVariantMap webdavConfiguration;
-  QString mBaseRemotePath;
 
   for ( const QString &localPath : localPaths )
   {
@@ -682,14 +679,14 @@ void WebdavConnection::uploadPaths( const QStringList &localPaths )
 
       if ( webdavConfigurationExists )
       {
-        webdavConfigurationPath = dir.absolutePath() + QDir::separator() + QStringLiteral( "qfield_webdav_configuration.json" );
-        webdavConfigurationFile.setFileName( webdavConfigurationPath );
+        const QString webdavConfigurationPath = dir.absolutePath() + QDir::separator() + QStringLiteral( "qfield_webdav_configuration.json" );
+        QFile webdavConfigurationFile( webdavConfigurationPath );
         webdavConfigurationFile.open( QFile::ReadOnly );
-        jsonDocument = QJsonDocument::fromJson( webdavConfigurationFile.readAll() );
+        webdavJson = QJsonDocument::fromJson( webdavConfigurationFile.readAll() );
 
-        if ( !jsonDocument.isEmpty() )
+        if ( !webdavJson.isEmpty() )
         {
-          webdavConfiguration = jsonDocument.toVariant().toMap();
+          webdavConfiguration = webdavJson.toVariant().toMap();
           setUrl( webdavConfiguration["url"].toString() );
           setUsername( webdavConfiguration["username"].toString() );
           setStorePassword( isPasswordStored() );
@@ -703,7 +700,7 @@ void WebdavConnection::uploadPaths( const QStringList &localPaths )
         }
       }
     }
-    else if ( webdavConfigurationExists && !jsonDocument.isEmpty() )
+    else if ( webdavConfigurationExists && !webdavJson.isEmpty() )
     {
       QString newRemotePath = webdavConfiguration["remote_path"].toString();
       if ( !remoteChildrenPath.isEmpty() )
@@ -713,7 +710,7 @@ void WebdavConnection::uploadPaths( const QStringList &localPaths )
       mProcessRemotePath = getCommonPath( newRemotePath, mProcessRemotePath );
     }
 
-    if ( webdavConfigurationExists && !jsonDocument.isEmpty() )
+    if ( webdavConfigurationExists && !webdavJson.isEmpty() )
     {
       if ( fi.isDir() )
       {

--- a/src/core/webdavconnection.h
+++ b/src/core/webdavconnection.h
@@ -87,7 +87,7 @@ class WebdavConnection : public QObject
 
     Q_INVOKABLE void importPath( const QString &remotePath, const QString &localPath );
     Q_INVOKABLE void downloadPath( const QString &localPath );
-    Q_INVOKABLE void uploadPath( const QString &localPath );
+    Q_INVOKABLE void uploadPaths( const QStringList &localPaths );
 
     Q_INVOKABLE void confirmRequest();
     Q_INVOKABLE void cancelRequest();

--- a/src/core/webdavconnection.h
+++ b/src/core/webdavconnection.h
@@ -126,6 +126,9 @@ class WebdavConnection : public QObject
     void getWebdavItems();
     void putLocalItems();
 
+    ///! Computes the common path between two given paths.
+    QString getCommonPath( const QString &addressA, const QString &addressB );
+
     QString mUrl;
     QString mUsername;
     QString mPassword;

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -31,7 +31,7 @@ Page {
     showBackButton: true
     showApplyButton: false
     showCancelButton: false
-    showMenuButton: localFilesModel.inSelectionMode
+    showMenuButton: localFilesModel.inSelectionMode && (table.selectedItemsPushableToQField || table.selectedItemsWebDavConfigured)
     backAsCancel: localFilesModel.inSelectionMode
 
     topMargin: mainWindow.sceneTopMargin
@@ -47,6 +47,21 @@ Page {
         parent.finished(false);
       }
     }
+
+    onOpenMenu: {
+      selectionMenu.open();
+    }
+  }
+
+  function determineMenuWidth(menu) {
+    let result = 50;
+    let padding = 0;
+    for (let i = 0; i < menu.count; ++i) {
+      let item = menu.itemAt(i);
+      result = Math.max(item.contentItem.implicitWidth, result);
+      padding = Math.max(item.leftPadding + item.rightPadding, padding);
+    }
+    return mainWindow.width > 0 ? Math.min(result + padding * 2, mainWindow.width - 20) : result + padding;
   }
 
   ColumnLayout {
@@ -142,6 +157,10 @@ Page {
           }
         }
 
+        property var selectedList: []
+        property bool selectedItemsWebDavConfigured
+        property bool selectedItemsPushableToQField
+
         delegate: Rectangle {
           id: rectangle
 
@@ -152,6 +171,7 @@ Page {
           property string itemPath: ItemPath
           property bool itemIsFavorite: ItemIsFavorite
           property bool itemChecked: ItemChecked
+          property bool itemHasWebdavConfiguration: ItemHasWebdavConfiguration
           property bool itemMenuLoadable: !projectFolderView && (ItemMetaType === LocalFilesModel.Project || ItemMetaType === LocalFilesModel.Dataset)
           property bool itemMenuVisible: ((ItemType === LocalFilesModel.SimpleFolder || ItemMetaType == LocalFilesModel.Dataset || ItemMetaType == LocalFilesModel.File) && table.model.currentPath !== 'root') || ((platformUtilities.capabilities & PlatformUtilities.CustomExport || platformUtilities.capabilities & PlatformUtilities.CustomSend) && (ItemMetaType === LocalFilesModel.Dataset)) || (ItemMetaType === LocalFilesModel.Dataset && ItemType === LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId)
 
@@ -279,6 +299,22 @@ Page {
                 itemMenu.itemHasWebdavConfiguration = ItemHasWebdavConfiguration;
                 itemMenu.popup(gc.x + width - itemMenu.width, gc.y - height);
               }
+            }
+          }
+
+          onItemCheckedChanged: {
+            const itemIndexInList = table.selectedList.findIndex(q => q === index);
+            if (itemIndexInList === -1) {
+              table.selectedList.push(index);
+            } else {
+              table.selectedList.splice(itemIndexInList, 1);
+            }
+            table.selectedItemsWebDavConfigured = true;
+            table.selectedItemsPushableToQField = true;
+            for (let i = 0; i < table.selectedList.length; ++i) {
+              const item = table.itemAtIndex(table.selectedList[i]);
+              table.selectedItemsWebDavConfigured = table.selectedItemsWebDavConfigured && item.itemHasWebdavConfiguration;
+              table.selectedItemsPushableToQField = table.selectedItemsPushableToQField && item.itemMetaType == LocalFilesModel.Dataset && item.itemType == LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId;
             }
           }
         }
@@ -409,16 +445,7 @@ Page {
 
       title: qsTr('Item Actions')
 
-      width: {
-        let result = 50;
-        let padding = 0;
-        for (let i = 0; i < count; ++i) {
-          let item = itemAt(i);
-          result = Math.max(item.contentItem.implicitWidth, result);
-          padding = Math.max(item.leftPadding + item.rightPadding, padding);
-        }
-        return mainWindow.width > 0 ? Math.min(result + padding * 2, mainWindow.width - 20) : result + padding;
-      }
+      width: determineMenuWidth(itemMenu)
 
       topMargin: sceneTopMargin
       bottomMargin: sceneBottomMargin
@@ -617,16 +644,7 @@ Page {
 
       title: qsTr('Import Actions')
 
-      width: {
-        let result = 50;
-        let padding = 0;
-        for (let i = 0; i < count; ++i) {
-          let item = itemAt(i);
-          result = Math.max(item.contentItem.implicitWidth, result);
-          padding = Math.max(item.leftPadding + item.rightPadding, padding);
-        }
-        return mainWindow.width > 0 ? Math.min(result + padding * 2, mainWindow.width - 20) : result + padding;
-      }
+      width: determineMenuWidth(importMenu)
 
       topMargin: sceneTopMargin
       bottomMargin: sceneBottomMargin
@@ -740,16 +758,7 @@ Page {
 
       title: qsTr('Project Actions')
 
-      width: {
-        let result = 50;
-        let padding = 0;
-        for (let i = 0; i < count; ++i) {
-          let item = itemAt(i);
-          result = Math.max(item.contentItem.implicitWidth, result);
-          padding = Math.max(item.leftPadding + item.rightPadding, padding);
-        }
-        return mainWindow.width > 0 ? Math.min(result + padding * 2, mainWindow.width - 20) : result + padding;
-      }
+      width: determineMenuWidth(projectMenu)
 
       topMargin: sceneTopMargin
       bottomMargin: sceneBottomMargin
@@ -804,6 +813,52 @@ Page {
             webdavConnectionLoader.item.openedProjectPath = projectInfo.filePath;
             iface.clearProject();
             webdavConnectionLoader.item.downloadPath(FileUtils.absolutePath(projectInfo.filePath));
+          }
+        }
+      }
+    }
+
+    Menu {
+      id: selectionMenu
+      x: parent.width - width - 8
+      width: determineMenuWidth(selectionMenu)
+
+      MenuItem {
+        id: uploadToWebdav
+
+        enabled: table.selectedItemsWebDavConfigured
+        visible: enabled
+
+        font: Theme.defaultFont
+        width: parent.width
+        height: enabled ? 48 : 0
+        leftPadding: Theme.menuItemLeftPadding
+
+        text: qsTr("Upload file(s) to WebDAV")
+        onTriggered: {
+          console.log("Send it to web dav!");
+        }
+      }
+
+      MenuItem {
+        id: pushToQfieldCloud
+
+        enabled: table.selectedItemsPushableToQField
+        visible: enabled
+
+        font: Theme.defaultFont
+        width: parent.width
+        height: enabled ? 48 : 0
+        leftPadding: Theme.menuItemLeftPadding
+
+        text: qsTr("Push file(s) to QFieldCloud")
+        onTriggered: {
+          for (let i = 0; i < table.selectedList.length; ++i) {
+            const item = table.itemAtIndex(table.selectedList[i]);
+            if (item.itemMetaType == LocalFilesModel.Dataset && item.itemType == LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId) {
+              QFieldCloudUtils.addPendingAttachment(cloudProjectsModel.currentProjectId, item.itemPath);
+              platformUtilities.uploadPendingAttachments(cloudConnection);
+            }
           }
         }
       }

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -479,7 +479,7 @@ Page {
 
         text: qsTr("Push to QFieldCloud")
         onTriggered: {
-          QFieldCloudUtils.addPendingAttachment(cloudProjectsModel.currentProjectId, itemMenu.itemPath);
+          QFieldCloudUtils.addPendingAttachments(cloudProjectsModel.currentProjectId, [itemMenu.itemPath]);
           platformUtilities.uploadPendingAttachments(cloudConnection);
           displayToast(qsTr("‘%1’ is being uploaded to QFieldCloud").arg(FileUtils.fileName(itemMenu.itemPath)));
         }
@@ -853,13 +853,15 @@ Page {
 
         text: qsTr("Push file(s) to QFieldCloud")
         onTriggered: {
+          var fileNames = [];
           for (let i = 0; i < table.selectedList.length; ++i) {
             const item = table.itemAtIndex(table.selectedList[i]);
-            if (item.itemMetaType == LocalFilesModel.Dataset && item.itemType == LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId) {
-              QFieldCloudUtils.addPendingAttachment(cloudProjectsModel.currentProjectId, item.itemPath);
-              platformUtilities.uploadPendingAttachments(cloudConnection);
-            }
+            const pushableToCloud = item.itemMetaType == LocalFilesModel.Dataset && item.itemType == LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId;
+            if (pushableToCloud)
+              fileNames.push(item.itemPath);
           }
+          QFieldCloudUtils.addPendingAttachments(cloudProjectsModel.currentProjectId, fileNames);
+          platformUtilities.uploadPendingAttachments(cloudConnection);
         }
       }
     }

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -367,6 +367,9 @@ Page {
           }
 
           onPressAndHold: mouse => {
+            if (localFilesModel.currentTitle === "Home") {
+              return;
+            }
             const item = table.itemAt(table.contentX + mouse.x, table.contentY + mouse.y);
             if (item)
               table.model.setChecked(item.itemIndex, !item.itemChecked);


### PR DESCRIPTION
**Description:**

This pull request implements enhancements based on issue #6005, enabling the ability to push multiple files to both `QFieldCloud` and `WebDAV`.

**Enhancements for Pushing Multiple Files to QFieldCloud:**
We have updated the `addPendingAttachment` function to `addPendingAttachments`, which now accepts `const QStringList &fileNames` instead of `const QString &fileName` as its input. Additionally, we have refactored all instances where this function is used.

**Enhancements for Pushing Multiple Files to WebDAV:**
Similarly, we have revised the `uploadPath` function to `uploadPaths`, which now utilizes `const QStringList &localPaths` instead of `const QString &localPath`. Consequently, we have also refactored all related usages of this method.

**UI Notes:**
1. A menu button will be displayed when the selection mode is active, provided that the selected items are either pushable to QFieldCloud or are configured for WebDAV.
2. We have introduced `determineMenuWidth` to eliminate duplicate code.
3. Once an operation is completed, we will clear the multi-selection for a smoother user experience.

**Demo:**   
  

[Screencast From 2025-03-01 18-51-08.webm](https://github.com/user-attachments/assets/2d16bb61-8f22-4e86-9578-842cbcb87f9d)

