### PR TITLE
Implement image stamping customization functionality

### DIFF
--- a/src/core/utils/fileutils.cpp
+++ b/src/core/utils/fileutils.cpp
@@ -431,9 +431,6 @@ void FileUtils::addImageStamp( const QString &imagePath, const QString &text, co
       format.setSizeUnit( Qgis::RenderUnit::Pixels );
     }
 
-    qDebug() << format.size();
-    qDebug() << format.color();
-
     if ( !imageDecoration.isEmpty() )
     {
       const QFileInfo fi( QgsProject::instance()->pathResolver().readPath( imageDecoration ) );
@@ -486,7 +483,8 @@ void FileUtils::addImageStamp( const QString &imagePath, const QString &text, co
       }
     }
 
-    QgsTextRenderer::drawText( QRectF( 10, 10, img.width() - 20, img.height() - 20 ), 0, horizontalAlignment, text.split( QStringLiteral( "\n" ) ), context, format, true, Qgis::TextVerticalAlignment::Bottom, Qgis::TextRendererFlag::WrapLines );
+    const double textHeight = QgsTextRenderer::textHeight( context, format, text.split( QStringLiteral( "\n" ) ), Qgis::TextLayoutMode::Rectangle, nullptr, Qgis::TextRendererFlag::WrapLines, img.width() - 20 );
+    QgsTextRenderer::drawText( QRectF( 10, img.height() - textHeight - 20, img.width() - 20, img.height() - 20 ), 0, horizontalAlignment, text.split( QStringLiteral( "\n" ) ), context, format, true, Qgis::TextVerticalAlignment::Top, Qgis::TextRendererFlag::WrapLines );
 
     img.save( imagePath, nullptr, 90 );
 

--- a/src/core/utils/fileutils.cpp
+++ b/src/core/utils/fileutils.cpp
@@ -29,10 +29,13 @@
 #include <QPainterPath>
 #include <QStandardPaths>
 #include <qgis.h>
+#include <qgsapplication.h>
 #include <qgsexiftools.h>
 #include <qgsfileutils.h>
+#include <qgsimagecache.h>
 #include <qgsproject.h>
 #include <qgsrendercontext.h>
+#include <qgssvgcache.h>
 #include <qgstextformat.h>
 #include <qgstextrenderer.h>
 
@@ -384,35 +387,106 @@ void FileUtils::addImageMetadata( const QString &imagePath, const GnssPositionIn
   }
 }
 
-void FileUtils::addImageStamp( const QString &imagePath, const QString &text )
+void FileUtils::addImageStamp( const QString &imagePath, const QString &text, const QString &textFormat, Qgis::TextHorizontalAlignment horizontalAlignment, const QString &imageDecoration )
 {
   if ( !QFileInfo::exists( imagePath ) || text.isEmpty() )
   {
     return;
   }
 
+  QgsReadWriteContext readWriteContent;
+  readWriteContent.setPathResolver( QgsProject::instance()->pathResolver() );
   QVariantMap metadata = QgsExifTools::readTags( imagePath );
   QImage img( imagePath );
   if ( !img.isNull() )
   {
     QPainter painter( &img );
     painter.setRenderHint( QPainter::Antialiasing );
-
-    QFont font = painter.font();
-    font.setPixelSize( std::min( img.width(), img.height() ) / 40 );
-    font.setBold( true );
-
     QgsRenderContext context = QgsRenderContext::fromQPainter( &painter );
     QgsTextFormat format;
-    format.setFont( font );
-    format.setSize( font.pixelSize() );
-    format.setSizeUnit( Qgis::RenderUnit::Pixels );
-    format.setColor( Qt::white );
-    format.buffer().setColor( Qt::black );
-    format.buffer().setSize( 2 );
-    format.buffer().setSizeUnit( Qgis::RenderUnit::Pixels );
-    format.buffer().setEnabled( true );
-    QgsTextRenderer::drawText( QRectF( 10, 10, img.width() - 20, img.height() - 20 ), 0, Qgis::TextHorizontalAlignment::Left, text.split( QStringLiteral( "\n" ) ), context, format, true, Qgis::TextVerticalAlignment::Bottom, Qgis::TextRendererFlag::WrapLines );
+    if ( !textFormat.isEmpty() )
+    {
+      QDomDocument document = QDomDocument();
+      document.setContent( textFormat );
+      format.readXml( document.documentElement(), readWriteContent );
+    }
+    else
+    {
+      QFont font = painter.font();
+      font.setPixelSize( std::min( img.width(), img.height() ) / 40 );
+      font.setBold( true );
+      format.setFont( font );
+      format.setSize( font.pixelSize() );
+      format.setSizeUnit( Qgis::RenderUnit::Pixels );
+      format.setColor( Qt::white );
+      format.buffer().setColor( Qt::black );
+      format.buffer().setSize( 2 );
+      format.buffer().setSizeUnit( Qgis::RenderUnit::Pixels );
+      format.buffer().setEnabled( true );
+    }
+
+    if ( format.sizeUnit() == Qgis::RenderUnit::Percentage )
+    {
+      format.setSize( std::min( img.width(), img.height() ) * format.size() / 100 );
+      format.setSizeUnit( Qgis::RenderUnit::Pixels );
+    }
+
+    qDebug() << format.size();
+    qDebug() << format.color();
+
+    if ( !imageDecoration.isEmpty() )
+    {
+      const QFileInfo fi( QgsProject::instance()->pathResolver().readPath( imageDecoration ) );
+      if ( fi.exists() )
+      {
+        const double lineHeight = context.convertFromPainterUnits( format.size(), format.sizeUnit() );
+        const bool isRaster = fi.suffix().toLower() != QStringLiteral( "svg" );
+
+        bool fitsInCache = false;
+        if ( isRaster )
+        {
+          const QSizeF decorationOriginalSize = QgsApplication::instance()->imageCache()->originalSize( fi.absoluteFilePath(), true );
+          const double decorationHeight = std::min( std::min( decorationOriginalSize.height(), img.height() / 6.0 ), lineHeight * 10.0 );
+          const double decorationWidth = decorationOriginalSize.width() * decorationHeight / decorationOriginalSize.height();
+          QImage decorationImage = QgsApplication::instance()->imageCache()->pathAsImage( fi.absoluteFilePath(), QSize( decorationWidth, decorationHeight ), true, 1, fitsInCache, true );
+          switch ( horizontalAlignment )
+          {
+            case Qgis::TextHorizontalAlignment::Left:
+            case Qgis::TextHorizontalAlignment::Justify:
+              painter.drawImage( QRectF( 10, 10, decorationWidth, decorationHeight ), decorationImage );
+              break;
+            case Qgis::TextHorizontalAlignment::Center:
+              painter.drawImage( QRectF( img.size().width() / 2 - decorationWidth / 2, 10, decorationWidth, decorationHeight ), decorationImage );
+              break;
+            case Qgis::TextHorizontalAlignment::Right:
+              painter.drawImage( QRectF( img.size().width() - decorationWidth - 10, 10, decorationWidth, decorationHeight ), decorationImage );
+              break;
+          }
+        }
+        else
+        {
+          const QSizeF decorationOriginalSize = QgsApplication::instance()->svgCache()->svgViewboxSize( fi.absoluteFilePath(), 100, QColor( 0, 0, 0 ), QColor( 255, 0, 0 ), 10, 1, 0, true );
+          const double decorationHeight = std::min( img.height() / 6.0, lineHeight * 10.0 );
+          const double decorationWidth = decorationOriginalSize.width() * decorationHeight / decorationOriginalSize.height();
+          QPicture decorationPicture = QgsApplication::instance()->svgCache()->svgAsPicture( fi.absoluteFilePath(), decorationWidth, QColor(), QColor(), 1.0, 1, fitsInCache, 0, true );
+          switch ( horizontalAlignment )
+          {
+            case Qgis::TextHorizontalAlignment::Left:
+            case Qgis::TextHorizontalAlignment::Justify:
+              painter.drawPicture( 10 + decorationWidth / 2, 10 + decorationHeight / 2, decorationPicture );
+              break;
+            case Qgis::TextHorizontalAlignment::Center:
+              painter.drawPicture( img.size().width() / 2, 10 + decorationHeight / 2, decorationPicture );
+              break;
+            case Qgis::TextHorizontalAlignment::Right:
+              painter.drawPicture( img.size().width() - 10 - decorationWidth / 2, 10 + decorationHeight / 2, decorationPicture );
+              break;
+          }
+        }
+      }
+    }
+
+    QgsTextRenderer::drawText( QRectF( 10, 10, img.width() - 20, img.height() - 20 ), 0, horizontalAlignment, text.split( QStringLiteral( "\n" ) ), context, format, true, Qgis::TextVerticalAlignment::Bottom, Qgis::TextRendererFlag::WrapLines );
 
     img.save( imagePath, nullptr, 90 );
 

--- a/src/core/utils/fileutils.h
+++ b/src/core/utils/fileutils.h
@@ -22,6 +22,7 @@
 #include <QCryptographicHash>
 #include <QObject>
 #include <QVariantMap>
+#include <qgis.h>
 #include <qgsfeedback.h>
 
 #define FILENAME_MAX_CHAR_LENGTH 255
@@ -110,9 +111,20 @@ class QFIELD_CORE_EXPORT FileUtils : public QObject
      */
     Q_INVOKABLE void restrictImageSize( const QString &imagePath, int maximumWidthHeight );
 
+    /**
+     * Adds positioning metadata to a given image.
+     * \param imagePath the image path
+     * \param positionInformation the GNSS position information used to add metadata details
+     */
     Q_INVOKABLE void addImageMetadata( const QString &imagePath, const GnssPositionInformation &positionInformation );
 
-    Q_INVOKABLE void addImageStamp( const QString &imagePath, const QString &text );
+    /**
+     * Prints details to a given image.
+     * \param imagePath the image path
+     * \param text the details text
+     * \param project an optional project from which custom stamping settings will be retrieved
+     */
+    Q_INVOKABLE void addImageStamp( const QString &imagePath, const QString &text, const QString &textFormat = QString(), Qgis::TextHorizontalAlignment horizontalAlignment = Qgis::TextHorizontalAlignment::Left, const QString &imageDecoration = QString() );
 
     static bool copyRecursively( const QString &sourceFolder, const QString &destFolder, QgsFeedback *feedback = nullptr, bool wipeDestFolder = true );
 

--- a/src/qml/QFieldCamera.qml
+++ b/src/qml/QFieldCamera.qml
@@ -103,11 +103,10 @@ Popup {
   ExpressionEvaluator {
     id: stampExpressionEvaluator
 
+    property string defaultTextTemplate: "[% format_date(now(), 'yyyy-MM-dd @ HH:mm') || if(@gnss_coordinate is not null, format('\n" + qsTr("Latitude") + " %1 | " + qsTr("Longitude") + " %2 | " + qsTr("Altitude") + " %3\n" + qsTr("Speed") + " %4 | " + qsTr("Orientation") + " %5', coalesce(format_number(y(@gnss_coordinate), 7), 'N/A'), coalesce(format_number(x(@gnss_coordinate), 7), 'N/A'), coalesce(format_number(z(@gnss_coordinate), 3) || ' m', 'N/A'), if(@gnss_ground_speed != 'nan', format_number(@gnss_ground_speed, 3) || ' m/s', 'N/A'), if(@gnss_orientation != 'nan', format_number(@gnss_orientation, 1) || ' °', 'N/A')), '') %]"
+
     mode: ExpressionEvaluator.ExpressionTemplateMode
-    expressionText: {
-      const defaultText = "[% format_date(now(), 'yyyy-MM-dd @ HH:mm') || if(@gnss_coordinate is not null, format('\n" + qsTr("Latitude") + " %1 | " + qsTr("Longitude") + " %2 | " + qsTr("Altitude") + " %3\n" + qsTr("Speed") + " %4 | " + qsTr("Orientation") + " %5', coalesce(format_number(y(@gnss_coordinate), 7), 'N/A'), coalesce(format_number(x(@gnss_coordinate), 7), 'N/A'), coalesce(format_number(z(@gnss_coordinate), 3) || ' m', 'N/A'), if(@gnss_ground_speed != 'nan', format_number(@gnss_ground_speed, 3) || ' m/s', 'N/A'), if(@gnss_orientation != 'nan', format_number(@gnss_orientation, 1) || ' °', 'N/A')), '') %]";
-      return iface.readProjectEntry("qfieldsync", "stampingDetailsTemplate", defaultText);
-    }
+    expressionText: ""
 
     project: qgisProject
     appExpressionContextScopesGenerator: AppExpressionContextScopesGenerator {
@@ -418,6 +417,7 @@ Popup {
                       FileUtils.addImageMetadata(currentPath, currentPosition);
                     }
                     if (cameraSettings.stamping || iface.readProjectBoolEntry("qfieldsync", "forceStamping")) {
+                      stampExpressionEvaluator.expressionText = iface.readProjectEntry("qfieldsync", "stampingDetailsTemplate", stampExpressionEvaluator.defaultTextTemplate);
                       FileUtils.addImageStamp(currentPath, stampExpressionEvaluator.evaluate(), iface.readProjectEntry("qfieldsync", "stampingFontStyle"), iface.readProjectNumEntry("qfieldsync", "stampingHorizontalAlignment", 0), iface.readProjectEntry("qfieldsync", "stampingImageDecoration"));
                     }
                   }

--- a/src/qml/QFieldCamera.qml
+++ b/src/qml/QFieldCamera.qml
@@ -106,7 +106,7 @@ Popup {
     mode: ExpressionEvaluator.ExpressionTemplateMode
     expressionText: {
       const defaultText = "[% format_date(now(), 'yyyy-MM-dd @ HH:mm') || if(@gnss_coordinate is not null, format('\n" + qsTr("Latitude") + " %1 | " + qsTr("Longitude") + " %2 | " + qsTr("Altitude") + " %3\n" + qsTr("Speed") + " %4 | " + qsTr("Orientation") + " %5', coalesce(format_number(y(@gnss_coordinate), 7), 'N/A'), coalesce(format_number(x(@gnss_coordinate), 7), 'N/A'), coalesce(format_number(z(@gnss_coordinate), 3) || ' m', 'N/A'), if(@gnss_ground_speed != 'nan', format_number(@gnss_ground_speed, 3) || ' m/s', 'N/A'), if(@gnss_orientation != 'nan', format_number(@gnss_orientation, 1) || ' °', 'N/A')), '') %]";
-      return iface.readProjectEntry("qfieldsync", "stampingDetailsExpression", defaultText);
+      return iface.readProjectEntry("qfieldsync", "stampingDetailsTemplate", defaultText);
     }
 
     project: qgisProject

--- a/src/qml/QFieldCamera.qml
+++ b/src/qml/QFieldCamera.qml
@@ -103,8 +103,11 @@ Popup {
   ExpressionEvaluator {
     id: stampExpressionEvaluator
 
-    mode: ExpressionEvaluator.ExpressionMode
-    expressionText: "format_date(now(), 'yyyy-MM-dd @ HH:mm') || if(@gnss_coordinate is not null, format('\n" + qsTr("Latitude") + " %1 | " + qsTr("Longitude") + " %2 | " + qsTr("Altitude") + " %3\n" + qsTr("Speed") + " %4 | " + qsTr("Orientation") + " %5', coalesce(format_number(y(@gnss_coordinate), 7), 'N/A'), coalesce(format_number(x(@gnss_coordinate), 7), 'N/A'), coalesce(format_number(z(@gnss_coordinate), 3) || ' m', 'N/A'), if(@gnss_ground_speed != 'nan', format_number(@gnss_ground_speed, 3) || ' m/s', 'N/A'), if(@gnss_orientation != 'nan', format_number(@gnss_orientation, 1) || ' °', 'N/A')), '')"
+    mode: ExpressionEvaluator.ExpressionTemplateMode
+    expressionText: {
+      const defaultText = "[% format_date(now(), 'yyyy-MM-dd @ HH:mm') || if(@gnss_coordinate is not null, format('\n" + qsTr("Latitude") + " %1 | " + qsTr("Longitude") + " %2 | " + qsTr("Altitude") + " %3\n" + qsTr("Speed") + " %4 | " + qsTr("Orientation") + " %5', coalesce(format_number(y(@gnss_coordinate), 7), 'N/A'), coalesce(format_number(x(@gnss_coordinate), 7), 'N/A'), coalesce(format_number(z(@gnss_coordinate), 3) || ' m', 'N/A'), if(@gnss_ground_speed != 'nan', format_number(@gnss_ground_speed, 3) || ' m/s', 'N/A'), if(@gnss_orientation != 'nan', format_number(@gnss_orientation, 1) || ' °', 'N/A')), '') %]";
+      return iface.readProjectEntry("qfieldsync", "stampingDetailsExpression", defaultText);
+    }
 
     project: qgisProject
     appExpressionContextScopesGenerator: AppExpressionContextScopesGenerator {
@@ -414,8 +417,8 @@ Popup {
                     if (cameraSettings.geoTagging && positionSource.active) {
                       FileUtils.addImageMetadata(currentPath, currentPosition);
                     }
-                    if (cameraSettings.stamping) {
-                      FileUtils.addImageStamp(currentPath, stampExpressionEvaluator.evaluate());
+                    if (cameraSettings.stamping || iface.readProjectBoolEntry("qfieldsync", "forceStamping")) {
+                      FileUtils.addImageStamp(currentPath, stampExpressionEvaluator.evaluate(), iface.readProjectEntry("qfieldsync", "stampingFontStyle"), iface.readProjectNumEntry("qfieldsync", "stampingHorizontalAlignment", 0), iface.readProjectEntry("qfieldsync", "stampingImageDecoration"));
                     }
                   }
                   cameraItem.finished(currentPath);


### PR DESCRIPTION
This PR adds image stamping customization functionality to QField, configured via a brand new subpanel in the project properties' QField panel on QGIS:

<img width="734" height="689" alt="image" src="https://github.com/user-attachments/assets/577ed4be-ad68-4baf-8bf6-161f422d53fd" />

The image stamping customization allows for users to:
- customize the details being stamped via the crafting of an expression-based multiline string
- customize the font color/size/drop shadow/etc. used to render the details
- customize the position (left / center / right) of the details
- add an image decoration overlay on top of the image being stamped
- force stamping of images irrespective of QField's own setting (useful for manager distributing over QFC)

As a result, people can come up with this kind of customized stamping with just a little bit of configuration:

![apiary_20250715152419984](https://github.com/user-attachments/assets/6d01726f-d929-4da9-a46a-29ac733829ac)

_Note the top-left logo and the QFC username detail_