### PR TITLE
Fix reliability of file association on Android

### DIFF
--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -52,12 +52,18 @@
     android:theme="@style/AppTheme">
     <activity
       android:name="ch.opengis.@APP_PACKAGE_NAME@.QFieldActivity"
+      android:taskAffinity="ch.opengis.@APP_PACKAGE_NAME@"
+      android:launchMode="singleInstance"
+      android:allowTaskReparenting="false"
+      android:documentLaunchMode="never"
+      android:alwaysRetainTaskState="true"
+      android:clearTaskOnLaunch="false"
       android:label="@APP_NAME@"
       android:icon="@AT@drawable/@APP_ICON@"
-      android:launchMode="singleTask"
       android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|locale|fontScale|keyboard|keyboardHidden|navigation"
       android:theme="@style/AppTheme"
       android:exported="true">
+
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.LAUNCHER"/>
@@ -92,7 +98,7 @@
       <intent-filter>
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />
-        <category android:name="android.intent.category.BROWSABLE"/>
+        <category android:name="android.intent.category.BROWSABLE" />
         <data android:scheme="file" />
         <data android:scheme="content" />
         <data android:host="*" />
@@ -114,7 +120,7 @@
       <intent-filter>
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />
-        <category android:name="android.intent.category.BROWSABLE"/>
+        <category android:name="android.intent.category.BROWSABLE" />
         <data android:scheme="file" />
         <data android:scheme="content" />
         <data android:host="*" />

--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -127,6 +127,7 @@ public class QFieldActivity extends QtActivity {
     public static native void resourceCanceled(String message);
 
     private Intent projectIntent;
+
     private float originalBrightness;
     private boolean handleVolumeKeys = false;
     private String pathsToExport;
@@ -152,7 +153,12 @@ public class QFieldActivity extends QtActivity {
 
     @Override
     public void onNewIntent(Intent intent) {
+        // Prevent activity restart
+        intent.setFlags(intent.getFlags() &
+                        ~(Intent.FLAG_ACTIVITY_NEW_TASK |
+                          Intent.FLAG_ACTIVITY_NEW_DOCUMENT));
         super.onNewIntent(intent);
+
         if (intent.getAction() == Intent.ACTION_VIEW ||
             intent.getAction() == Intent.ACTION_SEND) {
             projectIntent = intent;
@@ -522,8 +528,11 @@ public class QFieldActivity extends QtActivity {
             }
         }
 
-        Intent intent = new Intent();
+        Intent intent = new Intent(Intent.ACTION_VIEW);
         intent.setClass(QFieldActivity.this, QtActivity.class);
+        // Prevent activity restart
+        intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP |
+                        Intent.FLAG_ACTIVITY_SINGLE_TOP);
         try {
             ActivityInfo activityInfo = getPackageManager().getActivityInfo(
                 getComponentName(), PackageManager.GET_META_DATA);
@@ -548,6 +557,7 @@ public class QFieldActivity extends QtActivity {
             projectIntent = sourceIntent;
             intent.putExtra("QGS_PROJECT", "trigger_load");
         }
+
         setIntent(intent);
     }
 


### PR DESCRIPTION
These Android-specific changes dramatically increase the reliability of opening files (datasets, projects, zipped projects) from apps such as telegram.

Until now, if a QField session was already launched , opening a file sent via telegram would fail (QField would open, die, then restart). This made for some bad UX when someone first installs QField, launches it, then goes to telegram to open a file.

I've tried these changes *a lot*, and I can't find a combinaison now that fails to open files. I'm *really* happy about this one. Makes giving instructions to people being on-boarded fail-proof.

@mbernasocchi , ties to what we discussed over the weekend :)