### PR TITLE
Fix warnings in test_01_dateTime().

### DIFF
--- a/test/qml/tst_editorwidgets.qml
+++ b/test/qml/tst_editorwidgets.qml
@@ -34,7 +34,9 @@ TestCase {
   EditorWidgets.DateTime {
     id: dateTime
     property var mainWindow: mainWindowItem
-    fieldIsDate: false // to simulate LayerUtils.fieldType( field ) != 'QDate'
+    fieldIsDateTime: false
+    fieldIsDate: false
+    fieldIsString: false
     property string value: "2022-01-01"
     property var config: undefined
     property var field: undefined


### PR DESCRIPTION
We had 
```
QWARN  : test_qml::EditorWidgets::test_01_dateTime() "Could not convert argument 0 at"
QWARN  : test_qml::EditorWidgets::test_01_dateTime() 	 "expression for fieldIsString@file:///home/runner/work/QField/QField/src/qml/editorwidgets/DateTime.qml:35"
QWARN  : test_qml::EditorWidgets::test_01_dateTime() 	 "test_01_dateTime@file:///home/runner/work/QField/QField/test/qml/tst_editorwidgets.qml:216"
QWARN  : test_qml::EditorWidgets::test_01_dateTime() 	 "qtest_runInternal@qrc:/qt-project.org/imports/QtTest/TestCase.qml:1931"
QWARN  : test_qml::EditorWidgets::test_01_dateTime() 	 "qtest_runFunction@qrc:/qt-project.org/imports/QtTest/TestCase.qml:1947"
QWARN  : test_qml::EditorWidgets::test_01_dateTime() 	 "qtest_run@qrc:/qt-project.org/imports/QtTest/TestCase.qml:2127"
QWARN  : test_qml::EditorWidgets::test_01_dateTime() 	 "expression for onTriggered@qrc:/qt-project.org/imports/QtTest/TestSchedule.qml:23"
QWARN  : test_qml::EditorWidgets::test_01_dateTime() file:///home/runner/work/QField/QField/src/qml/editorwidgets/DateTime.qml:35: TypeError: Passing incompatible arguments to C++ functions from JavaScript is not allowed.
```
we had to override some props.