### PR TITLE
Update qfield_fr.ts - Trad "Not NULL"

### DIFF
--- a/i18n/qfield_fr.ts
+++ b/i18n/qfield_fr.ts
@@ -138,7 +138,7 @@
     </message>
     <message>
         <source>Not NULL</source>
-        <translation>Not NULL</translation>
+        <translation>Champs obligatoire</translation>
     </message>
     <message>
         <source>Unique</source>


### PR DESCRIPTION
Hello,
For users who speak French and are not geomaticians, it may be confusing to interpret the message of the ‘Not NULL’ constraint, which is why I suggest translating it to the following string: ‘Champs obligatoire’ or mandatory fields.

Ajout de la traduction 'Not NULL' → 'Champs obligatoire'
Add translation 'Not NULL' → 'Champs obligatoire'.

Hoping that this will soon be available in the application, it seems to me that it would be a great help to French users.
Thanks in advance !
(It's my first time using GitHub pull request, I hope I've done this properly).
![NotNULLConstraint](https://github.com/user-attachments/assets/2bd66b09-1939-4a14-a46f-83500aa82571)
