### PR TITLE
Backport crucial Qt 6.8.3 fixes to our overlay Qt ports

### DIFF
--- a/vcpkg/ports/qtbase/android_cursor_location.patch
+++ b/vcpkg/ports/qtbase/android_cursor_location.patch
@@ -1,0 +1,116 @@
+From 154560df217475825651682e463fccea5affcdd8 Mon Sep 17 00:00:00 2001
+From: Bartlomiej Moskal <bartlomiej.moskal@qt.io>
+Date: Wed, 5 Feb 2025 12:20:46 +0100
+Subject: [PATCH] Android: Fix cursorHandle and EditPopup positions
+
+After the commit 28df9a49776a88cb1a8e69348ae19a59b16a5b7e, a regression
+occurred in the positioning of cursorHandle and EditPopup.
+
+Previously, these positions were calculated using QtEditText
+coordinates, which worked correctly because the QtEditText size matched
+the QtWindow size. However, after the mentioned commit, the QtEditText
+size no longer reflects the window size. In this case, we need to use
+the parent View for calculations.
+
+This adjustment was already made for the single cursorHandle.
+
+This commit also updates the positioning of selection handles and the EditPopup.
+
+Fixes: QTBUG-132589
+Change-Id: I861292e363452d487284e3f603fe03a21a334aa4
+Reviewed-by: Assam Boudjelthia <assam.boudjelthia@qt.io>
+(cherry picked from commit 5bd26fda7a3f0a509a64847b58b916830ebc2d0c)
+Reviewed-by: Qt Cherry-pick Bot <cherrypick_bot@qt-project.org>
+(cherry picked from commit 941434e81fe073d55607267ea839025282413900)
+---
+ .../jar/src/org/qtproject/qt/android/CursorHandle.java    | 12 ++++++++++--
+ .../jar/src/org/qtproject/qt/android/EditPopupMenu.java   | 15 +++++++++++----
+ .../jar/src/org/qtproject/qt/android/QtEditText.java      |  2 +-
+ 3 files changed, 22 insertions(+), 7 deletions(-)
+
+diff --git a/src/android/jar/src/org/qtproject/qt/android/CursorHandle.java b/src/android/jar/src/org/qtproject/qt/android/CursorHandle.java
+index 519fe86968d3..79e25ea977aa 100644
+--- a/src/android/jar/src/org/qtproject/qt/android/CursorHandle.java
++++ b/src/android/jar/src/org/qtproject/qt/android/CursorHandle.java
+@@ -133,7 +133,15 @@ class CursorHandle implements ViewTreeObserver.OnPreDrawListener
+         initOverlay();
+ 
+         final int[] layoutLocation = new int[2];
+-        m_layout.getLocationOnScreen(layoutLocation);
++
++        // m_layout is QtEditText. Since it doesn't match the QtWindow size, we should use its
++        // parent for cursorHandle positioning. However, there may be cases where the parent is
++        // not set. In such cases, we need to use QtEditText instead.
++        View positioningView = (View) m_layout.getParent();
++        if (positioningView == null)
++            positioningView = m_layout;
++
++        positioningView.getLocationOnScreen(layoutLocation);
+ 
+         // These values are used for handling split screen case
+         final int[] activityLocation = new int[2];
+@@ -156,7 +164,7 @@ class CursorHandle implements ViewTreeObserver.OnPreDrawListener
+             m_popup.update(x2, y2, -1, -1);
+             m_cursorView.adjusted(x - m_posX, y - m_posY);
+         } else {
+-            m_popup.showAtLocation(m_layout, 0, x2, y2);
++            m_popup.showAtLocation(positioningView, 0, x2, y2);
+         }
+ 
+         m_posX = x;
+diff --git a/src/android/jar/src/org/qtproject/qt/android/EditPopupMenu.java b/src/android/jar/src/org/qtproject/qt/android/EditPopupMenu.java
+index cd107ab4882a..885c43225d2f 100644
+--- a/src/android/jar/src/org/qtproject/qt/android/EditPopupMenu.java
++++ b/src/android/jar/src/org/qtproject/qt/android/EditPopupMenu.java
+@@ -58,7 +58,14 @@ class EditPopupMenu implements ViewTreeObserver.OnPreDrawListener, View.OnLayout
+         Point viewSize = m_view.getCalculatedSize();
+ 
+         final int[] layoutLocation = new int[2];
+-        m_editText.getLocationOnScreen(layoutLocation);
++
++        // Since QtEditText doesn't match the QtWindow size, we should use its parent for
++        // EditPopupMenu positioning. However, there may be cases where the parent is
++        // not set. In such cases, we need to use QtEditText instead.
++        View positioningView = (View) m_editText.getParent();
++        if (positioningView == null)
++            positioningView = m_editText;
++        positioningView.getLocationOnScreen(layoutLocation);
+ 
+         // These values are used for handling split screen case
+         final int[] activityLocation = new int[2];
+@@ -88,8 +95,8 @@ class EditPopupMenu implements ViewTreeObserver.OnPreDrawListener, View.OnLayout
+             }
+         }
+ 
+-        if (m_editText.getWidth() < x + viewSize.x / 2)
+-            x2 = m_editText.getWidth() - viewSize.x;
++        if (positioningView.getWidth() < x + viewSize.x / 2)
++            x2 = positioningView.getWidth() - viewSize.x;
+ 
+         if (x2 < 0)
+             x2 = 0;
+@@ -97,7 +104,7 @@ class EditPopupMenu implements ViewTreeObserver.OnPreDrawListener, View.OnLayout
+         if (m_popup.isShowing())
+             m_popup.update(x2, y2, -1, -1);
+         else
+-            m_popup.showAtLocation(m_editText, 0, x2, y2);
++            m_popup.showAtLocation(positioningView, 0, x2, y2);
+ 
+         m_posX = x;
+         m_posY = y;
+diff --git a/src/android/jar/src/org/qtproject/qt/android/QtEditText.java b/src/android/jar/src/org/qtproject/qt/android/QtEditText.java
+index 69126192169c..edff72d6937d 100644
+--- a/src/android/jar/src/org/qtproject/qt/android/QtEditText.java
++++ b/src/android/jar/src/org/qtproject/qt/android/QtEditText.java
+@@ -267,7 +267,7 @@ class QtEditText extends View
+             break;
+         case CursorHandleShowNormal:
+             if (m_cursorHandle == null) {
+-                m_cursorHandle = new CursorHandle((Activity) getContext(), (View) getParent(),
++                m_cursorHandle = new CursorHandle((Activity) getContext(), this,
+                         CursorHandle.IdCursorHandle,
+                         android.R.attr.textSelectHandle, false);
+             }
+-- 
+2.16.3
+

--- a/vcpkg/ports/qtbase/bluetooth_mouse_fix.patch
+++ b/vcpkg/ports/qtbase/bluetooth_mouse_fix.patch
@@ -1,0 +1,141 @@
+From a3203542dced8b679633e666ff008ba5f017e827 Mon Sep 17 00:00:00 2001
+From: Andrew Forrest <andrewkforrest@gmail.com>
+Date: Mon, 3 Feb 2025 16:10:15 +0000
+Subject: [PATCH] Android: Fix mouse button processing
+
+Fixes clicking UI elements with a mouse on Android.
+
+8d8cbe87e21f05b7d611ed4be47299977288b267 introduced changes to support
+mouse buttons other than Qt::LeftButton, but the release always looked
+like no buttons changed, nor were they tracked (m_buttons is always
+Qt::NoButton). Qt was not notified of mouse up, so nothing was clickable.
+
+Now all mouse events go through sendMouseButtonEvents, and the last seen
+button state is tracked for every event. If a mouse up with no buttons
+occurs, the last seen set of buttons is used instead, so Qt correctly
+handles the event. Also adds the mouse button state information to
+mouse move events from Android, so the workaround for delivering
+Qt::LeftButton when a window is tracking a move while a button is
+pressed has been removed.
+
+Tested on a Samsung A1 with a Bluetooth mouse.
+
+Fixes: QTBUG-132700
+Fixes: QTBUG-130297
+Change-Id: I241282c2915d7e6cf99db7f0bc1ad2d541349077
+Reviewed-by: Assam Boudjelthia <assam.boudjelthia@qt.io>
+(cherry picked from commit d908e043984dcfed3aa80e30cd1cafacd13b644d)
+Reviewed-by: Qt Cherry-pick Bot <cherrypick_bot@qt-project.org>
+(cherry picked from commit 65e9eca63b3f522065018777ac07c5a71c08ff37)
+---
+ .../org/qtproject/qt/android/QtInputDelegate.java  |  6 ++--
+ src/plugins/platforms/android/androidjniinput.cpp  | 32 +++++++++++-----------
+ 2 files changed, 19 insertions(+), 19 deletions(-)
+
+diff --git a/src/android/jar/src/org/qtproject/qt/android/QtInputDelegate.java b/src/android/jar/src/org/qtproject/qt/android/QtInputDelegate.java
+index 89f2529ab870..2531942de565 100644
+--- a/src/android/jar/src/org/qtproject/qt/android/QtInputDelegate.java
++++ b/src/android/jar/src/org/qtproject/qt/android/QtInputDelegate.java
+@@ -517,7 +517,7 @@ class QtInputDelegate implements QtInputConnection.QtInputConnectionListener, Qt
+     // pointer methods
+     static native void mouseDown(int winId, int x, int y, int mouseButtonState);
+     static native void mouseUp(int winId, int x, int y, int mouseButtonState);
+-    static native void mouseMove(int winId, int x, int y);
++    static native void mouseMove(int winId, int x, int y, int mouseButtonState);
+     static native void mouseWheel(int winId, int x, int y, float hDelta, float vDelta);
+     static native void touchBegin(int winId);
+     static native void touchAdd(int winId, int pointerId, int action, boolean primary,
+@@ -643,12 +643,12 @@ class QtInputDelegate implements QtInputConnection.QtInputConnectionListener, Qt
+             case MotionEvent.ACTION_HOVER_MOVE:
+             case MotionEvent.ACTION_MOVE:
+                 if (event.getToolType(0) == MotionEvent.TOOL_TYPE_MOUSE) {
+-                    mouseMove(id, (int) event.getX(), (int) event.getY());
++                    mouseMove(id, (int) event.getX(), (int) event.getY(), event.getButtonState());
+                 } else {
+                     int dx = (int) (event.getX() - m_oldX);
+                     int dy = (int) (event.getY() - m_oldY);
+                     if (Math.abs(dx) > 5 || Math.abs(dy) > 5) {
+-                        mouseMove(id, (int) event.getX(), (int) event.getY());
++                        mouseMove(id, (int) event.getX(), (int) event.getY(), event.getButtonState());
+                         m_oldX = (int) event.getX();
+                         m_oldY = (int) event.getY();
+                     }
+diff --git a/src/plugins/platforms/android/androidjniinput.cpp b/src/plugins/platforms/android/androidjniinput.cpp
+index a0faedcc5b2f..461b2da51c96 100644
+--- a/src/plugins/platforms/android/androidjniinput.cpp
++++ b/src/plugins/platforms/android/androidjniinput.cpp
+@@ -28,7 +28,7 @@ Q_DECLARE_JNI_CLASS(QtInputInterface, "org/qtproject/qt/android/QtInputInterface
+ namespace QtAndroidInput
+ {
+     static bool m_ignoreMouseEvents = false;
+-    static Qt::MouseButtons m_buttons = Qt::NoButton;
++    static Qt::MouseButtons m_lastSeenButtons = Qt::NoButton;
+ 
+     static QRect m_softwareKeyboardRect;
+ 
+@@ -143,19 +143,22 @@ namespace QtAndroidInput
+     static void sendMouseButtonEvents(QWindow *topLevel, QPoint localPos, QPoint globalPos,
+                                       jint mouseButtonState, QEvent::Type type)
+     {
+-        const Qt::MouseButtons mouseButtons = toMouseButtons(mouseButtonState);
+-        const Qt::MouseButtons changedButtons = mouseButtons & ~m_buttons;
++        const Qt::MouseButtons qtButtons = toMouseButtons(mouseButtonState);
++        const bool mouseReleased = type == QEvent::MouseButtonRelease && qtButtons == Qt::NoButton;
++        const Qt::MouseButtons eventButtons = mouseReleased ? m_lastSeenButtons : qtButtons;
++        m_lastSeenButtons = qtButtons;
+ 
+-        if (changedButtons == Qt::NoButton)
+-            return;
+-
+-        static_assert (sizeof(changedButtons) <= sizeof(uint), "Qt::MouseButtons size changed. Adapt code.");
++        static_assert (sizeof(eventButtons) <= sizeof(uint), "Qt::MouseButtons size changed. Adapt code.");
+ 
+-        for (uint buttonInt = 0x1; static_cast<uint>(changedButtons) >= buttonInt; buttonInt <<= 1) {
++        if (eventButtons == Qt::NoButton) {
++            QWindowSystemInterface::handleMouseEvent(topLevel, localPos, globalPos, qtButtons, Qt::NoButton, type);
++            return;
++        }
++        for (uint buttonInt = 0x1; static_cast<uint>(eventButtons) >= buttonInt; buttonInt <<= 1) {
+             const auto button = static_cast<Qt::MouseButton>(buttonInt);
+-            if (changedButtons.testFlag(button)) {
++            if (eventButtons.testFlag(button)) {
+                 QWindowSystemInterface::handleMouseEvent(topLevel, localPos, globalPos,
+-                                                         mouseButtons, button, type);
++                                                         qtButtons, button, type);
+             }
+         }
+     }
+@@ -188,9 +191,8 @@ namespace QtAndroidInput
+         m_mouseGrabber.clear();
+     }
+ 
+-    static void mouseMove(JNIEnv */*env*/, jobject /*thiz*/, jint winId, jint x, jint y)
++    static void mouseMove(JNIEnv */*env*/, jobject /*thiz*/, jint winId, jint x, jint y, jint mouseButtonState)
+     {
+-
+         if (m_ignoreMouseEvents)
+             return;
+ 
+@@ -200,9 +202,7 @@ namespace QtAndroidInput
+             window = windowFromId(winId);
+         const QPoint localPos = window && window->handle() ?
+                                     window->handle()->mapFromGlobal(globalPos) : globalPos;
+-        QWindowSystemInterface::handleMouseEvent(window, localPos, globalPos,
+-                                                 Qt::MouseButtons(m_mouseGrabber ? Qt::LeftButton : Qt::NoButton),
+-                                                 Qt::NoButton, QEvent::MouseMove);
++        sendMouseButtonEvents(window, localPos, globalPos, mouseButtonState, QEvent::MouseMove);
+     }
+ 
+     static void mouseWheel(JNIEnv */*env*/, jobject /*thiz*/, jint winId, jint x, jint y, jfloat hdelta, jfloat vdelta)
+@@ -909,7 +909,7 @@ namespace QtAndroidInput
+         {"touchCancel", "(I)V", (void *)touchCancel},
+         {"mouseDown", "(IIII)V", (void *)mouseDown},
+         {"mouseUp", "(IIII)V", (void *)mouseUp},
+-        {"mouseMove", "(III)V", (void *)mouseMove},
++        {"mouseMove", "(IIII)V", (void *)mouseMove},
+         {"mouseWheel", "(IIIFF)V", (void *)mouseWheel},
+         {"longPress", "(III)V", (void *)longPress},
+         {"isTabletEventSupported", "()Z", (void *)isTabletEventSupported},
+-- 
+2.16.3
+

--- a/vcpkg/ports/qtbase/portfile.cmake
+++ b/vcpkg/ports/qtbase/portfile.cmake
@@ -23,6 +23,8 @@ set(${PORT}_PATCHES
         fix_deploy_windows.patch
         fix-link-lib-discovery.patch
         macdeployqt-symlinks.patch
+        bluetooth_mouse_fix.patch
+        android_cursor_location.patch
 )
  
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)

--- a/vcpkg/ports/qtmultimedia/portfile.cmake
+++ b/vcpkg/ports/qtmultimedia/portfile.cmake
@@ -7,6 +7,7 @@ set(${PORT}_PATCHES
     remove-static-ssl-stub.patch
     private_libs.patch
     ffmpeg-compile-def.patch
+    video_recording_fix.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/vcpkg/ports/qtmultimedia/video_recording_fix.patch
+++ b/vcpkg/ports/qtmultimedia/video_recording_fix.patch
@@ -1,0 +1,140 @@
+From c6a80aaa8afcee1d861d892dee8035252c251eef Mon Sep 17 00:00:00 2001
+From: Tim Blechmann <tim.blechmann@qt.io>
+Date: Mon, 6 Jan 2025 18:14:03 +0800
+Subject: [PATCH] FFmpeg: take audio channel count / sample rate into account
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf8
+Content-Transfer-Encoding: 8bit
+
+QMediaEncoderSettings contain settings for sampling rate and channel
+count, but these values have never been applied to the codec. Therefore
+sampling rate / channel count of the resulting medium were always taken
+from the input device.
+
+Change-Id: I8bceae576a010167fc152eb8cfd453ba93d395ce
+Reviewed-by: Artem Dyomin <artem.dyomin@qt.io>
+Reviewed-by: JÃ¸ger HansegÃ¥rd <joger.hansegard@qt.io>
+(cherry picked from commit 355a6dffc64c422c57a7e3be7a80012eaaf5eb83)
+Reviewed-by: Qt Cherry-pick Bot <cherrypick_bot@qt-project.org>
+(cherry picked from commit 270e9c06de748d607fa512632749cb1d9f4647e6)
+---
+ .../recordingengine/qffmpegencoderoptions.cpp      | 21 ++++++++++++
+ .../tst_qmediarecorderbackend.cpp                  | 40 ++++++++++++++++++++--
+ 2 files changed, 59 insertions(+), 2 deletions(-)
+
+diff --git a/src/plugins/multimedia/ffmpeg/recordingengine/qffmpegencoderoptions.cpp b/src/plugins/multimedia/ffmpeg/recordingengine/qffmpegencoderoptions.cpp
+index b374524ef4..3f66c2dcb0 100644
+--- a/src/plugins/multimedia/ffmpeg/recordingengine/qffmpegencoderoptions.cpp
++++ b/src/plugins/multimedia/ffmpeg/recordingengine/qffmpegencoderoptions.cpp
+@@ -2,10 +2,16 @@
+ // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+ #include "qffmpegencoderoptions_p.h"
+ 
++#include "qffmpegmediaformatinfo_p.h"
++
++#include <QtMultimedia/qaudioformat.h>
++
+ #if QT_CONFIG(vaapi)
+ #include <va/va.h>
+ #endif
+ 
++#include <libavutil/channel_layout.h>
++
+ QT_BEGIN_NAMESPACE
+ 
+ // unfortunately there is no common way to specify options for the encoders. The code here tries to map our settings sensibly
+@@ -348,6 +354,21 @@ void applyAudioEncoderOptions(const QMediaEncoderSettings &settings, const QByte
+     if (settings.encodingMode() == QMediaRecorder::ConstantBitRateEncoding || settings.encodingMode() == QMediaRecorder::AverageBitRateEncoding)
+         codec->bit_rate = settings.audioBitRate();
+ 
++    if (settings.audioSampleRate() != -1)
++        codec->sample_rate = settings.audioSampleRate();
++
++    if (settings.audioChannelCount() != -1) {
++        auto mask = QFFmpegMediaFormatInfo::avChannelLayout(
++                QAudioFormat::defaultChannelConfigForChannelCount(settings.audioChannelCount()));
++
++#if QT_FFMPEG_HAS_AV_CHANNEL_LAYOUT
++        av_channel_layout_from_mask(&codec->ch_layout, mask);
++#else
++        codec->channel_layout = mask;
++        codec->channels = qPopulationCount(codec->channel_layout);
++#endif
++    }
++
+     auto *table = audioCodecOptionTable;
+     while (table->name) {
+         if (codecName == table->name) {
+
+
+From 8a18d465152d93f2fbb0d670505dc7320e979265 Mon Sep 17 00:00:00 2001
+From: Bartlomiej Moskal <bartlomiej.moskal@qt.io>
+Date: Fri, 21 Feb 2025 15:09:29 +0100
+Subject: [PATCH] MediaCodec: Do not set level value for H265 Video Codec
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf8
+Content-Transfer-Encoding: 8bit
+
+The level value in FFmpeg is used to specify the compression constraints
+for an H.265/HEVC-encoded video. While values mapped in the array seems
+to be correct[0], they are not recognized by avcodec_open2() method.
+
+It seems that this is a regression[1] on ffmpeg side. It is already
+fixed[2], but the ffmpeg package from 7.1 tag doesn't contain the fix.
+The fix is already on release/7.1 branch.
+
+This fix uses avcodec_version() method to filter out not working FFmpeg
+versions.
+
+[0]https://github.com/FFmpeg/FFmpeg/blob/2066c5526d27168144db059c344df58ed5942aa3/libavcodec/mediacodecenc.c#L1241
+[1]https://github.com/FFmpeg/FFmpeg/commit/7753a9d62725d5bd8313e2d249acbe1c8af79ab1
+[2]https://github.com/FFmpeg/FFmpeg/commit/020d9f2b4886aa620252da4db7a4936378d6eb3a
+
+Fixes: QTBUG-133773
+Change-Id: I4f5051c14bf0523e383a7a0969cc50b131a96b2b
+Reviewed-by: JÃ¸ger HansegÃ¥rd <joger.hansegard@qt.io>
+Reviewed-by: Artem Dyomin <artem.dyomin@qt.io>
+(cherry picked from commit a773b7a3aea656cbbff14dcd627852096ba48632)
+Reviewed-by: Qt Cherry-pick Bot <cherrypick_bot@qt-project.org>
+(cherry picked from commit b2489f7d72e1eda84ad4591387245b8afc2c3799)
+---
+ .../ffmpeg/recordingengine/qffmpegencoderoptions.cpp     | 16 ++++++++++++++--
+ 1 file changed, 14 insertions(+), 2 deletions(-)
+
+diff --git a/src/plugins/multimedia/ffmpeg/recordingengine/qffmpegencoderoptions.cpp b/src/plugins/multimedia/ffmpeg/recordingengine/qffmpegencoderoptions.cpp
+index 3f66c2dcb0..d7ecfefd57 100644
+--- a/src/plugins/multimedia/ffmpeg/recordingengine/qffmpegencoderoptions.cpp
++++ b/src/plugins/multimedia/ffmpeg/recordingengine/qffmpegencoderoptions.cpp
+@@ -10,6 +10,12 @@
+ #include <va/va.h>
+ #endif
+ 
++#ifdef Q_OS_ANDROID
++extern "C" {
++#include <libavcodec/avcodec.h>
++}
++#endif
++
+ #include <libavutil/channel_layout.h>
+ 
+ QT_BEGIN_NAMESPACE
+@@ -276,8 +282,14 @@ static void apply_mediacodec(const QMediaEncoderSettings &settings, AVCodecConte
+         break;
+     }
+     case QMediaFormat::VideoCodec::H265: {
+-        const char *levels[] = { "h2.1", "h3.1", "h4.1", "h5.1", "h6.1" };
+-        av_dict_set(opts, "level", levels[settings.quality()], 1);
++        // Set the level only for FFmpeg versions that correctly recognize level values.
++        // Affected revisions: from n7.1 https://github.com/FFmpeg/FFmpeg/commit/7753a9d62725d5bd8313e2d249acbe1c8af79ab1
++        // up to https://github.com/FFmpeg/FFmpeg/commit/020d9f2b4886aa620252da4db7a4936378d6eb3a
++        if (avcodec_version() < 4000612 || avcodec_version() > 4002660) {
++            const char *levels[] = { "h2.1", "h3.1", "h4.1", "h5.1", "h6.1" };
++            av_dict_set(opts, "level", levels[settings.quality()], 1);
++        }
++
+         codec->profile = FF_PROFILE_HEVC_MAIN;
+         break;
+     }
+-- 
+2.16.3
+


### PR DESCRIPTION
The PR fixes https://github.com/opengisch/QField/issues/5779 (Using Qfield with bluetooth mouse does not seem to work properly in the newest version) using a patch developed by Qt. (reported by our friends at National Land Survey of Finland).

The PR also fixes the copy/paste and selection handle not showing up at the right location on Android (reported by our friends at Oslandia). _This should have a nice positive impact of people wanting to use app-wide plugins._

Finally, the PR fixes a video recording issue with our QField camera.