### PR TITLE
A bit of plugins polishing

### DIFF
--- a/src/core/pluginmanager.cpp
+++ b/src/core/pluginmanager.cpp
@@ -272,7 +272,11 @@ void PluginManager::refreshAppPlugins()
 
 QList<PluginInformation> PluginManager::availableAppPlugins() const
 {
-  return mAvailableAppPlugins.values();
+  QList<PluginInformation> plugins = mAvailableAppPlugins.values();
+  std::sort( plugins.begin(), plugins.end(), []( const PluginInformation &plugin1, const PluginInformation &plugin2 ) {
+    return plugin1.name().toLower() < plugin2.name().toLower();
+  } );
+  return std::move( plugins );
 }
 
 void PluginManager::enableAppPlugin( const QString &uuid )

--- a/src/qml/PluginManagerSettings.qml
+++ b/src/qml/PluginManagerSettings.qml
@@ -71,7 +71,7 @@ Popup {
 
         delegate: Rectangle {
           id: rectangle
-          width: parent.width
+          width: parent ? parent.width : 10
           height: inner.height + 10
           color: "transparent"
 


### PR DESCRIPTION
The PR polishes app-wide plugin experience in two ways: 

First, plugin manager's the list of installed plugins is now sorted, making it much easier to locate a plugin that's been installed.

More importantly, installing a plugin from a zipped archive now tolerates the following structure: 
- plugin_directory/main.qml;
- plugin_directory/metadata.txt;
- plugin_directory/.... 

When first launching the plugin framework, we required the plugin archive to have the main.qml in the _root_ of the zipppe archive, e.g.:
- main.qml;
- metadata.txt;
- ...

That form is a bit problematic for incoming plugin authors with prior experience authoring QGIS plugin as our big brother QGIS expects the plugin directory to be inside the zipped archive. We now support both styles. Win-win.