### PR TITLE
Insure the referencing feature list model's feature gatherer is thread-safe

### DIFF
--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -18,13 +18,13 @@ RelationEditorBase {
     //if cardinality is not set, the nmRelationId is empty
     id: relationEditorModel
     currentRelationId: relationId
-    currentNmRelationId: nmRelationId
+    currentNmRelationId: nmRelationId ? nmRelationId : ""
     feature: currentFeature
 
     property int featureFocus: -1
     onModelUpdated: {
       if (featureFocus > -1) {
-        referencingFeatureListView.currentIndex = relationEditorModel.getFeatureIdRow(featureFocus);
+        listView.currentIndex = relationEditorModel.getFeatureIdRow(featureFocus);
         featureFocus = -1;
       }
     }


### PR DESCRIPTION
Hoping this fixes the crash reported in https://github.com/opengisch/QField/issues/6261 . I've been able to replicate the crash (which does not happen all the time), and the gdb stack trace led me to realize our FeatureGatherer class was not thread safe. 