### PR TITLE
homepage slides: backgrounds separated from phones

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,43 +115,53 @@
 
       <!-- Wrapper for slides -->
       <div class="carousel-inner">
-        <div class="item active" style="background-image: url('images/qf_carousel/qf-collect-phone.jpg');">
-          <div class="carousel-caption custom-caption">
-            <h2 class="carousel-title">
-              Collect <br>and edit <span style="color: var(--qfield-color)">data.</span>
-            </h2>
-            <div class="qf-button">
-              <a href="https://qfield.org/get" target="_blank" title="Get started">
-                <i class="fas fa-rocket"></i> GET STARTED
-              </a>
+
+        <div class="item active" style="background-image: url('images/qf_carousel/qf-bg-collect.jpg');">
+          <div class="carousel-content">
+            <img src="images/qf_carousel/qf-phones-collect1.png" alt="Phone" class="phone-image">
+            <div class="carousel-caption custom-caption">
+              <h2 class="carousel-title">
+                Collect <br>and edit <span style="color: var(--qfield-color)">data.</span>
+              </h2>
+              <div class="qf-button">
+                <a href="https://qfield.org/get" target="_blank" title="Get started">
+                  <i class="fas fa-rocket"></i> GET STARTED
+                </a>
+              </div>
             </div>
           </div>
         </div>
 
-        <div class="item" style="background-image: url('images/qf_carousel/qf-sync-phone.jpg');">
-          <div class="carousel-caption custom-caption">
-            <h2 class="carousel-title">
-              Synchronise<br>and <span style="color: #4a6fae;">collaborate.</span>
-            </h2>
-            <div class="qfc-button">
-              <a href="https://qfield.cloud" target="_blank" title="Register now">
-                <i class="fas fa-cloud"></i> QFIELDCLOUD</a>
+        <div class="item" style="background-image: url('images/qf_carousel/qf-bg-sync.jpg');">
+          <div class="carousel-content">
+            <img src="images/qf_carousel/qf-phones-sync1.png" alt="Phone" class="phone-image">
+            <div class="carousel-caption custom-caption">
+              <h2 class="carousel-title">
+                Synchronise<br>and <span style="color: #4a6fae;">collaborate.</span>
+              </h2>
+              <div class="qfc-button">
+                <a href="https://qfield.cloud" target="_blank" title="Register now">
+                  <i class="fas fa-cloud"></i> QFIELDCLOUD</a>
+              </div>
             </div>
           </div>
         </div>
-        <div class="item" style="background-image: url('images/qf_carousel/qf-customize-plugins.jpg');">
-          <div class="carousel-caption custom-caption">
-            <h2 class="carousel-title">
-              Customise<br>with your <span style="color: var(--qfield-color);">plugins.</span>
-            </h2>
-            <div class="qf-button">
-              <a href="/assistance.html" target="_blank" title="Get in touch">
-                <i class="fas fa-handshake-angle"></i> GET ASSISTANCE</a>
+
+        <div class="item" style="background-image: url('images/qf_carousel/qf-bg-plugin.jpg');">
+          <div class="carousel-content">
+            <img src="images/qf_carousel/qf-phones-plugin1.png" alt="Phone" class="phone-image">
+            <div class="carousel-caption custom-caption">
+              <h2 class="carousel-title">
+                Customise<br>with your <span style="color: var(--qfield-color);">plugins.</span>
+              </h2>
+              <div class="qf-button">
+                <a href="/assistance.html" target="_blank" title="Get in touch">
+                  <i class="fas fa-handshake-angle"></i> GET ASSISTANCE</a>
+              </div>
             </div>
           </div>
         </div>
       </div>
-
 
       <!-- Left and right controls -->
       <a class="left carousel-control" href="#maincarousel" data-slide="prev">
@@ -162,7 +172,7 @@
         <span class="glyphicon glyphicon-chevron-right"></span>
         <span class="sr-only">Next</span>
       </a>
-    </div>
+      </div>
 
     <!-- Section #2: claim -->
     <section class="section-spacing text-center" style="margin-bottom: 25px">


### PR DESCRIPTION
It seemed that with the recent merges, the index.html wasn't updated with the latest slides html (the wrapper for slides section) and the carousel's backgrounds weren't separated from the phones anymore.
I changed it: it works for me on smaller screens but to be checked.