### PR TITLE
Add file content read/write utilities for QML extensions

### DIFF
--- a/src/core/utils/fileutils.cpp
+++ b/src/core/utils/fileutils.cpp
@@ -26,12 +26,15 @@
 #include <QMimeDatabase>
 #include <QPainter>
 #include <QPainterPath>
+#include <QStandardPaths>
 #include <qgis.h>
 #include <qgsexiftools.h>
 #include <qgsfileutils.h>
+#include <qgsproject.h>
 #include <qgsrendercontext.h>
 #include <qgstextformat.h>
 #include <qgstextrenderer.h>
+
 
 FileUtils::FileUtils( QObject *parent )
   : QObject( parent )
@@ -317,4 +320,251 @@ void FileUtils::addImageStamp( const QString &imagePath, const QString &text )
       QgsExifTools::tagImage( imagePath, key, metadata[key] );
     }
   }
+}
+
+bool FileUtils::isWithinProjectDirectory( const QString &filePath )
+{
+  // Get the project instance
+  QgsProject *project = QgsProject::instance();
+  if ( !project || project->fileName().isEmpty() )
+    return false;
+
+  QFileInfo projectFileInfo( project->fileName() );
+  if ( !projectFileInfo.exists() )
+    return false;
+
+  // Get the canonical path for the project directory
+  QString projectDirCanonical = QFileInfo( projectFileInfo.dir().absolutePath() ).canonicalFilePath();
+  if ( projectDirCanonical.isEmpty() )
+  {
+    // Fallback to absolutePath() if canonicalFilePath() is empty
+    projectDirCanonical = QFileInfo( projectFileInfo.dir().absolutePath() ).absoluteFilePath();
+    if ( projectDirCanonical.isEmpty() )
+      return false;
+  }
+
+  // Get target file info and its canonical path
+  QFileInfo targetInfo( filePath );
+  QString targetCanonical;
+
+  if ( targetInfo.exists() || targetInfo.isSymLink() )
+  {
+    targetCanonical = targetInfo.canonicalFilePath();
+    if ( targetCanonical.isEmpty() )
+    {
+      targetCanonical = targetInfo.absoluteFilePath();
+    }
+  }
+  else
+  {
+    // Walk up the directory tree until we find an existing parent
+    QDir dir = targetInfo.dir();
+    QStringList pendingSegments;
+
+    while ( !dir.exists() && dir.cdUp() )
+    {
+      pendingSegments.prepend( QFileInfo( dir.path() ).fileName() );
+    }
+
+    QString existingCanonical = QFileInfo( dir.path() ).canonicalFilePath();
+    if ( existingCanonical.isEmpty() )
+    {
+      existingCanonical = QFileInfo( dir.path() ).absoluteFilePath();
+      if ( existingCanonical.isEmpty() )
+        return false;
+    }
+
+    // Rebuild the target path from existing directories
+    QDir rebuiltDir( existingCanonical );
+    for ( const QString &segment : pendingSegments )
+    {
+      rebuiltDir.cd( segment );
+    }
+
+    targetCanonical = rebuiltDir.absoluteFilePath( targetInfo.fileName() );
+  }
+
+  // Normalize path separators
+  projectDirCanonical = QDir::fromNativeSeparators( projectDirCanonical );
+  targetCanonical = QDir::fromNativeSeparators( targetCanonical );
+
+  // Normalize paths for Windows (case-insensitive check)
+#ifdef Q_OS_WIN
+  projectDirCanonical = projectDirCanonical.toLower();
+  targetCanonical = targetCanonical.toLower();
+#endif
+
+  // Check if the target path is equal to or within the project directory
+  bool result = targetCanonical == projectDirCanonical || targetCanonical.startsWith( projectDirCanonical + "/" );
+
+  return result;
+}
+
+QByteArray FileUtils::readFileContent( const QString &filePath )
+{
+  QByteArray content;
+
+  if ( !isWithinProjectDirectory( filePath ) )
+  {
+    qWarning() << QStringLiteral( "Security warning: Attempted to read file outside project directory: %1" ).arg( filePath );
+    return QByteArray();
+  }
+
+  QFile file( filePath );
+
+  if ( file.exists() )
+  {
+    if ( file.open( QIODevice::ReadOnly ) )
+    {
+      content = file.readAll();
+      file.close();
+    }
+    else
+    {
+      qDebug() << QStringLiteral( "Failed to read file content: %1" ).arg( file.errorString() );
+    }
+  }
+  else
+  {
+    qDebug() << QStringLiteral( "File does not exist: %1" ).arg( filePath );
+  }
+
+  return content;
+}
+
+bool FileUtils::writeFileContent( const QString &filePath, const QByteArray &content )
+{
+  if ( !isWithinProjectDirectory( filePath ) )
+  {
+    qWarning() << QStringLiteral( "Security warning: Attempted to write file outside project directory: %1" ).arg( filePath );
+    return false;
+  }
+
+  QFile file( filePath );
+  QFileInfo fileInfo( filePath );
+  QDir directory = fileInfo.dir();
+
+  bool isLikelyWritable = false;
+
+#ifdef Q_OS_ANDROID
+  QString appStorage = QStandardPaths::writableLocation( QStandardPaths::AppDataLocation );
+  isLikelyWritable = filePath.startsWith( appStorage );
+#elif defined( Q_OS_IOS )
+  QString appStorage = QStandardPaths::writableLocation( QStandardPaths::AppDataLocation );
+  isLikelyWritable = filePath.startsWith( appStorage );
+#else
+  QFileInfo dirInfo( directory.absolutePath() );
+  isLikelyWritable = dirInfo.isWritable();
+#endif
+
+  if ( !isLikelyWritable )
+  {
+    qWarning() << QStringLiteral( "Writing to %1 may fail due to platform restrictions. Use PlatformUtilities.applicationDirectory() for a safe location." ).arg( filePath );
+  }
+
+  if ( !directory.exists() )
+  {
+    if ( !directory.mkpath( "." ) )
+    {
+      qDebug() << QStringLiteral( "Failed to create directory for file: %1. This may be due to permission restrictions." ).arg( filePath );
+      return false;
+    }
+  }
+
+  if ( file.open( QIODevice::WriteOnly ) )
+  {
+    qint64 bytesWritten = file.write( content );
+    file.close();
+
+    if ( bytesWritten != content.size() )
+    {
+      qDebug() << QStringLiteral( "Failed to write all data to file: %1" ).arg( filePath );
+      return false;
+    }
+
+    return true;
+  }
+  else
+  {
+    QString errorMsg = file.errorString();
+    if ( file.error() == QFile::PermissionsError )
+    {
+      errorMsg += QStringLiteral( " - This may be due to platform security restrictions." );
+    }
+    qDebug() << QStringLiteral( "Failed to open file for writing: %1" ).arg( errorMsg );
+    return false;
+  }
+}
+
+QVariantMap FileUtils::getFileInfo( const QString &filePath )
+{
+  QVariantMap info;
+
+  if ( !isWithinProjectDirectory( filePath ) )
+  {
+    qWarning() << QStringLiteral( "Security warning: Attempted to access file info outside project directory: %1" ).arg( filePath );
+    info["exists"] = false;
+    info["error"] = QStringLiteral( "Access denied: File is outside the current project directory" );
+    return info;
+  }
+
+  QFileInfo fileInfo( filePath );
+  QFile file( filePath );
+
+  if ( fileInfo.exists() )
+  {
+    info["exists"] = true;
+    info["fileName"] = fileInfo.fileName();
+    info["filePath"] = fileInfo.absoluteFilePath();
+    info["fileSize"] = fileInfo.size();
+    info["lastModified"] = fileInfo.lastModified();
+    info["suffix"] = fileInfo.suffix();
+
+    QMimeDatabase db;
+    info["mimeType"] = db.mimeTypeForFile( filePath ).name();
+
+    QByteArray md5Hash = fileChecksum( filePath, QCryptographicHash::Md5 );
+    if ( !md5Hash.isEmpty() )
+    {
+      info["md5"] = md5Hash.toHex();
+    }
+    else
+    {
+      info["md5Error"] = QStringLiteral( "Could not calculate MD5 hash - possibly due to permission restrictions" );
+    }
+
+    if ( file.open( QIODevice::ReadOnly ) )
+    {
+      file.close();
+
+      QByteArray content = readFileContent( filePath );
+
+      if ( !content.isEmpty() || fileInfo.size() == 0 )
+      {
+        info["content"] = content;
+        info["readable"] = true;
+      }
+      else
+      {
+        info["readable"] = false;
+        info["readError"] = QStringLiteral( "Failed to read file content" );
+      }
+    }
+    else
+    {
+      info["readable"] = false;
+      info["readError"] = file.errorString();
+
+      if ( file.error() == QFile::PermissionsError )
+      {
+        info["readError"] = info["readError"].toString() + QStringLiteral( " - This may be due to platform security restrictions" );
+      }
+    }
+  }
+  else
+  {
+    info["exists"] = false;
+  }
+
+  return info;
 }

--- a/src/core/utils/fileutils.cpp
+++ b/src/core/utils/fileutils.cpp
@@ -444,24 +444,6 @@ bool FileUtils::writeFileContent( const QString &filePath, const QByteArray &con
   QFileInfo fileInfo( filePath );
   QDir directory = fileInfo.dir();
 
-  bool isLikelyWritable = false;
-
-#ifdef Q_OS_ANDROID
-  QString appStorage = QStandardPaths::writableLocation( QStandardPaths::AppDataLocation );
-  isLikelyWritable = filePath.startsWith( appStorage );
-#elif defined( Q_OS_IOS )
-  QString appStorage = QStandardPaths::writableLocation( QStandardPaths::AppDataLocation );
-  isLikelyWritable = filePath.startsWith( appStorage );
-#else
-  QFileInfo dirInfo( directory.absolutePath() );
-  isLikelyWritable = dirInfo.isWritable();
-#endif
-
-  if ( !isLikelyWritable )
-  {
-    qWarning() << QStringLiteral( "Writing to %1 may fail due to platform restrictions. Use PlatformUtilities.applicationDirectory() for a safe location." ).arg( filePath );
-  }
-
   if ( !directory.exists() )
   {
     if ( !directory.mkpath( "." ) )

--- a/src/core/utils/fileutils.h
+++ b/src/core/utils/fileutils.h
@@ -21,6 +21,7 @@
 
 #include <QCryptographicHash>
 #include <QObject>
+#include <QVariantMap>
 #include <qgsfeedback.h>
 
 class GnssPositionInformation;
@@ -48,8 +49,52 @@ class QFIELD_CORE_EXPORT FileUtils : public QObject
     Q_INVOKABLE static QString fileSuffix( const QString &filePath );
     //! Returns a human-friendly size from bytes
     Q_INVOKABLE static QString representFileSize( qint64 bytes );
-    //! Returns the absolute path of tghe folder containing the \a filePath.
+    //! Returns the absolute path of the folder containing the \a filePath.
     Q_INVOKABLE static QString absolutePath( const QString &filePath );
+
+    /**
+    * Checks if a file path is securely within the current project directory.
+    * Security measures:
+    * - Prevents directory traversal attacks using path normalization
+    * - Handles symbolic links that could escape project boundaries
+    * - Supports cross-platform path comparisons (Windows, macOS, Linux, Android, iOS)
+    * - Validates non-existent files safely for write operations
+    * - Prevents partial directory matching by enforcing complete path containment
+    *
+    * \param filePath The path to check
+    * \return True if the path is safely within the current project directory
+    */
+    static bool isWithinProjectDirectory( const QString &filePath );
+
+    /**
+    * Reads the entire content of a file and returns it as a byte array.
+    * \param filePath The path to the file to be read
+    * \return The file content as a QByteArray
+    */
+    Q_INVOKABLE static QByteArray readFileContent( const QString &filePath );
+
+    /**
+    * Writes content to a file.
+    * \param filePath The path to the file to be written
+    * \param content The content to write to the file
+    * \return True if the write operation was successful, false otherwise
+    *
+    * \note Platform restrictions apply:
+    * - On Android: Writing is only permitted within the app's internal storage or
+    *   properly requested scoped storage locations.
+    * - On iOS: Writing is restricted to the app's sandbox.
+    * - Use PlatformUtilities.applicationDirectory() to get a safe write location.
+    */
+    Q_INVOKABLE static bool writeFileContent( const QString &filePath, const QByteArray &content );
+
+    /**
+    * Gets detailed information about a file including content, MD5 hash and metadata.
+    * This is useful for file validation, caching, and efficient file handling in QML.
+    * \param filePath The path to the file
+    * \return A map containing file metadata and optionally its content
+    */
+    Q_INVOKABLE static QVariantMap getFileInfo( const QString &filePath );
+
 
     /**
      * Insures that a given image's width and height are restricted to a maximum size.

--- a/src/core/utils/fileutils.h
+++ b/src/core/utils/fileutils.h
@@ -88,13 +88,14 @@ class QFIELD_CORE_EXPORT FileUtils : public QObject
     Q_INVOKABLE static bool writeFileContent( const QString &filePath, const QByteArray &content );
 
     /**
-    * Gets detailed information about a file including content, MD5 hash and metadata.
+    * Gets detailed information about a file including MD5 hash and metadata.
+    * Optionally includes the file content when fetchContent is true.
     * This is useful for file validation, caching, and efficient file handling in QML.
     * \param filePath The path to the file
+    * \param fetchContent Whether to include the file content in the returned information (default: false)
     * \return A map containing file metadata and optionally its content
     */
-    Q_INVOKABLE static QVariantMap getFileInfo( const QString &filePath );
-
+    Q_INVOKABLE static QVariantMap getFileInfo( const QString &filePath, bool fetchContent = false );
 
     /**
      * Insures that a given image's width and height are restricted to a maximum size.

--- a/test/test_fileutils.cpp
+++ b/test/test_fileutils.cpp
@@ -18,7 +18,10 @@
 #include "catch2.h"
 #include "utils/fileutils.h"
 
+#include <QDir>
+#include <QFileInfo>
 #include <QTemporaryFile>
+#include <qgsproject.h>
 
 TEST_CASE( "FileUtils" )
 {
@@ -61,5 +64,220 @@ TEST_CASE( "FileUtils" )
     REQUIRE( FileUtils::fileExists( fileName ) );
     delete f;
     REQUIRE( !FileUtils::fileExists( fileName ) );
+  }
+
+
+  SECTION( "IsWithinProjectDirectory" )
+  {
+    // Create a temporary directory for the project
+    QTemporaryDir tempProjectDir;
+    REQUIRE( tempProjectDir.isValid() );
+    QString projectPath = tempProjectDir.path() + QDir::separator() + "test_project.qgs";
+    QgsProject::instance()->setFileName( projectPath );
+    REQUIRE( QgsProject::instance()->write() );
+
+    // Test with a file inside the project directory
+    QString validPath = tempProjectDir.path() + QDir::separator() + "test_file.txt";
+    REQUIRE( FileUtils::isWithinProjectDirectory( validPath ) == true );
+
+    // Test with a file outside the project directory
+    QString invalidPath = QDir::tempPath() + QDir::separator() + "outside_dir" + QDir::separator() + "test_file.txt";
+    REQUIRE( FileUtils::isWithinProjectDirectory( invalidPath ) == false );
+
+    QgsProject::instance()->clear();
+  }
+
+
+  SECTION( "ReadWriteFileContent" )
+  {
+    QTemporaryDir tempProjectDir;
+    REQUIRE( tempProjectDir.isValid() );
+    QString projectPath = tempProjectDir.path() + QDir::separator() + "test_project.qgs";
+    QgsProject::instance()->setFileName( projectPath );
+    REQUIRE( QgsProject::instance()->write() );
+
+    // Create a file inside the project directory
+    QString filePath = tempProjectDir.path() + QDir::separator() + "test_file.txt";
+    QByteArray testData = "Test content for file operations";
+
+    REQUIRE( FileUtils::writeFileContent( filePath, testData ) == true );
+    REQUIRE( FileUtils::readFileContent( filePath ) == testData );
+
+    // Test with a file outside the project directory
+    QString outsidePath = QDir::tempPath() + QDir::separator() + "outside_dir" + QDir::separator() + "test.txt";
+    REQUIRE( FileUtils::writeFileContent( outsidePath, testData ) == false );
+    REQUIRE( FileUtils::readFileContent( outsidePath ).isEmpty() );
+
+    QgsProject::instance()->clear();
+  }
+
+
+  SECTION( "GetFileInfo" )
+  {
+    QTemporaryDir tempProjectDir;
+    REQUIRE( tempProjectDir.isValid() );
+    QString projectPath = tempProjectDir.path() + QDir::separator() + "test_project.qgs";
+    QgsProject::instance()->setFileName( projectPath );
+    REQUIRE( QgsProject::instance()->write() );
+
+    // Create a file inside the project directory
+    QString filePath = tempProjectDir.path() + QDir::separator() + "test_file.txt";
+    QByteArray testData = "Test content for file info";
+
+    // Write the file directly to ensure it exists
+    QFile file( filePath );
+    REQUIRE( file.open( QIODevice::WriteOnly ) );
+    file.write( testData );
+    file.close();
+
+    QVariantMap info = FileUtils::getFileInfo( filePath );
+    REQUIRE( info["exists"].toBool() == true );
+    REQUIRE( info["fileName"].toString() == QFileInfo( filePath ).fileName() );
+    REQUIRE( info["fileSize"].toLongLong() == testData.size() );
+    REQUIRE( info["content"].toByteArray() == testData );
+
+    // Test with a file outside the project directory
+    QString outsidePath = QDir::tempPath() + QDir::separator() + "outside_dir" + QDir::separator() + "test.txt";
+    QVariantMap restrictedInfo = FileUtils::getFileInfo( outsidePath );
+    REQUIRE( restrictedInfo["exists"].toBool() == false );
+    REQUIRE( restrictedInfo.contains( "error" ) );
+
+    QgsProject::instance()->clear();
+  }
+
+
+  SECTION( "SecurityChecks_DirectoryTraversal" )
+  {
+    QTemporaryDir tempProjectDir;
+    REQUIRE( tempProjectDir.isValid() );
+    QString projectPath = tempProjectDir.path() + QDir::separator() + "test_project.qgs";
+    QgsProject::instance()->setFileName( projectPath );
+    REQUIRE( QgsProject::instance()->write() );
+
+    QDir subDir( tempProjectDir.path() + QDir::separator() + "subdir" );
+    REQUIRE( subDir.mkpath( "." ) );
+
+    REQUIRE( FileUtils::isWithinProjectDirectory( tempProjectDir.path() + QDir::separator() + "test_file.txt" ) == true );
+    REQUIRE( FileUtils::isWithinProjectDirectory( subDir.path() + QDir::separator() + "test_file.txt" ) == true );
+
+    // Directory traversal attempts
+    REQUIRE( FileUtils::isWithinProjectDirectory( tempProjectDir.path() + QDir::separator() + ".." + QDir::separator() + "outside.txt" ) == false );
+    REQUIRE( FileUtils::isWithinProjectDirectory( tempProjectDir.path() + QDir::separator() + "subdir" + QDir::separator() + ".." + QDir::separator() + ".." + QDir::separator() + "outside.txt" ) == false );
+
+    QString escapePath = QDir::cleanPath( tempProjectDir.path() + QDir::separator() + ".." + QDir::separator() + "outside.txt" );
+    REQUIRE( FileUtils::isWithinProjectDirectory( escapePath ) == false );
+
+    QgsProject::instance()->clear();
+  }
+
+
+  SECTION( "SecurityChecks_SymbolicLinks" )
+  {
+#ifndef Q_OS_WIN
+    QTemporaryDir tempProjectDir;
+    REQUIRE( tempProjectDir.isValid() );
+    QString projectPath = tempProjectDir.path() + QDir::separator() + "test_project.qgs";
+    QgsProject::instance()->setFileName( projectPath );
+    REQUIRE( QgsProject::instance()->write() );
+
+    QTemporaryDir outsideDir;
+    REQUIRE( outsideDir.isValid() );
+
+    QString outsideFilePath = outsideDir.path() + QDir::separator() + "outside.txt";
+    QFile outsideFile( outsideFilePath );
+    REQUIRE( outsideFile.open( QIODevice::WriteOnly ) );
+    outsideFile.write( "Outside content" );
+    outsideFile.close();
+
+    QString symlinkPath = tempProjectDir.path() + QDir::separator() + "symlink.txt";
+    QFile::link( outsideFilePath, symlinkPath );
+
+    REQUIRE( FileUtils::isWithinProjectDirectory( symlinkPath ) == false );
+
+    QgsProject::instance()->clear();
+#endif
+  }
+
+
+  SECTION( "SecurityChecks_PartialPathMatching" )
+  {
+    QTemporaryDir tempProjectDir;
+    REQUIRE( tempProjectDir.isValid() );
+
+    QString projectDirName = "project_abc";
+    QString projectPath = tempProjectDir.path() + QDir::separator() + projectDirName;
+    QDir().mkdir( projectPath );
+
+    QString projectFilePath = projectPath + QDir::separator() + "test_project.qgs";
+    QgsProject::instance()->setFileName( projectFilePath );
+    REQUIRE( QgsProject::instance()->write() );
+
+    QString similarDirName = "project_abc_similar";
+    QString similarPath = tempProjectDir.path() + QDir::separator() + similarDirName;
+    QDir().mkdir( similarPath );
+
+    REQUIRE( FileUtils::isWithinProjectDirectory( projectPath + QDir::separator() + "valid.txt" ) == true );
+    REQUIRE( FileUtils::isWithinProjectDirectory( similarPath + QDir::separator() + "invalid.txt" ) == false );
+
+    QgsProject::instance()->clear();
+  }
+
+
+  SECTION( "SecurityChecks_CaseSensitivity" )
+  {
+    QTemporaryDir tempProjectDir;
+    REQUIRE( tempProjectDir.isValid() );
+    QString projectPath = tempProjectDir.path() + QDir::separator() + "test_project.qgs";
+    QgsProject::instance()->setFileName( projectPath );
+    REQUIRE( QgsProject::instance()->write() );
+
+    QString mixedCasePath = tempProjectDir.path();
+    if ( !mixedCasePath.isEmpty() )
+    {
+      for ( int i = 0; i < mixedCasePath.length(); i += 2 )
+      {
+        if ( mixedCasePath[i].isLetter() )
+        {
+          mixedCasePath[i] = mixedCasePath[i].toUpper();
+        }
+      }
+    }
+    mixedCasePath += QDir::separator();
+    mixedCasePath += "Test_FILE.txt";
+
+#ifdef Q_OS_WIN
+    REQUIRE( FileUtils::isWithinProjectDirectory( mixedCasePath ) == true );
+#endif
+
+    QgsProject::instance()->clear();
+  }
+
+
+  SECTION( "SecurityChecks_NonExistentFiles" )
+  {
+    QTemporaryDir tempProjectDir;
+    REQUIRE( tempProjectDir.isValid() );
+    QString projectPath = tempProjectDir.path() + QDir::separator() + "test_project.qgs";
+    QgsProject::instance()->setFileName( projectPath );
+    REQUIRE( QgsProject::instance()->write() );
+
+    QDir subDir( tempProjectDir.path() + QDir::separator() + "subdir" );
+    REQUIRE( subDir.mkpath( "." ) );
+
+    REQUIRE( FileUtils::isWithinProjectDirectory( subDir.path() + QDir::separator() + "nonexistent.txt" ) == true );
+    REQUIRE( FileUtils::isWithinProjectDirectory( tempProjectDir.path() + QDir::separator() + "nonexistent_dir" + QDir::separator() + "file.txt" ) == true );
+    REQUIRE( FileUtils::isWithinProjectDirectory( QDir::tempPath() + QDir::separator() + "nonexistent_outside_dir" + QDir::separator() + "file.txt" ) == false );
+
+    QgsProject::instance()->clear();
+  }
+
+
+  SECTION( "SecurityChecks_EmptyProject" )
+  {
+    QgsProject::instance()->clear();
+
+    REQUIRE( FileUtils::isWithinProjectDirectory( QDir::tempPath() + QDir::separator() + "any_file.txt" ) == false );
+    REQUIRE( FileUtils::isWithinProjectDirectory( "/absolute/path/file.txt" ) == false );
+    REQUIRE( FileUtils::isWithinProjectDirectory( "relative/path/file.txt" ) == false );
   }
 }

--- a/test/test_fileutils.cpp
+++ b/test/test_fileutils.cpp
@@ -130,17 +130,27 @@ TEST_CASE( "FileUtils" )
     file.write( testData );
     file.close();
 
+    // Test with fetchContent = false ( default )
     QVariantMap info = FileUtils::getFileInfo( filePath );
     REQUIRE( info["exists"].toBool() == true );
     REQUIRE( info["fileName"].toString() == QFileInfo( filePath ).fileName() );
     REQUIRE( info["fileSize"].toLongLong() == testData.size() );
-    REQUIRE( info["content"].toByteArray() == testData );
+    REQUIRE( info.contains( "content" ) ); // Key exists but should be empty
+    REQUIRE( info["content"].toByteArray().isEmpty() );
+
+    // Test with fetchContent = true
+    QVariantMap infoWithContent = FileUtils::getFileInfo( filePath, true );
+    REQUIRE( infoWithContent["exists"].toBool() == true );
+    REQUIRE( infoWithContent["fileName"].toString() == QFileInfo( filePath ).fileName() );
+    REQUIRE( infoWithContent["fileSize"].toLongLong() == testData.size() );
+    REQUIRE( infoWithContent["content"].toByteArray() == testData );
 
     // Test with a file outside the project directory
     QString outsidePath = QDir::tempPath() + QDir::separator() + "outside_dir" + QDir::separator() + "test.txt";
     QVariantMap restrictedInfo = FileUtils::getFileInfo( outsidePath );
     REQUIRE( restrictedInfo["exists"].toBool() == false );
     REQUIRE( restrictedInfo.contains( "error" ) );
+    REQUIRE( !restrictedInfo["error"].toString().isEmpty() );
 
     QgsProject::instance()->clear();
   }


### PR DESCRIPTION
**Problem**
While developing QField extensions, I discovered that the codebase lacks functions to read and write file content directly from QML. This absence makes several common extension scenarios difficult to implement:

- Reading file content to send via POST requests to APIs
- Storing local data when offline
- Implementing custom file-based caching with validation
- Processing local files (CSV, JSON, etc.) directly in QML

After examining FileUtils, PlatformUtilities, and QFieldCloudConnection, I found no existing functions that expose file content reading/writing capabilities to QML.

**Solution**
I've added three utility functions to the FileUtils class:

```
// Read entire file content as a byte array
Q_INVOKABLE static QByteArray readFileContent(const QString &filePath);

// Write content to a file with directory creation and permissions checks
Q_INVOKABLE static bool writeFileContent(const QString &filePath, const QByteArray &content);

// Get comprehensive file info including content, MD5, and metadata 
Q_INVOKABLE static QVariantMap getFileInfo(const QString &filePath);
```
**These functions enable QML extensions to:**

- Read files for processing or uploading
- Write files for local storage
- Get file metadata and content in a single call
- Validate files using MD5 hashes

**Implementation Details**

- The functions feature robust error handling and detailed logging
- Platform-specific considerations are included for Android and iOS security restrictions
- Permissions issues are gracefully handled with informative messages
- Documentation includes guidance on safe file locations

**QML Usage Examples**
Here are some practical examples of how these functions can be used in QML extensions:

```
// Read a file and send it to an API
var fileContent = FileUtils.readFileContent(filePath);
var xhr = new XMLHttpRequest();
xhr.open("POST", "https://api.example.com/upload");
xhr.send(fileContent);

```

**Note:** 
Due to problems with my local build environment, I have not been able to test these functions in a running QField instance. The implementation is based on studying the existing codebase patterns. I would be happy to provide unit tests if needed to ensure the functionality works as expected.
These additions will significantly enhance QField's extensibility without adding much complexity to the codebase.