### PR TITLE
Fix temporal filtering not respecting default project temporal navigation state

### DIFF
--- a/src/core/qgsquick/qgsquickmapsettings.cpp
+++ b/src/core/qgsquick/qgsquickmapsettings.cpp
@@ -356,9 +356,9 @@ void QgsQuickMapSettings::onReadProject( const QDomDocument &doc )
     const bool isTemporal = mProject->readNumEntry( QStringLiteral( "TemporalControllerWidget" ), QStringLiteral( "/NavigationMode" ), 0 ) != 0;
     const QString startString = QgsProject::instance()->readEntry( QStringLiteral( "TemporalControllerWidget" ), QStringLiteral( "/StartDateTime" ) );
     const QString endString = QgsProject::instance()->readEntry( QStringLiteral( "TemporalControllerWidget" ), QStringLiteral( "/EndDateTime" ) );
-    mMapSettings.setIsTemporal( isTemporal );
     mMapSettings.setTemporalRange( QgsDateTimeRange( QDateTime::fromString( startString, Qt::ISODateWithMs ),
                                                      QDateTime::fromString( endString, Qt::ISODateWithMs ) ) );
+    mMapSettings.setIsTemporal( isTemporal );
   }
 
   QDomNodeList nodes = doc.elementsByTagName( "mapcanvas" );

--- a/src/core/utils/expressioncontextutils.cpp
+++ b/src/core/utils/expressioncontextutils.cpp
@@ -149,11 +149,14 @@ void ExpressionContextUtils::setLayerVariables( QgsMapLayer *layer, const QVaria
   QStringList variableNames;
   QStringList variableValues;
 
-  QVariantMap::const_iterator it = variables.constBegin();
-  while ( ++it != variables.constEnd() )
+  if ( !variables.isEmpty() )
   {
-    variableNames << it.key();
-    variableValues << it.value().toString();
+    QVariantMap::const_iterator it = variables.constBegin();
+    while ( ++it != variables.constEnd() )
+    {
+      variableNames << it.key();
+      variableValues << it.value().toString();
+    }
   }
 
   layer->setCustomProperty( QStringLiteral( "variableNames" ), variableNames );

--- a/src/qml/editorwidgets/RelationEditorBase.qml
+++ b/src/qml/editorwidgets/RelationEditorBase.qml
@@ -43,6 +43,7 @@ EditorWidgetBase {
       height: !showAllItems && maximumVisibleItems > 0 ? Math.min(maximumVisibleItems * itemHeight, contentHeight) : contentHeight
       focus: true
       clip: true
+      boundsBehavior: Flickable.StopAtBounds
       highlightRangeMode: ListView.ApplyRange
       ScrollBar.vertical: QfScrollBar {
       }

--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -306,6 +306,7 @@ EditorWidgetBase {
           model: listModel
           width: parent.width
           height: searchFeaturePopup.height - searchBar.height - 50
+          boundsBehavior: Flickable.StopAtBounds
           clip: true
           ScrollBar.vertical: QfScrollBar {
           }

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -82,6 +82,7 @@ EditorWidgetBase {
       model: listModel
       focus: true
       clip: true
+      boundsBehavior: Flickable.StopAtBounds
 
       section.property: listModel.groupField != "" ? "groupFieldValue" : ""
       section.labelPositioning: ViewSection.CurrentLabelAtStart | ViewSection.InlineLabels


### PR DESCRIPTION
The logic got lost along the way it seems.

When someone saves a temporally-aware project with temporal navigation disabled, QField was meant to not activate its own temporal filtering. Upstream seems to have changed some of its behavior, whereas setting the map settings' temporal range (re-)enables temporal state. This PR addresses the behavior change to get us back to a sane behavior.

Fixes #6271 