### PR TITLE
Implement data defined feature form properties (field aliases and field editable state)

### DIFF
--- a/src/core/attributeformmodelbase.h
+++ b/src/core/attributeformmodelbase.h
@@ -107,6 +107,9 @@ class AttributeFormModelBase : public QStandardItemModel
     //! Update QML, HTML, and text widget code.
     void updateEditorWidgetCodes( const QString &fieldName );
 
+    //! Update expression-driven alias value.
+    void updateAliases( const QString &fieldName );
+
     //! Check if the given \a code requires update.
     bool codeRequiresUpdate( const QString &fieldName, const QString &code, const QRegularExpression &regEx );
 
@@ -138,6 +141,7 @@ class AttributeFormModelBase : public QStandardItemModel
     typedef QPair<QgsExpression, QStandardItem *> VisibilityExpression;
     QList<VisibilityExpression> mVisibilityExpressions;
     QMap<QStandardItem *, int> mFields;
+    QMap<QStandardItem *, QString> mAliasExpressions;
     QMap<QStandardItem *, QString> mEditorWidgetCodes;
     QMap<QString, CodeRequirements> mEditorWidgetCodesRequirements;
 

--- a/src/core/attributeformmodelbase.h
+++ b/src/core/attributeformmodelbase.h
@@ -107,8 +107,8 @@ class AttributeFormModelBase : public QStandardItemModel
     //! Update QML, HTML, and text widget code.
     void updateEditorWidgetCodes( const QString &fieldName );
 
-    //! Update expression-driven alias value.
-    void updateAliases( const QString &fieldName );
+    //! Update expression-driven alias and read-only values.
+    void updateDataDefinedProperties( const QString &fieldName );
 
     //! Check if the given \a code requires update.
     bool codeRequiresUpdate( const QString &fieldName, const QString &code, const QRegularExpression &regEx );
@@ -142,6 +142,7 @@ class AttributeFormModelBase : public QStandardItemModel
     QList<VisibilityExpression> mVisibilityExpressions;
     QMap<QStandardItem *, int> mFields;
     QMap<QStandardItem *, QString> mAliasExpressions;
+    QMap<QStandardItem *, QString> mReadOnlyExpressions;
     QMap<QStandardItem *, QString> mEditorWidgetCodes;
     QMap<QString, CodeRequirements> mEditorWidgetCodesRequirements;
 


### PR DESCRIPTION
This PR implements the two available data-defined properties tied to fields within feature forms, namely:
- field alias
- field's read-only/editable state

Both rely on an expression context that _includes_ QFieldCloud variables (@cloud_username and @cloud_useremail), which means we can now allow/disallow editing of certain fields based on which logged in QFieldCloud user is consuming a given cloud project.

As for the field alias, it can be useful to deliver multilingual forms when associated with e.g. a project-level variable that'd drive map canvas labels _as well as_ feature form attributes.

Implements https://github.com/opengisch/QField/issues/2417 