### PR TITLE
Align deployment target with Qt 6.8

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -22,7 +22,7 @@ jobs:
     name: build (ios)
     runs-on: macos-15
     env:
-      DEPLOYMENT_TARGET: '14.0'
+      DEPLOYMENT_TARGET: '16.0'
       BUILD_TYPE: 'Release'
       TRIPLET: 'arm64-ios'
 


### PR DESCRIPTION
See https://github.com/opengisch/QField/discussions/6118 for background information.

It's quite unfortunate we have to do this, but upstream Qt seems to be firm on sticking to the updated minimum requirement.