### PR TITLE
Refactor Menu Implementation with `QfMenu` Component

### DIFF
--- a/src/qml/About.qml
+++ b/src/qml/About.qml
@@ -189,20 +189,9 @@ Item {
     }
   }
 
-  Menu {
+  QfMenu {
     id: linksMenu
     title: qsTr("Links Menu")
-
-    width: {
-      var result = 0;
-      var padding = 0;
-      for (var i = 0; i < count; ++i) {
-        var item = itemAt(i);
-        result = Math.max(item.contentItem.implicitWidth, result);
-        padding = Math.max(item.padding, padding);
-      }
-      return result + padding * 2;
-    }
 
     MenuItem {
       text: qsTr('Changelog')

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -367,20 +367,9 @@ Popup {
     }
   }
 
-  Menu {
+  QfMenu {
     id: showFeaturesMenu
     title: qsTr("Show Features Menu")
-
-    width: {
-      var result = 0;
-      var padding = 0;
-      for (var i = 0; i < count; ++i) {
-        var item = itemAt(i);
-        result = Math.max(item.contentItem.implicitWidth, result);
-        padding = Math.max(item.padding, padding);
-      }
-      return result + padding * 2;
-    }
 
     MenuItem {
       text: qsTr('Show visible features list')

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -483,20 +483,9 @@ Rectangle {
     }
   }
 
-  Menu {
+  QfMenu {
     id: featureListMenu
     title: qsTr("Feature List Menu")
-
-    width: {
-      let result = 50;
-      let padding = 0;
-      for (let i = 0; i < count; ++i) {
-        let item = itemAt(i);
-        result = Math.max(item.contentItem.implicitWidth, result);
-        padding = Math.max(item.leftPadding + item.rightPadding, padding);
-      }
-      return mainWindow.width > 0 ? Math.min(result + padding, mainWindow.width - 20) : result + padding;
-    }
 
     topMargin: mainWindow.sceneTopMargin
     bottomMargin: mainWindow.sceneBottomMargin
@@ -613,24 +602,12 @@ Rectangle {
     }
   }
 
-  Menu {
+  QfMenu {
     id: featureMenu
     title: qsTr("Feature Menu")
 
     topMargin: mainWindow.sceneTopMargin
     bottomMargin: mainWindow.sceneBottomMargin
-
-    width: {
-      const toolbarWidth = featureMenuActionsToolbar.childrenRect.width + 4;
-      let result = 50;
-      let padding = 0;
-      for (let i = 1; i < count; ++i) {
-        let item = itemAt(i);
-        result = Math.max(item.contentItem.implicitWidth, result);
-        padding = Math.max(item.leftPadding + item.rightPadding, padding);
-      }
-      return mainWindow.width > 0 ? Math.min(result + padding, mainWindow.width - 20) : result + padding;
-    }
 
     Row {
       id: featureMenuActionsToolbar
@@ -816,7 +793,7 @@ Rectangle {
     }
   }
 
-  Menu {
+  QfMenu {
     id: atlasMenu
 
     property alias printTimer: timer
@@ -825,17 +802,6 @@ Rectangle {
     title: qsTr("Print Atlas Feature(s)")
 
     signal enablePrintItem(int rows)
-
-    width: {
-      let result = 50;
-      let padding = 0;
-      for (let i = 0; i < count; ++i) {
-        let item = itemAt(i);
-        result = Math.max(item.contentItem.implicitWidth, result);
-        padding = Math.max(item.leftPadding + item.rightPadding, padding);
-      }
-      return mainWindow.width > 0 ? Math.min(result + padding, mainWindow.width - 20) : result + padding;
-    }
 
     topMargin: mainWindow.sceneTopMargin
     bottomMargin: mainWindow.sceneBottomMargin

--- a/src/qml/PluginManagerSettings.qml
+++ b/src/qml/PluginManagerSettings.qml
@@ -204,20 +204,9 @@ Popup {
         }
       }
 
-      Menu {
+      QfMenu {
         id: pluginsManagementMenu
         title: qsTr('Plugins management menu')
-
-        width: {
-          let result = 50;
-          let padding = 0;
-          for (let i = 0; i < count; ++i) {
-            let item = itemAt(i);
-            result = Math.max(item.contentItem.implicitWidth, result);
-            padding = Math.max(item.leftPadding + item.rightPadding, padding);
-          }
-          return mainWindow.width > 0 ? Math.min(result + padding, mainWindow.width - 20) : result + padding;
-        }
 
         MenuItem {
           text: qsTr('Clear remembered permissions')

--- a/src/qml/QFieldCamera.qml
+++ b/src/qml/QFieldCamera.qml
@@ -645,23 +645,12 @@ Popup {
       }
     }
 
-    Menu {
+    QfMenu {
       id: cameraSelectionMenu
 
       topMargin: sceneTopMargin
       bottomMargin: sceneBottomMargin
       z: 10000 // 1000s are embedded feature forms, use higher value
-
-      width: {
-        let result = 50;
-        let padding = 0;
-        for (let i = 0; i < count; ++i) {
-          let item = itemAt(i);
-          result = Math.max(item.contentItem.implicitWidth, result);
-          padding = Math.max(item.leftPadding + item.rightPadding, padding);
-        }
-        return mainWindow.width > 0 ? Math.min(result + padding, mainWindow.width - 20) : 0;
-      }
 
       Repeater {
         model: mediaDevices.videoInputs
@@ -693,23 +682,12 @@ Popup {
       }
     }
 
-    Menu {
+    QfMenu {
       id: resolutionSelectionMenu
 
       topMargin: sceneTopMargin
       bottomMargin: sceneBottomMargin
       z: 10000 // 1000s are embedded feature forms, use higher value
-
-      width: {
-        let result = 50;
-        let padding = 0;
-        for (let i = 0; i < count; ++i) {
-          let item = itemAt(i);
-          result = Math.max(item.contentItem.implicitWidth, result);
-          padding = Math.max(item.leftPadding + item.rightPadding, padding);
-        }
-        return mainWindow.width > 0 ? Math.min(result + padding, mainWindow.width - 20) : 0;
-      }
 
       function ratioFromResolution(resolution) {
         let smallerValue = Math.min(resolution.width, resolution.height);

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -482,7 +482,7 @@ Page {
         }
       }
 
-      Menu {
+      QfMenu {
         id: projectActions
 
         property string projectId: ''
@@ -491,17 +491,6 @@ Page {
         property string projectLocalPath: ''
 
         title: qsTr('Project Actions')
-
-        width: {
-          let result = 50;
-          let padding = 0;
-          for (let i = 0; i < count; ++i) {
-            let item = itemAt(i);
-            result = Math.max(item.contentItem.implicitWidth, result);
-            padding = Math.max(item.leftPadding + item.rightPadding, padding);
-          }
-          return mainWindow.width > 0 ? Math.min(result + padding, mainWindow.width - 20) : result + padding;
-        }
 
         topMargin: mainWindow.sceneTopMargin
         bottomMargin: mainWindow.sceneBottomMargin

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -53,17 +53,6 @@ Page {
     }
   }
 
-  function determineMenuWidth(menu) {
-    let result = 50;
-    let padding = 0;
-    for (let i = 0; i < menu.count; ++i) {
-      let item = menu.itemAt(i);
-      result = Math.max(item.contentItem.implicitWidth, result);
-      padding = Math.max(item.leftPadding + item.rightPadding, padding);
-    }
-    return mainWindow.width > 0 ? Math.min(result + padding * 2, mainWindow.width - 20) : result + padding;
-  }
-
   ColumnLayout {
     id: files
     anchors.fill: parent
@@ -437,7 +426,7 @@ Page {
       }
     }
 
-    Menu {
+    QfMenu {
       id: itemMenu
 
       property int itemMetaType: 0
@@ -448,10 +437,9 @@ Page {
 
       title: qsTr('Item Actions')
 
-      width: determineMenuWidth(itemMenu)
-
       topMargin: sceneTopMargin
       bottomMargin: sceneBottomMargin
+      paddingMultiplier: 2
 
       // File items
       MenuItem {
@@ -642,15 +630,14 @@ Page {
       }
     }
 
-    Menu {
+    QfMenu {
       id: importMenu
 
       title: qsTr('Import Actions')
 
-      width: determineMenuWidth(importMenu)
-
       topMargin: sceneTopMargin
       bottomMargin: sceneBottomMargin
+      paddingMultiplier: 2
 
       MenuItem {
         id: importProjectFromFolder
@@ -756,15 +743,14 @@ Page {
       }
     }
 
-    Menu {
+    QfMenu {
       id: projectMenu
 
       title: qsTr('Project Actions')
 
-      width: determineMenuWidth(projectMenu)
-
       topMargin: sceneTopMargin
       bottomMargin: sceneBottomMargin
+      paddingMultiplier: 2
 
       MenuItem {
         id: updateProjectFromArchive
@@ -821,10 +807,10 @@ Page {
       }
     }
 
-    Menu {
+    QfMenu {
       id: selectionMenu
       x: parent.width - width - 8
-      width: determineMenuWidth(selectionMenu)
+      paddingMultiplier: 2
 
       MenuItem {
         id: uploadToWebdav

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -685,24 +685,13 @@ Page {
                 }
               }
 
-              Menu {
+              QfMenu {
                 id: recentProjectActions
 
                 property string recentProjectPath: ''
                 property int recentProjectType: 0
 
                 title: qsTr('Recent Project Actions')
-
-                width: {
-                  let result = 50;
-                  let padding = 0;
-                  for (let i = 0; i < count; ++i) {
-                    let item = itemAt(i);
-                    result = Math.max(item.contentItem.implicitWidth, result);
-                    padding = Math.max(item.leftPadding + item.rightPadding, padding);
-                  }
-                  return mainWindow.width > 0 ? Math.min(result + padding, mainWindow.width - 20) : result + padding;
-                }
 
                 topMargin: mainWindow.sceneTopMargin
                 bottomMargin: mainWindow.sceneBottomMargin

--- a/src/qml/editorwidgets/EditorWidgetBase.qml
+++ b/src/qml/editorwidgets/EditorWidgetBase.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import Theme
 
 Item {
   /**
@@ -10,21 +11,10 @@ Item {
   property bool isLoaded: false
   property bool hasMenu: false
 
-  property Menu menu: Menu {
+  property Menu menu: QfMenu {
     id: itemMenu
     title: qsTr("Item Menu")
     z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes
-
-    width: {
-      let result = 50;
-      let padding = 0;
-      for (var i = 0; i < count; ++i) {
-        let item = itemAt(i);
-        result = Math.max(item.contentItem.implicitWidth, result);
-        padding = Math.max(item.leftPadding + item.rightPadding, padding);
-      }
-      return mainWindow.width > 0 ? Math.min(result + padding, mainWindow.width - 20) : result + padding;
-    }
 
     topMargin: mainWindow.sceneTopMargin
     bottomMargin: mainWindow.sceneBottomMargin

--- a/src/qml/editorwidgets/RelationEditorBase.qml
+++ b/src/qml/editorwidgets/RelationEditorBase.qml
@@ -215,7 +215,7 @@ EditorWidgetBase {
     }
   }
 
-  property Menu childMenu: Menu {
+  property Menu childMenu: QfMenu {
     id: childMenu
     title: qsTr("Child Menu")
     z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes
@@ -227,17 +227,6 @@ EditorWidgetBase {
 
     onAboutToShow: {
       atlasMenuLoader.enabled = true;
-    }
-
-    width: {
-      let result = 50;
-      let padding = 0;
-      for (var i = 0; i < count; ++i) {
-        let item = itemAt(i);
-        result = Math.max(item.contentItem.implicitWidth, result);
-        padding = Math.max(item.leftPadding + item.rightPadding, padding);
-      }
-      return mainWindow.width > 0 ? Math.min(result + padding, mainWindow.width - 20) : result + padding;
     }
 
     topMargin: mainWindow.sceneTopMargin
@@ -304,7 +293,7 @@ EditorWidgetBase {
     id: atlasMenuLoader
     enabled: false
     sourceComponent: Component {
-      Menu {
+      QfMenu {
         id: atlasMenu
 
         property alias printInstantiator: atlasListInstantiator
@@ -314,17 +303,6 @@ EditorWidgetBase {
         title: qsTr("Print Atlas Feature(s)")
 
         signal enablePrintItem(int rows)
-
-        width: {
-          let result = 50;
-          let padding = 0;
-          for (let i = 0; i < count; ++i) {
-            let item = itemAt(i);
-            result = Math.max(item.contentItem.implicitWidth, result);
-            padding = Math.max(item.leftPadding + item.rightPadding, padding);
-          }
-          return mainWindow.width > 0 ? Math.min(result + padding, mainWindow.width - 20) : result + padding;
-        }
 
         topMargin: mainWindow.sceneTopMargin
         bottomMargin: mainWindow.sceneBottomMargin

--- a/src/qml/imports/Theme/QfMenu.qml
+++ b/src/qml/imports/Theme/QfMenu.qml
@@ -10,7 +10,7 @@ Menu {
     let result = 50;
     let padding = 0;
     for (let i = 0; i < control.count; ++i) {
-      let item = control.itemAt(i);
+      const item = control.itemAt(i);
       if (item) {
         if (item.contentItem) {
           result = Math.max(item.contentItem.implicitWidth, result);

--- a/src/qml/imports/Theme/QfMenu.qml
+++ b/src/qml/imports/Theme/QfMenu.qml
@@ -11,8 +11,12 @@ Menu {
     let padding = 0;
     for (let i = 0; i < control.count; ++i) {
       let item = control.itemAt(i);
-      result = Math.max(item.contentItem.implicitWidth, result);
-      padding = Math.max(item.leftPadding + item.rightPadding, padding);
+      if (item) {
+        if (item.contentItem) {
+          result = Math.max(item.contentItem.implicitWidth, result);
+        }
+        padding = Math.max(item.leftPadding + item.rightPadding, padding);
+      }
     }
     return mainWindow.width > 0 ? Math.min(result + padding * paddingMultiplier, mainWindow.width - 20) : result + padding;
   }

--- a/src/qml/imports/Theme/QfMenu.qml
+++ b/src/qml/imports/Theme/QfMenu.qml
@@ -1,0 +1,19 @@
+import QtQuick
+import QtQuick.Controls
+
+Menu {
+  id: control
+
+  property int paddingMultiplier: 1
+
+  width: {
+    let result = 50;
+    let padding = 0;
+    for (let i = 0; i < control.count; ++i) {
+      let item = control.itemAt(i);
+      result = Math.max(item.contentItem.implicitWidth, result);
+      padding = Math.max(item.leftPadding + item.rightPadding, padding);
+    }
+    return mainWindow.width > 0 ? Math.min(result + padding * paddingMultiplier, mainWindow.width - 20) : result + padding;
+  }
+}

--- a/src/qml/imports/Theme/QfMenu.qml
+++ b/src/qml/imports/Theme/QfMenu.qml
@@ -5,11 +5,14 @@ Menu {
   id: control
 
   property int paddingMultiplier: 1
+  property bool skipFirstRow: false
+  property real minimumRowWidth: 50
 
   width: {
-    let result = 50;
+    let result = minimumRowWidth;
     let padding = 0;
-    for (let i = 0; i < control.count; ++i) {
+    const initialRow = skipFirstRow ? 1 : 0;
+    for (let i = initialRow; i < control.count; ++i) {
       const item = control.itemAt(i);
       if (item) {
         if (item.contentItem) {

--- a/src/qml/imports/Theme/qmldir
+++ b/src/qml/imports/Theme/qmldir
@@ -21,3 +21,4 @@ QfScrollBar 1.0 QfScrollBar.qml
 QfSearchBar 1.0 QfSearchBar.qml
 QfVisibilityFadingRow 1.0 QfVisibilityFadingRow.qml
 QfDialog 1.0 QfDialog.qml
+QfMenu 1.0 QfMenu.qml

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2605,24 +2605,14 @@ ApplicationWindow {
     changeMode('measure');
   }
 
-  Menu {
+  QfMenu {
     id: mainMenu
     title: qsTr("Main Menu")
 
     topMargin: sceneTopMargin
     bottomMargin: sceneBottomMargin
-
-    width: {
-      let result = Math.max(50, undoRedoMetrics.width + undoButton.leftPadding * 2 + undoButton.rightPadding * 2 + 42 * 2);
-      let padding = 0;
-      // Skip first Row item
-      for (let i = 1; i < count; ++i) {
-        const item = itemAt(i);
-        result = Math.max(item.contentItem.implicitWidth, result);
-        padding = Math.max(item.leftPadding + item.rightPadding, padding);
-      }
-      return mainWindow.width > 0 ? Math.min(result + padding, mainWindow.width - 20) : result + padding;
-    }
+    skipFirstRow: true
+    minimumRowWidth: Math.max(50, undoRedoMetrics.width + undoButton.leftPadding * 2 + undoButton.rightPadding * 2 + 42 * 2)
 
     TextMetrics {
       id: undoRedoMetrics
@@ -2933,7 +2923,7 @@ ApplicationWindow {
     }
   }
 
-  Menu {
+  QfMenu {
     id: canvasMenu
     objectName: "canvasMenu"
 
@@ -2956,19 +2946,8 @@ ApplicationWindow {
 
     topMargin: sceneTopMargin
     bottomMargin: sceneBottomMargin
-
-    width: {
-      const toolbarWidth = canvasMenuActionsToolbar.childrenRect.width + 4;
-      let result = 0;
-      let padding = 0;
-      // Skip first Row item
-      for (let i = 1; i < count; ++i) {
-        const item = itemAt(i);
-        result = Math.max(item.contentItem.implicitWidth, result);
-        padding = Math.max(item.padding, padding);
-      }
-      return Math.min(Math.max(toolbarWidth, result + padding * 2), mainWindow.width - 20);
-    }
+    skipFirstRow: true
+    minimumRowWidth: canvasMenuActionsToolbar.childrenRect.width + 4
 
     Row {
       id: canvasMenuActionsToolbar

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2810,7 +2810,7 @@ ApplicationWindow {
     }
   }
 
-  Menu {
+  QfMenu {
     id: sensorMenu
 
     property alias printTimer: timer
@@ -2820,17 +2820,6 @@ ApplicationWindow {
 
     topMargin: sceneTopMargin
     bottomMargin: sceneBottomMargin
-
-    width: {
-      let result = 50;
-      let padding = 0;
-      for (let i = 0; i < count; ++i) {
-        let item = itemAt(i);
-        result = Math.max(item.contentItem.implicitWidth, result);
-        padding = Math.max(item.leftPadding + item.rightPadding, padding);
-      }
-      return mainWindow.width > 0 ? Math.min(result + padding, mainWindow.width - 20) : result + padding;
-    }
 
     MenuItem {
       text: qsTr('Select sensor below')
@@ -2883,7 +2872,7 @@ ApplicationWindow {
     }
   }
 
-  Menu {
+  QfMenu {
     id: printMenu
 
     property alias printTimer: timer
@@ -2893,17 +2882,6 @@ ApplicationWindow {
 
     topMargin: sceneTopMargin
     bottomMargin: sceneBottomMargin
-
-    width: {
-      let result = 50;
-      let padding = 0;
-      for (let i = 0; i < count; ++i) {
-        let item = itemAt(i);
-        result = Math.max(item.contentItem.implicitWidth, result);
-        padding = Math.max(item.leftPadding + item.rightPadding, padding);
-      }
-      return mainWindow.width > 0 ? Math.min(result + padding, mainWindow.width - 20) : result + padding;
-    }
 
     MenuItem {
       text: qsTr('Select layout below')
@@ -3109,7 +3087,7 @@ ApplicationWindow {
         id: canvasMenuFeatureListModel
       }
 
-      Menu {
+      QfMenu {
         id: featureMenu
 
         property int fid: featureId
@@ -3120,17 +3098,6 @@ ApplicationWindow {
 
         title: layerName + ': ' + featureName
         font: Theme.defaultFont
-
-        width: {
-          let result = 50;
-          let padding = 0;
-          for (let i = 0; i < count; ++i) {
-            let item = itemAt(i);
-            result = Math.max(item.contentItem.implicitWidth, result);
-            padding = Math.max(item.leftPadding + item.rightPadding, padding);
-          }
-          return mainWindow.width > 0 ? Math.min(result + padding, mainWindow.width - 20) : result + padding;
-        }
 
         Component.onCompleted: {
           if (featureMenu.icon !== undefined) {
@@ -3214,24 +3181,13 @@ ApplicationWindow {
     }
   }
 
-  Menu {
+  QfMenu {
     id: navigationMenu
     title: qsTr("Navigation Options")
     font: Theme.defaultFont
 
     topMargin: sceneTopMargin
     bottomMargin: sceneBottomMargin
-
-    width: {
-      let result = 50;
-      let padding = 0;
-      for (let i = 0; i < count; ++i) {
-        let item = itemAt(i);
-        result = Math.max(item.contentItem.implicitWidth, result);
-        padding = Math.max(item.leftPadding + item.rightPadding, padding);
-      }
-      return mainWindow.width > 0 ? Math.min(result + padding, mainWindow.width - 20) : result + padding;
-    }
 
     MenuItem {
       id: preciseViewItem
@@ -3282,24 +3238,14 @@ ApplicationWindow {
     }
   }
 
-  Menu {
+  QfMenu {
     id: preciseViewMenu
     title: qsTr("Precise View Settings")
     font: Theme.defaultFont
 
     topMargin: sceneTopMargin
     bottomMargin: sceneBottomMargin
-
-    width: {
-      let result = 50;
-      let padding = 0;
-      for (let i = 0; i < count; ++i) {
-        let item = itemAt(i);
-        result = Math.max(item.contentItem.implicitWidth, result);
-        padding = Math.max(item.leftPadding + item.rightPadding, padding);
-      }
-      return mainWindow.width > 0 ? Math.min(result + padding * 2, mainWindow.width - 20) : result + padding;
-    }
+    paddingMultiplier: 2
 
     MenuItem {
       text: qsTr("%1 Precision").arg(UnitTypes.formatDistance(0.10, 2, projectInfo.distanceUnits))
@@ -3455,24 +3401,13 @@ ApplicationWindow {
     }
   }
 
-  Menu {
+  QfMenu {
     id: gnssMenu
     title: qsTr("Positioning Options")
     font: Theme.defaultFont
 
     topMargin: sceneTopMargin
     bottomMargin: sceneBottomMargin
-
-    width: {
-      let result = 50;
-      let padding = 0;
-      for (let i = 0; i < count; ++i) {
-        let item = itemAt(i);
-        result = Math.max(item.contentItem.implicitWidth, result);
-        padding = Math.max(item.leftPadding + item.rightPadding, padding);
-      }
-      return mainWindow.width > 0 ? Math.min(result + padding, mainWindow.width - 20) : result + padding;
-    }
 
     MenuItem {
       id: positioningDeviceName

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -126,5 +126,6 @@
         <file>imports/Theme/QfScrollBar.qml</file>
         <file>imports/Theme/QfSearchBar.qml</file>
         <file>imports/Theme/QfDialog.qml</file>
+        <file>imports/Theme/QfMenu.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
# Pull Request Description

### Summary:
This pull request introduces the `QfMenu` QML item, which consolidates and simplifies the implementation of multiple menus across the application. By replacing redundant code in various menu components, we have streamlined the menu structure and improved code maintainability.

### Changes Made:
- Created `QfMenu` component to encapsulate menu width.

#### Before Refactoring:
The previous menu implementation required extensive code to calculate properties such as width. For example:
```qml
Menu {
    id: linksMenu
    title: qsTr("Links Menu")

    width: {
        var result = 0;
        var padding = 0;
        for (var i = 0; i < count; ++i) {
            var item = itemAt(i);
            result = Math.max(item.contentItem.implicitWidth, result);
            padding = Math.max(item.padding, padding);
        }
        return result + padding * 2;
    }
}
```

#### After Refactoring:
Menus can now be defined simply with:
```qml
QfMenu {
    id: linksMenu
    title: qsTr("Links Menu")
}
```