### PR TITLE
[Backport release-3_6] Allow non-HTTPS connections on iOS to connect to GNSS NMEA streams over HTTP TCP sockets

### DIFF
--- a/platform/ios/Info.plist.in
+++ b/platform/ios/Info.plist.in
@@ -86,6 +86,13 @@
     <key>CSResourcesFileMapped</key>
     <true/>
 
+    <!-- External GNSS through non-HTTPS TCP -->
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+    </dict>
+
     <!-- Copyright -->
     <key>NSHumanReadableCopyright</key>
     <string>${MACOSX_BUNDLE_COPYRIGHT}</string>


### PR DESCRIPTION
Backport #6375
 **Authored by:** @nirvn