### PR TITLE
Unlock feature identification on raster layers capable of returning features (WMS, ArcGIS Map Server, etc.)

### DIFF
--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -345,7 +345,7 @@ bool FeatureModel::setData( const QModelIndex &index, const QVariant &value, int
     case AttributeValue:
     {
       QVariant val( value );
-      QgsField fld = mLayer ? mLayer->fields().at( index.row() ) : mFeature.fields().at( index.row() );
+      const QgsField field = mLayer ? mLayer->fields().at( index.row() ) : mFeature.fields().at( index.row() );
 
       // Objects and arrays coming from the QML realm are QJSValue objects, convert to QVariant
       if ( val.canConvert<QJSValue>() )
@@ -353,9 +353,9 @@ bool FeatureModel::setData( const QModelIndex &index, const QVariant &value, int
         val = val.value<QJSValue>().toVariant();
       }
 
-      if ( !fld.convertCompatible( val ) )
+      if ( !field.convertCompatible( val ) )
       {
-        QgsMessageLog::logMessage( tr( "Value \"%1\" %4 could not be converted to a compatible value for field %2(%3)." ).arg( value.toString(), fld.name(), fld.typeName(), value.isNull() ? "NULL" : "NOT NULL" ) );
+        QgsMessageLog::logMessage( tr( "Value \"%1\" %4 could not be converted to a compatible value for field %2(%3)." ).arg( value.toString(), field.name(), field.typeName(), value.isNull() ? "NULL" : "NOT NULL" ) );
         return false;
       }
 

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -405,13 +405,17 @@ void FeatureModel::updateGeometryLocked()
 {
   bool geometryLocked = mGeometryLockedByDefault;
 
-  if ( mLayer && !mGeometryLockedExpression.isEmpty() )
+  if ( mLayer )
   {
-    QgsExpressionContext expressionContext = createExpressionContext();
-    expressionContext.setFeature( mFeature );
-    QgsExpression expression( mGeometryLockedExpression );
-    expression.prepare( &expressionContext );
-    geometryLocked = expression.evaluate( &expressionContext ).toBool();
+    geometryLocked = geometryLocked || mLayer->readOnly();
+    if ( !mLayer->readOnly() && !mGeometryLockedExpression.isEmpty() )
+    {
+      QgsExpressionContext expressionContext = createExpressionContext();
+      expressionContext.setFeature( mFeature );
+      QgsExpression expression( mGeometryLockedExpression );
+      expression.prepare( &expressionContext );
+      geometryLocked = expression.evaluate( &expressionContext ).toBool();
+    }
   }
 
   if ( mGeometryLocked != geometryLocked )

--- a/src/core/identifytool.h
+++ b/src/core/identifytool.h
@@ -43,13 +43,15 @@ class IdentifyTool : public QObject
   public:
     struct IdentifyResult
     {
-        IdentifyResult( QgsMapLayer *layer, const QgsFeature &feature )
+        IdentifyResult( QgsMapLayer *layer, const QgsFeature &feature, const QString &representationalLayerName = QString() )
           : layer( layer )
           , feature( feature )
+          , representationalLayerName( representationalLayerName )
         {}
 
         QgsMapLayer *layer;
         QgsFeature feature;
+        QString representationalLayerName;
     };
 
   public:

--- a/src/core/identifytool.h
+++ b/src/core/identifytool.h
@@ -24,6 +24,7 @@
 
 class QgsMapLayer;
 class QgsQuickMapSettings;
+class QgsRasterLayer;
 class QgsVectorLayer;
 class MultiFeatureListModel;
 
@@ -77,6 +78,7 @@ class IdentifyTool : public QObject
     void identify( const QPointF &point ) const;
 
     QList<IdentifyResult> identifyVectorLayer( QgsVectorLayer *layer, const QgsPointXY &point ) const;
+    QList<IdentifyResult> identifyRasterLayer( QgsRasterLayer *layer, const QgsPointXY &point ) const;
 
   private:
     QgsQuickMapSettings *mMapSettings = nullptr;
@@ -86,6 +88,7 @@ class IdentifyTool : public QObject
     double searchRadiusMU() const;
 
     QgsRectangle toLayerCoordinates( QgsMapLayer *layer, const QgsRectangle &rect ) const;
+    QgsPointXY toLayerCoordinates( QgsMapLayer *layer, const QgsPointXY &rect ) const;
 
     double mSearchRadiusMm;
 

--- a/src/core/identifytool.h
+++ b/src/core/identifytool.h
@@ -88,7 +88,7 @@ class IdentifyTool : public QObject
     double searchRadiusMU() const;
 
     QgsRectangle toLayerCoordinates( QgsMapLayer *layer, const QgsRectangle &rect ) const;
-    QgsPointXY toLayerCoordinates( QgsMapLayer *layer, const QgsPointXY &rect ) const;
+    QgsPointXY toLayerCoordinates( QgsMapLayer *layer, const QgsPointXY &point ) const;
 
     double mSearchRadiusMm;
 

--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -113,7 +113,7 @@ void MultiFeatureListModelBase::appendFeatures( const QList<IdentifyTool::Identi
       QgsVectorLayer *representationalLayer;
       if ( !mRepresentationalLayers.contains( layer ) )
       {
-        representationalLayer = QgsMemoryProviderUtils::createMemoryLayer( layer->name(), result.feature.fields() );
+        representationalLayer = QgsMemoryProviderUtils::createMemoryLayer( layer->name(), result.feature.fields(), result.feature.geometry().wkbType(), layer->crs() );
         representationalLayer->setReadOnly( true );
         mRepresentationalLayers[layer] = representationalLayer;
       }

--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -98,14 +98,14 @@ void MultiFeatureListModelBase::appendFeatures( const QList<IdentifyTool::Identi
         {
           mSelectedFeatures.append( item );
         }
-        else if ( mSelectedFeatures.size() > 1 && mSelectedFeatures.contains( item ) )
-        {
-          const qsizetype row = mFeatures.indexOf( item );
-          mSelectedFeatures.removeAll( item );
+      }
+      else if ( mSelectedFeatures.size() > 1 && mSelectedFeatures.contains( item ) )
+      {
+        const qsizetype row = mFeatures.indexOf( item );
+        mSelectedFeatures.removeAll( item );
 
-          QModelIndex index = createIndex( row, 0 );
-          emit dataChanged( index, index, QVector<int>() << MultiFeatureListModel::FeatureSelectedRole );
-        }
+        QModelIndex index = createIndex( row, 0 );
+        emit dataChanged( index, index, QVector<int>() << MultiFeatureListModel::FeatureSelectedRole );
       }
     }
     if ( QgsRasterLayer *layer = qobject_cast<QgsRasterLayer *>( result.layer ) )

--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -166,7 +166,6 @@ void MultiFeatureListModelBase::clear( const bool keepSelected )
     }
     mRepresentationalLayers.clear();
   }
-
   endResetModel();
 }
 
@@ -269,6 +268,8 @@ QVariant MultiFeatureListModelBase::data( const QModelIndex &index, int role ) c
     return QVariant();
 
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( feature->first );
+  if ( !vlayer )
+    return QVariant();
 
   switch ( role )
   {

--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -111,9 +111,9 @@ void MultiFeatureListModelBase::appendFeatures( const QList<IdentifyTool::Identi
     if ( QgsRasterLayer *layer = qobject_cast<QgsRasterLayer *>( result.layer ) )
     {
       QgsVectorLayer *representationalLayer;
-      if ( !mRepresentationalLayers.contains( layer ) )
+      if ( !mRepresentationalLayers.contains( layer ) || mRepresentationalLayers.value( layer )->name() != result.representationalLayerName )
       {
-        representationalLayer = QgsMemoryProviderUtils::createMemoryLayer( layer->name(), result.feature.fields(), result.feature.geometry().wkbType(), layer->crs() );
+        representationalLayer = QgsMemoryProviderUtils::createMemoryLayer( result.representationalLayerName, result.feature.fields(), result.feature.geometry().wkbType(), layer->crs() );
         representationalLayer->setReadOnly( true );
         mRepresentationalLayers[layer] = representationalLayer;
       }

--- a/src/core/multifeaturelistmodelbase.h
+++ b/src/core/multifeaturelistmodelbase.h
@@ -143,13 +143,15 @@ class MultiFeatureListModelBase : public QAbstractItemModel
     void geometryChanged( QgsFeatureId fid, const QgsGeometry &geometry );
 
   private:
-    inline QPair<QgsVectorLayer *, QgsFeature> *toFeature( const QModelIndex &index ) const
+    inline QPair<QgsMapLayer *, QgsFeature> *toFeature( const QModelIndex &index ) const
     {
-      return static_cast<QPair<QgsVectorLayer *, QgsFeature> *>( index.internalPointer() );
+      return static_cast<QPair<QgsMapLayer *, QgsFeature> *>( index.internalPointer() );
     }
 
-    QList<QPair<QgsVectorLayer *, QgsFeature>> mFeatures;
-    QList<QPair<QgsVectorLayer *, QgsFeature>> mSelectedFeatures;
+    QList<QPair<QgsMapLayer *, QgsFeature>> mFeatures;
+    QList<QPair<QgsMapLayer *, QgsFeature>> mSelectedFeatures;
+
+    QMap<QgsMapLayer *, QgsVectorLayer *> mRepresentationalLayers;
 };
 
 #endif // MULTIFEATURELISTMODELBASE_H

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -642,7 +642,7 @@ Rectangle {
         iconSource: Theme.getThemeVectorIcon("ic_paste_black_24dp")
         iconColor: enabled ? Theme.mainTextColor : Theme.mainTextDisabledColor
         bgcolor: enabled && hovered ? parent.hoveredColor : "#00ffffff"
-        enabled: clipboardManager && clipboardManager.holdsFeature
+        enabled: clipboardManager && clipboardManager.holdsFeature && featureForm.model.featureModel.currentLayer && !featureForm.model.featureModel.currentLayer.readOnly
 
         onClicked: {
           var feature = clipboardManager.pasteFeatureFromClipboard();
@@ -719,6 +719,7 @@ Rectangle {
     MenuSeparator {
       visible: moveFeatureBtn.visible || duplicateFeatureBtn.visible || deleteFeatureBtn.visible
       width: parent.width
+      height: visible ? undefined : 0
     }
 
     MenuItem {
@@ -739,7 +740,7 @@ Rectangle {
       id: duplicateFeatureBtn
       text: qsTr('Duplicate Feature')
       icon.source: Theme.getThemeVectorIcon("ic_duplicate_black_24dp")
-      enabled: (projectInfo.insertRights && (!selection.focusedLayer || !selection.focusedLayer.customProperty("QFieldSync/is_geometry_locked", false)))
+      enabled: (projectInfo.insertRights && (!selection.focusedLayer || !selection.focusedLayer.readOnly))
       visible: enabled
 
       font: Theme.defaultFont
@@ -768,7 +769,7 @@ Rectangle {
       id: transferFeatureAttributesBtn
       text: qsTr('Update Attributes from Feature')
       icon.source: Theme.getThemeVectorIcon("ic_transfer_into_black_24dp")
-      enabled: (projectInfo.insertRights && (!selection.focusedLayer || !selection.focusedLayer.customProperty("QFieldSync/is_geometry_locked", false)))
+      enabled: (projectInfo.insertRights && (!selection.focusedLayer || !featureForm.model.featureModel.geometryLocked))
       visible: enabled
 
       font: Theme.defaultFont
@@ -782,7 +783,7 @@ Rectangle {
       id: deleteFeatureBtn
       text: qsTr('Delete Feature')
       icon.source: Theme.getThemeVectorIcon("ic_delete_forever_white_24dp")
-      enabled: ((projectInfo.editRights || editButton.isCreatedCloudFeature) && (!selection.focusedLayer || !selection.focusedLayer.customProperty("QFieldSync/is_geometry_locked", false)))
+      enabled: ((projectInfo.editRights || editButton.isCreatedCloudFeature) && (!selection.focusedLayer || !featureForm.model.featureModel.geometryLocked))
       visible: enabled
 
       font: Theme.defaultFont


### PR DESCRIPTION
This PR implements feature identification fetching from WMS/ArcGIS MapServer/etc. raster layers, provided they are capable of returning features. Alongside our recent copy feature attributes to clipboard, it makes for a really nice enhancement.

For providers - such as ArcGIS MapServer - which provides geometries, we display a nice geometry highlight on top of the map (as we'd do with a vector layer:

![Screenshot From 2025-04-26 11-55-50](https://github.com/user-attachments/assets/476a426a-f0d1-43b6-bdfc-cac90cdda293)

The PR also cleans up handling of feature form for read-only layers.