### PR TITLE
[Backport release-3_5] Fix range editor widget's undefined min/max for integer field type

### DIFF
--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -7,10 +7,11 @@ EditorWidgetBase {
   id: rangeItem
   enabled: isEnabled
 
+  property bool isDouble: LayerUtils.fieldType(field) === 'double'
   property string widgetStyle: config["Style"] ? config["Style"] : "TextField"
   property int precision: config["Precision"] ? config["Precision"] : 1
-  property real min: config["Min"] !== undefined ? config["Min"] : -Infinity
-  property real max: config["Max"] !== undefined ? config["Max"] : Infinity
+  property real min: config["Min"] !== undefined ? config["Min"] : isDouble ? -Infinity : -2147483647
+  property real max: config["Max"] !== undefined ? config["Max"] : isDouble ? Infinity : 2147483647
   property real step: config["Step"] !== undefined ? config["Step"] : 1
   property string suffix: config["Suffix"] ? config["Suffix"] : ""
 
@@ -37,7 +38,7 @@ EditorWidgetBase {
       text: value !== undefined ? value : ''
 
       validator: {
-        if (LayerUtils.fieldType(field) === 'double') {
+        if (isDouble) {
           doubleValidator;
         } else {
           intValidator;

--- a/test/qml/tst_editorwidgets.qml
+++ b/test/qml/tst_editorwidgets.qml
@@ -147,10 +147,14 @@ TestCase {
     range.value = 3;
     compare(range.widgetStyle, "TextField");
     compare(range.precision, 1);
-    compare(range.min, -Infinity);
-    compare(range.max, Infinity);
     compare(range.step, 1);
     compare(range.suffix, "");
+    range.isDouble = false;
+    compare(range.min, -2147483647);
+    compare(range.max, 2147483647);
+    range.isDouble = true;
+    compare(range.min, -Infinity);
+    compare(range.max, Infinity);
 
     // Row
     // compare(sliderRow.visible, true) // ERROR ? should work but not working!


### PR DESCRIPTION
Backport #6205
 **Authored by:** @nirvn