### PR TITLE
Allow selecting a read-only vector layer to provide layer searches

### DIFF
--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -44,8 +44,6 @@ ListView {
       onClicked: mouse => {
         if (!allowActiveLayerChange)
           return;
-        if (ReadOnly || GeometryLocked)
-          return;
         if (VectorLayerPointer && VectorLayerPointer.isValid) {
           activeLayer = VectorLayerPointer;
           projectInfo.activeLayer = VectorLayerPointer;


### PR DESCRIPTION
Fixes https://github.com/opengisch/QField/issues/6231 as well as adding additional safeguards against digitizing on a read-only layer through stylus and mouse.