### PR TITLE
Avoid showing geometry editing button for datasets that do not support editing (e.g. file system permission prohibiting it

### DIFF
--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -303,7 +303,7 @@ Rectangle {
 
     property bool readOnly: false
 
-    visible: stateMachine.state === "digitize" && !selection.focusedGeometry.isNull && !featureForm.model.featureModel.geometryLocked && (projectInfo.editRights || editButton.isCreatedCloudFeature) && toolBar.state == "Navigation" && !readOnly && projectInfo.editRights
+    visible: stateMachine.state === "digitize" && !selection.focusedGeometry.isNull && !featureForm.model.featureModel.geometryLocked && (projectInfo.editRights || editButton.isCreatedCloudFeature) && toolBar.state == "Navigation" && editButton.supportsEditing && projectInfo.editRights
 
     anchors.right: editButton.left
     anchors.top: parent.top


### PR DESCRIPTION
Issue identified as part of https://github.com/opengisch/QField/issues/6229
