### PR TITLE
[Backport release-3_6] Fix dashboard guides re-appearing all the time during the first app launch

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -4542,9 +4542,12 @@ ApplicationWindow {
       }]
 
     Connections {
+      id: dashBoardConnections
       target: dashBoard
       enabled: settings ? settings.valueBool("/QField/showDashboardGuide", true) : false
+
       function onOpened() {
+        dashBoardConnections.enabled = false;
         dashboardTour.index = 0;
         dashboardTour.runTour();
         settings.setValue("/QField/showDashboardGuide", false);


### PR DESCRIPTION
Backport #6453
 **Authored by:** @nirvn