### PR TITLE
Expose map canvas point handler item to plugins

### DIFF
--- a/src/core/utils/geometryutils.cpp
+++ b/src/core/utils/geometryutils.cpp
@@ -304,3 +304,8 @@ QgsGeometry GeometryUtils::createGeometryFromWkt( const QString &wkt )
 {
   return QgsGeometry::fromWkt( wkt );
 }
+
+QgsRectangle GeometryUtils::createRectangleFromPoints( const QgsPoint &p1, const QgsPoint &p2 )
+{
+  return QgsRectangle( p1, p2 );
+}

--- a/src/core/utils/geometryutils.h
+++ b/src/core/utils/geometryutils.h
@@ -114,6 +114,9 @@ class QFIELD_CORE_EXPORT GeometryUtils : public QObject
 
     //! Returns a reprojected \a rectangle from the stated \a sourceCrs to a \a destinationCrs.
     static Q_INVOKABLE QgsRectangle reprojectRectangle( const QgsRectangle &rectangle, const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs );
+
+    //! Returns a rectangle from two points.
+    static Q_INVOKABLE QgsRectangle createRectangleFromPoints( const QgsPoint &p1, const QgsPoint &p2 );
 };
 
 #endif // GEOMETRYUTILS_H

--- a/src/core/utils/layerutils.cpp
+++ b/src/core/utils/layerutils.cpp
@@ -389,3 +389,9 @@ FeatureIterator LayerUtils::createFeatureIteratorFromExpression( QgsVectorLayer 
   const QgsFeatureRequest request = QgsFeatureRequest( QgsExpression( expression ) );
   return FeatureIterator( layer, request );
 }
+
+FeatureIterator LayerUtils::createFeatureIteratorFromRectangle( QgsVectorLayer *layer, const QgsRectangle &rectangle )
+{
+  const QgsFeatureRequest request = QgsFeatureRequest( rectangle );
+  return FeatureIterator( layer, request );
+}

--- a/src/core/utils/layerutils.h
+++ b/src/core/utils/layerutils.h
@@ -154,6 +154,11 @@ class LayerUtils : public QObject
      * Returns a feature iterator to get features matching a given \a expression within the provided \a layer.
      */
     Q_INVOKABLE static FeatureIterator createFeatureIteratorFromExpression( QgsVectorLayer *layer, const QString &expression );
+
+    /**
+     * Returns a feature iterator to get features overlapping a given \a rectangle within the provided \a layer.
+     */
+    Q_INVOKABLE static FeatureIterator createFeatureIteratorFromRectangle( QgsVectorLayer *layer, const QgsRectangle &rectangle );
 };
 
 #endif // LAYERUTILS_H

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -796,6 +796,7 @@ ApplicationWindow {
 
       MapCanvasPointHandler {
         id: pointHandler
+        objectName: "pointHandler"
       }
     }
 


### PR DESCRIPTION
Should have been done in 3.6! Better later than never.

With this in, plugins can register an handler and do stuff like:

```
const pointHandler = iface.findItemByObjectName("pointHandler")
const mapCanvas = iface.mapCanvas()
pointHandler.registerHandler("my_plugin", (point, type, interactionType) => {
  if (interactionType === "clicked") {
    // create a pair of point that'll represent a buffer area within which features are to be searched
    let tl = mapCanvas.mapSettings.screenToCoordinate(Qt.point(point.x - 4, point.y - 4))
    let br = mapCanvas.mapSettings.screenToCoordinate(Qt.point(point.x + 4, point.y + 4))
    
    let expression = "intersects(geom_from_wkt('POLYGON(("+tl.x+" "+tl.y+", "+br.x+" "+tl.y+", "+br.x+" "+br.y+", "+tl.x+" "+br.y+", "+tl.x+" "+tl.y+"))'), $geometry)"
    let it = LayerUtils.createFeatureIteratorFromExpression(qgisProject.mapLayersByName("my_layer")[0], expression)
    if (it.hasNext()) {
      // you've got a feature, play with it! :)
      const feature = it.next()
      console.log(feature.id)
      return true
    }
  }
  return false
});
```

Plugins should also take care of deregistering handlers when the project or app plugin is being destroyed:

```
pointHandler.deregisterHandler("my_plugin");
```

_Edit_

While at it, I've added two invokable functions  to create a QgsRectangle from two points and create a feature iterator filtering by rectangles. The example above becomes a lot nicer (and faster):

```
const pointHandler = iface.findItemByObjectName("pointHandler")
const mapCanvas = iface.mapCanvas()
pointHandler.registerHandler("my_plugin", (point, type, interactionType) => {
  if (interactionType === "clicked") {
    // create a pair of point that'll represent a buffer area within which features are to be searched
    const p1 = mapCanvas.mapSettings.screenToCoordinate(Qt.point(point.x - 4, point.y - 4))
    const p2 = mapCanvas.mapSettings.screenToCoordinate(Qt.point(point.x + 4, point.y + 4))
    const rectangle = GeometryUtils.createRectangleFromPoints(p1, p2);
    let it = LayerUtils.createFeatureIteratorFromRectangle(qgisProject.mapLayersByName("my_layer")[0], rectangle)
    if (it.hasNext()) {
      // you've got a feature, play with it! :)
      const feature = it.next()
      console.log(feature.id)
      return true
    }
  }
  return false
});
```
