### PR TITLE
Sanitize attachment filenames before saving so they are acceptable by QFieldCloud

### DIFF
--- a/src/core/utils/fileutils.h
+++ b/src/core/utils/fileutils.h
@@ -24,6 +24,8 @@
 #include <QVariantMap>
 #include <qgsfeedback.h>
 
+#define FILENAME_MAX_CHAR_LENGTH 255
+
 class GnssPositionInformation;
 
 /**
@@ -49,6 +51,10 @@ class QFIELD_CORE_EXPORT FileUtils : public QObject
     Q_INVOKABLE static QString fileSuffix( const QString &filePath );
     //! Returns a human-friendly size from bytes
     Q_INVOKABLE static QString representFileSize( qint64 bytes );
+    //! Tries to convert the given \a filePath with path to a cross OS valid file name with path
+    Q_INVOKABLE static QString sanitizeFilePath( const QString &filePath, const QString &replacement = QLatin1String( "_" ) );
+    //! Tries to convert the given \a filePathPart to a cross OS valid file name part
+    Q_INVOKABLE static QString sanitizeFilePathPart( const QString &filePathPart, const QString &replacement = QLatin1String( "_" ) );
     //! Returns the absolute path of the folder containing the \a filePath.
     Q_INVOKABLE static QString absolutePath( const QString &filePath );
 

--- a/test/test_fileutils.cpp
+++ b/test/test_fileutils.cpp
@@ -156,6 +156,122 @@ TEST_CASE( "FileUtils" )
   }
 
 
+  SECTION( "FileUtils_SanitizeFilePath" )
+  {
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "/path/to/file.txt" ) ) == QStringLiteral( "/path/to/file.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path/to/file.txt" ) ) == QStringLiteral( "path/to/file.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path/to/.bashrc" ) ) == QStringLiteral( "path/to/.bashrc" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "./path/to/file.txt" ) ) == QStringLiteral( "./path/to/file.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "../path/to/file.txt" ) ) == QStringLiteral( "../path/to/file.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "file.txt" ) ) == QStringLiteral( "file.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( ".bashrc" ) ) == QStringLiteral( ".bashrc" ) );
+    // Remove leading or trailing whitespace
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( " path/to/file.txt " ) ) == QStringLiteral( "path/to/file.txt" ) );
+    // no dot suffix
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "file." ) ) == QStringLiteral( "file_" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path./to./file." ) ) == QStringLiteral( "path_/to_/file_" ) );
+    // Windows paths
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "C:\\path\\to\\filename.txt" ) ) == QStringLiteral( "/C/path/to/filename.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path\\to\\filename.txt" ) ) == QStringLiteral( "path/to/filename.txt" ) );
+    // no wrapping whitespace
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "file " ) ) == QStringLiteral( "file" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( " file" ) ) == QStringLiteral( "file" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( " file " ) ) == QStringLiteral( "file" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path / to / file " ) ) == QStringLiteral( "path/to/file" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "//path////to///filename.txt" ) ) == QStringLiteral( "/path/to/filename.txt" ) );
+    // allow whitespace whitin the name
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path  to / file " ) ) == QStringLiteral( "path  to/file" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path  to file " ) ) == QStringLiteral( "path  to file" ) );
+    // no forbidden characters
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "<path>/<to>/<filename>.txt" ) ) == QStringLiteral( "_path_/_to_/_filename_.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "\"path\"/\"to\"/\"filename\".txt" ) ) == QStringLiteral( "_path_/_to_/_filename_.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "\\path\\/\\to\\/\\filename.txt" ) ) == QStringLiteral( "/path/to/filename.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "|path|/|to|/|filename|.txt" ) ) == QStringLiteral( "_path_/_to_/_filename_.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "?path?/?to?/?filename?.txt" ) ) == QStringLiteral( "_path_/_to_/_filename_.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "*path*/*to*/*filename*.txt" ) ) == QStringLiteral( "_path_/_to_/_filename_.txt" ) );
+    // no null char
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "%1path%1/%1to%1/%1filename%1.txt" ).arg( QString( QChar( '\0' ) ) ) ) == QStringLiteral( "_path_/_to_/_filename_.txt" ) );
+    // no reserved words
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path/NUL/NUL" ) ) == QStringLiteral( "path/_NUL/_NUL" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path/CON/CON" ) ) == QStringLiteral( "path/_CON/_CON" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path/COM0/COM0" ) ) == QStringLiteral( "path/_COM0/_COM0" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path/LPT0/LPT0" ) ) == QStringLiteral( "path/_LPT0/_LPT0" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path/PRN/PRN" ) ) == QStringLiteral( "path/_PRN/_PRN" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path/AUX/AUX" ) ) == QStringLiteral( "path/_AUX/_AUX" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path/nul/nul" ) ) == QStringLiteral( "path/_nul/_nul" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path/con/con" ) ) == QStringLiteral( "path/_con/_con" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path/com0/com0" ) ) == QStringLiteral( "path/_com0/_com0" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path/lpt0/lpt0" ) ) == QStringLiteral( "path/_lpt0/_lpt0" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path/prn/prn" ) ) == QStringLiteral( "path/_prn/_prn" ) );
+    // no reserved words with file extension either
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path/NUL.dir/NUL.txt" ) ) == QStringLiteral( "path/_NUL.dir/_NUL.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path/CON.dir/CON.txt" ) ) == QStringLiteral( "path/_CON.dir/_CON.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path/COM0.dir/COM0.txt" ) ) == QStringLiteral( "path/_COM0.dir/_COM0.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path/LPT0.dir/LPT0.txt" ) ) == QStringLiteral( "path/_LPT0.dir/_LPT0.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path/PRN.dir/PRN.txt" ) ) == QStringLiteral( "path/_PRN.dir/_PRN.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path/AUX.dir/AUX.txt" ) ) == QStringLiteral( "path/_AUX.dir/_AUX.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path/nul.dir/nul.txt" ) ) == QStringLiteral( "path/_nul.dir/_nul.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path/con.dir/con.txt" ) ) == QStringLiteral( "path/_con.dir/_con.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path/com0.dir/com0.txt" ) ) == QStringLiteral( "path/_com0.dir/_com0.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path/lpt0.dir/lpt0.txt" ) ) == QStringLiteral( "path/_lpt0.dir/_lpt0.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path/prn.dir/prn.txt" ) ) == QStringLiteral( "path/_prn.dir/_prn.txt" ) );
+    // too long strings should result in empty sanitized string
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "x" ).repeated( FILENAME_MAX_CHAR_LENGTH ) ) == QStringLiteral( "x" ).repeated( FILENAME_MAX_CHAR_LENGTH ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "x" ).repeated( FILENAME_MAX_CHAR_LENGTH + 1 ) ).isEmpty() );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "x" ).repeated( FILENAME_MAX_CHAR_LENGTH - 3 ).append( QStringLiteral( "/NUL" ) ) ).isEmpty() );
+  }
+
+
+  SECTION( "FileUtils_SanitizeFilePathPart" )
+  {
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "filename.txt" ) ) == QStringLiteral( "filename.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( ".bashrc" ) ) == QStringLiteral( ".bashrc" ) );
+    // no forbidden characters
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "<filename>.txt" ) ) == QStringLiteral( "_filename_.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "\"filename\".txt" ) ) == QStringLiteral( "_filename_.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "\\filename/.txt" ) ) == QStringLiteral( "_filename_.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "|filename|.txt" ) ) == QStringLiteral( "_filename_.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "?filename?.txt" ) ) == QStringLiteral( "_filename_.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "*filename*.txt" ) ) == QStringLiteral( "_filename_.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "path/to/filename*.txt" ) ) == QStringLiteral( "path_to_filename_.txt" ) );
+    // no dot suffix
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "file." ) ) == QStringLiteral( "file_" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "file.txt." ) ) == QStringLiteral( "file.txt_" ) );
+    // no wrapping whitespace
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "file " ) ) == QStringLiteral( "file" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( " file" ) ) == QStringLiteral( "file" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( " file " ) ) == QStringLiteral( "file" ) );
+    // allow whitespace whitin the name
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "path  to file " ) ) == QStringLiteral( "path  to file" ) );
+    // no null char
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "%1filename%1.txt" ).arg( QString( QChar( '\0' ) ) ) ) == QStringLiteral( "_filename_.txt" ) );
+    // no reserved words
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "NUL" ) ) == QStringLiteral( "_NUL" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "CON" ) ) == QStringLiteral( "_CON" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "COM0" ) ) == QStringLiteral( "_COM0" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "LPT0" ) ) == QStringLiteral( "_LPT0" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "PRN" ) ) == QStringLiteral( "_PRN" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "AUX" ) ) == QStringLiteral( "_AUX" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "nul" ) ) == QStringLiteral( "_nul" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "con" ) ) == QStringLiteral( "_con" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "com0" ) ) == QStringLiteral( "_com0" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "lpt0" ) ) == QStringLiteral( "_lpt0" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "prn" ) ) == QStringLiteral( "_prn" ) );
+    // no reserved words with file extension either
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "NUL.txt" ) ) == QStringLiteral( "_NUL.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "CON.txt" ) ) == QStringLiteral( "_CON.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "COM0.txt" ) ) == QStringLiteral( "_COM0.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "LPT0.txt" ) ) == QStringLiteral( "_LPT0.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "PRN.txt" ) ) == QStringLiteral( "_PRN.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "AUX.txt" ) ) == QStringLiteral( "_AUX.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "nul.txt" ) ) == QStringLiteral( "_nul.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "con.txt" ) ) == QStringLiteral( "_con.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "com0.txt" ) ) == QStringLiteral( "_com0.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "lpt0.txt" ) ) == QStringLiteral( "_lpt0.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "prn.txt" ) ) == QStringLiteral( "_prn.txt" ) );
+  }
+
+
   SECTION( "SecurityChecks_DirectoryTraversal" )
   {
     QTemporaryDir tempProjectDir;


### PR DESCRIPTION
QFieldCloud recently added a restriction for file names so they can work on all popular operating systems. However, the attachment naming expressions have no restrictions to what they are going to evaluate.

Therefore the new `FileUtils::sanitizeFilePath` function has been added that will convert the disallowed chars into underscores and return an empty string when the file path cannot be fixed, for example when it is too long.

If an empty string is returned,then the default naming kicks in to guarantee the filename can be saved and can be uploaded to QFieldCloud.

---

QFieldSync config:
![image](https://github.com/user-attachments/assets/882583cd-2c0b-4848-8996-b6580234c93c)
Resulting values:
![image](https://github.com/user-attachments/assets/fb82fc08-1ea2-46b5-8004-d2195dabc25e)
