### PR TITLE
Improve wrapping of local data view's filenames

### DIFF
--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -237,7 +237,7 @@ Page {
                 font.pointSize: Theme.defaultFont.pointSize
                 font.underline: itemMenuLoadable
                 color: itemMenuLoadable ? Theme.mainColor : Theme.mainTextColor
-                wrapMode: Text.WordWrap
+                wrapMode: Text.Wrap
               }
               Text {
                 id: itemInfo


### PR DESCRIPTION
Simply wrapping on word boundaries is not proper/enough when looking a filenames. Matches a similar fix we applied for QFieldCloud projects list view.

This now properly reflows:

![image](https://github.com/user-attachments/assets/ae6660a0-0a3a-4bd6-b8af-221fb3474535)
