### PR TITLE
Fix esc/back key not closing the QFieldCloud push/synchronize popup

### DIFF
--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -690,8 +690,9 @@ Rectangle {
   Keys.onReleased: event => {
     if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
       // if visible overlays (such as embedded feature forms) are present, don't take over
-      if (Overlay.overlay && Overlay.overlay.visibleChildren.length > 1 || (Overlay.overlay.visibleChildren.length === 1 && !toast.visible))
+      if (Overlay.overlay && Overlay.overlay.visibleChildren.length > 1 || (Overlay.overlay.visibleChildren.length === 1 && !toast.visible)) {
         return;
+      }
       if (state != "FeatureList") {
         if (featureListToolBar.state === "Edit") {
           featureForm.requestCancel();

--- a/src/qml/QFieldSketcher.qml
+++ b/src/qml/QFieldSketcher.qml
@@ -22,11 +22,7 @@ Popup {
   padding: 0
 
   closePolicy: Popup.CloseOnEscape
-  dim: true
-
-  onOpened: {
-    contentItem.forceActiveFocus();
-  }
+  focus: visible
 
   Settings {
     id: settings

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -4189,6 +4189,8 @@ ApplicationWindow {
   QFieldSketcher {
     id: sketcher
     visible: false
+
+    Component.onCompleted: focusstack.addFocusTaker(this)
   }
 
   Connections {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -4115,6 +4115,8 @@ ApplicationWindow {
 
     width: parent.width
     height: parent.height
+
+    Component.onCompleted: focusstack.addFocusTaker(this)
   }
 
   QFieldCloudPackageLayersFeedback {


### PR DESCRIPTION
Now that our ESC/back key behavior works reliably, the missing parts stand out that much more. This one _deserves_ fixing.