### PR TITLE
If users have explicitly set QT_SCALE_FACTOR environment variable, use logical DPI for map canvas rendering

### DIFF
--- a/src/core/qgsquick/qgsquickmapcanvasmap.cpp
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.cpp
@@ -288,7 +288,8 @@ void QgsQuickMapCanvasMap::onScreenChanged( QScreen *screen )
     {
       mMapSettings->setDevicePixelRatio( screen->devicePixelRatio() );
     }
-    mMapSettings->setOutputDpi( screen->physicalDotsPerInch() );
+
+    mMapSettings->setOutputDpi( !qgetenv( "QT_SCALE_FACTOR" ).isEmpty() ? screen->logicalDotsPerInch() : screen->physicalDotsPerInch() );
   }
 }
 


### PR DESCRIPTION
We should probably use logical DPI full stop, but we once tried it and our Android users didn't like the change. We can revisit for QField 4.0.

For the time being, we need it when testing scaling on Linux dev machines.