### PR TITLE
Implement remote plugin information cache and add a "trusted" state

### DIFF
--- a/src/core/pluginmanager.h
+++ b/src/core/pluginmanager.h
@@ -144,6 +144,11 @@ class PluginManager : public QObject
     Q_INVOKABLE void installFromUrl( const QString &url );
 
     /**
+     * Installs a plugin from the given repository \a uuid.
+     */
+    Q_INVOKABLE void installFromRepository( const QString &uuid );
+
+    /**
      * Uninstalls the application plugin identified by \a uuid.
      */
     Q_INVOKABLE void uninstall( const QString &uuid );

--- a/src/core/pluginmanager.h
+++ b/src/core/pluginmanager.h
@@ -43,6 +43,7 @@ struct PluginInformation
     QString downloadLink;
     QString remoteVersion;
 
+    bool trusted = false;
     bool enabled = false;
     bool configurable = false;
 

--- a/src/core/pluginmodel.cpp
+++ b/src/core/pluginmodel.cpp
@@ -305,7 +305,7 @@ void PluginModel::populateRemotePlugins()
 
       PluginInformation info;
       info.trusted = true;
-      info.uuid = obj.value( "key" ).toString();
+      info.uuid = obj.value( "uuid" ).toString();
       info.name = obj.value( "name" ).toString();
       info.description = obj.value( "description" ).toString();
       info.author = obj.value( "author" ).toString();
@@ -315,7 +315,10 @@ void PluginModel::populateRemotePlugins()
       info.downloadLink = obj.value( "download" ).toString();
       info.remotelyAvailable = true;
 
-      foundRemotePlugins[info.uuid] = info;
+      if ( !info.uuid.isEmpty() )
+      {
+        foundRemotePlugins[info.uuid] = info;
+      }
     }
 
     insertPluginsInformation( foundRemotePlugins, false );

--- a/src/core/pluginmodel.cpp
+++ b/src/core/pluginmodel.cpp
@@ -72,8 +72,6 @@ QVariant PluginModel::data( const QModelIndex &index, int role ) const
       return plugin.locallyAvailable;
     case AvailableRemotelyRole:
       return plugin.remotelyAvailable;
-    case DownloadLinkRole:
-      return plugin.downloadLink;
     case AvailableUpdateRole:
       return plugin.updateAvailable;
     default:
@@ -96,7 +94,6 @@ QHash<int, QByteArray> PluginModel::roleNames() const
     { VersionRole, "Version" },
     { InstalledLocallyRole, "InstalledLocally" },
     { AvailableRemotelyRole, "AvailableRemotely" },
-    { DownloadLinkRole, "DownloadLink" },
     { AvailableUpdateRole, "AvailableUpdate" } };
 }
 
@@ -272,6 +269,8 @@ void PluginModel::fetchRemotePlugins()
     cacheFile.close();
 
     populateRemotePlugins();
+
+    emit remoteFetched();
   } );
 }
 

--- a/src/core/pluginmodel.cpp
+++ b/src/core/pluginmodel.cpp
@@ -21,6 +21,7 @@
 
 #include <QDir>
 #include <QSettings>
+#include <QStandardPaths>
 #include <qjsonarray.h>
 #include <qjsondocument.h>
 #include <qjsonobject.h>
@@ -49,6 +50,8 @@ QVariant PluginModel::data( const QModelIndex &index, int role ) const
   {
     case UuidRole:
       return plugin.uuid;
+    case TrustedRole:
+      return plugin.trusted;
     case EnabledRole:
       return plugin.enabled;
     case ConfigurableRole:
@@ -82,6 +85,7 @@ QHash<int, QByteArray> PluginModel::roleNames() const
 {
   return {
     { UuidRole, "Uuid" },
+    { TrustedRole, "Trusted" },
     { EnabledRole, "Enabled" },
     { ConfigurableRole, "Configurable" },
     { NameRole, "Name" },
@@ -165,6 +169,7 @@ void PluginModel::insertPluginsInformation( QMap<QString, PluginInformation> &pl
       }
       else
       {
+        plugin.trusted = pluginInformation.trusted;
         plugin.remoteVersion = pluginInformation.remoteVersion;
         plugin.downloadLink = pluginInformation.downloadLink;
         plugin.remotelyAvailable = true;
@@ -193,10 +198,11 @@ void PluginModel::insertPluginsInformation( QMap<QString, PluginInformation> &pl
         // Plugin still locally available
         if ( plugin.remotelyAvailable )
         {
+          plugin.trusted = false;
           plugin.remoteVersion = QString();
           plugin.downloadLink = QString();
           plugin.remotelyAvailable = false;
-          emit dataChanged( index( i ), index( i ), { AvailableRemotelyRole, AvailableUpdateRole } );
+          emit dataChanged( index( i ), index( i ), { AvailableRemotelyRole, AvailableUpdateRole, TrustedRole } );
         }
         ++i;
       }
@@ -220,11 +226,15 @@ void PluginModel::insertPluginsInformation( QMap<QString, PluginInformation> &pl
 
 void PluginModel::refresh( bool fetchRemote )
 {
-  fetchLocalPlugins();
+  populateLocalPlugins();
 
   if ( fetchRemote )
   {
     fetchRemotePlugins();
+  }
+  else
+  {
+    populateRemotePlugins();
   }
 }
 
@@ -252,8 +262,28 @@ void PluginModel::fetchRemotePlugins()
     }
 
     const QByteArray responseData = reply->readAll();
+    QDir cacheDir( QStandardPaths::writableLocation( QStandardPaths::AppConfigLocation ) );
+    cacheDir.mkpath( QStringLiteral( "plugins" ) );
+    QFile cacheFile( QStringLiteral( "%1/plugins/cache.json" ).arg( QStandardPaths::writableLocation( QStandardPaths::AppConfigLocation ) ) );
+    if ( cacheFile.open( QIODeviceBase::WriteOnly ) )
+    {
+      cacheFile.write( responseData );
+    }
+    cacheFile.close();
+
+    populateRemotePlugins();
+  } );
+}
+
+void PluginModel::populateRemotePlugins()
+{
+  QFile cacheFile( QStringLiteral( "%1/plugins/cache.json" ).arg( QStandardPaths::writableLocation( QStandardPaths::AppConfigLocation ) ) );
+  if ( cacheFile.exists() && cacheFile.open( QIODeviceBase::ReadOnly ) )
+  {
+    const QByteArray cacheData = cacheFile.readAll();
+
     QJsonParseError parseError;
-    QJsonDocument jsonDoc = QJsonDocument::fromJson( responseData, &parseError );
+    QJsonDocument jsonDoc = QJsonDocument::fromJson( cacheData, &parseError );
     if ( parseError.error != QJsonParseError::NoError )
     {
       qDebug() << "JSON parse error when parsing remote plugins: " << parseError.errorString();
@@ -275,6 +305,7 @@ void PluginModel::fetchRemotePlugins()
       const QJsonObject obj = value.toObject();
 
       PluginInformation info;
+      info.trusted = true;
       info.uuid = obj.value( "key" ).toString();
       info.name = obj.value( "name" ).toString();
       info.description = obj.value( "description" ).toString();
@@ -289,10 +320,10 @@ void PluginModel::fetchRemotePlugins()
     }
 
     insertPluginsInformation( foundRemotePlugins, false );
-  } );
+  }
 }
 
-void PluginModel::fetchLocalPlugins()
+void PluginModel::populateLocalPlugins()
 {
   QMap<QString, PluginInformation> foundLocalPlugins;
   const QStringList dataDirs = PlatformUtilities::instance()->appDataDirs();

--- a/src/core/pluginmodel.h
+++ b/src/core/pluginmodel.h
@@ -34,6 +34,7 @@ class PluginModel : public QAbstractListModel
     enum PluginRoles
     {
       UuidRole = Qt::UserRole + 1,
+      TrustedRole,
       EnabledRole,
       ConfigurableRole,
       NameRole,
@@ -104,15 +105,10 @@ class PluginModel : public QAbstractListModel
     void isRefreshingChanged();
 
   private:
-    /**
-     * Scans the app data directories for plugins, reading metadata and preparing PluginInformation objects.
-     */
-    void fetchLocalPlugins();
-
-    /**
-     * Retrieve a JSON list of remotely available plugins, reading its metadata and preparing Plugin Information objects.
-     */
     void fetchRemotePlugins();
+
+    void populateLocalPlugins();
+    void populateRemotePlugins();
 
     /**
      * Reads the metadata (from metadata.txt) and prepares a PluginInformation for a given plugin directory.

--- a/src/core/pluginmodel.h
+++ b/src/core/pluginmodel.h
@@ -45,7 +45,6 @@ class PluginModel : public QAbstractListModel
       VersionRole,
       InstalledLocallyRole,
       AvailableRemotelyRole,
-      DownloadLinkRole,
       AvailableUpdateRole,
     };
     Q_ENUM( PluginRoles )
@@ -103,6 +102,7 @@ class PluginModel : public QAbstractListModel
 
   signals:
     void isRefreshingChanged();
+    void remoteFetched();
 
   private:
     void fetchRemotePlugins();

--- a/src/qml/PluginItem.qml
+++ b/src/qml/PluginItem.qml
@@ -125,7 +125,7 @@ Rectangle {
 
       Label {
         Layout.fillWidth: true
-        text: qsTr('Authored by %1%2%3').arg('<a href="details">').arg(Author).arg(' ⚠</a>')
+        text: qsTr('Authored by %1%2%3').arg('<a href="details">').arg(Author).arg(Trusted ? '' : ' ⚠</a>')
         font: Theme.tipFont
         color: Theme.secondaryTextColor
         wrapMode: Text.WordWrap

--- a/src/qml/PluginManagerSettings.qml
+++ b/src/qml/PluginManagerSettings.qml
@@ -11,6 +11,8 @@ import Theme
 Popup {
   id: popup
 
+  property bool availablePluginsFetched: false
+
   width: Math.min(400, mainWindow.width - Theme.popupScreenEdgeMargin)
   height: mainWindow.height - 160
   x: (parent.width - width) / 2
@@ -63,7 +65,7 @@ Popup {
           font: Theme.defaultFont
           onClicked: {
             filterBar.currentIndex = index;
-            if (index == 1) {
+            if (index == 1 && !popup.availablePluginsFetched) {
               pluginManager.pluginModel.refresh(true);
             }
           }
@@ -138,14 +140,14 @@ Popup {
             let uuids = pluginsList.downloadingUuids;
             uuids.push(Uuid);
             pluginsList.downloadingUuids = uuids;
-            pluginManager.installFromUrl(DownloadLink);
+            pluginManager.installFromRepository(Uuid);
           }
 
           onDownloadClicked: {
             let uuids = pluginsList.downloadingUuids;
             uuids.push(Uuid);
             pluginsList.downloadingUuids = uuids;
-            pluginManager.installFromUrl(DownloadLink);
+            pluginManager.installFromRepository(Uuid);
           }
         }
       }
@@ -164,7 +166,9 @@ Popup {
         onLinkActivated: link => {
           if (link === '#') {
             filterBar.currentIndex = 1;
-            pluginManager.pluginModel.refresh(true);
+            if (!popup.availablePluginsFetched) {
+              pluginManager.pluginModel.refresh(true);
+            }
           } else {
             Qt.openUrlExternally(link);
           }
@@ -183,6 +187,9 @@ Popup {
           text: qsTr("Install plugin from URL")
 
           onClicked: {
+            if (!popup.availablePluginsFetched) {
+              pluginManager.pluginModel.refresh(true);
+            }
             installFromUrlDialog.open();
           }
 
@@ -274,6 +281,7 @@ Popup {
     focus: true
 
     onAboutToShow: {
+      installFromUrlDialog.standardButton(Dialog.Ok).enabled = popup.availablePluginsFetched;
       installFromUrlInput.text = '';
     }
 
@@ -339,6 +347,15 @@ Popup {
 
     onAccepted: {
       pluginManager.uninstall(pluginUuid);
+    }
+  }
+
+  Connections {
+    target: pluginManager.pluginModel
+
+    function onRemoteFetched() {
+      popup.availablePluginsFetched = true;
+      installFromUrlDialog.standardButton(Dialog.Ok).enabled = true;
     }
   }
 

--- a/src/qml/PluginManagerSettings.qml
+++ b/src/qml/PluginManagerSettings.qml
@@ -103,6 +103,7 @@ Popup {
           onAuthorDetailsClicked: {
             authorDetails.authorName = Author;
             authorDetails.authorHomepage = Homepage;
+            authorDetails.authorTrusted = Trusted;
             authorDetails.open();
           }
 
@@ -225,6 +226,7 @@ Popup {
 
     property string authorName: ""
     property string authorHomepage: ""
+    property bool authorTrusted: false
 
     Column {
       width: mainWindow.width - 60 < authorWarningLabelMetrics.width ? mainWindow.width - 60 : authorWarningLabelMetrics.width
@@ -254,6 +256,7 @@ Popup {
       Label {
         id: authorWarningLabel
         width: parent.width
+        visible: !authorDetails.authorTrusted
         text: "⚠ " + qsTr("The author details shown above are self-reported by the plugin and not independently verified. Please make sure you trust the plugin's origin.")
         wrapMode: Text.WordWrap
         font: Theme.defaultFont


### PR DESCRIPTION
This PR implements a basic trusted state for plugins served/installed through the remotely available plugin endpoint JSON. 

The logic is quite simple ATM: if a given plugin UUID - at the moment the unique folder name - is listed in the remote plugin endpoint JSON, we consider the plugin to be trusted. To insure that this can't be abused easily, the manual installation of a plugin via URL now does a check against the remotely fetched plugin list and if the plugin to be install has the same UUID/folder name as what is listed remotely, we block the manual URL installation in favor of the list.

To make for the best possible experience, the remote plugin JSON is cached in the app's configuration directory and used on app launch to re-populate the trust status. If that location is compromised to begin with on a given device, the user has a more fundamental security issue than QField plugins :)

This allows us to get rid of the :warning: emoji icon for the plugins we curate on the endpoint for now, which makes for a much better user experience.

In the future, we will definitively want to re-visit the logic, but for now I feel it works quite well against a limited, manually curated list.