### PR TITLE
Remove text label from the show project folder button in the dashboard

### DIFF
--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -124,7 +124,7 @@ Drawer {
           }
 
           QfToolButton {
-            id: printItem
+            id: printItemButton
             anchors.verticalCenter: parent.verticalCenter
             round: true
             iconSource: Theme.getThemeVectorIcon("ic_print_black_24dp")
@@ -209,7 +209,7 @@ Drawer {
           }
 
           QfToolButton {
-            text: qsTr("Project Folder")
+            id: projectFolderButton
             anchors.verticalCenter: parent.verticalCenter
             font: Theme.defaultFont
             iconSource: Theme.getThemeVectorIcon("ic_project_folder_black_24dp")


### PR DESCRIPTION
The "Project Folder" is an unwanted leftover from the time this action was in the main menu. It's not visible by default _but_ if you change the font size of the app, you'll end up with this glitch:

![Screenshot From 2025-03-01 18-25-07](https://github.com/user-attachments/assets/2a33be9a-a5fe-49c9-af53-b31afea127b5)

Not ideal :wink: 