### PR TITLE
If '/' is the last character of a custom QFieldCloud server URL, slice it out

### DIFF
--- a/src/qml/QFieldCloudLogin.qml
+++ b/src/qml/QFieldCloudLogin.qml
@@ -260,9 +260,13 @@ Item {
   }
 
   function prefixUrlWithProtocol(url) {
-    if (!url || url.startsWith('http://') || url.startsWith('https://'))
-      return url;
-    return 'https://' + url;
+    let cleanedUrl = url.trim();
+    if (cleanedUrl.endsWith('/')) {
+      cleanedUrl = cleanedUrl.slice(0, -1);
+    }
+    if (!cleanedUrl || cleanedUrl.startsWith('http://') || cleanedUrl.startsWith('https://'))
+      return cleanedUrl;
+    return 'https://' + cleanedUrl;
   }
 
   function loginFormSumbitHandler() {


### PR DESCRIPTION
QFieldSync allows for a custom server URL that ends with '/', QField doesn't and fails to communicate with the endpoint. This PR fixes the situation by being tolerant of that final '/'.

@suricactus , all good with you?

Fixes https://github.com/opengisch/QField/issues/6044