### PR TITLE
Add preview rentering to map canvas

### DIFF
--- a/src/core/qgsquick/qgsquickmapcanvasmap.cpp
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.cpp
@@ -229,7 +229,7 @@ void QgsQuickMapCanvasMap::renderJobFinished()
     mSilentRefresh = true;
     refresh();
   }
-  else
+  else if ( mPreviewJobsEnabled )
   {
     startPreviewJobs();
   }
@@ -486,7 +486,6 @@ QSGNode *QgsQuickMapCanvasMap::updatePaintNode( QSGNode *oldNode, QQuickItem::Up
 
   node->setRect( rect );
   node->removeAllChildNodes();
-  qDebug() << rect;
   for ( auto [number, previewImage] : mPreviewImages.asKeyValueRange() )
   {
     QSGSimpleTextureNode *childNode = new QSGSimpleTextureNode();
@@ -665,6 +664,26 @@ QList<QgsMapLayer *> filterLayersForRender( const QList<QgsMapLayer *> &layers )
     filteredLayers.append( layer );
   }
   return filteredLayers;
+}
+
+bool QgsQuickMapCanvasMap::previewJobsEnabled() const
+{
+  return mPreviewJobsEnabled;
+}
+
+void QgsQuickMapCanvasMap::setPreviewJobsEnabled( bool enabled )
+{
+  if ( mPreviewJobsEnabled == enabled )
+    return;
+
+  mPreviewJobsEnabled = enabled;
+  emit previewJobsEnabledChanged();
+
+  if ( !mPreviewJobsEnabled )
+  {
+    // Clear previously stored preview images
+    mPreviewImages.clear();
+  }
 }
 
 void QgsQuickMapCanvasMap::startPreviewJobs()

--- a/src/core/qgsquick/qgsquickmapcanvasmap.cpp
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.cpp
@@ -429,10 +429,10 @@ void QgsQuickMapCanvasMap::setFreeze( bool freeze )
 
   mFreeze = freeze;
 
-  if ( mFreeze )
-    stopRendering();
-  else
+  if ( !mFreeze )
+  {
     refresh();
+  }
 
   emit freezeChanged();
 }
@@ -486,8 +486,7 @@ QSGNode *QgsQuickMapCanvasMap::updatePaintNode( QSGNode *oldNode, QQuickItem::Up
 
   node->setRect( rect );
   node->removeAllChildNodes();
-
-
+  qDebug() << rect;
   for ( auto [number, previewImage] : mPreviewImages.asKeyValueRange() )
   {
     QSGSimpleTextureNode *childNode = new QSGSimpleTextureNode();
@@ -673,7 +672,7 @@ void QgsQuickMapCanvasMap::startPreviewJobs()
   stopPreviewJobs();
 
   //canvas preview jobs aren't compatible with rotation
-  if ( !qgsDoubleNear( mMapSettings->mapSettings().rotation(), 0.0 ) )
+  if ( mImage.isNull() || !qgsDoubleNear( mImageMapSettings.rotation(), 0.0 ) )
     return;
 
   schedulePreviewJob( 0 );
@@ -681,7 +680,7 @@ void QgsQuickMapCanvasMap::startPreviewJobs()
 
 void QgsQuickMapCanvasMap::startPreviewJob( int number )
 {
-  QgsRectangle mapRect = mMapSettings->mapSettings().visibleExtent();
+  QgsRectangle mapRect = mImageMapSettings.visibleExtent();
 
   if ( number == 4 )
     number += 1;
@@ -690,7 +689,7 @@ void QgsQuickMapCanvasMap::startPreviewJob( int number )
   int i = number % 3;
 
   //copy settings, only update extent
-  QgsMapSettings jobSettings = mMapSettings->mapSettings();
+  QgsMapSettings jobSettings = mImageMapSettings;
 
   double dx = ( i - 1 ) * mapRect.width();
   double dy = ( 1 - j ) * mapRect.height();

--- a/src/core/qgsquick/qgsquickmapcanvasmap.cpp
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.cpp
@@ -26,6 +26,7 @@
 #include <qgsmaplayertemporalproperties.h>
 #include <qgsmaprenderercache.h>
 #include <qgsmaprendererparalleljob.h>
+#include <qgsmaprenderersequentialjob.h>
 #include <qgsmessagelog.h>
 #include <qgspallabeling.h>
 #include <qgsproject.h>
@@ -153,6 +154,7 @@ void QgsQuickMapCanvasMap::refreshMap()
   connect( mJob, &QgsMapRendererJob::renderingLayersFinished, this, &QgsQuickMapCanvasMap::renderJobUpdated );
   connect( mJob, &QgsMapRendererJob::finished, this, &QgsQuickMapCanvasMap::renderJobFinished );
   mJob->setCache( mCache.get() );
+  mJob->setLayerRenderingTimeHints( mLastLayerRenderTime );
 
   mJob->start();
 
@@ -226,6 +228,10 @@ void QgsQuickMapCanvasMap::renderJobFinished()
     mDeferredRefreshPending = false;
     mSilentRefresh = true;
     refresh();
+  }
+  else
+  {
+    startPreviewJobs();
   }
 }
 
@@ -479,6 +485,44 @@ QSGNode *QgsQuickMapCanvasMap::updatePaintNode( QSGNode *oldNode, QQuickItem::Up
   }
 
   node->setRect( rect );
+  node->removeAllChildNodes();
+
+
+  for ( auto [number, previewImage] : mPreviewImages.asKeyValueRange() )
+  {
+    QSGSimpleTextureNode *childNode = new QSGSimpleTextureNode();
+    childNode->setFiltering( QSGTexture::Linear );
+    QSGTexture *texture = window()->createTextureFromImage( previewImage );
+    childNode->setTexture( texture );
+    childNode->setOwnsTexture( true );
+
+    QRectF childRect( rect );
+    // Adjust left/right
+    if ( number == 0 || number == 3 || number == 6 )
+    {
+      childRect.setLeft( rect.left() - rect.width() );
+      childRect.setRight( rect.right() - rect.width() );
+    }
+    else if ( number == 2 || number == 5 || number == 8 )
+    {
+      childRect.setLeft( rect.left() + rect.width() );
+      childRect.setRight( rect.right() + rect.width() );
+    }
+    //Adjust top/bottom
+    if ( number < 3 )
+    {
+      childRect.setTop( rect.top() - rect.height() );
+      childRect.setBottom( rect.bottom() - rect.height() );
+    }
+    else if ( number > 5 )
+    {
+      childRect.setTop( rect.top() + rect.height() );
+      childRect.setBottom( rect.bottom() + rect.height() );
+    }
+    childNode->setRect( childRect );
+
+    node->appendChildNode( childNode );
+  }
 
   return node;
 }
@@ -535,6 +579,7 @@ void QgsQuickMapCanvasMap::stopRendering()
     mJob->cancelWithoutBlocking();
     mJob = nullptr;
   }
+  stopPreviewJobs();
 }
 
 void QgsQuickMapCanvasMap::zoomToFullExtent()
@@ -603,4 +648,140 @@ void QgsQuickMapCanvasMap::clearTemporalCache()
       mCache->clearCacheImage( QStringLiteral( "_preview_labels_" ) );
     }
   }
+}
+
+QList<QgsMapLayer *> filterLayersForRender( const QList<QgsMapLayer *> &layers )
+{
+  QList<QgsMapLayer *> filteredLayers;
+  for ( QgsMapLayer *layer : layers )
+  {
+    if ( QgsAnnotationLayer *annotationLayer = qobject_cast<QgsAnnotationLayer *>( layer ) )
+    {
+      if ( QgsMapLayer *linkedLayer = annotationLayer->linkedVisibilityLayer() )
+      {
+        if ( !layers.contains( linkedLayer ) )
+          continue;
+      }
+    }
+    filteredLayers.append( layer );
+  }
+  return filteredLayers;
+}
+
+void QgsQuickMapCanvasMap::startPreviewJobs()
+{
+  stopPreviewJobs();
+
+  //canvas preview jobs aren't compatible with rotation
+  if ( !qgsDoubleNear( mMapSettings->mapSettings().rotation(), 0.0 ) )
+    return;
+
+  schedulePreviewJob( 0 );
+}
+
+void QgsQuickMapCanvasMap::startPreviewJob( int number )
+{
+  QgsRectangle mapRect = mMapSettings->mapSettings().visibleExtent();
+
+  if ( number == 4 )
+    number += 1;
+
+  int j = number / 3;
+  int i = number % 3;
+
+  //copy settings, only update extent
+  QgsMapSettings jobSettings = mMapSettings->mapSettings();
+
+  double dx = ( i - 1 ) * mapRect.width();
+  double dy = ( 1 - j ) * mapRect.height();
+  QgsRectangle jobExtent = mapRect;
+
+  jobExtent.setXMaximum( jobExtent.xMaximum() + dx );
+  jobExtent.setXMinimum( jobExtent.xMinimum() + dx );
+  jobExtent.setYMaximum( jobExtent.yMaximum() + dy );
+  jobExtent.setYMinimum( jobExtent.yMinimum() + dy );
+
+  jobSettings.setExtent( jobExtent );
+  jobSettings.setFlag( Qgis::MapSettingsFlag::DrawLabeling, false );
+  jobSettings.setFlag( Qgis::MapSettingsFlag::RenderPreviewJob, true );
+  jobSettings.setFlag( Qgis::MapSettingsFlag::RecordProfile, false );
+
+  // truncate preview layers to fast layers
+  const QList<QgsMapLayer *> layers = jobSettings.layers();
+  QList<QgsMapLayer *> previewLayers;
+  QgsDataProvider::PreviewContext context;
+  context.maxRenderingTimeMs = MAXIMUM_LAYER_PREVIEW_TIME_MS;
+  for ( QgsMapLayer *layer : layers )
+  {
+    if ( layer->customProperty( QStringLiteral( "rendering/noPreviewJobs" ), false ).toBool() )
+    {
+      QgsDebugMsgLevel( QStringLiteral( "Layer %1 not rendered because it is explicitly blocked from preview jobs" ).arg( layer->id() ), 3 );
+      continue;
+    }
+    context.lastRenderingTimeMs = mLastLayerRenderTime.value( layer->id(), 0 );
+    QgsDataProvider *provider = layer->dataProvider();
+    if ( provider && !provider->renderInPreview( context ) )
+    {
+      QgsDebugMsgLevel( QStringLiteral( "Layer %1 not rendered because it does not match the renderInPreview criterion %2" ).arg( layer->id() ).arg( mLastLayerRenderTime.value( layer->id() ) ), 3 );
+      continue;
+    }
+
+    previewLayers << layer;
+  }
+  if ( QgsProject::instance()->mainAnnotationLayer()->dataProvider()->renderInPreview( context ) )
+  {
+    previewLayers.insert( 0, QgsProject::instance()->mainAnnotationLayer() );
+  }
+  jobSettings.setLayers( filterLayersForRender( previewLayers ) );
+
+  QgsMapRendererQImageJob *job = new QgsMapRendererSequentialJob( jobSettings );
+  job->setProperty( "number", number );
+  mPreviewJobs.append( job );
+  connect( job, &QgsMapRendererJob::finished, this, &QgsQuickMapCanvasMap::previewJobFinished );
+  job->start();
+}
+
+void QgsQuickMapCanvasMap::stopPreviewJobs()
+{
+  mPreviewTimer.stop();
+  for ( auto previewJob = mPreviewJobs.constBegin(); previewJob != mPreviewJobs.constEnd(); ++previewJob )
+  {
+    if ( *previewJob )
+    {
+      disconnect( *previewJob, &QgsMapRendererJob::finished, this, &QgsQuickMapCanvasMap::previewJobFinished );
+      connect( *previewJob, &QgsMapRendererQImageJob::finished, *previewJob, &QgsMapRendererQImageJob::deleteLater );
+      ( *previewJob )->cancelWithoutBlocking();
+    }
+  }
+  mPreviewJobs.clear();
+  mPreviewImages.clear();
+}
+
+void QgsQuickMapCanvasMap::schedulePreviewJob( int number )
+{
+  mPreviewTimer.setSingleShot( true );
+  mPreviewTimer.setInterval( PREVIEW_JOB_DELAY_MS );
+  disconnect( mPreviewTimerConnection );
+  mPreviewTimerConnection = connect( &mPreviewTimer, &QTimer::timeout, this, [=]() {
+    startPreviewJob( number );
+  } );
+  mPreviewTimer.start();
+}
+
+void QgsQuickMapCanvasMap::previewJobFinished()
+{
+  QgsMapRendererQImageJob *job = qobject_cast<QgsMapRendererQImageJob *>( sender() );
+  Q_ASSERT( job );
+
+  const int number = job->property( "number" ).toInt();
+  mPreviewImages.insert( number, job->renderedImage() );
+  mPreviewJobs.removeAll( job );
+  if ( number < 8 )
+  {
+    startPreviewJob( number + 1 );
+  }
+  delete job;
+
+  mDirty = true;
+  update();
 }

--- a/src/core/qgsquick/qgsquickmapcanvasmap.h
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.h
@@ -109,6 +109,14 @@ class QgsQuickMapCanvasMap : public QQuickItem
      */
     Q_PROPERTY( double forceDeferredLayersRepaint READ forceDeferredLayersRepaint WRITE setForceDeferredLayersRepaint NOTIFY forceDeferredLayersRepaintChanged )
 
+    /**
+     * When previewJobsEnabled is set to true, canvas map preview jobs (low priority
+     * render jobs which render portions of the view just outside of the canvas
+     * extent, to allow preview of these out-of-canvas areas when panning or zooming out
+     * the map) while be rendered.
+     */
+    Q_PROPERTY( bool previewJobsEnabled READ previewJobsEnabled WRITE setPreviewJobsEnabled NOTIFY previewJobsEnabledChanged )
+
   public:
     //! Create map canvas map
     explicit QgsQuickMapCanvasMap( QQuickItem *parent = nullptr );
@@ -164,6 +172,12 @@ class QgsQuickMapCanvasMap : public QQuickItem
     //!\copydoc QgsQuickMapCanvasMap::rightMargin
     void setRightMargin( double rightMargin );
 
+    //!\copydoc QgsQuickMapCanvasMap::previewJobsEnabled
+    bool previewJobsEnabled() const;
+
+    //!\copydoc QgsQuickMapCanvasMap::previewJobsEnabled
+    void setPreviewJobsEnabled( bool enabled );
+
     /**
      * Returns an image of the last successful map canvas rendering
      */
@@ -204,6 +218,9 @@ class QgsQuickMapCanvasMap : public QQuickItem
 
     //!\copydoc QgsQuickMapCanvasMap::rightMargin
     void rightMarginChanged();
+
+    //!\copydoc QgsQuickMapCanvasMap::previewJobsEnabled
+    bool previewJobsEnabledChanged() const;
 
   protected:
     void geometryChange( const QRectF &newGeometry, const QRectF &oldGeometry ) override;
@@ -283,6 +300,7 @@ class QgsQuickMapCanvasMap : public QQuickItem
 
     QHash<QString, int> mLastLayerRenderTime;
 
+    bool mPreviewJobsEnabled = false;
     QList<QgsMapRendererQImageJob *> mPreviewJobs;
     QTimer mPreviewTimer;
     QMetaObject::Connection mPreviewTimerConnection;

--- a/src/core/qgsquick/qgsquickmapcanvasmap.h
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.h
@@ -27,6 +27,7 @@
 #include <memory>
 
 class QgsMapRendererParallelJob;
+class QgsMapRendererQImageJob;
 class QgsMapRendererCache;
 class QgsLabelingResults;
 
@@ -232,11 +233,18 @@ class QgsQuickMapCanvasMap : public QQuickItem
      */
     void refresh();
 
+    void startPreviewJobs();
+    void stopPreviewJobs();
+    void schedulePreviewJob( int number );
+
   private slots:
     void refreshMap();
     void renderJobUpdated();
     void renderJobFinished();
     void layerRepaintRequested( bool deferred );
+    void startPreviewJob( int number );
+    void previewJobFinished();
+
     void onWindowChanged( QQuickWindow *window );
     void onScreenChanged( QScreen *screen );
     void onExtentChanged();
@@ -272,6 +280,13 @@ class QgsQuickMapCanvasMap : public QQuickItem
     bool mDeferredRefreshPending = false;
     double mQuality = 1.0;
     bool mForceDeferredLayersRepaint = false;
+
+    QHash<QString, int> mLastLayerRenderTime;
+
+    QList<QgsMapRendererQImageJob *> mPreviewJobs;
+    QTimer mPreviewTimer;
+    QMetaObject::Connection mPreviewTimerConnection;
+    QMap<int, QImage> mPreviewImages;
 
     QQuickWindow *mWindow = nullptr;
 };

--- a/src/core/qgsquick/qgsquickmapcanvasmap.h
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.h
@@ -110,12 +110,22 @@ class QgsQuickMapCanvasMap : public QQuickItem
     Q_PROPERTY( double forceDeferredLayersRepaint READ forceDeferredLayersRepaint WRITE setForceDeferredLayersRepaint NOTIFY forceDeferredLayersRepaintChanged )
 
     /**
-     * When previewJobsEnabled is set to true, canvas map preview jobs (low priority
-     * render jobs which render portions of the view just outside of the canvas
-     * extent, to allow preview of these out-of-canvas areas when panning or zooming out
-     * the map) while be rendered.
+     * When the previewJobsEnabled property is set to true, canvas map preview jobs
+     * (low priority render jobs which render portions of the view just outside of
+     * the canvas extent, to allow preview of these out-of-canvas areas when panning
+     * or zooming out the map) while be rendered.
      */
     Q_PROPERTY( bool previewJobsEnabled READ previewJobsEnabled WRITE setPreviewJobsEnabled NOTIFY previewJobsEnabledChanged )
+
+    /**
+     * The previewJobsQuadrants property is used to customize the preview jobs ordering.
+     * The possible quadrant integer values are:
+     *
+     * 0 (top left)    | 1 (top)    | 2 (top right)
+     * 3 (left)        | canvas     | 5 (right)
+     * 6 (bottom left) | 7 (bottom) | 8 (bottom right)
+     */
+    Q_PROPERTY( QList<int> previewJobsQuadrants READ previewJobsQuadrants WRITE setPreviewJobsQuadrants NOTIFY previewJobsQuadrantsChanged )
 
   public:
     //! Create map canvas map
@@ -178,6 +188,12 @@ class QgsQuickMapCanvasMap : public QQuickItem
     //!\copydoc QgsQuickMapCanvasMap::previewJobsEnabled
     void setPreviewJobsEnabled( bool enabled );
 
+    //!\copydoc QgsQuickMapCanvasMap::previewJobsQuadrants
+    QList<int> previewJobsQuadrants() const;
+
+    //!\copydoc QgsQuickMapCanvasMap::previewJobsQuadrants
+    void setPreviewJobsQuadrants( const QList<int> &quadrants );
+
     /**
      * Returns an image of the last successful map canvas rendering
      */
@@ -220,7 +236,10 @@ class QgsQuickMapCanvasMap : public QQuickItem
     void rightMarginChanged();
 
     //!\copydoc QgsQuickMapCanvasMap::previewJobsEnabled
-    bool previewJobsEnabledChanged() const;
+    void previewJobsEnabledChanged() const;
+
+    //!\copydoc QgsQuickMapCanvasMap::previewJobsQuadrants
+    void previewJobsQuadrantsChanged() const;
 
   protected:
     void geometryChange( const QRectF &newGeometry, const QRectF &oldGeometry ) override;
@@ -301,6 +320,7 @@ class QgsQuickMapCanvasMap : public QQuickItem
     QHash<QString, int> mLastLayerRenderTime;
 
     bool mPreviewJobsEnabled = false;
+    QList<int> mPreviewJobsQuadrants = { 0, 1, 2, 3, 5, 6, 7, 8 };
     QList<QgsMapRendererQImageJob *> mPreviewJobs;
     QTimer mPreviewTimer;
     QMetaObject::Connection mPreviewTimerConnection;

--- a/src/qml/MapCanvas.qml
+++ b/src/qml/MapCanvas.qml
@@ -30,6 +30,7 @@ Item {
   property alias isRendering: mapCanvasWrapper.isRendering
   property alias incrementalRendering: mapCanvasWrapper.incrementalRendering
   property alias quality: mapCanvasWrapper.quality
+  property alias previewJobsEnabled: mapCanvasWrapper.previewJobsEnabled
   property alias forceDeferredLayersRepaint: mapCanvasWrapper.forceDeferredLayersRepaint
 
   property bool interactive: true

--- a/src/qml/MapCanvas.qml
+++ b/src/qml/MapCanvas.qml
@@ -31,6 +31,7 @@ Item {
   property alias incrementalRendering: mapCanvasWrapper.incrementalRendering
   property alias quality: mapCanvasWrapper.quality
   property alias previewJobsEnabled: mapCanvasWrapper.previewJobsEnabled
+  property alias previewJobsQuadrants: mapCanvasWrapper.previewJobsQuadrants
   property alias forceDeferredLayersRepaint: mapCanvasWrapper.forceDeferredLayersRepaint
 
   property bool interactive: true

--- a/src/qml/MapCanvas.qml
+++ b/src/qml/MapCanvas.qml
@@ -86,6 +86,10 @@ Item {
     mapCanvasWrapper.zoom(point, 1.5);
   }
 
+  function stopRendering() {
+    mapCanvasWrapper.stopRendering();
+  }
+
   MapCanvasMap {
     id: mapCanvasWrapper
 

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -26,6 +26,7 @@ Page {
   property alias enableInfoCollection: registry.enableInfoCollection
   property alias enableMapRotation: registry.enableMapRotation
   property alias quality: registry.quality
+  property alias previewJobsEnabled: registry.previewJobsEnabled
   property alias snapToCommonAngleIsEnabled: registry.snapToCommonAngleIsEnabled
   property alias snapToCommonAngleIsRelative: registry.snapToCommonAngleIsRelative
   property alias snapToCommonAngleDegrees: registry.snapToCommonAngleDegrees
@@ -60,6 +61,7 @@ Page {
     property bool enableInfoCollection: true
     property bool enableMapRotation: true
     property double quality: 1.0
+    property bool previewJobsEnabled: true
 
     property bool snapToCommonAngleIsEnabled: false
     property bool snapToCommonAngleIsRelative: true
@@ -166,6 +168,12 @@ Page {
 
   ListModel {
     id: advancedSettingsModel
+    ListElement {
+      title: qsTr("Render preview content around visible map canvas")
+      description: qsTr("If enabled, areas just outside of the visible map canvas extent will be partially rendered to allow preview when zooming and panning")
+      settingAlias: "previewJobsEnabled"
+      isVisible: true
+    }
     ListElement {
       title: qsTr("Use native camera")
       description: qsTr("If disabled, QField will use a minimalist internal camera instead of the camera app on the device.<br>Tip: Enable this option and install the open camera app to create geo tagged photos.")
@@ -776,8 +784,6 @@ Page {
               columns: 2
               columnSpacing: 0
               rowSpacing: 5
-
-              visible: platformUtilities.capabilities & PlatformUtilities.NativeCamera || platformUtilities.capabilities & PlatformUtilities.SentryFramework
 
               Label {
                 text: qsTr('Advanced')

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -634,6 +634,7 @@ ApplicationWindow {
       isMapRotationEnabled: qfieldSettings.enableMapRotation
       incrementalRendering: true
       quality: qfieldSettings.quality
+      previewJobsEnabled: qfieldSettings.previewJobsEnabled
       forceDeferredLayersRepaint: trackings.count > 0
       freehandDigitizing: freehandButton.freehandDigitizing && freehandHandler.active
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3710,6 +3710,7 @@ ApplicationWindow {
       if (changelogPopup.visible)
         changelogPopup.close();
       dashBoard.layerTree.freeze();
+      mapCanvasMap.stopRendering();
       mapCanvasMap.freeze('projectload');
       busyOverlay.text = qsTr("Loading %1").arg(name !== '' ? name : path);
       busyOverlay.state = "visible";


### PR DESCRIPTION
Similar to what we have in QGIS. End result:

https://github.com/user-attachments/assets/2605f100-be80-40d3-9fb3-6962453f623b

This is actually quite nice as it doubles as a mean to prefetch XYZ tiles around the visible map extent, making browsing around the map that much nicer.

This is a requirement to a followup PR that will improve UX of map canvas located to position. 

Implements the following enhancement requested in 2020: https://github.com/opengisch/QField/issues/1532