### PR TITLE
QFieldCloud security improvements

### DIFF
--- a/src/core/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloudconnection.cpp
@@ -39,7 +39,7 @@
 QFieldCloudConnection::QFieldCloudConnection()
   : mUrl( QSettings().value( QStringLiteral( "/QFieldCloud/url" ), defaultUrl() ).toString() )
   , mUsername( QSettings().value( QStringLiteral( "/QFieldCloud/username" ) ).toString() )
-  , mToken( QSettings().value( QStringLiteral( "/QFieldCloud/token" ) ).toByteArray() )
+  , mTokenConfigId( QSettings().value( QStringLiteral( "/QFieldCloud/tokenConfigId" ) ).toString() )
   , mProvider( QSettings().value( QStringLiteral( "/QFieldCloud/provider" ) ).toString() )
   , mProviderConfigId( QSettings().value( QStringLiteral( "/QFieldCloud/providerConfigId" ) ).toString() )
 {
@@ -53,6 +53,18 @@ QFieldCloudConnection::QFieldCloudConnection()
   {
     mProviderConfigId.clear();
     QSettings().remove( "/QFieldCloud/providerConfigId" );
+  }
+
+  if ( QgsApplication::authManager()->availableAuthMethodConfigs().contains( mTokenConfigId ) )
+  {
+    QgsAuthMethodConfig config;
+    QgsApplication::instance()->authManager()->loadAuthenticationConfig( mTokenConfigId, config, true );
+    mToken = config.config( "qfieldcloud-token" ).toLatin1();
+  }
+  else
+  {
+    mTokenConfigId.clear();
+    QSettings().remove( "/QFieldCloud/tokenConfigId" );
   }
 }
 
@@ -548,7 +560,32 @@ void QFieldCloudConnection::setToken( const QByteArray &token )
     return;
 
   mToken = token;
-  QSettings().setValue( "/QFieldCloud/token", token );
+
+  if ( !mToken.isEmpty() )
+  {
+    QgsAuthMethodConfig config;
+    if ( QgsApplication::authManager()->availableAuthMethodConfigs().contains( mTokenConfigId ) )
+    {
+      QgsApplication::instance()->authManager()->loadAuthenticationConfig( mProviderConfigId, config, true );
+    }
+    else
+    {
+      config.setName( "qfieldcloud-credentials" );
+      config.setMethod( "Basic" );
+    }
+    config.setConfig( "qfieldcloud-token", mToken );
+    QgsApplication::instance()->authManager()->storeAuthenticationConfig( config, true );
+    QSettings().setValue( "/QFieldCloud/tokenConfigId", config.id() );
+  }
+  else
+  {
+    if ( !mTokenConfigId.isEmpty() )
+    {
+      QgsApplication::instance()->authManager()->removeAuthenticationConfig( mTokenConfigId );
+      mTokenConfigId.clear();
+      QSettings().remove( "/QFieldCloud/tokenConfigId" );
+    }
+  }
 
   emit tokenChanged();
 }
@@ -559,7 +596,13 @@ void QFieldCloudConnection::invalidateToken()
     return;
 
   mToken = QByteArray();
-  QSettings().remove( "/QFieldCloud/token" );
+
+  if ( !mTokenConfigId.isEmpty() )
+  {
+    QgsApplication::instance()->authManager()->removeAuthenticationConfig( mTokenConfigId );
+    mTokenConfigId.clear();
+    QSettings().remove( "/QFieldCloud/tokenConfigId" );
+  }
 
   emit tokenChanged();
 }

--- a/src/core/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloudconnection.cpp
@@ -228,7 +228,7 @@ void QFieldCloudConnection::getAuthenticationProviders()
   } );
 }
 
-void QFieldCloudConnection::login()
+void QFieldCloudConnection::login( const QString &password )
 {
   if ( !mProvider.isEmpty() )
   {
@@ -238,7 +238,16 @@ void QFieldCloudConnection::login()
       return;
     }
   }
+  else
+  {
+    if ( mToken.isEmpty() && password.isEmpty() )
+    {
+      emit loginFailed( tr( "Password missing" ) );
+      return;
+    }
+  }
 
+  setPassword( password );
   setStatus( ConnectionStatus::Connecting );
 
   const bool loginUsingToken = !mProvider.isEmpty() || ( !mToken.isEmpty() && ( mPassword.isEmpty() || mUsername.isEmpty() ) );

--- a/src/core/qfieldcloudconnection.h
+++ b/src/core/qfieldcloudconnection.h
@@ -161,7 +161,7 @@ class QFieldCloudConnection : public QObject
 
     CloudUserInformation userInformation() const;
 
-    Q_INVOKABLE void login();
+    Q_INVOKABLE void login( const QString &password = QString() );
     Q_INVOKABLE void logout();
 
     Q_INVOKABLE void getAuthenticationProviders();

--- a/src/core/qfieldcloudconnection.h
+++ b/src/core/qfieldcloudconnection.h
@@ -144,7 +144,7 @@ class QFieldCloudConnection : public QObject
     /**
      * Returns the connections URLs successfully logged in in the past.
      */
-    Q_INVOKABLE QStringList urls() const;
+    QStringList urls() const;
 
     QString provider() const;
     void setProvider( const QString &provider );

--- a/src/core/qfieldcloudconnection.h
+++ b/src/core/qfieldcloudconnection.h
@@ -243,6 +243,7 @@ class QFieldCloudConnection : public QObject
     QString mUsername;
     QString mPassword;
     QByteArray mToken;
+    QString mTokenConfigId;
 
     QMap<QString, AuthenticationProvider> mAvailableProviders;
     bool mIsFetchingAvailableProviders = false;

--- a/src/qml/QFieldCloudLogin.qml
+++ b/src/qml/QFieldCloudLogin.qml
@@ -336,10 +336,9 @@ Item {
       cloudConnection.logout();
     } else {
       cloudConnection.username = usernameField.text;
-      cloudConnection.password = passwordField.text;
       cloudConnection.provider = "";
       cloudConnection.url = serverUrlField.text !== '' && prefixUrlWithProtocol(serverUrlField.text) !== cloudConnection.defaultUrl ? prefixUrlWithProtocol(serverUrlField.text) : cloudConnection.defaultUrl;
-      cloudConnection.login();
+      cloudConnection.login(passwordField.text);
     }
   }
 

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -121,9 +121,8 @@ Popup {
 
             Rectangle {
               id: cloudAvatarMask
-              anchors.centerIn: parent
-              width: 46
-              height: 46
+              anchors.fill: parent
+              anchors.margins: 1
               radius: width / 2
               color: "white"
               visible: false
@@ -133,7 +132,7 @@ Popup {
             Image {
               id: cloudAvatar
               anchors.fill: parent
-              anchors.margins: 2
+              anchors.margins: 1
               fillMode: Image.PreserveAspectCrop
               smooth: true
               source: cloudConnection.avatarUrl !== '' ? cloudConnection.avatarUrl : 'qrc:/images/qfieldcloud_logo.svg'

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -75,9 +75,8 @@ Page {
 
         Rectangle {
           id: cloudAvatarMask
-          anchors.centerIn: parent
-          width: 46
-          height: 46
+          anchors.fill: parent
+          anchors.margins: 1
           radius: width / 2
           color: "white"
           visible: false
@@ -87,7 +86,7 @@ Page {
         Image {
           id: cloudAvatar
           anchors.fill: parent
-          anchors.margins: 2
+          anchors.margins: 1
           fillMode: Image.PreserveAspectFit
           smooth: true
           source: cloudConnection.avatarUrl !== '' ? cloudConnection.avatarUrl : 'qrc:/images/qfieldcloud_logo.svg'


### PR DESCRIPTION
Two security improvements form this PR.

First, we (finally) stop storing the authentication token in unprotected, easy-to-access settings space. I.e., until now, someone could simply type the following and get the token of an active QFieldCloud session:

```
let token = settings.value("QFieldCloud/token","")
```

Second, we also stop exposing the QFieldCloud user password via a property attached to the qfieldCloudConnection object. Until now, someone could easily catch passwords through these few lines:

```
Connections {
  target: qfieldCloudConnection

  function onPasswordChanged() {
    let password = qfieldCloudConnection
  }
}
```

As we've entered the plugin era, it's important we safeguard ourselves from these exposures.

_(The PR includes two tiny polishing commits, straightforward .h[eader] cleanup and QML avatar visual improvement)_