### PR TITLE
Brand new QFieldCloud project details view + QR code project details fetching

### DIFF
--- a/images/themes/qfield/nodpi/ic_cloud_project_localonly_48dp.svg
+++ b/images/themes/qfield/nodpi/ic_cloud_project_localonly_48dp.svg
@@ -3,16 +3,13 @@
  <g transform="translate(0 -280.07)">
   <path d="m12.7 292.37a4.113 4.113 0 0 0-4.101-4.101 4.1 4.1 0 0 0-3.973 3.101c-1.23 0.205-2.179 1.256-2.179 2.538a2.57 2.57 0 0 0 2.564 2.563h7.689c1.128 0 2.05-0.923 2.05-2.05 0-1.128-0.922-2.051-2.05-2.051z" fill="none" stroke="#fff" stroke-opacity=".5" stroke-width="1.0583"/>
   <g transform="translate(0 -.258)" fill="none" stroke="#80cc28" stroke-width=".397">
-   <g>
-    <path d="m9.243 283.65-2.628-0.67-3.97 1.057v10.055l3.97-1.059 3.968 1.059 3.97-1.059v-6.085" stroke-linecap="round"/>
-    <path d="m6.615 293.03v-10.054"/>
-    <path d="m10.583 294.09v-7.144"/>
-   </g>
+   <path d="m9.243 283.65-2.628-0.67-3.97 1.057v10.055l3.97-1.059 3.968 1.059 3.97-1.059v-6.085" stroke-linecap="round"/>
+   <path d="m6.615 293.03v-10.054"/>
+   <path d="m10.583 294.09v-7.144"/>
    <circle cx="12.568" cy="284.04" r="1.191" fill-opacity=".627" stroke-linecap="round" stroke-linejoin="round"/>
    <path d="M12.561 287.356c-.845-1.171-2.637-1.861-2.465-3.593.381-3.124 4.669-3.053 4.932.012.149 1.737-1.631 2.398-2.467 3.581z"/>
   </g>
   <path d="M12.7 292.37a4.113 4.113 0 00-4.101-4.101 4.1 4.1 0 00-3.973 3.101c-1.23.205-2.179 1.256-2.179 2.538a2.57 2.57 0 002.564 2.563H12.7c1.128 0 2.05-.923 2.05-2.05 0-1.128-.922-2.051-2.05-2.051z" fill="#212121" stroke-width=".265"/>
-  <text x="7.749" y="294.755" fill="#fff" font-family="sans-serif" font-size="10.583" font-weight="400" letter-spacing="0" stroke-width=".265" word-spacing="0" style="line-height:1.25" xml:space="preserve"><tspan x="7.749" y="294.755" fill="#fff" font-family="Fira Sans" font-size="7.056" font-weight="700" stroke-width=".265">!</tspan></text>
  </g>
  <style type="text/css"/>
 </svg>

--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -28,7 +28,6 @@
 #include <QImageReader>
 #include <QQuickItem>
 #include <QTemporaryFile>
-#include <QUrlQuery>
 #include <qgsapplication.h>
 #include <qgsauthmanager.h>
 #include <qgsmessagelog.h>
@@ -221,40 +220,6 @@ QVariantMap AppInterface::availableLanguages() const
     }
   }
   return languages;
-}
-
-QVariantMap AppInterface::getActionDetails( const QString &action ) const
-{
-  QVariantMap details;
-  if ( action.trimmed().isEmpty() )
-    return details;
-
-  QUrl actionUrl( action );
-  if ( actionUrl.scheme().toLower() == QStringLiteral( "qfield" ) )
-  {
-    // deal with qfield:// URLs
-    details["type"] = actionUrl.authority();
-  }
-  else if ( actionUrl.authority() == QStringLiteral( "qfield.org" ) && actionUrl.path().startsWith( "/action/" ) )
-  {
-    // deal with https://qfield.org/action/ URLs
-    details["type"] = actionUrl.path().mid( 8 );
-  }
-  else
-  {
-    return details;
-  }
-
-  if ( !actionUrl.query().isEmpty() )
-  {
-    const QList<std::pair<QString, QString>> queryItems = QUrlQuery( actionUrl ).queryItems( QUrl::FullyDecoded );
-    for ( const std::pair<QString, QString> &queryItem : queryItems )
-    {
-      details[queryItem.first] = queryItem.second;
-    }
-  }
-
-  return details;
 }
 
 bool AppInterface::isFileExtensionSupported( const QString &filename ) const

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -63,8 +63,6 @@ class AppInterface : public QObject
 
     Q_INVOKABLE QVariantMap availableLanguages() const;
 
-    Q_INVOKABLE QVariantMap getActionDetails( const QString &action ) const;
-
     Q_INVOKABLE bool isFileExtensionSupported( const QString &filename ) const;
 
     /**

--- a/src/core/barcodeimageprovider.cpp
+++ b/src/core/barcodeimageprovider.cpp
@@ -32,7 +32,7 @@ QImage BarcodeImageProvider::requestImage( const QString &id, QSize *size, const
 {
   // the id is passed on as an encoded URL string which needs decoding
   const QUrlQuery urlQuery = QUrlQuery( QUrl( id.toUtf8() ) );
-  const QString text = urlQuery.queryItemValue( QStringLiteral( "text" ) );
+  const QString text = urlQuery.queryItemValue( QStringLiteral( "text" ), QUrl::FullyDecoded );
   const QColor foregroundColor = QColor( urlQuery.queryItemValue( QStringLiteral( "color" ) ) );
 
   if ( text.isEmpty() )

--- a/src/core/qfieldcloud/qfieldcloudproject.cpp
+++ b/src/core/qfieldcloud/qfieldcloudproject.cpp
@@ -440,7 +440,24 @@ void QFieldCloudProject::downloadThumbnail()
 
     if ( rawReply->error() == QNetworkReply::NoError )
     {
-      QTemporaryFile file( QString( "%1/XXXXXX.%2" ).arg( QDir::tempPath(), QStringLiteral( "PNG" ) ) );
+      QString imageExtension( "PNG" );
+      const QString contentType = rawReply->header( QNetworkRequest::ContentTypeHeader ).toString();
+      if ( !contentType.isEmpty() )
+      {
+        if ( contentType.contains( QStringLiteral( "image/png" ) ) )
+        {
+          imageExtension = QStringLiteral( "PNG" );
+        }
+        else if ( contentType.contains( QStringLiteral( "image/jpg" ) ) || contentType.contains( QStringLiteral( "image/jpeg" ) ) )
+        {
+          imageExtension = QStringLiteral( "JPG" );
+        }
+        else if ( contentType.contains( QStringLiteral( "image/webp" ) ) )
+        {
+          imageExtension = QStringLiteral( "WEBP" );
+        }
+      }
+      QTemporaryFile file( QString( "%1/XXXXXX.%2" ).arg( QDir::tempPath(), imageExtension ) );
       file.setAutoRemove( false );
       file.open();
       file.write( rawReply->readAll() );

--- a/src/core/qfieldcloud/qfieldcloudproject.cpp
+++ b/src/core/qfieldcloud/qfieldcloudproject.cpp
@@ -436,7 +436,7 @@ void QFieldCloudProject::downloadThumbnail()
     QNetworkReply *rawReply = reply->currentRawReply();
 
     Q_ASSERT( reply->isFinished() );
-    Q_ASSERT( reply );
+    Q_ASSERT( rawReply );
 
     if ( rawReply->error() == QNetworkReply::NoError )
     {
@@ -1013,7 +1013,7 @@ void QFieldCloudProject::downloadFileConnections( const QString &fileKey )
     QNetworkReply *rawReply = reply->currentRawReply();
 
     Q_ASSERT( reply->isFinished() );
-    Q_ASSERT( reply );
+    Q_ASSERT( rawReply );
 
     // this is most probably the redirected request, nothing to do with this reply anymore, just ignore it
     if ( mDownloadFileTransfers[fileKey].networkReply != reply )

--- a/src/core/qfieldcloud/qfieldcloudproject.cpp
+++ b/src/core/qfieldcloud/qfieldcloudproject.cpp
@@ -155,6 +155,24 @@ void QFieldCloudProject::setLastRefreshedAt( const QDateTime &lastRefreshedAt )
   emit lastRefreshedAtChanged();
 }
 
+void QFieldCloudProject::setCreatedAt( const QDateTime &createdAt )
+{
+  if ( mCreatedAt == createdAt )
+    return;
+
+  mCreatedAt = createdAt;
+  emit createdAtChanged();
+}
+
+void QFieldCloudProject::setUpdatedAt( const QDateTime &updatedAt )
+{
+  if ( mUpdatedAt == updatedAt )
+    return;
+
+  mUpdatedAt = updatedAt;
+  emit updatedAtChanged();
+}
+
 void QFieldCloudProject::setDataLastUpdatedAt( const QDateTime &dataLastUpdatedAt )
 {
   if ( mDataLastUpdatedAt == dataLastUpdatedAt )
@@ -1655,6 +1673,8 @@ void QFieldCloudProject::refreshData( ProjectRefreshReason reason )
     setDescription( projectData.value( "description" ).toString() );
     setUserRole( projectData.value( "user_role" ).toString() );
     setUserRoleOrigin( mUserRoleOrigin = projectData.value( "user_role_origin" ).toString() );
+    setCreatedAt( QDateTime::fromString( projectData.value( "created_at" ).toString(), Qt::ISODate ) );
+    setUpdatedAt( QDateTime::fromString( projectData.value( "updated_at" ).toString(), Qt::ISODate ) );
     setIsPrivate( projectData.value( "is_public" ).isUndefined() ? projectData.value( "private" ).toBool() : !projectData.value( "is_public" ).toBool( false ) );
     setCanRepackage( projectData.value( "can_repackage" ).toBool() );
     setNeedsRepackaging( projectData.value( "needs_repackaging" ).toBool() );
@@ -1667,6 +1687,8 @@ void QFieldCloudProject::refreshData( ProjectRefreshReason reason )
     QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "description" ), mDescription );
     QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "userRole" ), mUserRole );
     QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "userRoleOrigin" ), mUserRoleOrigin );
+    QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "createdAt" ), mCreatedAt.toString( Qt::DateFormat::ISODate ) );
+    QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "updatedAt" ), mUpdatedAt.toString( Qt::DateFormat::ISODate ) );
     QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "isPrivate" ), mIsPrivate );
     QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "canRepackage" ), mCanRepackage );
     QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "needsRepackaging" ), mNeedsRepackaging );
@@ -1751,6 +1773,8 @@ QFieldCloudProject *QFieldCloudProject::fromDetails( const QVariantHash &details
   project->mUserRoleOrigin = details.value( "user_role_origin" ).toString();
   project->mCheckout = RemoteCheckout;
   project->mStatus = details.value( "status" ).toString() == "failed" ? ProjectStatus::Failing : ProjectStatus::Idle;
+  project->mCreatedAt = QDateTime::fromString( details.value( "created_at" ).toString(), Qt::ISODate );
+  project->mUpdatedAt = QDateTime::fromString( details.value( "updated_at" ).toString(), Qt::ISODate );
   project->mDataLastUpdatedAt = QDateTime::fromString( details.value( "data_last_updated_at" ).toString(), Qt::ISODate );
   project->mCanRepackage = details.value( "can_repackage" ).toBool();
   project->mNeedsRepackaging = details.value( "needs_repackaging" ).toBool();
@@ -1761,6 +1785,8 @@ QFieldCloudProject *QFieldCloudProject::fromDetails( const QVariantHash &details
   QFieldCloudUtils::setProjectSetting( project->id(), QStringLiteral( "description" ), project->description() );
   QFieldCloudUtils::setProjectSetting( project->id(), QStringLiteral( "userRole" ), project->userRole() );
   QFieldCloudUtils::setProjectSetting( project->id(), QStringLiteral( "userRoleOrigin" ), project->userRoleOrigin() );
+  QFieldCloudUtils::setProjectSetting( project->id(), QStringLiteral( "createdAt" ), project->createdAt().toString( Qt::DateFormat::ISODate ) );
+  QFieldCloudUtils::setProjectSetting( project->id(), QStringLiteral( "updatedAt" ), project->updatedAt().toString( Qt::DateFormat::ISODate ) );
   QFieldCloudUtils::setProjectSetting( project->id(), QStringLiteral( "canRepackage" ), project->canRepackage() );
   QFieldCloudUtils::setProjectSetting( project->id(), QStringLiteral( "needsRepackaging" ), project->needsRepackaging() );
   QFieldCloudUtils::setProjectSetting( project->id(), QStringLiteral( "localizedDatasetsProjectId" ), project->localizedDatasetsProjectId() );
@@ -1795,6 +1821,8 @@ QFieldCloudProject *QFieldCloudProject::fromLocalSettings( const QString &id, QF
   const QString status = QFieldCloudUtils::projectSetting( id, QStringLiteral( "status" ) ).toString();
   const QString userRole = QFieldCloudUtils::projectSetting( id, QStringLiteral( "userRole" ) ).toString();
   const QString userRoleOrigin = QFieldCloudUtils::projectSetting( id, QStringLiteral( "userRoleOrigin" ) ).toString();
+  const QDateTime createdAt = QDateTime::fromString( QFieldCloudUtils::projectSetting( id, QStringLiteral( "createdAt" ) ).toString(), Qt::DateFormat::ISODate );
+  const QDateTime updatedAt = QDateTime::fromString( QFieldCloudUtils::projectSetting( id, QStringLiteral( "updatedAt" ) ).toString(), Qt::DateFormat::ISODate );
   const QString localizedDatasetsProjectId = QFieldCloudUtils::projectSetting( id, QStringLiteral( "localizedDatasetsProjectId" ) ).toString();
 
   QFieldCloudProject *project = new QFieldCloudProject( id, connection, gpkgFlusher );
@@ -1806,6 +1834,8 @@ QFieldCloudProject *QFieldCloudProject::fromLocalSettings( const QString &id, QF
   project->mUserRoleOrigin = userRoleOrigin;
   project->mCheckout = LocalCheckout;
   project->mStatus = status == "failed" ? ProjectStatus::Failing : ProjectStatus::Idle;
+  project->mCreatedAt = createdAt;
+  project->mUpdatedAt = updatedAt;
   project->mDataLastUpdatedAt = QDateTime();
   project->mCanRepackage = false;
   project->mNeedsRepackaging = false;

--- a/src/core/qfieldcloud/qfieldcloudproject.cpp
+++ b/src/core/qfieldcloud/qfieldcloudproject.cpp
@@ -1794,8 +1794,9 @@ void QFieldCloudProject::removeLocally()
     dir.removeRecursively();
 
     setLocalPath( QString() );
-    setCheckout( RemoteCheckout );
     setModification( NoModification );
+    mCheckout = mCheckout & ~LocalCheckout;
+    emit checkoutChanged();
   }
 
   QSettings().remove( QStringLiteral( "QFieldCloud/projects/%1" ).arg( mId ) );

--- a/src/core/qfieldcloud/qfieldcloudproject.h
+++ b/src/core/qfieldcloud/qfieldcloudproject.h
@@ -40,6 +40,7 @@ class QFieldCloudProject : public QObject
     Q_PROPERTY( QString owner READ owner NOTIFY ownerChanged )
     Q_PROPERTY( QString description READ description NOTIFY descriptionChanged )
     Q_PROPERTY( QString localPath READ localPath NOTIFY localPathChanged )
+    Q_PROPERTY( QString thumbnailPath READ thumbnailPath NOTIFY thumbnailPathChanged )
 
     Q_PROPERTY( QDateTime createdAt READ createdAt NOTIFY createdAtChanged )
     Q_PROPERTY( QDateTime updatedAt READ updatedAt NOTIFY updatedAtChanged )
@@ -290,6 +291,10 @@ class QFieldCloudProject : public QObject
     int deltasCount() const { return mDeltasCount; }
     DeltaListModel *deltaListModel() const { return mDeltaListModel; }
 
+    QString thumbnailPath() const { return mThumbnailPath; }
+    void setThumbnailPath( const QString &thumbnailPath );
+    Q_INVOKABLE void downloadThumbnail();
+
     void packageAndDownload();
     void cancelDownload();
 
@@ -366,6 +371,8 @@ class QFieldCloudProject : public QObject
     void uploadDeltaProgressChanged();
 
     void deltaListModelChanged();
+
+    void thumbnailPathChanged();
 
     void downloadFinished( const QString &error = QString() );
     void downloaded( const QString &name, const QString &error = QString() );
@@ -482,6 +489,8 @@ class QFieldCloudProject : public QObject
 
     int mDeltasCount = 0;
     DeltaListModel *mDeltaListModel = nullptr;
+
+    QString mThumbnailPath;
 
     QString mLastExportedAt;
     QString mLastExportId;

--- a/src/core/qfieldcloud/qfieldcloudproject.h
+++ b/src/core/qfieldcloud/qfieldcloudproject.h
@@ -41,6 +41,9 @@ class QFieldCloudProject : public QObject
     Q_PROPERTY( QString description READ description NOTIFY descriptionChanged )
     Q_PROPERTY( QString localPath READ localPath NOTIFY localPathChanged )
 
+    Q_PROPERTY( QDateTime createdAt READ createdAt NOTIFY createdAtChanged )
+    Q_PROPERTY( QDateTime updatedAt READ updatedAt NOTIFY updatedAtChanged )
+
     Q_PROPERTY( ProjectStatus status READ status NOTIFY statusChanged )
     Q_PROPERTY( PackagingStatus packagingStatus READ packagingStatus NOTIFY packagingStatusChanged )
     Q_PROPERTY( QStringList packagedLayerErrors READ packagedLayerErrors NOTIFY packagedLayerErrorsChanged )
@@ -201,6 +204,12 @@ class QFieldCloudProject : public QObject
     ProjectStatus status() const { return mStatus; }
     void setStatus( ProjectStatus status );
 
+    QDateTime createdAt() const { return mCreatedAt; }
+    void setCreatedAt( const QDateTime &createdAt );
+
+    QDateTime updatedAt() const { return mUpdatedAt; }
+    void setUpdatedAt( const QDateTime &updatedAt );
+
     QDateTime dataLastUpdatedAt() const { return mDataLastUpdatedAt; }
     void setDataLastUpdatedAt( const QDateTime &dataLastUpdatedAt );
 
@@ -314,6 +323,9 @@ class QFieldCloudProject : public QObject
     void errorStatusChanged();
     void checkoutChanged();
     void statusChanged();
+
+    void createdAtChanged();
+    void updatedAtChanged();
     void dataLastUpdatedAtChanged();
 
     void canRepackageChanged();
@@ -434,9 +446,12 @@ class QFieldCloudProject : public QObject
     QString mDescription;
     QString mUserRole;
     QString mUserRoleOrigin;
+
     ProjectErrorStatus mErrorStatus = ProjectErrorStatus::NoErrorStatus;
     ProjectCheckouts mCheckout = ProjectCheckout::LocalCheckout;
     ProjectStatus mStatus = ProjectStatus::Idle;
+    QDateTime mCreatedAt;
+    QDateTime mUpdatedAt;
     QDateTime mDataLastUpdatedAt;
     bool mCanRepackage = false;
     bool mNeedsRepackaging = false;

--- a/src/core/qfieldcloud/qfieldcloudproject.h
+++ b/src/core/qfieldcloud/qfieldcloudproject.h
@@ -39,6 +39,7 @@ class QFieldCloudProject : public QObject
     Q_PROPERTY( QString name READ name NOTIFY nameChanged )
     Q_PROPERTY( QString owner READ owner NOTIFY ownerChanged )
     Q_PROPERTY( QString description READ description NOTIFY descriptionChanged )
+    Q_PROPERTY( QString localPath READ localPath NOTIFY localPathChanged )
 
     Q_PROPERTY( ProjectStatus status READ status NOTIFY statusChanged )
     Q_PROPERTY( PackagingStatus packagingStatus READ packagingStatus NOTIFY packagingStatusChanged )

--- a/src/core/qfieldcloud/qfieldcloudproject.h
+++ b/src/core/qfieldcloud/qfieldcloudproject.h
@@ -42,6 +42,9 @@ class QFieldCloudProject : public QObject
     Q_PROPERTY( QString localPath READ localPath NOTIFY localPathChanged )
     Q_PROPERTY( QString thumbnailPath READ thumbnailPath NOTIFY thumbnailPathChanged )
 
+    Q_PROPERTY( QString userRole READ userRole NOTIFY userRoleChanged )
+    Q_PROPERTY( QString userRoleOrigin READ userRoleOrigin NOTIFY userRoleOriginChanged )
+
     Q_PROPERTY( QDateTime createdAt READ createdAt NOTIFY createdAtChanged )
     Q_PROPERTY( QDateTime updatedAt READ updatedAt NOTIFY updatedAtChanged )
 

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -529,7 +529,7 @@ void QFieldCloudProjectsModel::insertProjects( const QList<QFieldCloudProject *>
           mProjects[i]->setDescription( project->description() );
           mProjects[i]->setUserRole( project->userRole() );
           mProjects[i]->setUserRoleOrigin( project->userRoleOrigin() );
-          mProjects[i]->setCreatedAt( project->updatedAt() );
+          mProjects[i]->setCreatedAt( project->createdAt() );
           mProjects[i]->setUpdatedAt( project->updatedAt() );
           mProjects[i]->setCanRepackage( project->canRepackage() );
           mProjects[i]->setNeedsRepackaging( project->needsRepackaging() );

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -169,10 +169,12 @@ void QFieldCloudProjectsModel::refreshProjectsList( bool shouldRefreshPublic, in
       request.setAttribute( static_cast<QNetworkRequest::Attribute>( ProjectsRequestAttribute::RefreshPublicProjects ), shouldRefreshPublic );
       request.setAttribute( static_cast<QNetworkRequest::Attribute>( ProjectsRequestAttribute::ProjectsFetchOffset ), projectFetchOffset );
 
+      mIsRefreshing = true;
+      emit isRefreshingChanged();
+
       mCloudConnection->setAuthenticationDetails( request );
       NetworkReply *reply = mCloudConnection->get( request, url, params );
       connect( reply, &NetworkReply::finished, this, &QFieldCloudProjectsModel::projectListReceived );
-
       break;
     }
     case QFieldCloudConnection::ConnectionStatus::Disconnected:
@@ -410,6 +412,9 @@ void QFieldCloudProjectsModel::projectListReceived()
 
   if ( rawReply->error() != QNetworkReply::NoError )
   {
+    mIsRefreshing = false;
+    emit isRefreshingChanged();
+
     emit warning( QFieldCloudConnection::errorString( rawReply ) );
     return;
   }
@@ -449,6 +454,9 @@ void QFieldCloudProjectsModel::projectListReceived()
         refreshProjectModification( mCurrentProject->id() );
       }
     }
+
+    mIsRefreshing = false;
+    emit isRefreshingChanged();
   }
 }
 

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -252,9 +252,10 @@ void QFieldCloudProjectsModel::removeLocalProject( const QString &projectId )
     if ( projectIndex.isValid() )
     {
       QFieldCloudProject *project = mProjects[projectIndex.row()];
+      project->removeLocally();
+
       if ( ( project->status() == QFieldCloudProject::ProjectStatus::Idle || project->status() == QFieldCloudProject::ProjectStatus::Failing ) && project->checkout() & QFieldCloudProject::RemoteCheckout )
       {
-        project->removeLocally();
         emit dataChanged( projectIndex, projectIndex, QVector<int>() << StatusRole << LocalPathRole << CheckoutRole );
       }
       else

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -150,13 +150,13 @@ QSet<QString> QFieldCloudProjectsModel::busyProjectIds() const
   return result;
 }
 
-void QFieldCloudProjectsModel::refreshProjectsList( bool shouldRefreshPublic, int projectFetchOffset )
+void QFieldCloudProjectsModel::refreshProjectsList( bool shouldResetModel, bool shouldFetchPublic, int projectFetchOffset )
 {
   switch ( mCloudConnection->status() )
   {
     case QFieldCloudConnection::ConnectionStatus::LoggedIn:
     {
-      QString url = shouldRefreshPublic ? QStringLiteral( "/api/v1/projects/public/" ) : QStringLiteral( "/api/v1/projects/" );
+      QString url = shouldFetchPublic ? QStringLiteral( "/api/v1/projects/public/" ) : QStringLiteral( "/api/v1/projects/" );
 
       QVariantMap params;
       params["limit"] = QString::number( mProjectsPerFetch );
@@ -166,7 +166,8 @@ void QFieldCloudProjectsModel::refreshProjectsList( bool shouldRefreshPublic, in
       request.setHeader( QNetworkRequest::ContentTypeHeader, "application/json" );
       request.setAttribute( QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::RedirectPolicy::NoLessSafeRedirectPolicy );
 
-      request.setAttribute( static_cast<QNetworkRequest::Attribute>( ProjectsRequestAttribute::RefreshPublicProjects ), shouldRefreshPublic );
+      request.setAttribute( static_cast<QNetworkRequest::Attribute>( ProjectsRequestAttribute::ResetModel ), shouldResetModel );
+      request.setAttribute( static_cast<QNetworkRequest::Attribute>( ProjectsRequestAttribute::FetchPublicProjects ), shouldFetchPublic );
       request.setAttribute( static_cast<QNetworkRequest::Attribute>( ProjectsRequestAttribute::ProjectsFetchOffset ), projectFetchOffset );
 
       mIsRefreshing = true;
@@ -359,7 +360,7 @@ void QFieldCloudProjectsModel::refreshProjectDeltaList( const QString &projectId
 
 void QFieldCloudProjectsModel::connectionStatusChanged()
 {
-  refreshProjectsList();
+  refreshProjectsList( false );
 }
 
 void QFieldCloudProjectsModel::usernameChanged()
@@ -420,9 +421,10 @@ void QFieldCloudProjectsModel::projectListReceived()
     return;
   }
 
-  const bool isPublic = rawReply->request().attribute( static_cast<QNetworkRequest::Attribute>( ProjectsRequestAttribute::RefreshPublicProjects ) ).toBool();
+  const bool resetModel = rawReply->request().attribute( static_cast<QNetworkRequest::Attribute>( ProjectsRequestAttribute::ResetModel ) ).toBool();
+  const bool fetchPublic = rawReply->request().attribute( static_cast<QNetworkRequest::Attribute>( ProjectsRequestAttribute::FetchPublicProjects ) ).toBool();
   const int projectFetchOffset = rawReply->request().attribute( static_cast<QNetworkRequest::Attribute>( ProjectsRequestAttribute::ProjectsFetchOffset ) ).toInt();
-  if ( projectFetchOffset == 0 )
+  if ( resetModel && projectFetchOffset == 0 )
   {
     beginResetModel();
     qDeleteAll( mProjects );
@@ -440,7 +442,7 @@ void QFieldCloudProjectsModel::projectListReceived()
   loadProjects( projects, projectFetchOffset > 0 );
   if ( projects.size() > 0 )
   {
-    refreshProjectsList( isPublic, projectFetchOffset + mProjectsPerFetch );
+    refreshProjectsList( resetModel, fetchPublic, projectFetchOffset + mProjectsPerFetch );
   }
   else
   {
@@ -519,9 +521,21 @@ void QFieldCloudProjectsModel::insertProjects( const QList<QFieldCloudProject *>
       {
         if ( mProjects[i]->checkout() == QFieldCloudProject::LocalCheckout && project->checkout() != QFieldCloudProject::LocalCheckout )
         {
-          delete mProjects[i];
-          mProjects[i] = project;
+          mProjects[i]->setCheckout( QFieldCloudProject::LocalAndRemoteCheckout );
+          mProjects[i]->setOwner( project->owner() );
+          mProjects[i]->setName( project->name() );
+          mProjects[i]->setDescription( project->description() );
+          mProjects[i]->setUserRole( project->userRole() );
+          mProjects[i]->setUserRoleOrigin( project->userRoleOrigin() );
+          mProjects[i]->setCreatedAt( project->updatedAt() );
+          mProjects[i]->setUpdatedAt( project->updatedAt() );
+          mProjects[i]->setCanRepackage( project->canRepackage() );
+          mProjects[i]->setNeedsRepackaging( project->needsRepackaging() );
+          mProjects[i]->setLocalizedDatasetsProjectId( project->localizedDatasetsProjectId() );
+          mProjects[i]->setDataLastUpdatedAt( project->dataLastUpdatedAt() );
           emit dataChanged( index( i, 0 ), index( i, 0 ) );
+
+          delete project;
         }
         found = true;
         break;

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -237,6 +237,7 @@ void QFieldCloudProjectsModel::appendProject( const QString &projectId )
   QNetworkRequest request( url );
   request.setHeader( QNetworkRequest::ContentTypeHeader, "application/json" );
   request.setAttribute( QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::RedirectPolicy::NoLessSafeRedirectPolicy );
+  request.setAttribute( static_cast<QNetworkRequest::Attribute>( QFieldCloudProjectsModel::ProjectsRequestAttribute::ProjectId ), projectId );
   mCloudConnection->setAuthenticationDetails( request );
 
   NetworkReply *reply = mCloudConnection->get( request, url );
@@ -387,9 +388,10 @@ void QFieldCloudProjectsModel::projectReceived()
 
   Q_ASSERT( rawReply );
 
+  const QString projectId = rawReply->request().attribute( static_cast<QNetworkRequest::Attribute>( ProjectsRequestAttribute::ProjectId ) ).toString();
   if ( rawReply->error() != QNetworkReply::NoError )
   {
-    emit warning( QFieldCloudConnection::errorString( rawReply ) );
+    emit projectAppended( projectId, true, QFieldCloudConnection::errorString( rawReply ) );
     return;
   }
 

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
@@ -169,6 +169,9 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     //! Return the cloud project for a given \a projectId.
     Q_INVOKABLE QFieldCloudProject *findProject( const QString &projectId ) const;
 
+    //! Fetches a cloud project for a given \a projectId and appends it to the model.
+    Q_INVOKABLE void appendProject( const QString &projectId );
+
   signals:
     void cloudConnectionChanged();
     void layerObserverChanged();
@@ -178,6 +181,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     void gpkgFlusherChanged();
     void warning( const QString &message );
 
+    void projectAppended( const QString &projectId );
     void projectDownloaded( const QString &projectId, const QString &projectName, const bool hasError, const QString &errorString = QString() );
     void pushFinished( const QString &projectId, bool isDownloadingProject, bool hasError, const QString &errorString = QString() );
 
@@ -187,6 +191,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     void connectionStatusChanged();
     void usernameChanged();
     void projectListReceived();
+    void projectReceived();
 
     void layerObserverLayerEdited( const QString &layerId );
 

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
@@ -92,7 +92,8 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     {
       FetchPublicProjects = QNetworkRequest::User + 1,
       ProjectsFetchOffset = QNetworkRequest::User + 2,
-      ResetModel = QNetworkRequest::User + 3
+      ResetModel = QNetworkRequest::User + 3,
+      ProjectId = QNetworkRequest::User + 4
     };
 
     Q_ENUM( ColumnRole )
@@ -195,9 +196,9 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     void gpkgFlusherChanged();
     void warning( const QString &message );
 
-    void projectAppended( const QString &projectId );
-    void projectDownloaded( const QString &projectId, const QString &projectName, const bool hasError, const QString &errorString = QString() );
-    void pushFinished( const QString &projectId, bool isDownloadingProject, bool hasError, const QString &errorString = QString() );
+    void projectAppended( const QString &projectId, const bool hasError = false, const QString &errorString = QString() );
+    void projectDownloaded( const QString &projectId, const QString &projectName, const bool hasError = false, const QString &errorString = QString() );
+    void pushFinished( const QString &projectId, bool isDownloadingProject, bool hasError = false, const QString &errorString = QString() );
 
     void deltaListModelChanged();
 

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
@@ -45,8 +45,12 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     Q_PROPERTY( LayerObserver *layerObserver READ layerObserver WRITE setLayerObserver NOTIFY layerObserverChanged )
     //! The current geopackage flusher
     Q_PROPERTY( QgsGpkgFlusher *gpkgFlusher READ gpkgFlusher WRITE setGpkgFlusher NOTIFY gpkgFlusherChanged )
+
+    //! Returns TRUE whether the model is being refreshed
+    Q_PROPERTY( bool isRefreshing READ isRefreshing NOTIFY isRefreshingChanged )
     //! Currently busy project ids.
     Q_PROPERTY( QSet<QString> busyProjectIds READ busyProjectIds NOTIFY busyProjectIdsChanged )
+
     //! The current cloud project id of the currently opened project (empty string for non-cloud projects).
     Q_PROPERTY( QString currentProjectId READ currentProjectId WRITE setCurrentProjectId NOTIFY currentProjectIdChanged )
     //! The current cloud project. (null for non-cloud projects).
@@ -105,6 +109,9 @@ class QFieldCloudProjectsModel : public QAbstractListModel
 
     //! Sets the layer observer.
     void setLayerObserver( LayerObserver *layerObserver );
+
+    //! Returns TRUE whether the model is being refreshed
+    bool isRefreshing() const { return mIsRefreshing; }
 
     //! Returns the cloud project id of the currently opened project.
     QString currentProjectId() const;
@@ -175,6 +182,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
   signals:
     void cloudConnectionChanged();
     void layerObserverChanged();
+    void isRefreshingChanged();
     void currentProjectIdChanged();
     void currentProjectChanged();
     void busyProjectIdsChanged();
@@ -198,10 +206,17 @@ class QFieldCloudProjectsModel : public QAbstractListModel
   private:
     void setupProjectConnections( QFieldCloudProject *project );
 
+    QModelIndex findProjectIndex( const QString &projectId ) const;
+
+    void loadProjects( const QJsonArray &remoteProjects = QJsonArray(), bool skipLocalProjects = false );
+    void insertProjects( const QList<QFieldCloudProject *> &projects );
+
     inline QString layerFileName( const QgsMapLayer *layer ) const;
 
     QList<QFieldCloudProject *> mProjects;
     QFieldCloudConnection *mCloudConnection = nullptr;
+
+    bool mIsRefreshing = false;
 
     QString mCurrentProjectId;
     QPointer<QFieldCloudProject> mCurrentProject;
@@ -210,11 +225,6 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     QgsGpkgFlusher *mGpkgFlusher = nullptr;
     QString mUsername;
     const int mProjectsPerFetch = 250;
-
-    QModelIndex findProjectIndex( const QString &projectId ) const;
-
-    void loadProjects( const QJsonArray &remoteProjects = QJsonArray(), bool skipLocalProjects = false );
-    void insertProjects( const QList<QFieldCloudProject *> &projects );
 };
 
 /**

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
@@ -90,8 +90,9 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     //! Attributes controlling fetching of projects
     enum class ProjectsRequestAttribute
     {
-      RefreshPublicProjects = QNetworkRequest::User + 1,
-      ProjectsFetchOffset = QNetworkRequest::User + 2
+      FetchPublicProjects = QNetworkRequest::User + 1,
+      ProjectsFetchOffset = QNetworkRequest::User + 2,
+      ResetModel = QNetworkRequest::User + 3
     };
 
     Q_ENUM( ColumnRole )
@@ -131,8 +132,13 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     //! Returns a set containing the currently busy project ids.
     QSet<QString> busyProjectIds() const;
 
-    //! Requests the cloud projects list from the server. If \a shouldRefreshPublic is false, it will refresh only user's project, otherwise will refresh the public projects only, starting from \a projectFetchOffset for pagination.
-    Q_INVOKABLE void refreshProjectsList( bool shouldRefreshPublic = false, int projectFetchOffset = 0 );
+    /**
+     * Requests the cloud projects list from the server.
+     * \param shouldResetModel set to TRUE to reset the model
+     * \param shouldFetchPublic set to TRUE to refresh public projects
+     * \param projectFetchOffset offset for pagination
+     */
+    Q_INVOKABLE void refreshProjectsList( bool shouldResetModel = true, bool shouldFetchPublic = false, int projectFetchOffset = 0 );
 
     //! Pushes all local deltas for given \a projectId. If \a shouldDownloadUpdates is true, also calls `downloadProject`.
     Q_INVOKABLE void projectUpload( const QString &projectId, const bool shouldDownloadUpdates );

--- a/src/core/utils/urlutils.cpp
+++ b/src/core/utils/urlutils.cpp
@@ -19,6 +19,7 @@
 
 #include <QFileInfo>
 #include <QUrl>
+#include <QUrlQuery>
 
 UrlUtils::UrlUtils( QObject *parent )
   : QObject( parent )
@@ -68,4 +69,64 @@ QString UrlUtils::urlDetail( const QString &url, const QString &detail )
     return urlInterface.query();
   }
   return QString();
+}
+
+
+QVariantMap UrlUtils::getActionDetails( const QString &url )
+{
+  QVariantMap details;
+  if ( url.trimmed().isEmpty() )
+    return details;
+
+  QUrl actionUrl( url );
+  if ( actionUrl.scheme().toLower() == QStringLiteral( "qfield" ) )
+  {
+    // deal with qfield:// URLs
+    details["type"] = actionUrl.authority();
+  }
+  else if ( actionUrl.authority() == QStringLiteral( "qfield.org" ) && actionUrl.path().startsWith( "/action/" ) )
+  {
+    // deal with https://qfield.org/action/ URLs
+    details["type"] = actionUrl.path().mid( 8 );
+  }
+  else
+  {
+    return details;
+  }
+
+  if ( !actionUrl.query().isEmpty() )
+  {
+    const QList<std::pair<QString, QString>> queryItems = QUrlQuery( actionUrl ).queryItems( QUrl::FullyDecoded );
+    for ( const std::pair<QString, QString> &queryItem : queryItems )
+    {
+      details[queryItem.first] = queryItem.second;
+    }
+  }
+
+  return details;
+}
+
+QString UrlUtils::createActionUrl( const QString &scheme, const QString &type, const QVariantMap &details )
+{
+  QUrl url;
+  if ( scheme == QStringLiteral( "qfield" ) )
+  {
+    url.setScheme( scheme );
+    url.setAuthority( type );
+  }
+  else if ( scheme == QStringLiteral( "https" ) )
+  {
+    url.setScheme( scheme );
+    url.setAuthority( QStringLiteral( "qfield.org" ) );
+    url.setPath( QStringLiteral( "/action/%1" ).arg( type ) );
+  }
+
+  QUrlQuery query;
+  for ( const QString &key : details.keys() )
+  {
+    query.addQueryItem( key, details.value( key ).toString() );
+  }
+  url.setQuery( query );
+
+  return url.toString();
 }

--- a/src/core/utils/urlutils.cpp
+++ b/src/core/utils/urlutils.cpp
@@ -81,12 +81,13 @@ QVariantMap UrlUtils::getActionDetails( const QString &url )
   QUrl actionUrl( url );
   if ( actionUrl.scheme().toLower() == QStringLiteral( "qfield" ) )
   {
-    // deal with qfield:// URLs
+    // deal with qfield://<type>?parameters URLs
     details["type"] = actionUrl.authority();
   }
   else if ( actionUrl.authority() == QStringLiteral( "qfield.org" ) && actionUrl.path().startsWith( "/action/" ) )
   {
-    // deal with https://qfield.org/action/ URLs
+    // deal with https://qfield.org/action/<type>?parameters URLs
+    // the type matches everything that follows the beginning of the path (i.e./action/)
     details["type"] = actionUrl.path().mid( 8 );
   }
   else

--- a/src/core/utils/urlutils.h
+++ b/src/core/utils/urlutils.h
@@ -49,6 +49,20 @@ class QFIELD_CORE_EXPORT UrlUtils : public QObject
      * - "query", e.g. param=true&other_parem=0
      */
     static Q_INVOKABLE QString urlDetail( const QString &url, const QString &detail );
+
+    /**
+     * Returns QField action details extracted from a compatible \a url.
+     */
+    static Q_INVOKABLE QVariantMap getActionDetails( const QString &url );
+
+    /**
+     * Returns a QField action url string.
+     * \param scheme the action scheme, a qfield value will return a "qfield://" scheme an https value
+     * will return an "https://qfield.org" scheme and domain name
+     * \param type the action type (local or cloud)
+     * \param details the action details transformed into URL query parameters
+     */
+    static Q_INVOKABLE QString createActionUrl( const QString &scheme, const QString &type, const QVariantMap &details );
 };
 
 #endif // URLUTILS_H

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -77,7 +77,7 @@ Page {
         clip: true
 
         Rectangle {
-          id: cloudAvatarMask
+          id: roundMask
           anchors.fill: parent
           anchors.margins: 1
           radius: width / 2
@@ -99,7 +99,7 @@ Page {
           sourceSize.height: height * screen.devicePixelRatio
           layer.enabled: true
           layer.effect: QfOpacityMask {
-            maskSource: cloudAvatarMask
+            maskSource: roundMask
           }
 
           onStatusChanged: {
@@ -641,19 +641,31 @@ Page {
               Layout.fillWidth: true
               spacing: 5
 
-              Image {
-                id: projectDetailsThumbnail
-                fillMode: Image.PreserveAspectFit
-                smooth: true
-                source: projectDetails.cloudProject != undefined && projectDetails.cloudProject.thumbnailPath !== "" ? 'file://' + projectDetails.cloudProject.thumbnailPath : ""
-                visible: source !== "" && status === Image.Ready
+              Rectangle {
+                id: projectDetailsThumbnailRect
                 width: 48
                 height: 48
-                sourceSize.width: width * screen.devicePixelRatio
-                sourceSize.height: height * screen.devicePixelRatio
-                layer.enabled: true
-                layer.effect: QfOpacityMask {
-                  maskSource: cloudAvatarMask
+                border.color: Theme.mainBackgroundColor
+                border.width: 1
+                radius: width / 2
+                clip: true
+
+                Image {
+                  id: projectDetailsThumbnail
+                  anchors.fill: parent
+                  anchors.margins: 1
+                  fillMode: Image.PreserveAspectFit
+                  smooth: true
+                  source: projectDetails.cloudProject != undefined && projectDetails.cloudProject.thumbnailPath !== "" ? 'file://' + projectDetails.cloudProject.thumbnailPath : ""
+                  visible: source !== "" && status === Image.Ready
+                  width: 48
+                  height: 48
+                  sourceSize.width: width * screen.devicePixelRatio
+                  sourceSize.height: height * screen.devicePixelRatio
+                  layer.enabled: true
+                  layer.effect: QfOpacityMask {
+                    maskSource: roundMask
+                  }
                 }
               }
 
@@ -669,89 +681,105 @@ Page {
               }
             }
 
-            Text {
-              id: projectDetailsDescriptionLabel
+            ColumnLayout {
               Layout.fillWidth: true
-              font: Theme.strongFont
-              color: Theme.mainTextColor
+              spacing: 5
 
-              text: qsTr("Description")
-            }
+              Text {
+                id: projectDetailsDescriptionLabel
+                Layout.fillWidth: true
+                font: Theme.strongFont
+                color: Theme.mainTextColor
 
-            Text {
-              id: projectDetailsDescription
-              Layout.fillWidth: true
-              font: Theme.defaultFont
-              color: Theme.secondaryTextColor
-              wrapMode: Text.WordWrap
-              textFormat: Text.MarkdownText
+                text: qsTr("Description")
+              }
 
-              text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.description.trim() : ""
+              Text {
+                id: projectDetailsDescription
+                Layout.fillWidth: true
+                font: Theme.defaultFont
+                color: Theme.secondaryTextColor
+                wrapMode: Text.WordWrap
+                textFormat: Text.MarkdownText
 
-              onLinkActivated: link => {
-                Qt.openUrlExternally(link);
+                text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.description.trim() : ""
+
+                onLinkActivated: link => {
+                  Qt.openUrlExternally(link);
+                }
               }
             }
 
-            Text {
-              id: projectDetailsOwnerLabel
+            ColumnLayout {
               Layout.fillWidth: true
-              font: Theme.strongFont
-              color: Theme.mainTextColor
+              spacing: 5
 
-              text: qsTr("Owner")
+              Text {
+                id: projectDetailsOwnerLabel
+                Layout.fillWidth: true
+                font: Theme.strongFont
+                color: Theme.mainTextColor
+
+                text: qsTr("Owner")
+              }
+
+              Text {
+                id: projectDetailsOwner
+                Layout.fillWidth: true
+                font: Theme.defaultFont
+                color: Theme.secondaryTextColor
+                wrapMode: Text.WordWrap
+
+                text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.owner : ""
+              }
             }
 
-            Text {
-              id: projectDetailsOwner
+            ColumnLayout {
               Layout.fillWidth: true
-              font: Theme.defaultFont
-              color: Theme.secondaryTextColor
-              wrapMode: Text.WordWrap
+              spacing: 5
 
-              text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.owner : ""
+              Text {
+                id: projectDetailsCreationDateLabel
+                Layout.fillWidth: true
+                font: Theme.strongFont
+                color: Theme.mainTextColor
+
+                text: qsTr("Creation date")
+              }
+
+              Text {
+                id: projectDetailsCreationDate
+                Layout.fillWidth: true
+                font: Theme.defaultFont
+                color: Theme.secondaryTextColor
+                wrapMode: Text.WordWrap
+
+                text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.createdAt : ""
+              }
             }
 
-            Text {
-              id: projectDetailsCreationDateLabel
+            ColumnLayout {
               Layout.fillWidth: true
-              font: Theme.strongFont
-              color: Theme.mainTextColor
+              spacing: 5
 
-              text: qsTr("Creation date")
-            }
+              Text {
+                id: projectDetailsUpdateDateLabel
+                Layout.fillWidth: true
+                font: Theme.strongFont
+                color: Theme.mainTextColor
 
-            Text {
-              id: projectDetailsCreationDate
-              Layout.fillWidth: true
-              font: Theme.defaultFont
-              color: Theme.secondaryTextColor
-              wrapMode: Text.WordWrap
+                text: qsTr("Latest update date")
+              }
 
-              text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.createdAt : ""
-            }
+              Text {
+                id: projectDetailsUpdateDate
+                Layout.fillWidth: true
+                font: Theme.defaultFont
+                color: Theme.secondaryTextColor
+                wrapMode: Text.WordWrap
 
-            Text {
-              id: projectDetailsUpdateDateLabel
-              Layout.fillWidth: true
-              font: Theme.strongFont
-              color: Theme.mainTextColor
-
-              text: qsTr("Latest update date")
-            }
-
-            Text {
-              id: projectDetailsUpdateDate
-              Layout.fillWidth: true
-              font: Theme.defaultFont
-              color: Theme.secondaryTextColor
-              wrapMode: Text.WordWrap
-
-              text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.updatedAt : ""
-            }
-
-            Item {
-              Layout.fillHeight: true
+                text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.updatedAt : ""
+              }
             }
           }
         }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -739,6 +739,47 @@ Page {
                   text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.updatedAt : ""
                 }
               }
+
+              ColumnLayout {
+                Layout.topMargin: 20
+                Layout.bottomMargin: 20
+                Layout.preferredWidth: projectDetailsCodeContainer.desiredWidth
+                Layout.alignment: Qt.AlignHCenter
+                spacing: 5
+
+                Rectangle {
+                  id: projectDetailsCodeContainer
+
+                  property int desiredWidth: Math.min(mainWindow.width - 40, 250)
+                  Layout.preferredWidth: desiredWidth
+                  Layout.preferredHeight: desiredWidth
+
+                  color: "transparent"
+                  radius: 4
+                  border.width: 1
+                  border.color: Theme.mainTextColor
+
+                  Image {
+                    anchors.fill: parent
+                    fillMode: Image.PreserveAspectFit
+
+                    sourceSize.width: projectDetailsCodeContainer.desiredWidth * Screen.devicePixelRatio
+                    sourceSize.height: projectDetailsCodeContainer.desiredWidth * Screen.devicePixelRatio
+                    source: projectDetails.cloudProject != undefined ? "image://barcode/?text=qfieldcloud?project=" + projectDetails.cloudProject.id + "&color=%2380cc28" : ""
+                  }
+                }
+
+                Text {
+                  id: projectDetailsCodeLabel
+                  Layout.preferredWidth: projectDetailsCodeContainer.desiredWidth - 20
+                  font: Theme.tinyFont
+                  color: Theme.secondaryTextColor
+                  wrapMode: Text.WordWrap
+                  horizontalAlignment: Text.AlignHCenter
+
+                  text: qsTr("This QR code can be scanned for users with the appropriate access to download and open this project")
+                }
+              }
             }
           }
         }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -217,7 +217,6 @@ Page {
             id: table
 
             property bool overshootRefresh: false
-            property bool refreshing: false
 
             model: QFieldCloudProjectsFilterModel {
               projectsModel: cloudProjectsModel
@@ -468,8 +467,8 @@ Page {
             Label {
               anchors.fill: parent
               anchors.margins: 20
-              visible: parent.count == 0 && filterBar.currentIndex === 0
-              text: table.refreshing ? qsTr("Refreshing projects list") : qsTr("No cloud projects found. To get started, %1read the documentation%2.").arg("<a href=\"https://docs.qfield.org/get-started/tutorials/get-started-qfc/\">").arg("</a>")
+              visible: cloudConnection.status === QFieldCloudConnection.LoggedIn && parent.count === 0 && filterBar.currentIndex === 0
+              text: cloudProjectsModel.isRefreshing ? qsTr("Refreshing projects list") : qsTr("No cloud projects found. To get started, %1read the documentation%2.").arg("<a href=\"https://docs.qfield.org/get-started/tutorials/get-started-qfc/\">").arg("</a>")
               font: Theme.defaultFont
               wrapMode: Text.WordWrap
               horizontalAlignment: Text.AlignHCenter
@@ -946,9 +945,6 @@ Page {
     target: cloudConnection
 
     function onStatusChanged() {
-      if (table.refreshing) {
-        table.refreshing = false;
-      }
       if (cloudConnection.status === QFieldCloudConnection.LoggedIn) {
         prepareCloudLogin();
       } else if (cloudConnection.status === QFieldCloudConnection.Disconnected) {
@@ -973,7 +969,6 @@ Page {
     if (cloudConnection.state !== QFieldCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0) {
       return;
     }
-    table.refreshing = true;
     cloudProjectsModel.refreshProjectsList(shouldRefreshPublic);
     displayToast(qsTr("Refreshing projects list"));
   }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -849,7 +849,7 @@ Page {
         if (cloudConnection.status == QFieldCloudConnection.LoggedIn) {
           cloudConnection.logout();
         } else {
-          prepareCloudLogin();
+          prepareCloudScreen();
         }
       }
     }
@@ -977,7 +977,7 @@ Page {
       if (results.type !== undefined && results.type === "cloud" && results.project !== undefined && results.project !== "") {
         codeReader.close();
         let cloudProject = cloudProjectsModel.findProject(requestedProjectDetails);
-        if (cloudProject !== undefined) {
+        if (cloudProject) {
           projectDetails.cloudProject = cloudProjectsModel.findProject(projectId);
           projectsSwipeView.currentIndex = 1;
         } else {
@@ -996,7 +996,7 @@ Page {
 
     function onStatusChanged() {
       if (cloudConnection.status === QFieldCloudConnection.LoggedIn) {
-        prepareCloudLogin();
+        prepareCloudScreen();
       } else if (cloudConnection.status === QFieldCloudConnection.Disconnected) {
         if (table.count === 0) {
           projectsSwipeView.visible = false;
@@ -1009,10 +1009,14 @@ Page {
   Connections {
     target: cloudProjectsModel
 
-    function onProjectAppended(projectId) {
+    function onProjectAppended(projectId, hasError, errorString) {
       requestedProjectDetails = "";
-      projectDetails.cloudProject = cloudProjectsModel.findProject(projectId);
-      projectsSwipeView.currentIndex = 1;
+      if (hasError) {
+        displayToast(qsTr("QFieldCloud project details fetching failed"));
+      } else {
+        projectDetails.cloudProject = cloudProjectsModel.findProject(projectId);
+        projectsSwipeView.currentIndex = 1;
+      }
     }
   }
 
@@ -1024,7 +1028,7 @@ Page {
     displayToast(qsTr("Refreshing projects list"));
   }
 
-  function prepareCloudLogin() {
+  function prepareCloudScreen() {
     if (visible) {
       if (cloudConnection.status == QFieldCloudConnection.Disconnected) {
         if (cloudConnection.hasToken || cloudConnection.hasProviderConfiguration) {
@@ -1048,7 +1052,7 @@ Page {
         connectionSettings.visible = false;
         if (requestedProjectDetails != "") {
           let cloudProject = cloudProjectsModel.findProject(requestedProjectDetails);
-          if (cloudProject !== undefined) {
+          if (cloudProject) {
             requestedProjectDetails = "";
             projectDetails.cloudProject = cloudProject;
             projectsSwipeView.currentIndex = 1;
@@ -1061,11 +1065,11 @@ Page {
   }
 
   Component.onCompleted: {
-    prepareCloudLogin();
+    prepareCloudScreen();
   }
 
   onVisibleChanged: {
-    prepareCloudLogin();
+    prepareCloudScreen();
   }
 
   Keys.onReleased: event => {

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -313,7 +313,7 @@ Page {
                   anchors.verticalCenter: inner.verticalCenter
                   source: {
                     if (cloudConnection.status !== QFieldCloudConnection.LoggedIn) {
-                      return Theme.getThemeVectorIcon('ic_cloud_project_offline_48dp');
+                      return Theme.getThemeVectorIcon('ic_cloud_project_localonly_48dp');
                     } else {
                       var status = '';
                       switch (Status) {
@@ -363,7 +363,7 @@ Page {
                     leftPadding: 3
                     text: {
                       if (cloudConnection.status !== QFieldCloudConnection.LoggedIn) {
-                        return qsTr('(Available locally)');
+                        return qsTr('Available locally');
                       } else {
                         var status = '';
 
@@ -405,10 +405,10 @@ Page {
                         if (!status) {
                           switch (Checkout) {
                           case QFieldCloudProject.LocalCheckout:
-                            status = qsTr('Available locally, missing on the cloud');
+                            status = UserRoleOrigin === "public" ? qsTr('Available locally') : qsTr('Available locally, missing on the cloud');
                             break;
                           case QFieldCloudProject.RemoteCheckout:
-                            status = qsTr('Available on the cloud, missing locally');
+                            status = qsTr('Available on the cloud');
                             break;
                           case QFieldCloudProject.LocalAndRemoteCheckout:
                             status = qsTr('Available locally');
@@ -420,8 +420,8 @@ Page {
                             break;
                           }
                         }
-                        var localChanges = (LocalDeltasCount > 0) ? qsTr('Has changes. ') : '';
-                        var str = '%2%3'.arg(localChanges).arg(status);
+                        var localChanges = (LocalDeltasCount > 0) ? qsTr(', has changes locally') : '';
+                        var str = status + localChanges;
                         return str.trim();
                       }
                     }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -39,7 +39,7 @@ Page {
         parent.finished();
       }
     }
-    
+
     onOpenMenu: qfieldCloudScreenOption.open()
   }
 

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -657,7 +657,7 @@ Page {
                 font.pointSize: Theme.titleFont.pointSize * 1.25
                 font.bold: true
                 color: Theme.mainTextColor
-                wrapMode: Text.WordWrap
+                wrapMode: Text.Wrap
 
                 text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.name : ""
               }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -411,7 +411,7 @@ Page {
                           }
                         }
                         var localChanges = (LocalDeltasCount > 0) ? qsTr('Has changes. ') : '';
-                        var str = '%1 (%2%3)'.arg(Description).arg(localChanges).arg(status);
+                        var str = '%2%3'.arg(localChanges).arg(status);
                         return str.trim();
                       }
                     }
@@ -620,12 +620,19 @@ Page {
         ScrollView {
           Layout.fillWidth: true
           Layout.fillHeight: true
+          contentWidth: width
+          contentHeight: projectDetailsLayout.height
+          ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+          ScrollBar.vertical: QfScrollBar {
+          }
 
           ColumnLayout {
-            anchors.fill: parent
+            id: projectDetailsLayout
+            width: parent.width - 10
             spacing: 10
 
             RowLayout {
+              Layout.fillWidth: true
               spacing: 5
 
               Image {
@@ -650,6 +657,7 @@ Page {
                 font.pointSize: Theme.titleFont.pointSize * 1.25
                 font.bold: true
                 color: Theme.mainTextColor
+                wrapMode: Text.WordWrap
 
                 text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.name : ""
               }
@@ -669,8 +677,14 @@ Page {
               Layout.fillWidth: true
               font: Theme.defaultFont
               color: Theme.secondaryTextColor
+              wrapMode: Text.WordWrap
+              textFormat: Text.MarkdownText
 
-              text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.description : ""
+              text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.description.trim() : ""
+
+              onLinkActivated: link => {
+                Qt.openUrlExternally(link);
+              }
             }
 
             Text {
@@ -687,6 +701,7 @@ Page {
               Layout.fillWidth: true
               font: Theme.defaultFont
               color: Theme.secondaryTextColor
+              wrapMode: Text.WordWrap
 
               text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.owner : ""
             }
@@ -705,6 +720,7 @@ Page {
               Layout.fillWidth: true
               font: Theme.defaultFont
               color: Theme.secondaryTextColor
+              wrapMode: Text.WordWrap
 
               text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.createdAt : ""
             }
@@ -723,8 +739,13 @@ Page {
               Layout.fillWidth: true
               font: Theme.defaultFont
               color: Theme.secondaryTextColor
+              wrapMode: Text.WordWrap
 
               text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.updatedAt : ""
+            }
+
+            Item {
+              Layout.fillHeight: true
             }
           }
         }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -617,6 +617,12 @@ Page {
 
         property var cloudProject: undefined
 
+        onCloudProjectChanged: {
+          if (cloudProject != undefined) {
+            cloudProject.downloadThumbnail();
+          }
+        }
+
         ScrollView {
           Layout.fillWidth: true
           Layout.fillHeight: true
@@ -639,7 +645,7 @@ Page {
                 id: projectDetailsThumbnail
                 fillMode: Image.PreserveAspectFit
                 smooth: true
-                source: projectDetails.cloudProject != undefined ? cloudConnection.url + "/api/v1/files/thumbnails/" + projectDetails.cloudProject.id + "/" : ""
+                source: projectDetails.cloudProject != undefined && projectDetails.cloudProject.thumbnailPath !== "" ? 'file://' + projectDetails.cloudProject.thumbnailPath : ""
                 visible: source !== "" && status === Image.Ready
                 width: 48
                 height: 48

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -28,8 +28,18 @@ Page {
 
     topMargin: mainWindow.sceneTopMargin
 
-    onFinished: parent.finished()
-
+    onFinished: {
+      if (connectionSettings.visible) {
+        connectionSettings.visible = false;
+        projectsSwipeView.visible = true;
+      } else if (projectsSwipeView.currentIndex === 1) {
+        projectDetails.cloudProject = undefined;
+        projectsSwipeView.currentIndex = 0;
+      } else {
+        parent.finished();
+      }
+    }
+    
     onOpenMenu: qfieldCloudScreenOption.open()
   }
 
@@ -639,7 +649,7 @@ Page {
 
             RowLayout {
               Layout.fillWidth: true
-              spacing: 5
+              spacing: 10
 
               Rectangle {
                 id: projectDetailsThumbnailRect
@@ -827,17 +837,6 @@ Page {
             projectDetails.cloudProject = undefined;
           }
         }
-
-        QfButton {
-          id: returnToProjectsListBtn
-          Layout.fillWidth: true
-          Layout.bottomMargin: mainWindow.sceneBottomMargin
-          text: qsTr("Return to projects list")
-          onClicked: {
-            projectsSwipeView.currentIndex = 0;
-            projectDetails.cloudProject = undefined;
-          }
-        }
       }
     }
   }
@@ -918,7 +917,6 @@ Page {
 
   function prepareCloudLogin() {
     if (visible) {
-      projectsSwipeView.currentIndex = 0;
       if (cloudConnection.status == QFieldCloudConnection.Disconnected) {
         if (cloudConnection.hasToken || cloudConnection.hasProviderConfiguration) {
           cloudConnection.login();
@@ -947,7 +945,7 @@ Page {
   Keys.onReleased: event => {
     if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
       event.accepted = true;
-      finished();
+      header.onFinished();
     }
   }
 }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -48,7 +48,7 @@ Page {
       Label {
         Layout.fillWidth: true
         padding: 10
-        opacity: projects.visible ? 1 : 0
+        opacity: projectsSwipeView.visible ? 1 : 0
         text: switch (cloudConnection.status) {
         case 0:
           qsTr('Disconnected from the cloud.');
@@ -116,10 +116,10 @@ Page {
           onClicked: {
             if (!connectionSettings.visible) {
               connectionSettings.visible = true;
-              projects.visible = false;
+              projectsSwipeView.visible = false;
             } else {
               connectionSettings.visible = false;
-              projects.visible = true;
+              projectsSwipeView.visible = true;
               refreshProjectsListBtn.forceActiveFocus();
             }
           }
@@ -159,431 +159,603 @@ Page {
       }
     }
 
-    ColumnLayout {
-      id: projects
+    SwipeView {
+      id: projectsSwipeView
       Layout.fillWidth: true
       Layout.fillHeight: true
       Layout.margins: 10
       Layout.topMargin: 0
-      spacing: 2
       visible: connectionInformation.visible
+      clip: true
+      interactive: false
 
-      QfTabBar {
-        id: filterBar
-        model: [qsTr("My Projects"), qsTr("Community")]
-        Layout.fillWidth: true
-        Layout.preferredHeight: defaultHeight
-        delegate: TabButton {
-          text: modelData
-          height: filterBar.defaultHeight
-          width: projects.width / filterBar.count
-          font: Theme.defaultFont
-          onClicked: {
-            filterBar.currentIndex = index;
+      ColumnLayout {
+        id: projects
+        spacing: 2
+
+        QfTabBar {
+          id: filterBar
+          model: [qsTr("My Projects"), qsTr("Community")]
+          Layout.fillWidth: true
+          Layout.preferredHeight: defaultHeight
+          delegate: TabButton {
+            text: modelData
+            height: filterBar.defaultHeight
+            width: projects.width / filterBar.count
+            font: Theme.defaultFont
+            onClicked: {
+              filterBar.currentIndex = index;
+            }
           }
         }
-      }
 
-      QfSearchBar {
-        id: searchBar
-        Layout.fillWidth: true
-        Layout.preferredHeight: 41
-        placeHolderText: qsTr("Search for project")
-      }
+        QfSearchBar {
+          id: searchBar
+          Layout.fillWidth: true
+          Layout.preferredHeight: 41
+          placeHolderText: qsTr("Search for project")
+        }
 
-      Rectangle {
-        Layout.fillWidth: true
-        Layout.fillHeight: true
-        color: Theme.controlBackgroundColor
-        border.color: Theme.controlBorderColor
-        border.width: 1
+        Rectangle {
+          Layout.fillWidth: true
+          Layout.fillHeight: true
+          color: Theme.controlBackgroundColor
+          border.color: Theme.controlBorderColor
+          border.width: 1
 
-        ListView {
-          id: table
+          ListView {
+            id: table
 
-          property bool overshootRefresh: false
-          property bool refreshing: false
+            property bool overshootRefresh: false
+            property bool refreshing: false
 
-          model: QFieldCloudProjectsFilterModel {
-            projectsModel: cloudProjectsModel
-            filter: filterBar.currentIndex === 0 ? QFieldCloudProjectsFilterModel.PrivateProjects : QFieldCloudProjectsFilterModel.PublicProjects
-            showLocalOnly: cloudConnection.status !== QFieldCloudConnection.LoggedIn
-            textFilter: searchBar.searchTerm
-            showInValidProjects: settings ? settings.valueBool("/QField/showInvalidProjects", false) : false
-            onFilterChanged: {
-              if (cloudConnection.state === QFieldCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0) {
-                refreshProjectsList(filter === QFieldCloudProjectsFilterModel.PublicProjects);
-              }
-            }
-          }
-
-          ScrollBar.vertical: QfScrollBar {
-            verticalPadding: 15
-          }
-
-          anchors.fill: parent
-          anchors.margins: 1
-          section.property: "Owner"
-          section.labelPositioning: ViewSection.CurrentLabelAtStart | ViewSection.InlineLabels
-          section.delegate: Component {
-            Rectangle {
-              width: parent.width
-              height: 30
-              color: Theme.controlBorderColor
-
-              Text {
-                anchors {
-                  horizontalCenter: parent.horizontalCenter
-                  verticalCenter: parent.verticalCenter
+            model: QFieldCloudProjectsFilterModel {
+              projectsModel: cloudProjectsModel
+              filter: filterBar.currentIndex === 0 ? QFieldCloudProjectsFilterModel.PrivateProjects : QFieldCloudProjectsFilterModel.PublicProjects
+              showLocalOnly: cloudConnection.status !== QFieldCloudConnection.LoggedIn
+              showInValidProjects: settings ? settings.valueBool("/QField/showInvalidProjects", false) : false
+              textFilter: searchBar.searchTerm
+              onFilterChanged: {
+                if (cloudConnection.state === QFieldCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0) {
+                  refreshProjectsList(filter === QFieldCloudProjectsFilterModel.PublicProjects);
                 }
-                font.bold: true
-                font.pointSize: Theme.resultFont.pointSize
-                color: Theme.mainTextColor
-                text: section
               }
             }
-          }
-          clip: true
 
-          onMovingChanged: {
-            if (!moving && overshootRefresh && cloudConnection.state === QFieldCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0) {
-              refreshProjectsList(filterBar.currentIndex !== 0);
-            }
-            overshootRefresh = false;
-          }
-
-          onVerticalOvershootChanged: {
-            if (verticalOvershoot < -100 || verticalOvershoot > 100)
-              overshootRefresh = true;
-          }
-
-          delegate: Rectangle {
-            id: rectangle
-
-            property bool isPressed: false
-            property string projectId: Id
-            property string projectOwner: Owner
-            property string projectName: Name
-            property string projectLocalPath: LocalPath
-            property int status: Status
-
-            width: parent ? parent.width : undefined
-            height: line.height + 6
-            color: "transparent"
-
-            ProgressBar {
-              anchors.bottom: line.bottom
-              anchors.bottomMargin: -4
-              anchors.left: line.left
-              anchors.leftMargin: line.leftPadding
-              width: line.width - 20
-              height: 6
-              indeterminate: PackagingStatus !== QFieldCloudProject.PackagingFinishedStatus && DownloadProgress === 0.0
-              value: DownloadProgress
-              visible: Status === QFieldCloudProject.ProjectStatus.Downloading
-              z: 1
+            ScrollBar.vertical: QfScrollBar {
+              verticalPadding: 15
             }
 
-            Row {
-              id: line
-              Layout.fillWidth: true
-              leftPadding: 6
-              rightPadding: 10
-              topPadding: 4
-              bottomPadding: 8
-              spacing: 0
+            anchors.fill: parent
+            anchors.margins: 1
+            section.property: "Owner"
+            section.labelPositioning: ViewSection.CurrentLabelAtStart | ViewSection.InlineLabels
+            section.delegate: Component {
+              Rectangle {
+                width: parent.width
+                height: 30
+                color: Theme.controlBorderColor
 
-              Image {
-                id: type
-                anchors.verticalCenter: inner.verticalCenter
-                source: {
-                  if (cloudConnection.status !== QFieldCloudConnection.LoggedIn) {
-                    return Theme.getThemeVectorIcon('ic_cloud_project_offline_48dp');
-                  } else {
-                    var status = '';
-                    switch (Status) {
-                    case QFieldCloudProject.ProjectStatus.Downloading:
-                      return Theme.getThemeVectorIcon('ic_cloud_project_download_48dp');
-                    case QFieldCloudProject.ProjectStatus.Uploading:
-                      return Theme.getThemeVectorIcon('ic_cloud_project_upload_48dp');
-                    case QFieldCloudProject.ProjectStatus.Failing:
-                      return Theme.getThemeVectorIcon('ic_cloud_project_failed_48dp');
-                    default:
-                      break;
-                    }
-                    switch (Checkout) {
-                    case QFieldCloudProject.LocalCheckout:
-                      return Theme.getThemeVectorIcon('ic_cloud_project_localonly_48dp');
-                    case QFieldCloudProject.RemoteCheckout:
-                      return Theme.getThemeVectorIcon('ic_cloud_project_download_48dp');
-                    default:
-                      break;
-                    }
-                    return Theme.getThemeVectorIcon('ic_cloud_project_48dp');
+                Text {
+                  anchors {
+                    horizontalCenter: parent.horizontalCenter
+                    verticalCenter: parent.verticalCenter
                   }
+                  font.bold: true
+                  font.pointSize: Theme.resultFont.pointSize
+                  color: Theme.mainTextColor
+                  text: section
                 }
-                sourceSize.width: 80
-                sourceSize.height: 80
-                width: 40
-                height: 40
-                opacity: Status === QFieldCloudProject.ProjectStatus.Downloading ? 0.3 : 1
               }
-              ColumnLayout {
-                id: inner
-                width: rectangle.width - type.width - 10
-                Text {
-                  id: projectTitle
-                  topPadding: 5
-                  leftPadding: 3
-                  text: Name
-                  font.pointSize: Theme.tipFont.pointSize
-                  font.underline: true
-                  color: Theme.mainColor
-                  opacity: rectangle.isPressed ? 0.8 : 1
-                  wrapMode: Text.WordWrap
-                  Layout.fillWidth: true
-                }
-                Text {
-                  id: projectNote
-                  leftPadding: 3
-                  text: {
+            }
+            clip: true
+
+            onMovingChanged: {
+              if (!moving && overshootRefresh && cloudConnection.state === QFieldCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0) {
+                refreshProjectsList(filterBar.currentIndex !== 0);
+              }
+              overshootRefresh = false;
+            }
+
+            onVerticalOvershootChanged: {
+              if (verticalOvershoot < -100 || verticalOvershoot > 100)
+                overshootRefresh = true;
+            }
+
+            delegate: Rectangle {
+              id: rectangle
+
+              property bool isPressed: false
+              property string projectId: Id
+              property string projectOwner: Owner
+              property string projectName: Name
+              property string projectLocalPath: LocalPath
+              property int status: Status
+
+              width: parent ? parent.width : undefined
+              height: line.height + 6
+              color: "transparent"
+
+              ProgressBar {
+                anchors.bottom: line.bottom
+                anchors.bottomMargin: -4
+                anchors.left: line.left
+                anchors.leftMargin: line.leftPadding
+                width: line.width - 20
+                height: 6
+                indeterminate: PackagingStatus !== QFieldCloudProject.PackagingFinishedStatus && DownloadProgress === 0.0
+                value: DownloadProgress
+                visible: Status === QFieldCloudProject.ProjectStatus.Downloading
+                z: 1
+              }
+
+              Row {
+                id: line
+                Layout.fillWidth: true
+                leftPadding: 6
+                rightPadding: 10
+                topPadding: 4
+                bottomPadding: 8
+                spacing: 0
+
+                Image {
+                  id: type
+                  anchors.verticalCenter: inner.verticalCenter
+                  source: {
                     if (cloudConnection.status !== QFieldCloudConnection.LoggedIn) {
-                      return qsTr('(Available locally)');
+                      return Theme.getThemeVectorIcon('ic_cloud_project_offline_48dp');
                     } else {
                       var status = '';
-
-                      // TODO I think these should be shown as UI badges
                       switch (Status) {
-                      case QFieldCloudProject.Idle:
-                        break;
-                      case QFieldCloudProject.Downloading:
-                        if (PackagingStatus === QFieldCloudProject.PackagingBusyStatus) {
-                          status = qsTr('QFieldCloud is packaging the latest data just for you; this might take some time, please hold tight');
-                        } else {
-                          if (PackagingStatus === QFieldCloudProject.PackagingFinishedStatus || DownloadProgress > 0.0) {
-                            if (DownloadSize > 0) {
-                              status = qsTr('Downloading, %1% of %2 fetched').arg(Math.round(DownloadProgress * 100)).arg(FileUtils.representFileSize(DownloadSize));
-                            } else {
-                              status = qsTr('Downloading, %1% fetched').arg(Math.round(DownloadProgress * 100));
-                            }
-                          } else {
-                            status = qsTr('Reaching out to QFieldCloud to download project');
-                          }
-                        }
-                        break;
-                      case QFieldCloudProject.Uploading:
-                        status = qsTr('Uploading…');
-                        break;
+                      case QFieldCloudProject.ProjectStatus.Downloading:
+                        return Theme.getThemeVectorIcon('ic_cloud_project_download_48dp');
+                      case QFieldCloudProject.ProjectStatus.Uploading:
+                        return Theme.getThemeVectorIcon('ic_cloud_project_upload_48dp');
+                      case QFieldCloudProject.ProjectStatus.Failing:
+                        return Theme.getThemeVectorIcon('ic_cloud_project_failed_48dp');
                       default:
                         break;
                       }
-                      switch (ErrorStatus) {
-                      case QFieldCloudProject.NoErrorStatus:
-                        break;
-                      case QFieldCloudProject.DownloadErrorStatus:
-                        status = qsTr('Downloading error. ') + ErrorString;
-                        break;
-                      case QFieldCloudProject.UploadErrorStatus:
-                        status = qsTr('Uploading error. ') + ErrorString;
+                      switch (Checkout) {
+                      case QFieldCloudProject.LocalCheckout:
+                        return Theme.getThemeVectorIcon('ic_cloud_project_localonly_48dp');
+                      case QFieldCloudProject.RemoteCheckout:
+                        return Theme.getThemeVectorIcon('ic_cloud_project_download_48dp');
+                      default:
                         break;
                       }
-                      if (!status) {
-                        switch (Checkout) {
-                        case QFieldCloudProject.LocalCheckout:
-                          status = qsTr('Available locally, missing on the cloud');
+                      return Theme.getThemeVectorIcon('ic_cloud_project_48dp');
+                    }
+                  }
+                  sourceSize.width: 80
+                  sourceSize.height: 80
+                  width: 40
+                  height: 40
+                  opacity: Status === QFieldCloudProject.ProjectStatus.Downloading ? 0.3 : 1
+                }
+                ColumnLayout {
+                  id: inner
+                  width: rectangle.width - type.width - 10
+                  Text {
+                    id: projectTitle
+                    topPadding: 5
+                    leftPadding: 3
+                    text: Name
+                    font.pointSize: Theme.tipFont.pointSize
+                    font.underline: true
+                    color: Theme.mainColor
+                    opacity: rectangle.isPressed ? 0.8 : 1
+                    wrapMode: Text.WordWrap
+                    Layout.fillWidth: true
+                  }
+                  Text {
+                    id: projectNote
+                    leftPadding: 3
+                    text: {
+                      if (cloudConnection.status !== QFieldCloudConnection.LoggedIn) {
+                        return qsTr('(Available locally)');
+                      } else {
+                        var status = '';
+
+                        // TODO I think these should be shown as UI badges
+                        switch (Status) {
+                        case QFieldCloudProject.Idle:
                           break;
-                        case QFieldCloudProject.RemoteCheckout:
-                          status = qsTr('Available on the cloud, missing locally');
-                          break;
-                        case QFieldCloudProject.LocalAndRemoteCheckout:
-                          status = qsTr('Available locally');
-                          if (ProjectOutdated) {
-                            status += qsTr(', updated data available on the cloud');
+                        case QFieldCloudProject.Downloading:
+                          if (PackagingStatus === QFieldCloudProject.PackagingBusyStatus) {
+                            status = qsTr('QFieldCloud is packaging the latest data just for you; this might take some time, please hold tight');
+                          } else {
+                            if (PackagingStatus === QFieldCloudProject.PackagingFinishedStatus || DownloadProgress > 0.0) {
+                              if (DownloadSize > 0) {
+                                status = qsTr('Downloading, %1% of %2 fetched').arg(Math.round(DownloadProgress * 100)).arg(FileUtils.representFileSize(DownloadSize));
+                              } else {
+                                status = qsTr('Downloading, %1% fetched').arg(Math.round(DownloadProgress * 100));
+                              }
+                            } else {
+                              status = qsTr('Reaching out to QFieldCloud to download project');
+                            }
                           }
+                          break;
+                        case QFieldCloudProject.Uploading:
+                          status = qsTr('Uploading…');
                           break;
                         default:
                           break;
                         }
+                        switch (ErrorStatus) {
+                        case QFieldCloudProject.NoErrorStatus:
+                          break;
+                        case QFieldCloudProject.DownloadErrorStatus:
+                          status = qsTr('Downloading error. ') + ErrorString;
+                          break;
+                        case QFieldCloudProject.UploadErrorStatus:
+                          status = qsTr('Uploading error. ') + ErrorString;
+                          break;
+                        }
+                        if (!status) {
+                          switch (Checkout) {
+                          case QFieldCloudProject.LocalCheckout:
+                            status = qsTr('Available locally, missing on the cloud');
+                            break;
+                          case QFieldCloudProject.RemoteCheckout:
+                            status = qsTr('Available on the cloud, missing locally');
+                            break;
+                          case QFieldCloudProject.LocalAndRemoteCheckout:
+                            status = qsTr('Available locally');
+                            if (ProjectOutdated) {
+                              status += qsTr(', updated data available on the cloud');
+                            }
+                            break;
+                          default:
+                            break;
+                          }
+                        }
+                        var localChanges = (LocalDeltasCount > 0) ? qsTr('Has changes. ') : '';
+                        var str = '%1 (%2%3)'.arg(Description).arg(localChanges).arg(status);
+                        return str.trim();
                       }
-                      var localChanges = (LocalDeltasCount > 0) ? qsTr('Has changes. ') : '';
-                      var str = '%1 (%2%3)'.arg(Description).arg(localChanges).arg(status);
-                      return str.trim();
                     }
+                    visible: text != ""
+                    font.pointSize: Theme.tipFont.pointSize - 2
+                    font.italic: true
+                    color: Theme.secondaryTextColor
+                    wrapMode: Text.WordWrap
+                    Layout.fillWidth: true
                   }
-                  visible: text != ""
-                  font.pointSize: Theme.tipFont.pointSize - 2
-                  font.italic: true
-                  color: Theme.secondaryTextColor
-                  wrapMode: Text.WordWrap
-                  Layout.fillWidth: true
+                }
+              }
+            }
+
+            Label {
+              anchors.fill: parent
+              anchors.margins: 20
+              visible: parent.count == 0 && filterBar.currentIndex === 0
+              text: table.refreshing ? qsTr("Refreshing projects list") : qsTr("No cloud projects found. To get started, %1read the documentation%2.").arg("<a href=\"https://docs.qfield.org/get-started/tutorials/get-started-qfc/\">").arg("</a>")
+              font: Theme.defaultFont
+              wrapMode: Text.WordWrap
+              horizontalAlignment: Text.AlignHCenter
+              verticalAlignment: Text.AlignVCenter
+              onLinkActivated: link => Qt.openUrlExternally(link)
+            }
+
+            MouseArea {
+              property Item pressedItem
+              propagateComposedEvents: false
+              anchors.fill: parent
+              onClicked: mouse => {
+                var item = table.itemAt(table.contentX + mouse.x, table.contentY + mouse.y);
+                if (item) {
+                  if (item.projectLocalPath !== '') {
+                    qfieldCloudScreen.visible = false;
+                    iface.loadFile(item.projectLocalPath);
+                  } else {
+                    projectDetails.cloudProject = cloudProjectsModel.findProject(item.projectId);
+                    projectsSwipeView.currentIndex = 1;
+                  }
+                }
+              }
+              onPressed: mouse => {
+                var item = table.itemAt(table.contentX + mouse.x, table.contentY + mouse.y);
+                if (item) {
+                  pressedItem = item;
+                  pressedItem.isPressed = true;
+                }
+              }
+              onCanceled: {
+                if (pressedItem) {
+                  pressedItem.isPressed = false;
+                  pressedItem = null;
+                }
+              }
+              onReleased: {
+                if (pressedItem) {
+                  pressedItem.isPressed = false;
+                  pressedItem = null;
+                }
+              }
+
+              onPressAndHold: mouse => {
+                var item = table.itemAt(table.contentX + mouse.x, table.contentY + mouse.y);
+                if (item) {
+                  projectActions.projectId = item.projectId;
+                  projectActions.projectOwner = item.projectOwner;
+                  projectActions.projectName = item.projectName;
+                  projectActions.projectLocalPath = item.projectLocalPath;
+                  downloadProject.visible = item.projectLocalPath === '' && item.status !== QFieldCloudProject.ProjectStatus.Downloading;
+                  openProject.visible = item.projectLocalPath !== '';
+                  removeProject.visible = item.projectLocalPath !== '';
+                  cancelDownloadProject.visible = item.status === QFieldCloudProject.ProjectStatus.Downloading;
+                  projectActions.popup(mouse.x, mouse.y);
                 }
               }
             }
           }
+        }
 
-          Label {
-            anchors.fill: parent
-            anchors.margins: 20
-            visible: parent.count == 0 && filterBar.currentIndex === 0
-            text: table.refreshing ? qsTr("Refreshing projects list") : qsTr("No cloud projects found. To get started, %1read the documentation%2.").arg("<a href=\"https://docs.qfield.org/get-started/tutorials/get-started-qfc/\">").arg("</a>")
+        QfMenu {
+          id: projectActions
+
+          property string projectId: ''
+          property string projectOwner: ''
+          property string projectName: ''
+          property string projectLocalPath: ''
+
+          title: qsTr('Project Actions')
+
+          topMargin: mainWindow.sceneTopMargin
+          bottomMargin: mainWindow.sceneBottomMargin
+
+          MenuItem {
+            id: viewProjectDetails
+
             font: Theme.defaultFont
-            wrapMode: Text.WordWrap
-            horizontalAlignment: Text.AlignHCenter
-            verticalAlignment: Text.AlignVCenter
-            onLinkActivated: link => Qt.openUrlExternally(link)
+            width: parent.width
+            height: visible ? 48 : 0
+            leftPadding: Theme.menuItemLeftPadding
+
+            text: qsTr("View Project Details")
+            onTriggered: {
+              projectDetails.cloudProject = cloudProjectsModel.findProject(projectActions.projectId);
+              projectsSwipeView.currentIndex = 1;
+            }
           }
 
-          MouseArea {
-            property Item pressedItem
-            propagateComposedEvents: false
+          MenuSeparator {
+            width: parent.width
+          }
+
+          MenuItem {
+            id: downloadProject
+
+            font: Theme.defaultFont
+            width: parent.width
+            height: visible ? 48 : 0
+            leftPadding: Theme.menuItemLeftPadding
+
+            text: qsTr("Download Project")
+            onTriggered: {
+              cloudProjectsModel.projectPackageAndDownload(projectActions.projectId);
+            }
+          }
+
+          MenuItem {
+            id: openProject
+
+            font: Theme.defaultFont
+            width: parent.width
+            height: visible ? 48 : 0
+            leftPadding: Theme.menuItemLeftPadding
+
+            text: qsTr("Open Project")
+            onTriggered: {
+              if (projectActions.projectLocalPath != '') {
+                qfieldCloudScreen.visible = false;
+                iface.loadFile(projectActions.projectLocalPath);
+              }
+            }
+          }
+
+          MenuItem {
+            id: removeProject
+
+            font: Theme.defaultFont
+            width: parent.width
+            height: visible ? 48 : 0
+            leftPadding: Theme.menuItemLeftPadding
+
+            text: qsTr("Remove Stored Project")
+            onTriggered: {
+              cloudProjectsModel.removeLocalProject(projectActions.projectId);
+              iface.removeRecentProject(projectActions.projectLocalPath);
+              welcomeScreen.model.reloadModel();
+              if (projectActions.projectLocalPath === qgisProject.fileName) {
+                iface.clearProject();
+              }
+            }
+          }
+
+          MenuItem {
+            id: cancelDownloadProject
+            font: Theme.defaultFont
+            width: parent.width
+            height: visible ? 48 : 0
+            leftPadding: Theme.menuItemLeftPadding
+            text: qsTr("Cancel Project Download")
+            onTriggered: {
+              cloudProjectsModel.projectCancelDownload(projectActions.projectId);
+            }
+          }
+        }
+
+        Text {
+          id: projectsTips
+          Layout.alignment: Qt.AlignLeft
+          Layout.fillWidth: true
+          Layout.topMargin: 5
+          Layout.bottomMargin: 5
+          text: qsTr("Press and hold over a cloud project for a menu of additional actions.")
+          font: Theme.tipFont
+          color: Theme.secondaryTextColor
+          wrapMode: Text.WordWrap
+        }
+
+        QfButton {
+          id: refreshProjectsListBtn
+          Layout.fillWidth: true
+          Layout.bottomMargin: mainWindow.sceneBottomMargin
+          text: qsTr("Refresh projects list")
+          enabled: cloudConnection.status === QFieldCloudConnection.LoggedIn && cloudConnection.state === QFieldCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0
+          onClicked: {
+            refreshProjectsList(filterBar.currentIndex !== 0);
+          }
+        }
+      }
+
+      ColumnLayout {
+        id: projectDetails
+        spacing: 10
+
+        property var cloudProject: undefined
+
+        ScrollView {
+          Layout.fillWidth: true
+          Layout.fillHeight: true
+
+          ColumnLayout {
             anchors.fill: parent
-            onClicked: mouse => {
-              var item = table.itemAt(table.contentX + mouse.x, table.contentY + mouse.y);
-              if (item) {
-                if (item.projectLocalPath !== '') {
-                  qfieldCloudScreen.visible = false;
-                  iface.loadFile(item.projectLocalPath);
-                } else {
-                  // fetch remote project
-                  displayToast(qsTr("Downloading project %1").arg(item.projectName));
-                  cloudProjectsModel.projectPackageAndDownload(item.projectId);
+            spacing: 10
+
+            RowLayout {
+              spacing: 5
+
+              Image {
+                id: projectDetailsThumbnail
+                fillMode: Image.PreserveAspectFit
+                smooth: true
+                source: projectDetails.cloudProject != undefined ? cloudConnection.url + "/api/v1/files/thumbnails/" + projectDetails.cloudProject.id + "/" : ""
+                width: 48
+                height: 48
+                sourceSize.width: width * screen.devicePixelRatio
+                sourceSize.height: height * screen.devicePixelRatio
+                layer.enabled: true
+                layer.effect: QfOpacityMask {
+                  maskSource: cloudAvatarMask
+                }
+
+                onStatusChanged: {
+                  // In case the avatar URL fails to load or the image is corrupted, revert to our lovely Nyuki
+                  if (status == Image.Error) {
+                    source = 'qrc:/images/qfieldcloud_logo.svg';
+                  }
                 }
               }
-            }
-            onPressed: mouse => {
-              var item = table.itemAt(table.contentX + mouse.x, table.contentY + mouse.y);
-              if (item) {
-                pressedItem = item;
-                pressedItem.isPressed = true;
-              }
-            }
-            onCanceled: {
-              if (pressedItem) {
-                pressedItem.isPressed = false;
-                pressedItem = null;
-              }
-            }
-            onReleased: {
-              if (pressedItem) {
-                pressedItem.isPressed = false;
-                pressedItem = null;
+
+              Text {
+                id: projectDetailsName
+                Layout.fillWidth: true
+                font: Theme.titleFont
+                color: Theme.mainTextColor
+
+                text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.name : ""
               }
             }
 
-            onPressAndHold: mouse => {
-              var item = table.itemAt(table.contentX + mouse.x, table.contentY + mouse.y);
-              if (item) {
-                projectActions.projectId = item.projectId;
-                projectActions.projectOwner = item.projectOwner;
-                projectActions.projectName = item.projectName;
-                projectActions.projectLocalPath = item.projectLocalPath;
-                downloadProject.visible = item.projectLocalPath === '' && item.status !== QFieldCloudProject.ProjectStatus.Downloading;
-                openProject.visible = item.projectLocalPath !== '';
-                removeProject.visible = item.projectLocalPath !== '';
-                cancelDownloadProject.visible = item.status === QFieldCloudProject.ProjectStatus.Downloading;
-                projectActions.popup(mouse.x, mouse.y);
-              }
+            Text {
+              id: projectDetailsDescriptionLabel
+              Layout.fillWidth: true
+              font: Theme.strongFont
+              color: Theme.mainTextColor
+
+              text: qsTr("Description")
+            }
+
+            Text {
+              id: projectDetailsDescription
+              Layout.fillWidth: true
+              font: Theme.defaultFont
+              color: Theme.secondaryTextColor
+
+              text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.description : ""
+            }
+
+            Text {
+              id: projectDetailsOwnerLabel
+              Layout.fillWidth: true
+              font: Theme.strongFont
+              color: Theme.mainTextColor
+
+              text: qsTr("Owner")
+            }
+
+            Text {
+              id: projectDetailsOwner
+              Layout.fillWidth: true
+              font: Theme.defaultFont
+              color: Theme.secondaryTextColor
+
+              text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.owner : ""
+            }
+
+            Text {
+              id: projectDetailsCreationDateLabel
+              Layout.fillWidth: true
+              font: Theme.strongFont
+              color: Theme.mainTextColor
+
+              text: qsTr("Creation date")
+            }
+
+            Text {
+              id: projectDetailsCreationDate
+              Layout.fillWidth: true
+              font: Theme.defaultFont
+              color: Theme.secondaryTextColor
+
+              //text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject. : ""
             }
           }
         }
-      }
 
-      QfMenu {
-        id: projectActions
+        QfButton {
+          id: downloadProjectBtn
+          Layout.fillWidth: true
+          text: qsTr("Download project")
+          visible: projectDetails.cloudProject != undefined && projectDetails.cloudProject.localPath === ""
+          enabled: projectDetails.cloudProject != undefined && projectDetails.cloudProject.status !== QFieldCloudProject.ProjectStatus.Downloading
 
-        property string projectId: ''
-        property string projectOwner: ''
-        property string projectName: ''
-        property string projectLocalPath: ''
-
-        title: qsTr('Project Actions')
-
-        topMargin: mainWindow.sceneTopMargin
-        bottomMargin: mainWindow.sceneBottomMargin
-
-        MenuItem {
-          id: downloadProject
-
-          font: Theme.defaultFont
-          width: parent.width
-          height: visible ? 48 : 0
-          leftPadding: Theme.menuItemLeftPadding
-
-          text: qsTr("Download Project")
-          onTriggered: {
-            cloudProjectsModel.projectPackageAndDownload(projectActions.projectId);
+          onClicked: {
+            if (projectDetails.cloudProject != undefined) {
+              displayToast(qsTr("Downloading project %1").arg(projectDetails.cloudProject.name));
+              cloudProjectsModel.projectPackageAndDownload(projectDetails.cloudProject.id);
+            }
           }
         }
 
-        MenuItem {
-          id: openProject
+        QfButton {
+          id: openProjectBtn
+          Layout.fillWidth: true
+          text: qsTr("Open project")
+          visible: projectDetails.cloudProject != undefined && projectDetails.cloudProject.localPath !== ""
 
-          font: Theme.defaultFont
-          width: parent.width
-          height: visible ? 48 : 0
-          leftPadding: Theme.menuItemLeftPadding
-
-          text: qsTr("Open Project")
-          onTriggered: {
-            if (projectActions.projectLocalPath != '') {
+          onClicked: {
+            if (projectDetails.cloudProject != undefined) {
               qfieldCloudScreen.visible = false;
-              iface.loadFile(projectActions.projectLocalPath);
+              iface.loadFile(projectDetails.cloudProject.localPath);
             }
+            projectsSwipeView.currentIndex = 0;
+            projectDetails.cloudProject = undefined;
           }
         }
 
-        MenuItem {
-          id: removeProject
-
-          font: Theme.defaultFont
-          width: parent.width
-          height: visible ? 48 : 0
-          leftPadding: Theme.menuItemLeftPadding
-
-          text: qsTr("Remove Stored Project")
-          onTriggered: {
-            cloudProjectsModel.removeLocalProject(projectActions.projectId);
-            iface.removeRecentProject(projectActions.projectLocalPath);
-            welcomeScreen.model.reloadModel();
-            if (projectActions.projectLocalPath === qgisProject.fileName) {
-              iface.clearProject();
-            }
+        QfButton {
+          id: returnToProjectsListBtn
+          Layout.fillWidth: true
+          Layout.bottomMargin: mainWindow.sceneBottomMargin
+          text: qsTr("Return to projects list")
+          onClicked: {
+            projectsSwipeView.currentIndex = 0;
+            projectDetails.cloudProject = undefined;
           }
-        }
-
-        MenuItem {
-          id: cancelDownloadProject
-          font: Theme.defaultFont
-          width: parent.width
-          height: visible ? 48 : 0
-          leftPadding: Theme.menuItemLeftPadding
-          text: qsTr("Cancel Project Download")
-          onTriggered: {
-            cloudProjectsModel.projectCancelDownload(projectActions.projectId);
-          }
-        }
-      }
-
-      Text {
-        id: projectsTips
-        Layout.alignment: Qt.AlignLeft
-        Layout.fillWidth: true
-        Layout.topMargin: 5
-        Layout.bottomMargin: 5
-        text: qsTr("Press and hold over a cloud project for a menu of additional actions.")
-        font: Theme.tipFont
-        color: Theme.secondaryTextColor
-        wrapMode: Text.WordWrap
-      }
-
-      QfButton {
-        id: refreshProjectsListBtn
-        Layout.fillWidth: true
-        Layout.bottomMargin: mainWindow.sceneBottomMargin
-        text: qsTr("Refresh projects list")
-        enabled: cloudConnection.status === QFieldCloudConnection.LoggedIn && cloudConnection.state === QFieldCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0
-        onClicked: {
-          refreshProjectsList(filterBar.currentIndex !== 0);
         }
       }
     }
@@ -637,10 +809,20 @@ Page {
         prepareCloudLogin();
       } else if (cloudConnection.status === QFieldCloudConnection.Disconnected) {
         if (table.count === 0) {
-          projects.visible = false;
+          projectsSwipeView.visible = false;
           connectionSettings.visible = true;
         }
       }
+    }
+  }
+
+  Connections {
+    target: cloudProjectsModel
+
+    function onProjectAppended(projectId) {
+      projectDetails.cloudProject = cloudProjectsModel.findProject(projectId);
+      console.log(projectDetails.cloudProject);
+      projectsSwipeView.currentIndex = 1;
     }
   }
 
@@ -658,15 +840,15 @@ Page {
       if (cloudConnection.status == QFieldCloudConnection.Disconnected) {
         if (cloudConnection.hasToken || cloudConnection.hasProviderConfiguration) {
           cloudConnection.login();
-          projects.visible = true;
+          projectsSwipeView.visible = true;
           connectionSettings.visible = false;
         } else {
-          projects.visible = false;
+          projectsSwipeView.visible = false;
           connectionSettings.visible = true;
         }
         cloudConnection.getAuthenticationProviders();
       } else {
-        projects.visible = true;
+        projectsSwipeView.visible = true;
         connectionSettings.visible = false;
       }
     }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -633,162 +633,169 @@ Page {
           }
         }
 
-        ScrollView {
+        ColumnLayout {
+          id: projectDetailsLayout
           Layout.fillWidth: true
           Layout.fillHeight: true
-          contentWidth: width
-          contentHeight: projectDetailsLayout.height
-          ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
-          ScrollBar.vertical: QfScrollBar {
-          }
+          spacing: 10
 
-          ColumnLayout {
-            id: projectDetailsLayout
-            width: parent.width - 10
+          RowLayout {
+            Layout.fillWidth: true
             spacing: 10
 
-            RowLayout {
-              Layout.fillWidth: true
-              spacing: 10
+            Rectangle {
+              id: projectDetailsThumbnailRect
+              width: 48
+              height: 48
+              border.color: Theme.mainBackgroundColor
+              border.width: 1
+              radius: width / 2
+              clip: true
 
-              Rectangle {
-                id: projectDetailsThumbnailRect
+              Image {
+                id: projectDetailsThumbnail
+                anchors.fill: parent
+                anchors.margins: 1
+                fillMode: Image.PreserveAspectFit
+                smooth: true
+                source: projectDetails.cloudProject != undefined && projectDetails.cloudProject.thumbnailPath !== "" ? 'file://' + projectDetails.cloudProject.thumbnailPath : ""
+                visible: source !== "" && status === Image.Ready
                 width: 48
                 height: 48
-                border.color: Theme.mainBackgroundColor
-                border.width: 1
-                radius: width / 2
-                clip: true
+                sourceSize.width: width * screen.devicePixelRatio
+                sourceSize.height: height * screen.devicePixelRatio
+                layer.enabled: true
+                layer.effect: QfOpacityMask {
+                  maskSource: roundMask
+                }
+              }
+            }
 
-                Image {
-                  id: projectDetailsThumbnail
-                  anchors.fill: parent
-                  anchors.margins: 1
-                  fillMode: Image.PreserveAspectFit
-                  smooth: true
-                  source: projectDetails.cloudProject != undefined && projectDetails.cloudProject.thumbnailPath !== "" ? 'file://' + projectDetails.cloudProject.thumbnailPath : ""
-                  visible: source !== "" && status === Image.Ready
-                  width: 48
-                  height: 48
-                  sourceSize.width: width * screen.devicePixelRatio
-                  sourceSize.height: height * screen.devicePixelRatio
-                  layer.enabled: true
-                  layer.effect: QfOpacityMask {
-                    maskSource: roundMask
+            Text {
+              id: projectDetailsName
+              Layout.fillWidth: true
+              font.pointSize: Theme.titleFont.pointSize * 1.25
+              font.bold: true
+              color: Theme.mainTextColor
+              wrapMode: Text.Wrap
+
+              text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.name : ""
+            }
+          }
+
+          ScrollView {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            contentWidth: width
+            contentHeight: projectDetailsBodyLayout.height
+            ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+            ScrollBar.vertical: QfScrollBar {
+            }
+
+            ColumnLayout {
+              id: projectDetailsBodyLayout
+              width: parent.width - 10
+              spacing: 10
+
+              ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 5
+
+                Text {
+                  id: projectDetailsDescriptionLabel
+                  Layout.fillWidth: true
+                  font: Theme.strongFont
+                  color: Theme.mainTextColor
+
+                  text: qsTr("Description")
+                }
+
+                Text {
+                  id: projectDetailsDescription
+                  Layout.fillWidth: true
+                  font: Theme.defaultFont
+                  color: Theme.secondaryTextColor
+                  wrapMode: Text.WordWrap
+                  textFormat: Text.MarkdownText
+
+                  text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.description.trim() : ""
+
+                  onLinkActivated: link => {
+                    Qt.openUrlExternally(link);
                   }
                 }
               }
 
-              Text {
-                id: projectDetailsName
+              ColumnLayout {
                 Layout.fillWidth: true
-                font.pointSize: Theme.titleFont.pointSize * 1.25
-                font.bold: true
-                color: Theme.mainTextColor
-                wrapMode: Text.Wrap
+                spacing: 5
 
-                text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.name : ""
-              }
-            }
+                Text {
+                  id: projectDetailsOwnerLabel
+                  Layout.fillWidth: true
+                  font: Theme.strongFont
+                  color: Theme.mainTextColor
 
-            ColumnLayout {
-              Layout.fillWidth: true
-              spacing: 5
+                  text: qsTr("Owner")
+                }
 
-              Text {
-                id: projectDetailsDescriptionLabel
-                Layout.fillWidth: true
-                font: Theme.strongFont
-                color: Theme.mainTextColor
+                Text {
+                  id: projectDetailsOwner
+                  Layout.fillWidth: true
+                  font: Theme.defaultFont
+                  color: Theme.secondaryTextColor
+                  wrapMode: Text.WordWrap
 
-                text: qsTr("Description")
-              }
-
-              Text {
-                id: projectDetailsDescription
-                Layout.fillWidth: true
-                font: Theme.defaultFont
-                color: Theme.secondaryTextColor
-                wrapMode: Text.WordWrap
-                textFormat: Text.MarkdownText
-
-                text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.description.trim() : ""
-
-                onLinkActivated: link => {
-                  Qt.openUrlExternally(link);
+                  text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.owner : ""
                 }
               }
-            }
 
-            ColumnLayout {
-              Layout.fillWidth: true
-              spacing: 5
-
-              Text {
-                id: projectDetailsOwnerLabel
+              ColumnLayout {
                 Layout.fillWidth: true
-                font: Theme.strongFont
-                color: Theme.mainTextColor
+                spacing: 5
 
-                text: qsTr("Owner")
+                Text {
+                  id: projectDetailsCreationDateLabel
+                  Layout.fillWidth: true
+                  font: Theme.strongFont
+                  color: Theme.mainTextColor
+
+                  text: qsTr("Creation date")
+                }
+
+                Text {
+                  id: projectDetailsCreationDate
+                  Layout.fillWidth: true
+                  font: Theme.defaultFont
+                  color: Theme.secondaryTextColor
+                  wrapMode: Text.WordWrap
+
+                  text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.createdAt : ""
+                }
               }
 
-              Text {
-                id: projectDetailsOwner
+              ColumnLayout {
                 Layout.fillWidth: true
-                font: Theme.defaultFont
-                color: Theme.secondaryTextColor
-                wrapMode: Text.WordWrap
+                spacing: 5
 
-                text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.owner : ""
-              }
-            }
+                Text {
+                  id: projectDetailsUpdateDateLabel
+                  Layout.fillWidth: true
+                  font: Theme.strongFont
+                  color: Theme.mainTextColor
 
-            ColumnLayout {
-              Layout.fillWidth: true
-              spacing: 5
+                  text: qsTr("Latest update date")
+                }
 
-              Text {
-                id: projectDetailsCreationDateLabel
-                Layout.fillWidth: true
-                font: Theme.strongFont
-                color: Theme.mainTextColor
+                Text {
+                  id: projectDetailsUpdateDate
+                  Layout.fillWidth: true
+                  font: Theme.defaultFont
+                  color: Theme.secondaryTextColor
+                  wrapMode: Text.WordWrap
 
-                text: qsTr("Creation date")
-              }
-
-              Text {
-                id: projectDetailsCreationDate
-                Layout.fillWidth: true
-                font: Theme.defaultFont
-                color: Theme.secondaryTextColor
-                wrapMode: Text.WordWrap
-
-                text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.createdAt : ""
-              }
-            }
-
-            ColumnLayout {
-              Layout.fillWidth: true
-              spacing: 5
-
-              Text {
-                id: projectDetailsUpdateDateLabel
-                Layout.fillWidth: true
-                font: Theme.strongFont
-                color: Theme.mainTextColor
-
-                text: qsTr("Latest update date")
-              }
-
-              Text {
-                id: projectDetailsUpdateDate
-                Layout.fillWidth: true
-                font: Theme.defaultFont
-                color: Theme.secondaryTextColor
-                wrapMode: Text.WordWrap
-
-                text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.updatedAt : ""
+                  text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.updatedAt : ""
+                }
               }
             }
           }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -633,6 +633,7 @@ Page {
                 fillMode: Image.PreserveAspectFit
                 smooth: true
                 source: projectDetails.cloudProject != undefined ? cloudConnection.url + "/api/v1/files/thumbnails/" + projectDetails.cloudProject.id + "/" : ""
+                visible: source !== "" && status === Image.Ready
                 width: 48
                 height: 48
                 sourceSize.width: width * screen.devicePixelRatio
@@ -641,19 +642,13 @@ Page {
                 layer.effect: QfOpacityMask {
                   maskSource: cloudAvatarMask
                 }
-
-                onStatusChanged: {
-                  // In case the avatar URL fails to load or the image is corrupted, revert to our lovely Nyuki
-                  if (status == Image.Error) {
-                    source = 'qrc:/images/qfieldcloud_logo.svg';
-                  }
-                }
               }
 
               Text {
                 id: projectDetailsName
                 Layout.fillWidth: true
-                font: Theme.titleFont
+                font.pointSize: Theme.titleFont.pointSize * 1.25
+                font.bold: true
                 color: Theme.mainTextColor
 
                 text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.name : ""
@@ -711,7 +706,25 @@ Page {
               font: Theme.defaultFont
               color: Theme.secondaryTextColor
 
-              //text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject. : ""
+              text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.createdAt : ""
+            }
+
+            Text {
+              id: projectDetailsUpdateDateLabel
+              Layout.fillWidth: true
+              font: Theme.strongFont
+              color: Theme.mainTextColor
+
+              text: qsTr("Latest update date")
+            }
+
+            Text {
+              id: projectDetailsUpdateDate
+              Layout.fillWidth: true
+              font: Theme.defaultFont
+              color: Theme.secondaryTextColor
+
+              text: projectDetails.cloudProject != undefined ? projectDetails.cloudProject.updatedAt : ""
             }
           }
         }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -45,8 +45,7 @@ Page {
 
   ColumnLayout {
     anchors.fill: parent
-    Layout.fillWidth: true
-    Layout.fillHeight: true
+    anchors.bottomMargin: mainWindow.sceneBottomMargin
     spacing: 2
 
     RowLayout {
@@ -534,7 +533,6 @@ Page {
         RowLayout {
           Layout.fillWidth: true
           Layout.topMargin: 5
-          Layout.bottomMargin: mainWindow.sceneBottomMargin
 
           QfButton {
             id: refreshProjectsListBtn

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -759,7 +759,20 @@ Page {
         QfButton {
           id: downloadProjectBtn
           Layout.fillWidth: true
-          text: qsTr("Download project")
+          text: {
+            if (projectDetails.cloudProject != undefined && projectDetails.cloudProject.status === QFieldCloudProject.ProjectStatus.Downloading) {
+              if (projectDetails.cloudProject.packagingStatus === QFieldCloudProject.PackagingBusyStatus) {
+                return qsTr("QFieldCloud is packaging project, hold tight");
+              } else {
+                if (projectDetails.cloudProject.downloadProgress > 0) {
+                  return qsTr("Downloading project") + " (%1%)".arg(Math.round(projectDetails.cloudProject.downloadProgress * 100));
+                } else {
+                  return qsTr("Downloading project");
+                }
+              }
+            }
+            return qsTr("Download project");
+          }
           visible: projectDetails.cloudProject != undefined && projectDetails.cloudProject.localPath === ""
           enabled: projectDetails.cloudProject != undefined && projectDetails.cloudProject.status !== QFieldCloudProject.ProjectStatus.Downloading
 
@@ -877,7 +890,7 @@ Page {
 
   function prepareCloudLogin() {
     if (visible) {
-      projectsSwipeView.currentIndex = 1;
+      projectsSwipeView.currentIndex = 0;
       if (cloudConnection.status == QFieldCloudConnection.Disconnected) {
         if (cloudConnection.hasToken || cloudConnection.hasProviderConfiguration) {
           cloudConnection.login();

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -763,7 +763,9 @@ Page {
 
                     sourceSize.width: projectDetailsCodeContainer.desiredWidth * Screen.devicePixelRatio
                     sourceSize.height: projectDetailsCodeContainer.desiredWidth * Screen.devicePixelRatio
-                    source: projectDetails.cloudProject != undefined ? "image://barcode/?text=qfieldcloud?project=" + projectDetails.cloudProject.id + "&color=%2380cc28" : ""
+                    source: projectDetails.cloudProject != undefined ? "image://barcode/?text=" + encodeURIComponent(UrlUtils.createActionUrl("qfield", "cloud", {
+                          "project": projectDetails.cloudProject.id
+                        })) + "&color=%2380cc28" : ""
                   }
                 }
 
@@ -968,10 +970,12 @@ Page {
     enabled: false
 
     function onDecoded(string) {
-      const results = string.match(/qfieldcloud\?project\=([^&]+)/);
-      if (results) {
+      const results = UrlUtils.getActionDetails(string);
+      console.log(string);
+      console.log(results.type);
+      if (results.type !== undefined && results.type === "cloud" && results.project !== undefined && results.project !== "") {
         codeReader.close();
-        cloudProjectsModel.appendProject(results[1]);
+        cloudProjectsModel.appendProject(results.project);
       }
     }
 

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -877,6 +877,7 @@ Page {
 
   function prepareCloudLogin() {
     if (visible) {
+      projectsSwipeView.currentIndex = 1;
       if (cloudConnection.status == QFieldCloudConnection.Disconnected) {
         if (cloudConnection.hasToken || cloudConnection.hasProviderConfiguration) {
           cloudConnection.login();

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3615,10 +3615,15 @@ ApplicationWindow {
 
     function onExecuteAction(action) {
       const details = UrlUtils.getActionDetails(action);
-      if (details.type === "local") {
-        if (details.import !== undefined) {
-          importPermissionDialog.url = details.import;
-          importPermissionDialog.open();
+      if (details.type === "local" && details.import !== undefined && details.import !== "") {
+        importPermissionDialog.url = details.import;
+        importPermissionDialog.open();
+      } else if (details.type === "cloud" && details.project !== undefined && details.project !== "") {
+        qfieldCloudScreen.requestedProjectDetails = details.project;
+        if (!qfieldCloudScreen.visible) {
+          qfieldCloudScreen.visible = true;
+        } else {
+          qfieldCloudScreen.prepareCloudLogin();
         }
       }
     }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3614,7 +3614,7 @@ ApplicationWindow {
     target: iface
 
     function onExecuteAction(action) {
-      const details = iface.getActionDetails(action);
+      const details = UrlUtils.getActionDetails(action);
       if (details.type === "local") {
         if (details.import !== undefined) {
           importPermissionDialog.url = details.import;

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3597,9 +3597,7 @@ ApplicationWindow {
   }
 
   function displayToast(message, type, action_text, action_function) {
-    //toastMessage.text = message
-    if (!welcomeScreen.visible)
-      toast.show(message, type, action_text, action_function);
+    toast.show(message, type, action_text, action_function);
   }
 
   Timer {
@@ -3623,7 +3621,7 @@ ApplicationWindow {
         if (!qfieldCloudScreen.visible) {
           qfieldCloudScreen.visible = true;
         } else {
-          qfieldCloudScreen.prepareCloudLogin();
+          qfieldCloudScreen.prepareCloudScreen();
         }
       }
     }

--- a/test/test_appinterface.cpp
+++ b/test/test_appinterface.cpp
@@ -22,23 +22,4 @@
 TEST_CASE( "AppInterface" )
 {
   AppInterface iface( nullptr );
-
-  SECTION( "getActionDetails" )
-  {
-    QVariantMap details = iface.getActionDetails( "https://qfield.org/action/local?import=https://my.website.com/project.zip" );
-    REQUIRE( details["type"] == QStringLiteral( "local" ) );
-    REQUIRE( details["import"] == QStringLiteral( "https://my.website.com/project.zip" ) );
-
-    details = iface.getActionDetails( "https://qfield.org/action/local?import=https%3A%2F%2Fmy.website.com%2Fproject.zip" );
-    REQUIRE( details["type"] == QStringLiteral( "local" ) );
-    REQUIRE( details["import"] == QStringLiteral( "https://my.website.com/project.zip" ) );
-
-    details = iface.getActionDetails( "qfield://local?import=https://my.website.com/project.zip" );
-    REQUIRE( details["type"] == QStringLiteral( "local" ) );
-    REQUIRE( details["import"] == QStringLiteral( "https://my.website.com/project.zip" ) );
-
-    details = iface.getActionDetails( "qfield://local?import=https%3A%2F%2Fmy.website.com%2Fproject.zip" );
-    REQUIRE( details["type"] == QStringLiteral( "local" ) );
-    REQUIRE( details["import"] == QStringLiteral( "https://my.website.com/project.zip" ) );
-  }
 }

--- a/test/test_urlutils.cpp
+++ b/test/test_urlutils.cpp
@@ -62,4 +62,41 @@ TEST_CASE( "UrlUtils" )
     REQUIRE( UrlUtils::urlDetail( url, "filename" ) == QStringLiteral( "project.zip" ) );
     REQUIRE( UrlUtils::urlDetail( url, "query" ) == QStringLiteral( "date=now&check=1" ) );
   }
+
+  SECTION( "getActionDetails" )
+  {
+    QVariantMap details = UrlUtils::getActionDetails( "https://qfield.org/action/local?import=https://my.website.com/project.zip" );
+    REQUIRE( details["type"] == QStringLiteral( "local" ) );
+    REQUIRE( details["import"] == QStringLiteral( "https://my.website.com/project.zip" ) );
+
+    details = UrlUtils::getActionDetails( "https://qfield.org/action/local?import=https%3A%2F%2Fmy.website.com%2Fproject.zip" );
+    REQUIRE( details["type"] == QStringLiteral( "local" ) );
+    REQUIRE( details["import"] == QStringLiteral( "https://my.website.com/project.zip" ) );
+
+    details = UrlUtils::getActionDetails( "qfield://local?import=https://my.website.com/project.zip" );
+    REQUIRE( details["type"] == QStringLiteral( "local" ) );
+    REQUIRE( details["import"] == QStringLiteral( "https://my.website.com/project.zip" ) );
+
+    details = UrlUtils::getActionDetails( "qfield://local?import=https%3A%2F%2Fmy.website.com%2Fproject.zip" );
+    REQUIRE( details["type"] == QStringLiteral( "local" ) );
+    REQUIRE( details["import"] == QStringLiteral( "https://my.website.com/project.zip" ) );
+  }
+
+  SECTION( "createActionUrl" )
+  {
+    QVariantMap details;
+    details["project"] = QStringLiteral( "123-456-789" );
+
+    QString url = UrlUtils::createActionUrl( "qfield", "cloud", details );
+    REQUIRE( url == QStringLiteral( "qfield://cloud?project=123-456-789" ) );
+    url = UrlUtils::createActionUrl( "https", "cloud", details );
+    REQUIRE( url == QStringLiteral( "https://qfield.org/action/cloud?project=123-456-789" ) );
+
+    details.clear();
+    details["import"] = QStringLiteral( "https://my.website.com/folder/project.zip?param=1" );
+    url = UrlUtils::createActionUrl( "qfield", "local", details );
+    REQUIRE( url == QStringLiteral( "qfield://local?import=https://my.website.com/folder/project.zip?param%3D1" ) );
+    url = UrlUtils::createActionUrl( "https", "local", details );
+    REQUIRE( url == QStringLiteral( "https://qfield.org/action/local?import=https://my.website.com/folder/project.zip?param%3D1" ) );
+  }
 }


### PR DESCRIPTION
Now that we have refactored the QFieldCloud-related classes, it's time to leverage the new possibilities it opened up. This PR implements a QFieldCloud project details view, which looks like this:

![image](https://github.com/user-attachments/assets/e7774760-a23b-40af-9aa6-be258b659fa4)

This does a couple of things really well which we were not doing before now:
- Project descriptions have gained relevance and usefulness by moving the project description away from the projects list into the project detail view. We can now write long descriptions without making the projects list look super odd, and the descriptions support markdown syntax which means hyperlinks to additional context et al.
- Project thumbnails are really nice, and the project details view embrace them.
- Project creation date and updated date details were missing altogether, they are there now.

As for UX, when the cloud project isn't downloaded yet, QField now opens the detailed view. If a cloud project is already available locally, we open the project directly. A long press on a cloud projects list item allows us to reach out to the project details view at all times.

Here's how much nicer it is to download a project now:

https://github.com/user-attachments/assets/e816a04c-e334-48fe-aa37-0893c548855b

This PR hides one more commit I have locally which is so nice it deserves a separate PR and a bit of suspense :wink: 