### PR TITLE
"Smooth ride", revamping the map canvas' "follow positioning" mode

### DIFF
--- a/src/core/qgsquick/qgsquickmapcanvasmap.cpp
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.cpp
@@ -608,12 +608,12 @@ void QgsQuickMapCanvasMap::zoomToFullExtent()
   refresh();
 }
 
-void QgsQuickMapCanvasMap::refresh()
+void QgsQuickMapCanvasMap::refresh( bool ignoreFreeze )
 {
   if ( mMapSettings->outputSize().isNull() )
     return; // the map image size has not been set yet
 
-  if ( !mFreeze )
+  if ( ignoreFreeze || !mFreeze )
     mRefreshTimer.start( 1 );
 }
 

--- a/src/core/qgsquick/qgsquickmapcanvasmap.cpp
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.cpp
@@ -171,6 +171,7 @@ void QgsQuickMapCanvasMap::renderJobUpdated()
 
   mImage = mJob->renderedImage();
   mImageMapSettings = mJob->mapSettings();
+  mPreviewImages.clear();
   mDirty = true;
   // Temporarily freeze the canvas, we only need to reset the geometry but not trigger a repaint
   bool freeze = mFreeze;
@@ -199,6 +200,7 @@ void QgsQuickMapCanvasMap::renderJobFinished()
 
   mImage = mJob->renderedImage();
   mImageMapSettings = mJob->mapSettings();
+  mPreviewImages.clear();
 
   // now we are in a slot called from mJob - do not delete it immediately
   // so the class is still valid when the execution returns to the class
@@ -725,6 +727,7 @@ void QgsQuickMapCanvasMap::setPreviewJobsQuadrants( const QList<int> &quadrants 
 void QgsQuickMapCanvasMap::startPreviewJobs()
 {
   stopPreviewJobs();
+  mPreviewImages.clear();
 
   if ( mImage.isNull() || mPreviewJobsQuadrants.isEmpty() )
   {
@@ -822,7 +825,6 @@ void QgsQuickMapCanvasMap::stopPreviewJobs()
     }
   }
   mPreviewJobs.clear();
-  mPreviewImages.clear();
 }
 
 void QgsQuickMapCanvasMap::schedulePreviewJob( int number )

--- a/src/core/qgsquick/qgsquickmapcanvasmap.h
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.h
@@ -105,6 +105,12 @@ class QgsQuickMapCanvasMap : public QQuickItem
     Q_PROPERTY( double quality READ quality WRITE setQuality NOTIFY qualityChanged )
 
     /**
+     * When the smooth property is set to true, canvas map panning, zooming,
+     * and rotation changes while be interpolated to create a smoother transition.
+     */
+    Q_PROPERTY( bool smooth READ smooth WRITE setSmooth NOTIFY smoothChanged )
+
+    /**
      * When the forceDeferredLayersRepaint property is set to true, all layer repaint signals will be deferred.
      */
     Q_PROPERTY( double forceDeferredLayersRepaint READ forceDeferredLayersRepaint WRITE setForceDeferredLayersRepaint NOTIFY forceDeferredLayersRepaintChanged )
@@ -163,6 +169,12 @@ class QgsQuickMapCanvasMap : public QQuickItem
 
     //! \copydoc QgsQuickMapCanvasMap::incrementalRendering
     void setQuality( double quality );
+
+    //!\copydoc QgsQuickMapCanvasMap::smooth
+    bool smooth() const;
+
+    //!\copydoc QgsQuickMapCanvasMap::smooth
+    void setSmooth( bool smooth );
 
     //!\copydoc QgsQuickMapCanvasMap::forceDeferredLayersRepaint
     bool forceDeferredLayersRepaint() const;
@@ -241,6 +253,9 @@ class QgsQuickMapCanvasMap : public QQuickItem
     //!\copydoc QgsQuickMapCanvasMap::previewJobsQuadrants
     void previewJobsQuadrantsChanged() const;
 
+    //!\copydoc QgsQuickMapCanvasMap::previewJobsQuadrants
+    void smoothChanged() const;
+
   protected:
     void geometryChange( const QRectF &newGeometry, const QRectF &oldGeometry ) override;
 
@@ -294,7 +309,7 @@ class QgsQuickMapCanvasMap : public QQuickItem
      */
     void destroyJob( QgsMapRendererJob *job );
     QgsMapSettings prepareMapSettings() const;
-    void updateTransform();
+    void updateTransform( bool skipSmooth = false );
     void zoomToFullExtent();
     void clearTemporalCache();
 
@@ -315,6 +330,7 @@ class QgsQuickMapCanvasMap : public QQuickItem
     bool mSilentRefresh = false;
     bool mDeferredRefreshPending = false;
     double mQuality = 1.0;
+    bool mSmooth = false;
     bool mForceDeferredLayersRepaint = false;
 
     QHash<QString, int> mLastLayerRenderTime;

--- a/src/core/qgsquick/qgsquickmapcanvasmap.h
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.h
@@ -267,7 +267,7 @@ class QgsQuickMapCanvasMap : public QQuickItem
      * Refresh the map canvas.
      * Does nothing when output size of map settings is not set
      */
-    void refresh();
+    void refresh( bool ignoreFreeze = false );
 
     void startPreviewJobs();
     void stopPreviewJobs();

--- a/src/qml/MapCanvas.qml
+++ b/src/qml/MapCanvas.qml
@@ -31,6 +31,7 @@ Item {
   property alias isRendering: mapCanvasWrapper.isRendering
   property alias incrementalRendering: mapCanvasWrapper.incrementalRendering
   property alias quality: mapCanvasWrapper.quality
+  property alias smooth: mapCanvasWrapper.smooth
   property alias previewJobsEnabled: mapCanvasWrapper.previewJobsEnabled
   property alias previewJobsQuadrants: mapCanvasWrapper.previewJobsQuadrants
   property alias forceDeferredLayersRepaint: mapCanvasWrapper.forceDeferredLayersRepaint
@@ -106,6 +107,27 @@ Item {
     property var __freezecount: ({})
 
     freeze: false
+
+    Behavior on x  {
+      NumberAnimation {
+        duration: 50
+      }
+    }
+    Behavior on y  {
+      NumberAnimation {
+        duration: 50
+      }
+    }
+    Behavior on scale  {
+      NumberAnimation {
+        duration: 50
+      }
+    }
+    Behavior on rotation  {
+      NumberAnimation {
+        duration: 50
+      }
+    }
   }
 
   TapHandler {

--- a/src/qml/MapCanvas.qml
+++ b/src/qml/MapCanvas.qml
@@ -24,6 +24,7 @@ import org.qgis
  */
 Item {
   id: mapArea
+  property alias mapCanvasWrapper: mapCanvasWrapper
   property alias mapSettings: mapCanvasWrapper.mapSettings
   property alias bottomMargin: mapCanvasWrapper.bottomMargin
   property alias rightMargin: mapCanvasWrapper.rightMargin
@@ -86,6 +87,10 @@ Item {
 
   function zoomOut(point) {
     mapCanvasWrapper.zoom(point, 1.5);
+  }
+
+  function refresh(ignoreFreeze) {
+    mapCanvasWrapper.refresh(ignoreFreeze === undefined ? false : ignoreFreeze);
   }
 
   function stopRendering() {

--- a/src/qml/MapCanvas.qml
+++ b/src/qml/MapCanvas.qml
@@ -105,27 +105,28 @@ Item {
     height: mapArea.height
 
     property var __freezecount: ({})
+    property int animationDuration: 50
 
     freeze: false
 
     Behavior on x  {
       NumberAnimation {
-        duration: 50
+        duration: mapCanvasWrapper.animationDuration
       }
     }
     Behavior on y  {
       NumberAnimation {
-        duration: 50
+        duration: mapCanvasWrapper.animationDuration
       }
     }
     Behavior on scale  {
       NumberAnimation {
-        duration: 50
+        duration: mapCanvasWrapper.animationDuration
       }
     }
     Behavior on rotation  {
       NumberAnimation {
-        duration: 50
+        duration: mapCanvasWrapper.animationDuration
       }
     }
   }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -634,6 +634,7 @@ ApplicationWindow {
       isMapRotationEnabled: qfieldSettings.enableMapRotation
       incrementalRendering: true
       quality: qfieldSettings.quality
+      smooth: gnssButton.followActive
       previewJobsEnabled: qfieldSettings.previewJobsEnabled
       forceDeferredLayersRepaint: trackings.count > 0
       freehandDigitizing: freehandButton.freehandDigitizing && freehandHandler.active

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2164,6 +2164,35 @@ ApplicationWindow {
             triggerRecenter = Math.abs(mapCanvasMap.mapCanvasWrapper.x) > mainWindow.width - followLocationMinMargin || Math.abs(mapCanvasMap.mapCanvasWrapper.y) > mainWindow.height - followLocationMinMargin;
           }
           if (triggerRecenter || forceRecenter) {
+            if (positionSource.positionInformation.directionValid) {
+              // Prioritize preview quadrants based on movement direction
+              const direction = positionSource.positionInformation.direction;
+              if (direction >= 337.5 || direction < 22.5) {
+                // moving ~north
+                mapCanvasMap.previewJobsQuadrants = [1, 2, 0, 5, 2, 8, 6, 7];
+              } else if (direction >= 22.5 && direction < 67.5) {
+                // moving ~northeast
+                mapCanvasMap.previewJobsQuadrants = [2, 5, 1, 8, 0, 7, 3, 6];
+              } else if (direction >= 67.5 && direction < 112.5) {
+                // moving ~east
+                mapCanvasMap.previewJobsQuadrants = [5, 8, 2, 7, 1, 6, 0, 3];
+              } else if (direction >= 112.5 && direction < 157.5) {
+                // moving ~southeast
+                mapCanvasMap.previewJobsQuadrants = [8, 7, 5, 6, 2, 3, 1, 0];
+              } else if (direction >= 157.5 && direction < 202.5) {
+                // moving ~south
+                mapCanvasMap.previewJobsQuadrants = [7, 8, 6, 5, 3, 2, 0, 1];
+              } else if (direction >= 202.5 && direction < 247.5) {
+                // moving ~southwest
+                mapCanvasMap.previewJobsQuadrants = [6, 7, 3, 8, 0, 5, 1, 2];
+              } else if (direction >= 247.5 && direction < 292.5) {
+                // moving ~west
+                mapCanvasMap.previewJobsQuadrants = [3, 6, 0, 7, 1, 8, 2, 5];
+              } else if (direction >= 292.5 && direction < 337.5) {
+                // moving ~northwest
+                mapCanvasMap.previewJobsQuadrants = [0, 1, 3, 2, 6, 5, 7, 8];
+              }
+            }
             mapCanvasMap.refresh(true);
           }
         }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2201,8 +2201,8 @@ ApplicationWindow {
           if (!isNaN(positionSource.orientation) && Math.abs(-positionSource.orientation - mapCanvas.mapSettings.rotation) >= 2) {
             gnssButton.followActiveSkipRotationChanged = true;
             mapCanvas.mapSettings.rotation = -positionSource.orientation;
-            const triggerRecenter = Math.abs(mapCanvasMap.mapCanvasWrapper.rotation) > 10;
-            if (triggerRecenter) {
+            const triggerRefresh = Math.abs(mapCanvasMap.mapCanvasWrapper.rotation) > 33.3;
+            if (triggerRefresh) {
               mapCanvasMap.refresh(true);
             }
           }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2169,7 +2169,7 @@ ApplicationWindow {
               const direction = positionSource.positionInformation.direction;
               if (direction >= 337.5 || direction < 22.5) {
                 // moving ~north
-                mapCanvasMap.previewJobsQuadrants = [1, 2, 0, 5, 2, 8, 6, 7];
+                mapCanvasMap.previewJobsQuadrants = [1, 2, 0, 5, 3, 8, 6, 7];
               } else if (direction >= 22.5 && direction < 67.5) {
                 // moving ~northeast
                 mapCanvasMap.previewJobsQuadrants = [2, 5, 1, 8, 0, 7, 3, 6];


### PR DESCRIPTION
This PR reworks the map canvas' "follow positioning" mode by insuring that the position stays in the middle of the screen while the map slips around. This makes for a much, _much_ better experience.

Before:

https://github.com/user-attachments/assets/7b8fa766-041e-4581-adb6-93e3cc1025da

PR:

https://github.com/user-attachments/assets/70243e78-4720-4db3-a32c-d35186b877f1

The PR leverages our newly-found ability at rendering content beyond the screen edge to be able to pan around while not triggering re-renders _all the time_. While I could not demonstrate this on my computer, the same logic has been applied to the device's compass when the map canvas is set to auto rotate along compass values.

In addition, the map canvas has a new smooth behavior, where panning, rotation, and zooming changes are interpolated. It makes GNSS devices reporting every few seconds look much nicer on the screen as it avoids chunky jumps.

(This PR includes commits from https://github.com/opengisch/QField/pull/6046 , I'll rebase when that is reviewed and merged)