### PR TITLE
Add devcontainer support for QField

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,61 @@
+// This Dev Container is based on linux build github action
+{
+  "name": "QField-Development",
+  "image": "ubuntu:22.04",
+
+  // IDE configuration
+  "customizations" : {
+    "jetbrains" : {
+      "backend" : "IntelliJ",
+      "settings" : {},
+      "plugins": []
+    },
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cpptools",
+        "ms-vscode.cmake-tools",
+        "twxs.cmake",
+        "ms-vscode.cpptools-extension-pack"
+      ],
+      "settings": {
+        "cmake.configureOnOpen": true,
+        "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
+        "editor.formatOnSave": true,
+        "files.trimTrailingWhitespace": true,
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "cmake.buildDirectory": "${workspaceFolder}/build"
+      }
+    }
+  },
+
+  "features": {
+    "ghcr.io/devcontainers-extra/features/pre-commit:2": {}
+  },
+
+  // X11 display configuration for GUI support
+  "mounts": [
+    {
+      "source": "/tmp/.X11-unix",
+      "target": "/tmp/.X11-unix",
+      "type": "bind"
+    },
+    {
+      "source": "${env:XAUTHORITY}",
+      "target": "/root/.Xauthority",
+      "type": "bind"
+    }
+  ],
+
+  "containerEnv": {
+    "DISPLAY": "${env:DISPLAY}",
+    "QT_X11_NO_MITSHM": "1"
+  },
+
+  // Network configuration
+  "runArgs": [
+    "--net=host"
+  ],
+
+
+  "onCreateCommand": "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y git curl wget zip bison gperf flex libtool libxcb-cursor-dev autopoint '^libxcb.*-dev' libx11-xcb-dev libegl1-mesa libegl1-mesa-dev libgl1-mesa-dev libglu1-mesa-dev mesa-common-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libxrandr-dev libxxf86vm-dev autoconf-archive libgstreamer-gl1.0-0 libgstreamer-plugins-base1.0-0 libfuse2 libpulse-dev libcups2-dev nasm python3-tk python3-jinja2",
+}

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -297,7 +297,6 @@ You are now ready to develop and run the project using Qt Creator!
 
 ## Dev Container
 
-
 QField provides a devcontainer configuration that helps you get started with development quickly. The devcontainer is based on Ubuntu 22.04 and includes all necessary dependencies.
 
 ### Prerequisites
@@ -316,7 +315,6 @@ QField provides a devcontainer configuration that helps you get started with dev
 1. Open the QField folder in VS Code
 2. When prompted, click "Reopen in Container" or run the "Remote-Containers: Reopen in Container" command
 3. Wait for the container to build and initialize
-
 
 ### Building in the Container
 

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -294,3 +294,38 @@ The commands below are using `apt`, so they are written for Debian based systems
    - Select the newly created kit with a Debug configuration, pointing to the `build-x64-linux` directory.
 
 You are now ready to develop and run the project using Qt Creator!
+
+## Dev Container
+
+
+QField provides a devcontainer configuration that helps you get started with development quickly. The devcontainer is based on Ubuntu 22.04 and includes all necessary dependencies.
+
+### Prerequisites
+
+- Podman or Docker installed on your system
+- CLion or Visual Studio Code with the "Dev Containers" extension
+
+### Using with CLion
+
+1. Open the QField project in your CLion
+2. The IDE should detect the devcontainer configuration and prompt you to use it
+3. Click "Reopen in Container" and wait for the environment to be ready
+
+### Using with VS Code
+
+1. Open the QField folder in VS Code
+2. When prompted, click "Reopen in Container" or run the "Remote-Containers: Reopen in Container" command
+3. Wait for the container to build and initialize
+
+
+### Building in the Container
+
+Once inside the container, you can follow the regular [vcpkg build instructions](#using-vcpkg) or use automated tools provided by the IDE. Pre-commit is shipped with the devcontainer, you just have to initialize it for the repo with `pre-commit install`.
+
+### GUI Support
+
+If you got xcb errors when starting the built QField, you can enable GUI support by running this command on your **host** system:
+
+```sh
+xhost +local:
+```


### PR DESCRIPTION
This PR adds a devcontainer support to get started with the development in an easy way. I also added some instructions of how to use it with CLion and VSCode. 

For now it supports only linux based hosts (because of X11 mounts), but a separate devcontainer could be made for Windows-WSL later on.