### PR TITLE
Get rid of IntValidator in favor of DoubleValidator to fix integer64/longlong compatibility

### DIFF
--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -10,8 +10,8 @@ EditorWidgetBase {
   property bool isDouble: field === undefined || (LayerUtils.fieldType(field) !== 'int' && LayerUtils.fieldType(field) !== 'qlonglong')
   property string widgetStyle: config["Style"] ? config["Style"] : "TextField"
   property int precision: config["Precision"] ? config["Precision"] : isDouble ? 2 : 0
-  property real min: config["Min"] !== undefined ? config["Min"] : isDouble ? -Infinity : -2147483647
-  property real max: config["Max"] !== undefined ? config["Max"] : isDouble ? Infinity : 2147483647
+  property real min: config["Min"] !== undefined ? config["Min"] : -Infinity
+  property real max: config["Max"] !== undefined ? config["Max"] : Infinity
   property real step: config["Step"] !== undefined ? config["Step"] : 1
   property string suffix: config["Suffix"] ? config["Suffix"] : ""
 
@@ -37,13 +37,7 @@ EditorWidgetBase {
 
       text: value !== undefined ? value : ''
 
-      validator: {
-        if (isDouble) {
-          doubleValidator;
-        } else {
-          intValidator;
-        }
-      }
+      validator: doubleValidator
 
       inputMethodHints: Qt.ImhFormattedNumbersOnly
 
@@ -251,5 +245,6 @@ EditorWidgetBase {
 
     bottom: rangeItem.min
     top: rangeItem.max
+    decimals: isDouble ? -1 : 0
   }
 }

--- a/test/qml/tst_editorwidgets.qml
+++ b/test/qml/tst_editorwidgets.qml
@@ -152,8 +152,8 @@ TestCase {
     compare(range.suffix, "");
     range.isDouble = false;
     compare(range.precision, 0);
-    compare(range.min, -2147483647);
-    compare(range.max, 2147483647);
+    compare(range.min, -Infinity);
+    compare(range.max, Infinity);
     range.isDouble = true;
     compare(range.precision, 2);
     compare(range.min, -Infinity);


### PR DESCRIPTION
Title says it all. This was problematic when QGIS projects would have a range editor widget for an integer64/longlong field with the default min/max. That min/max was not compatible with intvalidator, leading to an unuseable editor widget in QField.