### PR TITLE
Fetch-only support for external storage (WebDAV/AWS 3) within the attachment editor widget

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -60,6 +60,7 @@ set(QFIELD_CORE_SRCS
     drawingtemplatemodel.cpp
     expressionevaluator.cpp
     expressionvariablemodel.cpp
+    externalstorage.cpp
     featurechecklistmodel.cpp
     featurelistextentcontroller.cpp
     featurelistmodel.cpp
@@ -184,6 +185,7 @@ set(QFIELD_CORE_HDRS
     drawingtemplatemodel.h
     expressionevaluator.h
     expressionvariablemodel.h
+    externalstorage.h
     featurechecklistmodel.h
     featureexpressionvaluesgatherer.h
     featurelistextentcontroller.h

--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -29,6 +29,7 @@
 #include <QQuickItem>
 #include <QTemporaryFile>
 #include <qgsapplication.h>
+#include <qgsauthmanager.h>
 #include <qgsmessagelog.h>
 #include <qgsproject.h>
 #include <qgsruntimeprofiler.h>
@@ -226,6 +227,13 @@ bool AppInterface::isFileExtensionSupported( const QString &filename ) const
   const QFileInfo fi( filename );
   const QString suffix = fi.suffix().toLower();
   return SUPPORTED_PROJECT_EXTENSIONS.contains( suffix ) || SUPPORTED_VECTOR_EXTENSIONS.contains( suffix ) || SUPPORTED_RASTER_EXTENSIONS.contains( suffix );
+}
+
+bool AppInterface::isAuthenticationConfigurationAvailable( const QString &id ) const
+{
+  QgsAuthManager *authManager = QgsApplication::instance()->authManager();
+  QgsAuthMethodConfigsMap configs = authManager->availableAuthMethodConfigs();
+  return configs.contains( id );
 }
 
 void AppInterface::logMessage( const QString &message )

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -66,6 +66,11 @@ class AppInterface : public QObject
     Q_INVOKABLE bool isFileExtensionSupported( const QString &filename ) const;
 
     /**
+     * Returns TRUE if the authentication configuration \a id is available.
+     */
+    Q_INVOKABLE bool isAuthenticationConfigurationAvailable( const QString &id ) const;
+
+    /**
      * Adds a log \a message that will be visible to the user through the
      * message log panel, as well as added into the device's system logs
      * which will be captured by the sentry's reporting framework when enabled.

--- a/src/core/externalstorage.cpp
+++ b/src/core/externalstorage.cpp
@@ -1,0 +1,69 @@
+/***************************************************************************
+  externalstorage.cpp - ExternalStorage
+
+ ---------------------
+ begin                : 07.04.2025
+ copyright            : (C) 2025 by Mathieu Pellerin
+ email                : mathieu@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "externalstorage.h"
+
+#include <qgsapplication.h>
+
+ExternalStorage::ExternalStorage( QObject *parent )
+  : QObject( parent )
+{
+}
+
+Qgis::ContentStatus ExternalStorage::status() const
+{
+  return mFetchedContent ? mFetchedContent->status() : Qgis::ContentStatus::NotStarted;
+}
+
+QString ExternalStorage::type() const
+{
+  return mStorage ? mStorage->type() : QString();
+}
+
+void ExternalStorage::setType( const QString &type )
+{
+  mStorage.reset( QgsApplication::instance()->externalStorageRegistry()->externalStorageFromType( type ) );
+  emit typeChanged();
+}
+
+void ExternalStorage::fetch( const QString &url, const QString &authenticationId )
+{
+  if ( mStorage )
+  {
+    if ( mFetchedContent )
+    {
+      disconnect( mFetchedContent.get(), &QgsExternalStorageFetchedContent::fetched, this, &ExternalStorage::contentFetched );
+      mFetchedContent->cancel();
+      mFetchedContent->deleteLater();
+    }
+
+    mFetchedContent.reset( mStorage->fetch( url, authenticationId, Qgis::ActionStart::Immediate ) );
+    emit statusChanged();
+
+    connect( mFetchedContent.get(), &QgsExternalStorageFetchedContent::fetched, this, &ExternalStorage::contentFetched );
+  }
+}
+
+QString ExternalStorage::fetchedContent() const
+{
+  return mFetchedContent && mFetchedContent->status() == Qgis::ContentStatus::Finished ? mFetchedContent->filePath() : QString();
+}
+
+void ExternalStorage::contentFetched()
+{
+  emit statusChanged();
+  emit fetchedContentChanged();
+}

--- a/src/core/externalstorage.cpp
+++ b/src/core/externalstorage.cpp
@@ -60,18 +60,6 @@ void ExternalStorage::fetch( const QString &url, const QString &authenticationCo
       mFetchedContent->deleteLater();
     }
 
-    if ( !authenticationConfigurationId.isEmpty() )
-    {
-      QgsAuthManager *authManager = QgsApplication::instance()->authManager();
-      QgsAuthMethodConfigsMap configs = authManager->availableAuthMethodConfigs();
-      if ( !configs.contains( authenticationConfigurationId ) )
-      {
-        mLastError = tr( "The external storage's authentication configuration ID is missing, please insure it is imported into Field" );
-        emit lastErrorChanged();
-        return;
-      }
-    }
-
     mFetchedContent.reset( mStorage->fetch( url, authenticationConfigurationId, Qgis::ActionStart::Immediate ) );
     emit statusChanged();
     emit fetchedContentChanged();

--- a/src/core/externalstorage.h
+++ b/src/core/externalstorage.h
@@ -30,8 +30,9 @@ class ExternalStorage : public QObject
 
     Q_PROPERTY( Qgis::ContentStatus status READ status NOTIFY statusChanged )
     Q_PROPERTY( QString type READ type WRITE setType NOTIFY typeChanged )
+    Q_PROPERTY( QString lastError READ lastError NOTIFY lastErrorChanged );
 
-    Q_PROPERTY( QString fetchedContent READ fetchedContent NOTIFY authenticationIdChanged )
+    Q_PROPERTY( QString fetchedContent READ fetchedContent NOTIFY fetchedContentChanged )
 
   public:
     explicit ExternalStorage( QObject *parent = nullptr );
@@ -42,15 +43,17 @@ class ExternalStorage : public QObject
 
     void setType( const QString &type );
 
-    Q_INVOKABLE void fetch( const QString &url, const QString &authenticationId );
+    QString lastError() const;
 
     QString fetchedContent() const;
+
+    Q_INVOKABLE void fetch( const QString &url, const QString &authenticationConfigurationId );
 
   signals:
     void statusChanged();
     void typeChanged();
-    void authenticationIdChanged();
     void fetchedContentChanged();
+    void lastErrorChanged();
 
   private slots:
     void contentFetched();
@@ -58,7 +61,7 @@ class ExternalStorage : public QObject
   private:
     Qgis::ContentStatus mStatus = Qgis::ContentStatus::NotStarted;
     std::unique_ptr<QgsExternalStorage> mStorage;
-    QString mAuthenticationId;
+    QString mLastError;
 
     QString mFetchUrl;
     std::unique_ptr<QgsExternalStorageFetchedContent> mFetchedContent;

--- a/src/core/externalstorage.h
+++ b/src/core/externalstorage.h
@@ -30,7 +30,7 @@ class ExternalStorage : public QObject
 
     Q_PROPERTY( Qgis::ContentStatus status READ status NOTIFY statusChanged )
     Q_PROPERTY( QString type READ type WRITE setType NOTIFY typeChanged )
-    Q_PROPERTY( QString lastError READ lastError NOTIFY lastErrorChanged );
+    Q_PROPERTY( QString lastError READ lastError NOTIFY lastErrorChanged )
 
     Q_PROPERTY( QString fetchedContent READ fetchedContent NOTIFY fetchedContentChanged )
 
@@ -51,7 +51,6 @@ class ExternalStorage : public QObject
     /**
      * Sets the current external storage type string. The type string must be tied to an
      * external storage object that was added in the QgsApplication::externalStorageRegistry().
-     *
      */
     void setType( const QString &type );
 

--- a/src/core/externalstorage.h
+++ b/src/core/externalstorage.h
@@ -37,16 +37,41 @@ class ExternalStorage : public QObject
   public:
     explicit ExternalStorage( QObject *parent = nullptr );
 
+    /**
+     * Returns the current status of the external storage object. When a fetch operation has been triggered,
+     * the status will reflect the last fetched content operation.
+     */
     Qgis::ContentStatus status() const;
 
+    /**
+     * Returns the current external storage type string.
+     */
     QString type() const;
 
+    /**
+     * Sets the current external storage type string. The type string must be tied to an
+     * external storage object that was added in the QgsApplication::externalStorageRegistry().
+     *
+     */
     void setType( const QString &type );
 
+    /**
+     * Returns the last error emitted by an external storage operation.
+     */
     QString lastError() const;
 
+    /**
+     * Returns the file path of a successfully fetched content operation.
+     */
     QString fetchedContent() const;
 
+    /**
+     * Triggers a fetch operation to download the content from an external storage and
+     * make it available locally.
+     * \param url the remote URL of the content
+     * \param authenticationConfigurationId the authentication configuration ID used to
+     * connect to the external storage endpoint
+     */
     Q_INVOKABLE void fetch( const QString &url, const QString &authenticationConfigurationId );
 
   signals:

--- a/src/core/externalstorage.h
+++ b/src/core/externalstorage.h
@@ -57,10 +57,11 @@ class ExternalStorage : public QObject
 
   private slots:
     void contentFetched();
+    void contentErrorOccurred( const QString &errorString );
 
   private:
     Qgis::ContentStatus mStatus = Qgis::ContentStatus::NotStarted;
-    std::unique_ptr<QgsExternalStorage> mStorage;
+    QgsExternalStorage *mStorage = nullptr;
     QString mLastError;
 
     QString mFetchUrl;

--- a/src/core/externalstorage.h
+++ b/src/core/externalstorage.h
@@ -1,0 +1,67 @@
+/***************************************************************************
+  externalstorage.h - ExternalStorage
+
+ ---------------------
+ begin                : 07.04.2025
+ copyright            : (C) 2025 by Mathieu Pellerin
+ email                : mathieu@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef EXTERNALSTORAGE_H
+#define EXTERNALSTORAGE_H
+
+#include <QObject>
+#include <qgsexternalstorage.h>
+#include <qgsexternalstorageregistry.h>
+
+/**
+ * \ingroup core
+ */
+class ExternalStorage : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY( Qgis::ContentStatus status READ status NOTIFY statusChanged )
+    Q_PROPERTY( QString type READ type WRITE setType NOTIFY typeChanged )
+
+    Q_PROPERTY( QString fetchedContent READ fetchedContent NOTIFY authenticationIdChanged )
+
+  public:
+    explicit ExternalStorage( QObject *parent = nullptr );
+
+    Qgis::ContentStatus status() const;
+
+    QString type() const;
+
+    void setType( const QString &type );
+
+    Q_INVOKABLE void fetch( const QString &url, const QString &authenticationId );
+
+    QString fetchedContent() const;
+
+  signals:
+    void statusChanged();
+    void typeChanged();
+    void authenticationIdChanged();
+    void fetchedContentChanged();
+
+  private slots:
+    void contentFetched();
+
+  private:
+    Qgis::ContentStatus mStatus = Qgis::ContentStatus::NotStarted;
+    std::unique_ptr<QgsExternalStorage> mStorage;
+    QString mAuthenticationId;
+
+    QString mFetchUrl;
+    std::unique_ptr<QgsExternalStorageFetchedContent> mFetchedContent;
+};
+
+#endif // EXTERNALSTORAGE_H

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -52,6 +52,7 @@
 #include "expressioncontextutils.h"
 #include "expressionevaluator.h"
 #include "expressionvariablemodel.h"
+#include "externalstorage.h"
 #include "featurechecklistmodel.h"
 #include "featurehistory.h"
 #include "featurelistextentcontroller.h"
@@ -452,6 +453,7 @@ void QgisMobileapp::initDeclarative( QQmlEngine *engine )
   qmlRegisterType<DrawingCanvas>( "org.qfield", 1, 0, "DrawingCanvas" );
   qmlRegisterType<SubModel>( "org.qfield", 1, 0, "SubModel" );
   qmlRegisterType<ExpressionVariableModel>( "org.qfield", 1, 0, "ExpressionVariableModel" );
+  qmlRegisterType<ExternalStorage>( "org.qfield", 1, 0, "ExternalStorage" );
   qmlRegisterType<BadLayerHandler>( "org.qfield", 1, 0, "BadLayerHandler" );
   qmlRegisterType<SnappingUtils>( "org.qfield", 1, 0, "SnappingUtils" );
   qmlRegisterType<DistanceArea>( "org.qfield", 1, 0, "DistanceArea" );

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -108,6 +108,11 @@ EditorWidgetBase {
     }
   }
 
+  ExternalStorage {
+    id: externalStorage
+    type: config["StorageType"] !== undefined ? config["StorageType"] : ""
+  }
+
   ExpressionEvaluator {
     id: expressionEvaluator
     feature: currentFeature

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -22,7 +22,7 @@ EditorWidgetBase {
     if (qgisProject == undefined)
       return "";
     var path = "";
-    if (config["RelativeStorage"] === 1) {
+    if (config["RelativeStorage"] === 1 || externalStorage.type != "") {
       path = qgisProject.homePath;
       if (!path.endsWith("/"))
         path = path + "/";

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -80,7 +80,13 @@ EditorWidgetBase {
       const fullValueExists = FileUtils.fileExists(fullValue);
       if (!fullValueExists && externalStorage.type != "") {
         prepareValue("");
-        externalStorage.fetch(value, config["StorageAuthConfigId"]);
+        if (config["StorageAuthConfigId"] !== "" && !iface.isAuthenticationConfigurationAvailable(config["StorageAuthConfigId"])) {
+          mainWindow.displayToast(qsTr("The external storage's authentication configuration ID is missing, please insure it is imported into QField"), "error", qsTr("Learn more"), function () {
+              Qt.openUrlExternally('https://docs.qfield.org/how-to/authentication/');
+            });
+        } else {
+          externalStorage.fetch(value, config["StorageAuthConfigId"]);
+        }
       } else {
         prepareValue(fullValue);
       }
@@ -131,7 +137,7 @@ EditorWidgetBase {
     }
 
     onLastErrorChanged: {
-      mainWindow.displayToast(lastError, 'error');
+      mainWindow.displayToast(lastError, "error");
     }
   }
 

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -77,6 +77,20 @@ EditorWidgetBase {
     if (currentValue != undefined && currentValue !== '') {
       const isHttp = value.startsWith('http://') || value.startsWith('https://');
       var fullValue = isHttp ? value : prefixToRelativePath + value;
+      const fullValueExists = FileUtils.fileExists(fullValue);
+      if (!fullValueExists && externalStorage.type != "") {
+        prepareValue("");
+        externalStorage.fetch(value, config["StorageAuthConfigId"]);
+      } else {
+        prepareValue(fullValue);
+      }
+    } else {
+      prepareValue("");
+    }
+  }
+
+  function prepareValue(fullValue) {
+    if (fullValue !== "") {
       var mimeType = FileUtils.mimeTypeName(fullValue);
       isImage = !config.UseLink && mimeType.startsWith("image/") && FileUtils.isImageMimeTypeSupported(mimeType);
       isAudio = !config.UseLink && mimeType.startsWith("audio/");
@@ -111,6 +125,10 @@ EditorWidgetBase {
   ExternalStorage {
     id: externalStorage
     type: config["StorageType"] !== undefined ? config["StorageType"] : ""
+
+    onFetchedContentChanged: {
+      prepareValue(fetchedContent);
+    }
   }
 
   ExpressionEvaluator {

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -129,6 +129,10 @@ EditorWidgetBase {
     onFetchedContentChanged: {
       prepareValue(fetchedContent);
     }
+
+    onLastErrorChanged: {
+      mainWindow.displayToast(lastError, 'error');
+    }
   }
 
   ExpressionEvaluator {


### PR DESCRIPTION
This PR implements a fetch-only (i.e. read-only) support for external storage-driven attachment editor widget, i.e. when a given attribute's editor widget is configured like this in QGIS:

![image](https://github.com/user-attachments/assets/6901b0c9-6e04-4f8a-99bb-865a099c76c6)

This is a nice step towards on-demand content for attachments, and increase our (already quite high) attribute form interoperability between QField and QGIS.