### PR TITLE
Auto open form for single feature result

### DIFF
--- a/src/core/identifytool.cpp
+++ b/src/core/identifytool.cpp
@@ -72,6 +72,8 @@ void IdentifyTool::identify( const QPointF &point ) const
       mModel->appendFeatures( results );
     }
   }
+
+  emit identifyFinished();
 }
 
 QList<IdentifyTool::IdentifyResult> IdentifyTool::identifyVectorLayer( QgsVectorLayer *layer, const QgsPointXY &point ) const

--- a/src/core/identifytool.h
+++ b/src/core/identifytool.h
@@ -71,6 +71,7 @@ class IdentifyTool : public QObject
     void searchRadiusMmChanged();
     void modelChanged();
     void deactivatedChanged();
+    void identifyFinished() const;
 
   public slots:
     void identify( const QPointF &point ) const;

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -16,6 +16,7 @@ Page {
   property alias showScaleBar: registry.showScaleBar
   property alias fullScreenIdentifyView: registry.fullScreenIdentifyView
   property alias locatorKeepScale: registry.locatorKeepScale
+  property alias autoOpenFormSingleIdentify: registry.autoOpenFormSingleIdentify
   property alias numericalDigitizingInformation: registry.numericalDigitizingInformation
   property alias showBookmarks: registry.showBookmarks
   property alias nativeCamera2: registry.nativeCamera2
@@ -51,6 +52,7 @@ Page {
     property bool showScaleBar: true
     property bool fullScreenIdentifyView: false
     property bool locatorKeepScale: false
+    property bool autoOpenFormSingleIdentify: false
     property bool numericalDigitizingInformation: false
     property bool showBookmarks: true
     property bool nativeCamera2: false
@@ -162,6 +164,12 @@ Page {
       title: qsTr("Fixed scale navigation")
       description: qsTr("When fixed scale navigation is active, focusing on a search result will pan to the feature. With fixed scale navigation disabled it will pan and zoom to the feature.")
       settingAlias: "locatorKeepScale"
+      isVisible: true
+    }
+    ListElement {
+      title: qsTr("Automatically open form for single feature identification")
+      description: qsTr("When enabled, the feature form will open automatically if only one feature is identified, skipping the feature list.")
+      settingAlias: "autoOpenFormSingleIdentify"
       isVisible: true
     }
   }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -791,6 +791,13 @@ ApplicationWindow {
       mapSettings: mapCanvas.mapSettings
       model: isMenuRequest ? canvasMenuFeatureListModel : featureForm.model
       searchRadiusMm: 3
+
+      onIdentifyFinished: {
+        if (qfieldSettings.autoOpenFormSingleIdentify && !isMenuRequest && featureForm.model.count === 1) {
+          featureForm.selection.focusedItem = 0;
+          featureForm.state = "FeatureForm";
+        }
+      }
     }
 
     /** A rubberband for measuring **/


### PR DESCRIPTION
### Automatically Open Form for Single Feature Identification

#### Description

This pull request introduces a new feature: **Automatically Open Form for Single Feature Identification**. The purpose of this feature is to streamline the user experience when identifying features on the map.

Currently, when users identify a single feature, they are required to go through a two-step process: first, selecting the feature from a list, and then clicking to open the feature form. This can feel redundant, as the list serves no purpose in cases where there's only one feature identified. With this update, users can enable a setting to skip the list and directly open the feature form when a single feature is identified. 

#### Key Changes
1. **Settings Update**:
   - A new setting `autoOpenFormSingleIdentify` has been introduced in the application settings. This setting allows users to enable or disable the automatic form opening behavior.
     - **Title**: Automatically open form for single feature identification
     - **Description**: When enabled, the feature form will open automatically if only one feature is identified, skipping the feature list.

2. **Behavioral Change**:
   - When the setting `autoOpenFormSingleIdentify` is enabled, and only one feature is identified:
     - The feature form will open automatically.
     - This eliminates the need for users to manually select the feature from the list.

![image](https://github.com/user-attachments/assets/c10584f6-041c-467a-8972-78006aa4baf3)

#### Additional Notes

- This feature is **disabled by default** to maintain the current behavior unless explicitly enabled by the user.
