### PR TITLE
Add a mechanism to explicitly close a feature iterator

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -55,9 +55,6 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_KEY_DEPLOYMENT_CERTIFICATES }}
 
-      - name: 🐩 Install CMake and Ninja
-        uses: lukka/get-cmake@latest
-
       - name: 🔨 Prepare build env
         run: |
           brew install automake bison flex gnu-sed autoconf-archive nasm libtool xcbeautify mono

--- a/src/core/utils/layerutils.h
+++ b/src/core/utils/layerutils.h
@@ -27,6 +27,10 @@ class QgsRasterLayer;
 class QgsSymbol;
 
 /**
+ * A class providing a feature iterator interface to be used within QML/javascript environment.
+ *
+ * Users of this class must manually call its close() once feature iteration is finished.
+ *
  * \ingroup core
  */
 class FeatureIterator
@@ -63,6 +67,11 @@ class FeatureIterator
         mHasNextChecked = false;
       }
       return mCurrentFeature;
+    }
+
+    Q_INVOKABLE void close()
+    {
+      mFeatureIterator.close();
     }
 
   private:
@@ -136,7 +145,7 @@ class LayerUtils : public QObject
     Q_INVOKABLE static bool hasMValue( QgsVectorLayer *layer );
 
     /**
-     * Returns a feature request to get features.
+     * Returns a feature iterator to get features matching a given \a expression within the provided \a layer.
      */
     Q_INVOKABLE static FeatureIterator createFeatureIteratorFromExpression( QgsVectorLayer *layer, const QString &expression );
 };


### PR DESCRIPTION
Fixes https://github.com/opengisch/QField/issues/6141

The long story short here is that the garbage collection of var iterator = LayerUtils.createFeatureIteratorFromExpression(...) isn't happening in due time, and we therefore need a way to close the feature iterator to free up the associated dataset connection. 

The PR adds an invokable close() function as well as bit of documentation to that affect.