### PR TITLE
Improve security of the authentication manager's database + Fix QFieldCloud attachment upload on Android

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -78,6 +78,7 @@ void initGraphics()
 
 void initAuthManager( QgsAuthManager *authManager )
 {
+#ifndef Q_OS_LINUX
   authManager->setPasswordHelperEnabled( false );
   if ( authManager->verifyMasterPassword( QStringLiteral( "qfield" ) ) )
   {
@@ -104,6 +105,10 @@ void initAuthManager( QgsAuthManager *authManager )
     // if no master password set by user yet, just generate a new one and store it in the system keychain
     authManager->createAndStoreRandomMasterPasswordInKeyChain();
   }
+#else
+  authManager->setPasswordHelperEnabled( false );
+  authManager->setMasterPassword( QStringLiteral( "qfield" ) );
+#endif
 }
 
 int main( int argc, char **argv )

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -117,13 +117,6 @@ int main( int argc, char **argv )
   QCoreApplication::setOrganizationDomain( "opengis.ch" );
   QCoreApplication::setApplicationName( qfield::appName );
 
-  PlatformUtilities *platformUtils = PlatformUtilities::instance();
-  platformUtils->initSystem();
-
-  // Let's make sure we have a writable path for the QGIS profile on every platform
-  const QString profilePath = platformUtils->systemLocalDataLocation( QStringLiteral( "profiles/default" ) );
-  QDir().mkdir( profilePath );
-
   Q_INIT_RESOURCE( qml );
 
 #if defined( Q_OS_ANDROID )
@@ -134,6 +127,18 @@ int main( int argc, char **argv )
       // This service only deals with background attachment uploads;
       // it will terminate once all uploads are done
       QFieldCloudService service( argc, argv );
+
+      PlatformUtilities *platformUtils = PlatformUtilities::instance();
+      platformUtils->initSystem();
+
+      // Let's make sure we have a writable path for the QGIS profile on every platform
+      const QString profilePath = platformUtils->systemLocalDataLocation( QStringLiteral( "profiles/default" ) );
+      QDir().mkdir( profilePath );
+
+#ifdef RELATIVE_PREFIX_PATH
+      qputenv( "SSL_CERT_FILE", QDir::toNativeSeparators( PlatformUtilities::instance()->systemSharedDataLocation() + "/cacert.pem" ).toLocal8Bit() );
+      qputenv( "GDAL_DATA", QDir::toNativeSeparators( PlatformUtilities::instance()->systemSharedDataLocation() + "/gdal" ).toLocal8Bit() );
+#endif
 
       // Workaround QgsApplication::initQgis crashing adding app fonts
       QDir profileDir( profilePath );
@@ -169,6 +174,13 @@ int main( int argc, char **argv )
   QCoreApplication *dummyApp = new QCoreApplication( argc, argv );
   const QSettings settings;
   const QString customLanguage = settings.value( "/customLanguage", QString() ).toString();
+
+  PlatformUtilities *platformUtils = PlatformUtilities::instance();
+  platformUtils->initSystem();
+
+  // Let's make sure we have a writable path for the QGIS profile on every platform
+  const QString profilePath = platformUtils->systemLocalDataLocation( QStringLiteral( "profiles/default" ) );
+  QDir().mkdir( profilePath );
 
 #if WITH_SENTRY
   const bool enableSentry = settings.value( "/enableInfoCollection", true ).toBool();

--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -231,7 +231,7 @@ bool AppInterface::isFileExtensionSupported( const QString &filename ) const
 
 bool AppInterface::isAuthenticationConfigurationAvailable( const QString &id ) const
 {
-  QgsAuthManager *authManager = QgsApplication::instance()->authManager();
+  QgsAuthManager *authManager = QgsApplication::authManager();
   QgsAuthMethodConfigsMap configs = authManager->availableAuthMethodConfigs();
   return configs.contains( id );
 }

--- a/src/core/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloudconnection.cpp
@@ -58,7 +58,7 @@ QFieldCloudConnection::QFieldCloudConnection()
   if ( QgsApplication::authManager()->availableAuthMethodConfigs().contains( mTokenConfigId ) )
   {
     QgsAuthMethodConfig config;
-    QgsApplication::instance()->authManager()->loadAuthenticationConfig( mTokenConfigId, config, true );
+    QgsApplication::authManager()->loadAuthenticationConfig( mTokenConfigId, config, true );
     mToken = config.config( "qfieldcloud-token" ).toLatin1();
   }
   else
@@ -323,7 +323,7 @@ void QFieldCloudConnection::login( const QString &password )
 
       if ( !mProvider.isEmpty() && !mProviderConfigId.isEmpty() )
       {
-        QgsApplication::instance()->authManager()->removeAuthenticationConfig( mProviderConfigId );
+        QgsApplication::authManager()->removeAuthenticationConfig( mProviderConfigId );
         mProviderConfigId.clear();
         QSettings().remove( "/QFieldCloud/providerConfigId" );
         emit providerConfigurationChanged();
@@ -391,7 +391,7 @@ void QFieldCloudConnection::logout()
 
   if ( !mProviderConfigId.isEmpty() )
   {
-    QgsApplication::instance()->authManager()->removeAuthenticationConfig( mProviderConfigId );
+    QgsApplication::authManager()->removeAuthenticationConfig( mProviderConfigId );
     mProviderConfigId.clear();
     QSettings().remove( "/QFieldCloud/providerConfigId" );
     emit providerConfigurationChanged();
@@ -566,7 +566,7 @@ void QFieldCloudConnection::setToken( const QByteArray &token )
     QgsAuthMethodConfig config;
     if ( QgsApplication::authManager()->availableAuthMethodConfigs().contains( mTokenConfigId ) )
     {
-      QgsApplication::instance()->authManager()->loadAuthenticationConfig( mProviderConfigId, config, true );
+      QgsApplication::authManager()->loadAuthenticationConfig( mProviderConfigId, config, true );
     }
     else
     {
@@ -574,14 +574,14 @@ void QFieldCloudConnection::setToken( const QByteArray &token )
       config.setMethod( "Basic" );
     }
     config.setConfig( "qfieldcloud-token", mToken );
-    QgsApplication::instance()->authManager()->storeAuthenticationConfig( config, true );
+    QgsApplication::authManager()->storeAuthenticationConfig( config, true );
     QSettings().setValue( "/QFieldCloud/tokenConfigId", config.id() );
   }
   else
   {
     if ( !mTokenConfigId.isEmpty() )
     {
-      QgsApplication::instance()->authManager()->removeAuthenticationConfig( mTokenConfigId );
+      QgsApplication::authManager()->removeAuthenticationConfig( mTokenConfigId );
       mTokenConfigId.clear();
       QSettings().remove( "/QFieldCloud/tokenConfigId" );
     }
@@ -599,7 +599,7 @@ void QFieldCloudConnection::invalidateToken()
 
   if ( !mTokenConfigId.isEmpty() )
   {
-    QgsApplication::instance()->authManager()->removeAuthenticationConfig( mTokenConfigId );
+    QgsApplication::authManager()->removeAuthenticationConfig( mTokenConfigId );
     mTokenConfigId.clear();
     QSettings().remove( "/QFieldCloud/tokenConfigId" );
   }
@@ -665,7 +665,7 @@ void QFieldCloudConnection::setAuthenticationDetails( QNetworkRequest &request )
       config.setMethod( "OAuth2" );
       config.setConfig( "oauth2config", json.toJson() );
       config.setConfig( "qfieldcloud-sso-id", providerId );
-      QgsApplication::instance()->authManager()->storeAuthenticationConfig( config, true );
+      QgsApplication::authManager()->storeAuthenticationConfig( config, true );
 
       mProviderConfigId = config.id();
       QSettings().setValue( QStringLiteral( "/QFieldCloud/providerConfigId" ), mProviderConfigId );
@@ -674,11 +674,11 @@ void QFieldCloudConnection::setAuthenticationDetails( QNetworkRequest &request )
     else
     {
       QgsAuthMethodConfig config;
-      QgsApplication::instance()->authManager()->loadAuthenticationConfig( mProviderConfigId, config, true );
+      QgsApplication::authManager()->loadAuthenticationConfig( mProviderConfigId, config, true );
       providerId = config.config( "qfieldcloud-sso-id" );
     }
 
-    QgsApplication::instance()->authManager()->updateNetworkRequest( request, mProviderConfigId );
+    QgsApplication::authManager()->updateNetworkRequest( request, mProviderConfigId );
     request.setRawHeader( "X-QFC-IDP-ID", providerId.toLatin1() );
 
     const QList<QNetworkCookie> cookies = QgsNetworkAccessManager::instance()->cookieJar()->cookiesForUrl( mUrl );

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -300,7 +300,7 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
         const QStringList configurations = configurationsDir.entryList( QStringList() << QStringLiteral( "*.xml" ) << QStringLiteral( "*.XML" ), QDir::Files );
         for ( const QString &configuration : configurations )
         {
-          QgsApplication::instance()->authManager()->importAuthenticationConfigsFromXml( configurationsDir.absoluteFilePath( configuration ), QString(), true );
+          QgsApplication::authManager()->importAuthenticationConfigsFromXml( configurationsDir.absoluteFilePath( configuration ), QString(), true );
         }
       }
     }

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -291,8 +291,6 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
 
   if ( !dataDirs.isEmpty() )
   {
-    QgsApplication::instance()->authManager()->setPasswordHelperEnabled( false );
-    QgsApplication::instance()->authManager()->setMasterPassword( QString( "qfield" ) );
     // import authentication method configurations
     for ( const QString &dataDir : dataDirs )
     {

--- a/src/core/webdavconnection.cpp
+++ b/src/core/webdavconnection.cpp
@@ -100,7 +100,7 @@ void WebdavConnection::checkStoredPassword()
 
   if ( !mUrl.isEmpty() && !mUsername.isEmpty() )
   {
-    QgsAuthManager *authManager = QgsApplication::instance()->authManager();
+    QgsAuthManager *authManager = QgsApplication::authManager();
     QgsAuthMethodConfigsMap configs = authManager->availableAuthMethodConfigs();
     for ( QgsAuthMethodConfig &config : configs )
     {
@@ -120,7 +120,7 @@ void WebdavConnection::checkStoredPassword()
 
 void WebdavConnection::applyStoredPassword()
 {
-  QgsAuthManager *authManager = QgsApplication::instance()->authManager();
+  QgsAuthManager *authManager = QgsApplication::authManager();
   QgsAuthMethodConfigsMap configs = authManager->availableAuthMethodConfigs();
   if ( mStorePassword )
   {
@@ -446,7 +446,7 @@ void WebdavConnection::getWebdavItems()
 
 void WebdavConnection::forgetHistory( const QString &url, const QString &username )
 {
-  QgsAuthManager *authManager = QgsApplication::instance()->authManager();
+  QgsAuthManager *authManager = QgsApplication::authManager();
   QgsAuthMethodConfigsMap configs = authManager->availableAuthMethodConfigs();
   QSettings settings;
   if ( !username.isEmpty() )

--- a/src/service/qfieldcloudservice.cpp
+++ b/src/service/qfieldcloudservice.cpp
@@ -23,6 +23,10 @@
 QFieldCloudService::QFieldCloudService( int &argc, char **argv )
   : QAndroidService( argc, argv )
 {
+}
+
+void QFieldCloudService::execute()
+{
   QSettings settings;
   QEventLoop loop( this );
   QFieldCloudConnection connection;
@@ -35,8 +39,6 @@ QFieldCloudService::QFieldCloudService( int &argc, char **argv )
 
   QJniObject activity = QCoreApplication::instance()->nativeInterface<QNativeInterface::QAndroidApplication>()->context();
   activity.callMethod<void>( "stopSelf" );
-
-  exit( 0 );
 }
 
 QFieldCloudService::~QFieldCloudService()

--- a/src/service/qfieldcloudservice.h
+++ b/src/service/qfieldcloudservice.h
@@ -28,6 +28,8 @@ class QFIELD_SERVICE_EXPORT QFieldCloudService : public QAndroidService
   public:
     QFieldCloudService( int &argc, char **argv );
     ~QFieldCloudService() override;
+
+    void execute();
 };
 
 #endif // QFIELDCLOUDSERVICE_H

--- a/vcpkg/ports/qtkeychain-qt6/portfile.cmake
+++ b/vcpkg/ports/qtkeychain-qt6/portfile.cmake
@@ -1,0 +1,59 @@
+message(WARNING "qtkeychain is a third-party extension to Qt and is not affiliated with The Qt Company")
+
+if(VCPKG_TARGET_IS_IOS)
+    vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO frankosterfeld/qtkeychain
+        REF "0.14.3"
+        SHA512 d1d87553db94bf54da1373016a847476e6cd608db6d427ed72532658e2272501daf45d7c9976efdde2f26ab3810ba9dbfec2518d46dee5a76ecaa369bfee2e4a
+        HEAD_REF master
+    )
+else()
+    vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO frankosterfeld/qtkeychain
+        REF "${VERSION}"
+        SHA512 b1068ae513d5eab8f300186497ddcce4075e11a2a569deddbc949177efaa27970ed7bdce0b1aff61a021144540e942f60c9259b975601a92c60b8a742754624a
+        HEAD_REF master
+    )
+endif()
+
+if(VCPKG_CROSSCOMPILING)
+   list(APPEND QTKEYCHAIN_OPTIONS -DQT_HOST_PATH=${CURRENT_HOST_INSTALLED_DIR})
+   list(APPEND QTKEYCHAIN_OPTIONS -DQT_HOST_PATH_CMAKE_DIR:PATH=${CURRENT_HOST_INSTALLED_DIR}/share)
+   # remove when https://github.com/microsoft/vcpkg/pull/16111 is merged
+   if(VCPKG_TARGET_ARCHITECTURE STREQUAL arm64 AND VCPKG_TARGET_IS_WINDOWS)
+       list(APPEND QTKEYCHAIN_OPTIONS -DCMAKE_CROSSCOMPILING=ON -DCMAKE_SYSTEM_PROCESSOR:STRING=ARM64 -DCMAKE_SYSTEM_NAME:STRING=Windows)
+   endif()
+endif()
+
+list(APPEND QTKEYCHAIN_OPTIONS -DBUILD_TEST_APPLICATION:BOOL=OFF)
+list(APPEND QTKEYCHAIN_OPTIONS -DLIBSECRET_SUPPORT:BOOL=OFF)
+
+# FIXME: Why does build translations fail on arm64-windows?
+if (VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE STREQUAL arm64)
+     list(APPEND QTKEYCHAIN_OPTIONS -DBUILD_TRANSLATIONS:BOOL=OFF)
+else()
+     list(APPEND QTKEYCHAIN_OPTIONS -DBUILD_TRANSLATIONS:BOOL=ON)
+endif()
+
+vcpkg_cmake_configure(
+    DISABLE_PARALLEL_CONFIGURE
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DBUILD_WITH_QT6=ON
+         ${QTKEYCHAIN_OPTIONS}
+)
+vcpkg_cmake_install()
+
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Qt6Keychain PACKAGE_NAME Qt6Keychain)
+
+# Remove unneeded dirs
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+# Handle copyright
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/vcpkg/ports/qtkeychain-qt6/vcpkg.json
+++ b/vcpkg/ports/qtkeychain-qt6/vcpkg.json
@@ -1,0 +1,28 @@
+{
+  "name": "qtkeychain-qt6",
+  "version": "0.15.0",
+  "description": "(Unaffiliated with Qt) Platform-independent Qt6 API for storing passwords securely",
+  "homepage": "https://github.com/frankosterfeld/qtkeychain",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    {
+      "name": "qtbase",
+      "default-features": false
+    },
+    {
+      "name": "qttools",
+      "host": true,
+      "features": [
+        "linguist"
+      ]
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
We can rely on new API in QGIS 3.42 to strengthen our authentication manager's database security/safety.

Since we're now (righteously :wink:)  storing QFieldCloud authentication details in the QgsAuthManager, we need to initiate QgsApplication when launching the attachment upload service on Android.