### PR TITLE
Set stylus freehand digitizing start threshold to _zero_ so we have a precise start

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -435,6 +435,7 @@ ApplicationWindow {
       enabled: freehandButton.visible && freehandButton.freehandDigitizing && !digitizingToolbar.rubberbandModel.frozen && (!featureForm.visible || digitizingToolbar.geometryRequested)
       acceptedDevices: !qfieldSettings.mouseAsTouchScreen ? PointerDevice.Stylus | PointerDevice.Mouse : PointerDevice.Stylus
       grabPermissions: PointerHandler.CanTakeOverFromHandlersOfSameType | PointerHandler.CanTakeOverFromHandlersOfDifferentType | PointerHandler.ApprovesTakeOverByAnything
+      dragThreshold: 0
 
       onActiveChanged: {
         if (active) {


### PR DESCRIPTION
The DragHandler driving freehand digitizing had a small threshold which meant that a stylus starting to draw would end up panning the map around a bit, leading to imprecise freehand digitizing motions. This PR fixes it.

Discovered by our very own @suricactus 