### PR TITLE
Fix badge alignment of geometryless layers

### DIFF
--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -211,7 +211,7 @@ ListView {
         Text {
           id: layerName
           width: rectangle.width - itemPadding - 46 // legend icon + right padding
-          - collapsedState.width - (layerVisibility.isVisible ? layerVisibility.width : 0) - badges.width
+          - collapsedState.width - (layerVisibility.isVisible ? layerVisibility.width : -5) - badges.width
           padding: 3
           leftPadding: 0
           text: Name


### PR DESCRIPTION
Fixes issue seen below (notice the misaligned read-only badge for the schedule layer):

![Screenshot From 2025-05-24 11-48-12](https://github.com/user-attachments/assets/e73eb32f-53f1-484b-b785-493954944f8c)
