### PR TITLE
Do not hard-wipe the last rubberband coordinate when resetting

### DIFF
--- a/src/core/rubberbandmodel.cpp
+++ b/src/core/rubberbandmodel.cpp
@@ -319,7 +319,6 @@ void RubberbandModel::removeVertex()
 void RubberbandModel::reset()
 {
   removeVertices( 0, mPointList.size() - 1 );
-  mPointList.replace( 0, QgsPoint() );
 
   mFrozen = false;
   emit frozenChanged();


### PR DESCRIPTION
Fixes issue https://github.com/opengisch/QField/issues/6068 (and likely a few more unreported issues).

This essentially reverts a change that was made to accommodate our trackers' use of the rubber band model, but other changes made it safe to revert (based on multiple tests I've done today).