### PR TITLE
Change the preposition to be lower case in "Update Attributes from Feature" string

### DIFF
--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -766,7 +766,7 @@ Rectangle {
 
     MenuItem {
       id: transferFeatureAttributesBtn
-      text: qsTr('Update Attributes From Feature')
+      text: qsTr('Update Attributes from Feature')
       icon.source: Theme.getThemeVectorIcon("ic_transfer_into_black_24dp")
       enabled: (projectInfo.insertRights && (!selection.focusedLayer || !selection.focusedLayer.customProperty("QFieldSync/is_geometry_locked", false)))
       visible: enabled


### PR DESCRIPTION

Basically the title, all prepositions are lower case, but somehow this one slipped to be capitalized and it looks alien.

![image](https://github.com/user-attachments/assets/8a336ea9-2a84-41aa-b319-03d7a41a1659)
