### PR TITLE
When the user de-activate positioning within a session, let the positioning service notification reflect that

### DIFF
--- a/src/service/qfieldpositioningservice.cpp
+++ b/src/service/qfieldpositioningservice.cpp
@@ -69,10 +69,15 @@ QFieldPositioningService::QFieldPositioningService( int &argc, char **argv )
         triggerShowNotification();
         mNotificationTimer.start();
       }
+      else
+      {
+        triggerReturnNotification();
+      }
     }
     else
     {
       mNotificationTimer.stop();
+      triggerStopNotification();
     }
   } );
 }
@@ -90,6 +95,15 @@ void QFieldPositioningService::triggerShowNotification()
 void QFieldPositioningService::triggerReturnNotification()
 {
   QJniObject message = QJniObject::fromString( tr( "Positioning service running" ) );
+  QJniObject::callStaticMethod<void>( "ch/opengis/" APP_PACKAGE_NAME "/QFieldPositioningService",
+                                      "triggerShowNotification",
+                                      message.object<jstring>(),
+                                      false );
+}
+
+void QFieldPositioningService::triggerStopNotification()
+{
+  QJniObject message = QJniObject::fromString( tr( "Positioning service stopped" ) );
   QJniObject::callStaticMethod<void>( "ch/opengis/" APP_PACKAGE_NAME "/QFieldPositioningService",
                                       "triggerShowNotification",
                                       message.object<jstring>(),

--- a/src/service/qfieldpositioningservice.h
+++ b/src/service/qfieldpositioningservice.h
@@ -37,6 +37,7 @@ class QFIELD_SERVICE_EXPORT QFieldPositioningService : public QAndroidService
   private slots:
     void triggerShowNotification();
     void triggerReturnNotification();
+    void triggerStopNotification();
 
   private:
     PositioningSource *mPositioningSource = nullptr;


### PR DESCRIPTION
ATM, when we turn positioning off (long press on the positioning button -> uncheck [x] enable positioning), Android users might be mislead into thinking the positioning is still on as the service's notification isn't updated. Let's do that so users feel like they are achieving what they want.