### PR TITLE
QFieldGuide: fix indicator position.

### DIFF
--- a/src/qml/QFieldGuide.qml
+++ b/src/qml/QFieldGuide.qml
@@ -325,11 +325,16 @@ Popup {
 
     x: {
       if (internalObject.target[0]) {
-        return internalObject.pos.x + internalObject.target[0].width / 2 + (hintPanel.dir ? -8 : 8);
+        return internalObject.pos.x + internalObject.target[0].width / 2 - pointerToItem.width / 2;
       }
       return 0;
     }
-    y: hintPanel.dir ? hintPanel.y + hintPanel.height : hintPanel.y
+    y: {
+      if (internalObject.target[0]) {
+        return internalObject.pos.y + (hintPanel.dir ? -(height + 4) : internalObject.target[0].height + 4);
+      }
+      return 0;
+    }
 
     ShapePath {
       fillColor: Theme.mainBackgroundColor


### PR DESCRIPTION
### Pull Request Description

This pull request fixes the incorrect positioning of the indicator in `QFieldGuide`.

**Issue**
The indicator was misaligned, resulting in a poor visual experience.   

[Screencast From 2025-05-13 16-36-51.webm](https://github.com/user-attachments/assets/7d915564-ed8f-425c-8545-b57a62365ef2)
   

**Fix**
Made minor geometry adjustments to correctly position the indicator.   

[Screencast From 2025-05-13 16-32-21.webm](https://github.com/user-attachments/assets/19d04355-a2c3-4abd-a33c-e416fd7073ee)

