### PR TITLE
Hard-lock on positions

### DIFF
--- a/src/qml/Toast.qml
+++ b/src/qml/Toast.qml
@@ -10,7 +10,7 @@ Popup {
 
   property string type: 'info'
   property int edgeSpacing: 52
-  property bool animationEnabled: false
+  property bool timeoutFeedback: false
   property real virtualKeyboardHeight: {
     const top = Qt.inputMethod.keyboardRectangle.top / Screen.devicePixelRatio;
     if (top > 0) {
@@ -55,7 +55,7 @@ Popup {
       id: animationProgressBar
       padding: 2
       anchors.fill: parent
-      visible: animationEnabled
+      visible: timeoutFeedback
       z: toastRow.z - 1
       value: animationTimer.position / toastTimer.interval
 
@@ -70,7 +70,7 @@ Popup {
           width: animationProgressBar.visualPosition * parent.width
           height: parent.height
           radius: 2
-          color: "#8080cc28"
+          color: Qt.hsla(Theme.mainColor.hslHue, Theme.mainColor.hslSaturation, Theme.mainColor.hslLightness, 0.5)
           visible: !animationProgressBar.indeterminate
         }
       }
@@ -123,6 +123,8 @@ Popup {
           if (act !== undefined) {
             act();
           }
+          toast.close();
+          animationTimer.stopAct = undefined;
         }
       }
     }
@@ -144,7 +146,7 @@ Popup {
   Timer {
     id: animationTimer
     interval: 50
-    repeat: animationEnabled
+    repeat: timeoutFeedback
 
     property real position: 0
     property var stopAct: undefined
@@ -157,7 +159,7 @@ Popup {
         if (stopAct !== undefined) {
           stopAct();
         }
-        animationEnabled = false;
+        timeoutFeedback = false;
       }
     }
 
@@ -179,20 +181,20 @@ Popup {
       toastContent.visible = false;
       toast.close();
       animationTimer.reset();
-      animationEnabled = false;
+      timeoutFeedback = false;
     }
   }
 
-  function show(text, type, action_text, action_function, stop_function, is_animation_enabled) {
+  function show(text, type, action_text, action_function, timeout_feedback, timeout_function) {
     toastMessage.text = text;
     toast.type = type || 'info';
-    if (is_animation_enabled !== undefined) {
-      toast.animationEnabled = is_animation_enabled;
+    if (timeout_feedback !== undefined) {
+      toast.timeoutFeedback = timeout_feedback;
     } else {
-      toast.animationEnabled = false;
+      toast.timeoutFeedback = false;
     }
-    if (stop_function !== undefined) {
-      animationTimer.stopAct = stop_function;
+    if (timeout_function !== undefined) {
+      animationTimer.stopAct = timeout_function;
     }
     if (action_text !== undefined && action_function !== undefined) {
       toastAction.text = action_text;
@@ -207,7 +209,7 @@ Popup {
     toast.open();
     toast.opacity = 1;
     toastTimer.restart();
-    if (toast.animationEnabled) {
+    if (toast.timeoutFeedback) {
       animationTimer.reset();
       animationTimer.restart();
     }

--- a/src/qml/Toast.qml
+++ b/src/qml/Toast.qml
@@ -124,7 +124,7 @@ Popup {
             act();
           }
           toast.close();
-          animationTimer.stopAct = undefined;
+          animationTimer.timeoutAct = undefined;
         }
       }
     }
@@ -149,15 +149,15 @@ Popup {
     repeat: timeoutFeedback
 
     property real position: 0
-    property var stopAct: undefined
+    property var timeoutAct: undefined
 
     onTriggered: {
       position += interval;
       if (animationProgressBar.value === 1) {
         animationTimer.stop();
         reset();
-        if (stopAct !== undefined) {
-          stopAct();
+        if (timeoutAct !== undefined) {
+          timeoutAct();
         }
         timeoutFeedback = false;
       }
@@ -193,8 +193,8 @@ Popup {
         toastTimer.restart();
         return;
       } else {
-        if (animationTimer.stopAct !== undefined) {
-          animationTimer.stopAct();
+        if (animationTimer.timeoutAct !== undefined) {
+          animationTimer.timeoutAct();
         }
       }
     }
@@ -206,7 +206,7 @@ Popup {
       toast.timeoutFeedback = false;
     }
     if (timeout_function !== undefined) {
-      animationTimer.stopAct = timeout_function;
+      animationTimer.timeoutAct = timeout_function;
     }
     if (action_text !== undefined && action_function !== undefined) {
       toastAction.text = action_text;

--- a/src/qml/Toast.qml
+++ b/src/qml/Toast.qml
@@ -177,7 +177,7 @@ Popup {
   }
 
   onOpacityChanged: {
-    if (opacity == 0) {
+    if (opacity === 0) {
       toastContent.visible = false;
       toast.close();
       animationTimer.reset();
@@ -186,6 +186,18 @@ Popup {
   }
 
   function show(text, type, action_text, action_function, timeout_feedback, timeout_function) {
+    if (toastTimer.running) {
+      if (toastMessage.text === text) {
+        animationTimer.reset();
+        animationTimer.restart();
+        toastTimer.restart();
+        return;
+      } else {
+        if (animationTimer.stopAct !== undefined) {
+          animationTimer.stopAct();
+        }
+      }
+    }
     toastMessage.text = text;
     toast.type = type || 'info';
     if (timeout_feedback !== undefined) {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -769,7 +769,7 @@ ApplicationWindow {
           gnssButton.followActive = false;
           gnssButton.followOrientationActive = false;
           mapSettingsConnections.autoReFollowLocation = true;
-          displayToast(qsTr('Follow location again'), 'info', qsTr('Stop'), mapSettingsConnections.cancelAutoFollowLocation, mapSettingsConnections.followLocation, true);
+          displayToast(qsTr('Follow location again'), 'info', qsTr('Unlock'), mapSettingsConnections.cancelAutoFollowLocation, mapSettingsConnections.followLocation, true);
         }
         if (gnssButton.followActive)
           gnssButton.followActiveSkipExtentChanged = true;
@@ -2283,10 +2283,10 @@ ApplicationWindow {
               gnssButton.followActive = false;
               gnssButton.followOrientationActive = false;
               mapSettingsConnections.autoReFollowLocation = true;
-              displayToast(qsTr('Follow location again'), 'info', qsTr('Stop'), mapSettingsConnections.cancelAutoFollowLocation, mapSettingsConnections.followLocation, true);
+              displayToast(qsTr('Follow location again'), 'info', qsTr('Unlock'), mapSettingsConnections.cancelAutoFollowLocation, mapSettingsConnections.followLocation, true);
             }
           } else if (mapSettingsConnections.autoReFollowLocation) {
-            displayToast(qsTr('Follow location again'), 'info', qsTr('Stop'), mapSettingsConnections.cancelAutoFollowLocation, mapSettingsConnections.followLocation, true);
+            displayToast(qsTr('Follow location again'), 'info', qsTr('Unlock'), mapSettingsConnections.cancelAutoFollowLocation, mapSettingsConnections.followLocation, true);
           }
         }
 


### PR DESCRIPTION
### Pull Request Description
This pull request aims to implement a more robust mechanism to maintain the "lock on position" mode for users, particularly those driving and requiring the ability to zoom, pan, or rotate the map while preserving tracking functionality.

#### **✨ Approach**
- Introduced a 5-second auto-relock mechanism after map panning, ensuring that the map automatically re-centers on the user's position unless explicitly unlocked.
- Added a visual progress bar within the toaster message to indicate the relock timer. This provides users with feedback about the relock countdown.
- Included an "Unlock" button within the toaster message for users to permanently disable auto-relocking if needed.

#### **UI Changes**
- Updated the `Toast.qml` component:
  - Added a new `animationEnabled` property to support animations like the relock countdown.
  - Implemented a progress bar as part of the toast's background to visually display the auto-relock timer.
  - Modified the toast's `show` function to handle additional parameters for animation and stop-action behavior.
- Enhanced `qgismobileapp.qml`:
  - Integrated logic to handle map gestures (panning, zooming, and rotation) that reset the auto-relock timer.
  - Added `autoReFollowLocation` property and related functions (`cancelAutoFollowLocation` and `followLocation`) to manage the relock mechanism.
  - Updated the `displayToast` function to include parameters for the progress bar and unlock functionality.

#### **WIP** 

Zoom gestures and rotation events on Android.

#### **Demo**  
  

[Screencast From 2025-05-11 22-13-41.webm](https://github.com/user-attachments/assets/92d3d501-18d2-40d2-b45c-d7b36ec2e2db)
