### PR TITLE
QFieldCloud-related classes revamp and improvements

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -101,6 +101,7 @@ set(QFIELD_CORE_SRCS
     projectsimageprovider.cpp
     qfieldappauthrequesthandler.cpp
     qfieldcloudconnection.cpp
+    qfieldcloudproject.cpp
     qfieldcloudprojectsmodel.cpp
     qgismobileapp.cpp
     qgsgeometrywrapper.cpp
@@ -227,6 +228,7 @@ set(QFIELD_CORE_HDRS
     projectsimageprovider.h
     qfieldappauthrequesthandler.h
     qfieldcloudconnection.h
+    qfieldcloudproject.h
     qfieldcloudprojectsmodel.h
     qgismobileapp.h
     qgsgeometrywrapper.h

--- a/src/core/qfieldcloudproject.cpp
+++ b/src/core/qfieldcloudproject.cpp
@@ -53,6 +53,240 @@ void QFieldCloudProject::setLocalizedDatasetsProjectId( const QString &id )
   emit localizedDatasetsProjectIdChanged();
 }
 
+void QFieldCloudProject::setIsPrivate( bool isPrivate )
+{
+  if ( mIsPrivate == isPrivate )
+    return;
+
+  mIsPrivate = isPrivate;
+  emit isPrivateChanged();
+}
+
+void QFieldCloudProject::setOwner( const QString &owner )
+{
+  if ( mOwner == owner )
+    return;
+
+  mOwner = owner;
+  emit ownerChanged();
+}
+
+void QFieldCloudProject::setName( const QString &name )
+{
+  if ( mName == name )
+    return;
+
+  mName = name;
+  emit nameChanged();
+}
+
+void QFieldCloudProject::setDescription( const QString &description )
+{
+  if ( mDescription == description )
+    return;
+
+  mDescription = description;
+  emit descriptionChanged();
+}
+
+void QFieldCloudProject::setUserRole( const QString &userRole )
+{
+  if ( mUserRole == userRole )
+    return;
+
+  mUserRole = userRole;
+  emit userRoleChanged();
+}
+
+void QFieldCloudProject::setUserRoleOrigin( const QString &userRoleOrigin )
+{
+  if ( mUserRoleOrigin == userRoleOrigin )
+    return;
+
+  mUserRoleOrigin = userRoleOrigin;
+  emit userRoleOriginChanged();
+}
+
+void QFieldCloudProject::setCanRepackage( bool canRepackage )
+{
+  if ( mCanRepackage == canRepackage )
+    return;
+
+  mCanRepackage = canRepackage;
+  emit canRepackageChanged();
+}
+
+void QFieldCloudProject::setNeedsRepackaging( bool needsRepackaging )
+{
+  if ( mNeedsRepackaging == needsRepackaging )
+    return;
+
+  mNeedsRepackaging = needsRepackaging;
+  emit needsRepackagingChanged();
+}
+
+void QFieldCloudProject::setIsOutdated( bool isOutdated )
+{
+  if ( mIsOutdated == isOutdated )
+    return;
+
+  mIsOutdated = isOutdated;
+  emit isOutdatedChanged();
+}
+
+void QFieldCloudProject::setProjectFileIsOutdated( bool projectFileIsOutdated )
+{
+  if ( mProjectFileIsOutdated == projectFileIsOutdated )
+    return;
+
+  mProjectFileIsOutdated = projectFileIsOutdated;
+  emit projectFileIsOutdatedChanged();
+}
+
+void QFieldCloudProject::setLastRefreshedAt( const QDateTime &lastRefreshedAt )
+{
+  if ( mLastRefreshedAt == lastRefreshedAt )
+    return;
+
+  mLastRefreshedAt = lastRefreshedAt;
+  emit lastRefreshedAtChanged();
+}
+
+void QFieldCloudProject::setDataLastUpdatedAt( const QDateTime &dataLastUpdatedAt )
+{
+  if ( mDataLastUpdatedAt == dataLastUpdatedAt )
+    return;
+
+  mDataLastUpdatedAt = dataLastUpdatedAt;
+  emit dataLastUpdatedAtChanged();
+}
+
+void QFieldCloudProject::setErrorStatus( ProjectErrorStatus errorStatus )
+{
+  if ( mErrorStatus == errorStatus )
+    return;
+
+  mErrorStatus = errorStatus;
+  emit errorStatusChanged();
+}
+
+void QFieldCloudProject::setCheckout( ProjectCheckouts checkout )
+{
+  if ( mCheckout == checkout )
+    return;
+
+  mCheckout = checkout;
+  emit checkoutChanged();
+}
+
+void QFieldCloudProject::setStatus( ProjectStatus status )
+{
+  if ( mStatus == status )
+    return;
+
+  mStatus = status;
+  emit statusChanged();
+}
+
+void QFieldCloudProject::setModification( ProjectModification modification )
+{
+  if ( mModification == modification )
+    return;
+
+  mModification = modification;
+  emit modificationChanged();
+}
+
+void QFieldCloudProject::setLocalPath( const QString &localPath )
+{
+  if ( mLocalPath == localPath )
+    return;
+
+  mLocalPath = localPath;
+  emit localPathChanged();
+}
+
+void QFieldCloudProject::setDeltaFileId( const QString &deltaFileId )
+{
+  if ( mDeltaFileId == deltaFileId )
+    return;
+
+  mDeltaFileId = deltaFileId;
+  emit deltaFileIdChanged();
+}
+
+void QFieldCloudProject::setDeltaFileUploadStatus( DeltaFileStatus deltaFileUploadStatus )
+{
+  if ( mDeltaFileUploadStatus == deltaFileUploadStatus )
+    return;
+
+  mDeltaFileUploadStatus = deltaFileUploadStatus;
+  emit deltaFileUploadStatusChanged();
+}
+
+void QFieldCloudProject::setDeltaFileUploadStatusString( const QString &deltaFileUploadStatusString )
+{
+  if ( mDeltaFileUploadStatusString == deltaFileUploadStatusString )
+    return;
+
+  mDeltaFileUploadStatusString = deltaFileUploadStatusString;
+  emit deltaFileUploadStatusStringChanged();
+}
+
+void QFieldCloudProject::setDeltaLayersToDownload( const QStringList &deltaLayersToDownload )
+{
+  if ( mDeltaLayersToDownload == deltaLayersToDownload )
+    return;
+
+  mDeltaLayersToDownload = deltaLayersToDownload;
+  emit deltaLayersToDownloadChanged();
+}
+
+void QFieldCloudProject::setIsPackagingActive( bool isPackagingActive )
+{
+  if ( mIsPackagingActive == isPackagingActive )
+    return;
+
+  mIsPackagingActive = isPackagingActive;
+  emit isPackagingActiveChanged();
+}
+
+void QFieldCloudProject::setIsPackagingFailed( bool isPackagingFailed )
+{
+  if ( mIsPackagingFailed == isPackagingFailed )
+    return;
+
+  mIsPackagingFailed = isPackagingFailed;
+  emit isPackagingFailedChanged();
+}
+
+void QFieldCloudProject::setPackagingStatus( PackagingStatus packagingStatus )
+{
+  if ( mPackagingStatus == packagingStatus )
+    return;
+
+  mPackagingStatus = packagingStatus;
+  emit packagingStatusChanged();
+}
+
+void QFieldCloudProject::setPackagingStatusString( const QString &packagingStatusString )
+{
+  if ( mPackagingStatusString == packagingStatusString )
+    return;
+
+  mPackagingStatusString = packagingStatusString;
+  emit packagingStatusStringChanged();
+}
+
+void QFieldCloudProject::setPackagedLayerErrors( const QStringList &packagedLayerErrors )
+{
+  if ( mPackagedLayerErrors == packagedLayerErrors )
+    return;
+
+  mPackagedLayerErrors = packagedLayerErrors;
+  emit packagedLayerErrorsChanged();
+}
+
 void QFieldCloudProject::setForceAutoPush( bool force )
 {
   if ( mForceAutoPush == force )
@@ -80,6 +314,42 @@ void QFieldCloudProject::setAutoPushIntervalMins( int minutes )
   mAutoPushIntervalMins = minutes;
   QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "autoPushIntervalMins" ), mAutoPushIntervalMins );
   emit autoPushIntervalMinsChanged();
+}
+
+void QFieldCloudProject::setLastLocalPushDeltas( const QString &lastLocalPushDeltas )
+{
+  if ( mLastLocalPushDeltas == lastLocalPushDeltas )
+    return;
+
+  mLastLocalPushDeltas = lastLocalPushDeltas;
+  emit lastLocalPushDeltasChanged();
+}
+
+void QFieldCloudProject::setLastLocalExportedAt( const QString &lastLocalExportedAt )
+{
+  if ( mLastLocalExportedAt == lastLocalExportedAt )
+    return;
+
+  mLastLocalExportedAt = lastLocalExportedAt;
+  emit lastLocalExportedAtChanged();
+}
+
+void QFieldCloudProject::setLastLocalExportId( const QString &lastLocalExportId )
+{
+  if ( mLastLocalExportId == lastLocalExportId )
+    return;
+
+  mLastLocalExportId = lastLocalExportId;
+  emit lastLocalExportIdChanged();
+}
+
+void QFieldCloudProject::setLastLocalDataLastUpdatedAt( const QDateTime &lastLocalDataLastUpdatedAt )
+{
+  if ( mLastLocalDataLastUpdatedAt == lastLocalDataLastUpdatedAt )
+    return;
+
+  mLastLocalDataLastUpdatedAt = lastLocalDataLastUpdatedAt;
+  emit lastLocalDataLastUpdatedAtChanged();
 }
 
 void QFieldCloudProject::refreshFileOutdatedStatus()
@@ -132,39 +402,29 @@ void QFieldCloudProject::packageAndDownload()
     return;
   }
 
-  mPackagingStatus = PackagingUnstartedStatus;
-  mPackagingStatusString = QString();
-  mPackagedLayerErrors.clear();
   mDownloadFileTransfers.clear();
   mDownloadFilesFinished = 0;
   mDownloadFilesFailed = 0;
   mDownloadBytesTotal = 0;
   mDownloadBytesReceived = 0;
   mDownloadProgress = 0;
-  mStatus = ProjectStatus::Downloading;
-  mErrorStatus = NoErrorStatus;
-  mModification = NoModification;
-
-  emit packagingStatusChanged();
-  emit packagingStatusStringChanged();
-  emit packagedLayerErrorsChanged();
-  emit downloadFilesFinishedChanged();
-  emit downloadFilesFailedChanged();
   emit downloadBytesTotalChanged();
   emit downloadBytesReceivedChanged();
   emit downloadProgressChanged();
-  emit statusChanged();
-  emit errorStatusChanged();
-  emit modificationChanged();
+
+  setPackagingStatus( PackagingUnstartedStatus );
+  setPackagingStatusString( QString() );
+  setPackagedLayerErrors( QStringList() );
+  setStatus( ProjectStatus::Downloading );
+  setErrorStatus( NoErrorStatus );
+  setModification( NoModification );
 
   auto repackageIfNeededAndThenDownload = [=]() {
     if ( mNeedsRepackaging )
     {
       QgsLogger::debug( QStringLiteral( "Project %1: repackaging triggered." ).arg( mId ) );
 
-      mPackagingStatus = PackagingBusyStatus;
-      emit packagingStatusChanged();
-
+      setPackagingStatus( PackagingBusyStatus );
       startJob( JobType::Package );
 
       QObject *tempProjectJobFinishedParent = new QObject( this ); // we need this to unsubscribe
@@ -192,17 +452,15 @@ void QFieldCloudProject::packageAndDownload()
 
           mJobs.take( type );
 
-          mPackagingStatus = PackagingErrorStatus;
-          mPackagingStatusString = errorString;
-          emit packagingStatusChanged();
+          setPackagingStatus( PackagingErrorStatus );
+          setPackagingStatusString( errorString );
 
           emit downloadFinished( tr( "Packaging job finished unsuccessfully for `%1`. %2" ).arg( mName ).arg( errorString ) );
           return;
         }
 
-        mPackagingStatus = PackagingFinishedStatus;
-        mPackagingStatusString = QString();
-        emit packagingStatusChanged();
+        setPackagingStatus( PackagingFinishedStatus );
+        setPackagingStatusString( QString() );
 
         download();
       } );
@@ -282,15 +540,15 @@ void QFieldCloudProject::packageAndDownload()
     const bool hasError = !error.isNull();
     if ( hasError )
     {
-      mErrorStatus = DownloadErrorStatus;
+      setErrorStatus( DownloadErrorStatus );
       QgsMessageLog::logMessage( QStringLiteral( "Downloading project `%1` finished with an error: %2" ).arg( mId ).arg( error ) );
     }
     else
     {
-      mErrorStatus = NoErrorStatus;
+      setErrorStatus( NoErrorStatus );
     }
 
-    mStatus = ProjectStatus::Idle;
+    setStatus( ProjectStatus::Idle );
 
     emit downloaded( mName, error );
   } );
@@ -529,10 +787,9 @@ void QFieldCloudProject::downloadFiles()
   // Don't call download project files, if there are no project files
   if ( mActiveFilesToDownload.isEmpty() )
   {
-    mStatus = ProjectStatus::Idle;
+    setStatus( ProjectStatus::Idle );
     mDownloadProgress = 1;
 
-    emit statusChanged();
     emit downloadProgressChanged();
 
     return;
@@ -785,15 +1042,15 @@ void QFieldCloudProject::downloadFileConnections( const QString &fileKey )
           AppInterface::instance()->reloadProject();
         }
 
-        mStatus = ProjectStatus::Idle;
-        mErrorStatus = NoErrorStatus;
-        mCheckout = ProjectCheckout::LocalAndRemoteCheckout;
-        mLocalPath = QFieldCloudUtils::localProjectFilePath( mUsername, mId );
-        mLastLocalExportedAt = QDateTime::currentDateTimeUtc().toString( Qt::ISODate );
-        mLastLocalExportId = QUuid::createUuid().toString( QUuid::WithoutBraces );
-        mLastLocalDataLastUpdatedAt = mDataLastUpdatedAt;
-        mIsOutdated = false;
-        mProjectFileIsOutdated = false;
+        setStatus( ProjectStatus::Idle );
+        setErrorStatus( NoErrorStatus );
+        setCheckout( ProjectCheckout::LocalAndRemoteCheckout );
+        setLocalPath( QFieldCloudUtils::localProjectFilePath( mUsername, mId ) );
+        setLastLocalExportedAt( QDateTime::currentDateTimeUtc().toString( Qt::ISODate ) );
+        setLastLocalExportId( QUuid::createUuid().toString( QUuid::WithoutBraces ) );
+        setLastLocalDataLastUpdatedAt( mDataLastUpdatedAt );
+        setIsOutdated( false );
+        setProjectFileIsOutdated( false );
 
         QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastExportedAt" ), mLastExportedAt );
         QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastExportId" ), mLastExportId );
@@ -802,16 +1059,6 @@ void QFieldCloudProject::downloadFileConnections( const QString &fileKey )
         QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastLocalDataLastUpdatedAt" ), mLastLocalDataLastUpdatedAt );
         QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastProjectFileMd5" ), QString() );
         QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "projectFileOudated" ), false );
-
-        emit statusChanged();
-        emit errorStatusChanged();
-        emit checkoutChanged();
-        emit localPathChanged();
-        emit lastLocalExportedAtChanged();
-        emit lastLocalExportedIdChanged();
-        emit lastDataLastUpdatedAtChanged();
-        emit isOutdatedChanged();
-        emit projectFileIsOutdatedChanged();
 
         emit downloadFinished();
       }
@@ -907,7 +1154,7 @@ void QFieldCloudProject::upload( LayerObserver *layerObserver, bool shouldDownlo
 
   if ( shouldDownloadUpdates && deltaFileWrapper->count() == 0 )
   {
-    mStatus = ProjectStatus::Idle;
+    setStatus( ProjectStatus::Idle );
     packageAndDownload();
     return;
   }
@@ -930,16 +1177,12 @@ void QFieldCloudProject::upload( LayerObserver *layerObserver, bool shouldDownlo
 
   deltaFileWrapper->setIsPushing( true );
 
-  mStatus = ProjectStatus::Uploading;
-  mDeltaFileId = deltaFileWrapper->id();
-  mDeltaFileUploadStatus = DeltaLocalStatus;
-  mDeltaFileUploadStatusString = QString();
+  setStatus( ProjectStatus::Uploading );
+  setDeltaFileId( deltaFileWrapper->id() );
+  setDeltaFileUploadStatus( DeltaLocalStatus );
+  setDeltaFileUploadStatusString( QString() );
   mUploadDeltaProgress = 0.0;
 
-  emit statusChanged();
-  emit deltaFileIdChanged();
-  emit deltaFileUploadStatusChanged();
-  emit deltaFileUploadStatusStringChanged();
   emit uploadDeltaProgressChanged();
 
   refreshModification( layerObserver );
@@ -980,8 +1223,7 @@ void QFieldCloudProject::upload( LayerObserver *layerObserver, bool shouldDownlo
   if ( deltaFileToUpload.isEmpty() )
   {
     deltaFileWrapper->setIsPushing( false );
-    mStatus = ProjectStatus::Idle;
-    emit statusChanged();
+    setStatus( ProjectStatus::Idle );
     return;
   }
 
@@ -1007,7 +1249,7 @@ void QFieldCloudProject::upload( LayerObserver *layerObserver, bool shouldDownlo
     // if there is an error, cannot continue sync
     if ( deltasReply->error() != QNetworkReply::NoError )
     {
-      mDeltaFileUploadStatusString = QFieldCloudConnection::errorString( deltasReply );
+      setDeltaFileUploadStatusString( QFieldCloudConnection::errorString( deltasReply ) );
       // TODO check why exactly we failed
       // maybe the project does not exist, then create it?
       QgsMessageLog::logMessage( QStringLiteral( "Failed to upload delta file, reason:\n%1\n%2" ).arg( deltasReply->errorString(), mDeltaFileUploadStatusString ) );
@@ -1019,11 +1261,10 @@ void QFieldCloudProject::upload( LayerObserver *layerObserver, bool shouldDownlo
     }
 
     mUploadDeltaProgress = 1.0;
-    mDeltaFileUploadStatus = DeltaPendingStatus;
-    mDeltaLayersToDownload = layerObserver->deltaFileWrapper()->deltaLayerIds();
+    setDeltaFileUploadStatus( DeltaPendingStatus );
+    setDeltaLayersToDownload( layerObserver->deltaFileWrapper()->deltaLayerIds() );
 
     emit uploadDeltaProgressChanged();
-    emit deltaFileUploadStatusChanged();
 
     emit networkDeltaUploaded();
   } );
@@ -1042,9 +1283,11 @@ void QFieldCloudProject::upload( LayerObserver *layerObserver, bool shouldDownlo
     }
     else
     {
-      mStatus = ProjectStatus::Idle;
       mModification ^= LocalModification;
-      mLastLocalPushDeltas = QDateTime::currentDateTimeUtc().toString( Qt::ISODate );
+      emit modificationChanged();
+
+      setStatus( ProjectStatus::Idle );
+      setLastLocalPushDeltas( QDateTime::currentDateTimeUtc().toString( Qt::ISODate ) );
 
       QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastLocalPushDeltas" ), mLastLocalPushDeltas );
 
@@ -1057,10 +1300,6 @@ void QFieldCloudProject::upload( LayerObserver *layerObserver, bool shouldDownlo
       {
         QgsMessageLog::logMessage( QStringLiteral( "Failed to reset delta file after delta push. %1" ).arg( deltaFileWrapper->errorString() ) );
       }
-
-      emit statusChanged();
-      emit modificationChanged();
-      emit lastLocalPushDeltasChanged();
 
       emit uploadFinished( false );
 
@@ -1111,15 +1350,13 @@ void QFieldCloudProject::upload( LayerObserver *layerObserver, bool shouldDownlo
         if ( !deltaFileWrapper->toFile() )
           QgsMessageLog::logMessage( QStringLiteral( "Failed to reset delta file. %1" ).arg( deltaFileWrapper->errorString() ) );
 
-        mStatus = ProjectStatus::Idle;
         mModification ^= LocalModification;
         mModification |= RemoteModification;
-        mLastLocalPushDeltas = QDateTime::currentDateTimeUtc().toString( Qt::ISODate );
+        emit modificationChanged();
+        setStatus( ProjectStatus::Idle );
+        setLastLocalPushDeltas( QDateTime::currentDateTimeUtc().toString( Qt::ISODate ) );
 
         QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastLocalPushDeltas" ), mLastLocalPushDeltas );
-
-        emit modificationChanged();
-        emit lastLocalPushDeltasChanged();
 
         // download the updated files, so the files are for sure the same on the client and on the server
         if ( shouldDownloadUpdates )
@@ -1139,11 +1376,8 @@ void QFieldCloudProject::upload( LayerObserver *layerObserver, bool shouldDownlo
 
 void QFieldCloudProject::cancelUpload()
 {
-  mStatus = ProjectStatus::Idle;
-  mErrorStatus = UploadErrorStatus;
-
-  emit statusChanged();
-  emit errorStatusChanged();
+  setStatus( ProjectStatus::Idle );
+  setErrorStatus( UploadErrorStatus );
 
   emit uploadFinished( false, mDeltaFileUploadStatusString );
 
@@ -1204,7 +1438,7 @@ void QFieldCloudProject::startJob( JobType type )
 
 void QFieldCloudProject::getDeltaStatus()
 {
-  mDeltaFileUploadStatusString = QString();
+  setDeltaFileUploadStatusString( QString() );
 
   NetworkReply *deltaStatusReply = mCloudConnection->get( QStringLiteral( "/api/v1/deltas/%1/%2/" ).arg( mId, mDeltaFileId ) );
   connect( deltaStatusReply, &NetworkReply::finished, this, [=]() {
@@ -1216,14 +1450,11 @@ void QFieldCloudProject::getDeltaStatus()
 
     if ( rawReply->error() != QNetworkReply::NoError )
     {
-      mDeltaFileUploadStatus = DeltaErrorStatus;
+      setDeltaFileUploadStatus( DeltaErrorStatus );
       // TODO this is oversimplification. e.g. 404 error is when the requested delta file id is not existant
-      mDeltaFileUploadStatusString = QFieldCloudConnection::errorString( rawReply );
+      setDeltaFileUploadStatusString( QFieldCloudConnection::errorString( rawReply ) );
 
-      emit deltaFileUploadStatusChanged();
-      emit deltaFileUploadStatusStringChanged();
       emit networkDeltaStatusChecked();
-
       return;
     }
 
@@ -1231,33 +1462,25 @@ void QFieldCloudProject::getDeltaStatus()
     DeltaListModel deltaListModel( doc );
     if ( !deltaListModel.isValid() )
     {
-      mDeltaFileUploadStatus = DeltaErrorStatus;
-      mDeltaFileUploadStatusString = deltaListModel.errorString();
+      setDeltaFileUploadStatus( DeltaErrorStatus );
+      setDeltaFileUploadStatusString( deltaListModel.errorString() );
 
-      emit deltaFileUploadStatusChanged();
-      emit deltaFileUploadStatusStringChanged();
       emit networkDeltaStatusChecked();
-
       return;
     }
 
-    mDeltaFileUploadStatusString = deltaListModel.errorString();
+    setDeltaFileUploadStatusString( QString() );
 
     if ( !deltaListModel.allHaveFinalStatus() )
     {
-      mDeltaFileUploadStatus = DeltaPendingStatus;
+      setDeltaFileUploadStatus( DeltaPendingStatus );
 
-      emit deltaFileUploadStatusChanged();
-      emit deltaFileUploadStatusStringChanged();
       emit networkDeltaStatusChecked();
-
       return;
     }
 
-    mDeltaFileUploadStatus = DeltaAppliedStatus;
+    setDeltaFileUploadStatus( DeltaAppliedStatus );
 
-    emit deltaFileUploadStatusChanged();
-    emit deltaFileUploadStatusStringChanged();
     emit networkDeltaStatusChecked();
   } );
 }
@@ -1427,29 +1650,17 @@ void QFieldCloudProject::refreshData( ProjectRefreshReason reason )
       return;
     }
 
-    mName = projectData.value( "name" ).toString();
-    mOwner = projectData.value( "owner" ).toString();
-    mDescription = projectData.value( "description" ).toString();
-    mUserRole = projectData.value( "user_role" ).toString();
-    mUserRoleOrigin = projectData.value( "user_role_origin" ).toString();
-    mIsPrivate = projectData.value( "is_public" ).isUndefined() ? projectData.value( "private" ).toBool() : !projectData.value( "is_public" ).toBool( false );
-    mCanRepackage = projectData.value( "can_repackage" ).toBool();
-    mNeedsRepackaging = projectData.value( "needs_repackaging" ).toBool();
-    mLastRefreshedAt = QDateTime::currentDateTimeUtc();
-    mDataLastUpdatedAt = QDateTime::fromString( projectData.value( "data_last_updated_at" ).toString(), Qt::ISODate );
-    mIsOutdated = mLastLocalDataLastUpdatedAt.isValid() ? mDataLastUpdatedAt > mLastLocalDataLastUpdatedAt : false;
-
-    emit nameChanged();
-    emit ownerChanged();
-    emit descriptionChanged();
-    emit userRoleChanged();
-    emit userRoleOriginChanged();
-    emit isPrivateChanged();
-    emit canRepackageChanged();
-    emit needsRepackagingChanged();
-    emit lastRefreshedAtChanged();
-    emit dataLastUpdatedAtChanged();
-    emit isOutdatedChanged();
+    setName( projectData.value( "name" ).toString() );
+    setOwner( projectData.value( "owner" ).toString() );
+    setDescription( projectData.value( "description" ).toString() );
+    setUserRole( projectData.value( "user_role" ).toString() );
+    setUserRoleOrigin( mUserRoleOrigin = projectData.value( "user_role_origin" ).toString() );
+    setIsPrivate( projectData.value( "is_public" ).isUndefined() ? projectData.value( "private" ).toBool() : !projectData.value( "is_public" ).toBool( false ) );
+    setCanRepackage( projectData.value( "can_repackage" ).toBool() );
+    setNeedsRepackaging( projectData.value( "needs_repackaging" ).toBool() );
+    setLastRefreshedAt( QDateTime::currentDateTimeUtc() );
+    setDataLastUpdatedAt( QDateTime::fromString( projectData.value( "data_last_updated_at" ).toString(), Qt::ISODate ) );
+    setIsOutdated( mLastLocalDataLastUpdatedAt.isValid() ? mDataLastUpdatedAt > mLastLocalDataLastUpdatedAt : false );
 
     QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "name" ), mName );
     QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "owner" ), mOwner );
@@ -1506,19 +1717,12 @@ void QFieldCloudProject::cancelDownload()
 
   QgsMessageLog::logMessage( QStringLiteral( "Download of project id `%1` aborted" ).arg( mId ) );
 
-  mPackagingStatus = PackagingAbortStatus;
-  mPackagingStatusString = tr( "aborted" );
-  mErrorStatus = NoErrorStatus;
-  mIsPackagingActive = false;
-  mIsPackagingFailed = true;
-  mStatus = ProjectStatus::Idle;
-
-  emit packagingStatusChanged();
-  emit packagingStatusStringChanged();
-  emit errorStatusChanged();
-  emit isPackagingActiveChanged();
-  emit isPackagingFailedChanged();
-  emit statusChanged();
+  setPackagingStatus( PackagingAbortStatus );
+  setPackagingStatusString( tr( "aborted" ) );
+  setErrorStatus( NoErrorStatus );
+  setIsPackagingActive( false );
+  setIsPackagingFailed( true );
+  setStatus( ProjectStatus::Idle );
 }
 
 void QFieldCloudProject::removeLocally()
@@ -1528,13 +1732,9 @@ void QFieldCloudProject::removeLocally()
   {
     dir.removeRecursively();
 
-    mLocalPath = QString();
-    mCheckout = RemoteCheckout;
-    mModification = NoModification;
-
-    emit localPathChanged();
-    emit checkoutChanged();
-    emit modificationChanged();
+    setLocalPath( QString() );
+    setCheckout( RemoteCheckout );
+    setModification( NoModification );
   }
 
   QSettings().remove( QStringLiteral( "QFieldCloud/projects/%1" ).arg( mId ) );
@@ -1590,7 +1790,6 @@ QFieldCloudProject *QFieldCloudProject::fromLocalSettings( const QString &id, QF
   const QString owner = QFieldCloudUtils::projectSetting( id, QStringLiteral( "owner" ) ).toString();
   const QString name = QFieldCloudUtils::projectSetting( id, QStringLiteral( "name" ) ).toString();
   const QString description = QFieldCloudUtils::projectSetting( id, QStringLiteral( "description" ) ).toString();
-  const QString updatedAt = QFieldCloudUtils::projectSetting( id, QStringLiteral( "updatedAt" ) ).toString();
   const QString userRole = QFieldCloudUtils::projectSetting( id, QStringLiteral( "userRole" ) ).toString();
   const QString userRoleOrigin = QFieldCloudUtils::projectSetting( id, QStringLiteral( "userRoleOrigin" ) ).toString();
 

--- a/src/core/qfieldcloudproject.cpp
+++ b/src/core/qfieldcloudproject.cpp
@@ -1,0 +1,1604 @@
+/***************************************************************************
+    qfieldcloudconnection.cpp
+    ---------------------
+    begin                : April 2025
+    copyright            : (C) 2025 by Mathieu Pellerin
+    email                : mathieu at opengis dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "deltafilewrapper.h"
+#include "deltalistmodel.h"
+#include "fileutils.h"
+#include "layerobserver.h"
+#include "qfieldcloudconnection.h"
+#include "qfieldcloudproject.h"
+#include "qfieldcloudutils.h"
+
+#include <qgsmessagelog.h>
+
+#define MAX_REDIRECTS_ALLOWED 10
+#define MAX_PARALLEL_REQUESTS 6
+#define CACHE_PROJECT_DATA_SECS 1
+
+QFieldCloudProject::QFieldCloudProject( const QString &id, QFieldCloudConnection *connection )
+  : mId( id ), mCloudConnection( connection )
+{
+  if ( mCloudConnection )
+  {
+    connect( mCloudConnection, &QFieldCloudConnection::usernameChanged, this, [=] { mUsername = mCloudConnection->username(); } );
+    mUsername = mCloudConnection->username();
+  }
+}
+
+QFieldCloudProject::~QFieldCloudProject()
+{
+  delete mDeltaListModel;
+}
+
+void QFieldCloudProject::setForceAutoPush( bool force )
+{
+  if ( mForceAutoPush == force )
+    return;
+
+  mForceAutoPush = force;
+  emit forceAutoPushChanged();
+}
+
+void QFieldCloudProject::setAutoPushEnabled( bool enabled )
+{
+  if ( mAutoPushEnabled == enabled )
+    return;
+
+  mAutoPushEnabled = enabled;
+  QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "autoPushEnabled" ), mAutoPushEnabled );
+  emit autoPushEnabledChanged();
+}
+
+void QFieldCloudProject::setAutoPushIntervalMins( int minutes )
+{
+  if ( mAutoPushIntervalMins == minutes )
+    return;
+
+  mAutoPushIntervalMins = minutes;
+  QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "autoPushIntervalMins" ), mAutoPushIntervalMins );
+  emit autoPushIntervalMinsChanged();
+}
+
+void QFieldCloudProject::refreshFileOutdatedStatus()
+{
+  NetworkReply *reply = mCloudConnection->get( QStringLiteral( "/api/v1/files/%1/" ).arg( mId ) );
+
+  connect( reply, &NetworkReply::finished, reply, [=]() {
+    QNetworkReply *rawReply = reply->currentRawReply();
+    reply->deleteLater();
+
+    if ( rawReply->error() != QNetworkReply::NoError )
+    {
+      QgsLogger::debug( QStringLiteral( "Project %1: failed to refresh the project file outdated satus. %2" ).arg( mId, QFieldCloudConnection::errorString( rawReply ) ) );
+      return;
+    }
+
+    const QJsonArray files = QJsonDocument::fromJson( rawReply->readAll() ).array();
+    const QString lastProjectFileMd5 = QFieldCloudUtils::projectSetting( mId, QStringLiteral( "lastProjectFileMd5" ), QString() ).toString();
+    for ( const auto file : files )
+    {
+      QVariantHash fileDetails = file.toObject().toVariantHash();
+      const QString fileName = fileDetails.value( "name" ).toString().toLower();
+      if ( fileName.endsWith( QStringLiteral( ".qgs" ) ) || fileName.endsWith( QStringLiteral( ".qgz" ) ) )
+      {
+        if ( lastProjectFileMd5.isEmpty() )
+        {
+          // First check, store for future comparison
+          QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastProjectFileMd5" ), fileDetails.value( "md5sum" ).toString() );
+        }
+        else if ( lastProjectFileMd5 != fileDetails.value( "md5sum" ).toString() )
+        {
+          mProjectFileIsOutdated = true;
+          QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "projectFileOudated" ), true );
+          emit projectFileIsOutdatedChanged();
+        }
+      }
+    }
+  } );
+}
+
+void QFieldCloudProject::packageAndDownload()
+{
+  QgsLogger::debug( QStringLiteral( "Project %1: package and download initiated." ).arg( mId ) );
+
+  if ( !mCloudConnection )
+    return;
+
+  if ( mStatus != ProjectStatus::Idle )
+  {
+    return;
+  }
+
+  mPackagingStatus = PackagingUnstartedStatus;
+  mPackagingStatusString = QString();
+  mPackagedLayerErrors.clear();
+  mDownloadFileTransfers.clear();
+  mDownloadFilesFinished = 0;
+  mDownloadFilesFailed = 0;
+  mDownloadBytesTotal = 0;
+  mDownloadBytesReceived = 0;
+  mDownloadProgress = 0;
+  mStatus = ProjectStatus::Downloading;
+  mErrorStatus = NoErrorStatus;
+  mModification = NoModification;
+
+  emit packagingStatusChanged();
+  emit packagingStatusStringChanged();
+  emit packagedLayerErrorsChanged();
+  emit downloadFilesFinishedChanged();
+  emit downloadFilesFailedChanged();
+  emit downloadBytesTotalChanged();
+  emit downloadBytesReceivedChanged();
+  emit downloadProgressChanged();
+  emit statusChanged();
+  emit errorStatusChanged();
+  emit modificationChanged();
+
+  auto repackageIfNeededAndThenDownload = [=]() {
+    if ( mNeedsRepackaging )
+    {
+      QgsLogger::debug( QStringLiteral( "Project %1: repackaging triggered." ).arg( mId ) );
+
+      mPackagingStatus = PackagingBusyStatus;
+      emit packagingStatusChanged();
+
+      startJob( JobType::Package );
+
+      QObject *tempProjectJobFinishedParent = new QObject( this ); // we need this to unsubscribe
+      connect( this, &QFieldCloudProject::jobFinished, tempProjectJobFinishedParent, [=]( const JobType type, const QString &errorString ) {
+        if ( type != JobType::Package )
+        {
+          QMetaEnum me = QMetaEnum::fromType<JobType>();
+          QgsLogger::debug( QStringLiteral( "Project %1: unexpected job type, expected %2 but %3 received." ).arg( mId, me.valueToKey( static_cast<int>( JobType::Package ) ), me.valueToKey( static_cast<int>( type ) ) ) );
+          Q_ASSERT( 0 );
+          return;
+        }
+
+        tempProjectJobFinishedParent->deleteLater();
+
+        if ( mPackagingStatus == PackagingAbortStatus )
+        {
+          // no need to emit why we aborted packaging, whoever sets the packagingStatus is responsible to inform the user
+          QgsLogger::debug( QStringLiteral( "Project %1: packaging finished, but project operations are aborted." ).arg( mId ) );
+          return;
+        }
+
+        if ( mJobs[type].status != JobFinishedStatus )
+        {
+          QgsLogger::warning( QStringLiteral( "Project %1: packaging has an error: %2" ).arg( mId, errorString ) );
+
+          mJobs.take( type );
+
+          mPackagingStatus = PackagingErrorStatus;
+          mPackagingStatusString = errorString;
+          emit packagingStatusChanged();
+
+          emit downloadFinished( tr( "Packaging job finished unsuccessfully for `%1`. %2" ).arg( mName ).arg( errorString ) );
+          return;
+        }
+
+        mPackagingStatus = PackagingFinishedStatus;
+        mPackagingStatusString = QString();
+        emit packagingStatusChanged();
+
+        download();
+      } );
+    }
+    else
+    {
+      download();
+    }
+  };
+
+  // Check and refresh project data if needed, because it might be outdated
+  if ( !mLastRefreshedAt.isValid() || mLastRefreshedAt.secsTo( QDateTime::currentDateTimeUtc() ) > CACHE_PROJECT_DATA_SECS )
+  {
+    QgsLogger::debug( QStringLiteral( "Project %1: refreshing data..." ).arg( mId ) );
+
+    refreshData( ProjectRefreshReason::Package );
+
+    QObject *tempProjectRefreshParent = new QObject( this ); // we need this to unsubscribe
+    connect( this, &QFieldCloudProject::dataRefreshed, tempProjectRefreshParent, [=]( const ProjectRefreshReason reason, const QString &error ) {
+      if ( reason != ProjectRefreshReason::Package )
+      {
+        QgsLogger::critical( QStringLiteral( "Project %1: unexpected job type, expected %2 but %3 received." ).arg( mId ).arg( static_cast<int>( ProjectRefreshReason::Package ), static_cast<int>( reason ) ) );
+        Q_ASSERT( 0 );
+        return;
+      }
+
+      tempProjectRefreshParent->deleteLater();
+
+      if ( mPackagingStatus == PackagingAbortStatus )
+      {
+        // no need to emit why we aborted packaging, whoever sets the packagingStatus is responsible to inform the user
+        QgsLogger::debug( QStringLiteral( "Project %1: refreshing data finished, but project operations are aborted." ).arg( mId ) );
+        return;
+      }
+
+      if ( !error.isNull() )
+      {
+        QgsLogger::debug( QStringLiteral( "Project %1: refreshing data finished with an error: %2." ).arg( mId, error ) );
+        emit downloadFinished( tr( "Failed to refresh the latest info for `%1`: %2" ).arg( mName, error ) );
+        return;
+      }
+
+      repackageIfNeededAndThenDownload();
+    } );
+  }
+  else
+  {
+    repackageIfNeededAndThenDownload();
+  }
+
+  QObject *tempProjectDownloadFinishedParent = new QObject( this ); // we need this to unsubscribe
+  connect( this, &QFieldCloudProject::downloadFinished, tempProjectDownloadFinishedParent, [=]( const QString &error ) {
+    tempProjectDownloadFinishedParent->deleteLater();
+
+    if ( mPackagingStatus == PackagingAbortStatus )
+    {
+      // no need to emit why we aborted packaging, it is callers responsibility to inform the user
+      QgsLogger::debug( QStringLiteral( "Project %1: downloading project finished, but project operations are aborted." ).arg( mId ) );
+      return;
+    }
+
+    const QStringList fileKeys = mDownloadFileTransfers.keys();
+    for ( const QString &fileKey : fileKeys )
+    {
+      if ( mDownloadFileTransfers[fileKey].networkReply )
+      {
+        if ( !mDownloadFileTransfers[fileKey].networkReply->isFinished() )
+        {
+          mDownloadFileTransfers[fileKey].networkReply->abort();
+        }
+        mDownloadFileTransfers[fileKey].networkReply->deleteLater();
+      }
+    }
+
+    mActiveFilesToDownload.clear();
+
+    const bool hasError = !error.isNull();
+    if ( hasError )
+    {
+      mErrorStatus = DownloadErrorStatus;
+      QgsMessageLog::logMessage( QStringLiteral( "Downloading project `%1` finished with an error: %2" ).arg( mId ).arg( error ) );
+    }
+    else
+    {
+      mErrorStatus = NoErrorStatus;
+    }
+
+    mStatus = ProjectStatus::Idle;
+
+    emit downloaded( mName, error );
+  } );
+}
+
+void QFieldCloudProject::download()
+{
+  QVariantMap params;
+  params.insert( "skip_metadata", "1" );
+  NetworkReply *reply = mCloudConnection->get( QStringLiteral( "/api/v1/packages/%1/latest/" ).arg( mId ), params );
+
+  connect( reply, &NetworkReply::finished, reply, [=]() {
+    reply->deleteLater();
+
+    if ( mPackagingStatus == PackagingAbortStatus )
+    {
+      // no need to emit why we aborted packaging, it is callers responsibility to inform the user
+      QgsLogger::debug( QStringLiteral( "Project %1: adding download file connections, but the project is aborted." ).arg( mId ) );
+      return;
+    }
+
+    QNetworkReply *rawReply = reply->currentRawReply();
+
+    if ( rawReply->error() != QNetworkReply::NoError )
+    {
+      QgsLogger::debug( QStringLiteral( "Project %1: failed to get latest package data. %2" ).arg( mId, QFieldCloudConnection::errorString( rawReply ) ) );
+      emit downloadFinished( tr( "Failed to get latest package data." ) );
+      return;
+    }
+
+    const QJsonObject payload = QJsonDocument::fromJson( rawReply->readAll() ).object();
+    const QString packageId = payload.value( QStringLiteral( "package_id" ) ).toString();
+    const QString packagedAt = payload.value( QStringLiteral( "packaged_at" ) ).toString();
+
+    if ( packageId.isNull() || packagedAt.isNull() || !payload.value( QStringLiteral( "files" ) ).isArray() )
+    {
+      QgsLogger::debug( QStringLiteral( "Project %1: JSON for package does not contain the expected fields: package_id(string), packaged_at(string), files(array), layers(object)" ).arg( mId ) );
+      emit downloadFinished( tr( "Latest package data response error." ) );
+      return;
+    }
+
+    const QJsonArray files = payload.value( QStringLiteral( "files" ) ).toArray();
+    for ( const QJsonValue fileValue : files )
+    {
+      const QJsonObject fileObject = fileValue.toObject();
+      const int fileSize = fileObject.value( QStringLiteral( "size" ) ).toInt();
+      const QString fileName = fileObject.value( QStringLiteral( "name" ) ).toString();
+      const QString projectFileName = QStringLiteral( "%1/%2/%3/%4" ).arg( QFieldCloudUtils::localCloudDirectory(), mUsername, mId, fileName );
+      // NOTE the cloud API is giving the false impression that the file keys `md5sum` is having a MD5 or another checksum.
+      // This actually is an Object Storage (S3) implementation specific ETag.
+      const QString cloudEtag = fileObject.value( QStringLiteral( "md5sum" ) ).toString();
+      const QString localEtag = FileUtils::fileEtag( projectFileName );
+
+      if ( !fileObject.value( QStringLiteral( "size" ) ).isDouble() || fileName.isEmpty() || cloudEtag.isEmpty() )
+      {
+        QgsLogger::debug( QStringLiteral( "Project %1: package in \"files\" list does not contain the expected fields: size(int), name(string), md5sum(string)" ).arg( mId ) );
+        emit downloadFinished( tr( "Latest package data structure error." ) );
+        return;
+      }
+
+      if ( cloudEtag == localEtag )
+        continue;
+
+      mDownloadFileTransfers.insert( QStringLiteral( "%1/%2" ).arg( mId, fileName ), FileTransfer( fileName, fileSize, mId ) );
+      mDownloadBytesTotal += std::max( fileSize, 0 );
+    }
+
+    emit downloadBytesTotalChanged();
+
+    const QJsonObject layers = payload.value( QStringLiteral( "layers" ) ).toObject();
+    QStringList localizedDatasets;
+    bool hasLayerExportErrror = false;
+    for ( const QString &layerKey : layers.keys() )
+    {
+      QJsonObject layer = layers.value( layerKey ).toObject();
+      QString layerName = layer.value( QStringLiteral( "name" ) ).toString();
+      QString layerStatus = layer.value( QStringLiteral( "error_code" ) ).toString();
+
+      if ( layerKey.isEmpty() || layerName.isEmpty() || layerStatus.isEmpty() || !layer.value( QStringLiteral( "is_valid" ) ).isBool() )
+      {
+        QgsLogger::debug( QStringLiteral( "Project %1: JSON structure package in \"layers\" list does not contain the expected fields: name(string), error_code(string), is_valid(bool)" ).arg( mId ) );
+      }
+      else
+      {
+        if ( layer.value( QStringLiteral( "is_localized" ) ).toBool() )
+        {
+          const QString localizedDataset = layer.value( "datasource" ).toString().mid( 10 );
+          if ( !localizedDataset.isEmpty() )
+          {
+            localizedDatasets << localizedDataset;
+          }
+        }
+        else if ( !layer.value( QStringLiteral( "is_valid" ) ).toBool() )
+        {
+          QString errorSummary = layer.value( QStringLiteral( "error_summary" ) ).toString() + layer.value( QStringLiteral( "provider_error_summary" ) ).toString();
+
+          mPackagedLayerErrors.append( tr( "Project %1: Packaged layer `%2` is not valid. Error code %3, error message: %4" ).arg( mId, layerName, layerStatus, errorSummary ) );
+          QgsMessageLog::logMessage( mPackagedLayerErrors.last() );
+
+          hasLayerExportErrror = true;
+        }
+      }
+    }
+
+    if ( hasLayerExportErrror )
+    {
+      QgsLogger::debug( QStringLiteral( "Project %1: packaged files list request finished with some failed layers:\n%2" ).arg( mId, mPackagedLayerErrors.join( QStringLiteral( "\n" ) ) ) );
+      emit packagedLayerErrorsChanged();
+    }
+
+    mLastExportId = packageId;
+    mLastExportedAt = packagedAt;
+
+    if ( !localizedDatasets.isEmpty() && mLocalizedDatasetsProjects.contains( mOwner ) )
+    {
+      NetworkReply *localizedDatasetsReply = mCloudConnection->get( QStringLiteral( "/api/v1/files/%1/" ).arg( mLocalizedDatasetsProjects[project->owner] ) );
+      connect( localizedDatasetsReply, &NetworkReply::finished, localizedDatasetsReply, [=]() {
+        QNetworkReply *localizedDatasetsRawReply = localizedDatasetsReply->currentRawReply();
+        localizedDatasetsReply->deleteLater();
+
+        if ( localizedDatasetsRawReply->error() != QNetworkReply::NoError )
+        {
+          QgsLogger::debug( QStringLiteral( "Project %1: failed to get latest package data. %2" ).arg( mId, QFieldCloudConnection::errorString( rawReply ) ) );
+          emit downloadFinished( tr( "Failed to get latest package data." ) );
+          return;
+        }
+
+        const QJsonArray files = QJsonDocument::fromJson( localizedDatasetsRawReply->readAll() ).array();
+        for ( const QJsonValue fileValue : files )
+        {
+          const QJsonObject fileObject = fileValue.toObject();
+          const QString fileName = fileObject.value( QStringLiteral( "name" ) ).toString();
+          if ( localizedDatasets.contains( fileName ) )
+          {
+            const int fileSize = fileObject.value( QStringLiteral( "size" ) ).toInt();
+            const QString absoluteFileName = QStringLiteral( "%1/%2/%3/%4" ).arg( QFieldCloudUtils::localCloudDirectory(), mUsername, mLocalizedDatasetsProjects[project->owner], fileName );
+            // NOTE the cloud API is giving the false impression that the file keys `md5sum` is having a MD5 or another checksum.
+            // This actually is an Object Storage (S3) implementation specific ETag.
+            const QString cloudEtag = fileObject.value( QStringLiteral( "md5sum" ) ).toString();
+            const QString localEtag = FileUtils::fileEtag( absoluteFileName );
+
+            if (
+              !fileObject.value( QStringLiteral( "size" ) ).isDouble()
+              || fileName.isEmpty()
+              || cloudEtag.isEmpty() )
+            {
+              QgsLogger::debug( QStringLiteral( "Project %1: package in \"files\" list does not contain the expected fields: size(int), name(string), md5sum(string)" ).arg( mLocalizedDatasetsProjects[project->owner] ) );
+              emit downloadFinished( tr( "Latest package data structure error." ) );
+              return;
+            }
+
+            if ( cloudEtag == localEtag )
+              continue;
+
+            mDownloadFileTransfers.insert( QStringLiteral( "%1/%2" ).arg( mLocalizedDatasetsProjects[project->owner], fileName ), FileTransfer( fileName, fileSize, mLocalizedDatasetsProjects[project->owner] ) );
+            mDownloadBytesTotal += std::max( fileSize, 0 );
+          }
+        }
+
+        emit downloadBytesTotalChanged();
+
+        QgsLogger::debug( QStringLiteral( "Project %1: packaged files to download - %2 files, namely: %3" ).arg( mId ).arg( mDownloadFileTransfers.count() ).arg( mDownloadFileTransfers.keys().join( ", " ) ) );
+
+        updateActiveProjectFilesToDownload();
+        projectDownloadFiles();
+      } );
+    }
+    else
+    {
+      QgsLogger::debug( QStringLiteral( "Project %1: packaged files to download - %2 files, namely: %3" ).arg( mId ).arg( mDownloadFileTransfers.count() ).arg( mDownloadFileTransfers.keys().join( ", " ) ) );
+
+      updateActiveProjectFilesToDownload();
+      projectDownloadFiles();
+    }
+  } );
+}
+
+void QFieldCloudProject::updateActiveFilesToDownload()
+{
+  if ( !mCloudConnection )
+    return;
+
+  const QStringList fileKeys = mDownloadFileTransfers.keys();
+
+  if ( fileKeys.isEmpty() )
+  {
+    mActiveFilesToDownload.clear();
+    return;
+  }
+
+  for ( const QString &fileKey : fileKeys )
+  {
+    if ( mDownloadFileTransfers[fileKey].networkReply )
+    {
+      if ( mDownloadFileTransfers[fileKey].networkReply->isFinished() )
+      {
+        if ( mActiveFilesToDownload.removeOne( fileKey ) )
+        {
+          // QgsLogger::debug( QStringLiteral( "Project %1, file `%2`: removed from the list of active download files" ).arg( projectId, fileName ) );
+        }
+        continue;
+      }
+      else
+      {
+        // the request is still active
+        continue;
+      }
+    }
+
+    if ( mActiveFilesToDownload.size() >= MAX_PARALLEL_REQUESTS )
+    {
+      return;
+    }
+
+    // QgsLogger::debug( QStringLiteral( "Project %1, file `%2`: appended to the active download files list" ).arg( projectId, fileName ) );
+
+    mActiveFilesToDownload.append( fileKey );
+  }
+
+  if ( mActiveFilesToDownload.count() > 0 )
+  {
+    QgsLogger::debug( QStringLiteral( "Project %1: active download files list contains %2 files, namely: %3" ).arg( mId ).arg( mActiveFilesToDownload.count() ).arg( mActiveFilesToDownload.join( ", " ) ) );
+  }
+  else
+  {
+    QgsLogger::debug( QStringLiteral( "Project %1: active download files list is empty" ).arg( mId ) );
+  }
+}
+
+void QFieldCloudProject::downloadFiles()
+{
+  // calling updateActiveProjectFilesToDownload() before calling this function is mandatory
+
+  if ( !mCloudConnection )
+    return;
+
+  // Don't call download project files, if there are no project files
+  if ( mActiveFilesToDownload.isEmpty() )
+  {
+    mStatus = ProjectStatus::Idle;
+    mDownloadProgress = 1;
+
+    emit statusChanged();
+    emit downloadProgressChanged();
+
+    return;
+  }
+
+  QgsLogger::debug( QStringLiteral( "Project %1: active download files list before actual download: %2" ).arg( mId, mActiveFilesToDownload.join( ", " ) ) );
+
+  for ( const QString &fileKey : std::as_const( mActiveFilesToDownload ) )
+  {
+    if ( mDownloadFileTransfers[fileKey].networkReply )
+    {
+      // Download is already in progress
+      continue;
+    }
+
+    NetworkReply *reply = downloadFile( mDownloadFileTransfers[fileKey].projectId, mDownloadFileTransfers[fileKey].fileName, mDownloadFileTransfers[fileKey].projectId == mId );
+
+    QTemporaryFile *file = new QTemporaryFile( reply );
+    file->setAutoRemove( false );
+
+    if ( !file->open() )
+    {
+      mDownloadFilesFailed++;
+      emit downloadFinished( tr( "Failed to open temporary file for `%1`, reason:\n%2" ).arg( mDownloadFileTransfers[fileKey].fileName ).arg( file->errorString() ) );
+      return;
+    }
+
+    mDownloadFileTransfers[fileKey].tmpFile = file->fileName();
+    mDownloadFileTransfers[fileKey].networkReply = reply;
+
+    downloadFileConnections( fileKey );
+  }
+}
+
+void QFieldCloudProject::downloadFileConnections( const QString &fileKey )
+{
+  if ( mDownloadFileTransfers.contains( fileKey ) )
+  {
+    Q_ASSERT( false );
+    return;
+  }
+
+  NetworkReply *reply = mDownloadFileTransfers[fileKey].networkReply;
+  if ( !reply )
+  {
+    Q_ASSERT( false );
+    return;
+  }
+
+  const QStringList fileKeys = mDownloadFileTransfers.keys();
+
+  QgsLogger::debug( QStringLiteral( "Project %1, file `%2`: requested." ).arg( mDownloadFileTransfers[fileKey].projectId, mDownloadFileTransfers[fileKey].fileName ) );
+
+  connect( reply, &NetworkReply::redirected, reply, [=]( const QUrl &url ) {
+    QUrl oldUrl = mDownloadFileTransfers[fileKey].lastRedirectUrl;
+
+    mDownloadFileTransfers[fileKey].redirectsCount++;
+    mDownloadFileTransfers[fileKey].lastRedirectUrl = url;
+
+    if ( mDownloadFileTransfers[fileKey].redirectsCount >= MAX_REDIRECTS_ALLOWED )
+    {
+      QgsLogger::debug( QStringLiteral( "Project %1, file `%2`: too many redirects, last two urls are `%3` and `%4`" ).arg( mId, fileKey, oldUrl.toString(), url.toString() ) );
+      reply->abort();
+      return;
+    }
+
+    if ( oldUrl == url )
+    {
+      QgsLogger::debug( QStringLiteral( "Project %1, file `%2`: has redirects to the same URL `%3`" ).arg( mId, fileKey, url.toString() ) );
+      reply->abort();
+      return;
+    }
+
+    QgsLogger::debug( QStringLiteral( "Package %1, file `%2`: redirected to `%3`" ).arg( mId, fileKey, url.toString() ) );
+
+    QNetworkRequest request;
+    mDownloadFileTransfers[fileKey].networkReply = mCloudConnection->get( request, url );
+    mDownloadFileTransfers[fileKey].networkReply->setParent( reply );
+
+    // we need to somehow finish the request, otherwise it will remain unfinished for the QFieldCloudConnection
+    reply->abort();
+
+    downloadFileConnections( fileKey );
+  } );
+
+  connect( reply, &NetworkReply::downloadProgress, reply, [=]( int bytesReceived, int bytesTotal ) {
+    QNetworkReply *rawReply = reply->currentRawReply();
+    if ( !rawReply )
+    {
+      return;
+    }
+
+    const QString temporaryFileName = mDownloadFileTransfers[fileKey].tmpFile;
+    QFile file( temporaryFileName );
+    QString errorMessageDetail;
+    QString errorMessage;
+    bool hasError = false;
+
+    if ( file.open( QIODevice::WriteOnly | QIODevice::Append ) )
+    {
+      file.write( rawReply->readAll() );
+
+      if ( file.error() != QFile::NoError )
+      {
+        hasError = true;
+        errorMessageDetail = file.errorString();
+        errorMessage = tr( "File system error. Failed to write file to temporary location `%1`." ).arg( temporaryFileName );
+      }
+
+      file.close();
+    }
+    else
+    {
+      hasError = true;
+      errorMessageDetail = file.errorString();
+      errorMessage = tr( "File system error. Failed to open file for writing on temporary `%1`." ).arg( temporaryFileName );
+    }
+
+    // check if the code above failed with error
+    if ( hasError )
+    {
+      logFailedDownload( fileKey, errorMessage, errorMessageDetail );
+      rawReply->abort();
+      return;
+    }
+
+    Q_UNUSED( bytesTotal )
+
+    mDownloadBytesReceived -= mDownloadFileTransfers[fileKey].bytesTransferred;
+    mDownloadBytesReceived += bytesReceived;
+    mDownloadFileTransfers[fileKey].bytesTransferred = bytesReceived;
+    mDownloadProgress = std::clamp( ( static_cast<double>( mDownloadBytesReceived ) / std::max( mDownloadBytesTotal, 1 ) ), 0., 1. );
+
+    emit downloadBytesReceivedChanged();
+    emit downloadProgressChanged();
+  } );
+
+  connect( reply, &NetworkReply::finished, reply, [=]() {
+    if ( mPackagingStatus == PackagingAbortStatus )
+    {
+      return;
+    }
+
+    QNetworkReply *rawReply = reply->currentRawReply();
+
+    Q_ASSERT( reply->isFinished() );
+    Q_ASSERT( reply );
+
+    // this is most probably the redirected request, nothing to do with this reply anymore, just ignore it
+    if ( mDownloadFileTransfers[fileKey].networkReply != reply )
+    {
+      return;
+    }
+
+    mDownloadFilesFinished++;
+
+    bool hasError = false;
+    QString errorMessageDetail;
+    QString errorMessage;
+
+    if ( rawReply->error() != QNetworkReply::NoError )
+    {
+      hasError = true;
+      errorMessageDetail = QFieldCloudConnection::errorString( rawReply );
+      errorMessage = tr( "Network error. Failed to download file `%1`." ).arg( fileKey );
+    }
+
+    if ( !hasError )
+    {
+      mDownloadBytesReceived -= mDownloadFileTransfers[fileKey].bytesTransferred;
+      mDownloadBytesReceived += mDownloadFileTransfers[fileKey].bytesTotal;
+      mDownloadProgress = std::clamp( ( static_cast<double>( mDownloadBytesReceived ) / std::max( mDownloadBytesTotal, 1 ) ), 0., 1. );
+
+      emit downloadBytesReceivedChanged();
+      emit downloadProgressChanged();
+    }
+
+    // check if the code above failed with error
+    if ( hasError )
+    {
+      logFailedDownload( fileKey, errorMessage, errorMessageDetail );
+      rawReply->abort();
+      return;
+    }
+
+    QgsLogger::debug( QStringLiteral( "Package %1, file `%2`: downloaded" ).arg( mId, fileKey ) );
+
+    updateActiveFilesToDownload();
+
+    if ( mDownloadFilesFinished == fileKeys.count() )
+    {
+      QgsLogger::debug( QStringLiteral( "Project %1: All files downloaded." ).arg( mId ) );
+      Q_ASSERT( mActiveFilesToDownload.size() == 0 );
+
+      if ( !hasError )
+      {
+        //const bool currentProjectReloadNeeded = project->id == mCurrentProjectId;
+        //QStringList gpkgFileNames;
+        //if ( currentProjectReloadNeeded )
+        //{
+        //  // we need to close the project to safely flush the gpkg files and avoid file lock on Windows
+        //  const QStringList unprefixedGpkgFileNames = filterGpkgFileNames( fileNames );
+        //  gpkgFileNames = projectFileNames( mProject->homePath(), unprefixedGpkgFileNames );
+        //  mProject->clear();
+
+        //  for ( const QString &fileName : gpkgFileNames )
+        //    mGpkgFlusher->stop( fileName );
+        //}
+
+        // move the files from their temporary location to their permanent one
+        if ( !moveDownloadedFilesToPermanentStorage() )
+        {
+          emit downloadFinished( tr( "Failed to copy some of the downloaded files on your device. Check your device storage." ) );
+          return;
+        }
+
+        //if ( currentProjectReloadNeeded )
+        //{
+        //  deleteGpkgShmAndWal( gpkgFileNames );
+        //  AppInterface::instance()->reloadProject();
+        //}
+
+        mErrorStatus = NoErrorStatus;
+        mCheckout = ProjectCheckout::LocalAndRemoteCheckout;
+        mLocalPath = QFieldCloudUtils::localProjectFilePath( mUsername, mId );
+        mLastLocalExportedAt = QDateTime::currentDateTimeUtc().toString( Qt::ISODate );
+        mLastLocalExportId = QUuid::createUuid().toString( QUuid::WithoutBraces );
+        mLastLocalDataLastUpdatedAt = mDataLastUpdatedAt;
+        mIsOutdated = false;
+        mProjectFileIsOutdated = false;
+
+        QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastExportedAt" ), mLastExportedAt );
+        QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastExportId" ), mLastExportId );
+        QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastLocalExportedAt" ), mLastLocalExportedAt );
+        QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastLocalExportId" ), mLastLocalExportId );
+        QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastLocalDataLastUpdatedAt" ), mLastLocalDataLastUpdatedAt );
+        QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastProjectFileMd5" ), QString() );
+        QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "projectFileOudated" ), false );
+
+        emit errorStatusChanged();
+        emit checkoutChanged();
+        emit localPathChanged();
+        emit lastLocalExportedAtChanged();
+        emit lastLocalExportedIdChanged();
+        emit lastDataLastUpdatedAtChanged();
+        emit isOutdatedChanged();
+        emit projectFileIsOutdatedChanged();
+
+        emit downloadFinished();
+      }
+    }
+    else
+    {
+      downloadFiles();
+    }
+  } );
+}
+
+NetworkReply *QFieldCloudProject::downloadFile( const QString &projectId, const QString &fileName, bool fromLatestPackage )
+{
+  QNetworkRequest request;
+  request.setAttribute( QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::RedirectPolicy::UserVerifiedRedirectPolicy );
+  mCloudConnection->setAuthenticationDetails( request );
+
+  return mCloudConnection->get( request, fromLatestPackage ? QStringLiteral( "/api/v1/packages/%1/latest/files/%2/" ).arg( projectId, fileName ) : QStringLiteral( "/api/v1/files/%1/%2/" ).arg( projectId, fileName ) );
+}
+
+bool QFieldCloudProject::moveDownloadedFilesToPermanentStorage()
+{
+  bool hasError = false;
+  const QStringList fileKeys = mDownloadFileTransfers.keys();
+
+  for ( const QString &fileKey : fileKeys )
+  {
+    QFileInfo fileInfo( mDownloadFileTransfers[fileKey].fileName );
+    QFile file( mDownloadFileTransfers[fileKey].tmpFile );
+    QDir dir( QStringLiteral( "%1/%2/%3/%4" ).arg( QFieldCloudUtils::localCloudDirectory(), mUsername, mDownloadFileTransfers[fileKey].projectId, fileInfo.path() ) );
+
+    if ( !hasError && !dir.exists() && !dir.mkpath( QStringLiteral( "." ) ) )
+    {
+      hasError = true;
+      QgsMessageLog::logMessage( QStringLiteral( "Failed to create directory at `%1`" ).arg( dir.path() ) );
+    }
+
+    const QString destinationFileName( QDir::cleanPath( dir.filePath( fileInfo.fileName() ) ) );
+
+    // if the file already exists, we need to delete it first, as QT does not support overwriting
+    // NOTE: it is possible that someone creates the file in the meantime between this and the next if statement
+    if ( !hasError && QFile::exists( destinationFileName ) && !file.remove( destinationFileName ) )
+    {
+      hasError = true;
+      QgsMessageLog::logMessage( QStringLiteral( "Failed to remove file before overwriting stored at `%1`, reason:\n%2" ).arg( destinationFileName ).arg( file.errorString() ) );
+    }
+
+    if ( !hasError && !file.copy( destinationFileName ) )
+    {
+      hasError = true;
+      QgsMessageLog::logMessage( QStringLiteral( "Failed to write downloaded file stored at `%1`, reason:\n%2" ).arg( destinationFileName ).arg( file.errorString() ) );
+
+      if ( !QFile::remove( dir.filePath( mDownloadFileTransfers[fileKey].fileName ) ) )
+        QgsMessageLog::logMessage( QStringLiteral( "Failed to remove partly overwritten file stored at `%1`" ).arg( destinationFileName ) );
+    }
+
+    if ( !file.remove() )
+    {
+      QgsMessageLog::logMessage( QStringLiteral( "Failed to remove temporary file `%1`" ).arg( destinationFileName ) );
+    }
+  }
+
+  return !hasError;
+}
+
+void QFieldCloudProject::logFailedDownload( const QString &fileKey, const QString &errorMessage, const QString &errorMessageDetail )
+{
+  mDownloadFilesFailed++;
+
+  QgsLogger::debug( QStringLiteral( "Project %1, file `%2`: %3 %4" ).arg( mId, fileKey, errorMessage, errorMessageDetail ) );
+
+  // translate the user messages
+  const QString baseMessage = tr( "Project `%1`, file `%2`: %3" ).arg( mName, fileKey, errorMessage );
+  const QString trimmedMessage = baseMessage + QStringLiteral( " " ) + tr( "System message: " )
+                                 + ( ( errorMessageDetail.size() > 100 )
+                                       ? ( errorMessageDetail.left( 100 ) + tr( " (see more in the QField error log)…" ) )
+                                       : errorMessageDetail );
+
+  QgsMessageLog::logMessage( QStringLiteral( "%1\n%2" ).arg( baseMessage, errorMessageDetail ) );
+
+  emit downloadFinished( trimmedMessage );
+}
+
+
+void QFieldCloudProject::upload( LayerObserver *layerObserver, bool shouldDownloadUpdates )
+{
+  if ( mStatus != ProjectStatus::Idle )
+  {
+    return;
+  }
+
+  DeltaFileWrapper *deltaFileWrapper = layerObserver->deltaFileWrapper();
+
+  if ( shouldDownloadUpdates && deltaFileWrapper->count() == 0 )
+  {
+    mStatus = ProjectStatus::Idle;
+    packageAndDownload();
+    return;
+  }
+
+  if ( !( mModification & LocalModification ) )
+  {
+    return;
+  }
+
+  if ( !layerObserver->deltaFileWrapper()->toFile() )
+  {
+    return;
+  }
+
+  if ( deltaFileWrapper->hasError() )
+  {
+    QgsMessageLog::logMessage( QStringLiteral( "The delta file has an error: %1" ).arg( deltaFileWrapper->errorString() ) );
+    return;
+  }
+
+  deltaFileWrapper->setIsPushing( true );
+
+  mStatus = ProjectStatus::Uploading;
+  mDeltaFileId = deltaFileWrapper->id();
+  mDeltaFileUploadStatus = DeltaLocalStatus;
+  mDeltaFileUploadStatusString = QString();
+  mUploadDeltaProgress = 0.0;
+
+  emit statusChanged();
+  emit deltaFileIdChanged();
+  emit deltaFileUploadStatusChanged();
+  emit deltaFileUploadStatusStringChanged();
+  emit uploadDeltaProgressChanged();
+
+  refreshModification( layerObserver );
+
+  // //////////
+  // prepare attachment files to be uploaded
+  // //////////
+
+  const QFileInfo projectInfo( QFieldCloudUtils::localProjectFilePath( mUsername, mId ) );
+  const QDir projectDir( projectInfo.absolutePath() );
+  const QStringList attachmentFileNames = deltaFileWrapper->attachmentFileNames().keys();
+
+  for ( const QString &fileName : attachmentFileNames )
+  {
+    if ( fileName.isEmpty() )
+      continue;
+
+    QString absoluteFilePath = fileName;
+    QFileInfo fileInfo( fileName );
+    if ( fileInfo.isRelative() )
+    {
+      absoluteFilePath = projectDir.absoluteFilePath( fileName );
+      fileInfo = QFileInfo( absoluteFilePath );
+    }
+
+    if ( !fileInfo.exists() || !fileInfo.isFile() )
+    {
+      QgsMessageLog::logMessage( QStringLiteral( "Attachment file '%1' does not exist" ).arg( absoluteFilePath ) );
+      continue;
+    }
+
+    const long long fileSize = fileInfo.size();
+
+    // ? should we also check the checksums of the files being uploaded? they are available at deltaFile->attachmentFileNames()->values()
+    QFieldCloudUtils::addPendingAttachments( mId, { absoluteFilePath } );
+  }
+
+  QString deltaFileToUpload = deltaFileWrapper->toFileForUpload();
+
+  if ( deltaFileToUpload.isEmpty() )
+  {
+    deltaFileWrapper->setIsPushing( false );
+    mStatus = ProjectStatus::Idle;
+    emit statusChanged();
+    return;
+  }
+
+  // //////////
+  // 1) upload the deltas
+  // //////////
+  NetworkReply *deltasCloudReply = mCloudConnection->post( QStringLiteral( "/api/v1/deltas/%1/" ).arg( mId ), QVariantMap(), QStringList( { deltaFileToUpload } ) );
+
+  Q_ASSERT( deltasCloudReply );
+
+  connect( deltasCloudReply, &NetworkReply::uploadProgress, this, [=]( int bytesSent, int bytesTotal ) {
+    mUploadDeltaProgress = std::clamp( ( static_cast<double>( bytesSent ) / bytesTotal ), 0., 1. );
+    emit uploadDeltaProgressChanged();
+  } );
+
+  connect( deltasCloudReply, &NetworkReply::finished, this, [=]() {
+    QNetworkReply *deltasReply = deltasCloudReply->currentRawReply();
+    deltasCloudReply->deleteLater();
+
+    Q_ASSERT( deltasCloudReply->isFinished() );
+    Q_ASSERT( deltasReply );
+
+    // if there is an error, cannot continue sync
+    if ( deltasReply->error() != QNetworkReply::NoError )
+    {
+      mDeltaFileUploadStatusString = QFieldCloudConnection::errorString( deltasReply );
+      // TODO check why exactly we failed
+      // maybe the project does not exist, then create it?
+      QgsMessageLog::logMessage( QStringLiteral( "Failed to upload delta file, reason:\n%1\n%2" ).arg( deltasReply->errorString(), mDeltaFileUploadStatusString ) );
+
+      layerObserver->deltaFileWrapper()->setIsPushing( false );
+
+      cancelUpload();
+      return;
+    }
+
+    mUploadDeltaProgress = 1.0;
+    mDeltaFileUploadStatus = DeltaPendingStatus;
+    mDeltaLayersToDownload = layerObserver->deltaFileWrapper()->deltaLayerIds();
+
+    emit uploadDeltaProgressChanged();
+    emit deltaFileUploadStatusChanged();
+
+    emit networkDeltaUploaded();
+  } );
+
+
+  // //////////
+  // 2) delta successfully uploaded
+  // //////////
+  QObject *networkDeltaUploadedParent = new QObject( this ); // we need this to unsubscribe
+  connect( this, &QFieldCloudProject::networkDeltaUploaded, networkDeltaUploadedParent, [=]() {
+    delete networkDeltaUploadedParent;
+
+    if ( shouldDownloadUpdates )
+    {
+      getDeltaStatus();
+    }
+    else
+    {
+      mStatus = ProjectStatus::Idle;
+      mModification ^= LocalModification;
+      mLastLocalPushDeltas = QDateTime::currentDateTimeUtc().toString( Qt::ISODate );
+
+      QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastLocalPushDeltas" ), mLastLocalPushDeltas );
+
+      DeltaFileWrapper *deltaFileWrapper = layerObserver->deltaFileWrapper();
+      deltaFileWrapper->reset();
+      deltaFileWrapper->resetId();
+      deltaFileWrapper->setIsPushing( false );
+
+      if ( !deltaFileWrapper->toFile() )
+      {
+        QgsMessageLog::logMessage( QStringLiteral( "Failed to reset delta file after delta push. %1" ).arg( deltaFileWrapper->errorString() ) );
+      }
+
+      emit statusChanged();
+      emit modificationChanged();
+      emit lastLocalPushDeltasChanged();
+
+      emit uploadFinished( false );
+
+      refreshData( ProjectRefreshReason::DeltaUploaded );
+    }
+  } );
+
+  // //////////
+  // 3) new delta status received. Never give up to get a successful status.
+  // //////////
+  QObject *networkDeltaStatusCheckedParent = new QObject( this ); // we need this to unsubscribe
+  connect( this, &QFieldCloudProject::networkDeltaStatusChecked, networkDeltaStatusCheckedParent, [=]() {
+    DeltaFileWrapper *deltaFileWrapper = layerObserver->deltaFileWrapper();
+
+    switch ( mDeltaFileUploadStatus )
+    {
+      case DeltaLocalStatus:
+        // delta file should be already sent!!!
+        Q_ASSERT( 0 );
+        [[fallthrough]];
+
+      case DeltaPendingStatus:
+      case DeltaBusyStatus:
+        // infinite retry, there should be one day, when we can get the status!
+        QTimer::singleShot( sDelayBeforeStatusRetry, [=]() { getDeltaStatus(); } );
+        break;
+
+      case DeltaErrorStatus:
+        delete networkDeltaStatusCheckedParent;
+        deltaFileWrapper->resetId();
+        deltaFileWrapper->setIsPushing( false );
+
+        if ( !deltaFileWrapper->toFile() )
+          QgsMessageLog::logMessage( QStringLiteral( "Failed update committed delta file." ) );
+
+        cancelUpload();
+        return;
+
+      case DeltaConflictStatus:
+      case DeltaNotAppliedStatus:
+      case DeltaAppliedStatus:
+        delete networkDeltaStatusCheckedParent;
+
+        deltaFileWrapper->reset();
+        deltaFileWrapper->resetId();
+        deltaFileWrapper->setIsPushing( false );
+
+        if ( !deltaFileWrapper->toFile() )
+          QgsMessageLog::logMessage( QStringLiteral( "Failed to reset delta file. %1" ).arg( deltaFileWrapper->errorString() ) );
+
+        mStatus = ProjectStatus::Idle;
+        mModification ^= LocalModification;
+        mModification |= RemoteModification;
+        mLastLocalPushDeltas = QDateTime::currentDateTimeUtc().toString( Qt::ISODate );
+
+        QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastLocalPushDeltas" ), mLastLocalPushDeltas );
+
+        emit modificationChanged();
+        emit lastLocalPushDeltasChanged();
+
+        // download the updated files, so the files are for sure the same on the client and on the server
+        if ( shouldDownloadUpdates )
+        {
+          emit uploadFinished( true, QString() );
+          packageAndDownload();
+        }
+        else
+        {
+          emit statusChanged();
+          emit uploadFinished( false, QString() );
+          refreshData( ProjectRefreshReason::DeltaUploaded );
+        }
+    }
+  } );
+}
+
+void QFieldCloudProject::cancelUpload()
+{
+  mStatus = ProjectStatus::Idle;
+  mErrorStatus = UploadErrorStatus;
+
+  emit statusChanged();
+  emit errorStatusChanged();
+
+  emit uploadFinished( false, mDeltaFileUploadStatusString );
+
+  return;
+}
+
+
+void QFieldCloudProject::startJob( JobType type )
+{
+  mJobs[type] = Job( QString(), mId, type );
+
+  QString jobTypeName = getJobTypeAsString( type );
+  QgsLogger::debug( QStringLiteral( "Project %1: creating a new `%2` job..." ).arg( mId, jobTypeName ) );
+  NetworkReply *reply = mCloudConnection->post( QStringLiteral( "/api/v1/jobs/" ),
+                                                QVariantMap(
+                                                  {
+                                                    { "project_id", mId },
+                                                    { "type", jobTypeName },
+                                                  } ) );
+
+  connect( reply, &NetworkReply::finished, reply, [=]() {
+    reply->deleteLater();
+
+    if ( mPackagingStatus == PackagingAbortStatus )
+    {
+      // no need to emit why we aborted packaging, it is callers responsibility to inform the user
+      QgsLogger::debug( QStringLiteral( "Project %1: job creation finished, but project operations are aborted." ).arg( mId ) );
+      return;
+    }
+
+    QNetworkReply *rawReply = reply->currentRawReply();
+
+    if ( rawReply->error() != QNetworkReply::NoError )
+    {
+      QString errorString = QFieldCloudConnection::errorString( rawReply );
+      QgsLogger::debug( QStringLiteral( "Project %1: job creation failed with an error: %2" ).arg( mId, errorString ) );
+      emit jobFinished( type, errorString );
+      return;
+    }
+
+    const QJsonObject payload = QJsonDocument::fromJson( rawReply->readAll() ).object();
+    const QString jobId = payload.value( QStringLiteral( "id" ) ).toString();
+
+    if ( jobId.isEmpty() )
+    {
+      QgsLogger::debug( QStringLiteral( "Project %1: job creation finished, but missing id key from the response payload" ).arg( mId ) );
+      emit jobFinished( type, tr( "Job creation finished, but the server response is missing required fields: id(string)" ).arg( jobId ) );
+      return;
+    }
+
+    QgsLogger::debug( QStringLiteral( "Project %1: created job with id `%2`" ).arg( mId ).arg( jobId ) );
+
+    mJobs[type].id = jobId;
+
+    getJobStatus( type );
+  } );
+}
+
+void QFieldCloudProject::getDeltaStatus()
+{
+  mDeltaFileUploadStatusString = QString();
+
+  NetworkReply *deltaStatusReply = mCloudConnection->get( QStringLiteral( "/api/v1/deltas/%1/%2/" ).arg( mId, mDeltaFileId ) );
+  connect( deltaStatusReply, &NetworkReply::finished, this, [=]() {
+    QNetworkReply *rawReply = deltaStatusReply->currentRawReply();
+    deltaStatusReply->deleteLater();
+
+    Q_ASSERT( deltaStatusReply->isFinished() );
+    Q_ASSERT( rawReply );
+
+    if ( rawReply->error() != QNetworkReply::NoError )
+    {
+      mDeltaFileUploadStatus = DeltaErrorStatus;
+      // TODO this is oversimplification. e.g. 404 error is when the requested delta file id is not existant
+      mDeltaFileUploadStatusString = QFieldCloudConnection::errorString( rawReply );
+
+      emit deltaFileUploadStatusChanged();
+      emit deltaFileUploadStatusStringChanged();
+      emit networkDeltaStatusChecked();
+
+      return;
+    }
+
+    const QJsonDocument doc = QJsonDocument::fromJson( rawReply->readAll() );
+    DeltaListModel deltaListModel( doc );
+    if ( !deltaListModel.isValid() )
+    {
+      mDeltaFileUploadStatus = DeltaErrorStatus;
+      mDeltaFileUploadStatusString = deltaListModel.errorString();
+
+      emit deltaFileUploadStatusChanged();
+      emit deltaFileUploadStatusStringChanged();
+      emit networkDeltaStatusChecked();
+
+      return;
+    }
+
+    mDeltaFileUploadStatusString = deltaListModel.errorString();
+
+    if ( !deltaListModel.allHaveFinalStatus() )
+    {
+      mDeltaFileUploadStatus = DeltaPendingStatus;
+
+      emit deltaFileUploadStatusChanged();
+      emit deltaFileUploadStatusStringChanged();
+      emit networkDeltaStatusChecked();
+
+      return;
+    }
+
+    mDeltaFileUploadStatus = DeltaAppliedStatus;
+
+    emit deltaFileUploadStatusChanged();
+    emit deltaFileUploadStatusStringChanged();
+    emit networkDeltaStatusChecked();
+  } );
+}
+
+void QFieldCloudProject::getJobStatus( const JobType type )
+{
+  if ( mPackagingStatus == PackagingAbortStatus )
+  {
+    // no need to emit why we aborted packaging, it is callers responsibility to inform the user
+    QgsLogger::debug( QStringLiteral( "Project %1: getting job status, but project operations are aborted." ).arg( mId ) );
+    return;
+  }
+
+  if ( !mJobs.contains( type ) )
+  {
+    const QString jobTypeName = getJobTypeAsString( type );
+    QgsLogger::debug( QStringLiteral( "Project %1: getting job status, but no `%2` job triggered yet." ).arg( mId, jobTypeName ) );
+    emit jobFinished( type, tr( "Getting job status, but no `%2` job triggered yet." ).arg( jobTypeName ) );
+    return;
+  }
+
+  const QString jobId = mJobs[type].id;
+  QgsLogger::debug( QStringLiteral( "Project %1, job %2: getting job status..." ).arg( mId, jobId ) );
+  NetworkReply *reply = mCloudConnection->get( QStringLiteral( "/api/v1/jobs/%1/" ).arg( jobId ) );
+
+  connect( reply, &NetworkReply::finished, this, [=]() {
+    reply->deleteLater();
+
+    if ( mPackagingStatus == PackagingAbortStatus )
+    {
+      // no need to emit why we aborted packaging, it is callers responsibility to inform the user
+      QgsLogger::debug( QStringLiteral( "Project %1, job %2: getting job status finished, but project operations are aborted." ).arg( mId, jobId ) );
+      return;
+    }
+
+    QNetworkReply *rawReply = reply->currentRawReply();
+
+    if ( rawReply->error() != QNetworkReply::NoError )
+    {
+      QString errorString = QFieldCloudConnection::errorString( rawReply );
+      QgsLogger::debug( QStringLiteral( "Project %1, job %2: getting job status finished with an error: %3." ).arg( mId, jobId, errorString ) );
+      mJobs[type].status = JobFailedStatus;
+      emit jobFinished( type, errorString );
+      return;
+    }
+
+    const QJsonObject payload = QJsonDocument::fromJson( rawReply->readAll() ).object();
+    const QString jobStatusString = payload.value( QStringLiteral( "status" ) ).toString();
+
+    if ( jobStatusString.isEmpty() )
+    {
+      QgsLogger::debug( QStringLiteral( "Project %1, job %2: getting job status finished, but missing status key from the response payload" ).arg( mId, jobId ) );
+
+      mJobs[type].status = JobFailedStatus;
+      emit jobFinished( type, tr( "job(%1) status response does not contain all the expected keys: status(string)" ).arg( jobId ) );
+      return;
+    }
+
+    mJobs[type].status = getJobStatusFromString( jobStatusString );
+
+    QgsLogger::debug( QStringLiteral( "Project %1, job %2: getting job status finished with `%3`" ).arg( mId, jobId, jobStatusString ) );
+
+    switch ( mJobs[type].status )
+    {
+      case JobPendingStatus:
+      case JobQueuedStatus:
+      case JobStartedStatus:
+      case JobStoppedStatus:
+        // infinite retry, there should be one day, when we can get the status!
+        QTimer::singleShot( sDelayBeforeStatusRetry, [=]() {
+          getJobStatus( type );
+        } );
+        break;
+
+      case JobFailedStatus:
+        emit jobFinished( type, tr( "Job(%1) finished with a failed status." ).arg( jobId ) );
+        return;
+      case JobFinishedStatus:
+        emit jobFinished( type );
+        return;
+    }
+  } );
+}
+
+QFieldCloudProject::JobStatus QFieldCloudProject::getJobStatusFromString( const QString &status )
+{
+  const QString statusLower = status.toLower();
+  if ( statusLower == QStringLiteral( "pending" ) )
+    return QFieldCloudProject::JobPendingStatus;
+  else if ( statusLower == QStringLiteral( "queued" ) )
+    return QFieldCloudProject::JobQueuedStatus;
+  else if ( statusLower == QStringLiteral( "started" ) )
+    return QFieldCloudProject::JobStartedStatus;
+  else if ( statusLower == QStringLiteral( "stopped" ) )
+    return QFieldCloudProject::JobStoppedStatus;
+  else if ( statusLower == QStringLiteral( "finished" ) )
+    return QFieldCloudProject::JobFinishedStatus;
+  //cppcheck-suppress duplicateBranch
+  else if ( statusLower == QStringLiteral( "failed" ) )
+    return QFieldCloudProject::JobFailedStatus;
+  else
+    // "STATUS_ERROR" or any unknown status is considered an error
+    return QFieldCloudProject::JobFailedStatus;
+}
+
+QString QFieldCloudProject::getJobTypeAsString( JobType jobType )
+{
+  switch ( jobType )
+  {
+    case QFieldCloudProject::JobType::Package:
+      return QStringLiteral( "package" );
+  }
+
+  return QString();
+}
+
+void QFieldCloudProject::refreshModification( LayerObserver *layerObserver )
+{
+  ProjectModifications oldModifications = mModification;
+
+  if ( layerObserver->deltaFileWrapper()->count() > 0 )
+  {
+    mModification |= LocalModification;
+  }
+  else if ( mModification & QFieldCloudProject::LocalModification )
+  {
+    mModification ^= LocalModification;
+  }
+
+  if ( oldModifications != mModification )
+  {
+    emit modificationChanged();
+  }
+}
+
+void QFieldCloudProject::refreshData( ProjectRefreshReason reason )
+{
+  NetworkReply *reply = mCloudConnection->get( QStringLiteral( "/api/v1/projects/%1/" ).arg( mId ) );
+  connect( reply, &NetworkReply::finished, reply, [=]() {
+    QNetworkReply *rawReply = reply->currentRawReply();
+
+    reply->deleteLater();
+
+    if ( rawReply->error() != QNetworkReply::NoError )
+    {
+      emit dataRefreshed( reason, QFieldCloudConnection::errorString( rawReply ) );
+      return;
+    }
+
+    const QJsonObject projectData = QJsonDocument::fromJson( rawReply->readAll() ).object();
+    const QString projectId = projectData.value( "id" ).toString();
+    if ( mId != projectId )
+      return;
+
+    QgsLogger::debug( QStringLiteral( "Project %1: data refreshed." ).arg( mId ) );
+
+    if (
+      !projectData.value( "name" ).isString()
+      || !projectData.value( "owner" ).isString()
+      || !projectData.value( "description" ).isString()
+      || !projectData.value( "user_role" ).isString()
+      || !projectData.value( "is_public" ).isBool()
+      || !projectData.value( "can_repackage" ).isBool()
+      || !projectData.value( "needs_repackaging" ).isBool() )
+    {
+      emit dataRefreshed( reason, tr( "project(%1) trigger response refresh not contain all the expected keys: name(string), owner(string), description(string), user_role(string), is_public(bool), can_repackage(bool), needs_repackaging(bool)" ).arg( projectId ) );
+      return;
+    }
+
+    mName = projectData.value( "name" ).toString();
+    mOwner = projectData.value( "owner" ).toString();
+    mDescription = projectData.value( "description" ).toString();
+    mUserRole = projectData.value( "user_role" ).toString();
+    mUserRoleOrigin = projectData.value( "user_role_origin" ).toString();
+    mIsPrivate = projectData.value( "is_public" ).isUndefined() ? projectData.value( "private" ).toBool() : !projectData.value( "is_public" ).toBool( false );
+    mCanRepackage = projectData.value( "can_repackage" ).toBool();
+    mNeedsRepackaging = projectData.value( "needs_repackaging" ).toBool();
+    mLastRefreshedAt = QDateTime::currentDateTimeUtc();
+    mDataLastUpdatedAt = QDateTime::fromString( projectData.value( "data_last_updated_at" ).toString(), Qt::ISODate );
+    mIsOutdated = mLastLocalDataLastUpdatedAt.isValid() ? mDataLastUpdatedAt > mLastLocalDataLastUpdatedAt : false;
+
+    emit nameChanged();
+    emit ownerChanged();
+    emit descriptionChanged();
+    emit userRoleChanged();
+    emit userRoleOriginChanged();
+    emit isPrivateChanged();
+    emit canRepackageChanged();
+    emit needsRepackagingChanged();
+    emit lastRefreshedAtChanged();
+    emit dataLastUpdatedAtChanged();
+    emit isOutdatedChanged();
+
+    QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "name" ), mName );
+    QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "owner" ), mOwner );
+    QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "description" ), mDescription );
+    QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "userRole" ), mUserRole );
+    QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "userRoleOrigin" ), mUserRoleOrigin );
+    QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "isPrivate" ), mIsPrivate );
+    QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "canRepackage" ), mCanRepackage );
+    QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "needsRepackaging" ), mNeedsRepackaging );
+
+    emit dataRefreshed( reason );
+  } );
+}
+
+void QFieldCloudProject::refreshDeltaList()
+{
+  if ( mDeltaListModel )
+  {
+    delete mDeltaListModel;
+    mDeltaListModel = nullptr;
+    emit deltaListModelChanged();
+  }
+
+  NetworkReply *deltaStatusReply = mCloudConnection->get( QStringLiteral( "/api/v1/deltas/%1/" ).arg( mId ) );
+  connect( deltaStatusReply, &NetworkReply::finished, this, [=]() {
+    QNetworkReply *rawReply = deltaStatusReply->currentRawReply();
+    deltaStatusReply->deleteLater();
+
+    Q_ASSERT( deltaStatusReply->isFinished() );
+    Q_ASSERT( rawReply );
+
+    if ( rawReply->error() != QNetworkReply::NoError )
+    {
+      return;
+    }
+
+    const QJsonDocument doc = QJsonDocument::fromJson( rawReply->readAll() );
+    mDeltaListModel = new DeltaListModel( doc );
+    emit deltaListModelChanged();
+  } );
+}
+void QFieldCloudProject::cancelDownload()
+{
+  const QStringList fileKeys = mDownloadFileTransfers.keys();
+  for ( const QString &fileKey : fileKeys )
+  {
+    NetworkReply *reply = mDownloadFileTransfers[fileKey].networkReply;
+
+    if ( reply )
+      reply->abort();
+
+    mDownloadFileTransfers.remove( fileKey );
+  }
+
+  QgsMessageLog::logMessage( QStringLiteral( "Download of project id `%1` aborted" ).arg( mId ) );
+
+  mPackagingStatus = PackagingAbortStatus;
+  mPackagingStatusString = tr( "aborted" );
+  mErrorStatus = NoErrorStatus;
+  mIsPackagingActive = false;
+  mIsPackagingFailed = true;
+  mStatus = ProjectStatus::Idle;
+
+  emit packagingStatusChanged();
+  emit packagingStatusStringChanged();
+  emit errorStatusChanged();
+  emit isPackagingActiveChanged();
+  emit isPackagingFailedChanged();
+  emit statusChanged();
+}
+
+void QFieldCloudProject::removeLocally()
+{
+  QDir dir( QStringLiteral( "%1/%2/%3" ).arg( QFieldCloudUtils::localCloudDirectory(), mUsername, mId ) );
+  if ( dir.exists() )
+  {
+    dir.removeRecursively();
+
+    mLocalPath = QString();
+    mCheckout = RemoteCheckout;
+    mModification = NoModification;
+
+    emit localPathChanged();
+    emit checkoutChanged();
+    emit modificationChanged();
+  }
+
+  QSettings().remove( QStringLiteral( "QFieldCloud/projects/%1" ).arg( mId ) );
+}
+
+QFieldCloudProject *QFieldCloudProject::fromDetails( const QVariantHash &details, QFieldCloudConnection *connection )
+{
+  QFieldCloudProject *project = new QFieldCloudProject( details.value( "id" ).toString(), connection );
+  project->mIsPrivate = details.value( "private" ).toBool();
+  project->mOwner = details.value( "owner" ).toString();
+  project->mName = details.value( "name" ).toString();
+  project->mDescription = details.value( "description" ).toString();
+  project->mUserRole = details.value( "user_role" ).toString();
+  project->mUserRoleOrigin = details.value( "user_role_origin" ).toString();
+  project->mCheckout = RemoteCheckout;
+  project->mStatus = ProjectStatus::Idle;
+  project->mDataLastUpdatedAt = QDateTime::fromString( details.value( "data_last_updated_at" ).toString(), Qt::ISODate );
+  project->mCanRepackage = details.value( "can_repackage" ).toBool();
+  project->mNeedsRepackaging = details.value( "needs_repackaging" ).toBool();
+
+  QFieldCloudUtils::setProjectSetting( project->id(), QStringLiteral( "owner" ), project->owner() );
+  QFieldCloudUtils::setProjectSetting( project->id(), QStringLiteral( "name" ), project->name() );
+  QFieldCloudUtils::setProjectSetting( project->id(), QStringLiteral( "description" ), project->description() );
+  QFieldCloudUtils::setProjectSetting( project->id(), QStringLiteral( "userRole" ), project->userRole() );
+  QFieldCloudUtils::setProjectSetting( project->id(), QStringLiteral( "userRoleOrigin" ), project->userRoleOrigin() );
+  QFieldCloudUtils::setProjectSetting( project->id(), QStringLiteral( "canRepackage" ), project->canRepackage() );
+  QFieldCloudUtils::setProjectSetting( project->id(), QStringLiteral( "needsRepackaging" ), project->needsRepackaging() );
+
+  QString username = connection ? connection->username() : QString();
+  if ( !username.isEmpty() )
+  {
+    project->mLocalPath = QFieldCloudUtils::localProjectFilePath( username, project->id() );
+    QDir localPath( QStringLiteral( "%1/%2/%3" ).arg( QFieldCloudUtils::localCloudDirectory(), username, project->id() ) );
+    if ( localPath.exists() )
+    {
+      project->mCheckout = LocalAndRemoteCheckout;
+      restoreLocalSettings( project, localPath );
+    }
+  }
+
+  project->mLastRefreshedAt = QDateTime::currentDateTimeUtc();
+  return project;
+}
+
+QFieldCloudProject *QFieldCloudProject::fromLocalSettings( const QString &id, QFieldCloudConnection *connection )
+{
+  const QString projectPrefix = QStringLiteral( "QFieldCloud/projects/%1" ).arg( id );
+  if ( !QSettings().contains( QStringLiteral( "%1/name" ).arg( projectPrefix ) ) )
+  {
+    return nullptr;
+  }
+
+  const QString owner = QFieldCloudUtils::projectSetting( id, QStringLiteral( "owner" ) ).toString();
+  const QString name = QFieldCloudUtils::projectSetting( id, QStringLiteral( "name" ) ).toString();
+  const QString description = QFieldCloudUtils::projectSetting( id, QStringLiteral( "description" ) ).toString();
+  const QString updatedAt = QFieldCloudUtils::projectSetting( id, QStringLiteral( "updatedAt" ) ).toString();
+  const QString userRole = QFieldCloudUtils::projectSetting( id, QStringLiteral( "userRole" ) ).toString();
+  const QString userRoleOrigin = QFieldCloudUtils::projectSetting( id, QStringLiteral( "userRoleOrigin" ) ).toString();
+
+  QFieldCloudProject *project = new QFieldCloudProject( id, connection );
+  project->mIsPrivate = true;
+  project->mOwner = owner;
+  project->mName = name;
+  project->mDescription = description;
+  project->mUserRole = userRole;
+  project->mUserRoleOrigin = userRoleOrigin;
+  project->mCheckout = LocalCheckout;
+  project->mStatus = ProjectStatus::Idle;
+  project->mDataLastUpdatedAt = QDateTime();
+  project->mCanRepackage = false;
+  project->mNeedsRepackaging = false;
+
+  QString username = connection ? connection->username() : QString();
+  if ( !username.isEmpty() )
+  {
+    project->mLocalPath = QFieldCloudUtils::localProjectFilePath( username, project->mId );
+  }
+
+  QDir localPath( QStringLiteral( "%1/%2/%3" ).arg( QFieldCloudUtils::localCloudDirectory(), username, project->mId ) );
+  restoreLocalSettings( project, localPath );
+
+  return project;
+}
+
+void QFieldCloudProject::restoreLocalSettings( QFieldCloudProject *project, const QDir &localPath )
+{
+  project->mDeltasCount = DeltaFileWrapper( QgsProject::instance(), QStringLiteral( "%1/deltafile.json" ).arg( localPath.absolutePath() ) ).count();
+  project->mLastExportId = QFieldCloudUtils::projectSetting( project->id(), QStringLiteral( "lastExportId" ) ).toString();
+  project->mLastExportedAt = QFieldCloudUtils::projectSetting( project->id(), QStringLiteral( "lastExportedAt" ) ).toString();
+  project->mLastLocalExportId = QFieldCloudUtils::projectSetting( project->id(), QStringLiteral( "lastLocalExportId" ) ).toString();
+  project->mLastLocalExportedAt = QFieldCloudUtils::projectSetting( project->id(), QStringLiteral( "lastLocalExportedAt" ) ).toString();
+  project->mLastLocalPushDeltas = QFieldCloudUtils::projectSetting( project->id(), QStringLiteral( "lastLocalPushDeltas" ) ).toString();
+  project->mLastLocalDataLastUpdatedAt = QFieldCloudUtils::projectSetting( project->id(), QStringLiteral( "lastLocalDataLastUpdatedAt" ) ).toDateTime();
+  project->mIsOutdated = project->mDataLastUpdatedAt > project->mLastLocalDataLastUpdatedAt;
+  project->mProjectFileIsOutdated = QFieldCloudUtils::projectSetting( project->id(), QStringLiteral( "projectFileOudated" ), false ).toBool();
+  project->mAutoPushEnabled = QFieldCloudUtils::projectSetting( project->id(), QStringLiteral( "autoPushEnabled" ), false ).toBool();
+  project->mAutoPushIntervalMins = QFieldCloudUtils::projectSetting( project->id(), QStringLiteral( "autoPushIntervalMins" ), 30 ).toInt();
+
+  // generate local export id if not present. Possible reasons for missing localExportId are:
+  // - just upgraded QField that introduced the field
+  // - the local settings were somehow deleted, but not the project itself
+  if ( project->lastLocalExportId().isEmpty() )
+  {
+    project->mLastLocalExportId = QUuid::createUuid().toString( QUuid::WithoutBraces );
+    QFieldCloudUtils::setProjectSetting( project->id(), QStringLiteral( "lastLocalExportId" ), project->lastLocalExportId() );
+  }
+};

--- a/src/core/qfieldcloudproject.cpp
+++ b/src/core/qfieldcloudproject.cpp
@@ -32,7 +32,6 @@ QFieldCloudProject::QFieldCloudProject( const QString &id, QFieldCloudConnection
 {
   if ( mCloudConnection )
   {
-    connect( mCloudConnection, &QFieldCloudConnection::usernameChanged, this, [=] { mUsername = mCloudConnection->username(); } );
     mUsername = mCloudConnection->username();
   }
 }

--- a/src/core/qfieldcloudproject.cpp
+++ b/src/core/qfieldcloudproject.cpp
@@ -24,6 +24,7 @@
 
 #include <QDirIterator>
 #include <QFileInfo>
+#include <QQmlEngine>
 #include <qgsmessagelog.h>
 
 #define MAX_REDIRECTS_ALLOWED 10
@@ -33,6 +34,8 @@
 QFieldCloudProject::QFieldCloudProject( const QString &id, QFieldCloudConnection *connection, QgsGpkgFlusher *gpkgFlusher )
   : mId( id ), mCloudConnection( connection ), mGpkgFlusher( gpkgFlusher )
 {
+  QQmlEngine::setObjectOwnership( this, QQmlEngine::CppOwnership );
+
   if ( mCloudConnection )
   {
     mUsername = mCloudConnection->username();
@@ -482,7 +485,7 @@ void QFieldCloudProject::packageAndDownload()
     connect( this, &QFieldCloudProject::dataRefreshed, tempProjectRefreshParent, [=]( const ProjectRefreshReason reason, const QString &error ) {
       if ( reason != ProjectRefreshReason::Package )
       {
-        QgsLogger::critical( QStringLiteral( "Project %1: unexpected job type, expected %2 but %3 received." ).arg( mId ).arg( static_cast<int>( ProjectRefreshReason::Package ), static_cast<int>( reason ) ) );
+        QgsLogger::critical( QStringLiteral( "Project %1: unexpected job type, expected %2 but %3 received." ).arg( mId ).arg( static_cast<int>( ProjectRefreshReason::Package ) ).arg( static_cast<int>( reason ) ) );
         Q_ASSERT( 0 );
         return;
       }
@@ -1368,6 +1371,7 @@ void QFieldCloudProject::upload( LayerObserver *layerObserver, bool shouldDownlo
         {
           emit statusChanged();
           emit uploadFinished( false, QString() );
+
           refreshData( ProjectRefreshReason::DeltaUploaded );
         }
     }

--- a/src/core/qfieldcloudproject.cpp
+++ b/src/core/qfieldcloudproject.cpp
@@ -369,11 +369,11 @@ void QFieldCloudProject::refreshFileOutdatedStatus()
       return;
     }
 
-    const QJsonArray files = QJsonDocument::fromJson( rawReply->readAll() ).array();
     const QString lastProjectFileMd5 = QFieldCloudUtils::projectSetting( mId, QStringLiteral( "lastProjectFileMd5" ), QString() ).toString();
-    for ( const auto file : files )
+    const QJsonArray files = QJsonDocument::fromJson( rawReply->readAll() ).array();
+    for ( const QJsonValue fileValue : files )
     {
-      QVariantHash fileDetails = file.toObject().toVariantHash();
+      QVariantHash fileDetails = fileValue.toObject().toVariantHash();
       const QString fileName = fileDetails.value( "name" ).toString().toLower();
       if ( fileName.endsWith( QStringLiteral( ".qgs" ) ) || fileName.endsWith( QStringLiteral( ".qgz" ) ) )
       {

--- a/src/core/qfieldcloudproject.cpp
+++ b/src/core/qfieldcloudproject.cpp
@@ -560,7 +560,7 @@ void QFieldCloudProject::downloadFiles()
 
 void QFieldCloudProject::downloadFileConnections( const QString &fileKey )
 {
-  if ( mDownloadFileTransfers.contains( fileKey ) )
+  if ( !mDownloadFileTransfers.contains( fileKey ) )
   {
     Q_ASSERT( false );
     return;

--- a/src/core/qfieldcloudproject.cpp
+++ b/src/core/qfieldcloudproject.cpp
@@ -393,66 +393,67 @@ void QFieldCloudProject::download()
     mLastExportId = packageId;
     mLastExportedAt = packagedAt;
 
-    if ( !localizedDatasets.isEmpty() && mLocalizedDatasetsProjects.contains( mOwner ) )
+    //TODO
+    if ( false ) //( !localizedDatasets.isEmpty() && mLocalizedDatasetsProjects.contains( mOwner ) )
     {
-      NetworkReply *localizedDatasetsReply = mCloudConnection->get( QStringLiteral( "/api/v1/files/%1/" ).arg( mLocalizedDatasetsProjects[project->owner] ) );
-      connect( localizedDatasetsReply, &NetworkReply::finished, localizedDatasetsReply, [=]() {
-        QNetworkReply *localizedDatasetsRawReply = localizedDatasetsReply->currentRawReply();
-        localizedDatasetsReply->deleteLater();
+      //  NetworkReply *localizedDatasetsReply = mCloudConnection->get( QStringLiteral( "/api/v1/files/%1/" ).arg( mLocalizedDatasetsProjects[mOwner] ) );
+      //  connect( localizedDatasetsReply, &NetworkReply::finished, localizedDatasetsReply, [=]() {
+      //    QNetworkReply *localizedDatasetsRawReply = localizedDatasetsReply->currentRawReply();
+      //    localizedDatasetsReply->deleteLater();
 
-        if ( localizedDatasetsRawReply->error() != QNetworkReply::NoError )
-        {
-          QgsLogger::debug( QStringLiteral( "Project %1: failed to get latest package data. %2" ).arg( mId, QFieldCloudConnection::errorString( rawReply ) ) );
-          emit downloadFinished( tr( "Failed to get latest package data." ) );
-          return;
-        }
+      //    if ( localizedDatasetsRawReply->error() != QNetworkReply::NoError )
+      //    {
+      //      QgsLogger::debug( QStringLiteral( "Project %1: failed to get latest package data. %2" ).arg( mId, QFieldCloudConnection::errorString( rawReply ) ) );
+      //      emit downloadFinished( tr( "Failed to get latest package data." ) );
+      //      return;
+      //    }
 
-        const QJsonArray files = QJsonDocument::fromJson( localizedDatasetsRawReply->readAll() ).array();
-        for ( const QJsonValue fileValue : files )
-        {
-          const QJsonObject fileObject = fileValue.toObject();
-          const QString fileName = fileObject.value( QStringLiteral( "name" ) ).toString();
-          if ( localizedDatasets.contains( fileName ) )
-          {
-            const int fileSize = fileObject.value( QStringLiteral( "size" ) ).toInt();
-            const QString absoluteFileName = QStringLiteral( "%1/%2/%3/%4" ).arg( QFieldCloudUtils::localCloudDirectory(), mUsername, mLocalizedDatasetsProjects[project->owner], fileName );
-            // NOTE the cloud API is giving the false impression that the file keys `md5sum` is having a MD5 or another checksum.
-            // This actually is an Object Storage (S3) implementation specific ETag.
-            const QString cloudEtag = fileObject.value( QStringLiteral( "md5sum" ) ).toString();
-            const QString localEtag = FileUtils::fileEtag( absoluteFileName );
+      //    const QJsonArray files = QJsonDocument::fromJson( localizedDatasetsRawReply->readAll() ).array();
+      //    for ( const QJsonValue fileValue : files )
+      //    {
+      //      const QJsonObject fileObject = fileValue.toObject();
+      //      const QString fileName = fileObject.value( QStringLiteral( "name" ) ).toString();
+      //      if ( localizedDatasets.contains( fileName ) )
+      //      {
+      //        const int fileSize = fileObject.value( QStringLiteral( "size" ) ).toInt();
+      //        const QString absoluteFileName = QStringLiteral( "%1/%2/%3/%4" ).arg( QFieldCloudUtils::localCloudDirectory(), mUsername, mLocalizedDatasetsProjects[mOwner], fileName );
+      //        // NOTE the cloud API is giving the false impression that the file keys `md5sum` is having a MD5 or another checksum.
+      //        // This actually is an Object Storage (S3) implementation specific ETag.
+      //        const QString cloudEtag = fileObject.value( QStringLiteral( "md5sum" ) ).toString();
+      //        const QString localEtag = FileUtils::fileEtag( absoluteFileName );
 
-            if (
-              !fileObject.value( QStringLiteral( "size" ) ).isDouble()
-              || fileName.isEmpty()
-              || cloudEtag.isEmpty() )
-            {
-              QgsLogger::debug( QStringLiteral( "Project %1: package in \"files\" list does not contain the expected fields: size(int), name(string), md5sum(string)" ).arg( mLocalizedDatasetsProjects[project->owner] ) );
-              emit downloadFinished( tr( "Latest package data structure error." ) );
-              return;
-            }
+      //        if (
+      //          !fileObject.value( QStringLiteral( "size" ) ).isDouble()
+      //          || fileName.isEmpty()
+      //          || cloudEtag.isEmpty() )
+      //        {
+      //          QgsLogger::debug( QStringLiteral( "Project %1: package in \"files\" list does not contain the expected fields: size(int), name(string), md5sum(string)" ).arg( mLocalizedDatasetsProjects[mOwner] ) );
+      //          emit downloadFinished( tr( "Latest package data structure error." ) );
+      //          return;
+      //        }
 
-            if ( cloudEtag == localEtag )
-              continue;
+      //        if ( cloudEtag == localEtag )
+      //          continue;
 
-            mDownloadFileTransfers.insert( QStringLiteral( "%1/%2" ).arg( mLocalizedDatasetsProjects[project->owner], fileName ), FileTransfer( fileName, fileSize, mLocalizedDatasetsProjects[project->owner] ) );
-            mDownloadBytesTotal += std::max( fileSize, 0 );
-          }
-        }
+      //        mDownloadFileTransfers.insert( QStringLiteral( "%1/%2" ).arg( mLocalizedDatasetsProjects[mOwner], fileName ), FileTransfer( fileName, fileSize, mLocalizedDatasetsProjects[mOwner] ) );
+      //        mDownloadBytesTotal += std::max( fileSize, 0 );
+      //      }
+      //    }
+      //
+      //    emit downloadBytesTotalChanged();
 
-        emit downloadBytesTotalChanged();
+      //    QgsLogger::debug( QStringLiteral( "Project %1: packaged files to download - %2 files, namely: %3" ).arg( mId ).arg( mDownloadFileTransfers.count() ).arg( mDownloadFileTransfers.keys().join( ", " ) ) );
 
-        QgsLogger::debug( QStringLiteral( "Project %1: packaged files to download - %2 files, namely: %3" ).arg( mId ).arg( mDownloadFileTransfers.count() ).arg( mDownloadFileTransfers.keys().join( ", " ) ) );
-
-        updateActiveProjectFilesToDownload();
-        projectDownloadFiles();
-      } );
+      //    updateActiveFilesToDownload();
+      //    downloadFiles();
+      //  } );
     }
     else
     {
       QgsLogger::debug( QStringLiteral( "Project %1: packaged files to download - %2 files, namely: %3" ).arg( mId ).arg( mDownloadFileTransfers.count() ).arg( mDownloadFileTransfers.keys().join( ", " ) ) );
 
-      updateActiveProjectFilesToDownload();
-      projectDownloadFiles();
+      updateActiveFilesToDownload();
+      downloadFiles();
     }
   } );
 }

--- a/src/core/qfieldcloudproject.cpp
+++ b/src/core/qfieldcloudproject.cpp
@@ -44,6 +44,15 @@ QFieldCloudProject::~QFieldCloudProject()
   delete mDeltaListModel;
 }
 
+void QFieldCloudProject::setLocalizedDatasetsProjectId( const QString &id )
+{
+  if ( mLocalizedDatasetsProjectId == id )
+    return;
+
+  mLocalizedDatasetsProjectId = id;
+  emit localizedDatasetsProjectIdChanged();
+}
+
 void QFieldCloudProject::setForceAutoPush( bool force )
 {
   if ( mForceAutoPush == force )
@@ -395,60 +404,58 @@ void QFieldCloudProject::download()
     mLastExportId = packageId;
     mLastExportedAt = packagedAt;
 
-    //TODO
-    if ( false ) //( !localizedDatasets.isEmpty() && mLocalizedDatasetsProjects.contains( mOwner ) )
+    if ( !localizedDatasets.isEmpty() && !mLocalizedDatasetsProjectId.isEmpty() )
     {
-      //  NetworkReply *localizedDatasetsReply = mCloudConnection->get( QStringLiteral( "/api/v1/files/%1/" ).arg( mLocalizedDatasetsProjects[mOwner] ) );
-      //  connect( localizedDatasetsReply, &NetworkReply::finished, localizedDatasetsReply, [=]() {
-      //    QNetworkReply *localizedDatasetsRawReply = localizedDatasetsReply->currentRawReply();
-      //    localizedDatasetsReply->deleteLater();
+      NetworkReply *localizedDatasetsReply = mCloudConnection->get( QStringLiteral( "/api/v1/files/%1/" ).arg( mLocalizedDatasetsProjectId ) );
+      connect( localizedDatasetsReply, &NetworkReply::finished, localizedDatasetsReply, [=]() {
+        QNetworkReply *localizedDatasetsRawReply = localizedDatasetsReply->currentRawReply();
+        localizedDatasetsReply->deleteLater();
 
-      //    if ( localizedDatasetsRawReply->error() != QNetworkReply::NoError )
-      //    {
-      //      QgsLogger::debug( QStringLiteral( "Project %1: failed to get latest package data. %2" ).arg( mId, QFieldCloudConnection::errorString( rawReply ) ) );
-      //      emit downloadFinished( tr( "Failed to get latest package data." ) );
-      //      return;
-      //    }
+        if ( localizedDatasetsRawReply->error() != QNetworkReply::NoError )
+        {
+          QgsLogger::debug( QStringLiteral( "Project %1: failed to get latest package data. %2" ).arg( mId, QFieldCloudConnection::errorString( rawReply ) ) );
+          emit downloadFinished( tr( "Failed to get latest package data." ) );
+          return;
+        }
 
-      //    const QJsonArray files = QJsonDocument::fromJson( localizedDatasetsRawReply->readAll() ).array();
-      //    for ( const QJsonValue fileValue : files )
-      //    {
-      //      const QJsonObject fileObject = fileValue.toObject();
-      //      const QString fileName = fileObject.value( QStringLiteral( "name" ) ).toString();
-      //      if ( localizedDatasets.contains( fileName ) )
-      //      {
-      //        const int fileSize = fileObject.value( QStringLiteral( "size" ) ).toInt();
-      //        const QString absoluteFileName = QStringLiteral( "%1/%2/%3/%4" ).arg( QFieldCloudUtils::localCloudDirectory(), mUsername, mLocalizedDatasetsProjects[mOwner], fileName );
-      //        // NOTE the cloud API is giving the false impression that the file keys `md5sum` is having a MD5 or another checksum.
-      //        // This actually is an Object Storage (S3) implementation specific ETag.
-      //        const QString cloudEtag = fileObject.value( QStringLiteral( "md5sum" ) ).toString();
-      //        const QString localEtag = FileUtils::fileEtag( absoluteFileName );
+        const QJsonArray files = QJsonDocument::fromJson( localizedDatasetsRawReply->readAll() ).array();
+        for ( const QJsonValue fileValue : files )
+        {
+          const QJsonObject fileObject = fileValue.toObject();
+          const QString fileName = fileObject.value( QStringLiteral( "name" ) ).toString();
+          if ( localizedDatasets.contains( fileName ) )
+          {
+            const int fileSize = fileObject.value( QStringLiteral( "size" ) ).toInt();
+            const QString absoluteFileName = QStringLiteral( "%1/%2/%3/%4" ).arg( QFieldCloudUtils::localCloudDirectory(), mUsername, mLocalizedDatasetsProjectId, fileName );
+            // NOTE the cloud API is giving the false impression that the file keys `md5sum` is having a MD5 or another checksum.
+            // This actually is an Object Storage (S3) implementation specific ETag.
+            const QString cloudEtag = fileObject.value( QStringLiteral( "md5sum" ) ).toString();
+            const QString localEtag = FileUtils::fileEtag( absoluteFileName );
 
-      //        if (
-      //          !fileObject.value( QStringLiteral( "size" ) ).isDouble()
-      //          || fileName.isEmpty()
-      //          || cloudEtag.isEmpty() )
-      //        {
-      //          QgsLogger::debug( QStringLiteral( "Project %1: package in \"files\" list does not contain the expected fields: size(int), name(string), md5sum(string)" ).arg( mLocalizedDatasetsProjects[mOwner] ) );
-      //          emit downloadFinished( tr( "Latest package data structure error." ) );
-      //          return;
-      //        }
+            if (
+              !fileObject.value( QStringLiteral( "size" ) ).isDouble()
+              || fileName.isEmpty()
+              || cloudEtag.isEmpty() )
+            {
+              QgsLogger::debug( QStringLiteral( "Project %1: package in \"files\" list does not contain the expected fields: size(int), name(string), md5sum(string)" ).arg( mLocalizedDatasetsProjectId ) );
+              emit downloadFinished( tr( "Latest package data structure error." ) );
+              return;
+            }
 
-      //        if ( cloudEtag == localEtag )
-      //          continue;
+            if ( cloudEtag == localEtag )
+              continue;
 
-      //        mDownloadFileTransfers.insert( QStringLiteral( "%1/%2" ).arg( mLocalizedDatasetsProjects[mOwner], fileName ), FileTransfer( fileName, fileSize, mLocalizedDatasetsProjects[mOwner] ) );
-      //        mDownloadBytesTotal += std::max( fileSize, 0 );
-      //      }
-      //    }
-      //
-      //    emit downloadBytesTotalChanged();
+            mDownloadFileTransfers.insert( QStringLiteral( "%1/%2" ).arg( mLocalizedDatasetsProjectId, fileName ), FileTransfer( fileName, fileSize, mLocalizedDatasetsProjectId ) );
+            mDownloadBytesTotal += std::max( fileSize, 0 );
+          }
+        }
+        emit downloadBytesTotalChanged();
 
-      //    QgsLogger::debug( QStringLiteral( "Project %1: packaged files to download - %2 files, namely: %3" ).arg( mId ).arg( mDownloadFileTransfers.count() ).arg( mDownloadFileTransfers.keys().join( ", " ) ) );
+        QgsLogger::debug( QStringLiteral( "Project %1: packaged files to download - %2 files, namely: %3" ).arg( mId ).arg( mDownloadFileTransfers.count() ).arg( mDownloadFileTransfers.keys().join( ", " ) ) );
 
-      //    updateActiveFilesToDownload();
-      //    downloadFiles();
-      //  } );
+        updateActiveFilesToDownload();
+        downloadFiles();
+      } );
     }
     else
     {
@@ -963,8 +970,6 @@ void QFieldCloudProject::upload( LayerObserver *layerObserver, bool shouldDownlo
       QgsMessageLog::logMessage( QStringLiteral( "Attachment file '%1' does not exist" ).arg( absoluteFilePath ) );
       continue;
     }
-
-    const long long fileSize = fileInfo.size();
 
     // ? should we also check the checksums of the files being uploaded? they are available at deltaFile->attachmentFileNames()->values()
     QFieldCloudUtils::addPendingAttachments( mId, { absoluteFilePath } );

--- a/src/core/qfieldcloudproject.h
+++ b/src/core/qfieldcloudproject.h
@@ -209,7 +209,7 @@ class QFieldCloudProject : public QObject
     void setNeedsRepackaging( bool needsRepackaging );
 
     bool isOutdated() const { return mIsOutdated; }
-    void setIsOutdated( bool isOudated );
+    void setIsOutdated( bool isOutdated );
 
     bool projectFileIsOutdated() const { return mProjectFileIsOutdated; }
     void setProjectFileIsOutdated( bool projectFileIsOutdated );

--- a/src/core/qfieldcloudproject.h
+++ b/src/core/qfieldcloudproject.h
@@ -34,6 +34,32 @@ class QFieldCloudProject : public QObject
 {
     Q_OBJECT
 
+    Q_PROPERTY( QString id READ id NOTIFY idChanged )
+    Q_PROPERTY( QString name READ name NOTIFY nameChanged )
+    Q_PROPERTY( QString owner READ owner NOTIFY ownerChanged )
+    Q_PROPERTY( QString description READ description NOTIFY descriptionChanged )
+
+    Q_PROPERTY( ProjectStatus status READ status NOTIFY statusChanged )
+    Q_PROPERTY( PackagingStatus packagingStatus READ packagingStatus NOTIFY packagingStatusChanged )
+
+    Q_PROPERTY( int downloadBytesTotal READ downloadBytesTotal NOTIFY downloadBytesTotalChanged )
+    Q_PROPERTY( int downloadBytesReceived READ downloadBytesReceived NOTIFY downloadBytesReceivedChanged )
+    Q_PROPERTY( double downloadProgress READ downloadProgress NOTIFY downloadProgressChanged )
+
+    Q_PROPERTY( double uploadDeltaProgress READ uploadDeltaProgress NOTIFY uploadDeltaProgressChanged )
+    Q_PROPERTY( DeltaFileStatus deltaFileUploadStatus READ deltaFileUploadStatus NOTIFY deltaFileUploadStatusChanged )
+    Q_PROPERTY( DeltaListModel *deltaListModel READ deltaListModel NOTIFY deltaListModelChanged )
+
+    Q_PROPERTY( bool forceAutoPush READ forceAutoPush NOTIFY forceAutoPushChanged )
+    Q_PROPERTY( bool autoPushEnabled READ autoPushEnabled NOTIFY autoPushEnabledChanged )
+    Q_PROPERTY( int autoPushIntervalMins READ autoPushIntervalMins NOTIFY autoPushIntervalMinsChanged )
+
+    Q_PROPERTY( QString lastLocalPushDeltas READ lastLocalPushDeltas NOTIFY lastLocalPushDeltasChanged )
+    Q_PROPERTY( QString lastLocalExportedAt READ lastLocalExportedAt NOTIFY lastLocalExportedAtChanged )
+
+    Q_PROPERTY( bool isOutdated READ isOutdated NOTIFY isOutdatedChanged )
+    Q_PROPERTY( bool projectFileIsOutdated READ projectFileIsOutdated NOTIFY projectFileIsOutdatedChanged )
+
   public:
     //! Whether the project is busy or idle.
     enum class ProjectStatus

--- a/src/core/qfieldcloudproject.h
+++ b/src/core/qfieldcloudproject.h
@@ -24,6 +24,7 @@
 #include <QVariantMap>
 
 class DeltaListModel;
+class QgsGpkgFlusher;
 class LayerObserver;
 class QFieldCloudConnection;
 
@@ -162,7 +163,7 @@ class QFieldCloudProject : public QObject
 
     Q_ENUM( ProjectRefreshReason )
 
-    QFieldCloudProject( const QString &id = QString(), QFieldCloudConnection *connection = nullptr );
+    QFieldCloudProject( const QString &id = QString(), QFieldCloudConnection *connection = nullptr, QgsGpkgFlusher *gpkgFlusher = nullptr );
     ~QFieldCloudProject();
 
     QString id() const { return mId; }
@@ -240,8 +241,8 @@ class QFieldCloudProject : public QObject
     static QFieldCloudProject::JobStatus getJobStatusFromString( const QString &status );
     static QString getJobTypeAsString( QFieldCloudProject::JobType jobType );
 
-    static QFieldCloudProject *fromDetails( const QVariantHash &details, QFieldCloudConnection *connection );
-    static QFieldCloudProject *fromLocalSettings( const QString &id, QFieldCloudConnection *connection );
+    static QFieldCloudProject *fromDetails( const QVariantHash &details, QFieldCloudConnection *connection, QgsGpkgFlusher *gpkgFlusher = nullptr );
+    static QFieldCloudProject *fromLocalSettings( const QString &id, QFieldCloudConnection *connection, QgsGpkgFlusher *gpkgFlusher = nullptr );
     static void restoreLocalSettings( QFieldCloudProject *project, const QDir &localPath );
 
   signals:
@@ -430,6 +431,8 @@ class QFieldCloudProject : public QObject
 
     QFieldCloudConnection *mCloudConnection = nullptr;
     QString mUsername;
+
+    QgsGpkgFlusher *mGpkgFlusher = nullptr;
 
     static const int sDelayBeforeStatusRetry = 1000;
 };

--- a/src/core/qfieldcloudproject.h
+++ b/src/core/qfieldcloudproject.h
@@ -52,7 +52,7 @@ class QFieldCloudProject : public QObject
     Q_PROPERTY( DeltaFileStatus deltaFileUploadStatus READ deltaFileUploadStatus NOTIFY deltaFileUploadStatusChanged )
     Q_PROPERTY( DeltaListModel *deltaListModel READ deltaListModel NOTIFY deltaListModelChanged )
 
-    Q_PROPERTY( bool forceAutoPush READ forceAutoPush NOTIFY forceAutoPushChanged )
+    Q_PROPERTY( bool forceAutoPush READ forceAutoPush WRITE setForceAutoPush NOTIFY forceAutoPushChanged )
     Q_PROPERTY( bool autoPushEnabled READ autoPushEnabled WRITE setAutoPushEnabled NOTIFY autoPushEnabledChanged )
     Q_PROPERTY( int autoPushIntervalMins READ autoPushIntervalMins NOTIFY autoPushIntervalMinsChanged )
 

--- a/src/core/qfieldcloudproject.h
+++ b/src/core/qfieldcloudproject.h
@@ -1,0 +1,419 @@
+/***************************************************************************
+    qfieldcloudproject.h
+    ---------------------
+    begin                : April 2025
+    copyright            : (C) 2025 by Mathieu Pellerin
+    email                : mathieu at opengis dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QFIELDCLOUDPROJECT_H
+#define QFIELDCLOUDPROJECT_H
+
+#include "networkmanager.h"
+#include "networkreply.h"
+
+#include <QObject>
+#include <QPointer>
+#include <QVariantMap>
+
+class DeltaListModel;
+class LayerObserver;
+class QFieldCloudConnection;
+
+/**
+ * \ingroup core
+ */
+class QFieldCloudProject : public QObject
+{
+    Q_OBJECT
+
+  public:
+    //! Whether the project is busy or idle.
+    enum class ProjectStatus
+    {
+      Idle,
+      Downloading,
+      Uploading,
+    };
+
+    Q_ENUM( ProjectStatus )
+
+    //! Whether the project has experienced an error.
+    enum ProjectErrorStatus
+    {
+      NoErrorStatus,
+      DownloadErrorStatus,
+      UploadErrorStatus,
+    };
+
+    Q_ENUM( ProjectErrorStatus )
+
+    //! Whether the project has been available locally and/or remotely.
+    enum ProjectCheckout
+    {
+      RemoteCheckout = 2 << 0,
+      LocalCheckout = 2 << 1,
+      LocalAndRemoteCheckout = RemoteCheckout | LocalCheckout
+    };
+
+    Q_ENUM( ProjectCheckout )
+    Q_DECLARE_FLAGS( ProjectCheckouts, ProjectCheckout )
+    Q_FLAG( ProjectCheckouts )
+
+    //! Whether the project has no or local and/or remote modification. Indicates wheter can be synced.
+    enum ProjectModification
+    {
+      NoModification = 0,
+      LocalModification = 2 << 0,
+      RemoteModification = 2 << 1,
+      LocalAndRemoteModification = RemoteModification | LocalModification
+    };
+
+    Q_ENUM( ProjectModification )
+    Q_DECLARE_FLAGS( ProjectModifications, ProjectModification )
+    Q_FLAG( ProjectModifications )
+
+    //! The status of the running server job for applying deltas on a project.
+    enum DeltaFileStatus
+    {
+      DeltaErrorStatus,
+      DeltaLocalStatus,
+      DeltaPendingStatus,
+      DeltaBusyStatus,
+      DeltaConflictStatus,
+      DeltaNotAppliedStatus,
+      DeltaAppliedStatus,
+    };
+
+    Q_ENUM( DeltaFileStatus )
+
+    //! The status of the running server job for packaging a project.
+    enum PackagingStatus
+    {
+      PackagingUnstartedStatus,
+      PackagingErrorStatus,
+      PackagingBusyStatus,
+      PackagingFinishedStatus,
+      PackagingAbortStatus,
+    };
+
+    Q_ENUM( PackagingStatus )
+
+    //! The status of the running server job.
+    enum JobStatus
+    {
+      JobPendingStatus,
+      JobQueuedStatus,
+      JobStartedStatus,
+      JobFinishedStatus,
+      JobStoppedStatus,
+      JobFailedStatus,
+    };
+
+    Q_ENUM( JobStatus )
+
+    //! The status of the running server job.
+    enum class JobType
+    {
+      Package,
+    };
+
+    Q_ENUM( JobType )
+
+    //! The reason why projectRefreshData was called
+    enum class ProjectRefreshReason
+    {
+      Package,
+      DeltaUploaded
+    };
+
+    Q_ENUM( ProjectRefreshReason )
+
+    QFieldCloudProject( const QString &id = QString(), QFieldCloudConnection *connection = nullptr );
+    ~QFieldCloudProject();
+
+    QString id() const { return mId; }
+    bool isPrivate() const { return mIsPrivate; }
+    QString owner() const { return mOwner; }
+    QString name() const { return mName; }
+    QString description() const { return mDescription; }
+    QString userRole() const { return mUserRole; }
+    QString userRoleOrigin() const { return mUserRoleOrigin; }
+
+    ProjectErrorStatus errorStatus() const { return mErrorStatus; }
+    ProjectCheckouts checkout() const { return mCheckout; }
+    ProjectStatus status() const { return mStatus; }
+    QDateTime dataLastUpdatedAt() const { return mDataLastUpdatedAt; }
+
+    bool canRepackage() const { return mCanRepackage; }
+    bool needsRepackaging() const { return mNeedsRepackaging; }
+    bool isOutdated() const { return mIsOutdated; }
+    bool projectFileIsOutdated() const { return mProjectFileIsOutdated; }
+
+    ProjectModifications modification() const { return mModification; }
+    QString localPath() const { return mLocalPath; }
+
+    QString deltaFileId() const { return mDeltaFileId; }
+    DeltaFileStatus deltaFileUploadStatus() const { return mDeltaFileUploadStatus; }
+    QString deltaFileUploadStatusString() const { return mDeltaFileUploadStatusString; }
+    QStringList deltaLayersToDownload() const { return mDeltaLayersToDownload; }
+
+    bool isPackagingActive() const { return mIsPackagingActive; }
+    bool isPackagingFailed() const { return mIsPackagingFailed; }
+    PackagingStatus packagingStatus() const { return mPackagingStatus; }
+    QString packagingStatusString() const { return mPackagingStatusString; }
+    QStringList packagedLayerErrors() const { return mPackagedLayerErrors; }
+
+    bool forceAutoPush() const { return mForceAutoPush; }
+    void setForceAutoPush( bool force );
+    bool autoPushEnabled() const { return mAutoPushEnabled; }
+    void setAutoPushEnabled( bool enabled );
+    int autoPushIntervalMins() const { return mAutoPushIntervalMins; }
+    void setAutoPushIntervalMins( int minutes );
+
+    QString lastLocalPushDeltas() const { return mLastLocalPushDeltas; }
+    QString lastLocalExportedAt() const { return mLastLocalExportId; }
+    QString lastLocalExportId() const { return mLastLocalExportId; }
+    QDateTime lastLocalDataLastUpdatedAt() const { return mLastLocalDataLastUpdatedAt; }
+    QDateTime lastRefreshedAt() const { return mLastRefreshedAt; }
+
+    int downloadFilesFinished() const { return mDownloadFilesFinished; }
+    int downloadFilesFailed() const { return mDownloadFilesFailed; }
+    int downloadBytesTotal() const { return mDownloadBytesTotal; }
+    int downloadBytesReceived() const { return mDownloadBytesReceived; }
+    double downloadProgress() const { return mDownloadProgress; }
+
+
+    double uploadDeltaProgress() const { return mUploadDeltaProgress; }
+    int deltasCount() const { return mDeltasCount; }
+    DeltaListModel *deltaListModel() const { return mDeltaListModel; }
+
+    // ----------
+
+    void packageAndDownload();
+    void cancelDownload();
+
+    void upload( LayerObserver *layerObserver, bool shouldDownloadUpdates );
+    void cancelUpload();
+
+    void refreshDeltaList();
+    void refreshFileOutdatedStatus();
+    void refreshModification( LayerObserver *layerObserver );
+
+    void removeLocally();
+
+    // ----------
+
+    static QFieldCloudProject::JobStatus getJobStatusFromString( const QString &status );
+    static QString getJobTypeAsString( QFieldCloudProject::JobType jobType );
+
+    static QFieldCloudProject *fromDetails( const QVariantHash &details, QFieldCloudConnection *connection );
+    static QFieldCloudProject *fromLocalSettings( const QString &id, QFieldCloudConnection *connection );
+    static void restoreLocalSettings( QFieldCloudProject *project, const QDir &localPath );
+
+  signals:
+    void idChanged();
+    void isPrivateChanged();
+    void ownerChanged();
+    void nameChanged();
+    void descriptionChanged();
+    void userRoleChanged();
+    void userRoleOriginChanged();
+
+    void errorStatusChanged();
+    void checkoutChanged();
+    void statusChanged();
+    void dataLastUpdatedAtChanged();
+
+    void canRepackageChanged();
+    void needsRepackagingChanged();
+    void isOutdatedChanged();
+    void projectFileIsOutdatedChanged();
+
+    void modificationChanged();
+    void localPathChanged();
+
+    void deltaFileIdChanged();
+    void deltaFileUploadStatusChanged();
+    void deltaFileUploadStatusStringChanged();
+    void deltaLayersToDownloadChanged();
+
+    void isPackagingActiveChanged();
+    void isPackagingFailedChanged();
+    void packagingStatusChanged();
+    void packagingStatusStringChanged();
+    void packagedLayerErrorsChanged();
+
+    void forceAutoPushChanged();
+    void autoPushEnabledChanged();
+    void autoPushIntervalMinsChanged();
+
+    void lastLocalExportedAtChanged();
+    void lastLocalExportedIdChanged();
+    void lastDataLastUpdatedAtChanged();
+
+    void lastLocalDataLastUpdatedAtChanged();
+    void lastRefreshedAtChanged();
+    void lastLocalPushDeltasChanged();
+
+    void downloadFilesFinishedChanged();
+    void downloadFilesFailedChanged();
+    void downloadBytesTotalChanged();
+    void downloadBytesReceivedChanged();
+    void downloadProgressChanged();
+
+    void uploadDeltaProgressChanged();
+
+    void deltaListModelChanged();
+
+    // ---
+
+    void downloadFinished( QString error = QString() );
+    void downloaded( const QString &name, QString error = QString() );
+
+    void uploadFinished( bool isDownloading, QString error = QString() );
+
+    void networkDeltaUploaded();
+    void networkDeltaStatusChecked();
+
+    void dataRefreshed( ProjectRefreshReason reason, QString error = QString() );
+    void jobFinished( JobType type, QString error = QString() );
+
+  private:
+    void download();
+    void downloadFiles();
+    void updateActiveFilesToDownload();
+
+    void startJob( JobType type );
+
+    void getJobStatus( JobType type );
+    void getDeltaStatus();
+
+    void refreshData( ProjectRefreshReason reason );
+
+    NetworkReply *downloadFile( const QString &projectId, const QString &fileName, bool fromLatestPackage = true );
+    void downloadFileConnections( const QString &fileKey );
+
+    bool moveDownloadedFilesToPermanentStorage();
+    void logFailedDownload( const QString &fileKey, const QString &errorMessage, const QString &errorMessageDetail );
+
+    struct FileTransfer
+    {
+        FileTransfer(
+          const QString &fileName,
+          const long long bytesTotal,
+          const QString &projectId )
+          : fileName( fileName ), bytesTotal( bytesTotal ), projectId( projectId ) {};
+
+        FileTransfer() = default;
+
+        QString fileName;
+        long long bytesTotal;
+        QString projectId;
+
+        QString tmpFile;
+        long long bytesTransferred = 0;
+        bool isFinished = false;
+        QPointer<NetworkReply> networkReply;
+        QNetworkReply::NetworkError error = QNetworkReply::NoError;
+        QStringList layerIds;
+        int redirectsCount = 0;
+        QUrl lastRedirectUrl;
+    };
+
+    //! Tracks the job status (status, error etc) for a particular project. For now 1 project can have only 1 job of a type.
+    struct Job
+    {
+        Job(
+          const QString &id,
+          const QString &projectId,
+          const QFieldCloudProject::JobType type )
+          : id( id ), projectId( projectId ), type( type ) {};
+
+        Job() = default;
+
+        QString id;
+        QString projectId;
+        QFieldCloudProject::JobType type;
+        QFieldCloudProject::JobStatus status = QFieldCloudProject::JobPendingStatus;
+    };
+
+    QString mId;
+
+    bool mIsPrivate = true;
+    QString mOwner;
+    QString mName;
+    QString mDescription;
+    QString mUserRole;
+    QString mUserRoleOrigin;
+    ProjectErrorStatus mErrorStatus = ProjectErrorStatus::NoErrorStatus;
+    ProjectCheckouts mCheckout;
+    ProjectStatus mStatus;
+    QDateTime mDataLastUpdatedAt;
+    bool mCanRepackage = false;
+    bool mNeedsRepackaging = false;
+    bool mIsOutdated = false;
+    bool mProjectFileIsOutdated = false;
+    ProjectModifications mModification = ProjectModification::NoModification;
+    QString mLocalPath;
+
+    QString mDeltaFileId;
+    DeltaFileStatus mDeltaFileUploadStatus = DeltaLocalStatus;
+    QString mDeltaFileUploadStatusString;
+    QStringList mDeltaLayersToDownload;
+
+    bool mIsPackagingActive = false;
+    bool mIsPackagingFailed = false;
+    PackagingStatus mPackagingStatus = PackagingUnstartedStatus;
+    QString mPackagingStatusString;
+    QStringList mPackagedLayerErrors;
+
+    QStringList mActiveFilesToDownload;
+    QMap<QString, FileTransfer> mDownloadFileTransfers;
+    int mDownloadFilesFinished = 0;
+    int mDownloadFilesFailed = 0;
+    int mDownloadBytesTotal = 0;
+    int mDownloadBytesReceived = 0;
+    double mDownloadProgress = 0.0; // range from 0.0 to 1.0
+
+    double mUploadDeltaProgress = 0.0; // range from 0.0 to 1.0
+    int mDeltasCount = 0;
+    DeltaListModel *mDeltaListModel = nullptr;
+
+    QString mLastExportedAt;
+    QString mLastExportId;
+    QString mLastLocalExportedAt;
+    QString mLastLocalExportId;
+    QString mLastLocalPushDeltas;
+
+    QDateTime mLastLocalDataLastUpdatedAt;
+    QDateTime mLastRefreshedAt;
+
+    bool mForceAutoPush = false;
+    bool mAutoPushEnabled = false;
+    int mAutoPushIntervalMins = 30;
+
+    QMap<JobType, Job> mJobs;
+
+    QFieldCloudConnection *mCloudConnection = nullptr;
+    QString mUsername;
+
+    static const int sDelayBeforeStatusRetry = 1000;
+};
+
+Q_DECLARE_METATYPE( QFieldCloudProject::ProjectStatus )
+Q_DECLARE_METATYPE( QFieldCloudProject::ProjectCheckout )
+Q_DECLARE_METATYPE( QFieldCloudProject::ProjectCheckouts )
+Q_DECLARE_OPERATORS_FOR_FLAGS( QFieldCloudProject::ProjectCheckouts )
+Q_DECLARE_METATYPE( QFieldCloudProject::ProjectModification )
+Q_DECLARE_METATYPE( QFieldCloudProject::ProjectModifications )
+Q_DECLARE_OPERATORS_FOR_FLAGS( QFieldCloudProject::ProjectModifications )
+
+#endif // QFIELDCLOUDPROJECT_H

--- a/src/core/qfieldcloudproject.h
+++ b/src/core/qfieldcloudproject.h
@@ -42,6 +42,7 @@ class QFieldCloudProject : public QObject
 
     Q_PROPERTY( ProjectStatus status READ status NOTIFY statusChanged )
     Q_PROPERTY( PackagingStatus packagingStatus READ packagingStatus NOTIFY packagingStatusChanged )
+    Q_PROPERTY( QStringList packagedLayerErrors READ packagedLayerErrors NOTIFY packagedLayerErrorsChanged )
 
     Q_PROPERTY( int downloadBytesTotal READ downloadBytesTotal NOTIFY downloadBytesTotalChanged )
     Q_PROPERTY( int downloadBytesReceived READ downloadBytesReceived NOTIFY downloadBytesReceivedChanged )

--- a/src/core/qfieldcloudproject.h
+++ b/src/core/qfieldcloudproject.h
@@ -51,7 +51,7 @@ class QFieldCloudProject : public QObject
     Q_PROPERTY( DeltaListModel *deltaListModel READ deltaListModel NOTIFY deltaListModelChanged )
 
     Q_PROPERTY( bool forceAutoPush READ forceAutoPush NOTIFY forceAutoPushChanged )
-    Q_PROPERTY( bool autoPushEnabled READ autoPushEnabled NOTIFY autoPushEnabledChanged )
+    Q_PROPERTY( bool autoPushEnabled READ autoPushEnabled WRITE setAutoPushEnabled NOTIFY autoPushEnabledChanged )
     Q_PROPERTY( int autoPushIntervalMins READ autoPushIntervalMins NOTIFY autoPushIntervalMinsChanged )
 
     Q_PROPERTY( QString lastLocalPushDeltas READ lastLocalPushDeltas NOTIFY lastLocalPushDeltasChanged )

--- a/src/core/qfieldcloudproject.h
+++ b/src/core/qfieldcloudproject.h
@@ -168,6 +168,10 @@ class QFieldCloudProject : public QObject
     ~QFieldCloudProject();
 
     QString id() const { return mId; }
+
+    QString localizedDatasetsProjectId() const { return mLocalizedDatasetsProjectId; }
+    void setLocalizedDatasetsProjectId( const QString &id );
+
     bool isPrivate() const { return mIsPrivate; }
     QString owner() const { return mOwner; }
     QString name() const { return mName; }
@@ -248,6 +252,8 @@ class QFieldCloudProject : public QObject
 
   signals:
     void idChanged();
+    void localizedDatasetsProjectIdChanged();
+
     void isPrivateChanged();
     void ownerChanged();
     void nameChanged();
@@ -374,6 +380,7 @@ class QFieldCloudProject : public QObject
     };
 
     QString mId;
+    QString mLocalizedDatasetsProjectId;
 
     bool mIsPrivate = true;
     QString mOwner;

--- a/src/core/qfieldcloudproject.h
+++ b/src/core/qfieldcloudproject.h
@@ -173,61 +173,111 @@ class QFieldCloudProject : public QObject
     void setLocalizedDatasetsProjectId( const QString &id );
 
     bool isPrivate() const { return mIsPrivate; }
+    void setIsPrivate( bool isPrivate );
+
     QString owner() const { return mOwner; }
+    void setOwner( const QString &owner );
+
     QString name() const { return mName; }
+    void setName( const QString &name );
+
     QString description() const { return mDescription; }
+    void setDescription( const QString &description );
+
     QString userRole() const { return mUserRole; }
+    void setUserRole( const QString &userRole );
+
     QString userRoleOrigin() const { return mUserRoleOrigin; }
+    void setUserRoleOrigin( const QString &userRoleOrigin );
 
     ProjectErrorStatus errorStatus() const { return mErrorStatus; }
+    void setErrorStatus( ProjectErrorStatus errorStatus );
+
     ProjectCheckouts checkout() const { return mCheckout; }
+    void setCheckout( ProjectCheckouts checkout );
+
     ProjectStatus status() const { return mStatus; }
+    void setStatus( ProjectStatus status );
+
     QDateTime dataLastUpdatedAt() const { return mDataLastUpdatedAt; }
+    void setDataLastUpdatedAt( const QDateTime &dataLastUpdatedAt );
 
     bool canRepackage() const { return mCanRepackage; }
+    void setCanRepackage( bool canRepackage );
+
     bool needsRepackaging() const { return mNeedsRepackaging; }
+    void setNeedsRepackaging( bool needsRepackaging );
+
     bool isOutdated() const { return mIsOutdated; }
+    void setIsOutdated( bool isOudated );
+
     bool projectFileIsOutdated() const { return mProjectFileIsOutdated; }
+    void setProjectFileIsOutdated( bool projectFileIsOutdated );
 
     ProjectModifications modification() const { return mModification; }
+    void setModification( ProjectModification modification );
+
     QString localPath() const { return mLocalPath; }
+    void setLocalPath( const QString &localPath );
 
     QString deltaFileId() const { return mDeltaFileId; }
+    void setDeltaFileId( const QString &deltaFileId );
+
     DeltaFileStatus deltaFileUploadStatus() const { return mDeltaFileUploadStatus; }
+    void setDeltaFileUploadStatus( DeltaFileStatus deltaFileUploadStatus );
+
     QString deltaFileUploadStatusString() const { return mDeltaFileUploadStatusString; }
+    void setDeltaFileUploadStatusString( const QString &deltaFileUploadStatusString );
+
     QStringList deltaLayersToDownload() const { return mDeltaLayersToDownload; }
+    void setDeltaLayersToDownload( const QStringList &deltaLayersToDownload );
 
     bool isPackagingActive() const { return mIsPackagingActive; }
+    void setIsPackagingActive( bool isPackagingActive );
+
     bool isPackagingFailed() const { return mIsPackagingFailed; }
+    void setIsPackagingFailed( bool isPackagingFailed );
+
     PackagingStatus packagingStatus() const { return mPackagingStatus; }
+    void setPackagingStatus( PackagingStatus packagingStatus );
+
     QString packagingStatusString() const { return mPackagingStatusString; }
+    void setPackagingStatusString( const QString &packagingStatusString );
+
     QStringList packagedLayerErrors() const { return mPackagedLayerErrors; }
+    void setPackagedLayerErrors( const QStringList &packagedLayerErrors );
 
     bool forceAutoPush() const { return mForceAutoPush; }
     void setForceAutoPush( bool force );
+
     bool autoPushEnabled() const { return mAutoPushEnabled; }
     void setAutoPushEnabled( bool enabled );
+
     int autoPushIntervalMins() const { return mAutoPushIntervalMins; }
     void setAutoPushIntervalMins( int minutes );
 
     QString lastLocalPushDeltas() const { return mLastLocalPushDeltas; }
-    QString lastLocalExportedAt() const { return mLastLocalExportId; }
-    QString lastLocalExportId() const { return mLastLocalExportId; }
-    QDateTime lastLocalDataLastUpdatedAt() const { return mLastLocalDataLastUpdatedAt; }
-    QDateTime lastRefreshedAt() const { return mLastRefreshedAt; }
+    void setLastLocalPushDeltas( const QString &lastLocalPushDeltas );
 
-    int downloadFilesFinished() const { return mDownloadFilesFinished; }
-    int downloadFilesFailed() const { return mDownloadFilesFailed; }
+    QString lastLocalExportedAt() const { return mLastLocalExportedAt; }
+    void setLastLocalExportedAt( const QString &lastLocalExportedAt );
+
+    QString lastLocalExportId() const { return mLastLocalExportId; }
+    void setLastLocalExportId( const QString &lastLocalExportId );
+
+    QDateTime lastLocalDataLastUpdatedAt() const { return mLastLocalDataLastUpdatedAt; }
+    void setLastLocalDataLastUpdatedAt( const QDateTime &lastLocalDataLastUpdatedAt );
+
+    QDateTime lastRefreshedAt() const { return mLastRefreshedAt; }
+    void setLastRefreshedAt( const QDateTime &lastRefreshedAt );
+
     int downloadBytesTotal() const { return mDownloadBytesTotal; }
     int downloadBytesReceived() const { return mDownloadBytesReceived; }
     double downloadProgress() const { return mDownloadProgress; }
-
-
     double uploadDeltaProgress() const { return mUploadDeltaProgress; }
+
     int deltasCount() const { return mDeltasCount; }
     DeltaListModel *deltaListModel() const { return mDeltaListModel; }
-
-    // ----------
 
     void packageAndDownload();
     void cancelDownload();
@@ -240,8 +290,6 @@ class QFieldCloudProject : public QObject
     void refreshModification( LayerObserver *layerObserver );
 
     void removeLocally();
-
-    // ----------
 
     static QFieldCloudProject::JobStatus getJobStatusFromString( const QString &status );
     static QString getJobTypeAsString( QFieldCloudProject::JobType jobType );
@@ -290,15 +338,13 @@ class QFieldCloudProject : public QObject
     void autoPushIntervalMinsChanged();
 
     void lastLocalExportedAtChanged();
-    void lastLocalExportedIdChanged();
+    void lastLocalExportIdChanged();
     void lastDataLastUpdatedAtChanged();
 
     void lastLocalDataLastUpdatedAtChanged();
     void lastRefreshedAtChanged();
     void lastLocalPushDeltasChanged();
 
-    void downloadFilesFinishedChanged();
-    void downloadFilesFailedChanged();
     void downloadBytesTotalChanged();
     void downloadBytesReceivedChanged();
     void downloadProgressChanged();
@@ -307,18 +353,16 @@ class QFieldCloudProject : public QObject
 
     void deltaListModelChanged();
 
-    // ---
+    void downloadFinished( const QString &error = QString() );
+    void downloaded( const QString &name, const QString &error = QString() );
 
-    void downloadFinished( QString error = QString() );
-    void downloaded( const QString &name, QString error = QString() );
-
-    void uploadFinished( bool isDownloading, QString error = QString() );
+    void uploadFinished( bool isDownloading, const QString &error = QString() );
 
     void networkDeltaUploaded();
     void networkDeltaStatusChecked();
 
-    void dataRefreshed( ProjectRefreshReason reason, QString error = QString() );
-    void jobFinished( JobType type, QString error = QString() );
+    void dataRefreshed( ProjectRefreshReason reason, const QString &error = QString() );
+    void jobFinished( JobType type, const QString &error = QString() );
 
   private:
     void download();
@@ -389,8 +433,8 @@ class QFieldCloudProject : public QObject
     QString mUserRole;
     QString mUserRoleOrigin;
     ProjectErrorStatus mErrorStatus = ProjectErrorStatus::NoErrorStatus;
-    ProjectCheckouts mCheckout;
-    ProjectStatus mStatus;
+    ProjectCheckouts mCheckout = ProjectCheckout::LocalCheckout;
+    ProjectStatus mStatus = ProjectStatus::Idle;
     QDateTime mDataLastUpdatedAt;
     bool mCanRepackage = false;
     bool mNeedsRepackaging = false;
@@ -416,9 +460,9 @@ class QFieldCloudProject : public QObject
     int mDownloadFilesFailed = 0;
     int mDownloadBytesTotal = 0;
     int mDownloadBytesReceived = 0;
-    double mDownloadProgress = 0.0; // range from 0.0 to 1.0
-
+    double mDownloadProgress = 0.0;    // range from 0.0 to 1.0
     double mUploadDeltaProgress = 0.0; // range from 0.0 to 1.0
+
     int mDeltasCount = 0;
     DeltaListModel *mDeltaListModel = nullptr;
 

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -120,25 +120,6 @@ QString QFieldCloudProjectsModel::currentProjectId() const
 
 void QFieldCloudProjectsModel::setCurrentProjectId( const QString &currentProjectId )
 {
-  if ( currentProjectId != QString() )
-  {
-    QFieldCloudProject *cloudProject = findProject( currentProjectId );
-    if ( cloudProject )
-    {
-      const bool forceAutoPush = QgsProject::instance()->readBoolEntry( QStringLiteral( "qfieldsync" ), QStringLiteral( "forceAutoPush" ), false );
-      if ( forceAutoPush )
-      {
-        cloudProject->setForceAutoPush( true );
-        cloudProject->setAutoPushEnabled( true );
-        cloudProject->setAutoPushIntervalMins( QgsProject::instance()->readNumEntry( QStringLiteral( "qfieldsync" ), QStringLiteral( "forceAutoPushIntervalMins" ) ) );
-      }
-      else
-      {
-        cloudProject->setForceAutoPush( false );
-      }
-    }
-  }
-
   if ( mCurrentProjectId == currentProjectId )
     return;
 

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -485,10 +485,11 @@ void QFieldCloudProjectsModel::insertProjects( const QList<QFieldCloudProject *>
     {
       newProjectsCount++;
       mProjects.append( project );
-      beginInsertRows( QModelIndex(), currentCount, currentCount + newProjectsCount - 1 );
-      endInsertRows();
     }
   }
+
+  beginInsertRows( QModelIndex(), currentCount, currentCount + newProjectsCount - 1 );
+  endInsertRows();
 }
 
 void QFieldCloudProjectsModel::setupProjectConnections( QFieldCloudProject *project )
@@ -639,6 +640,7 @@ void QFieldCloudProjectsModel::loadProjects( const QJsonArray &remoteProjects, b
     if ( cloudProject->name() == QStringLiteral( "localized_datasets" ) )
     {
       mLocalizedDatasetsProjects[cloudProject->owner()] = cloudProject->id();
+      delete cloudProject;
     }
     else
     {
@@ -684,6 +686,7 @@ void QFieldCloudProjectsModel::loadProjects( const QJsonArray &remoteProjects, b
         if ( cloudProject->name() == QStringLiteral( "localized_datasets" ) )
         {
           mLocalizedDatasetsProjects[cloudProject->owner()] = cloudProject->id();
+          delete cloudProject;
         }
         else
         {

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -437,11 +437,9 @@ void QFieldCloudProjectsModel::usernameChanged()
   mUsername = mCloudConnection->username();
 }
 
-void QFieldCloudProjectsModel::layerObserverLayerEdited( const QString &layerId )
+void QFieldCloudProjectsModel::layerObserverLayerEdited( const QString & )
 {
-  Q_UNUSED( layerId )
   QFieldCloudProject *project = findProject( mCurrentProjectId );
-
   if ( !project )
   {
     QgsMessageLog::logMessage( QStringLiteral( "Layer observer triggered `isDirtyChanged` signal incorrectly" ) );
@@ -1092,7 +1090,6 @@ void QFieldCloudProjectsModel::updateLocalizedDataPaths( const QString &projectP
                                             [&localizedDataPath]( const QString &path ) { return !path.startsWith( QFieldCloudUtils::localCloudDirectory() ); } ),
                             localizedDataPaths.end() );
   localizedDataPaths << localizedDataPath;
-  qDebug() << localizedDataPaths;
   QgsApplication::instance()->localizedDataPathRegistry()->setPaths( localizedDataPaths );
 }
 

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -914,37 +914,6 @@ void QFieldCloudProjectsModel::setGpkgFlusher( QgsGpkgFlusher *flusher )
   emit gpkgFlusherChanged();
 }
 
-bool QFieldCloudProjectsModel::deleteGpkgShmAndWal( const QStringList &gpkgFileNames )
-{
-  bool isSuccess = true;
-
-  for ( const QString &fileName : gpkgFileNames )
-  {
-    QFile shmFile( QStringLiteral( "%1-shm" ).arg( fileName ) );
-    if ( shmFile.exists() )
-    {
-      if ( !shmFile.remove() )
-      {
-        QgsMessageLog::logMessage( QStringLiteral( "Failed to remove -shm file '%1' " ).arg( shmFile.fileName() ) );
-        isSuccess = false;
-      }
-    }
-
-    QFile walFile( QStringLiteral( "%1-wal" ).arg( fileName ) );
-
-    if ( walFile.exists() )
-    {
-      if ( !walFile.remove() )
-      {
-        QgsMessageLog::logMessage( QStringLiteral( "Failed to remove -wal file '%1' " ).arg( walFile.fileName() ) );
-        isSuccess = false;
-      }
-    }
-  }
-
-  return isSuccess;
-}
-
 void QFieldCloudProjectsModel::updateLocalizedDataPaths( const QString &projectPath )
 {
   const QString projectId = QFieldCloudUtils::getProjectId( projectPath );

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -407,6 +407,14 @@ void QFieldCloudProjectsModel::projectListReceived()
   }
   else
   {
+    for ( QFieldCloudProject *project : mProjects )
+    {
+      if ( mLocalizedDatasetsProjects.contains( project->owner() ) )
+      {
+        project->setLocalizedDatasetsProjectId( mLocalizedDatasetsProjects[project->owner()] );
+      }
+    }
+
     // All projects fetched, refresh current project details if found
     if ( !mCurrentProjectId.isEmpty() && findProject( mCurrentProjectId ) )
     {

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 
 #include "deltafilewrapper.h"
+#include "deltalistmodel.h"
 #include "layerobserver.h"
 #include "qfield.h"
 #include "qfieldcloudconnection.h"

--- a/src/core/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloudprojectsmodel.cpp
@@ -488,26 +488,26 @@ void QFieldCloudProjectsModel::setupProjectConnections( QFieldCloudProject *proj
     emit dataChanged( idx, idx, QVector<int>() << ProjectFileOutdatedRole );
   } );
 
-  connect( project, &QFieldCloudProject::downloaded, this, [=]( QString name, QString error ) {
+  connect( project, &QFieldCloudProject::downloaded, this, [=]( const QString &name, const QString &error ) {
     QFieldCloudProject *p = static_cast<QFieldCloudProject *>( sender() );
     QModelIndex idx = findProjectIndex( p->id() );
     emit projectDownloaded( p->id(), name, !error.isEmpty(), error );
     emit dataChanged( idx, idx, QVector<int>() << StatusRole << PackagingStatusRole << ErrorStatusRole << ErrorStringRole );
   } );
 
-  connect( project, &QFieldCloudProject::uploadFinished, this, [=]( bool isDownloading, QString error ) {
+  connect( project, &QFieldCloudProject::uploadFinished, this, [=]( bool isDownloading, const QString &error ) {
     QFieldCloudProject *p = static_cast<QFieldCloudProject *>( sender() );
     QModelIndex idx = findProjectIndex( p->id() );
     emit pushFinished( p->id(), isDownloading, !error.isEmpty(), error );
   } );
 
-  connect( project, &QFieldCloudProject::dataRefreshed, this, [=]( QFieldCloudProject::ProjectRefreshReason reason, QString error ) {
+  connect( project, &QFieldCloudProject::dataRefreshed, this, [=]( QFieldCloudProject::ProjectRefreshReason reason, const QString &error ) {
     QFieldCloudProject *p = static_cast<QFieldCloudProject *>( sender() );
     QModelIndex idx = findProjectIndex( p->id() );
     emit dataChanged( idx, idx );
   } );
 
-  connect( project, &QFieldCloudProject::jobFinished, this, [=]( QFieldCloudProject::JobType type, QString error ) {
+  connect( project, &QFieldCloudProject::jobFinished, this, [=]( QFieldCloudProject::JobType type, const QString &error ) {
     QFieldCloudProject *p = static_cast<QFieldCloudProject *>( sender() );
     QModelIndex idx = findProjectIndex( p->id() );
     emit dataChanged( idx, idx );

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -40,6 +40,19 @@ class QFieldCloudProjectsModel : public QAbstractListModel
 {
     Q_OBJECT
 
+    //! The current cloud connection.
+    Q_PROPERTY( QFieldCloudConnection *cloudConnection READ cloudConnection WRITE setCloudConnection NOTIFY cloudConnectionChanged )
+    //! The current layer observer.
+    Q_PROPERTY( LayerObserver *layerObserver READ layerObserver WRITE setLayerObserver NOTIFY layerObserverChanged )
+    //! The current geopackage flusher
+    Q_PROPERTY( QgsGpkgFlusher *gpkgFlusher READ gpkgFlusher WRITE setGpkgFlusher NOTIFY gpkgFlusherChanged )
+    //! Currently busy project ids.
+    Q_PROPERTY( QSet<QString> busyProjectIds READ busyProjectIds NOTIFY busyProjectIdsChanged )
+    //! The current cloud project id of the currently opened project (empty string for non-cloud projects).
+    Q_PROPERTY( QString currentProjectId READ currentProjectId WRITE setCurrentProjectId NOTIFY currentProjectIdChanged )
+    //! The current cloud project. (null for non-cloud projects).
+    Q_PROPERTY( QFieldCloudProject *currentProject READ currentProject NOTIFY currentProjectChanged )
+
   public:
     enum ColumnRole
     {
@@ -64,7 +77,6 @@ class QFieldCloudProjectsModel : public QAbstractListModel
       UploadDeltaStatusStringRole,
       LocalDeltasCountRole,
       LocalPathRole,
-      CanSyncRole,
       LastLocalExportedAtRole,
       LastLocalPushDeltasRole,
       UserRoleRole,
@@ -86,17 +98,11 @@ class QFieldCloudProjectsModel : public QAbstractListModel
 
     QFieldCloudProjectsModel();
 
-    //! Stores the current cloud connection.
-    Q_PROPERTY( QFieldCloudConnection *cloudConnection READ cloudConnection WRITE setCloudConnection NOTIFY cloudConnectionChanged )
-
     //! Returns the currently used cloud connection.
     QFieldCloudConnection *cloudConnection() const;
 
     //! Sets the cloud connection.
     void setCloudConnection( QFieldCloudConnection *cloudConnection );
-
-    //! Stores the current layer observer.
-    Q_PROPERTY( LayerObserver *layerObserver READ layerObserver WRITE setLayerObserver NOTIFY layerObserverChanged )
 
     //! Returns the currently used layer observer.
     LayerObserver *layerObserver() const;
@@ -104,32 +110,20 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     //! Sets the layer observer.
     void setLayerObserver( LayerObserver *layerObserver );
 
-    //! Stores the cloud project id of the currently opened project. Empty string if missing.
-    Q_PROPERTY( QString currentProjectId READ currentProjectId WRITE setCurrentProjectId NOTIFY currentProjectIdChanged )
-
     //! Returns the cloud project id of the currently opened project.
     QString currentProjectId() const;
 
     //! Sets the cloud project id of the currently opened project.
     void setCurrentProjectId( const QString &currentProjectId );
 
-    //! Stores the geopackage flusher
-    Q_PROPERTY( QgsGpkgFlusher *gpkgFlusher READ gpkgFlusher WRITE setGpkgFlusher NOTIFY gpkgFlusherChanged )
+    //! Returns the cloud project of the currently oepened project or NULL for non-cloud projects.
+    QFieldCloudProject *currentProject() const;
 
     //! Returns the geopackage flusher
     QgsGpkgFlusher *gpkgFlusher() const { return mGpkgFlusher; }
 
     //! Sets the geopackage flusher
     void setGpkgFlusher( QgsGpkgFlusher *flusher );
-
-    //! Stores the cloud project data of the currently opened project. Empty map if missing.
-    Q_PROPERTY( QVariant currentProjectData READ currentProjectData NOTIFY currentProjectDataChanged )
-
-    //! Returns the cloud project data of the currently opened project.
-    QVariantMap currentProjectData() const;
-
-    //! Stores a set of the currently busy project ids.
-    Q_PROPERTY( QSet<QString> busyProjectIds READ busyProjectIds NOTIFY busyProjectIdsChanged )
 
     //! Returns a set containing the currently busy project ids.
     QSet<QString> busyProjectIds() const;
@@ -198,9 +192,8 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     void cloudConnectionChanged();
     void layerObserverChanged();
     void currentProjectIdChanged();
-    void currentProjectDataChanged();
+    void currentProjectChanged();
     void busyProjectIdsChanged();
-    void canSyncCurrentProjectChanged();
     void gpkgFlusherChanged();
     void warning( const QString &message );
 
@@ -233,8 +226,6 @@ class QFieldCloudProjectsModel : public QAbstractListModel
 
     QModelIndex findProjectIndex( const QString &projectId ) const;
     QFieldCloudProject *findProject( const QString &projectId ) const;
-
-    bool canSyncProject( const QString &projectId ) const;
 
     bool deleteGpkgShmAndWal( const QStringList &gpkgFileNames );
 

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -197,7 +197,10 @@ class QFieldCloudProjectsModel : public QAbstractListModel
 
     QList<QFieldCloudProject *> mProjects;
     QFieldCloudConnection *mCloudConnection = nullptr;
+
     QString mCurrentProjectId;
+    QPointer<QFieldCloudProject> mCurrentProject;
+
     LayerObserver *mLayerObserver = nullptr;
     QgsGpkgFlusher *mGpkgFlusher = nullptr;
     QString mUsername;

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -81,10 +81,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
       LastLocalPushDeltasRole,
       UserRoleRole,
       UserRoleOriginRole,
-      DeltaListRole,
-      ForceAutoPushRole,
-      AutoPushEnabledRole,
-      AutoPushIntervalMinsRole,
+      DeltaListRole
     };
 
     //! Attributes controlling fetching of projects
@@ -175,15 +172,6 @@ class QFieldCloudProjectsModel : public QAbstractListModel
 
     //! Cancels ongoing cloud project download with \a projectId.
     Q_INVOKABLE void projectCancelDownload( const QString &projectId );
-
-    //! Forces the cloud project auto-push enabled state to be TRUE
-    Q_INVOKABLE void projectSetForceAutoPush( const QString &projectId, bool force );
-
-    //! Toggles the cloud project auto-push enabled state
-    Q_INVOKABLE void projectSetAutoPushEnabled( const QString &projectId, bool enabled );
-
-    //! Sets the interval in \a minutes between which the project will auto-push changes
-    Q_INVOKABLE void projectSetAutoPushIntervalMins( const QString &projectId, int minutes );
 
     //! Configure localized data paths for cloud projects when available
     Q_INVOKABLE void updateLocalizedDataPaths( const QString &projectPath );

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -215,8 +215,6 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     QModelIndex findProjectIndex( const QString &projectId ) const;
     QFieldCloudProject *findProject( const QString &projectId ) const;
 
-    bool deleteGpkgShmAndWal( const QStringList &gpkgFileNames );
-
     void loadProjects( const QJsonArray &remoteProjects = QJsonArray(), bool skipLocalProjects = false );
     void insertProjects( const QList<QFieldCloudProject *> &projects );
 };

--- a/src/core/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloudprojectsmodel.h
@@ -31,7 +31,6 @@ class QNetworkRequest;
 class QFieldCloudConnection;
 class LayerObserver;
 class QgsMapLayer;
-class QgsProject;
 
 /**
  * \ingroup core
@@ -125,9 +124,6 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     //! Returns a set containing the currently busy project ids.
     QSet<QString> busyProjectIds() const;
 
-    //! Returns the cloud project data for given \a projectId.
-    Q_INVOKABLE QVariantMap getProjectData( const QString &projectId ) const;
-
     //! Requests the cloud projects list from the server. If \a shouldRefreshPublic is false, it will refresh only user's project, otherwise will refresh the public projects only, starting from \a projectFetchOffset for pagination.
     Q_INVOKABLE void refreshProjectsList( bool shouldRefreshPublic = false, int projectFetchOffset = 0 );
 
@@ -145,12 +141,6 @@ class QFieldCloudProjectsModel : public QAbstractListModel
 
     //! Discards the delta records of the current cloud project.
     Q_INVOKABLE bool discardLocalChangesFromCurrentProject();
-
-    //! Returns the cloud project status for given \a projectId.
-    Q_INVOKABLE QFieldCloudProject::ProjectStatus projectStatus( const QString &projectId ) const;
-
-    //! Returns the cloud project modification for given \a projectId.
-    Q_INVOKABLE QFieldCloudProject::ProjectModifications projectModification( const QString &projectId ) const;
 
     //! Updates the project modification for given \a projectId.
     Q_INVOKABLE void refreshProjectModification( const QString &projectId );
@@ -173,8 +163,11 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     //! Cancels ongoing cloud project download with \a projectId.
     Q_INVOKABLE void projectCancelDownload( const QString &projectId );
 
-    //! Configure localized data paths for cloud projects when available
+    //! Configure localized data paths for cloud projects when available.
     Q_INVOKABLE void updateLocalizedDataPaths( const QString &projectPath );
+
+    //! Return the cloud project for a given \a projectId.
+    Q_INVOKABLE QFieldCloudProject *findProject( const QString &projectId ) const;
 
   signals:
     void cloudConnectionChanged();
@@ -206,14 +199,12 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     QFieldCloudConnection *mCloudConnection = nullptr;
     QString mCurrentProjectId;
     LayerObserver *mLayerObserver = nullptr;
-    QgsProject *mProject = nullptr;
     QgsGpkgFlusher *mGpkgFlusher = nullptr;
     QString mUsername;
     const int mProjectsPerFetch = 250;
     QMap<QString, QString> mLocalizedDatasetsProjects;
 
     QModelIndex findProjectIndex( const QString &projectId ) const;
-    QFieldCloudProject *findProject( const QString &projectId ) const;
 
     void loadProjects( const QJsonArray &remoteProjects = QJsonArray(), bool skipLocalProjects = false );
     void insertProjects( const QList<QFieldCloudProject *> &projects );

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -103,6 +103,7 @@
 #include "projectutils.h"
 #include "qfield.h"
 #include "qfieldcloudconnection.h"
+#include "qfieldcloudproject.h"
 #include "qfieldcloudprojectsmodel.h"
 #include "qfieldcloudutils.h"
 #include "qfieldlocatorfilter.h"
@@ -423,9 +424,9 @@ void QgisMobileapp::initDeclarative( QQmlEngine *engine )
   qRegisterMetaType<GeometryUtils::GeometryOperationResult>( "GeometryOperationResult" );
   qRegisterMetaType<QFieldCloudConnection::ConnectionStatus>( "QFieldCloudConnection::ConnectionStatus" );
   qRegisterMetaType<CloudUserInformation>( "CloudUserInformation" );
-  qRegisterMetaType<QFieldCloudProjectsModel::ProjectStatus>( "QFieldCloudProjectsModel::ProjectStatus" );
-  qRegisterMetaType<QFieldCloudProjectsModel::ProjectCheckout>( "QFieldCloudProjectsModel::ProjectCheckout" );
-  qRegisterMetaType<QFieldCloudProjectsModel::ProjectModification>( "QFieldCloudProjectsModel::ProjectModification" );
+  qRegisterMetaType<QFieldCloudProject::ProjectStatus>( "QFieldCloudProject::ProjectStatus" );
+  qRegisterMetaType<QFieldCloudProject::ProjectCheckout>( "QFieldCloudProject::ProjectCheckout" );
+  qRegisterMetaType<QFieldCloudProject::ProjectModification>( "QFieldCloudProject::ProjectModification" );
   qRegisterMetaType<Tracker::MeasureType>( "Tracker::MeasureType" );
   qRegisterMetaType<PositioningSource::ElevationCorrectionMode>( "PositioningSource::ElevationCorrectionMode" );
 
@@ -493,6 +494,7 @@ void QgisMobileapp::initDeclarative( QQmlEngine *engine )
   qmlRegisterType<ChangelogContents>( "org.qfield", 1, 0, "ChangelogContents" );
   qmlRegisterType<LayerResolver>( "org.qfield", 1, 0, "LayerResolver" );
   qmlRegisterType<QFieldCloudConnection>( "org.qfield", 1, 0, "QFieldCloudConnection" );
+  qmlRegisterType<QFieldCloudProject>( "org.qfield", 1, 0, "QFieldCloudProject" );
   qmlRegisterType<QFieldCloudProjectsModel>( "org.qfield", 1, 0, "QFieldCloudProjectsModel" );
   qmlRegisterType<QFieldCloudProjectsFilterModel>( "org.qfield", 1, 0, "QFieldCloudProjectsFilterModel" );
   qmlRegisterType<DeltaListModel>( "org.qfield", 1, 0, "DeltaListModel" );

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -140,24 +140,24 @@ Drawer {
             id: cloudButton
             anchors.verticalCenter: parent.verticalCenter
             iconSource: {
-              if (cloudConnection.status === QFieldCloudConnection.LoggedIn) {
-                switch (cloudProjectsModel.currentProjectData.Status) {
+              if (cloudConnection.status === QFieldCloudConnection.LoggedIn && cloudProjectsModel.currentProject) {
+                switch (cloudProjectsModel.currentProject.status) {
                 case QFieldCloudProject.Downloading:
-                  switch (cloudProjectsModel.currentProjectData.PackagingStatus) {
+                  switch (cloudProjectsModel.currentProject.packagingStatus) {
                   case QFieldCloudProject.PackagingFinishedStatus:
                     return Theme.getThemeVectorIcon('ic_cloud_download_24dp');
                   default:
                     return Theme.getThemeVectorIcon('ic_cloud_active_24dp');
                   }
                 case QFieldCloudProject.Uploading:
-                  switch (cloudProjectsModel.currentProjectData.UploadDeltaStatus) {
+                  switch (cloudProjectsModel.currentProject.deltaFileUploadStatus) {
                   case QFieldCloudProject.DeltaFileLocalStatus:
                     return Theme.getThemeVectorIcon('ic_cloud_upload_24dp');
                   default:
                     return Theme.getThemeVectorIcon('ic_cloud_active_24dp');
                   }
                 case QFieldCloudProject.Idle:
-                  return cloudProjectsModel.currentProjectData.ProjectFileOutdated ? Theme.getThemeVectorIcon('ic_cloud_attention_24dp') : Theme.getThemeVectorIcon('ic_cloud_active_24dp');
+                  return cloudProjectsModel.currentProject.projectFileIsOutdated ? Theme.getThemeVectorIcon('ic_cloud_attention_24dp') : Theme.getThemeVectorIcon('ic_cloud_active_24dp');
                 default:
                   return Theme.getThemeVectorIcon('ic_cloud_white_24dp');
                 }
@@ -200,7 +200,7 @@ Drawer {
                 duration: 2000
                 target: cloudButton
               }
-              running: cloudProjectsModel.currentProjectData.Status === QFieldCloudProject.Downloading || cloudProjectsModel.currentProjectData.Status === QFieldCloudProject.Uploading
+              running: cloudProjectsModel.currentProject && (cloudProjectsModel.currentProject.status === QFieldCloudProject.Downloading || cloudProjectsModel.currentProject.status === QFieldCloudProject.Uploading)
               loops: Animation.Infinite
 
               onStopped: {

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -184,6 +184,7 @@ Drawer {
               }
               showCloudPopup();
             }
+
             bottomRightIndicatorText: cloudProjectsModel.layerObserver.deltaFileWrapper.count > 0 ? cloudProjectsModel.layerObserver.deltaFileWrapper.count : cloudProjectsModel.layerObserver.deltaFileWrapper.count >= 10 ? '+' : ''
 
             SequentialAnimation {

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -142,21 +142,21 @@ Drawer {
             iconSource: {
               if (cloudConnection.status === QFieldCloudConnection.LoggedIn) {
                 switch (cloudProjectsModel.currentProjectData.Status) {
-                case QFieldCloudProjectsModel.Downloading:
+                case QFieldCloudProject.Downloading:
                   switch (cloudProjectsModel.currentProjectData.PackagingStatus) {
-                  case QFieldCloudProjectsModel.PackagingFinishedStatus:
+                  case QFieldCloudProject.PackagingFinishedStatus:
                     return Theme.getThemeVectorIcon('ic_cloud_download_24dp');
                   default:
                     return Theme.getThemeVectorIcon('ic_cloud_active_24dp');
                   }
-                case QFieldCloudProjectsModel.Uploading:
+                case QFieldCloudProject.Uploading:
                   switch (cloudProjectsModel.currentProjectData.UploadDeltaStatus) {
-                  case QFieldCloudProjectsModel.DeltaFileLocalStatus:
+                  case QFieldCloudProject.DeltaFileLocalStatus:
                     return Theme.getThemeVectorIcon('ic_cloud_upload_24dp');
                   default:
                     return Theme.getThemeVectorIcon('ic_cloud_active_24dp');
                   }
-                case QFieldCloudProjectsModel.Idle:
+                case QFieldCloudProject.Idle:
                   return cloudProjectsModel.currentProjectData.ProjectFileOutdated ? Theme.getThemeVectorIcon('ic_cloud_attention_24dp') : Theme.getThemeVectorIcon('ic_cloud_active_24dp');
                 default:
                   return Theme.getThemeVectorIcon('ic_cloud_white_24dp');
@@ -199,7 +199,7 @@ Drawer {
                 duration: 2000
                 target: cloudButton
               }
-              running: cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Downloading || cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Uploading
+              running: cloudProjectsModel.currentProjectData.Status === QFieldCloudProject.Downloading || cloudProjectsModel.currentProjectData.Status === QFieldCloudProject.Uploading
               loops: Animation.Infinite
 
               onStopped: {

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -343,9 +343,9 @@ Popup {
               if (transferError.visible) {
                 transferError.detailsText = errorString;
               }
-              const projectData = cloudProjectsModel.getProjectData(projectId);
-              if (projectData.PackagedLayerErrors.length !== 0) {
-                cloudPackageLayersFeedback.packagedLayersListViewModel = projectData.PackagedLayerErrors;
+              const cloudProject = cloudProjectsModel.findProject(projectId);
+              if (cloudProject.packagedLayerErrors.length !== 0) {
+                cloudPackageLayersFeedback.packagedLayersListViewModel = cloudProject.packagedLayerErrors;
                 cloudPackageLayersFeedback.visible = true;
               }
             }

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -483,10 +483,12 @@ Popup {
               MouseArea {
                 anchors.fill: parent
                 onClicked: {
-                  if (!!cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.forceAutoPush) {
-                    displayToast(qsTr('The current project does not allow for auto-push to be turned off'));
-                  } else {
-                    cloudProjectsModel.projectSetAutoPushEnabled(cloudProjectsModel.currentProjectId, !autoPush.checked);
+                  if (cloudProjectsModel.currentProject) {
+                    if (!!cloudProjectsModel.currentProject.forceAutoPush) {
+                      displayToast(qsTr('The current project does not allow for auto-push to be turned off'));
+                    } else {
+                      cloudProjectsModel.currentProject.autoPushEnabled = !autoPush.checked;
+                    }
                   }
                 }
               }
@@ -502,7 +504,9 @@ Popup {
               checked: !!(cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.autoPushEnabled)
 
               onClicked: {
-                cloudProjectsModel.projectSetAutoPushEnabled(cloudProjectsModel.currentProjectId, checked);
+                if (cloudProjectsModel.currentProject) {
+                  cloudProjectsModel.currentProject.autoPushEnabled = checked;
+                }
               }
             }
 

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -21,7 +21,7 @@ Popup {
       showCancelButton: false
       showApplyButton: false
 
-      busyIndicatorState: cloudConnection.status === QFieldCloudConnection.Connecting || cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Uploading || cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Downloading ? 'on' : 'off'
+      busyIndicatorState: cloudConnection.status === QFieldCloudConnection.Connecting || cloudProjectsModel.currentProjectData.Status === QFieldCloudProject.Uploading || cloudProjectsModel.currentProjectData.Status === QFieldCloudProject.Downloading ? 'on' : 'off'
 
       topMargin: mainWindow.sceneTopMargin
 
@@ -156,7 +156,7 @@ Popup {
                 anchors.fill: parent
 
                 onClicked: {
-                  if (cloudConnection.status !== QFieldCloudConnection.LoggedIn || cloudProjectsModel.currentProjectData.Status !== QFieldCloudProjectsModel.Idle)
+                  if (cloudConnection.status !== QFieldCloudConnection.LoggedIn || cloudProjectsModel.currentProjectData.Status !== QFieldCloudProject.Idle)
                     return;
                   if (!connectionSettings.visible) {
                     connectionSettings.visible = true;
@@ -186,15 +186,15 @@ Popup {
 
         Text {
           id: statusText
-          visible: cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Downloading || cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Uploading
+          visible: cloudProjectsModel.currentProjectData.Status === QFieldCloudProject.Downloading || cloudProjectsModel.currentProjectData.Status === QFieldCloudProject.Uploading
           font: Theme.tipFont
           color: Theme.secondaryTextColor
           text: switch (cloudProjectsModel.currentProjectData.Status) {
-          case QFieldCloudProjectsModel.Downloading:
-            if (cloudProjectsModel.currentProjectData.PackagingStatus === QFieldCloudProjectsModel.PackagingBusyStatus) {
+          case QFieldCloudProject.Downloading:
+            if (cloudProjectsModel.currentProjectData.PackagingStatus === QFieldCloudProject.PackagingBusyStatus) {
               return qsTr('QFieldCloud is packaging the latest data just for you; this might take some time, please hold tight');
             } else {
-              if (cloudProjectsModel.currentProjectData.PackagingStatus === QFieldCloudProjectsModel.PackagingFinishedStatus || cloudProjectsModel.currentProjectData.DownloadProgress > 0.0) {
+              if (cloudProjectsModel.currentProjectData.PackagingStatus === QFieldCloudProject.PackagingFinishedStatus || cloudProjectsModel.currentProjectData.DownloadProgress > 0.0) {
                 if (cloudProjectsModel.currentProjectData.DownloadSize > 0) {
                   return qsTr('Downloading, %1% of %2 fetched').arg(Math.round(cloudProjectsModel.currentProjectData.DownloadProgress * 100)).arg(FileUtils.representFileSize(cloudProjectsModel.currentProjectData.DownloadSize));
                 } else {
@@ -204,9 +204,9 @@ Popup {
                 return qsTr('Reaching out to QFieldCloud to download project');
               }
             }
-          case QFieldCloudProjectsModel.Uploading:
+          case QFieldCloudProject.Uploading:
             switch (cloudProjectsModel.currentProjectData.UploadDeltaStatus) {
-            case QFieldCloudProjectsModel.DeltaFileLocalStatus:
+            case QFieldCloudProject.DeltaFileLocalStatus:
               return qsTr('Uploading %1%…').arg(Math.round(cloudProjectsModel.currentProjectData.UploadDeltaProgress * 100));
             default:
               return qsTr('QFieldCloud is applying the latest uploaded changes. This might take some time, please hold tight…');
@@ -231,7 +231,7 @@ Popup {
           width: 128
           height: 128
           color: 'transparent'
-          visible: cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Downloading || cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Uploading
+          visible: cloudProjectsModel.currentProjectData.Status === QFieldCloudProject.Downloading || cloudProjectsModel.currentProjectData.Status === QFieldCloudProject.Uploading
 
           Image {
             id: statusIcon
@@ -239,16 +239,16 @@ Popup {
             fillMode: Image.PreserveAspectFit
             smooth: true
             source: switch (cloudProjectsModel.currentProjectData.Status) {
-            case QFieldCloudProjectsModel.Downloading:
+            case QFieldCloudProject.Downloading:
               switch (cloudProjectsModel.currentProjectData.PackagingStatus) {
-              case QFieldCloudProjectsModel.PackagingFinishedStatus || cloudProjectsModel.currentProjectData.DownloadProgress > 0.0:
+              case QFieldCloudProject.PackagingFinishedStatus || cloudProjectsModel.currentProjectData.DownloadProgress > 0.0:
                 return Theme.getThemeVectorIcon('ic_cloud_download_24dp');
               default:
                 return Theme.getThemeVectorIcon('ic_cloud_active_24dp');
               }
-            case QFieldCloudProjectsModel.Uploading:
+            case QFieldCloudProject.Uploading:
               switch (cloudProjectsModel.currentProjectData.UploadDeltaStatus) {
-              case QFieldCloudProjectsModel.DeltaFileLocalStatus:
+              case QFieldCloudProject.DeltaFileLocalStatus:
                 return Theme.getThemeVectorIcon('ic_cloud_upload_24dp');
               default:
                 return Theme.getThemeVectorIcon('ic_cloud_active_24dp');
@@ -285,9 +285,9 @@ Popup {
             anchors.horizontalCenter: parent.horizontalCenter
             width: parent.width
             height: 6
-            indeterminate: cloudProjectsModel.currentProjectData.PackagingStatus !== QFieldCloudProjectsModel.PackagingFinishedStatus && cloudProjectsModel.currentProjectData.DownloadProgress === 0.0
+            indeterminate: cloudProjectsModel.currentProjectData.PackagingStatus !== QFieldCloudProject.PackagingFinishedStatus && cloudProjectsModel.currentProjectData.DownloadProgress === 0.0
             value: cloudProjectsModel.currentProjectData.DownloadProgress ? cloudProjectsModel.currentProjectData.DownloadProgress : 0
-            visible: cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.ProjectStatus.Downloading
+            visible: cloudProjectsModel.currentProjectData.Status === QFieldCloudProject.ProjectStatus.Downloading
           }
         }
 
@@ -296,7 +296,7 @@ Popup {
 
           property bool hasError: false
 
-          visible: hasError && cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Idle && !connectionSettings.visible
+          visible: hasError && cloudProjectsModel.currentProjectData.Status === QFieldCloudProject.Idle && !connectionSettings.visible
 
           Layout.fillWidth: true
           Layout.leftMargin: 10
@@ -348,7 +348,7 @@ Popup {
           Layout.maximumWidth: 525
           Layout.alignment: Qt.AlignHCenter
           width: parent.width
-          visible: !connectionSettings.visible && cloudProjectsModel.currentProjectData.Status === QFieldCloudProjectsModel.Idle
+          visible: !connectionSettings.visible && cloudProjectsModel.currentProjectData.Status === QFieldCloudProject.Idle
           columns: 1
           columnSpacing: parent.columnSpacing
           rowSpacing: parent.rowSpacing

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -21,7 +21,7 @@ Popup {
       showCancelButton: false
       showApplyButton: false
 
-      busyIndicatorState: cloudConnection.status === QFieldCloudConnection.Connecting || cloudProjectsModel.currentProjectData.Status === QFieldCloudProject.Uploading || cloudProjectsModel.currentProjectData.Status === QFieldCloudProject.Downloading ? 'on' : 'off'
+      busyIndicatorState: cloudProjectsModel.currentProject && (cloudConnection.status === QFieldCloudConnection.Connecting || cloudProjectsModel.currentProject.status === QFieldCloudProject.Uploading || cloudProjectsModel.currentProject.status === QFieldCloudProject.Downloading ? 'on' : 'off')
 
       topMargin: mainWindow.sceneTopMargin
 
@@ -156,7 +156,7 @@ Popup {
                 anchors.fill: parent
 
                 onClicked: {
-                  if (cloudConnection.status !== QFieldCloudConnection.LoggedIn || cloudProjectsModel.currentProjectData.Status !== QFieldCloudProject.Idle)
+                  if (cloudConnection.status !== QFieldCloudConnection.LoggedIn || !cloudProjectsModel.currentProject || cloudProjectsModel.currentProject.status !== QFieldCloudProject.Idle)
                     return;
                   if (!connectionSettings.visible) {
                     connectionSettings.visible = true;
@@ -173,7 +173,7 @@ Popup {
 
         Text {
           id: wrongAccountText
-          visible: cloudProjectsModel.currentProjectId != '' && cloudProjectsModel.currentProjectId !== cloudProjectsModel.currentProjectData.Id
+          visible: cloudProjectsModel.currentProjectId != '' && cloudProjectsModel.currentProject && cloudProjectsModel.currentProjectId !== cloudProjectsModel.currentProject.id
           font: Theme.tipFont
           color: Theme.secondaryTextColor
           text: qsTr('This QFieldCloud project was first downloaded with another cloud account. Please sign in with the original account for this project to use the QFieldCloud functionality.')
@@ -186,33 +186,38 @@ Popup {
 
         Text {
           id: statusText
-          visible: cloudProjectsModel.currentProjectData.Status === QFieldCloudProject.Downloading || cloudProjectsModel.currentProjectData.Status === QFieldCloudProject.Uploading
+          visible: cloudProjectsModel.currentProject && (cloudProjectsModel.currentProject.status === QFieldCloudProject.Downloading || cloudProjectsModel.currentProject.status === QFieldCloudProject.Uploading)
           font: Theme.tipFont
           color: Theme.secondaryTextColor
-          text: switch (cloudProjectsModel.currentProjectData.Status) {
-          case QFieldCloudProject.Downloading:
-            if (cloudProjectsModel.currentProjectData.PackagingStatus === QFieldCloudProject.PackagingBusyStatus) {
-              return qsTr('QFieldCloud is packaging the latest data just for you; this might take some time, please hold tight');
-            } else {
-              if (cloudProjectsModel.currentProjectData.PackagingStatus === QFieldCloudProject.PackagingFinishedStatus || cloudProjectsModel.currentProjectData.DownloadProgress > 0.0) {
-                if (cloudProjectsModel.currentProjectData.DownloadSize > 0) {
-                  return qsTr('Downloading, %1% of %2 fetched').arg(Math.round(cloudProjectsModel.currentProjectData.DownloadProgress * 100)).arg(FileUtils.representFileSize(cloudProjectsModel.currentProjectData.DownloadSize));
+          text: {
+            if (cloudProjectsModel.currentProject) {
+              switch (cloudProjectsModel.currentProject.status) {
+              case QFieldCloudProject.Downloading:
+                if (cloudProjectsModel.currentProject.packagingStatus === QFieldCloudProject.PackagingBusyStatus) {
+                  return qsTr('QFieldCloud is packaging the latest data just for you; this might take some time, please hold tight');
                 } else {
-                  return qsTr('Downloading, %1% fetched').arg(Math.round(cloudProjectsModel.currentProjectData.DownloadProgress * 100));
+                  if (cloudProjectsModel.currentProject.packagingStatus === QFieldCloudProject.PackagingFinishedStatus || cloudProjectsModel.currentProject.downloadProgress > 0.0) {
+                    if (cloudProjectsModel.currentProject.downloadBytesTotal > 0) {
+                      return qsTr('Downloading, %1% of %2 fetched').arg(Math.round(cloudProjectsModel.currentProject.downloadProgress * 100)).arg(FileUtils.representFileSize(cloudProjectsModel.currentProject.downloadBytesTotal));
+                    } else {
+                      return qsTr('Downloading, %1% fetched').arg(Math.round(cloudProjectsModel.currentProject.downloadProgress * 100));
+                    }
+                  } else {
+                    return qsTr('Reaching out to QFieldCloud to download project');
+                  }
                 }
-              } else {
-                return qsTr('Reaching out to QFieldCloud to download project');
+              case QFieldCloudProject.Uploading:
+                switch (cloudProjectsModel.currentProject.deltaFileUploadStatus) {
+                case QFieldCloudProject.DeltaFileLocalStatus:
+                  return qsTr('Uploading %1%…').arg(Math.round(cloudProjectsModel.currentProject.uploadDeltaProgress * 100));
+                default:
+                  return qsTr('QFieldCloud is applying the latest uploaded changes. This might take some time, please hold tight…');
+                }
+              default:
+                '';
               }
             }
-          case QFieldCloudProject.Uploading:
-            switch (cloudProjectsModel.currentProjectData.UploadDeltaStatus) {
-            case QFieldCloudProject.DeltaFileLocalStatus:
-              return qsTr('Uploading %1%…').arg(Math.round(cloudProjectsModel.currentProjectData.UploadDeltaProgress * 100));
-            default:
-              return qsTr('QFieldCloud is applying the latest uploaded changes. This might take some time, please hold tight…');
-            }
-          default:
-            '';
+            return '';
           }
 
           wrapMode: Text.WordWrap
@@ -231,30 +236,35 @@ Popup {
           width: 128
           height: 128
           color: 'transparent'
-          visible: cloudProjectsModel.currentProjectData.Status === QFieldCloudProject.Downloading || cloudProjectsModel.currentProjectData.Status === QFieldCloudProject.Uploading
+          visible: cloudProjectsModel.currentProject && (cloudProjectsModel.currentProject.status === QFieldCloudProject.Downloading || cloudProjectsModel.currentProject.status === QFieldCloudProject.Uploading)
 
           Image {
             id: statusIcon
             anchors.fill: parent
             fillMode: Image.PreserveAspectFit
             smooth: true
-            source: switch (cloudProjectsModel.currentProjectData.Status) {
-            case QFieldCloudProject.Downloading:
-              switch (cloudProjectsModel.currentProjectData.PackagingStatus) {
-              case QFieldCloudProject.PackagingFinishedStatus || cloudProjectsModel.currentProjectData.DownloadProgress > 0.0:
-                return Theme.getThemeVectorIcon('ic_cloud_download_24dp');
-              default:
-                return Theme.getThemeVectorIcon('ic_cloud_active_24dp');
+            source: {
+              if (cloudProjectsModel.currentProject) {
+                switch (cloudProjectsModel.currentProject.status) {
+                case QFieldCloudProject.Downloading:
+                  switch (cloudProjectsModel.currentProject.packagingStatus) {
+                  case QFieldCloudProject.PackagingFinishedStatus || cloudProjectsModel.currentProject.downloadProgress > 0.0:
+                    return Theme.getThemeVectorIcon('ic_cloud_download_24dp');
+                  default:
+                    return Theme.getThemeVectorIcon('ic_cloud_active_24dp');
+                  }
+                case QFieldCloudProject.Uploading:
+                  switch (cloudProjectsModel.currentProject.deltaFileUploadStatus) {
+                  case QFieldCloudProject.DeltaFileLocalStatus:
+                    return Theme.getThemeVectorIcon('ic_cloud_upload_24dp');
+                  default:
+                    return Theme.getThemeVectorIcon('ic_cloud_active_24dp');
+                  }
+                default:
+                  '';
+                }
               }
-            case QFieldCloudProject.Uploading:
-              switch (cloudProjectsModel.currentProjectData.UploadDeltaStatus) {
-              case QFieldCloudProject.DeltaFileLocalStatus:
-                return Theme.getThemeVectorIcon('ic_cloud_upload_24dp');
-              default:
-                return Theme.getThemeVectorIcon('ic_cloud_active_24dp');
-              }
-            default:
-              '';
+              return '';
             }
             width: parent.width
             height: parent.height
@@ -285,9 +295,9 @@ Popup {
             anchors.horizontalCenter: parent.horizontalCenter
             width: parent.width
             height: 6
-            indeterminate: cloudProjectsModel.currentProjectData.PackagingStatus !== QFieldCloudProject.PackagingFinishedStatus && cloudProjectsModel.currentProjectData.DownloadProgress === 0.0
-            value: cloudProjectsModel.currentProjectData.DownloadProgress ? cloudProjectsModel.currentProjectData.DownloadProgress : 0
-            visible: cloudProjectsModel.currentProjectData.Status === QFieldCloudProject.ProjectStatus.Downloading
+            indeterminate: cloudProjectsModel.currentProject && (cloudProjectsModel.currentProject.packagingStatus !== QFieldCloudProject.PackagingFinishedStatus && cloudProjectsModel.currentProject.downloadProgress === 0.0)
+            value: cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.downloadProgress ? cloudProjectsModel.currentProject.downloadProgress : 0
+            visible: cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.status === QFieldCloudProject.ProjectStatus.Downloading
           }
         }
 
@@ -296,7 +306,7 @@ Popup {
 
           property bool hasError: false
 
-          visible: hasError && cloudProjectsModel.currentProjectData.Status === QFieldCloudProject.Idle && !connectionSettings.visible
+          visible: hasError && cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.status === QFieldCloudProject.Idle && !connectionSettings.visible
 
           Layout.fillWidth: true
           Layout.leftMargin: 10
@@ -348,7 +358,7 @@ Popup {
           Layout.maximumWidth: 525
           Layout.alignment: Qt.AlignHCenter
           width: parent.width
-          visible: !connectionSettings.visible && cloudProjectsModel.currentProjectData.Status === QFieldCloudProject.Idle
+          visible: !connectionSettings.visible && cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.status === QFieldCloudProject.Idle
           columns: 1
           columnSpacing: parent.columnSpacing
           rowSpacing: parent.rowSpacing
@@ -377,7 +387,7 @@ Popup {
             Layout.fillWidth: true
             text: qsTr('Synchronize')
             visible: !cloudProjectsModel.layerObserver.deltaFileWrapper.hasError()
-            enabled: !!(cloudProjectsModel.currentProjectData && cloudProjectsModel.currentProjectData.CanSync) && !cloudProjectsModel.layerObserver.deltaFileWrapper.hasError()
+            enabled: !!(cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.status === QFieldCloudProject.Idle) && !cloudProjectsModel.layerObserver.deltaFileWrapper.hasError()
             icon.source: Theme.getThemeVectorIcon('ic_cloud_synchronize_24dp')
 
             onClicked: projectUpload(true)
@@ -400,7 +410,7 @@ Popup {
             Layout.fillWidth: true
             text: qsTr('Push changes')
             visible: !cloudProjectsModel.layerObserver.deltaFileWrapper.hasError()
-            enabled: !!(cloudProjectsModel.currentProjectData && cloudProjectsModel.currentProjectData.CanSync) && cloudProjectsModel.layerObserver.deltaFileWrapper.count > 0 && !cloudProjectsModel.layerObserver.deltaFileWrapper.hasError()
+            enabled: !!(cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.status === QFieldCloudProject.Idle) && cloudProjectsModel.layerObserver.deltaFileWrapper.count > 0 && !cloudProjectsModel.layerObserver.deltaFileWrapper.hasError()
             icon.source: Theme.getThemeVectorIcon('ic_cloud_upload_24dp')
 
             onClicked: projectUpload(false)
@@ -468,12 +478,12 @@ Popup {
               wrapMode: Text.WordWrap
               color: autoPush.checked ? Theme.mainTextColor : Theme.secondaryTextColor
 
-              text: qsTr('Automatically push changes every %n minute(s)', '', 0 + cloudProjectsModel.currentProjectData.AutoPushIntervalMins)
+              text: qsTr('Automatically push changes every %n minute(s)', '', 0 + (cloudProjectsModel.currentProject ? cloudProjectsModel.currentProject.autoPushIntervalMins : 0))
 
               MouseArea {
                 anchors.fill: parent
                 onClicked: {
-                  if (!!cloudProjectsModel.currentProjectData.ForceAutoPush) {
+                  if (!!cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.forceAutoPush) {
                     displayToast(qsTr('The current project does not allow for auto-push to be turned off'));
                   } else {
                     cloudProjectsModel.projectSetAutoPushEnabled(cloudProjectsModel.currentProjectId, !autoPush.checked);
@@ -488,8 +498,8 @@ Popup {
               Layout.alignment: Qt.AlignVCenter
               width: implicitContentWidth
               small: true
-              enabled: !cloudProjectsModel.currentProjectData.ForceAutoPush
-              checked: !!cloudProjectsModel.currentProjectData.AutoPushEnabled
+              enabled: !(cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.forceAutoPush)
+              checked: !!(cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.autoPushEnabled)
 
               onClicked: {
                 cloudProjectsModel.projectSetAutoPushEnabled(cloudProjectsModel.currentProjectId, checked);
@@ -498,13 +508,13 @@ Popup {
 
             Timer {
               id: autoPushTimer
-              running: !!cloudProjectsModel.currentProjectData.AutoPushEnabled
-              interval: (cloudProjectsModel.currentProjectData.AutoPushIntervalMins) * 60 * 1000
+              running: !!(cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.autoPushEnabled)
+              interval: (cloudProjectsModel.currentProject ? cloudProjectsModel.currentProject.autoPushIntervalMins : 0) * 60 * 1000
               repeat: true
 
               onRunningChanged: {
-                if (running && pushButton.enabled) {
-                  const dtStr = cloudProjectsModel.currentProjectData.LastLocalPushDeltas;
+                if (running && pushButton.enabled && cloudProjectsModel.currentProject) {
+                  const dtStr = cloudProjectsModel.currentProject.lastLocalPushDeltas;
                   if (dtStr) {
                     const dt = new Date(dtStr);
                     const now = new Date();
@@ -528,8 +538,11 @@ Popup {
             font: Theme.tipFont
             color: Theme.secondaryTextColor
             text: {
+              if (!cloudProjectsModel.currentProject) {
+                return '';
+              }
               var exportText = '';
-              var exportDt = cloudProjectsModel.currentProjectData.LastLocalExportedAt;
+              var exportDt = cloudProjectsModel.currentProject.lastLocalExportedAt;
               var timeDeltaMinutes = null;
               if (exportDt) {
                 exportDt = new Date(exportDt);
@@ -544,7 +557,7 @@ Popup {
                   exportText = qsTr('Last synchronized on %1').arg(exportDt.toLocaleString());
               }
               var pushText = '';
-              var pushDt = cloudProjectsModel.currentProjectData.LastLocalPushDeltas;
+              var pushDt = cloudProjectsModel.currentProject.lastLocalPushDeltas;
               if (pushDt) {
                 pushDt = new Date(pushDt);
                 timeDeltaMinutes = parseInt(Math.max(new Date() - pushDt, 0) / (60 * 1000));
@@ -668,21 +681,21 @@ Popup {
     }
     if (cloudConnection.status === QFieldCloudConnection.Connecting) {
       displayToast(qsTr('Connecting cloud'));
-    } else if (cloudProjectsModel.currentProjectData.ProjectFileOutdated) {
+    } else if (cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.projectFileIsOutdated) {
       displayToast(qsTr('This project has an updated project file on the cloud, you are advised to synchronize.'), 'warning');
-    } else if (cloudProjectsModel.currentProjectData.ProjectOutdated) {
+    } else if (cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.isOutdated) {
       displayToast(qsTr('This project has updated data on the cloud, you should synchronize.'));
     }
   }
 
   function projectUpload(shouldDownloadUpdates) {
-    if (cloudProjectsModel.currentProjectData && cloudProjectsModel.currentProjectData.CanSync) {
+    if (cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.status === QFieldCloudProject.Idle) {
       cloudProjectsModel.projectUpload(cloudProjectsModel.currentProjectId, shouldDownloadUpdates);
     }
   }
 
   function revertLocalChangesFromCurrentProject() {
-    if (cloudProjectsModel.currentProjectData && cloudProjectsModel.currentProjectData.CanSync) {
+    if (cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.status === QFieldCloudProject.Idle) {
       if (cloudProjectsModel.revertLocalChangesFromCurrentProject(cloudProjectsModel.currentProjectId)) {
         displayToast(qsTr('Local changes reverted'));
       } else {

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -274,9 +274,9 @@ Page {
               anchors.leftMargin: line.leftPadding
               width: line.width - 20
               height: 6
-              indeterminate: PackagingStatus !== QFieldCloudProjectsModel.PackagingFinishedStatus && DownloadProgress === 0.0
+              indeterminate: PackagingStatus !== QFieldCloudProject.PackagingFinishedStatus && DownloadProgress === 0.0
               value: DownloadProgress
-              visible: Status === QFieldCloudProjectsModel.ProjectStatus.Downloading
+              visible: Status === QFieldCloudProject.ProjectStatus.Downloading
               z: 1
             }
 
@@ -298,17 +298,17 @@ Page {
                   } else {
                     var status = '';
                     switch (Status) {
-                    case QFieldCloudProjectsModel.ProjectStatus.Downloading:
+                    case QFieldCloudProject.ProjectStatus.Downloading:
                       return Theme.getThemeVectorIcon('ic_cloud_project_download_48dp');
-                    case QFieldCloudProjectsModel.ProjectStatus.Uploading:
+                    case QFieldCloudProject.ProjectStatus.Uploading:
                       return Theme.getThemeVectorIcon('ic_cloud_project_upload_48dp');
                     default:
                       break;
                     }
                     switch (Checkout) {
-                    case QFieldCloudProjectsModel.LocalCheckout:
+                    case QFieldCloudProject.LocalCheckout:
                       return Theme.getThemeVectorIcon('ic_cloud_project_localonly_48dp');
-                    case QFieldCloudProjectsModel.RemoteCheckout:
+                    case QFieldCloudProject.RemoteCheckout:
                       return Theme.getThemeVectorIcon('ic_cloud_project_download_48dp');
                     default:
                       break;
@@ -320,7 +320,7 @@ Page {
                 sourceSize.height: 80
                 width: 40
                 height: 40
-                opacity: Status === QFieldCloudProjectsModel.ProjectStatus.Downloading ? 0.3 : 1
+                opacity: Status === QFieldCloudProject.ProjectStatus.Downloading ? 0.3 : 1
               }
               ColumnLayout {
                 id: inner
@@ -348,13 +348,13 @@ Page {
 
                       // TODO I think these should be shown as UI badges
                       switch (Status) {
-                      case QFieldCloudProjectsModel.ProjectStatus.Idle:
+                      case QFieldCloudProject.ProjectStatus.Idle:
                         break;
-                      case QFieldCloudProjectsModel.ProjectStatus.Downloading:
-                        if (PackagingStatus === QFieldCloudProjectsModel.PackagingBusyStatus) {
+                      case QFieldCloudProject.ProjectStatus.Downloading:
+                        if (PackagingStatus === QFieldCloudProject.PackagingBusyStatus) {
                           status = qsTr('QFieldCloud is packaging the latest data just for you; this might take some time, please hold tight');
                         } else {
-                          if (PackagingStatus === QFieldCloudProjectsModel.PackagingFinishedStatus || DownloadProgress > 0.0) {
+                          if (PackagingStatus === QFieldCloudProject.PackagingFinishedStatus || DownloadProgress > 0.0) {
                             if (DownloadSize > 0) {
                               status = qsTr('Downloading, %1% of %2 fetched').arg(Math.round(DownloadProgress * 100)).arg(FileUtils.representFileSize(DownloadSize));
                             } else {
@@ -365,31 +365,31 @@ Page {
                           }
                         }
                         break;
-                      case QFieldCloudProjectsModel.ProjectStatus.Uploading:
+                      case QFieldCloudProject.ProjectStatus.Uploading:
                         status = qsTr('Uploading…');
                         break;
                       default:
                         break;
                       }
                       switch (ErrorStatus) {
-                      case QFieldCloudProjectsModel.NoErrorStatus:
+                      case QFieldCloudProject.NoErrorStatus:
                         break;
-                      case QFieldCloudProjectsModel.DownloadErrorStatus:
+                      case QFieldCloudProject.DownloadErrorStatus:
                         status = qsTr('Downloading error. ') + ErrorString;
                         break;
-                      case QFieldCloudProjectsModel.UploadErrorStatus:
+                      case QFieldCloudProject.UploadErrorStatus:
                         status = qsTr('Uploading error. ') + ErrorString;
                         break;
                       }
                       if (!status) {
                         switch (Checkout) {
-                        case QFieldCloudProjectsModel.LocalCheckout:
+                        case QFieldCloudProject.LocalCheckout:
                           status = qsTr('Available locally, missing on the cloud');
                           break;
-                        case QFieldCloudProjectsModel.RemoteCheckout:
+                        case QFieldCloudProject.RemoteCheckout:
                           status = qsTr('Available on the cloud, missing locally');
                           break;
-                        case QFieldCloudProjectsModel.LocalAndRemoteCheckout:
+                        case QFieldCloudProject.LocalAndRemoteCheckout:
                           status = qsTr('Available locally');
                           if (ProjectOutdated) {
                             status += qsTr(', updated data available on the cloud');
@@ -471,10 +471,10 @@ Page {
                 projectActions.projectOwner = item.projectOwner;
                 projectActions.projectName = item.projectName;
                 projectActions.projectLocalPath = item.projectLocalPath;
-                downloadProject.visible = item.projectLocalPath === '' && item.status !== QFieldCloudProjectsModel.ProjectStatus.Downloading;
+                downloadProject.visible = item.projectLocalPath === '' && item.status !== QFieldCloudProject.ProjectStatus.Downloading;
                 openProject.visible = item.projectLocalPath !== '';
                 removeProject.visible = item.projectLocalPath !== '';
-                cancelDownloadProject.visible = item.status === QFieldCloudProjectsModel.ProjectStatus.Downloading;
+                cancelDownloadProject.visible = item.status === QFieldCloudProject.ProjectStatus.Downloading;
                 projectActions.popup(mouse.x, mouse.y);
               }
             }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -348,9 +348,9 @@ Page {
 
                       // TODO I think these should be shown as UI badges
                       switch (Status) {
-                      case QFieldCloudProject.ProjectStatus.Idle:
+                      case QFieldCloudProject.Idle:
                         break;
-                      case QFieldCloudProject.ProjectStatus.Downloading:
+                      case QFieldCloudProject.Downloading:
                         if (PackagingStatus === QFieldCloudProject.PackagingBusyStatus) {
                           status = qsTr('QFieldCloud is packaging the latest data just for you; this might take some time, please hold tight');
                         } else {
@@ -365,7 +365,7 @@ Page {
                           }
                         }
                         break;
-                      case QFieldCloudProject.ProjectStatus.Uploading:
+                      case QFieldCloudProject.Uploading:
                         status = qsTr('Uploading…');
                         break;
                       default:

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3742,9 +3742,8 @@ ApplicationWindow {
       const cloudProjectId = QFieldCloudUtils.getProjectId(qgisProject.fileName);
       cloudProjectsModel.currentProjectId = cloudProjectId;
       cloudProjectsModel.refreshProjectModification(cloudProjectId);
-      if (cloudProjectId !== '') {
-        var cloudProjectData = cloudProjectsModel.getProjectData(cloudProjectId);
-        switch (cloudProjectData.UserRole) {
+      if (cloudProjectsModel.currentProject) {
+        switch (cloudProjectsModel.currentProject.userRole) {
         case 'reader':
           stateMachine.state = "browse";
           projectInfo.hasInsertRights = false;

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -4009,7 +4009,7 @@ ApplicationWindow {
     onWarning: message => displayToast(message)
 
     onDeltaListModelChanged: function () {
-      qfieldCloudDeltaHistory.model = cloudProjectsModel.currentProjectData.DeltaList;
+      qfieldCloudDeltaHistory.model = cloudProjectsModel.currentProject.deltaListModel;
     }
   }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3743,6 +3743,14 @@ ApplicationWindow {
       cloudProjectsModel.currentProjectId = cloudProjectId;
       cloudProjectsModel.refreshProjectModification(cloudProjectId);
       if (cloudProjectsModel.currentProject) {
+        const forceAutoPush = iface.readProjectBoolEntry("qfieldsync", "forceAutoPush", false);
+        if (forceAutoPush) {
+          cloudProjectsModel.currentProject.forceAutoPush = true;
+          cloudProjectsModel.currentProject.autoPushEnabled = true;
+          cloudProjectsModel.currentProject.autoPushIntervalsMins = iface.readProjectNumEntry("qfieldsync", "forceAutoPushIntervalMins", 30);
+        } else {
+          cloudProjectsModel.currentProject.forceAutoPush = false;
+        }
         switch (cloudProjectsModel.currentProject.userRole) {
         case 'reader':
           stateMachine.state = "browse";


### PR DESCRIPTION
(This is built on top of https://github.com/opengisch/QField/pull/6168 ; I'll leave the other one open to easily review the localized dataset addition)

This PR applies a massive refactoring to the cloud-related aspects of QField by pulling out virtually all of the cloud project-specific code that was added over time into the QFieldCloudProjectsModel class, which had become really difficult to manage and understand (for both newcomers to the code as well as veterans! :wink:). As a result of the work, a new QFieldCloudProject class has been added. We've moved away from a struct into a proper QObject class, with Q_PROPERTY, Q_INVOKABLE functions, signals, et al.

One of the most significant win here is that we can finally expose cloud project objects within QML itself. Until now, we were relying to a bit of a hack (see the RIP Q_PROPERTY currentProjectData / and the Q_INVOKABLE getProjectData()) to be able to do a bit of read-only handling on the QML side as well as tons of project-prefixed Q_INVOKABLE functions. What more, we had to constantly check whether a given project struct was still held within the model, etc. which added lots of redundant code that complexified the reading of the code.

This is a thing of the past now. We can now handle cloud projects properly within QML. If you want to see a great example of how nice things are now, check how the auto push changes to cloud code has changed in this PR. Much, _much_ better.

In the process, I've spotted and plugged in a few leaks here and there.

The process was ... laborious. I'm glad we have left this debt beyond though.

PS, @suricactus , your tons of Q_ASSERTs did wonders in lowering the risks of regressions here, I've hit a few along the way :) 

PSS, another win I forgot to mention: now that we have a proper QFieldCloudProject.h[eader], this will allow us to add a bit of documentation to what is a relatively complex set of members etc. Moreover, we had some conflicting cloud project members vs. model role exposing those members that are now gone, and again just makes the whole thing a bit clearer.