### PR TITLE
Add Contextual Hints for Dashboard Buttons and Interactive Guide Actions

### DIFF
--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -113,6 +113,7 @@ Drawer {
 
           QfToolButton {
             id: measurementButton
+            objectName: "MeasurementButton"
             anchors.verticalCenter: parent.verticalCenter
             round: true
             iconSource: Theme.getThemeVectorIcon("ic_measurement_black_24dp")
@@ -126,6 +127,7 @@ Drawer {
 
           QfToolButton {
             id: printItemButton
+            objectName: "PrintItemButton"
             anchors.verticalCenter: parent.verticalCenter
             round: true
             iconSource: Theme.getThemeVectorIcon("ic_print_black_24dp")
@@ -139,6 +141,7 @@ Drawer {
 
           QfToolButton {
             id: cloudButton
+            objectName: "CloudButton"
             anchors.verticalCenter: parent.verticalCenter
             iconSource: {
               if (cloudConnection.status === QFieldCloudConnection.LoggedIn && cloudProjectsModel.currentProject) {
@@ -212,6 +215,7 @@ Drawer {
 
           QfToolButton {
             id: projectFolderButton
+            objectName: "ProjectFolderButton"
             anchors.verticalCenter: parent.verticalCenter
             font: Theme.defaultFont
             iconSource: Theme.getThemeVectorIcon("ic_project_folder_black_24dp")
@@ -401,6 +405,7 @@ Drawer {
 
       Switch {
         id: modeSwitch
+        objectName: "ModeSwitch"
         width: 56 + 36
         height: 48
         anchors.right: parent.right

--- a/src/qml/QFieldGuide.qml
+++ b/src/qml/QFieldGuide.qml
@@ -39,8 +39,13 @@ Popup {
   }
   onIndexChanged: {
     canvas.requestPaint();
-    if (index == 1)
+    if (index == 1) {
       enablePanelAnimation = true;
+    }
+    if (steps[index] && steps[index].type === "action") {
+      steps[index].forwardAction();
+      delayedPainter.restart();
+    }
   }
 
   function blockGuide() {
@@ -71,8 +76,6 @@ Popup {
           } else {
             objectAfterAction = steps[index].target();
           }
-          steps[index].forwardAction();
-          delayedPainter.restart();
           return objectAfterAction;
         }
       }

--- a/src/qml/QFieldGuide.qml
+++ b/src/qml/QFieldGuide.qml
@@ -189,13 +189,13 @@ Popup {
     }
 
     x: {
-      if (internalObject.target[0]) {
+      if (internalObject.target && internalObject.target[0]) {
         return Math.min(Math.max(8, internalObject.pos.x + internalObject.target[0].width / 2 - width / 2), guide.width - width - 10);
       }
       return 0;
     }
     y: {
-      if (internalObject.target[0]) {
+      if (internalObject.target && internalObject.target[0]) {
         var ty = internalObject.pos.y + internalObject.target[0].height + guide.targetMargins + 15;
         if ((ty + height) >= guide.height) {
           return internalObject.pos.y - height - guide.targetMargins - 8;
@@ -262,8 +262,8 @@ Popup {
 
     AnimatedImage {
       id: animatedHint
-      visible: internalObject.step.animatedGuide !== undefined
-      source: visible ? internalObject.step.animatedGuide : ""
+      visible: internalObject.step ? internalObject.step.animatedGuide !== undefined : false
+      source: visible ? internalObject.step ? internalObject.step.animatedGuide : "" : ""
       anchors {
         bottom: parent.bottom
         left: parent.left
@@ -350,13 +350,13 @@ Popup {
     visible: panelXAnimation.running || panelYAnimation.running ? 0 : 1
 
     x: {
-      if (internalObject.target[0]) {
+      if (internalObject.target && internalObject.target[0]) {
         return internalObject.pos.x + internalObject.target[0].width / 2 - pointerToItem.width / 2;
       }
       return 0;
     }
     y: {
-      if (internalObject.target[0]) {
+      if (internalObject.target && internalObject.target[0]) {
         return internalObject.pos.y + (hintPanel.dir ? -(height + 4) : internalObject.target[0].height + 4);
       }
       return 0;

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -4473,23 +4473,65 @@ ApplicationWindow {
     id: mapCanvasTour
     baseRoot: mainWindow
     objectName: 'mapCanvasTour'
+    z: dashBoard.z + 1
 
     steps: [{
+        "type": "information",
         "title": qsTr("Dashboard"),
         "description": qsTr("This button opens the dashboard. With the dashboard you can interact with the legend and map theme, or start digitizing by activating the editing mode. Long-pressing the button gives you immediate access to the main menu."),
         "target": () => [menuButton]
       }, {
+        "type": "information",
         "title": qsTr("Positioning"),
         "description": qsTr("This button toggles the positioning system. When enabled, a position marker will appear top of the map. Long-pressing the button will open the positioning menu where additional functionalities can be explored."),
         "target": () => [gnssButton]
       }, {
+        "type": "information",
         "title": qsTr("Search"),
         "description": qsTr("The search bar provides you with a quick way to find features within your project, jump to a typed latitude and longitude point, and much more."),
         "target": () => [locatorItem]
       }, {
+        "type": "information",
         "title": qsTr("Zoom"),
         "description": qsTr("In addition to the pinch gesture, these buttons help you quickly zoom in and out."),
         "target": () => [zoomToolbar]
+      }, {
+        "type": "action",
+        "title": qsTr(""),
+        "description": qsTr(""),
+        "forwardAction": () => {
+          dashBoard.open();
+          mapCanvasTour.index = mapCanvasTour.index + 1;
+        },
+        "backwardAction": () => {
+          dashBoard.close();
+          mapCanvasTour.index = mapCanvasTour.index - 2;
+        }
+      }, {
+        "type": "information",
+        "title": qsTr("Measurement"),
+        "description": qsTr("Toggle the measurement tool to calculate distances and areas on the map. Use this tool to measure the length of lines or the area of polygons by clicking on the map."),
+        "target": () => [iface.findItemByObjectName('MeasurementButton')]
+      }, {
+        "type": "information",
+        "title": qsTr("Print"),
+        "description": qsTr("Access print layouts and export options for the current project. Create professional maps and reports with custom layouts, legends, and scale bars."),
+        "target": () => [iface.findItemByObjectName('PrintItemButton')]
+      }, {
+        "type": "information",
+        "title": qsTr("Cloud"),
+        "description": qsTr("Manage QField Cloud synchronization. Upload and download project data, collaborate with team members, and keep your field data synchronized across devices."),
+        "target": () => [iface.findItemByObjectName('CloudButton')]
+      }, {
+        "type": "information",
+        "title": qsTr("Project folder"),
+        "description": qsTr("Open the project folder to access project files, data sources, and related documents. Useful for managing project resources and understanding data structure."),
+        "target": () => [iface.findItemByObjectName('ProjectFolderButton')]
+      }, {
+        "type": "information",
+        "title": qsTr("Mode"),
+        "description": qsTr("Switch between browse and digitize modes. Browse mode allows you to view and navigate the map, while digitize mode enables you to create and edit features."),
+        "target": () => [iface.findItemByObjectName('ModeSwitch')]
       }]
 
     function startOnFreshRun() {
@@ -4498,6 +4540,12 @@ ApplicationWindow {
         runTour();
       }
       settings.setValue("/QField/showMapCanvasGuide", false);
+    }
+
+    onGuideFinished: {
+      if (dashBoard.opened) {
+        dashBoard.close();
+      }
     }
   }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -4473,7 +4473,6 @@ ApplicationWindow {
     id: mapCanvasTour
     baseRoot: mainWindow
     objectName: 'mapCanvasTour'
-    z: dashBoard.z + 1
 
     steps: [{
         "type": "information",
@@ -4495,19 +4494,25 @@ ApplicationWindow {
         "title": qsTr("Zoom"),
         "description": qsTr("In addition to the pinch gesture, these buttons help you quickly zoom in and out."),
         "target": () => [zoomToolbar]
-      }, {
-        "type": "action",
-        "title": qsTr(""),
-        "description": qsTr(""),
-        "forwardAction": () => {
-          dashBoard.open();
-          mapCanvasTour.index = mapCanvasTour.index + 1;
-        },
-        "backwardAction": () => {
-          dashBoard.close();
-          mapCanvasTour.index = mapCanvasTour.index - 2;
-        }
-      }, {
+      }]
+
+    function startOnFreshRun() {
+      const startupGuide = settings.valueBool("/QField/showMapCanvasGuide", true);
+      if (startupGuide) {
+        runTour();
+      }
+      settings.setValue("/QField/showMapCanvasGuide", false);
+    }
+  }
+
+  QFieldGuide {
+    id: dashboardTour
+    baseRoot: mainWindow
+    objectName: 'dashboardTour'
+    z: dashBoard.z + 1
+    index: -1
+
+    steps: [{
         "type": "information",
         "title": qsTr("Measurement"),
         "description": qsTr("Toggle the measurement tool to calculate distances and areas on the map. Use this tool to measure the length of lines or the area of polygons by clicking on the map."),
@@ -4534,17 +4539,13 @@ ApplicationWindow {
         "target": () => [iface.findItemByObjectName('ModeSwitch')]
       }]
 
-    function startOnFreshRun() {
-      const startupGuide = settings.valueBool("/QField/showMapCanvasGuide", true);
-      if (startupGuide) {
-        runTour();
-      }
-      settings.setValue("/QField/showMapCanvasGuide", false);
-    }
-
-    onGuideFinished: {
-      if (dashBoard.opened) {
-        dashBoard.close();
+    Connections {
+      target: dashBoard
+      enabled: settings ? settings.valueBool("/QField/showDashboardGuide", true) : false
+      function onOpened() {
+        dashboardTour.index = 0;
+        dashboardTour.runTour();
+        settings.setValue("/QField/showDashboardGuide", false);
       }
     }
   }
@@ -4555,6 +4556,7 @@ ApplicationWindow {
     function blockGuides() {
       mapCanvasTour.blockGuide();
       settings.setValue("/QField/showMapCanvasGuide", false);
+      settings.setValue("/QField/dashboardTour", false);
     }
   }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -4514,29 +4514,29 @@ ApplicationWindow {
 
     steps: [{
         "type": "information",
+        "title": qsTr("Digitizing toggle"),
+        "description": qsTr("Switch between browse and digitize modes. Browse mode focuses on delivering the best experience viewing the map and its features, while digitize mode enables you to create features and edit geometries."),
+        "target": () => [iface.findItemByObjectName('ModeSwitch')]
+      }, {
+        "type": "information",
         "title": qsTr("Measurement"),
-        "description": qsTr("Toggle the measurement tool to calculate distances and areas on the map. Use this tool to measure the length of lines or the area of polygons by clicking on the map."),
+        "description": qsTr("Toggle the measurement tool to calculate distances and areas on the map."),
         "target": () => [iface.findItemByObjectName('MeasurementButton')]
       }, {
         "type": "information",
         "title": qsTr("Print"),
-        "description": qsTr("Access print layouts and export options for the current project. Create professional maps and reports with custom layouts, legends, and scale bars."),
+        "description": qsTr("Export the map canvas to PDF using configured project print and atlas layouts."),
         "target": () => [iface.findItemByObjectName('PrintItemButton')]
       }, {
         "type": "information",
-        "title": qsTr("Cloud"),
-        "description": qsTr("Manage QField Cloud synchronization. Upload and download project data, collaborate with team members, and keep your field data synchronized across devices."),
+        "title": qsTr("QFieldCloud"),
+        "description": qsTr("Push changes, synchronize or revert changes to and from QFieldCloud when a cloud project is opened."),
         "target": () => [iface.findItemByObjectName('CloudButton')]
       }, {
         "type": "information",
         "title": qsTr("Project folder"),
-        "description": qsTr("Open the project folder to access project files, data sources, and related documents. Useful for managing project resources and understanding data structure."),
+        "description": qsTr("Open the project folder to access project files, data sources, and related documents. Useful for managing project resources, manually uploading data to QFieldCloud, and sharing datasets, attachments, and layouts."),
         "target": () => [iface.findItemByObjectName('ProjectFolderButton')]
-      }, {
-        "type": "information",
-        "title": qsTr("Mode"),
-        "description": qsTr("Switch between browse and digitize modes. Browse mode allows you to view and navigate the map, while digitize mode enables you to create and edit features."),
-        "target": () => [iface.findItemByObjectName('ModeSwitch')]
       }]
 
     Connections {
@@ -4556,7 +4556,7 @@ ApplicationWindow {
     function blockGuides() {
       mapCanvasTour.blockGuide();
       settings.setValue("/QField/showMapCanvasGuide", false);
-      settings.setValue("/QField/dashboardTour", false);
+      settings.setValue("/QField/showDashBoardGuide", false);
     }
   }
 


### PR DESCRIPTION
## 🚀 Description

This PR upgrades the in-app guide system to provide contextual hints on more dashboard buttons in QField!

### ✨ Key Changes

- **More Button Hints:**  
  Added `objectName` properties to key dashboard buttons—`Measurement`, `Print`, `Cloud`, `Project Folder`, and `Mode Switch`—so they can be targeted with guide overlays.

- **Interactive Guide Steps:**  
  Introduced "action" steps in the guide system, allowing the guide to open/close the dashboard automatically and highlight elements even if hidden at first.

- **👀 Better Onboarding:**  
  Users now see helpful explanations and highlights for all major dashboard features, making QField easier to learn and use!

---  

### 📸 Demo _Updated_  


[Screencast From 2025-06-30 21-28-20.webm](https://github.com/user-attachments/assets/230ad6e3-ab84-4035-a55e-1e193557a71f)
