### PR TITLE
Implement imported folder naming customization

### DIFF
--- a/src/core/webdavconnection.cpp
+++ b/src/core/webdavconnection.cpp
@@ -643,18 +643,27 @@ void WebdavConnection::putLocalItems()
   }
 }
 
-void WebdavConnection::importPath( const QString &remotePath, const QString &localPath )
+void WebdavConnection::importPath( const QString &remotePath, const QString &localPath, QString localFolder )
 {
   if ( mUrl.isEmpty() || mUsername.isEmpty() || ( mPassword.isEmpty() && mStoredPassword.isEmpty() ) )
     return;
 
   setupConnection();
 
-  QString localFolder = QStringLiteral( "%1 - %2 - %3" ).arg( mWebdavConnection.hostname(), mWebdavConnection.username(), remotePath );
+  if ( localFolder.isEmpty() )
+  {
+    localFolder = QStringLiteral( "%1 - %2" ).arg( remotePath, mWebdavConnection.username() );
+  }
   localFolder.replace( QRegularExpression( "[\\\\\\/\\<\\>\\:\\|\\?\\*\\\"]" ), QString( "_" ) );
 
   QDir localDir( localPath );
-  localDir.mkpath( localFolder );
+  QString localFolderCheck = localFolder;
+  int folderSuffix = 0;
+  while ( localDir.exists( localFolderCheck ) )
+  {
+    localFolderCheck = QStringLiteral( "%1 - %2" ).arg( localFolder, QString::number( ++folderSuffix ) );
+  }
+  localFolder = localFolderCheck;
 
   mProcessRemotePath = remotePath;
   mProcessLocalPath = QDir::cleanPath( localPath + QDir::separator() + localFolder ) + QDir::separator();

--- a/src/core/webdavconnection.h
+++ b/src/core/webdavconnection.h
@@ -144,8 +144,9 @@ class WebdavConnection : public QObject
      * Imports a remote path into a local path stored on the device.
      * \a remotePath the remote path on the WebDAV endpoint.
      * \a localPath the local path
+     * \a localFolder the local folder name containing the imported remote path content
      */
-    Q_INVOKABLE void importPath( const QString &remotePath, const QString &localPath );
+    Q_INVOKABLE void importPath( const QString &remotePath, const QString &localPath, QString localFolder = QString() );
 
     /**
      * Download new and modified files from an imported remote path.

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -1540,7 +1540,7 @@ Page {
         webdavConnectionLoader.item.username = importWebdavUserInput.editText;
         webdavConnectionLoader.item.password = importWebdavPasswordInput.text;
         webdavConnectionLoader.item.storePassword = importWebdavStorePasswordCheck.checked;
-        webdavConnectionLoader.item.importPath(importWebdavPathInput.model[importWebdavPathInput.currentIndex], platformUtilities.applicationDirectory() + "/Imported Projects/");
+        webdavConnectionLoader.item.importPath(importWebdavPathInput.model[importWebdavPathInput.currentIndex], platformUtilities.applicationDirectory() + "/Imported Projects/", importWebdavImportedFolderName.text);
       }
     }
   }

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -1420,12 +1420,15 @@ Page {
                   }
                   return false;
                 }
-                property bool isImported: {
+                property string importedPath: {
                   if (importWebdavDialog.importHistory["urls"][importWebdavUrlInput.editText] !== undefined && importWebdavDialog.importHistory["urls"][importWebdavUrlInput.editText]["users"][importWebdavUserInput.editText] !== undefined) {
-                    return importWebdavDialog.importHistory["urls"][importWebdavUrlInput.editText]["users"][importWebdavUserInput.editText]["importPaths"].indexOf(modelData) >= 0;
+                    if (importWebdavDialog.importHistory["urls"][importWebdavUrlInput.editText]["users"][importWebdavUserInput.editText]["importPaths"][modelData] !== undefined) {
+                      return importWebdavDialog.importHistory["urls"][importWebdavUrlInput.editText]["users"][importWebdavUserInput.editText]["importPaths"][modelData];
+                    }
                   }
-                  return false;
+                  return "";
                 }
+                property bool isImported: importedPath != ""
 
                 Item {
                   id: expandSpacing
@@ -1475,7 +1478,7 @@ Page {
                     elide: Text.ElideRight
                     wrapMode: Text.WordWrap
                     color: Theme.secondaryTextColor
-                    text: qsTr("Imported and available locally")
+                    text: qsTr("Available locally in ‘%1’").arg(lineDialog.importedPath)
                   }
                 }
               }

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -1422,7 +1422,6 @@ Page {
                 }
                 property bool isImported: {
                   if (importWebdavDialog.importHistory["urls"][importWebdavUrlInput.editText] !== undefined && importWebdavDialog.importHistory["urls"][importWebdavUrlInput.editText]["users"][importWebdavUserInput.editText] !== undefined) {
-                    console.log(importWebdavDialog.importHistory["urls"][importWebdavUrlInput.editText]["users"][importWebdavUserInput.editText]["importPaths"]);
                     return importWebdavDialog.importHistory["urls"][importWebdavUrlInput.editText]["users"][importWebdavUserInput.editText]["importPaths"].indexOf(modelData) >= 0;
                   }
                   return false;

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -1520,7 +1520,7 @@ Page {
 
         Label {
           width: parent.width
-          text: qsTr("Imported folder name:")
+          text: qsTr("Imported folder name")
           wrapMode: Text.WordWrap
           font: Theme.defaultFont
           color: Theme.secondaryTextColor

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Controls.Material.impl
 import QtQuick.Layouts
 import QtQml.Models
 import org.qfield
@@ -1314,22 +1315,52 @@ Page {
         width: swipeDialog.width
         spacing: 10
 
-        Label {
-          width: parent.width
-          visible: importWebdavPathInput.visible
-          text: qsTr("Select the remote folder to import:")
-          wrapMode: Text.WordWrap
-          font: Theme.defaultFont
-          color: Theme.mainTextColor
+        Row {
+          spacing: 5
+
+          Label {
+            anchors.verticalCenter: importWebdavRefetchFoldersButton.verticalCenter
+            width: parent.parent.width - importWebdavRefetchFoldersButton.width - parent.spacing
+            text: qsTr("Select the remote folder to import:")
+            wrapMode: Text.WordWrap
+            font: Theme.defaultFont
+            color: Theme.mainTextColor
+          }
+
+          QfToolButton {
+            id: importWebdavRefetchFoldersButton
+            enabled: !webdavConnectionLoader.item || !webdavConnectionLoader.item.isFetchingAvailablePaths
+            visible: !webdavConnectionLoader.item || !webdavConnectionLoader.item.isFetchingAvailablePaths
+            iconSource: Theme.getThemeVectorIcon("refresh_24dp")
+            iconColor: Theme.mainTextColor
+            bgcolor: "transparent"
+            width: 36
+            height: 36
+            padding: 0
+
+            onClicked: {
+              importWebdavPathInput.currentIndex = -1;
+              webdavConnectionLoader.item.fetchAvailablePaths();
+            }
+          }
+
+          BusyIndicator {
+            id: importWebdavRefreshFoldersIndicator
+            anchors.verticalCenter: importWebdavRefetchFoldersButton.verticalCenter
+            width: importWebdavRefetchFoldersButton.width
+            height: importWebdavRefetchFoldersButton.width
+            visible: webdavConnectionLoader.item && webdavConnectionLoader.item.isFetchingAvailablePaths
+            running: visible
+          }
         }
 
-        Rectangle {
+        MaterialTextContainer {
           id: importWebdavPathContainer
           width: parent.width
           height: 340
-          color: Theme.controlBackgroundColor
-          border.color: Theme.controlBorderColor
-          border.width: 1
+          outlineColor: importWebdavPathInput.Material.hintTextColor
+          focusedOutlineColor: importWebdavPathInput.Material.accentColor
+          controlHasActiveFocus: importWebdavPathInput.activeFocus
 
           ListView {
             id: importWebdavPathInput
@@ -1352,11 +1383,10 @@ Page {
 
             delegate: Rectangle {
               id: rectangleDialog
-
-              anchors.margins: 10
               width: parent ? parent.width : undefined
               height: lineDialog.isVisible ? lineDialog.height + 20 : 0
-              color: importWebdavPathInput.currentIndex == index ? Theme.mainColor : Theme.mainBackgroundColor
+              color: importWebdavPathInput.currentIndex == index ? Theme.mainColor : "transparent"
+              radius: 4
               clip: true
 
               Row {
@@ -1435,7 +1465,7 @@ Page {
                     elide: Text.ElideRight
                     wrapMode: Text.WordWrap
                     color: !lineDialog.isImported ? Theme.mainTextColor : Theme.secondaryTextColor
-                    text: lineDialog.label !== "" ? lineDialog.label : qsTr("(root folder)")
+                    text: lineDialog.label !== "" ? lineDialog.label : "(" + qsTr("root folder") + ")"
                   }
                   Text {
                     id: noteTextDialog
@@ -1453,11 +1483,15 @@ Page {
 
               /* bottom border */
               Rectangle {
-                anchors.bottom: parent.bottom
+                anchors {
+                  bottom: parent.bottom
+                  left: parent.left
+                  leftMargin: 2
+                }
+                visible: lineDialog.isVisible && importWebdavPathInput.currentIndex != index
                 height: 1
                 color: Theme.controlBorderColor
-                width: parent.width
-                visible: lineDialog.isVisible
+                width: parent.width - anchors.leftMargin * 2
               }
 
               MouseArea {
@@ -1466,6 +1500,7 @@ Page {
                 anchors.rightMargin: 48
                 onClicked: mouse => {
                   importWebdavPathInput.currentIndex = index;
+                  importWebdavImportedFolderName.text = (lineDialog.label !== "" ? lineDialog.label : qsTr("root folder")) + " - " + webdavConnectionLoader.item.username;
                 }
                 onDoubleClicked: mouse => {
                   const index = importWebdavPathInput.expandedPaths.indexOf(modelData);
@@ -1481,29 +1516,18 @@ Page {
           }
         }
 
-        Row {
-          spacing: 5
+        Label {
+          width: parent.width
+          text: qsTr("Imported folder name:")
+          wrapMode: Text.WordWrap
+          font: Theme.defaultFont
+          color: Theme.secondaryTextColor
+        }
 
-          QfButton {
-            id: importWebdavRefetchFoldersButton
-            width: parent.parent.width - (importWebdavRefreshFoldersIndicator.visible ? importWebdavRefreshFoldersIndicator.width : 0)
-            enabled: !webdavConnectionLoader.item || !webdavConnectionLoader.item.isFetchingAvailablePaths
-            text: !enabled ? qsTr("Refreshing remote folders") : qsTr("Refresh remote folders")
-
-            onClicked: {
-              importWebdavPathInput.currentIndex = -1;
-              webdavConnectionLoader.item.fetchAvailablePaths();
-            }
-          }
-
-          BusyIndicator {
-            id: importWebdavRefreshFoldersIndicator
-            anchors.verticalCenter: importWebdavRefetchFoldersButton.verticalCenter
-            width: 48
-            height: 48
-            visible: webdavConnectionLoader.item && webdavConnectionLoader.item.isFetchingAvailablePaths
-            running: visible
-          }
+        TextField {
+          id: importWebdavImportedFolderName
+          enabled: !webdavConnectionLoader.item || !webdavConnectionLoader.item.isFetchingAvailablePaths
+          width: parent.width
         }
       }
     }


### PR DESCRIPTION
This PR implements the ability for users to customize the name of the folder containing imported content from a remote WebDAV folder.

Here's a screenshot of the new UI:

![image](https://github.com/user-attachments/assets/ca1eb0f9-0f4d-4907-9bb4-ce883f9b72bc)

Since we now allow for customized names, the tree showing the remote WebDAV folders now indicates the name of the local folder when already imported:

![image](https://github.com/user-attachments/assets/26de476d-f1d1-4f0c-bbb0-7bbe0ae516ba)

Since we now let user control the folder name, an additional safeguard was added to insure name collisions are avoided to prevent worlds colliding :)

Finally, to make room for the new label and text input, the refresh remote folders button was relocated to sit above the remote folders list, in a more muted fashion. This move makes a lot of sense as the button was not likely to be used frequently to begin with. It makes for a nicer UX overall.

Bonus, some tiny UI styling tweaks made the remote folders list look nicer using native material border implementation.

