### PR TITLE
Fix CI builds on release-3_5 branch

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -227,7 +227,7 @@ jobs:
 
   deploy_to_playstore:
     name: deploy to play store
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build
     if: ${{ ( github.event_name == 'release' || ( github.event_name == 'push' && github.ref == 'refs/heads/master' ) ) }}
     steps:
@@ -272,7 +272,7 @@ jobs:
 
   comment_pr:
     name: comment (pr)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build
     if: ${{ github.event_name == 'pull_request' }}
     steps:
@@ -307,7 +307,7 @@ jobs:
 
   comment_commit:
     name: comment (commit)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build
     if: ${{ github.event_name == 'push' }}
     steps:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -180,9 +180,6 @@ jobs:
         run: |
           echo "$SIGNINGKEY" | base64 --decode > ./keystore.p12
 
-      - name: Cache .gradle
-        uses: burrunan/gradle-cache-action@v2
-
       - name: Package
         env:
           KEYNAME: qfield

--- a/.github/workflows/code_layout.yml
+++ b/.github/workflows/code_layout.yml
@@ -36,7 +36,7 @@ jobs:
 
   cppcheck-1_9:
     name: cpp check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           xvfb-run cmake --build build --config ${{ env.BUILD_TYPE }}
 
-      - uses: ZedThree/clang-tidy-review@v0.20.1
+      - uses: ZedThree/clang-tidy-review@v0.21.0
         id: review
         if: github.event_name == 'pull_request'
         with:

--- a/.github/workflows/script_checks.yml
+++ b/.github/workflows/script_checks.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Minimal efforts to return to a functional CI on the release-3_5 branch.

We'll get a bunch of cppcheck warnings on _pre-existing_ code which we've fixed on master but I don't think we should spend time backporting. We'll be on QField 3.6 soon enough.