### PR TITLE
Navigation → Azimuth : Printing a positive value when bearing > 180°

### DIFF
--- a/src/core/navigation.cpp
+++ b/src/core/navigation.cpp
@@ -292,6 +292,7 @@ void Navigation::updateDetails()
     mVerticalDistance = std::numeric_limits<double>::quiet_NaN();
   }
   mBearing = mDa.bearing( mLocation, destinationPoint ) * 180 / M_PI;
+  mBearing = std::fmod(bearingDeg + 360.0, 360.0);
 
   emit detailsChanged();
 


### PR DESCRIPTION
Added line 295 to force values returned negative in the range 180.1° to 360° to appear positive (modulo of the result forcing it to be in the range 0° to 360°).

Example : If the value returned is -45°, it's 315° which is returned. 

For users, this more intuitive and similar to a compass use.