### PR TITLE
Add feature processing capability to individual features.

### DIFF
--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -724,6 +724,20 @@ Rectangle {
     }
 
     MenuItem {
+      id: processFeatureButton
+      text: qsTr('Process Feature')
+      icon.source: Theme.getThemeVectorIcon("ic_processing_black_24dp")
+      enabled: ((projectInfo.editRights || editButton.isCreatedCloudFeature) && (!selection.focusedLayer || !featureForm.model.featureModel.geometryLocked))
+      visible: enabled
+
+      font: Theme.defaultFont
+      height: visible ? 48 : 0
+      leftPadding: Theme.menuItemLeftPadding
+
+      onTriggered: processingFeatureClicked()
+    }
+
+    MenuItem {
       id: moveFeatureBtn
       text: qsTr('Move Feature')
       icon.source: Theme.getThemeVectorIcon("ic_move_white_24dp")
@@ -792,19 +806,6 @@ Rectangle {
       leftPadding: Theme.menuItemLeftPadding
 
       onTriggered: deleteClicked()
-    }
-
-    MenuItem {
-      id: processFeatureButton
-      text: qsTr('Process Feature')
-      icon.source: Theme.getThemeVectorIcon("ic_processing_black_24dp")
-      enabled: projectInfo.editRights
-
-      font: Theme.defaultFont
-      height: visible ? 48 : 0
-      leftPadding: Theme.menuItemLeftPadding
-
-      onTriggered: processingFeatureClicked()
     }
   }
 

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -61,6 +61,7 @@ Rectangle {
   signal multiProcessingClicked
 
   signal processingRunClicked
+  signal processFeatureClicked
 
   anchors.top: parent.top
   anchors.left: parent.left
@@ -212,7 +213,7 @@ Rectangle {
     anchors.top: parent.top
     anchors.topMargin: toolBar.topMargin
 
-    visible: toolBar.state != "Edit" && !toolBar.multiSelection
+    visible: enabled
     width: visible ? 48 : 0
     height: 48
     clip: true
@@ -220,7 +221,7 @@ Rectangle {
     iconSource: toolBar.state == "Navigation" ? Theme.getThemeVectorIcon("ic_chevron_left_white_24dp") : Theme.getThemeVectorIcon("ic_arrow_left_white_24dp")
     iconColor: Theme.mainOverlayColor
 
-    enabled: toolBar.state != "Edit" && !toolBar.multiSelection
+    enabled: toolBar.state != "Edit" && !toolBar.multiSelection && toolBar.state !== "ProcessingLaunch" && toolBar.state != "ProcessingAlgorithmsList"
 
     onClicked: {
       if (toolBar.model && (selection.focusedItem > 0)) {
@@ -417,7 +418,7 @@ Rectangle {
     anchors.top: parent.top
     anchors.topMargin: toolBar.topMargin
 
-    visible: (toolBar.state == "Processing" || toolBar.state == "ProcessingLaunch" || toolBar.state == "Indication") && toolBar.multiSelection && toolBar.model
+    visible: (toolBar.state == "Processing" || toolBar.state == "ProcessingLaunch" || toolBar.state == "Indication") && (toolBar.multiSelection) && toolBar.model  || ( toolBar.state === "ProcessingLaunch" )
     width: visible ? 48 : 0
     height: 48
     clip: true
@@ -425,7 +426,7 @@ Rectangle {
     iconSource: Theme.getThemeVectorIcon("ic_clear_white_24dp")
     iconColor: Theme.mainOverlayColor
 
-    enabled: (toolBar.multiSelection && toolBar.model)
+    enabled: (toolBar.multiSelection && toolBar.model) || toolBar.state === "ProcessingLaunch"
 
     onClicked: toggleMultiSelection()
 
@@ -791,6 +792,19 @@ Rectangle {
       leftPadding: Theme.menuItemLeftPadding
 
       onTriggered: deleteClicked()
+    }
+
+    MenuItem {
+      id: processFeatureButton
+      text: qsTr('Process Feature')
+      icon.source: Theme.getThemeVectorIcon("ic_processing_black_24dp")
+      enabled: projectInfo.editRights
+
+      font: Theme.defaultFont
+      height: visible ? 48 : 0
+      leftPadding: Theme.menuItemLeftPadding
+
+      onTriggered: processFeatureClicked();
     }
   }
 

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -61,7 +61,7 @@ Rectangle {
   signal multiProcessingClicked
 
   signal processingRunClicked
-  signal processFeatureClicked
+  signal processingFeatureClicked
 
   anchors.top: parent.top
   anchors.left: parent.left
@@ -221,7 +221,7 @@ Rectangle {
     iconSource: toolBar.state == "Navigation" ? Theme.getThemeVectorIcon("ic_chevron_left_white_24dp") : Theme.getThemeVectorIcon("ic_arrow_left_white_24dp")
     iconColor: Theme.mainOverlayColor
 
-    enabled: toolBar.state != "Edit" && !toolBar.multiSelection && toolBar.state !== "ProcessingLaunch" && toolBar.state != "ProcessingAlgorithmsList"
+    enabled: toolBar.state != "Edit" && !toolBar.multiSelection
 
     onClicked: {
       if (toolBar.model && (selection.focusedItem > 0)) {
@@ -418,7 +418,7 @@ Rectangle {
     anchors.top: parent.top
     anchors.topMargin: toolBar.topMargin
 
-    visible: (toolBar.state == "Processing" || toolBar.state == "ProcessingLaunch" || toolBar.state == "Indication") && (toolBar.multiSelection) && toolBar.model  || ( toolBar.state === "ProcessingLaunch" )
+    visible: toolBar.multiSelection && toolBar.model && (toolBar.state === "Processing" || toolBar.state === "ProcessingLaunch" || toolBar.state === "Indication")
     width: visible ? 48 : 0
     height: 48
     clip: true
@@ -426,7 +426,7 @@ Rectangle {
     iconSource: Theme.getThemeVectorIcon("ic_clear_white_24dp")
     iconColor: Theme.mainOverlayColor
 
-    enabled: (toolBar.multiSelection && toolBar.model) || toolBar.state === "ProcessingLaunch"
+    enabled: (toolBar.multiSelection && toolBar.model)
 
     onClicked: toggleMultiSelection()
 
@@ -804,7 +804,7 @@ Rectangle {
       height: visible ? 48 : 0
       leftPadding: Theme.menuItemLeftPadding
 
-      onTriggered: processFeatureClicked();
+      onTriggered: processingFeatureClicked()
     }
   }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -788,9 +788,12 @@ ApplicationWindow {
       searchRadiusMm: 3
 
       onIdentifyFinished: {
-        if (qfieldSettings.autoOpenFormSingleIdentify && !isMenuRequest && featureForm.model.count === 1) {
-          featureForm.selection.focusedItem = 0;
-          featureForm.state = "FeatureForm";
+        if (!featureForm.multiSelection) {
+          if (qfieldSettings.autoOpenFormSingleIdentify && !isMenuRequest && featureForm.model.count === 1) {
+            featureForm.selection.focusedItem = 0;
+            featureForm.state = "FeatureForm";
+            featureForm.singleFeatureIdentified = true;
+          }
         }
       }
     }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -788,12 +788,9 @@ ApplicationWindow {
       searchRadiusMm: 3
 
       onIdentifyFinished: {
-        if (!featureForm.multiSelection) {
-          if (qfieldSettings.autoOpenFormSingleIdentify && !isMenuRequest && featureForm.model.count === 1) {
-            featureForm.selection.focusedItem = 0;
-            featureForm.state = "FeatureForm";
-            featureForm.singleFeatureIdentified = true;
-          }
+        if (qfieldSettings.autoOpenFormSingleIdentify && !isMenuRequest && !featureForm.multiSelection && featureForm.model.count === 1) {
+          featureForm.selection.focusedItem = 0;
+          featureForm.state = "FeatureForm";
         }
       }
     }


### PR DESCRIPTION
## Description

This PR introduces the ability to process individual features directly from the feature form. Previously, processing actions were mainly available in multi-selection or list contexts. With this enhancement, users can now trigger processing algorithms on a single feature without having to leave the feature form, streamlining the workflow and improving usability.

## ✨ Key Changes

- Added a new `Process Feature` menu item within the feature form options.
- Introduced the `singleFeatureIdentified` property and related logic to track and handle single feature identification.
- Updated `NavigationBar.qml`, `FeatureListForm.qml` and `qgismobileapp.qml` to wire up the new behavior and UI elements.

## Usage

- When a single feature is identified and opened in the feature form, users will see the new **Process Feature** option.
- Selecting this option will open the processing algorithms list, allowing users to run processing tasks on that specific feature.

## Demo & Tests
  

[Screencast From 2025-05-31 00-35-20.webm](https://github.com/user-attachments/assets/84c4356d-3afc-4f7c-a8e4-83fd74ebecc2)


## Additional Notes
https://github.com/opengisch/QField/pull/6223#issuecomment-2834678479