### PR TITLE
Introduction of an android scheme to allow for URL-driven actions (inc. QR code decoded URLs)

### DIFF
--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -80,6 +80,13 @@
       <intent-filter>
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="https" android:host="qfield.org" android:pathPrefix="/action" />
+      </intent-filter>
+
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
         <data android:scheme="content" />
         <data android:mimeType="application/octet-stream" />
       </intent-filter>

--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -73,6 +73,13 @@
       <intent-filter>
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="qfield" />
+      </intent-filter>
+
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
         <data android:scheme="content" />
         <data android:mimeType="application/octet-stream" />
       </intent-filter>

--- a/platform/android/AndroidManifest.xml.in
+++ b/platform/android/AndroidManifest.xml.in
@@ -80,13 +80,6 @@
       <intent-filter>
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />
-        <category android:name="android.intent.category.BROWSABLE" />
-        <data android:scheme="https" android:host="qfield.org" android:pathPrefix="/action" />
-      </intent-filter>
-
-      <intent-filter>
-        <action android:name="android.intent.action.VIEW" />
-        <category android:name="android.intent.category.DEFAULT" />
         <data android:scheme="content" />
         <data android:mimeType="application/octet-stream" />
       </intent-filter>

--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -167,6 +167,13 @@ public class QFieldActivity extends QtActivity {
             if (scheme.equals("qfield")) {
                 qfieldIntent = intent;
                 processQFieldIntent();
+            } else if (scheme.equals("https")) {
+                Uri uri = intent.getData();
+                String host = uri.getHost();
+                if (host.equals("qfield.org")) {
+                    qfieldIntent = intent;
+                    processQFieldIntent();
+                }
             } else {
                 projectIntent = intent;
                 processProjectIntent();
@@ -571,6 +578,13 @@ public class QFieldActivity extends QtActivity {
             if (scheme.equals("qfield")) {
                 qfieldIntent = sourceIntent;
                 intent.putExtra("QF_ACTION", "trigger_load");
+            } else if (scheme.equals("https")) {
+                Uri uri = sourceIntent.getData();
+                String host = uri.getHost();
+                if (host.equals("qfield.org")) {
+                    qfieldIntent = sourceIntent;
+                    intent.putExtra("QF_ACTION", "trigger_load");
+                }
             } else {
                 projectIntent = sourceIntent;
                 intent.putExtra("QGS_PROJECT", "trigger_load");

--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -118,6 +118,7 @@ public class QFieldActivity extends QtActivity {
 
     public static native void openProject(String url);
     public static native void openPath(String path);
+    public static native void executeAction(String action);
 
     public static native void volumeKeyDown(int volumeKeyCode);
     public static native void volumeKeyUp(int volumeKeyCode);
@@ -127,6 +128,7 @@ public class QFieldActivity extends QtActivity {
     public static native void resourceCanceled(String message);
 
     private Intent projectIntent;
+    private Intent qfieldIntent;
 
     private float originalBrightness;
     private boolean handleVolumeKeys = false;
@@ -161,8 +163,14 @@ public class QFieldActivity extends QtActivity {
 
         if (intent.getAction() == Intent.ACTION_VIEW ||
             intent.getAction() == Intent.ACTION_SEND) {
-            projectIntent = intent;
-            processProjectIntent();
+            String scheme = intent.getScheme();
+            if (scheme.equals("qfield")) {
+                qfieldIntent = intent;
+                processQFieldIntent();
+            } else {
+                projectIntent = intent;
+                processProjectIntent();
+            }
         }
     }
 
@@ -206,6 +214,11 @@ public class QFieldActivity extends QtActivity {
         Vibrator v = (Vibrator)getSystemService(Context.VIBRATOR_SERVICE);
         v.vibrate(VibrationEffect.createOneShot(
             milliseconds, VibrationEffect.DEFAULT_AMPLITUDE));
+    }
+
+    private void processQFieldIntent() {
+        String data = qfieldIntent.getDataString();
+        executeAction(data);
     }
 
     private void processProjectIntent() {
@@ -554,8 +567,14 @@ public class QFieldActivity extends QtActivity {
         Intent sourceIntent = getIntent();
         if (sourceIntent.getAction() == Intent.ACTION_VIEW ||
             sourceIntent.getAction() == Intent.ACTION_SEND) {
-            projectIntent = sourceIntent;
-            intent.putExtra("QGS_PROJECT", "trigger_load");
+            String scheme = sourceIntent.getScheme();
+            if (scheme.equals("qfield")) {
+                qfieldIntent = sourceIntent;
+                intent.putExtra("QF_ACTION", "trigger_load");
+            } else {
+                projectIntent = sourceIntent;
+                intent.putExtra("QGS_PROJECT", "trigger_load");
+            }
         }
 
         setIntent(intent);

--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -28,6 +28,7 @@
 #include <QImageReader>
 #include <QQuickItem>
 #include <QTemporaryFile>
+#include <QUrlQuery>
 #include <qgsapplication.h>
 #include <qgsauthmanager.h>
 #include <qgsmessagelog.h>
@@ -220,6 +221,32 @@ QVariantMap AppInterface::availableLanguages() const
     }
   }
   return languages;
+}
+
+QVariantMap AppInterface::getActionDetails( const QString &action ) const
+{
+  QVariantMap details;
+
+  if ( action.trimmed().isEmpty() )
+    return details;
+
+  QUrl actionUrl( action );
+  if ( actionUrl.scheme().toLower() != QStringLiteral( "qfield" ) )
+  {
+    return details;
+  }
+
+  details["type"] = actionUrl.authority();
+  if ( !actionUrl.query().isEmpty() )
+  {
+    const QList<std::pair<QString, QString>> queryItems = QUrlQuery( actionUrl ).queryItems( QUrl::FullyDecoded );
+    for ( const std::pair<QString, QString> &queryItem : queryItems )
+    {
+      details[queryItem.first] = queryItem.second;
+    }
+  }
+
+  return details;
 }
 
 bool AppInterface::isFileExtensionSupported( const QString &filename ) const

--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -226,17 +226,25 @@ QVariantMap AppInterface::availableLanguages() const
 QVariantMap AppInterface::getActionDetails( const QString &action ) const
 {
   QVariantMap details;
-
   if ( action.trimmed().isEmpty() )
     return details;
 
   QUrl actionUrl( action );
-  if ( actionUrl.scheme().toLower() != QStringLiteral( "qfield" ) )
+  if ( actionUrl.scheme().toLower() == QStringLiteral( "qfield" ) )
+  {
+    // deal with qfield:// URLs
+    details["type"] = actionUrl.authority();
+  }
+  else if ( actionUrl.authority() == QStringLiteral( "qfield.org" ) && actionUrl.path().startsWith( "/action/" ) )
+  {
+    // deal with https://qfield.org/action/ URLs
+    details["type"] = actionUrl.path().mid( 8 );
+  }
+  else
   {
     return details;
   }
 
-  details["type"] = actionUrl.authority();
   if ( !actionUrl.query().isEmpty() )
   {
     const QList<std::pair<QString, QString>> queryItems = QUrlQuery( actionUrl ).queryItems( QUrl::FullyDecoded );

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -63,6 +63,8 @@ class AppInterface : public QObject
 
     Q_INVOKABLE QVariantMap availableLanguages() const;
 
+    Q_INVOKABLE QVariantMap getActionDetails( const QString &action ) const;
+
     Q_INVOKABLE bool isFileExtensionSupported( const QString &filename ) const;
 
     /**
@@ -184,6 +186,9 @@ class AppInterface : public QObject
 
     //! Requests QField to open its local data picker screen to show the \a path content.
     void openPath( const QString &path );
+
+    //! Requests QField to execute a given \a action.
+    void executeAction( const QString &action );
 
     //! Emitted when a volume key is pressed while QField is set to handle those keys.
     void volumeKeyDown( int volumeKeyCode );

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -43,7 +43,7 @@ class AppInterface : public QObject
       Q_ASSERT( false );
     }
 
-    Q_INVOKABLE void importUrl( const QString &url );
+    Q_INVOKABLE void importUrl( const QString &url, bool loadOnImport = false );
 
     Q_INVOKABLE bool hasProjectOnLaunch() const;
     Q_INVOKABLE bool loadFile( const QString &path, const QString &name = QString() );

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -143,6 +143,25 @@ void AndroidPlatformUtilities::loadQgsProject() const
   }
 }
 
+bool AndroidPlatformUtilities::hasQfAction() const
+{
+  return !getIntentExtra( "QF_ACTION" ).isEmpty();
+}
+
+void AndroidPlatformUtilities::executeQfAction() const
+{
+  if ( mActivity.isValid() && hasQfAction() )
+  {
+    runOnAndroidMainThread( [] {
+      auto activity = qtAndroidContext();
+      if ( activity.isValid() )
+      {
+        activity.callMethod<void>( "processQFieldIntent" );
+      }
+    } );
+  }
+}
+
 QStringList AndroidPlatformUtilities::appDataDirs() const
 {
   const QString dataDirs = getIntentExtra( "QFIELD_APP_DATA_DIRS" );
@@ -817,6 +836,17 @@ JNIEXPORT void JNICALL JNI_FUNCTION_NAME( APP_PACKAGE_JNI_NAME, QFieldActivity, 
     const char *pathStr = env->GetStringUTFChars( path, NULL );
     AppInterface::instance()->loadFile( QString( pathStr ) );
     env->ReleaseStringUTFChars( path, pathStr );
+  }
+  return;
+}
+
+JNIEXPORT void JNICALL JNI_FUNCTION_NAME( APP_PACKAGE_JNI_NAME, QFieldActivity, executeAction )( JNIEnv *env, jobject obj, jstring action )
+{
+  if ( AppInterface::instance() )
+  {
+    const char *actionStr = env->GetStringUTFChars( action, NULL );
+    AppInterface::instance()->executeAction( QString( actionStr ) );
+    env->ReleaseStringUTFChars( action, actionStr );
   }
   return;
 }

--- a/src/core/platforms/android/androidplatformutilities.h
+++ b/src/core/platforms/android/androidplatformutilities.h
@@ -35,6 +35,9 @@ class AndroidPlatformUtilities : public PlatformUtilities
     bool hasQgsProject() const override;
     void loadQgsProject() const override;
 
+    bool hasQfAction() const override;
+    void executeQfAction() const override;
+
     QStringList appDataDirs() const override;
     QString applicationDirectory() const override;
     QStringList additionalApplicationDirectories() const override;

--- a/src/core/platforms/platformutilities.cpp
+++ b/src/core/platforms/platformutilities.cpp
@@ -156,6 +156,16 @@ void PlatformUtilities::loadQgsProject() const
   }
 }
 
+bool PlatformUtilities::hasQfAction() const
+{
+  return false;
+}
+
+void PlatformUtilities::executeQfAction() const
+{
+  return;
+}
+
 QStringList PlatformUtilities::appDataDirs() const
 {
   return QStringList() << QStandardPaths::standardLocations( QStandardPaths::DocumentsLocation ).first() + QStringLiteral( "/QField Documents/QField/" );

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -107,6 +107,18 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
     virtual void loadQgsProject() const;
 
     /**
+     * Returns the current action string
+     * \see loadQfAction
+     */
+    virtual bool hasQfAction() const;
+
+    /**
+     * Loads the action provided during launch.
+     * \see hasQfAction
+     */
+    virtual void executeQfAction() const;
+
+    /**
      * \returns a list of data directories where user data is searched.
      *          User data are pg_service.conf, authentication config, grids, ...
      */

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -670,7 +670,11 @@ void QgisMobileapp::onAfterFirstRendering()
   if ( mFirstRenderingFlag )
   {
     mPluginManager->restoreAppPlugins();
-    if ( PlatformUtilities::instance()->hasQgsProject() )
+    if ( PlatformUtilities::instance()->hasQfAction() )
+    {
+      PlatformUtilities::instance()->executeQfAction();
+    }
+    else if ( PlatformUtilities::instance()->hasQgsProject() )
     {
       PlatformUtilities::instance()->loadQgsProject();
     }

--- a/src/core/utils/urlutils.cpp
+++ b/src/core/utils/urlutils.cpp
@@ -34,12 +34,38 @@ bool UrlUtils::isRelativeOrFileUrl( const QString &url )
   return QUrl( url ).isRelative();
 }
 
-QUrl UrlUtils::fromString( const QString &string )
+QUrl UrlUtils::fromString( const QString &url )
 {
-  if ( QFileInfo::exists( string ) )
+  if ( QFileInfo::exists( url ) )
   {
-    return QUrl::fromLocalFile( string );
+    return QUrl::fromLocalFile( url );
   }
 
-  return QUrl( string );
+  return QUrl( url );
+}
+
+QString UrlUtils::urlDetail( const QString &url, const QString &detail )
+{
+  QUrl urlInterface( url );
+  if ( detail.compare( QStringLiteral( "scheme" ), Qt::CaseInsensitive ) == 0 )
+  {
+    return urlInterface.scheme();
+  }
+  else if ( detail.compare( QStringLiteral( "authority" ), Qt::CaseInsensitive ) == 0 )
+  {
+    return urlInterface.authority();
+  }
+  else if ( detail.compare( QStringLiteral( "path" ), Qt::CaseInsensitive ) == 0 )
+  {
+    return urlInterface.path();
+  }
+  else if ( detail.compare( QStringLiteral( "filename" ), Qt::CaseInsensitive ) == 0 )
+  {
+    return urlInterface.fileName();
+  }
+  else if ( detail.compare( QStringLiteral( "query" ), Qt::CaseInsensitive ) == 0 )
+  {
+    return urlInterface.query();
+  }
+  return QString();
 }

--- a/src/core/utils/urlutils.h
+++ b/src/core/utils/urlutils.h
@@ -37,8 +37,18 @@ class QFIELD_CORE_EXPORT UrlUtils : public QObject
      */
     static Q_INVOKABLE bool isRelativeOrFileUrl( const QString &url );
 
-    //! Returns a URL from a \a string with logic to handle local paths
-    static Q_INVOKABLE QUrl fromString( const QString &string );
+    //! Returns a URL from a \a url with logic to handle local paths
+    static Q_INVOKABLE QUrl fromString( const QString &url );
+
+    /**
+     * Returns a \a detail from an \a url. The possible components are:
+     * - "scheme", e.g. https
+     * - "authority", e.g. qfield.org
+     * - "path", e.g. /my/home.html
+     * - "fileName", e.g. file.zip
+     * - "query", e.g. param=true&other_parem=0
+     */
+    static Q_INVOKABLE QString urlDetail( const QString &url, const QString &detail );
 };
 
 #endif // URLUTILS_H

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3606,6 +3606,15 @@ ApplicationWindow {
   Connections {
     target: iface
 
+    function onExecuteAction(action) {
+      const details = iface.getActionDetails(action);
+      if (details.type === "local") {
+        if (details.import !== undefined) {
+          iface.importUrl(details.import);
+        }
+      }
+    }
+
     function onVolumeKeyUp(volumeKeyCode) {
       if (stateMachine.state === 'browse' || !mapCanvasMap.isEnabled) {
         return;

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3610,7 +3610,7 @@ ApplicationWindow {
       const details = iface.getActionDetails(action);
       if (details.type === "local") {
         if (details.import !== undefined) {
-          iface.importUrl(details.import);
+          iface.importUrl(details.import, true);
         }
       }
     }
@@ -3647,8 +3647,14 @@ ApplicationWindow {
     function onImportEnded(path) {
       busyOverlay.state = "hidden";
       if (path !== '') {
-        qfieldLocalDataPickerScreen.model.currentPath = path;
-        qfieldLocalDataPickerScreen.visible = true;
+        if (FileUtils.fileExists(path)) {
+          // A project or dataset path is provided, load it
+          iface.loadFile(path);
+        } else {
+          // A directory path is provided, display it
+          qfieldLocalDataPickerScreen.model.currentPath = path;
+          qfieldLocalDataPickerScreen.visible = true;
+        }
         welcomeScreen.visible = false;
       } else {
         displayToast(qsTr('Import URL failed'));

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3610,7 +3610,8 @@ ApplicationWindow {
       const details = iface.getActionDetails(action);
       if (details.type === "local") {
         if (details.import !== undefined) {
-          iface.importUrl(details.import, true);
+          importPermissionDialog.url = details.import;
+          importPermissionDialog.open();
         }
       }
     }
@@ -4277,13 +4278,53 @@ ApplicationWindow {
   }
 
   QfDialog {
+    id: importPermissionDialog
+    parent: mainWindow.contentItem
+    z: 10000 // 1000s are embedded feature forms, user a higher value to insure the dialog will always show above embedded feature forms
+
+    width: Math.min(mainWindow.width - Theme.popupScreenEdgeMargin * 2, 400)
+
+    property string url: ""
+    property string serverName: ""
+    property string fileName: ""
+
+    onAboutToShow: {
+      serverName = UrlUtils.urlDetail(url, "authority");
+      fileName = UrlUtils.urlDetail(url, "filename");
+      if (fileName === "") {
+        fileName = UrlUtils.urlDetail(url, "path");
+      }
+    }
+
+    title: qsTr("Import Confirmation")
+
+    Column {
+      width: parent.width
+
+      Label {
+        width: parent.width
+        wrapMode: Text.WordWrap
+        text: qsTr("Do you want to import <b>%1</b> from <b>%2</b> into QField?").arg(importPermissionDialog.fileName).arg(importPermissionDialog.serverName)
+      }
+    }
+
+    onAccepted: {
+      iface.importUrl(importPermissionDialog.url, true);
+    }
+
+    standardButtons: Dialog.Yes | Dialog.No
+  }
+
+  QfDialog {
     id: pluginPermissionDialog
     parent: mainWindow.contentItem
     z: 10000 // 1000s are embedded feature forms, user a higher value to insure the dialog will always show above embedded feature forms
 
+    width: Math.min(mainWindow.width - Theme.popupScreenEdgeMargin * 2, 400)
+
     property alias permanent: permanentCheckBox.checked
 
-    title: ''
+    title: qsTr("Plugin Permission")
 
     Column {
       Label {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -96,5 +96,6 @@ ADD_CATCH2_TEST(attributeformmodeltest test_attributeformmodel.cpp FALSE)
 ADD_CATCH2_TEST(orderedrelationmodeltest test_orderedrelationmodel.cpp FALSE)
 ADD_CATCH2_TEST(referencingfeaturelistmodeltest test_referencingfeaturelistmodel.cpp FALSE)
 ADD_CATCH2_TEST(expressionevaluatortest test_expressionevaluator.cpp TRUE)
+ADD_CATCH2_TEST(appinterfacetest test_appinterface.cpp TRUE)
 
 ADD_QFIELD_QML_TEST(qmltest test_qml.cpp)

--- a/test/test_appinterface.cpp
+++ b/test/test_appinterface.cpp
@@ -1,9 +1,9 @@
 /***************************************************************************
-                        test_urlutils.h
+                        test_appinterface.h
                         --------------------
-  begin                : Jun 2020
-  copyright            : (C) 2020 by Ivan Ivanov
-  email                : ivan@opengis.ch
+  begin                : April 2025
+  copyright            : (C) 2025 by Mathieu Pellerin
+  email                : mathieu@opengis.ch
 ***************************************************************************/
 
 /***************************************************************************

--- a/test/test_appinterface.cpp
+++ b/test/test_appinterface.cpp
@@ -1,0 +1,44 @@
+/***************************************************************************
+                        test_urlutils.h
+                        --------------------
+  begin                : Jun 2020
+  copyright            : (C) 2020 by Ivan Ivanov
+  email                : ivan@opengis.ch
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "appinterface.h"
+#include "catch2.h"
+
+
+TEST_CASE( "AppInterface" )
+{
+  AppInterface iface( nullptr );
+
+  SECTION( "getActionDetails" )
+  {
+    QVariantMap details = iface.getActionDetails( "https://qfield.org/action/local?import=https://my.website.com/project.zip" );
+    REQUIRE( details["type"] == QStringLiteral( "local" ) );
+    REQUIRE( details["import"] == QStringLiteral( "https://my.website.com/project.zip" ) );
+
+    details = iface.getActionDetails( "https://qfield.org/action/local?import=https%3A%2F%2Fmy.website.com%2Fproject.zip" );
+    REQUIRE( details["type"] == QStringLiteral( "local" ) );
+    REQUIRE( details["import"] == QStringLiteral( "https://my.website.com/project.zip" ) );
+
+    details = iface.getActionDetails( "qfield://local?import=https://my.website.com/project.zip" );
+    REQUIRE( details["type"] == QStringLiteral( "local" ) );
+    REQUIRE( details["import"] == QStringLiteral( "https://my.website.com/project.zip" ) );
+
+    details = iface.getActionDetails( "qfield://local?import=https%3A%2F%2Fmy.website.com%2Fproject.zip" );
+    REQUIRE( details["type"] == QStringLiteral( "local" ) );
+    REQUIRE( details["import"] == QStringLiteral( "https://my.website.com/project.zip" ) );
+  }
+}

--- a/test/test_urlutils.cpp
+++ b/test/test_urlutils.cpp
@@ -51,4 +51,15 @@ TEST_CASE( "UrlUtils" )
     // a URL string (e.g. http(s)) will be handled as such
     REQUIRE( UrlUtils::fromString( QStringLiteral( "https://www.opengis.ch/" ) ).toString() == QStringLiteral( "https://www.opengis.ch/" ) );
   }
+
+  SECTION( "urlDetail" )
+  {
+    const QString url( "https://sub.qfield.org/latest/project.zip?date=now&check=1" );
+
+    REQUIRE( UrlUtils::urlDetail( url, "scheme" ) == QStringLiteral( "https" ) );
+    REQUIRE( UrlUtils::urlDetail( url, "authority" ) == QStringLiteral( "sub.qfield.org" ) );
+    REQUIRE( UrlUtils::urlDetail( url, "path" ) == QStringLiteral( "/latest/project.zip" ) );
+    REQUIRE( UrlUtils::urlDetail( url, "filename" ) == QStringLiteral( "project.zip" ) );
+    REQUIRE( UrlUtils::urlDetail( url, "query" ) == QStringLiteral( "date=now&check=1" ) );
+  }
 }


### PR DESCRIPTION
This PR implements a qfield:// scheme to allow for URL-driven actions on Android. ATM, there is only one action:

`qfield://local?import=https://docs.qfield.org/assets/projects/bee_farming_project.zip`

When using Android's camera, users can scan a QR code that decodes into the above URL scheme, which will lead them to import the project/dataset URL.

Project QR code example:
![project](https://github.com/user-attachments/assets/930bc30b-263c-4a8b-a6be-1813e9bd6e24)

In action:

https://github.com/user-attachments/assets/d4a71aa6-a13d-44b9-af7e-c17958b37085

_When this PR (https://github.com/opengisch/QField/pull/6212) will be merged, the scheme will also handle cloud project details action._