### PR TITLE
Properly remove newline when a text editor widget is set to non-multiline

### DIFF
--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -25,7 +25,7 @@ EditorWidgetBase {
     wrapMode: Text.Wrap
     textFormat: (config['IsMultiline'] === true && config['UseHtml']) || StringUtils.hasLinks(value) ? TextEdit.RichText : TextEdit.AutoText
 
-    text: value == null ? '' : config['IsMultiline'] === true ? config['UseHtml'] === true ? value : StringUtils.insertLinks(value) : StringUtils.insertLinks(value).replace('\n', '')
+    text: value == null ? '' : config['IsMultiline'] === true ? config['UseHtml'] === true ? value : StringUtils.insertLinks(value) : StringUtils.insertLinks(value).replace(/\n/g, '')
 
     onLinkActivated: link => {
       Qt.openUrlExternally(link);


### PR DESCRIPTION
Fixes https://github.com/opengisch/QField/issues/6207 .