### PR TITLE
Fix dashboard guides re-appearing all the time during the first app launch

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -4546,9 +4546,12 @@ ApplicationWindow {
       }]
 
     Connections {
+      id: dashBoardConnections
       target: dashBoard
       enabled: settings ? settings.valueBool("/QField/showDashboardGuide", true) : false
+
       function onOpened() {
+        dashBoardConnections.enabled = false;
         dashboardTour.index = 0;
         dashboardTour.runTour();
         settings.setValue("/QField/showDashboardGuide", false);


### PR DESCRIPTION
@mohsenD98 , I missed this when reviewing your dashboard guide code: when you use invokable settings value functions, they will not be properties but rather a static value. 

In this case, it means the dashboard connection would *not* get disabled when you changed the settings value (via setValue), which in turn means the guides would re-open any time you open the dashboard within the same initial app launch.

Fixes https://github.com/opengisch/QField/issues/6451