### PR TITLE
[Backport release-3_6] fix: typo in the relation editor about con(s)traints

### DIFF
--- a/src/qml/editorwidgets/RelationEditorBase.qml
+++ b/src/qml/editorwidgets/RelationEditorBase.qml
@@ -66,7 +66,7 @@ EditorWidgetBase {
         Text {
           visible: isEnabled
           color: Theme.secondaryTextColor
-          text: isEnabled && !constraintsHardValid ? qsTr('Ensure contraints are met') : ''
+          text: isEnabled && !constraintsHardValid ? qsTr('Ensure constraints are met') : ''
           anchors {
             leftMargin: 10
             left: parent.left


### PR DESCRIPTION
Backport #6394
 **Authored by:** @suricactus