### PR TITLE
[Backport release-3_6] Insure navigation bearing serves a value between 0 to 360 degree

### DIFF
--- a/src/core/navigation.cpp
+++ b/src/core/navigation.cpp
@@ -292,6 +292,7 @@ void Navigation::updateDetails()
     mVerticalDistance = std::numeric_limits<double>::quiet_NaN();
   }
   mBearing = mDa.bearing( mLocation, destinationPoint ) * 180 / M_PI;
+  mBearing = std::fmod( mBearing + 360.0, 360.0 );
 
   emit detailsChanged();
 


### PR DESCRIPTION
Backport #6399
 **Authored by:** @nirvn