### PR TITLE
Fix map center positioning with rotation and information drawer

### DIFF
--- a/src/core/qgsquick/qgsquickmapsettings.cpp
+++ b/src/core/qgsquick/qgsquickmapsettings.cpp
@@ -148,8 +148,8 @@ void QgsQuickMapSettings::setCenter( const QgsPoint &center, bool handleMargins 
 
     // Adjust margins based on rotation
     const double rotationRadians = mMapSettings.rotation() * M_PI / 180.0;
-    const double xAdjustment = baseXAdjustment * cos(rotationRadians) - baseYAdjustment * sin(rotationRadians);
-    const double yAdjustment = baseXAdjustment * sin(rotationRadians) + baseYAdjustment * cos(rotationRadians);
+    const double xAdjustment = baseXAdjustment * cos( rotationRadians ) - baseYAdjustment * sin( rotationRadians );
+    const double yAdjustment = baseXAdjustment * sin( rotationRadians ) + baseYAdjustment * cos( rotationRadians );
 
     e.setXMinimum( e.xMinimum() + delta.x() - xAdjustment );
     e.setXMaximum( e.xMaximum() + delta.x() - xAdjustment );

--- a/src/core/qgsquick/qgsquickmapsettings.cpp
+++ b/src/core/qgsquick/qgsquickmapsettings.cpp
@@ -142,8 +142,14 @@ void QgsQuickMapSettings::setCenter( const QgsPoint &center, bool handleMargins 
   QgsRectangle e = mMapSettings.extent();
   if ( handleMargins )
   {
-    const double xAdjustment = mRightMargin * devicePixelRatio() * mMapSettings.mapUnitsPerPixel() / 2;
-    const double yAdjustment = mBottomMargin * devicePixelRatio() * mMapSettings.mapUnitsPerPixel() / 2;
+    // Calculate base margin adjustments (split in half for centering)
+    const double baseXAdjustment = mRightMargin * devicePixelRatio() * mMapSettings.mapUnitsPerPixel() / 2;
+    const double baseYAdjustment = mBottomMargin * devicePixelRatio() * mMapSettings.mapUnitsPerPixel() / 2;
+
+    // Adjust margins based on rotation
+    const double rotationRadians = mMapSettings.rotation() * M_PI / 180.0;
+    const double xAdjustment = baseXAdjustment * cos(rotationRadians) - baseYAdjustment * sin(rotationRadians);
+    const double yAdjustment = baseXAdjustment * sin(rotationRadians) + baseYAdjustment * cos(rotationRadians);
 
     e.setXMinimum( e.xMinimum() + delta.x() - xAdjustment );
     e.setXMaximum( e.xMaximum() + delta.x() - xAdjustment );

--- a/src/core/qgsquick/qgsquickmapsettings.cpp
+++ b/src/core/qgsquick/qgsquickmapsettings.cpp
@@ -140,7 +140,7 @@ void QgsQuickMapSettings::setCenter( const QgsPoint &center, bool handleMargins 
 
   const QgsVector delta = QgsPointXY( center ) - mMapSettings.extent().center();
   QgsRectangle e = mMapSettings.extent();
-  if ( handleMargins )
+  if ( handleMargins && ( !qgsDoubleNear( mRightMargin, 0.0 ) || !qgsDoubleNear( mBottomMargin, 0.0 ) ) )
   {
     // Calculate base margin adjustments (split in half for centering)
     const double baseXAdjustment = mRightMargin * devicePixelRatio() * mMapSettings.mapUnitsPerPixel() / 2;

--- a/src/qml/geometryeditors/VertexEditor.qml
+++ b/src/qml/geometryeditors/VertexEditor.qml
@@ -152,7 +152,7 @@ QfVisibilityFadingRow {
     visible: featureModel && (featureModel.vertexModel.canAddVertex || featureModel.vertexModel.editingMode === VertexModel.AddVertex)
     bgcolor: enabled && featureModel && featureModel.vertexModel.canPreviousVertex ? Theme.toolButtonBackgroundColor : Theme.toolButtonBackgroundSemiOpaqueColor
     iconSource: Theme.getThemeVectorIcon("ic_chevron_left_white_24dp")
-    iconColor: enabled && featureModel && featureModel.vertexModel.canNextVertex ? Theme.toolButtonColor : Theme.toolButtonBackgroundSemiOpaqueColor
+    iconColor: enabled && featureModel && featureModel.vertexModel.canPreviousVertex ? Theme.toolButtonColor : Theme.toolButtonBackgroundSemiOpaqueColor
 
     onClicked: {
       if (vertexEditorToolbar.currentVertexModified) {


### PR DESCRIPTION
## Pull Request Description
When clicking the "next feature" button in geometry editing mode, the map center position was incorrect when:
1. The map was rotated
2. The information drawer was open

This happened because the margin adjustments for the information drawer weren't properly accounting for map rotation.

## ✨ Solution
The fix modifies the `setCenter` function in `QgsQuickMapSettings` to properly handle margin adjustments with rotation. Here's how it works:

### 1. Base Margin Calculation
```cpp
const double baseXAdjustment = mRightMargin * devicePixelRatio() * mMapSettings.mapUnitsPerPixel() / 2;
const double baseYAdjustment = mBottomMargin * devicePixelRatio() * mMapSettings.mapUnitsPerPixel() / 2;
```
- We calculate the base margin adjustments in map units
- The division by 2 is crucial because the margin needs to be split between both sides of the center point
- This ensures proper centering when rotation is 0

### 2. Rotation Adjustment
```cpp
const double rotationRadians = mMapSettings.rotation() * M_PI / 180.0;
const double xAdjustment = baseXAdjustment * cos(rotationRadians) - baseYAdjustment * sin(rotationRadians);
const double yAdjustment = baseXAdjustment * sin(rotationRadians) + baseYAdjustment * cos(rotationRadians);
```
- We convert the rotation angle to radians
- ✨ We use rotation matrices to transform the margin adjustments:
  - `xAdjustment = baseX * cos(θ) - baseY * sin(θ)`
  - `yAdjustment = baseX * sin(θ) + baseY * cos(θ)`
- This properly rotates the margin adjustments to account for the map's rotation


## Issue   
  
[issue before.webm](https://github.com/user-attachments/assets/7b733900-6f31-4aed-8172-54a961387346)


## Fixed

[Screencast From 2025-05-21 20-11-00.webm](https://github.com/user-attachments/assets/8e7ecf68-95fb-48f9-9b88-28472e964e9f)
