### PR TITLE
Stop rendering when freezing canvas for anything but follow events

### DIFF
--- a/src/qml/MapCanvas.qml
+++ b/src/qml/MapCanvas.qml
@@ -78,6 +78,9 @@ Item {
   function freeze(id) {
     mapCanvasWrapper.__freezecount[id] = true;
     mapCanvasWrapper.freeze = true;
+    if (id !== 'follow') {
+      mapCanvasWrapper.stopRendering();
+    }
   }
 
   function unfreeze(id) {


### PR DESCRIPTION
A regression was conveyed on the play store about "sluggish" behavior with QField 3.6, I suspect it has to do with us not stopping rendering while panning / zooming / rotating. We can go back to the previous behavior while leaving the new behavior on when locked to canvas (aka 'follow').