### PR TITLE
fix: accidentally killed `+` support in attachments filenames due to windows insane slashes

### DIFF
--- a/src/core/utils/fileutils.cpp
+++ b/src/core/utils/fileutils.cpp
@@ -94,7 +94,7 @@ QString FileUtils::sanitizeFilePath( const QString &filePath, const QString &rep
 
   // replace multiple slashes
   sanitized.replace( QRegularExpression( "/+" ), QLatin1String( "/" ) );
-  sanitized.replace( QRegularExpression( "\\+" ), QLatin1String( "\\" ) );
+  sanitized.replace( QRegularExpression( "[\\\\]+" ), QLatin1String( "\\" ) );
   // replace windows dives path with UNIX style path
   sanitized.replace( QRegularExpression( "^([a-zA-Z]):\\\\" ), QLatin1String( "/\\1/" ) );
   // replace windows slashes to UNIX slashes

--- a/test/test_fileutils.cpp
+++ b/test/test_fileutils.cpp
@@ -178,7 +178,9 @@ TEST_CASE( "FileUtils" )
     REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( " file" ) ) == QStringLiteral( "file" ) );
     REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( " file " ) ) == QStringLiteral( "file" ) );
     REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path / to / file " ) ) == QStringLiteral( "path/to/file" ) );
+    // single slash is enough
     REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "//path////to///filename.txt" ) ) == QStringLiteral( "/path/to/filename.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "\\\\\\path\\\\to\\filename.txt" ) ) == QStringLiteral( "/path/to/filename.txt" ) );
     // allow whitespace whitin the name
     REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path  to / file " ) ) == QStringLiteral( "path  to/file" ) );
     REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path  to file " ) ) == QStringLiteral( "path  to file" ) );
@@ -219,6 +221,9 @@ TEST_CASE( "FileUtils" )
     REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "x" ).repeated( FILENAME_MAX_CHAR_LENGTH ) ) == QStringLiteral( "x" ).repeated( FILENAME_MAX_CHAR_LENGTH ) );
     REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "x" ).repeated( FILENAME_MAX_CHAR_LENGTH + 1 ) ).isEmpty() );
     REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "x" ).repeated( FILENAME_MAX_CHAR_LENGTH - 3 ).append( QStringLiteral( "/NUL" ) ) ).isEmpty() );
+    // preserve the plus sign (#6334)
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "path+to/file+name.txt" ) ) == QStringLiteral( "path+to/file+name.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePath( QStringLiteral( "file/+name.txt" ) ) == QStringLiteral( "file/+name.txt" ) );
   }
 
 
@@ -269,6 +274,9 @@ TEST_CASE( "FileUtils" )
     REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "com0.txt" ) ) == QStringLiteral( "_com0.txt" ) );
     REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "lpt0.txt" ) ) == QStringLiteral( "_lpt0.txt" ) );
     REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "prn.txt" ) ) == QStringLiteral( "_prn.txt" ) );
+    // preserve the plus sign (#6334)
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "file+name.txt" ) ) == QStringLiteral( "file+name.txt" ) );
+    REQUIRE( FileUtils::sanitizeFilePathPart( QStringLiteral( "file/+name.txt" ) ) == QStringLiteral( "file_+name.txt" ) );
   }
 
 


### PR DESCRIPTION
Seems I failed to understand how escaping works. Added tests for robustness.

Fixes https://github.com/opengisch/QField/issues/6334