### PR TITLE
Trying to upgrade to Xcode 16 to build against iOS SDK 18

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -65,13 +65,6 @@ jobs:
         with:
           xcode-version: 16.2
 
-      - name: 🔏 Setup code signing
-        if: ${{ env.SENTRY_AUTH_TOKEN != '' }}
-        env:
-          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-        run: |
-          bundle exec fastlane ios setup_signing type:${{ env.IOS_SIGN_TYPE }}  app_identifier:${{ env.IOS_APP_IDENTIFIER }} #  --verbose
-
       - name: 🍹 Prepare ios build env
         if: ${{ env.SENTRY_AUTH_TOKEN != '' }}
         run: |
@@ -149,6 +142,13 @@ jobs:
           name: build-logs-${{ env.TRIPLET }}
           path: |
             /Users/runner/builddir/**/*.log
+
+      - name: 🔏 Setup code signing
+        if: ${{ env.SENTRY_AUTH_TOKEN != '' }}
+        env:
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+        run: |
+          bundle exec fastlane ios setup_signing type:${{ env.IOS_SIGN_TYPE }}  app_identifier:${{ env.IOS_APP_IDENTIFIER }} #  --verbose
 
       - name: 📦 Package
         if: ${{ env.SENTRY_AUTH_TOKEN != '' }}

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -37,7 +37,7 @@ jobs:
         if: ${{ env.SENTRY_AUTH_TOKEN != '' }}
         run: |
           rm -rf /Applications/Xcode_14*
-          rm -rf /Applications/Xcode_16*
+          rm -rf /Applications/Xcode_15*
           rm -rf /Users/runner/Library/Android/sdk
 
       - name: 🌾 Prepare variables
@@ -96,7 +96,7 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1.6.0
         if: ${{ env.SENTRY_AUTH_TOKEN != '' }}
         with:
-          xcode-version: latest-stable
+          xcode-version: 16.2
 
       - name: 🍮 ccache
         uses: hendrikmuhs/ccache-action@v1

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -122,6 +122,7 @@ jobs:
                 -D SENTRY_DSN=${{ secrets.SENTRY_DSN }} \
                 -D SENTRY_ENV="${APP_ENV}" \
                 -D ENABLE_BITCODE=OFF \
+                -DVCPKG_INSTALL_OPTIONS="--debug" \
                 -D ENABLE_ARC=ON \
                 -D QT_IOS_TEAM_ID="${{ secrets.IOS_TEAM_ID }}" \
                 -D QT_IOS_CODE_SIGN_IDENTITY="${{ env.IOS_CODE_SIGN_IDENTITY }}" \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -122,7 +122,6 @@ jobs:
                 -D SENTRY_DSN=${{ secrets.SENTRY_DSN }} \
                 -D SENTRY_ENV="${APP_ENV}" \
                 -D ENABLE_BITCODE=OFF \
-                -DVCPKG_INSTALL_OPTIONS="--debug" \
                 -D ENABLE_ARC=ON \
                 -D QT_IOS_TEAM_ID="${{ secrets.IOS_TEAM_ID }}" \
                 -D QT_IOS_CODE_SIGN_IDENTITY="${{ env.IOS_CODE_SIGN_IDENTITY }}" \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -59,13 +59,18 @@ jobs:
           ruby-version: '3.2' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
+      - name: 🍭 Setup XCode
+        uses: maxim-lobanov/setup-xcode@v1.6.0
+        if: ${{ env.SENTRY_AUTH_TOKEN != '' }}
+        with:
+          xcode-version: 16.2
+
       - name: 🔏 Setup code signing
         if: ${{ env.SENTRY_AUTH_TOKEN != '' }}
         env:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
         run: |
           bundle exec fastlane ios setup_signing type:${{ env.IOS_SIGN_TYPE }}  app_identifier:${{ env.IOS_APP_IDENTIFIER }} #  --verbose
-
 
       - name: 🍹 Prepare ios build env
         if: ${{ env.SENTRY_AUTH_TOKEN != '' }}
@@ -91,12 +96,6 @@ jobs:
         if: ${{ env.SENTRY_AUTH_TOKEN != '' }}
         with:
           python-version: '3.11'
-
-      - name: 🍭 Setup XCode
-        uses: maxim-lobanov/setup-xcode@v1.6.0
-        if: ${{ env.SENTRY_AUTH_TOKEN != '' }}
-        with:
-          xcode-version: 16.2
 
       - name: 🍮 ccache
         uses: hendrikmuhs/ccache-action@v1

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   build:
     name: build (ios)
-    runs-on: macos-14
+    runs-on: macos-15
     env:
       DEPLOYMENT_TARGET: '14.0'
       BUILD_TYPE: 'Release'


### PR DESCRIPTION
Background on why this is needed in the form of a message from Apple's App Store:

_ITMS-90725: SDK version issue - This app was built with the iOS 17.5 SDK. Starting April 24, 2025, all iOS and iPadOS apps must be built with the iOS 18 SDK or later, included in Xcode 16 or later, in order to be uploaded to App Store Connect or submitted for distribution._