### PR TITLE
Allow for plugins to add a description to search bar locator filters

### DIFF
--- a/src/core/locator/activelayerfeatureslocatorfilter.h
+++ b/src/core/locator/activelayerfeatureslocatorfilter.h
@@ -56,6 +56,7 @@ class ActiveLayerFeaturesLocatorFilter : public QgsLocatorFilter
     // Note that the name is important here, has to match the QgsLocator::CORE_FILTERS one to give us a 1-letter prefix
     QString name() const override { return QStringLiteral( "features" ); }
     QString displayName() const override { return tr( "Features from active layer" ); }
+    QString description() const override { return tr( "Returns a list of features from the active layer with matching attributes. Restricting matching to a single attribute is done by identifying its name prefixed with an '@'." ); }
     Priority priority() const override { return Medium; }
     QString prefix() const override { return QStringLiteral( "f" ); }
 

--- a/src/core/locator/bookmarklocatorfilter.h
+++ b/src/core/locator/bookmarklocatorfilter.h
@@ -43,6 +43,7 @@ class BookmarkLocatorFilter : public QgsLocatorFilter
     BookmarkLocatorFilter *clone() const override;
     QString name() const override { return QStringLiteral( "bookmarks" ); }
     QString displayName() const override { return tr( "Spatial bookmarks" ); }
+    QString description() const override { return tr( "Returns a list of user and currently open project bookmarks with matching names." ); }
     Priority priority() const override { return Highest; }
     QString prefix() const override { return QStringLiteral( "b" ); }
     QgsLocatorFilter::Flags flags() const override { return QgsLocatorFilter::FlagFast; }

--- a/src/core/locator/expressioncalculatorlocatorfilter.h
+++ b/src/core/locator/expressioncalculatorlocatorfilter.h
@@ -44,6 +44,7 @@ class ExpressionCalculatorLocatorFilter : public QgsLocatorFilter
     ExpressionCalculatorLocatorFilter *clone() const override;
     QString name() const override { return QStringLiteral( "calculator" ); }
     QString displayName() const override { return tr( "Calculator" ); }
+    QString description() const override { return tr( "Returns the value of an expression typed in the search bar." ); }
     Priority priority() const override { return Highest; }
     QString prefix() const override { return QStringLiteral( "=" ); }
     QgsLocatorFilter::Flags flags() const override { return QgsLocatorFilter::FlagFast; }

--- a/src/core/locator/featureslocatorfilter.h
+++ b/src/core/locator/featureslocatorfilter.h
@@ -61,6 +61,7 @@ class FeaturesLocatorFilter : public QgsLocatorFilter
     FeaturesLocatorFilter *clone() const override;
     QString name() const override { return QStringLiteral( "allfeatures" ); }
     QString displayName() const override { return tr( "Features in all layers" ); }
+    QString description() const override { return tr( "Returns a list of features accross all searchable layers with matching display name." ); }
     Priority priority() const override { return Medium; }
     QString prefix() const override { return QStringLiteral( "af" ); }
 

--- a/src/core/locator/gotolocatorfilter.h
+++ b/src/core/locator/gotolocatorfilter.h
@@ -45,6 +45,7 @@ class GotoLocatorFilter : public QgsLocatorFilter
     GotoLocatorFilter *clone() const override;
     QString name() const override { return QStringLiteral( "goto" ); }
     QString displayName() const override { return tr( "Go to coordinate" ); }
+    QString description() const override { return tr( "Returns a point from a pair of X and Y coordinates - or WGS84 latitude and longitude - typed in the search bar." ); }
     Priority priority() const override { return Medium; }
     QString prefix() const override { return QStringLiteral( "go" ); }
     QgsLocatorFilter::Flags flags() const override { return QgsLocatorFilter::FlagFast; }

--- a/src/core/locator/helplocatorfilter.h
+++ b/src/core/locator/helplocatorfilter.h
@@ -41,8 +41,9 @@ class HelpLocatorFilter : public QgsLocatorFilter
 
     explicit HelpLocatorFilter( LocatorModelSuperBridge *locatorBridge, QObject *parent = nullptr );
     HelpLocatorFilter *clone() const override;
-    QString name() const override { return QStringLiteral( "optionpages" ); } // name should be "help" but we're working around QGIS guarding against 1-character prefix
+    QString name() const override { return QStringLiteral( "optionpages" ); }
     QString displayName() const override { return tr( "QField Documentation" ); }
+    QString description() const override { return tr( "Returns QField documentation pages matching terms." ); }
     Priority priority() const override { return Medium; }
     QString prefix() const override { return QStringLiteral( "?" ); }
 

--- a/src/core/locator/locatormodelsuperbridge.cpp
+++ b/src/core/locator/locatormodelsuperbridge.cpp
@@ -293,15 +293,6 @@ QHash<int, QByteArray> LocatorFiltersModel::roleNames() const
 
 QVariant LocatorFiltersModel::data( const QModelIndex &index, int role ) const
 {
-  const static QMap<QString, QString> sLocatorFilterDescriptions = {
-    { QStringLiteral( "features" ), tr( "Returns a list of features from the active layer with matching attributes. Restricting matching to a single attribute is done by identifying its name prefixed with an '@'." ) },
-    { QStringLiteral( "allfeatures" ), tr( "Returns a list of features accross all searchable layers with matching display name." ) },
-    { QStringLiteral( "goto" ), tr( "Returns a point from a pair of X and Y coordinates - or WGS84 latitude and longitude - typed in the search bar." ) },
-    { QStringLiteral( "bookmarks" ), tr( "Returns a list of user and currently open project bookmarks with matching names." ) },
-    { QStringLiteral( "calculator" ), tr( "Returns the value of an expression typed in the search bar." ) },
-    { QStringLiteral( "optionpages" ), tr( "Returns QField documentation pages matching terms." ) },
-    { QStringLiteral( "pelias-finland" ), tr( "Returns a list of locations and addresses within Finland with matching terms." ) } };
-
   if ( !mLocatorModelSuperBridge->locator() || !index.isValid() || index.parent().isValid() || index.row() < 0 || index.row() >= rowCount( QModelIndex() ) )
     return QVariant();
 
@@ -312,7 +303,7 @@ QVariant LocatorFiltersModel::data( const QModelIndex &index, int role ) const
       return filterForIndex( index )->displayName();
 
     case DescriptionRole:
-      return sLocatorFilterDescriptions.value( filterForIndex( index )->name() );
+      return filterForIndex( index )->description();
 
     case PrefixRole:
       return filterForIndex( index )->activePrefix();

--- a/src/core/locator/qfieldlocatorfilter.cpp
+++ b/src/core/locator/qfieldlocatorfilter.cpp
@@ -111,6 +111,15 @@ void QFieldLocatorFilter::setPrefix( const QString &prefix )
   emit prefixChanged();
 }
 
+void QFieldLocatorFilter::setDescription( const QString &description )
+{
+  if ( mDescription == description )
+    return;
+
+  mDescription = description;
+  emit descriptionChanged();
+}
+
 void QFieldLocatorFilter::fetchResultsEnded()
 {
   mFetchResultsEnded = true;

--- a/src/core/locator/qfieldlocatorfilter.h
+++ b/src/core/locator/qfieldlocatorfilter.h
@@ -39,6 +39,7 @@ class QFieldLocatorFilter : public QgsLocatorFilter
     Q_PROPERTY( QString name READ name WRITE setName NOTIFY nameChanged )
     Q_PROPERTY( QString displayName READ displayName WRITE setDisplayName NOTIFY displayNameChanged )
     Q_PROPERTY( QString prefix READ prefix WRITE setPrefix NOTIFY prefixChanged )
+    Q_PROPERTY( QString description READ description WRITE setDescription NOTIFY descriptionChanged )
 
     Q_PROPERTY( QVariantMap parameters READ parameters WRITE setParameters NOTIFY parametersChanged )
     Q_PROPERTY( QUrl source READ source WRITE setSource NOTIFY sourceChanged )
@@ -83,6 +84,14 @@ class QFieldLocatorFilter : public QgsLocatorFilter
      * \note The prefix must be >= 3 characters otherwise it will be ignored.
      */
     void setPrefix( const QString &prefix );
+
+    //! \copydoc QgsLocatorFilter::description
+    QString description() const override { return mDescription; }
+
+    /**
+     * Sets a description for the filter.
+     */
+    void setDescription( const QString &description );
 
     /**
      * Returns the source QML file which will process the locator filter results.
@@ -134,6 +143,9 @@ class QFieldLocatorFilter : public QgsLocatorFilter
     //! Emitted when the prefix has changed
     void prefixChanged();
 
+    //! Emitted when the description has changed
+    void descriptionChanged();
+
     //! Emitted when the parameters object has changed
     void parametersChanged();
 
@@ -151,6 +163,7 @@ class QFieldLocatorFilter : public QgsLocatorFilter
     QString mName;
     QString mDisplayName;
     QString mPrefix;
+    QString mDescription;
 
     bool mFetchResultsEnded = false;
 


### PR DESCRIPTION
Because a blank space really doesn't make our search bar integration shine.

Before:
![Screenshot From 2025-07-08 15-55-20](https://github.com/user-attachments/assets/2886ab30-a06a-4981-8a43-cd5d3ccae8ba)

PR:
![Screenshot From 2025-07-08 15-54-50](https://github.com/user-attachments/assets/bd745058-406d-44c3-bcc4-1078e81e521c)
