### PR TITLE
UI polish: Fix feature form layout, scroll behavior, and overscroll flicking

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -168,6 +168,7 @@ Page {
           clip: true
           ScrollBar.vertical: QfScrollBar {
           }
+          boundsBehavior: Flickable.StopAtBounds
 
           Rectangle {
             anchors.fill: parent

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -229,6 +229,11 @@ Rectangle {
   color: Theme.mainBackgroundColor
   clip: true
 
+  WheelHandler {
+    onWheel: {
+    }
+  }
+
   QtObject {
     id: props
 

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -61,24 +61,24 @@ Rectangle {
   width: {
     if (props.isVisible || featureFormList.canvasOperationRequested) {
       if (fullScreenView || parent.width <= parent.height || parent.width < 300) {
-        parent.width;
+        return parent.width;
       } else {
-        Math.min(Math.max(200, parent.width / 2.25), parent.width);
+        return Math.min(Math.max(200, parent.width / 2.25), parent.width);
       }
     } else {
-      0;
+      return 0;
     }
   }
   height: {
     if (props.isVisible || featureFormList.canvasOperationRequested) {
       if (fullScreenView || parent.width > parent.height) {
-        parent.height;
+        return parent.height;
       } else {
         isVertical = true;
-        Math.min(Math.max(200, parent.height / 2), parent.height);
+        return Math.min(Math.max(200, parent.height / 2), parent.height);
       }
     } else {
-      0;
+      return 0;
     }
   }
 

--- a/src/qml/OverlayFeatureFormDrawer.qml
+++ b/src/qml/OverlayFeatureFormDrawer.qml
@@ -26,16 +26,16 @@ Drawer {
 
   width: {
     if (overlayFeatureFormDrawer.fullScreenView || parent.width < parent.height || parent.width < 300) {
-      parent.width;
+      return parent.width;
     } else {
-      Math.min(Math.max(200, parent.width / 2.25), parent.width);
+      return Math.min(Math.max(200, parent.width / 2.25), parent.width);
     }
   }
   height: {
-    if (overlayFeatureFormDrawer.fullScreenView || parent.width > parent.height) {
-      parent.height;
+    if (overlayFeatureFormDrawer.fullScreenView || parent.width >= parent.height) {
+      return parent.height;
     } else {
-      Math.min(Math.max(200, parent.height / 2), parent.height);
+      return Math.min(Math.max(200, parent.height / 2), parent.height);
     }
   }
 


### PR DESCRIPTION
### 🚀 Description

This PR addresses several UI/UX issues to improve consistency and user interaction with the feature form.

### ✨ Key Fixes

1. **Feature Form Layout on Square Screens**

   * Fixed an issue where, on perfectly square screens, opening a new feature via digitizing would render the feature form with an awkward half-screen layout.
   * The form now properly utilizes available space.

<img width="438" height="475" alt="Screenshot From 2025-07-17 15-05-38" src="https://github.com/user-attachments/assets/d6a6a2ff-88fd-4804-81a3-adc83f208b1a" />


2. **Prevent Overscroll Flicking**

   * Added `Flickable.StopAtBounds` to the feature list view to avoid unnecessary movement when reaching scroll boundaries.

3. **Scroll Wheel Behavior**

   * Fixed a problem where mouse wheel events would bypass the feature form when it had no scroll, unintentionally triggering map zooms.
   * Mouse wheel interaction is now properly contained within the form when expected.
