### PR TITLE
Make Markdown images responsive in changelog viewer.

### DIFF
--- a/src/core/changelogcontents.cpp
+++ b/src/core/changelogcontents.cpp
@@ -111,6 +111,9 @@ void ChangelogContents::request()
     changelog = changelog.replace( regexpAllTitles, QStringLiteral( "\n###\n##\\1\n\n\n" ) );
     changelog = "Up to release **" + versionNumbersOnly + "**" + changelog;
 
+    const QRegularExpression imageMdSyntax( QStringLiteral( "!\\[([^\\]]*)\\]\\(([^)]+)\\)" ) );
+    changelog = changelog.replace( imageMdSyntax, QStringLiteral( "<img src=\"\\2\" alt=\"\\1\" style=\"max-width:100%; height:auto;\" />" ) );
+
 #if defined( Q_OS_ANDROID )
     const QString platformName = QLatin1String( "android" );
 #elif defined( Q_OS_IOS )

--- a/src/qml/Changelog.qml
+++ b/src/qml/Changelog.qml
@@ -75,17 +75,13 @@ Popup {
             textFormat: Text.MarkdownText
             wrapMode: Text.WordWrap
 
-            function makeImagesResponsive(markdown) {
-              return markdown.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<img src="$2" alt="$1" style="max-width:100%; height:auto;" />');
-            }
-
             text: {
               switch (changelogContents.status) {
               case ChangelogContents.IdleStatus:
               case ChangelogContents.LoadingStatus:
                 return '';
               case ChangelogContents.SuccessStatus:
-                return makeImagesResponsive(changelogContents.markdown);
+                return changelogContents.markdown;
               case ChangelogContents.ErrorStatus:
                 return qsTr('Error while fetching changelog, try again later.');
               }

--- a/src/qml/Changelog.qml
+++ b/src/qml/Changelog.qml
@@ -75,13 +75,17 @@ Popup {
             textFormat: Text.MarkdownText
             wrapMode: Text.WordWrap
 
+            function makeImagesResponsive(markdown) {
+              return markdown.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<img src="$2" alt="$1" style="max-width:100%; height:auto;" />');
+            }
+
             text: {
               switch (changelogContents.status) {
               case ChangelogContents.IdleStatus:
               case ChangelogContents.LoadingStatus:
                 return '';
               case ChangelogContents.SuccessStatus:
-                return changelogContents.markdown;
+                return makeImagesResponsive(changelogContents.markdown);
               case ChangelogContents.ErrorStatus:
                 return qsTr('Error while fetching changelog, try again later.');
               }


### PR DESCRIPTION
## Description
This PR fixes an issue where large images in the changelog view could overflow the screen on smaller devices.

### ✨ Key Changes
- Ensured images are responsive using `style="max-width:100%; height:auto;"`

### 📸 Before & After
| Before                                                         | After                                                         |
| -------------------------------------------------------------- | ------------------------------------------------------------- |
|![image](https://github.com/user-attachments/assets/6f421035-2e50-4d7c-9e74-8c062138b575) |![image](https://github.com/user-attachments/assets/6dbfc394-e145-430d-bbf4-48b22e07d85b)
 

