### PR TITLE
Fix relation reference editor widget not sorting its list

### DIFF
--- a/src/qml/editorwidgets/RelationReference.qml
+++ b/src/qml/editorwidgets/RelationReference.qml
@@ -22,7 +22,7 @@ EditorWidgetBase {
     currentLayer: _rel.referencedLayer
     keyField: _rel.resolveReferencedField(field.name)
     addNull: !!config['AllowNULL'] // no, it is not a misspelled version of config['AllowNull']
-    orderByValue: !!config['OrderByValue']
+    orderByValue: true
     attributeField: field
     currentFormFeature: currentFeature
     appExpressionContextScopesGenerator: appScopesGenerator


### PR DESCRIPTION
This PR fixes https://github.com/opengisch/QField/issues/6152 -- long story short here, in QGIS, the equivalent editor widget _always_ sorts its list by display name. Users expecting a sorted list in QField should have their expectations met.