### PR TITLE
Fix margin handling of rotated extent to fix zoom to feature et al

### DIFF
--- a/src/core/featurelistextentcontroller.cpp
+++ b/src/core/featurelistextentcontroller.cpp
@@ -50,14 +50,23 @@ void FeatureListExtentController::zoomToSelected( bool skipIfIntersects ) const
 {
   if ( mModel && mSelection && mSelection->focusedItem() > -1 && mMapSettings )
   {
-    QgsFeature feat = mSelection->focusedFeature();
+    const QgsFeature feature = mSelection->focusedFeature();
     QgsVectorLayer *layer = mSelection->focusedLayer();
 
     if ( layer && layer->geometryType() != Qgis::GeometryType::Unknown && layer->geometryType() != Qgis::GeometryType::Null )
     {
-      QgsRectangle extent = FeatureUtils::extent( mMapSettings, layer, feat );
-      if ( !skipIfIntersects || !mMapSettings->extent().intersects( extent ) )
-        mMapSettings->setExtent( extent, true );
+      if ( feature.geometry().type() == Qgis::GeometryType::Point && feature.geometry().constGet()->partCount() == 1 )
+      {
+        mMapSettings->setCenter( QgsPoint( feature.geometry().asPoint() ), true );
+      }
+      else
+      {
+        QgsRectangle extent = FeatureUtils::extent( mMapSettings, layer, feature );
+        if ( !skipIfIntersects || !mMapSettings->extent().intersects( extent ) )
+        {
+          mMapSettings->setExtent( extent, true );
+        }
+      }
     }
   }
 }

--- a/src/core/utils/featureutils.cpp
+++ b/src/core/utils/featureutils.cpp
@@ -85,7 +85,7 @@ QgsRectangle FeatureUtils::extent( QgsQuickMapSettings *mapSettings, QgsVectorLa
       geom.transform( transf );
 
       QgsRectangle extent;
-      if ( geom.type() == Qgis::GeometryType::Point )
+      if ( geom.type() == Qgis::GeometryType::Point && geom.constGet()->partCount() == 1 )
       {
         extent = mapSettings->extent();
         QgsVector delta = QgsPointXY( geom.asPoint() ) - extent.center();


### PR DESCRIPTION
Before PR:

https://github.com/user-attachments/assets/de96dd8d-ba6e-4689-abba-520e0799d1c8

With PR:

https://github.com/user-attachments/assets/fabbfb53-988d-4806-a077-9fd0e6338993

:heart_eyes: 

The two changes here are:
- reworking how we modify extent when bottom/right margin are present to make it more robust (and maybe slightly easier to understand as we're combining the map canvas + the extent being passed)
- to insure we're spot on the center of the rotated extent, we use setCenter() after passing on the extent

I think the end result works quite nicely here and I'm hoping this is the last time we revisit this :) 