### PR TITLE
improve correctness of GNSS datetime handling

### DIFF
--- a/src/core/positioning/internalgnssreceiver.cpp
+++ b/src/core/positioning/internalgnssreceiver.cpp
@@ -177,7 +177,9 @@ void InternalGnssReceiver::handleSatellitesInUseUpdated( const QList<QGeoSatelli
                                                               mSatellitesInfo, 0, 0, 0,
                                                               mLastGnssPositionInformation.hacc(),
                                                               mLastGnssPositionInformation.vacc(),
-                                                              mLastGnssPositionInformation.utcDateTime(),
+                                                              mLastGnssPositionInformation.utcDateTime().isValid() ? 
+                                                                mLastGnssPositionInformation.utcDateTime() : 
+                                                                QDateTime::currentDateTimeUtc(),
                                                               QChar(), 0, -1, static_cast<int>( mSatellitesID.size() ), QChar( 'A' ), mSatellitesID, mSatelliteInformationValid,
                                                               mLastGnssPositionInformation.verticalSpeed(),
                                                               mLastGnssPositionInformation.magneticVariation(),

--- a/src/core/positioning/positioningsource.cpp
+++ b/src/core/positioning/positioningsource.cpp
@@ -298,7 +298,7 @@ void PositioningSource::lastGnssPositionInformationChanged( const GnssPositionIn
                                                      lastGnssPositionInformation.vdop(),
                                                      lastGnssPositionInformation.hacc(),
                                                      lastGnssPositionInformation.vacc(),
-                                                     lastGnssPositionInformation.utcDateTime().isValid() ? lastGnssPositionInformation.utcDateTime() : QDateTime::currentDateTimeUtc(),
+                                                     lastGnssPositionInformation.utcDateTime(),
                                                      lastGnssPositionInformation.fixMode(),
                                                      lastGnssPositionInformation.fixType(),
                                                      lastGnssPositionInformation.quality(),

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -306,16 +306,21 @@ void Tracker::processPositionInformation( const GnssPositionInformation &positio
   if ( !mIsActive && !mIsReplaying )
     return;
 
-  mLastDevicePositionTimestampMSecsSinceEpoch = positionInformation.utcDateTime().toMSecsSinceEpoch();
+  mLastDevicePositionTimestampMSecsSinceEpoch = positionInformation.utcDateTime().isValid() ? 
+                                                 positionInformation.utcDateTime().toMSecsSinceEpoch() : 
+                                                 QDateTime::currentDateTimeUtc().toMSecsSinceEpoch();
 
   double measureValue = 0.0;
   switch ( mMeasureType )
   {
     case Tracker::SecondsSinceStart:
-      measureValue = positionInformation.utcDateTime().toSecsSinceEpoch() - mStartPositionTimestamp.toSecsSinceEpoch();
+      if ( positionInformation.utcDateTime().isValid() && mStartPositionTimestamp.isValid() )
+        measureValue = positionInformation.utcDateTime().toSecsSinceEpoch() - mStartPositionTimestamp.toSecsSinceEpoch();
       break;
     case Tracker::Timestamp:
-      measureValue = positionInformation.utcDateTime().toSecsSinceEpoch();
+      measureValue = positionInformation.utcDateTime().isValid() ? 
+                     positionInformation.utcDateTime().toSecsSinceEpoch() : 
+                     QDateTime::currentDateTimeUtc().toSecsSinceEpoch();
       break;
     case Tracker::GroundSpeed:
       measureValue = positionInformation.speed();

--- a/src/core/utils/expressioncontextutils.cpp
+++ b/src/core/utils/expressioncontextutils.cpp
@@ -44,7 +44,11 @@ QgsExpressionContextScope *ExpressionContextUtils::positionScope( const GnssPosi
   const QgsGeometry point = QgsGeometry( new QgsPoint( positionInformation.longitude(), positionInformation.latitude(), positionInformation.elevation() ) );
 
   addPositionVariable( scope, QStringLiteral( "coordinate" ), QVariant::fromValue<QgsGeometry>( point ), positionLocked );
-  addPositionVariable( scope, QStringLiteral( "timestamp" ), positionInformation.utcDateTime(), positionLocked );
+  addPositionVariable( scope, QStringLiteral( "timestamp" ), 
+                      positionInformation.utcDateTime().isValid() ? 
+                        positionInformation.utcDateTime() : 
+                        QDateTime::currentDateTimeUtc(), 
+                      positionLocked );
   addPositionVariable( scope, QStringLiteral( "direction" ), positionInformation.direction(), positionLocked ); // Speed direction
   addPositionVariable( scope, QStringLiteral( "ground_speed" ), positionInformation.speed(), positionLocked );
   addPositionVariable( scope, QStringLiteral( "orientation" ), positionInformation.orientation(), positionLocked ); // Compass/magnetometer orientation

--- a/src/core/utils/fileutils.cpp
+++ b/src/core/utils/fileutils.cpp
@@ -373,8 +373,11 @@ void FileUtils::addImageMetadata( const QString &imagePath, const GnssPositionIn
     metadata["Exif.GPSInfo.GPSSpeedRef"] = "K";
   }
 
-  metadata["Exif.GPSInfo.GPSDateStamp"] = positionInformation.utcDateTime().date();
-  metadata["Exif.GPSInfo.GPSTimeStamp"] = positionInformation.utcDateTime().time();
+  if ( positionInformation.utcDateTime().isValid() )
+  {
+    metadata["Exif.GPSInfo.GPSDateStamp"] = positionInformation.utcDateTime().date();
+    metadata["Exif.GPSInfo.GPSTimeStamp"] = positionInformation.utcDateTime().time();
+  }
 
   metadata["Exif.GPSInfo.GPSSatellites"] = QString::number( positionInformation.satellitesUsed() ).rightJustified( 2, '0' );
 

--- a/src/core/utils/positioningutils.cpp
+++ b/src/core/utils/positioningutils.cpp
@@ -74,7 +74,9 @@ GnssPositionInformation PositioningUtils::averagedPositionInformation( const QLi
   double verticalSpeed = std::numeric_limits<double>::quiet_NaN();
   double magneticVariation = std::numeric_limits<double>::quiet_NaN();
 
-  QDateTime utcDateTime = positionsInformation.last().utcDateTime();
+  QDateTime utcDateTime = positionsInformation.last().utcDateTime().isValid() ? 
+                          positionsInformation.last().utcDateTime() : 
+                          QDateTime::currentDateTimeUtc();
 
   QList<QgsSatelliteInfo> satellitesInView = positionsInformation.at( 0 ).satellitesInView();
   int satellitesUsed = satellitesInView.size();


### PR DESCRIPTION
This prevents initial positioning window not being greyed out even when there has never been a GNSS fix.

This also avoids pretending the system time is the GNSS time in EXIF metadata.  That could potentially break someone's batch image processing, so maybe add to release notes.