### PR TITLE
Fix all features locator's bad expression creation

### DIFF
--- a/src/core/locator/featureslocatorfilter.cpp
+++ b/src/core/locator/featureslocatorfilter.cpp
@@ -71,9 +71,7 @@ QStringList FeaturesLocatorFilter::prepare( const QString &string, const QgsLoca
 #endif
     QString enhancedSearch = string;
     enhancedSearch.replace( " ", "%" );
-    req.setFilterExpression( QStringLiteral( "%1 ILIKE '%%2%'" )
-                               .arg( layer->displayExpression() )
-                               .arg( enhancedSearch ) );
+    req.setFilterExpression( QStringLiteral( "%1 ILIKE '%%2%'" ).arg( layer->displayExpression(), enhancedSearch ) );
     req.setLimit( 30 );
 
     std::shared_ptr<PreparedLayer> preparedLayer( new PreparedLayer() );


### PR DESCRIPTION
By using .arg twice when creating the filter expression string, we were messing with any %1 present in the display expression (e.g. `format('room %1', "roomName")` )