### PR TITLE
Add Checksum Verification and Directory Upload Support for QFieldCloud

### DIFF
--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -1352,8 +1352,8 @@ void QFieldCloudProjectsModel::projectUpload( const QString &projectId, const bo
 
     const long long fileSize = fileInfo.size();
 
-    // ? should we also check the checksums of the files being uploaded? they are available at deltaFile->attachmentFileNames()->values() || Or just send true instead of false!
-    QFieldCloudUtils::addPendingAttachments( project->id, { absoluteFilePath }, mCloudConnection, false );
+    // ? should we also check the checksums of the files being uploaded? they are available at deltaFile->attachmentFileNames()->values()
+    QFieldCloudUtils::addPendingAttachments( project->id, { absoluteFilePath } );
   }
 
   QString deltaFileToUpload = deltaFileWrapper->toFileForUpload();

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -1352,8 +1352,8 @@ void QFieldCloudProjectsModel::projectUpload( const QString &projectId, const bo
 
     const long long fileSize = fileInfo.size();
 
-    // ? should we also check the checksums of the files being uploaded? they are available at deltaFile->attachmentFileNames()->values()
-    QFieldCloudUtils::addPendingAttachments( project->id, { absoluteFilePath } );
+    // ? should we also check the checksums of the files being uploaded? they are available at deltaFile->attachmentFileNames()->values() || Or just send true instead of false!
+    QFieldCloudUtils::addPendingAttachments( project->id, { absoluteFilePath }, mCloudConnection, false );
   }
 
   QString deltaFileToUpload = deltaFileWrapper->toFileForUpload();

--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -154,7 +154,7 @@ const QMultiMap<QString, QString> QFieldCloudUtils::getPendingAttachments()
 
 void QFieldCloudUtils::addPendingAttachments( const QString &projectId, const QStringList &fileNames, QFieldCloudConnection *cloudConnection, const bool &checkSumCheck )
 {
-  if ( checkSumCheck )
+  if ( checkSumCheck && cloudConnection )
   {
     QVariantMap params;
     params.insert( "skip_metadata", 1 );

--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -176,7 +176,7 @@ void QFieldCloudUtils::addPendingAttachments( const QString &projectId, const QS
         const QJsonArray files = QJsonDocument::fromJson( rawReply->readAll() ).array();
         QHash<QString, QString> fileChecksumMap;
 
-        for ( const QJsonValue &fileValue : files )
+        for ( const QJsonValueConstRef &fileValue : files )
         {
           const QJsonObject fileObject = fileValue.toObject();
           const QString cloudEtag = fileObject.value( QStringLiteral( "md5sum" ) ).toString();

--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -13,7 +13,9 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "fileutils.h"
 #include "platformutilities.h"
+#include "qfieldcloudconnection.h"
 #include "qfieldcloudutils.h"
 #include "stringutils.h"
 
@@ -150,24 +152,73 @@ const QMultiMap<QString, QString> QFieldCloudUtils::getPendingAttachments()
   return std::move( files );
 }
 
-void QFieldCloudUtils::addPendingAttachments( const QString &projectId, const QStringList &fileNames )
+void QFieldCloudUtils::addPendingAttachments( const QString &projectId, const QStringList &fileNames, QFieldCloudConnection *cloudConnection, const bool &checkSumCheck )
 {
   QLockFile attachmentsLock( QStringLiteral( "%1/attachments.lock" ).arg( QFieldCloudUtils::localCloudDirectory() ) );
   if ( attachmentsLock.tryLock( 10000 ) )
   {
-    QFile attachmentsFile( QStringLiteral( "%1/attachments.csv" ).arg( QFieldCloudUtils::localCloudDirectory() ) );
-    attachmentsFile.open( QFile::Append | QFile::Text );
-    QTextStream attachmentsStream( &attachmentsFile );
-    QFileInfo fi( attachmentsFile );
+    if ( checkSumCheck )
+    {
+      QVariantMap params;
+      params.insert( "skip_metadata", 1 );
+      NetworkReply *reply = cloudConnection->get( QStringLiteral( "/api/v1/files/%1/" ).arg( projectId ), params );
 
-    for ( const QString &fileName : fileNames )
+      connect( reply, &NetworkReply::finished, reply, [=]() {
+        QNetworkReply *rawReply = reply->currentRawReply();
+        reply->deleteLater();
+
+        if ( rawReply->error() != QNetworkReply::NoError )
+        {
+          QgsLogger::debug( QStringLiteral( "Project %1: failed to retrieve file information. %2" ).arg( projectId, QFieldCloudConnection::errorString( rawReply ) ) );
+          return;
+        }
+
+        const QJsonArray files = QJsonDocument::fromJson( rawReply->readAll() ).array();
+        QHash<QString, QString> fileChecksumMap;
+
+        for ( const QJsonValue &fileValue : files )
+        {
+          const QJsonObject fileObject = fileValue.toObject();
+          const QString cloudEtag = fileObject.value( QStringLiteral( "md5sum" ) ).toString();
+          const QString fileName = fileObject.value( QStringLiteral( "name" ) ).toString();
+          fileChecksumMap.insert( fileName, cloudEtag );
+        }
+
+        writeToAttachmentsFile( projectId, fileNames, &fileChecksumMap, checkSumCheck );
+      } );
+    }
+    else
+    {
+      writeToAttachmentsFile( projectId, fileNames, nullptr, false );
+    }
+  }
+}
+
+void QFieldCloudUtils::writeToAttachmentsFile( const QString &projectId, const QStringList &fileNames, const QHash<QString, QString> *fileChecksumMap, bool checkSumCheck )
+{
+  QFile attachmentsFile( QStringLiteral( "%1/attachments.csv" ).arg( QFieldCloudUtils::localCloudDirectory() ) );
+  attachmentsFile.open( QFile::Append | QFile::Text );
+  QTextStream attachmentsStream( &attachmentsFile );
+
+  for ( const QString &fileName : fileNames )
+  {
+    QString cloudFileName = "";
+    const QString localEtag = FileUtils::fileEtag( fileName );
+    const QStringList fileNameParts = fileName.split( projectId + "/" );
+
+    if ( fileNameParts.size() > 1 )
+    {
+      cloudFileName = fileNameParts[1];
+    }
+
+    if ( !checkSumCheck || localEtag != fileChecksumMap->value( cloudFileName ) )
     {
       QStringList values = QStringList() << projectId << fileName;
-      attachmentsStream << StringUtils::stringListToCsv( values )
-                        << Qt::endl;
+      attachmentsStream << StringUtils::stringListToCsv( values ) << Qt::endl;
     }
-    attachmentsFile.close();
   }
+
+  attachmentsFile.close();
 }
 
 void QFieldCloudUtils::removePendingAttachment( const QString &projectId, const QString &fileName )

--- a/src/core/utils/qfieldcloudutils.h
+++ b/src/core/utils/qfieldcloudutils.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-    qfieldcloudutils.cpp
+    qfieldcloudutils.h
     ---------------------
     begin                : February 2020
     copyright            : (C) 2020 by Mathieu Pellerin
@@ -134,14 +134,24 @@ class QFieldCloudUtils : public QObject
     //! Returns the list of attachments that have not yet been uploaded to the cloud.
     static const QMultiMap<QString, QString> getPendingAttachments();
 
-    //! Adds an array of \a fileNames for a given \a projectId to the pending attachments list
-    Q_INVOKABLE static void addPendingAttachments( const QString &projectId, const QStringList &fileNames );
+    /**
+     * Adds an array of \a fileNames for a given \a projectId to the pending attachments list.
+     * If \a checkSumCheck is true, checks file checksums with the server; otherwise, adds all files without validation.
+     *
+     * @param projectId The project ID for which files are added.
+     * @param fileNames The list of file names to be added.
+     * @param cloudConnection The cloud connection used to fetch file data.
+     * @param checkSumCheck Whether to validate files by comparing checksums with the server.
+     */
+    Q_INVOKABLE static void addPendingAttachments( const QString &projectId, const QStringList &fileNames, QFieldCloudConnection *cloudConnection, const bool &checkSumCheck );
 
     //! Adds removes a \a fileName for a given \a projectId to the pending attachments list
     static void removePendingAttachment( const QString &projectId, const QString &fileName );
 
   private:
     static inline const QString errorCodeOverQuota { QStringLiteral( "over_quota" ) };
+
+    static void writeToAttachmentsFile( const QString &projectId, const QStringList &fileNames, const QHash<QString, QString> *fileChecksumMap, bool checkSumCheck );
 };
 
 #endif // QFIELDCLOUDUTILS_H

--- a/src/core/utils/qfieldcloudutils.h
+++ b/src/core/utils/qfieldcloudutils.h
@@ -135,15 +135,15 @@ class QFieldCloudUtils : public QObject
     static const QMultiMap<QString, QString> getPendingAttachments();
 
     /**
-     * Adds an array of \a fileNames for a given \a projectId to the pending attachments list.
+     * Adds an array of files and/or folders for a given cloud project to the pending upload attachments list.
      * If \a checkSumCheck is true, checks file checksums with the server; otherwise, adds all files without validation.
      *
      * @param projectId The project ID for which files are added.
-     * @param fileNames The list of file names to be added.
+     * @param fileNames The list of file and/or folder path(s) to be added.
      * @param cloudConnection The cloud connection used to fetch file data.
      * @param checkSumCheck Whether to validate files by comparing checksums with the server.
      */
-    Q_INVOKABLE static void addPendingAttachments( const QString &projectId, const QStringList &fileNames, QFieldCloudConnection *cloudConnection, const bool &checkSumCheck );
+    Q_INVOKABLE static void addPendingAttachments( const QString &projectId, const QStringList &fileNames, QFieldCloudConnection *cloudConnection = nullptr, const bool &checkSumCheck = false );
 
     //! Adds removes a \a fileName for a given \a projectId to the pending attachments list
     static void removePendingAttachment( const QString &projectId, const QString &fileName );

--- a/src/core/utils/qfieldcloudutils.h
+++ b/src/core/utils/qfieldcloudutils.h
@@ -151,7 +151,11 @@ class QFieldCloudUtils : public QObject
   private:
     static inline const QString errorCodeOverQuota { QStringLiteral( "over_quota" ) };
 
-    static void writeToAttachmentsFile( const QString &projectId, const QStringList &fileNames, const QHash<QString, QString> *fileChecksumMap, bool checkSumCheck );
+    static void writeToAttachmentsFile( const QString &projectId, const QStringList &fileNames, const QHash<QString, QString> *fileChecksumMap, const bool &checkSumCheck );
+
+    static void writeFilesFromDirectory( const QString &dirPath, const QString &projectId, const QHash<QString, QString> *fileChecksumMap, const bool &checkSumCheck, QTextStream &attachmentsStream );
+
+    static void writeFileDetails( const QString &fileName, const QString &projectId, const QHash<QString, QString> *fileChecksumMap, const bool &checkSumCheck, QTextStream &attachmentsStream );
 };
 
 #endif // QFIELDCLOUDUTILS_H

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -160,7 +160,7 @@ Page {
           property string itemPath: ItemPath
           property bool itemIsFavorite: ItemIsFavorite
           property bool itemChecked: ItemChecked
-          property bool withinQFieldCloudProjectFolder: cloudProjectsModel.currentProjectId !== "" && itemPath.search(cloudProjectsModel.currentProjectId) !== -1
+          property bool itemWithinQFieldCloudProjectFolder: cloudProjectsModel.currentProjectId !== "" && itemPath.search(cloudProjectsModel.currentProjectId) !== -1
           property bool itemHasWebdavConfiguration: ItemHasWebdavConfiguration
           property bool itemMenuLoadable: !projectFolderView && (ItemMetaType === LocalFilesModel.Project || ItemMetaType === LocalFilesModel.Dataset)
           property bool itemMenuVisible: ((ItemType === LocalFilesModel.SimpleFolder || ItemMetaType == LocalFilesModel.Dataset || ItemMetaType == LocalFilesModel.File) && table.model.currentPath !== 'root') || ((platformUtilities.capabilities & PlatformUtilities.CustomExport || platformUtilities.capabilities & PlatformUtilities.CustomSend) && (ItemMetaType === LocalFilesModel.Dataset)) || (ItemMetaType === LocalFilesModel.Dataset && ItemType === LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId)
@@ -286,7 +286,7 @@ Page {
                 itemMenu.itemType = ItemType;
                 itemMenu.itemPath = ItemPath;
                 itemMenu.itemIsFavorite = ItemIsFavorite;
-                itemMenu.withinQFieldCloudProjectFolder = rectangle.withinQFieldCloudProjectFolder;
+                itemMenu.itemWithinQFieldCloudProjectFolder = rectangle.itemWithinQFieldCloudProjectFolder;
                 itemMenu.itemHasWebdavConfiguration = ItemHasWebdavConfiguration;
                 itemMenu.popup(gc.x + width - itemMenu.width, gc.y - height);
               }
@@ -305,7 +305,7 @@ Page {
             for (let i = 0; i < table.selectedList.length; ++i) {
               const item = table.itemAtIndex(table.selectedList[i]);
               table.selectedItemsWebDavConfigured = table.selectedItemsWebDavConfigured && item.itemHasWebdavConfiguration;
-              table.selectedItemsPushableToQField = (table.selectedItemsPushableToQField && item.itemMetaType == LocalFilesModel.Dataset && item.itemType == LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId) || (item.itemMetaType == LocalFilesModel.Folder && item.withinQFieldCloudProjectFolder);
+              table.selectedItemsPushableToQField = (table.selectedItemsPushableToQField && item.itemMetaType == LocalFilesModel.Dataset && item.itemType == LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId) || (item.itemMetaType == LocalFilesModel.Folder && item.itemWithinQFieldCloudProjectFolder);
             }
           }
         }
@@ -436,7 +436,7 @@ Page {
       property string itemPath: ''
       property bool itemIsFavorite: false
       property bool itemHasWebdavConfiguration: false
-      property bool withinQFieldCloudProjectFolder: false
+      property bool itemWithinQFieldCloudProjectFolder: false
 
       title: qsTr('Item Actions')
 
@@ -463,7 +463,7 @@ Page {
 
       MenuItem {
         id: pushDatasetToCloud
-        enabled: (itemMenu.itemMetaType == LocalFilesModel.Dataset && itemMenu.itemType == LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId) || (itemMenu.itemMetaType == LocalFilesModel.Folder && itemMenu.withinQFieldCloudProjectFolder)
+        enabled: (itemMenu.itemMetaType == LocalFilesModel.Dataset && itemMenu.itemType == LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId) || (itemMenu.itemMetaType == LocalFilesModel.Folder && itemMenu.itemWithinQFieldCloudProjectFolder)
         visible: enabled
 
         font: Theme.defaultFont
@@ -855,7 +855,7 @@ Page {
           var fileNames = [];
           for (let i = 0; i < table.selectedList.length; ++i) {
             const item = table.itemAtIndex(table.selectedList[i]);
-            const pushableToCloud = (item.itemMetaType == LocalFilesModel.Dataset && item.itemType == LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId) || (item.itemMetaType == LocalFilesModel.Folder && item.withinQFieldCloudProjectFolder);
+            const pushableToCloud = (item.itemMetaType == LocalFilesModel.Dataset && item.itemType == LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId) || (item.itemMetaType == LocalFilesModel.Folder && item.itemWithinQFieldCloudProjectFolder);
             if (pushableToCloud) {
               fileNames.push(item.itemPath);
             }

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -470,7 +470,7 @@ Page {
 
         text: qsTr("Push to QFieldCloud")
         onTriggered: {
-          QFieldCloudUtils.addPendingAttachments(cloudProjectsModel.currentProjectId, [itemMenu.itemPath]);
+          QFieldCloudUtils.addPendingAttachments(cloudProjectsModel.currentProjectId, [itemMenu.itemPath], cloudConnection, true);
           platformUtilities.uploadPendingAttachments(cloudConnection);
           displayToast(qsTr("‘%1’ is being uploaded to QFieldCloud").arg(FileUtils.fileName(itemMenu.itemPath)));
         }
@@ -858,7 +858,7 @@ Page {
             }
           }
           if (fileNames.length > 0) {
-            QFieldCloudUtils.addPendingAttachments(cloudProjectsModel.currentProjectId, fileNames);
+            QFieldCloudUtils.addPendingAttachments(cloudProjectsModel.currentProjectId, fileNames, cloudConnection, true);
             platformUtilities.uploadPendingAttachments(cloudConnection);
             localFilesModel.clearSelection();
           } else {

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -160,6 +160,7 @@ Page {
           property string itemPath: ItemPath
           property bool itemIsFavorite: ItemIsFavorite
           property bool itemChecked: ItemChecked
+          property bool withinQFieldCloudProjectFolder: cloudProjectsModel.currentProjectId !== "" && itemPath.search(cloudProjectsModel.currentProjectId) !== -1
           property bool itemHasWebdavConfiguration: ItemHasWebdavConfiguration
           property bool itemMenuLoadable: !projectFolderView && (ItemMetaType === LocalFilesModel.Project || ItemMetaType === LocalFilesModel.Dataset)
           property bool itemMenuVisible: ((ItemType === LocalFilesModel.SimpleFolder || ItemMetaType == LocalFilesModel.Dataset || ItemMetaType == LocalFilesModel.File) && table.model.currentPath !== 'root') || ((platformUtilities.capabilities & PlatformUtilities.CustomExport || platformUtilities.capabilities & PlatformUtilities.CustomSend) && (ItemMetaType === LocalFilesModel.Dataset)) || (ItemMetaType === LocalFilesModel.Dataset && ItemType === LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId)
@@ -285,6 +286,7 @@ Page {
                 itemMenu.itemType = ItemType;
                 itemMenu.itemPath = ItemPath;
                 itemMenu.itemIsFavorite = ItemIsFavorite;
+                itemMenu.withinQFieldCloudProjectFolder = rectangle.withinQFieldCloudProjectFolder;
                 itemMenu.itemHasWebdavConfiguration = ItemHasWebdavConfiguration;
                 itemMenu.popup(gc.x + width - itemMenu.width, gc.y - height);
               }
@@ -303,7 +305,7 @@ Page {
             for (let i = 0; i < table.selectedList.length; ++i) {
               const item = table.itemAtIndex(table.selectedList[i]);
               table.selectedItemsWebDavConfigured = table.selectedItemsWebDavConfigured && item.itemHasWebdavConfiguration;
-              table.selectedItemsPushableToQField = (table.selectedItemsPushableToQField && item.itemMetaType == LocalFilesModel.Dataset && item.itemType == LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId) || item.itemMetaType == LocalFilesModel.Folder;
+              table.selectedItemsPushableToQField = (table.selectedItemsPushableToQField && item.itemMetaType == LocalFilesModel.Dataset && item.itemType == LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId) || (item.itemMetaType == LocalFilesModel.Folder && item.withinQFieldCloudProjectFolder);
             }
           }
         }
@@ -434,6 +436,7 @@ Page {
       property string itemPath: ''
       property bool itemIsFavorite: false
       property bool itemHasWebdavConfiguration: false
+      property bool withinQFieldCloudProjectFolder: false
 
       title: qsTr('Item Actions')
 
@@ -460,7 +463,7 @@ Page {
 
       MenuItem {
         id: pushDatasetToCloud
-        enabled: itemMenu.itemMetaType == LocalFilesModel.Dataset && itemMenu.itemType == LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId
+        enabled: (itemMenu.itemMetaType == LocalFilesModel.Dataset && itemMenu.itemType == LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId) || (itemMenu.itemMetaType == LocalFilesModel.Folder && itemMenu.withinQFieldCloudProjectFolder)
         visible: enabled
 
         font: Theme.defaultFont
@@ -852,7 +855,7 @@ Page {
           var fileNames = [];
           for (let i = 0; i < table.selectedList.length; ++i) {
             const item = table.itemAtIndex(table.selectedList[i]);
-            const pushableToCloud = (item.itemMetaType == LocalFilesModel.Dataset && item.itemType == LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId) || item.itemMetaType == LocalFilesModel.Folder;
+            const pushableToCloud = (item.itemMetaType == LocalFilesModel.Dataset && item.itemType == LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId) || (item.itemMetaType == LocalFilesModel.Folder && item.withinQFieldCloudProjectFolder);
             if (pushableToCloud) {
               fileNames.push(item.itemPath);
             }

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -303,7 +303,7 @@ Page {
             for (let i = 0; i < table.selectedList.length; ++i) {
               const item = table.itemAtIndex(table.selectedList[i]);
               table.selectedItemsWebDavConfigured = table.selectedItemsWebDavConfigured && item.itemHasWebdavConfiguration;
-              table.selectedItemsPushableToQField = table.selectedItemsPushableToQField && item.itemMetaType == LocalFilesModel.Dataset && item.itemType == LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId;
+              table.selectedItemsPushableToQField = (table.selectedItemsPushableToQField && item.itemMetaType == LocalFilesModel.Dataset && item.itemType == LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId) || item.itemMetaType == LocalFilesModel.Folder;
             }
           }
         }
@@ -852,7 +852,7 @@ Page {
           var fileNames = [];
           for (let i = 0; i < table.selectedList.length; ++i) {
             const item = table.itemAtIndex(table.selectedList[i]);
-            const pushableToCloud = item.itemMetaType == LocalFilesModel.Dataset && item.itemType == LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId;
+            const pushableToCloud = (item.itemMetaType == LocalFilesModel.Dataset && item.itemType == LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId) || item.itemMetaType == LocalFilesModel.Folder;
             if (pushableToCloud) {
               fileNames.push(item.itemPath);
             }


### PR DESCRIPTION
### Pull Request Description

#### Overview:
This pull request introduces several improvements to the file upload functionality, specifically for enhancing efficiency and extending support for pushing entire directories to QFieldCloud. The changes introduced include checksum verification to ensure that unchanged files are not uploaded again, reducing unnecessary data transfer, as well as enabling directory uploads.

#### Changes:
1. **Checksum Verification for File Uploads**:
   The file upload process has been optimized by introducing checksum verification. This ensures that files that have not been modified are not uploaded again, leading to significant efficiency improvements and reduced data transfer. The checksum verification mechanism is implemented using ETags for file comparison.

2. **Support for Uploading Entire Directories**:
   A new functionality has been added to allow uploading entire directories to QFieldCloud. The new code recursively scans a directory and processes its files, ensuring that all files within the directory are correctly handled and uploaded if necessary.

3. **Refactor of the `addPendingAttachments` Function**:
   The existing `addPendingAttachments` function has been refactored and renamed to `writeToAttachmentsFile`. The new function allows both individual files and directories to be handled, and integrates the checksum verification logic.

   ```cpp
   void QFieldCloudUtils::writeToAttachmentsFile( const QString &projectId, const QStringList &fileNames, const QHash<QString, QString> *fileChecksumMap, const bool &checkSumCheck )
   {
     // New implementation that processes files and directories, including checksum verification.
   }
   ```

4. **New Helper Functions**:
   - `writeFilesFromDirectory`: A recursive function to process all files within a directory and push them to QFieldCloud.
   - `writeFileDetails`: This function writes the file details to the attachments file and checks the checksum for file comparison before uploading.

   ```cpp
   void QFieldCloudUtils::writeFilesFromDirectory( const QString &dirPath, const QString &projectId, const QHash<QString, QString> *fileChecksumMap, const bool &checkSumCheck, QTextStream &attachmentsStream );
   
   void QFieldCloudUtils::writeFileDetails( const QString &fileName, const QString &projectId, const QHash<QString, QString> *fileChecksumMap, const bool &checkSumCheck, QTextStream &attachmentsStream );
   ```

5. **New QML Property for Detecting Project Folder**:
   A new QML property `itemWithinQFieldCloudProjectFolder` has been added to check if the item is within the QFieldCloud project folder. This property ensures that only items within the project folder are considered for upload.

   ```qml
   property bool itemWithinQFieldCloudProjectFolder: cloudProjectsModel.currentProjectId !== "" && itemPath.search(cloudProjectsModel.currentProjectId) !== -1
   ```

   It is now used in the following conditional logic to determine whether a folder is part of the project:

   ```qml
   || (item.itemMetaType == LocalFilesModel.Folder && item.itemWithinQFieldCloudProjectFolder);
   ```
---

#### Test Scenario:

1. Created a PDF file.
2. Uploaded the folder containing the PDF.
3. Verified that one version of the PDF appears in QFieldCloud.
4. Created multiple PDF files within the folder.
5. Uploaded the entire folder again.
6. Confirmed that all PDFs within the folder still show as version 1.
7. Uploaded the entire folder once more.
8. Verified that all PDFs remain on their original version (version 1).
9. Added a single new PDF file to the folder.
10. Uploaded the folder again.
11. Confirmed that all files still remain on their original version (version 1).

#### Conclusion:
Both checksum verification and directory upload functionalities are working as intended. The checksum verification is successfully preventing unnecessary uploads of unchanged files, ensuring efficient data transfer.  
