### PR TITLE
Add an image provider dedicated to generating QR codes

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -54,6 +54,7 @@ set(QFIELD_CORE_SRCS
     attributeformmodelbase.cpp
     audiorecorder.cpp
     barcodedecoder.cpp
+    barcodeimageprovider.cpp
     badlayerhandler.cpp
     bookmarkmodel.cpp
     clipboardmanager.cpp
@@ -180,6 +181,7 @@ set(QFIELD_CORE_HDRS
     attributeformmodelbase.h
     audiorecorder.h
     barcodedecoder.h
+    barcodeimageprovider.h
     badlayerhandler.h
     bookmarkmodel.h
     clipboardmanager.h

--- a/src/core/barcodeimageprovider.cpp
+++ b/src/core/barcodeimageprovider.cpp
@@ -40,8 +40,8 @@ QImage BarcodeImageProvider::requestImage( const QString &id, QSize *size, const
     return QImage();
   }
 
-  const int width = requestedSize.width() > 0 ? requestedSize.width() : 255;
-  const int height = requestedSize.height() > 0 ? requestedSize.height() : 255;
+  const int width = requestedSize.width() > 0 ? requestedSize.width() : DEFAULT_BARCODE_SIZE;
+  const int height = requestedSize.height() > 0 ? requestedSize.height() : DEFAULT_BARCODE_SIZE;
 
   ZXing::MultiFormatWriter writer( ZXing::BarcodeFormat::QRCode );
   ZXing::BitMatrix matrix = writer.encode( text.toStdString(), width, height );
@@ -50,25 +50,24 @@ QImage BarcodeImageProvider::requestImage( const QString &id, QSize *size, const
   QImage barcodeImage( bitmap.data(), bitmap.width(), bitmap.height(), bitmap.width(), QImage::Format::Format_Grayscale8 );
   barcodeImage.convertTo( QImage::Format::Format_ARGB32 );
 
-  QRgb white = qRgba( 255, 255, 255, 255 );
-  QRgb black = qRgba( 0, 0, 0, 255 );
+  const QRgb white = qRgba( 255, 255, 255, 255 );
+  const QRgb black = qRgba( 0, 0, 0, 255 );
 
-  QRgb transparent = qRgba( 255, 255, 255, 0 );
-  QRgb color = foregroundColor.isValid() ? foregroundColor.rgba() : qRgba( 0, 0, 0, 255 );
+  const QRgb transparent = qRgba( 255, 255, 255, 0 );
+  const QRgb color = foregroundColor.isValid() ? foregroundColor.rgba() : qRgba( 0, 0, 0, 255 );
 
   for ( int y = 0; y < barcodeImage.height(); ++y )
   {
-    QRgb *s = reinterpret_cast<QRgb *>( barcodeImage.scanLine( y ) );
-
-    for ( int x = 0; x < barcodeImage.width(); ++x, ++s )
+    QRgb *pixel = reinterpret_cast<QRgb *>( barcodeImage.scanLine( y ) );
+    for ( int x = 0; x < barcodeImage.width(); ++x, ++pixel )
     {
-      if ( *s == white )
+      if ( *pixel == white )
       {
-        *s = transparent;
+        *pixel = transparent;
       }
-      else if ( *s == black )
+      else if ( *pixel == black )
       {
-        *s = color;
+        *pixel = color;
       }
     }
   }

--- a/src/core/barcodeimageprovider.cpp
+++ b/src/core/barcodeimageprovider.cpp
@@ -1,0 +1,77 @@
+/***************************************************************************
+  barcodeimageprovider.cpp - BarcodeImageProvider
+
+ ---------------------
+ begin                : 26.04.2025
+ copyright            : (C) 2025 by Mathieu Pellerin
+ email                : mathieu at opengis dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "barcodeimageprovider.h"
+
+#include <QFileInfo>
+#include <QUrlQuery>
+
+#include <ZXing/BarcodeFormat.h>
+#include <ZXing/BitMatrix.h>
+#include <ZXing/MultiFormatWriter.h>
+
+BarcodeImageProvider::BarcodeImageProvider()
+  : QQuickImageProvider( Image )
+{
+}
+
+QImage BarcodeImageProvider::requestImage( const QString &id, QSize *size, const QSize &requestedSize )
+{
+  // the id is passed on as an encoded URL string which needs decoding
+  const QUrlQuery urlQuery = QUrlQuery( QUrl( id.toUtf8() ) );
+  const QString text = urlQuery.queryItemValue( QStringLiteral( "text" ) );
+  const QColor foregroundColor = QColor( urlQuery.queryItemValue( QStringLiteral( "color" ) ) );
+
+  if ( text.isEmpty() )
+  {
+    return QImage();
+  }
+
+  const int width = requestedSize.width() > 0 ? requestedSize.width() : 255;
+  const int height = requestedSize.height() > 0 ? requestedSize.height() : 255;
+
+  ZXing::MultiFormatWriter writer( ZXing::BarcodeFormat::QRCode );
+  ZXing::BitMatrix matrix = writer.encode( text.toStdString(), width, height );
+  ZXing::Matrix<uint8_t> bitmap = ZXing::ToMatrix<uint8_t>( matrix );
+
+  QImage barcodeImage( bitmap.data(), bitmap.width(), bitmap.height(), bitmap.width(), QImage::Format::Format_Grayscale8 );
+  barcodeImage.convertTo( QImage::Format::Format_ARGB32 );
+
+  QRgb white = qRgba( 255, 255, 255, 255 );
+  QRgb black = qRgba( 0, 0, 0, 255 );
+
+  QRgb transparent = qRgba( 255, 255, 255, 0 );
+  QRgb color = foregroundColor.isValid() ? foregroundColor.rgba() : qRgba( 0, 0, 0, 255 );
+
+  for ( int y = 0; y < barcodeImage.height(); ++y )
+  {
+    QRgb *s = reinterpret_cast<QRgb *>( barcodeImage.scanLine( y ) );
+
+    for ( int x = 0; x < barcodeImage.width(); ++x, ++s )
+    {
+      if ( *s == white )
+      {
+        *s = transparent;
+      }
+      else if ( *s == black )
+      {
+        *s = color;
+      }
+    }
+  }
+
+  return barcodeImage.copy();
+}

--- a/src/core/barcodeimageprovider.h
+++ b/src/core/barcodeimageprovider.h
@@ -1,0 +1,33 @@
+/***************************************************************************
+  barcodeimageprovider.h - BarcodeImageProvider
+
+ ---------------------
+ begin                : 26.04.2025
+ copyright            : (C) 2025 by Mathieu Pellerin
+ email                : mathieu at opengis dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef BARCODEIMAGEPROVIDER_H
+#define BARCODEIMAGEPROVIDER_H
+
+#include <QQuickImageProvider>
+
+/**
+ * \ingroup core
+ */
+class BarcodeImageProvider : public QQuickImageProvider
+{
+  public:
+    explicit BarcodeImageProvider();
+
+    QQmlImageProviderBase::ImageType imageType() const override { return QQmlImageProviderBase::Image; }
+    QImage requestImage( const QString &id, QSize *size, const QSize &requestedSize ) override;
+};
+
+#endif // BARCODEIMAGEPROVIDER_H

--- a/src/core/barcodeimageprovider.h
+++ b/src/core/barcodeimageprovider.h
@@ -18,6 +18,8 @@
 
 #include <QQuickImageProvider>
 
+#define DEFAULT_BARCODE_SIZE 255
+
 /**
  * \ingroup core
  */

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -43,6 +43,7 @@
 #include "audiorecorder.h"
 #include "badlayerhandler.h"
 #include "barcodedecoder.h"
+#include "barcodeimageprovider.h"
 #include "changelogcontents.h"
 #include "coordinatereferencesystemutils.h"
 #include "deltafilewrapper.h"
@@ -278,6 +279,7 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   mLegendImageProvider = new LegendImageProvider( mFlatLayerTree->layerTreeModel() );
   mLocalFilesImageProvider = new LocalFilesImageProvider();
   mProjectsImageProvider = new ProjectsImageProvider();
+  mBarcodeImageProvider = new BarcodeImageProvider();
 
   mBookmarkModel = new BookmarkModel( QgsApplication::bookmarkManager(), mProject->bookmarkManager(), this );
   mDrawingTemplateModel = new DrawingTemplateModel( this );
@@ -590,6 +592,7 @@ void QgisMobileapp::registerGlobalVariables()
   addImageProvider( QLatin1String( "legend" ), mLegendImageProvider );
   addImageProvider( QLatin1String( "localfiles" ), mLocalFilesImageProvider );
   addImageProvider( QLatin1String( "projects" ), mProjectsImageProvider );
+  addImageProvider( QLatin1String( "barcode" ), mBarcodeImageProvider );
 }
 
 

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -42,6 +42,7 @@
 
 class AppInterface;
 class AppMissingGridHandler;
+class BarcodeImageProvider;
 class QgsOfflineEditing;
 class QgsQuickMapCanvasMap;
 class LayerTreeMapCanvasBridge;
@@ -227,6 +228,7 @@ class QFIELD_CORE_EXPORT QgisMobileapp : public QQmlApplicationEngine
     LegendImageProvider *mLegendImageProvider = nullptr;
     LocalFilesImageProvider *mLocalFilesImageProvider = nullptr;
     ProjectsImageProvider *mProjectsImageProvider = nullptr;
+    BarcodeImageProvider *mBarcodeImageProvider = nullptr;
 
     QgsProject *mProject = nullptr;
     QString mProjectFilePath;


### PR DESCRIPTION
This allows us to do stuff like at zero cost (since we already ship the underlying library used here):
  
```
Image {
  width: 400
  height: 200
  source: "image://barcode/?text=check-this-cool-code&color=green"
  sourceSize.width: 400
  sourceSize.height: 200
}
```

It'll be useful for us, and I can imagine it's an interesting functionality to have for plugin developers too.