### PR TITLE
Copy and pasting a feature from one layer to another.

### DIFF
--- a/src/core/clipboardmanager.h
+++ b/src/core/clipboardmanager.h
@@ -64,6 +64,14 @@ class ClipboardManager : public QObject
      */
     Q_INVOKABLE QgsFeature pasteFeatureFromClipboard();
 
+    /**
+     * Pastes the copied feature from the clipboard into the given editable layer.
+     * The feature is made compatible with the layer before being inserted.
+     * \param layer destination vector layer
+     * \returns TRUE if insertion was successful
+     */
+    Q_INVOKABLE bool pasteAsNewFeatureFromClipboardIntoLayer( QgsVectorLayer *layer );
+
   signals:
 
     void holdsFeatureChanged();


### PR DESCRIPTION
## 🚀 Description  

This PR implements support for pasting features from clipboard into compatible vector layers in QField.

### ✨ Key Changes

- Show a list of layers where paste operation is possible (based on feature compatibility).
- Implement paste functionality to add new features from clipboard into the selected layer.


### Demo – First Glance Overview


##### _Known issues are still being addressed and will be updated soon_


