### PR TITLE
Fix minimum API level for foreground service type

### DIFF
--- a/platform/android/src/ch/opengis/qfield/QFieldPositioningService.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldPositioningService.java
@@ -157,7 +157,7 @@ public class QFieldPositioningService extends QtService {
         Notification notification = builder.build();
 
         try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 startForeground(NOTIFICATION_ID, notification,
                                 ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION);
             } else {


### PR DESCRIPTION
I was misreading the documentation, the Build.VERSION_CODES.UPSIDE_DOWN_CAKE minimum has to do with the manifest, not the function parameter.