### PR TITLE
Handle topological addition of vertices across layers when using the vertex editor tool

### DIFF
--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -1053,6 +1053,7 @@ void FeatureModel::applyVertexModelTopography()
   if ( !mVertexModel )
     return;
 
+  const QVector<QgsPoint> pointsAdded = mVertexModel->verticesAdded();
   const QVector<QPair<QgsPoint, QgsPoint>> pointsMoved = mVertexModel->verticesMoved();
   const QVector<QgsPoint> pointsDeleted = mVertexModel->verticesDeleted();
 
@@ -1065,6 +1066,11 @@ void FeatureModel::applyVertexModelTopography()
     if ( vectorLayer != mLayer )
     {
       vectorLayer->startEditing();
+    }
+
+    for ( const auto &point : pointsAdded )
+    {
+      vectorLayer->addTopologicalPoints( point );
     }
 
     QgsPointLocator loc( vectorLayer );

--- a/src/core/vertexmodel.cpp
+++ b/src/core/vertexmodel.cpp
@@ -618,10 +618,13 @@ void VertexModel::selectVertexAtPosition( const QgsPoint &mapPoint, double thres
     {
       if ( autoInsert )
       {
+        setCurrentVertex( closestRow );
+        addToHistory( VertexAddition );
+
         // makes a new vertex as an existing vertex
         beginResetModel();
         mVertices[closestRow].type = ExistingVertex;
-        setCurrentVertex( closestRow );
+        mVertices[closestRow].originalPoint = mVertices[closestRow].point;
         createCandidates();
         setEditingMode( EditVertex );
         endResetModel();
@@ -839,6 +842,19 @@ QVector<QgsPoint> VertexModel::flatVertices( int ringId ) const
   if ( mGeometryType == Qgis::GeometryType::Polygon )
   {
     vertices << vertices.constFirst();
+  }
+  return vertices;
+}
+
+QVector<QgsPoint> VertexModel::verticesAdded() const
+{
+  QVector<QgsPoint> vertices;
+  for ( int i = 0; i <= mHistoryIndex; i++ )
+  {
+    if ( mHistory[i].type == VertexAddition )
+    {
+      vertices << mHistory[i].vertex.point;
+    }
   }
   return vertices;
 }

--- a/src/core/vertexmodel.h
+++ b/src/core/vertexmodel.h
@@ -240,6 +240,9 @@ class QFIELD_CORE_EXPORT VertexModel : public QAbstractListModel
     //! For a polygon, if ringId is not given the current ring will be returned
     QVector<QgsPoint> flatVertices( int ringId = -1 ) const;
 
+    //! Returns a list of added vertices not found in linked geometry
+    QVector<QgsPoint> verticesAdded() const;
+
     //! Returns a list of moved vertices found in linked geometry
     QVector<QPair<QgsPoint, QgsPoint>> verticesMoved() const;
 


### PR DESCRIPTION
Screencast time:

https://github.com/user-attachments/assets/4a6e02af-adce-49b5-8b86-6b560c08cd13

The PR adds a missing bit in our vertex editor tool whereas _addition of new vertices_ were never injected into topological relationships across layers.