### PR TITLE
Disable the OK button ok the Import WebDAV folder dialog until a folder has been selected

### DIFF
--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -981,8 +981,8 @@ Page {
         onIsFetchingAvailablePathsChanged: {
           if (!isFetchingAvailablePaths && importWebdavDialog.visible) {
             swipeDialog.currentIndex = 1;
-            importWebdavPathInput.currentIndex = -1;
             importWebdavPathInput.model = availablePaths;
+            importWebdavPathInput.currentIndex = -1;
           }
         }
       }
@@ -1115,6 +1115,7 @@ Page {
 
     onAboutToShow: {
       swipeDialog.currentIndex = 0;
+      importWebdavDialog.standardButton(Dialog.Ok).enabled = false;
       reloadHistory();
     }
 
@@ -1342,6 +1343,12 @@ Page {
 
             property var expandedPaths: []
             property int expandedPathsClicks: 0
+
+            onCurrentIndexChanged: {
+              if (swipeDialog.currentIndex === 1) {
+                importWebdavDialog.standardButton(Dialog.Ok).enabled = currentIndex > -1;
+              }
+            }
 
             delegate: Rectangle {
               id: rectangleDialog


### PR DESCRIPTION
ATM, the import WebDAV folder dialog can be a bit misleading as it allows users to click on OK after entering their credentials but _before_ selecting a folder (which results in the dialog being closed and nothing happening).

To make it extra clear to the user that they need to click on the Fetch remote folder button, let's disable the OK button until the user has selected an actual folder. That'll better communicate the required steps.