### PR TITLE
Insure navigation bearing serves a value between 0 to 360 degree

### DIFF
--- a/src/core/navigation.cpp
+++ b/src/core/navigation.cpp
@@ -292,6 +292,7 @@ void Navigation::updateDetails()
     mVerticalDistance = std::numeric_limits<double>::quiet_NaN();
   }
   mBearing = mDa.bearing( mLocation, destinationPoint ) * 180 / M_PI;
+  mBearing = std::fmod( mBearing + 360.0, 360.0 );
 
   emit detailsChanged();
 


### PR DESCRIPTION
Original fix provided by @AntoElCrackito here (https://github.com/opengisch/QField/pull/6378).

