### PR TITLE
Avoid scary clipboard message when launching the app

### DIFF
--- a/src/core/clipboardmanager.cpp
+++ b/src/core/clipboardmanager.cpp
@@ -28,7 +28,6 @@ ClipboardManager::ClipboardManager( QObject *parent )
   , mClipboard( QApplication::clipboard() )
 {
   connect( QApplication::clipboard(), &QClipboard::dataChanged, this, &ClipboardManager::dataChanged );
-  dataChanged();
 }
 
 void ClipboardManager::dataChanged()

--- a/src/core/clipboardmanager.cpp
+++ b/src/core/clipboardmanager.cpp
@@ -38,11 +38,21 @@ void ClipboardManager::dataChanged()
     return;
   }
 
+  const QMimeData *mimeData = mClipboard->mimeData();
+  if ( mimeData->hasHtml() && !mHtmlFeature.isEmpty() && mimeData->html() == mHtmlFeature )
+  {
+    // On Android, data changed can be triggered multiple times, yet the content
+    // stays the same, assume this is what is happening here.
+    return;
+  }
+
+  mHoldsFeature = false;
   mHasNativeFeature = false;
   mNativeFeature = QgsFeature();
+  mHtmlFeature.clear();
 
   bool holdsFeature = false;
-  const QMimeData *mimeData = mClipboard->mimeData();
+
   if ( mimeData->hasHtml() )
   {
     QDomDocument doc;
@@ -99,13 +109,14 @@ void ClipboardManager::copyFeatureToClipboard( const QgsFeature &feature, bool i
 <!DOCTYPE html>
 <html>
  <head>
-  <meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\"/>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
  </head>
  <body>
-  <table border=\"1\" qfield=\"1\"><tr>%1</tr></table>
+  <table border="1" qfield="1"><tr>%1</tr></table>
  </body>
 </html>)""" )
                        .arg( htmlLines.join( QStringLiteral( "</tr><tr>" ) ) ) );
+  mHtmlFeature = mimeData->html();
 
   mSkipDataChanged = true;
   mClipboard->setMimeData( mimeData );

--- a/src/core/clipboardmanager.h
+++ b/src/core/clipboardmanager.h
@@ -78,6 +78,7 @@ class ClipboardManager : public QObject
     bool mHoldsFeature = false;
     bool mHasNativeFeature = false;
     QgsFeature mNativeFeature;
+    QString mHtmlFeature;
 };
 
 #endif // PROJECTINFO_H


### PR DESCRIPTION
This message scares people, let's get rid of it: 

![Screenshot_20250525-085109](https://github.com/user-attachments/assets/783ea777-d04c-4c9c-8bfe-b05c68fb859f)

The one downside is that, on app launch, if someone had copied a feature string data from an email or message (a 0.1% chance of ever being the case), QField wouldn't be aware of this on launch. I think it's a fair trade to avoid scaring people.