### PR TITLE
Enable Merge for Single-Part Geometries in QField

### DIFF
--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -483,8 +483,8 @@ bool MultiFeatureListModelBase::mergeSelection()
 
   if ( !QgsWkbTypes::isMultiType( vlayer->wkbType() ) )
   {
-    const QgsGeometryCollection *c = qgsgeometry_cast<const QgsGeometryCollection *>( combinedGeometry.constGet() );
-    if ( ( c && c->partCount() > 1 ) || !combinedGeometry.convertToSingleType() )
+    const QgsGeometryCollection *geometryCollection = qgsgeometry_cast<const QgsGeometryCollection *>( combinedGeometry.constGet() );
+    if ( ( geometryCollection && geometryCollection->partCount() > 1 ) || !combinedGeometry.convertToSingleType() )
     {
       isSuccess = false;
     }

--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -520,6 +520,7 @@ bool MultiFeatureListModelBase::mergeSelection()
       // commit changes
       isSuccess = vlayer->commitChanges();
       mSelectedFeatures.clear();
+      emit dataChanged( index( 0, 0 ), index( rowCount( QModelIndex() ) - 1, 0 ), QVector<int>() << MultiFeatureListModel::FeatureSelectedRole );
       emit selectedCountChanged();
     }
     else

--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -22,6 +22,7 @@
 
 #include <qgscoordinatereferencesystem.h>
 #include <qgsgeometry.h>
+#include <qgsgeometrycollection.h>
 #include <qgsmessagelog.h>
 #include <qgsproject.h>
 #include <qgsrelationmanager.h>
@@ -480,9 +481,13 @@ bool MultiFeatureListModelBase::mergeSelection()
     }
   }
 
-  if ( combinedGeometry.wkbType() != vlayer->wkbType() )
+  if ( !QgsWkbTypes::isMultiType( vlayer->wkbType() ) )
   {
-    isSuccess = false;
+    const QgsGeometryCollection *c = qgsgeometry_cast<const QgsGeometryCollection *>( combinedGeometry.constGet() );
+    if ( ( c && c->partCount() > 1 ) || !combinedGeometry.convertToSingleType() )
+    {
+      isSuccess = false;
+    }
   }
 
   if ( isSuccess )


### PR DESCRIPTION
### Pull Request Description

#### **Summary**
This pull request enhances the `merge selected features` functionality by enabling it for both single-part and multi-part polygons and lines. The merge operation is still subject to layer permissions and constraints.

#### **✨ Key Changes**
1. **`canMergeSelection` Method**:
   - Updated to allow merging for both single-part (`isSingleType`) and multi-part (`isMultiType`) geometries.

2. **`mergeSelection` Method**:
   - Added checks to ensure single-part geometries can only merge if valid (e.g., single-type conversion succeeds).
   - Adjusted success handling to clear selections and emit changes only after a successful commit.  

#### **Behavior**
- Merge is now possible for single-part geometries under valid conditions.
- Ensures robust handling of merge failures.
  

  
[Screencast From 2025-05-05 17-18-02.webm](https://github.com/user-attachments/assets/591d42ef-55b3-4427-9a8a-1493c22648f9)
