### PR TITLE
Keep track of a couple of IMU details in the GNSS position information, expose them as expression variables

### DIFF
--- a/src/core/positioning/gnsspositioninformation.cpp
+++ b/src/core/positioning/gnsspositioninformation.cpp
@@ -26,7 +26,7 @@ GnssPositionInformation::GnssPositionInformation( double latitude, double longit
                                                   const QList<QgsSatelliteInfo> &satellitesInView, double pdop, double hdop, double vdop, double hacc, double vacc,
                                                   QDateTime utcDateTime, QChar fixMode, int fixType, int quality, int satellitesUsed, QChar status, const QList<int> &satPrn,
                                                   bool satInfoComplete, double verticalSpeed, double magneticVariation, int averagedCount, const QString &sourceName,
-                                                  bool imuCorrection, double orientation )
+                                                  bool imuCorrection, double imuRoll, double imuPitch, double imuHeading, double imuSteering, double orientation )
   : mLatitude( latitude )
   , mLongitude( longitude )
   , mElevation( elevation )
@@ -52,6 +52,10 @@ GnssPositionInformation::GnssPositionInformation( double latitude, double longit
   , mAveragedCount( averagedCount )
   , mSourceName( sourceName )
   , mImuCorrection( imuCorrection )
+  , mImuRoll( imuRoll )
+  , mImuPitch( imuPitch )
+  , mImuHeading( imuHeading )
+  , mImuSteering( imuSteering )
   , mOrientation( orientation )
 {
 }
@@ -79,6 +83,10 @@ bool GnssPositionInformation::operator==( const GnssPositionInformation &other )
          mMagneticVariation == other.mMagneticVariation &&
          mSourceName == other.mSourceName &&
          mImuCorrection== other.mImuCorrection &&
+         mImuRoll == other.mImuRoll &&
+         mImuPitch == other.mImuPitch &&
+         mImuHeading == other.mImuHeading &&
+         mImuSteering == other.mImuSteering &&
          mOrientation == other.mOrientation;
   // clang-format on
 }
@@ -188,7 +196,8 @@ QDataStream &operator<<( QDataStream &stream, const GnssPositionInformation &pos
                 << position.mFixMode << position.mFixType << position.mQuality
                 << position.mSatellitesUsed << position.mStatus << position.mSatPrn << position.mSatInfoComplete
                 << position.mVerticalSpeed << position.mMagneticVariation << position.mSourceName
-                << position.mAveragedCount << position.mImuCorrection << position.mOrientation;
+                << position.mAveragedCount << position.mImuCorrection << position.mImuRoll << position.mImuPitch << position.mImuHeading << position.mImuSteering
+                << position.mOrientation;
 }
 
 //cppcheck-suppress constParameter
@@ -200,7 +209,8 @@ QDataStream &operator>>( QDataStream &stream, GnssPositionInformation &position 
          >> position.mFixMode >> position.mFixType >> position.mQuality
          >> position.mSatellitesUsed >> position.mStatus >> position.mSatPrn >> position.mSatInfoComplete
          >> position.mVerticalSpeed >> position.mMagneticVariation >> position.mSourceName
-         >> position.mAveragedCount >> position.mImuCorrection >> position.mOrientation;
+         >> position.mAveragedCount >> position.mImuCorrection >> position.mImuRoll >> position.mImuPitch >> position.mImuHeading >> position.mImuSteering
+         >> position.mOrientation;
 }
 
 QDataStream &operator<<( QDataStream &stream, const QgsSatelliteInfo &satelliteInfo )

--- a/src/core/positioning/gnsspositioninformation.h
+++ b/src/core/positioning/gnsspositioninformation.h
@@ -84,8 +84,16 @@ class GnssPositionInformation
     Q_PROPERTY( int averagedCount READ averagedCount )
     Q_PROPERTY( QString sourceName READ sourceName )
     Q_PROPERTY( bool imuCorrection READ imuCorrection )
+    Q_PROPERTY( double imuRoll READ imuRoll )
+    Q_PROPERTY( bool imuRollValid READ imuRollValid )
+    Q_PROPERTY( double imuPitch READ imuPitch )
+    Q_PROPERTY( bool imuPitchValid READ imuPitchValid )
+    Q_PROPERTY( double imuHeading READ imuHeading )
+    Q_PROPERTY( bool imuHeadingValid READ imuHeadingValid )
+    Q_PROPERTY( double imuSteering READ imuSteering )
+    Q_PROPERTY( bool imuSteeringValid READ imuSteeringValid )
     Q_PROPERTY( double orientation READ orientation )
-    Q_PROPERTY( double orientationValid READ orientationValid )
+    Q_PROPERTY( bool orientationValid READ orientationValid )
 
   public:
     /**

--- a/src/core/positioning/gnsspositioninformation.h
+++ b/src/core/positioning/gnsspositioninformation.h
@@ -107,7 +107,9 @@ class GnssPositionInformation
                              double hacc = std::numeric_limits<double>::quiet_NaN(), double vacc = std::numeric_limits<double>::quiet_NaN(), QDateTime utcDateTime = QDateTime(),
                              QChar fixMode = QChar(), int fixType = 0, int quality = -1, int satellitesUsed = 0, QChar status = QChar(), const QList<int> &satPrn = QList<int>(), bool satInfoComplete = false,
                              double verticalSpeed = std::numeric_limits<double>::quiet_NaN(), double magneticVariation = std::numeric_limits<double>::quiet_NaN(), int averagedCount = 0, const QString &sourceName = QString(),
-                             bool imuCorrection = false, double orientation = std::numeric_limits<double>::quiet_NaN() );
+                             bool imuCorrection = false, double imuRoll = std::numeric_limits<double>::quiet_NaN(), double imuPitch = std::numeric_limits<double>::quiet_NaN(),
+                             double imuHeading = std::numeric_limits<double>::quiet_NaN(), double imuSteering = std::numeric_limits<double>::quiet_NaN(),
+                             double orientation = std::numeric_limits<double>::quiet_NaN() );
 
     bool operator==( const GnssPositionInformation &other ) const;
     bool operator!=( const GnssPositionInformation &other ) const { return !operator==( other ); }
@@ -201,7 +203,6 @@ class GnssPositionInformation
     double hacc() const { return mHacc; }
     bool haccValid() const { return !std::isnan( mHacc ); }
 
-
     /**
      * Vertical accuracy in meters
      * VRMS
@@ -292,10 +293,38 @@ class GnssPositionInformation
     int averagedCount() const { return mAveragedCount; }
 
     /**
-     * Returns whether the IMU correction is active
+     * Returns TRUE when IMU correction is active
      */
     void setImuCorrection( bool imuCorrection ) { mImuCorrection = imuCorrection; }
     bool imuCorrection() const { return mImuCorrection; }
+
+    /**
+     * IMU roll
+     */
+    void setImuRoll( double roll ) { mImuRoll = roll; }
+    double imuRoll() const { return mImuRoll; }
+    bool imuRollValid() const { return !std::isnan( mImuRoll ); }
+
+    /**
+     * IMU pitch
+     */
+    void setImuPitch( double pitch ) { mImuPitch = pitch; }
+    double imuPitch() const { return mImuPitch; }
+    bool imuPitchValid() const { return !std::isnan( mImuPitch ); }
+
+    /**
+     * IMU heading
+     */
+    void setImuHeading( double heading ) { mImuHeading = heading; }
+    double imuHeading() const { return mImuHeading; }
+    bool imuHeadingValid() const { return !std::isnan( mImuHeading ); }
+
+    /**
+     * IMU steering
+     */
+    void setImuSteering( double steering ) { mImuSteering = steering; }
+    double imuSteering() const { return mImuSteering; }
+    bool imuSteeringValid() const { return !std::isnan( mImuSteering ); }
 
     /**
      * Orientation (in degrees)
@@ -330,6 +359,10 @@ class GnssPositionInformation
     int mAveragedCount = 0;
     QString mSourceName;
     bool mImuCorrection;
+    double mImuRoll = std::numeric_limits<double>::quiet_NaN();
+    double mImuPitch = std::numeric_limits<double>::quiet_NaN();
+    double mImuHeading = std::numeric_limits<double>::quiet_NaN();
+    double mImuSteering = std::numeric_limits<double>::quiet_NaN();
     double mOrientation = std::numeric_limits<double>::quiet_NaN();
 
     friend QDataStream &operator<<( QDataStream &stream, const GnssPositionInformation &position );

--- a/src/core/positioning/nmeagnssreceiver.cpp
+++ b/src/core/positioning/nmeagnssreceiver.cpp
@@ -66,7 +66,7 @@ void NmeaGnssReceiver::stateChanged( const QgsGpsInformation &info )
                                                               info.satellitesUsed, info.status,
                                                               info.satPrn, info.satInfoComplete, std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN(),
                                                               0, QStringLiteral( "nmea" ),
-                                                              mImuPosition.valid );
+                                                              mImuPosition.valid, mImuPosition.roll, mImuPosition.pitch, mImuPosition.heading, mImuPosition.steering );
     }
     else
     {

--- a/src/core/positioning/positioningsource.cpp
+++ b/src/core/positioning/positioningsource.cpp
@@ -311,6 +311,10 @@ void PositioningSource::lastGnssPositionInformationChanged( const GnssPositionIn
                                                      lastGnssPositionInformation.averagedCount(),
                                                      lastGnssPositionInformation.sourceName(),
                                                      lastGnssPositionInformation.imuCorrection(),
+                                                     lastGnssPositionInformation.imuRoll(),
+                                                     lastGnssPositionInformation.imuPitch(),
+                                                     lastGnssPositionInformation.imuHeading(),
+                                                     lastGnssPositionInformation.imuSteering(),
                                                      mOrientation );
 
   if ( mAveragedPosition )

--- a/src/core/utils/expressioncontextutils.cpp
+++ b/src/core/utils/expressioncontextutils.cpp
@@ -41,51 +41,35 @@ ExpressionContextUtils::ExpressionContextUtils( QObject *parent )
 QgsExpressionContextScope *ExpressionContextUtils::positionScope( const GnssPositionInformation &positionInformation, bool positionLocked )
 {
   QgsExpressionContextScope *scope = new QgsExpressionContextScope( QObject::tr( "Position" ) );
-
   const QgsGeometry point = QgsGeometry( new QgsPoint( positionInformation.longitude(), positionInformation.latitude(), positionInformation.elevation() ) );
-  const QDateTime timestamp = positionInformation.utcDateTime();
-  const qreal direction = positionInformation.direction();
-  const qreal groundSpeed = positionInformation.speed();
-  const qreal orientation = positionInformation.orientation();
-  const qreal magneticVariation = positionInformation.magneticVariation();
-  const qreal horizontalAccuracy = positionInformation.hacc();
-  const qreal verticalAccuracy = positionInformation.vacc();
-  const qreal horizontalVerticalAccuracy = positionInformation.hvacc();
-  const qreal verticalSpeed = positionInformation.verticalSpeed();
-  const qreal precisionDilution = positionInformation.pdop();
-  const qreal horizontalDilution = positionInformation.hdop();
-  const qreal verticalDilution = positionInformation.vdop();
-  const int numberOfUsedSatelites = positionInformation.satellitesUsed();
-  const QList<int> usedSatelites = positionInformation.satPrn();
-  const QString qualityDescription = positionInformation.qualityDescription();
-  const QString fixStatusDescription = positionInformation.fixStatusDescription();
-  const QString fixMode = positionInformation.fixMode();
-  const int averagedCount = positionInformation.averagedCount();
-  const QString sourceName = positionInformation.sourceName();
 
   addPositionVariable( scope, QStringLiteral( "coordinate" ), QVariant::fromValue<QgsGeometry>( point ), positionLocked );
-  addPositionVariable( scope, QStringLiteral( "timestamp" ), timestamp, positionLocked );
-  addPositionVariable( scope, QStringLiteral( "direction" ), direction, positionLocked );
-  addPositionVariable( scope, QStringLiteral( "ground_speed" ), groundSpeed, positionLocked );
-  addPositionVariable( scope, QStringLiteral( "orientation" ), orientation, positionLocked );
-  addPositionVariable( scope, QStringLiteral( "magnetic_variation" ), magneticVariation, positionLocked );
-  addPositionVariable( scope, QStringLiteral( "horizontal_accuracy" ), horizontalAccuracy, positionLocked );
-  addPositionVariable( scope, QStringLiteral( "vertical_accuracy" ), verticalAccuracy, positionLocked );
-  addPositionVariable( scope, QStringLiteral( "3d_accuracy" ), horizontalVerticalAccuracy, positionLocked );
-  addPositionVariable( scope, QStringLiteral( "vertical_speed" ), verticalSpeed, positionLocked );
-  addPositionVariable( scope, QStringLiteral( "source_name" ), sourceName, positionLocked, QStringLiteral( "manual" ) );
-  addPositionVariable( scope, QStringLiteral( "horizontal_accuracy" ), horizontalAccuracy, positionLocked );
-  addPositionVariable( scope, QStringLiteral( "vertical_accuracy" ), verticalAccuracy, positionLocked );
+  addPositionVariable( scope, QStringLiteral( "timestamp" ), positionInformation.utcDateTime(), positionLocked );
+  addPositionVariable( scope, QStringLiteral( "direction" ), positionInformation.direction(), positionLocked ); // Speed direction
+  addPositionVariable( scope, QStringLiteral( "ground_speed" ), positionInformation.speed(), positionLocked );
+  addPositionVariable( scope, QStringLiteral( "orientation" ), positionInformation.orientation(), positionLocked ); // Compass/magnetometer orientation
+  addPositionVariable( scope, QStringLiteral( "magnetic_variation" ), positionInformation.magneticVariation(), positionLocked );
+  addPositionVariable( scope, QStringLiteral( "horizontal_accuracy" ), positionInformation.hacc(), positionLocked );
+  addPositionVariable( scope, QStringLiteral( "vertical_accuracy" ), positionInformation.vacc(), positionLocked );
+  addPositionVariable( scope, QStringLiteral( "3d_accuracy" ), positionInformation.hvacc(), positionLocked );
+  addPositionVariable( scope, QStringLiteral( "vertical_speed" ), positionInformation.verticalSpeed(), positionLocked );
+  addPositionVariable( scope, QStringLiteral( "source_name" ), positionInformation.sourceName(), positionLocked, QStringLiteral( "manual" ) );
 
-  addPositionVariable( scope, QStringLiteral( "pdop" ), precisionDilution, positionLocked );
-  addPositionVariable( scope, QStringLiteral( "hdop" ), horizontalDilution, positionLocked );
-  addPositionVariable( scope, QStringLiteral( "vdop" ), verticalDilution, positionLocked );
-  addPositionVariable( scope, QStringLiteral( "number_of_used_satellites" ), numberOfUsedSatelites, positionLocked );
-  addPositionVariable( scope, QStringLiteral( "used_satellites" ), QVariant::fromValue( usedSatelites ), positionLocked );
-  addPositionVariable( scope, QStringLiteral( "quality_description" ), qualityDescription, positionLocked );
-  addPositionVariable( scope, QStringLiteral( "fix_status_description" ), fixStatusDescription, positionLocked );
-  addPositionVariable( scope, QStringLiteral( "fix_mode" ), fixMode, positionLocked );
-  addPositionVariable( scope, QStringLiteral( "averaged_count" ), averagedCount, positionLocked );
+  addPositionVariable( scope, QStringLiteral( "pdop" ), positionInformation.pdop(), positionLocked ); // precision dilution
+  addPositionVariable( scope, QStringLiteral( "hdop" ), positionInformation.hdop(), positionLocked ); // horizontal dilution
+  addPositionVariable( scope, QStringLiteral( "vdop" ), positionInformation.vdop(), positionLocked ); // vertical dilution
+  addPositionVariable( scope, QStringLiteral( "number_of_used_satellites" ), positionInformation.satellitesUsed(), positionLocked );
+  addPositionVariable( scope, QStringLiteral( "used_satellites" ), QVariant::fromValue( positionInformation.satPrn() ), positionLocked );
+  addPositionVariable( scope, QStringLiteral( "quality_description" ), positionInformation.qualityDescription(), positionLocked );
+  addPositionVariable( scope, QStringLiteral( "fix_status_description" ), positionInformation.fixStatusDescription(), positionLocked );
+  addPositionVariable( scope, QStringLiteral( "fix_mode" ), positionInformation.fixMode(), positionLocked );
+  addPositionVariable( scope, QStringLiteral( "averaged_count" ), positionInformation.averagedCount(), positionLocked );
+
+  addPositionVariable( scope, QStringLiteral( "imu_correction" ), positionInformation.imuCorrection(), positionLocked );
+  addPositionVariable( scope, QStringLiteral( "imu_roll" ), positionInformation.imuRoll(), positionLocked );
+  addPositionVariable( scope, QStringLiteral( "imu_pitch" ), positionInformation.imuPitch(), positionLocked );
+  addPositionVariable( scope, QStringLiteral( "imu_heading" ), positionInformation.imuHeading(), positionLocked );
+  addPositionVariable( scope, QStringLiteral( "imu_steering" ), positionInformation.imuSteering(), positionLocked );
 
   return scope;
 }

--- a/test/qml/tst_positioning.qml
+++ b/test/qml/tst_positioning.qml
@@ -162,6 +162,10 @@ TestCase {
     wait(2500);
     compare(positioning.positionInformation.qualityDescription, "Float RTK + IMU");
     compare(positioning.positionInformation.imuCorrection, true);
+    compare(positioning.positionInformation.imuRollValid, true);
+    compare(positioning.positionInformation.imuPitchValid, true);
+    compare(positioning.positionInformation.imuHeadingValid, true);
+    compare(positioning.positionInformation.imuSteeringValid, true);
   }
 
   function test_07_happyMonch2IMU() {
@@ -174,6 +178,10 @@ TestCase {
     wait(2500);
     compare(positioning.positionInformation.qualityDescription, "Fixed RTK + IMU");
     compare(positioning.positionInformation.imuCorrection, true);
+    compare(positioning.positionInformation.imuRollValid, true);
+    compare(positioning.positionInformation.imuPitchValid, true);
+    compare(positioning.positionInformation.imuHeadingValid, true);
+    compare(positioning.positionInformation.imuSteeringValid, true);
 
     // Expected values for positioningInformations
     const expectedPositioningInformationsValues = [{


### PR DESCRIPTION
This PR exposes a couple of IMU-specific details to the positioning expression scope, namely @gnss_imu_roll, @gnss_imu_pitch, @gnss_imu_heading, and @gnss_imu_steering.

@mbernasocchi , as discussed.