### PR TITLE
Use QFC authentication details to style SSO buttons

### DIFF
--- a/src/qml/QFieldCloudLogin.qml
+++ b/src/qml/QFieldCloudLogin.qml
@@ -246,6 +246,12 @@ Item {
         text: qsTr("Sign in using %1").arg(modelData.name)
         height: 48
 
+        bgcolor: modelData.details.styles !== undefined ? Theme.darkTheme ? modelData.details.styles.dark.color_fill : modelData.details.styles.light.color_fill : Theme.mainColor
+        borderColor: modelData.details.styles !== undefined ? Theme.darkTheme ? modelData.details.styles.dark.color_stroke : modelData.details.styles.light.color_stroke : Theme.mainColor
+        color: modelData.details.styles !== undefined ? Theme.darkTheme ? modelData.details.styles.dark.color_text : modelData.details.styles.light.color_text : Theme.buttonTextColor
+        icon.source: modelData.details.styles !== undefined ? Theme.darkTheme ? modelData.details.styles.dark.logo : modelData.details.styles.light.logo : ""
+        icon.color: "transparent"
+
         onClicked: {
           loginFormSubmitProvider(modelData.id);
         }


### PR DESCRIPTION
@gounux , @lukasgraf , this PR implement authentication provider styling (as implemented in QFC PR https://github.com/opengisch/QFieldCloud/pull/1192)

![image](https://github.com/user-attachments/assets/59fe3b7e-319d-4abb-bcdd-3da2b5d6adef)

