### PR TITLE
Show the cloud "notification" logo on the canvas when it has notifications

### DIFF
--- a/src/qml/imports/Theme/QfBadge.qml
+++ b/src/qml/imports/Theme/QfBadge.qml
@@ -1,0 +1,28 @@
+import QtQuick
+import QtQuick.Controls
+
+Rectangle {
+  property alias badgeText: inText
+
+  anchors {
+    top: parent.top
+    right: parent.right
+    rightMargin: 2
+    topMargin: 2
+  }
+
+  width: 12
+  height: 12
+  radius: width / 2
+
+  border.width: 1.5
+  border.color: "white"
+
+  Text {
+    id: inText
+    anchors.fill: parent
+    font.pixelSize: text.length === 1 ? height / 1.6 : height / 1.8
+    horizontalAlignment: Qt.AlignHCenter
+    verticalAlignment: Qt.AlignVCenter
+  }
+}

--- a/src/qml/imports/Theme/QfBadge.qml
+++ b/src/qml/imports/Theme/QfBadge.qml
@@ -2,21 +2,34 @@ import QtQuick
 import QtQuick.Controls
 
 Rectangle {
-  property alias badgeText: inText
+  id: badge
 
-  anchors {
-    top: parent.top
-    right: parent.right
-    rightMargin: 2
-    topMargin: 2
-  }
+  property alias badgeText: inText
+  property int alignment: QfBadge.TopRight
+
+  property int topMargin: 2
+  property int bottomMargin: 2
+  property int leftMargin: 2
+  property int rightMargin: 2
 
   width: 12
   height: 12
   radius: width / 2
 
   border.width: 1.5
-  border.color: "white"
+  border.color: Theme.darkTheme ? Theme.mainTextColor : Theme.mainBackgroundColor
+
+  anchors {
+    top: (alignment === QfBadge.TopLeft || alignment === QfBadge.TopRight) ? parent.top : undefined
+    bottom: (alignment === QfBadge.BottomLeft || alignment === QfBadge.BottomRight) ? parent.bottom : undefined
+    left: (alignment === QfBadge.TopLeft || alignment === QfBadge.BottomLeft) ? parent.left : undefined
+    right: (alignment === QfBadge.TopRight || alignment === QfBadge.BottomRight) ? parent.right : undefined
+
+    topMargin: badge.topMargin
+    bottomMargin: badge.bottomMargin
+    leftMargin: badge.leftMargin
+    rightMargin: badge.rightMargin
+  }
 
   Text {
     id: inText

--- a/src/qml/imports/Theme/QfBadge.qml
+++ b/src/qml/imports/Theme/QfBadge.qml
@@ -17,7 +17,7 @@ Rectangle {
   radius: width / 2
 
   border.width: 1.5
-  border.color: Theme.darkTheme ? Theme.mainTextColor : Theme.mainBackgroundColor
+  border.color: Theme.mainBackgroundColor
 
   anchors {
     top: (alignment === QfBadge.TopLeft || alignment === QfBadge.TopRight) ? parent.top : undefined
@@ -34,7 +34,7 @@ Rectangle {
   Text {
     id: inText
     anchors.fill: parent
-    font.pixelSize: text.length === 1 ? height / 1.6 : height / 1.8
+    font.pointSize: Math.max(8, height > 0 ? (text.length === 1 ? height / 2 : height / 2.2) : 8)
     horizontalAlignment: Qt.AlignHCenter
     verticalAlignment: Qt.AlignVCenter
   }

--- a/src/qml/imports/Theme/QfBadge.qml
+++ b/src/qml/imports/Theme/QfBadge.qml
@@ -4,8 +4,15 @@ import QtQuick.Controls
 Rectangle {
   id: badge
 
+  enum Alignment {
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    BottomRight
+  }
+
   property alias badgeText: inText
-  property int alignment: QfBadge.TopRight
+  property int alignment: QfBadge.Alignment.TopRight
 
   property int topMargin: 2
   property int bottomMargin: 2
@@ -20,10 +27,10 @@ Rectangle {
   border.color: Theme.mainBackgroundColor
 
   anchors {
-    top: (alignment === QfBadge.TopLeft || alignment === QfBadge.TopRight) ? parent.top : undefined
-    bottom: (alignment === QfBadge.BottomLeft || alignment === QfBadge.BottomRight) ? parent.bottom : undefined
-    left: (alignment === QfBadge.TopLeft || alignment === QfBadge.BottomLeft) ? parent.left : undefined
-    right: (alignment === QfBadge.TopRight || alignment === QfBadge.BottomRight) ? parent.right : undefined
+    top: (alignment === QfBadge.Alignment.TopLeft || alignment === QfBadge.Alignment.TopRight) ? parent.top : undefined
+    bottom: (alignment === QfBadge.Alignment.BottomLeft || alignment === QfBadge.Alignment.BottomRight) ? parent.bottom : undefined
+    left: (alignment === QfBadge.Alignment.TopLeft || alignment === QfBadge.Alignment.BottomLeft) ? parent.left : undefined
+    right: (alignment === QfBadge.Alignment.TopRight || alignment === QfBadge.Alignment.BottomRight) ? parent.right : undefined
 
     topMargin: badge.topMargin
     bottomMargin: badge.bottomMargin

--- a/src/qml/imports/Theme/QfToolButton.qml
+++ b/src/qml/imports/Theme/QfToolButton.qml
@@ -64,28 +64,24 @@ RoundButton {
   Material.foreground: icon.color
   font: Theme.tipFont
 
-  Rectangle {
-    id: bottomRightIndicator
-    color: bottomRightIndicatorBgColor
-    anchors.bottom: button.bottom
-    anchors.right: button.right
-    anchors.bottomMargin: 7
-    anchors.rightMargin: 5
+  QfBadge {
     width: button.width / 2.5
     height: width
     visible: bottomRightIndicatorText
-    radius: width
-    border.width: 2
+    color: bottomRightIndicatorBgColor
     border.color: Theme.mainColor
+    border.width: 2
     z: 2
 
-    Text {
-      anchors.fill: parent
-      color: bottomRightIndicatorFgColor
-      text: bottomRightIndicatorText
-      font.pixelSize: bottomRightIndicatorText.length == 1 ? height / 1.6 : height / 1.8
-      horizontalAlignment: Qt.AlignHCenter
-      verticalAlignment: Qt.AlignVCenter
+    anchors {
+      top: undefined
+      bottom: button.bottom
+      right: button.right
+      bottomMargin: 7
+      rightMargin: 5
     }
+
+    badgeText.color: bottomRightIndicatorFgColor
+    badgeText.text: bottomRightIndicatorText
   }
 }

--- a/src/qml/imports/Theme/QfToolButton.qml
+++ b/src/qml/imports/Theme/QfToolButton.qml
@@ -65,7 +65,7 @@ RoundButton {
   font: Theme.tipFont
 
   QfBadge {
-    alignment: QfBadge.BottomRight
+    alignment: QfBadge.Alignment.BottomRight
 
     z: 2
     width: button.width / 2.5

--- a/src/qml/imports/Theme/QfToolButton.qml
+++ b/src/qml/imports/Theme/QfToolButton.qml
@@ -65,23 +65,20 @@ RoundButton {
   font: Theme.tipFont
 
   QfBadge {
+    alignment: QfBadge.BottomRight
+
+    z: 2
     width: button.width / 2.5
     height: width
     visible: bottomRightIndicatorText
     color: bottomRightIndicatorBgColor
     border.color: Theme.mainColor
     border.width: 2
-    z: 2
-
-    anchors {
-      top: undefined
-      bottom: button.bottom
-      right: button.right
-      bottomMargin: 7
-      rightMargin: 5
-    }
 
     badgeText.color: bottomRightIndicatorFgColor
     badgeText.text: bottomRightIndicatorText
+
+    bottomMargin: 7
+    rightMargin: 5
   }
 }

--- a/src/qml/imports/Theme/qmldir
+++ b/src/qml/imports/Theme/qmldir
@@ -2,6 +2,7 @@ module Theme
 singleton Theme 1.0 Theme.qml
 QfComboBox 1.0 QfComboBox.qml
 QfActionButton 1.0 QfActionButton.qml
+QfBadge 1.0 QfBadge.qml
 QfSlider 1.0 QfSlider.qml
 QfSwitch 1.0 QfSwitch.qml
 QfButton 1.0 QfButton.qml

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1556,6 +1556,7 @@ ApplicationWindow {
         }
 
         QfBadge {
+          alignment: QfBadge.TopRight
           visible: cloudProjectsModel.layerObserver.deltaFileWrapper.count > 0
           color: Theme.cloudColor
         }
@@ -2260,6 +2261,7 @@ ApplicationWindow {
         }
 
         QfBadge {
+          alignment: QfBadge.TopRight
           visible: positioningSettings.accuracyIndicator && gnssButton.state === "On"
           color: !positionSource.positionInformation || !positionSource.positionInformation.haccValid || positionSource.positionInformation.hacc > positioningSettings.accuracyBad ? Theme.accuracyBad : positionSource.positionInformation.hacc > positioningSettings.accuracyExcellent ? Theme.accuracyTolerated : Theme.accuracyExcellent
         }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1555,21 +1555,7 @@ ApplicationWindow {
           mainMenu.popup(menuButton.x, menuButton.y);
         }
 
-        Rectangle {
-          anchors {
-            top: parent.top
-            right: parent.right
-            rightMargin: 2
-            topMargin: 2
-          }
-
-          width: 12
-          height: 12
-          radius: width / 2
-
-          border.width: 1.5
-          border.color: "white"
-
+        QfBadge {
           visible: cloudProjectsModel.layerObserver.deltaFileWrapper.count > 0
           color: Theme.cloudColor
         }
@@ -2273,21 +2259,7 @@ ApplicationWindow {
           }
         }
 
-        Rectangle {
-          anchors {
-            top: parent.top
-            right: parent.right
-            rightMargin: 2
-            topMargin: 2
-          }
-
-          width: 12
-          height: 12
-          radius: width / 2
-
-          border.width: 1.5
-          border.color: "white"
-
+        QfBadge {
           visible: positioningSettings.accuracyIndicator && gnssButton.state === "On"
           color: !positionSource.positionInformation || !positionSource.positionInformation.haccValid || positionSource.positionInformation.hacc > positioningSettings.accuracyBad ? Theme.accuracyBad : positionSource.positionInformation.hacc > positioningSettings.accuracyExcellent ? Theme.accuracyTolerated : Theme.accuracyExcellent
         }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1554,6 +1554,25 @@ ApplicationWindow {
         onPressAndHold: {
           mainMenu.popup(menuButton.x, menuButton.y);
         }
+
+        Rectangle {
+          anchors {
+            top: parent.top
+            right: parent.right
+            rightMargin: 2
+            topMargin: 2
+          }
+
+          width: 12
+          height: 12
+          radius: width / 2
+
+          border.width: 1.5
+          border.color: "white"
+
+          visible: cloudProjectsModel.layerObserver.deltaFileWrapper.count > 0
+          color: Theme.cloudColor
+        }
       }
 
       QfActionButton {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1556,7 +1556,7 @@ ApplicationWindow {
         }
 
         QfBadge {
-          alignment: QfBadge.TopRight
+          alignment: QfBadge.Alignment.TopRight
           visible: cloudProjectsModel.layerObserver.deltaFileWrapper.count > 0
           color: Theme.cloudColor
         }
@@ -2261,7 +2261,7 @@ ApplicationWindow {
         }
 
         QfBadge {
-          alignment: QfBadge.TopRight
+          alignment: QfBadge.Alignment.TopRight
           visible: positioningSettings.accuracyIndicator && gnssButton.state === "On"
           color: !positionSource.positionInformation || !positionSource.positionInformation.haccValid || positionSource.positionInformation.hacc > positioningSettings.accuracyBad ? Theme.accuracyBad : positionSource.positionInformation.hacc > positioningSettings.accuracyExcellent ? Theme.accuracyTolerated : Theme.accuracyExcellent
         }

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -108,6 +108,14 @@
         <file>imports/Theme/qmldir</file>
         <file>imports/Theme/QfSwipeAnimator.qml</file>
         <file>imports/Theme/QfVisibilityFadingRow.qml</file>
+        <file>imports/Theme/QfProgrerssRing.qml</file>
+        <file>imports/Theme/QfScrollBar.qml</file>
+        <file>imports/Theme/QfSearchBar.qml</file>
+        <file>imports/Theme/QfDialog.qml</file>
+        <file>imports/Theme/QfMenu.qml</file>
+        <file>imports/Theme/QfTimeItem.qml</file>
+        <file>imports/Theme/QfCalendarItem.qml</file>
+        <file>imports/Theme/QfBadge.qml</file>
         <file>TrackerSettings.qml</file>
         <file>TrackingSession.qml</file>
         <file>EmbeddedFeatureForm.qml</file>
@@ -125,12 +133,5 @@
         <file>PluginItem.qml</file>
         <file>InformationDrawer.qml</file>
         <file>QFieldGuide.qml</file>
-        <file>imports/Theme/QfProgrerssRing.qml</file>
-        <file>imports/Theme/QfScrollBar.qml</file>
-        <file>imports/Theme/QfSearchBar.qml</file>
-        <file>imports/Theme/QfDialog.qml</file>
-        <file>imports/Theme/QfMenu.qml</file>
-        <file>imports/Theme/QfTimeItem.qml</file>
-        <file>imports/Theme/QfCalendarItem.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
## 🚀 Description
This PR introduces a reusable `QfBadge` component and integrates it into the UI to improve consistency and maintainability. It also enhances the user experience by showing a badge indicator when a project has local changes that can be synced or pushed to `QFieldCloud`.

### ✨ Key Changes
- Added a new `QfBadge` component to standardize badge rendering across the app.
- Replaced previous inline badge implementations with `QfBadge`.
- Displayed a badge on the main menu button when the project has changes that are ready to be synced or pushed to QFieldCloud.

### Demo: 

<img width="520" height="63" alt="image" src="https://github.com/user-attachments/assets/ed6c54f8-9e92-477d-874d-ecaa769bf9c1" />

[Screencast From 2025-07-16 12-23-53.webm](https://github.com/user-attachments/assets/e3e433fc-c1b8-40e2-93a1-cd5df459210f)
