### PR TITLE
Overlay to Block UI Interaction During Busy State.

### DIFF
--- a/src/qml/BusyOverlay.qml
+++ b/src/qml/BusyOverlay.qml
@@ -133,4 +133,16 @@ Rectangle {
     id: busyMessageFontMetrics
     font: busyMessage.font
   }
+
+  MouseArea {
+    id: busyOverlayCatcher
+    anchors.fill: parent
+    enabled: busyOverlay.visible
+
+    onClicked: mouse => {
+      // Needed to avoid people interacting with the UI while the busy overlay is visible
+      // (e.g. while uploading to webDAV, users shouldn't be allowed to select other files or navigate to other pages)
+      return;
+    }
+  }
 }


### PR DESCRIPTION
# Pull Request Description
### Summary:
This pull request introduces a `MouseArea` overlay within the `BusyOverlay.qml` component to prevent user interaction with the UI while a busy overlay is displayed. The overlay is specifically designed to block interactions during critical operations, such as file uploads to webDAV, ensuring a seamless and error-free user experience.

### Changes Made:
- Added a `MouseArea` called `busyOverlayCatcher` that fills the parent area of the `BusyOverlay.qml`.
- The `enabled` property of `MouseArea` is set to `busyOverlay.visible`, ensuring that it only activates when the busy overlay is visible.
- Implemented an `onClicked` signal handler that effectively suppresses any interaction by returning early when the overlay is active. This disallows users from selecting other files or navigating to different pages during the upload process.