### PR TITLE
Fix attachment upload on devices within which multiple cloud users are logging in

### DIFF
--- a/src/core/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloudconnection.cpp
@@ -784,7 +784,7 @@ int QFieldCloudConnection::uploadPendingAttachments()
   if ( mUploadPendingCount > 0 )
     return mUploadPendingCount;
 
-  QMultiMap<QString, QString> attachments = QFieldCloudUtils::getPendingAttachments();
+  QMultiMap<QString, QString> attachments = QFieldCloudUtils::getPendingAttachments( mUsername );
   if ( attachments.isEmpty() )
   {
     emit pendingAttachmentsUploadFinished();
@@ -799,7 +799,7 @@ int QFieldCloudConnection::uploadPendingAttachments()
 
 void QFieldCloudConnection::processPendingAttachments()
 {
-  QMultiMap<QString, QString> attachments = QFieldCloudUtils::getPendingAttachments();
+  QMultiMap<QString, QString> attachments = QFieldCloudUtils::getPendingAttachments( mUsername );
   mUploadPendingCount = attachments.size();
 
   QMultiMap<QString, QString>::const_iterator it = attachments.constBegin();
@@ -809,7 +809,7 @@ void QFieldCloudConnection::processPendingAttachments()
     {
       // A pending attachment has been deleted from the local device, remove
       // This can happen when for e.g. users remove a cloud project from their devices
-      QFieldCloudUtils::removePendingAttachment( it.key(), it.value() );
+      QFieldCloudUtils::removePendingAttachment( mUsername, it.key(), it.value() );
       ++it;
       continue;
     }
@@ -868,7 +868,7 @@ void QFieldCloudConnection::processPendingAttachments()
         AppInterface::instance()->sendLog( QStringLiteral( "QFieldCloud file upload HTTP code oddity!" ), QString() );
       }
 
-      QFieldCloudUtils::removePendingAttachment( projectId, fileName );
+      QFieldCloudUtils::removePendingAttachment( mUsername, projectId, fileName );
       mUploadPendingCount--;
       mUploadFailingCount = 0;
 

--- a/src/core/qfieldcloudproject.cpp
+++ b/src/core/qfieldcloudproject.cpp
@@ -1214,7 +1214,7 @@ void QFieldCloudProject::upload( LayerObserver *layerObserver, bool shouldDownlo
     }
 
     // ? should we also check the checksums of the files being uploaded? they are available at deltaFile->attachmentFileNames()->values()
-    QFieldCloudUtils::addPendingAttachments( mId, { absoluteFilePath } );
+    QFieldCloudUtils::addPendingAttachments( mUsername, mId, { absoluteFilePath } );
   }
 
   QString deltaFileToUpload = deltaFileWrapper->toFileForUpload();

--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -161,12 +161,12 @@ const QMultiMap<QString, QString> QFieldCloudUtils::getPendingAttachments( const
     const QStringList migratedUsernames = migratedAttachmentDetails.keys();
     for ( const QString &migratedUsername : migratedUsernames )
     {
-      const QStringList projectIds = migratedAttachmentDetails[migratedUsername].uniqueKeys();
-      for ( const QString &projectId : projectIds )
+      const QStringList migratedProjectIds = migratedAttachmentDetails[migratedUsername].uniqueKeys();
+      for ( const QString &migratedProjectId : migratedProjectIds )
       {
         // Play safe, create user folder
         QDir().mkpath( QStringLiteral( "%1/%2" ).arg( QFieldCloudUtils::localCloudDirectory(), migratedUsername ) );
-        addPendingAttachments( migratedUsername, projectId, migratedAttachmentDetails[migratedUsername].values( projectId ) );
+        addPendingAttachments( migratedUsername, migratedProjectId, migratedAttachmentDetails[migratedUsername].values( migratedProjectId ) );
       }
     }
 

--- a/src/core/utils/qfieldcloudutils.h
+++ b/src/core/utils/qfieldcloudutils.h
@@ -134,10 +134,10 @@ class QFieldCloudUtils : public QObject
     static const QVariant projectSetting( const QString &projectId, const QString &setting, const QVariant &defaultValue = QVariant() );
 
     //! Returns TRUE if pending attachments are detected.
-    Q_INVOKABLE static bool hasPendingAttachments();
+    Q_INVOKABLE static bool hasPendingAttachments( const QString &username );
 
     //! Returns the list of attachments that have not yet been uploaded to the cloud.
-    static const QMultiMap<QString, QString> getPendingAttachments();
+    static const QMultiMap<QString, QString> getPendingAttachments( const QString &username );
 
     /**
      * Adds an array of files and/or folders for a given cloud project to the pending upload attachments list.
@@ -148,15 +148,15 @@ class QFieldCloudUtils : public QObject
      * @param cloudConnection The cloud connection used to fetch file data.
      * @param checkSumCheck Whether to validate files by comparing checksums with the server.
      */
-    Q_INVOKABLE static void addPendingAttachments( const QString &projectId, const QStringList &fileNames, QFieldCloudConnection *cloudConnection = nullptr, const bool &checkSumCheck = false );
+    Q_INVOKABLE static void addPendingAttachments( const QString &username, const QString &projectId, const QStringList &fileNames, QFieldCloudConnection *cloudConnection = nullptr, const bool &checkSumCheck = false );
 
     //! Removes a \a fileName for a given \a projectId to the pending attachments list
-    static void removePendingAttachment( const QString &projectId, const QString &fileName );
+    static void removePendingAttachment( const QString &username, const QString &projectId, const QString &fileName );
 
   private:
     static inline const QString errorCodeOverQuota { QStringLiteral( "over_quota" ) };
 
-    static void writeToAttachmentsFile( const QString &projectId, const QStringList &fileNames, const QHash<QString, QString> *fileChecksumMap, const bool &checkSumCheck );
+    static void writeToAttachmentsFile( const QString &username, const QString &projectId, const QStringList &fileNames, const QHash<QString, QString> *fileChecksumMap, const bool &checkSumCheck );
 
     static void writeFilesFromDirectory( const QString &dirPath, const QString &projectId, const QHash<QString, QString> *fileChecksumMap, const bool &checkSumCheck, QTextStream &attachmentsStream );
 

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -473,7 +473,7 @@ Page {
 
         text: qsTr("Push to QFieldCloud")
         onTriggered: {
-          QFieldCloudUtils.addPendingAttachments(cloudProjectsModel.currentProjectId, [itemMenu.itemPath], cloudConnection, true);
+          QFieldCloudUtils.addPendingAttachments(projectInfo.cloudUserInformation.username, cloudProjectsModel.currentProjectId, [itemMenu.itemPath], cloudConnection, true);
           platformUtilities.uploadPendingAttachments(cloudConnection);
           displayToast(qsTr("‘%1’ is being uploaded to QFieldCloud").arg(FileUtils.fileName(itemMenu.itemPath)));
         }
@@ -861,7 +861,7 @@ Page {
             }
           }
           if (fileNames.length > 0) {
-            QFieldCloudUtils.addPendingAttachments(cloudProjectsModel.currentProjectId, fileNames, cloudConnection, true);
+            QFieldCloudUtils.addPendingAttachments(projectInfo.cloudUserInformation.username, cloudProjectsModel.currentProjectId, fileNames, cloudConnection, true);
             platformUtilities.uploadPendingAttachments(cloudConnection);
             localFilesModel.clearSelection();
           } else {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3972,7 +3972,7 @@ ApplicationWindow {
         displayToast(qsTr('Connecting...'));
       } else if (cloudConnection.status === QFieldCloudConnection.LoggedIn) {
         displayToast(qsTr('Signed in'));
-        if (QFieldCloudUtils.hasPendingAttachments()) {
+        if (QFieldCloudUtils.hasPendingAttachments(cloudConnection.username)) {
           // Go ahead and upload pending attachments in the background
           platformUtilities.uploadPendingAttachments(cloudConnection);
         }
@@ -4007,7 +4007,7 @@ ApplicationWindow {
       if (!isDownloadingProject) {
         displayToast(qsTr("Changes successfully pushed to QFieldCloud"));
       }
-      if (QFieldCloudUtils.hasPendingAttachments()) {
+      if (QFieldCloudUtils.hasPendingAttachments(cloudConnection.username)) {
         // Go ahead and upload pending attachments in the background
         platformUtilities.uploadPendingAttachments(cloudConnection);
       }


### PR DESCRIPTION
(Temporarily includes https://github.com/opengisch/QField/pull/6190)

This PR fixes https://github.com/opengisch/QField/issues/6169 , and in doing so does a better job at compartmentalizing pending attachments into distinct users.

Long story short, we used to add all pending attachments into a single queue. That queue would end up "stuck" when users would log into a different user within the same QField instance / device.

The PR breaks that queue into one queue _per user_, and only tries to upload files from the logged in user.