### PR TITLE
Insure that various actions in QField (such as feature duplication, feature attributes transfers, etc.) do not lead to duplicate source primary key values.

### DIFF
--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -780,13 +780,23 @@ void FeatureModel::resetAttributes( bool partialReset )
 bool FeatureModel::updateAttributesFromFeature( const QgsFeature &feature )
 {
   bool updated = false;
+  QList<int> primaryKeyAttributes;
+  if ( mLayer )
+  {
+    primaryKeyAttributes << mLayer->primaryKeyAttributes();
+    const QString sourcePrimaryKeys = mLayer->customProperty( QStringLiteral( "QFieldSync/sourceDataPrimaryKeys" ) ).toString();
+    if ( !sourcePrimaryKeys.isEmpty() && mFeature.fields().lookupField( sourcePrimaryKeys ) >= 0 )
+    {
+      primaryKeyAttributes << mFeature.fields().lookupField( sourcePrimaryKeys );
+    }
+  }
   const QgsFields fields = feature.fields();
   for ( int i = 0; i < fields.size(); i++ )
   {
     const int idx = mFeature.fields().lookupField( fields[i].name() );
     if ( idx >= 0 )
     {
-      if ( mLayer && mLayer->primaryKeyAttributes().contains( idx ) )
+      if ( primaryKeyAttributes.contains( idx ) )
       {
         continue;
       }

--- a/src/core/utils/geometryutils.cpp
+++ b/src/core/utils/geometryutils.cpp
@@ -211,10 +211,53 @@ GeometryUtils::GeometryOperationResult GeometryUtils::addRingFromRubberband( Qgs
   return static_cast<GeometryUtils::GeometryOperationResult>( layer->addRing( ring, &fid ) );
 }
 
-GeometryUtils::GeometryOperationResult GeometryUtils::splitFeatureFromRubberband( QgsVectorLayer *layer, RubberbandModel *rubberBandModel )
+GeometryUtils::GeometryOperationResult GeometryUtils::splitFeatureFromRubberband( QgsVectorLayer *layer, QgsFeatureId fid, RubberbandModel *rubberBandModel )
 {
+  if ( !layer || !rubberBandModel )
+    return GeometryUtils::GeometryOperationResult::NothingHappened;
+
+  // The connection below will be triggered when the new feature is committed and will provide
+  // the saved feature ID needed to fetch the saved feature back from the data provider
+  QgsFeatureIds createdFeatureIds;
+  QMetaObject::Connection connection = connect( layer, &QgsVectorLayer::featureAdded, [&createdFeatureIds]( QgsFeatureId fid ) { createdFeatureIds << fid; } );
+
+  layer->selectByIds( QgsFeatureIds() << fid, Qgis::SelectBehavior::SetSelection );
+
+  const bool wasEditing = ( layer->editBuffer() );
+  if ( !wasEditing )
+  {
+    layer->startEditing();
+  }
+  else
+  {
+    layer->commitChanges( false );
+  }
+
   QgsPointSequence line = rubberBandModel->pointSequence( layer->crs(), Qgis::WkbType::Point, false );
-  return static_cast<GeometryUtils::GeometryOperationResult>( layer->splitFeatures( line, true ) );
+  GeometryUtils::GeometryOperationResult result = static_cast<GeometryUtils::GeometryOperationResult>( layer->splitFeatures( line, true ) );
+  if ( result != GeometryUtils::GeometryOperationResult::Success )
+  {
+    layer->rollBack();
+  }
+  else
+  {
+    const QString sourcePrimaryKeys = layer->customProperty( QStringLiteral( "QFieldSync/sourceDataPrimaryKeys" ) ).toString();
+    if ( !sourcePrimaryKeys.isEmpty() && layer->fields().lookupField( sourcePrimaryKeys ) >= 0 )
+    {
+      const int sourcePrimaryKeysIndex = layer->fields().lookupField( sourcePrimaryKeys );
+      for ( const QgsFeatureId &fid : createdFeatureIds )
+      {
+        layer->changeAttributeValue( fid, sourcePrimaryKeysIndex, QVariant() );
+      }
+    }
+    layer->commitChanges( wasEditing );
+  }
+
+  layer->removeSelection();
+
+  disconnect( connection );
+
+  return result;
 }
 
 QgsPoint GeometryUtils::coordinateToPoint( const QGeoCoordinate &coor )

--- a/src/core/utils/geometryutils.h
+++ b/src/core/utils/geometryutils.h
@@ -81,9 +81,8 @@ class QFIELD_CORE_EXPORT GeometryUtils : public QObject
 
     /**
      * Performs a split using the line in the rubberband model.
-     * \note Requires a given vector layer to have selected feature(s).
      */
-    static Q_INVOKABLE GeometryOperationResult splitFeatureFromRubberband( QgsVectorLayer *layer, RubberbandModel *rubberBandModel );
+    static Q_INVOKABLE GeometryOperationResult splitFeatureFromRubberband( QgsVectorLayer *layer, QgsFeatureId fid, RubberbandModel *rubberBandModel );
 
     //! Converts QGeoCoordinate to QgsPoint.
     static Q_INVOKABLE QgsPoint coordinateToPoint( const QGeoCoordinate &coor );

--- a/src/core/utils/layerutils.cpp
+++ b/src/core/utils/layerutils.cpp
@@ -379,11 +379,12 @@ QgsFeature LayerUtils::duplicateFeature( QgsVectorLayer *layer, QgsFeature featu
 
     // Insure the source primary ID of a duplicated child feature is correctly set to null (i.e. new feature within the source dataset)
     sourcePrimaryKeys = chl->customProperty( QStringLiteral( "QFieldSync/sourceDataPrimaryKeys" ) ).toString();
-    for ( auto fid : fids )
+    if ( !sourcePrimaryKeys.isEmpty() && chl->fields().lookupField( sourcePrimaryKeys ) >= 0 )
     {
-      if ( chl->fields().lookupField( sourcePrimaryKeys ) >= 0 )
+      const int sourcePrimaryKeysIndex = chl->fields().lookupField( sourcePrimaryKeys );
+      for ( auto fid : fids )
       {
-        chl->changeAttributeValue( fid, chl->fields().lookupField( sourcePrimaryKeys ), QVariant() );
+        chl->changeAttributeValue( fid, sourcePrimaryKeysIndex, QVariant() );
       }
     }
 

--- a/src/core/utils/layerutils.cpp
+++ b/src/core/utils/layerutils.cpp
@@ -305,7 +305,7 @@ bool LayerUtils::deleteFeature( QgsProject *project, QgsVectorLayer *layer, cons
   return isSuccess;
 }
 
-QgsFeature LayerUtils::duplicateFeature( QgsVectorLayer *layer, const QgsFeature &feature )
+QgsFeature LayerUtils::duplicateFeature( QgsVectorLayer *layer, QgsFeature feature )
 {
   if ( !layer )
   {
@@ -323,6 +323,13 @@ QgsFeature LayerUtils::duplicateFeature( QgsVectorLayer *layer, const QgsFeature
   {
     QgsMessageLog::logMessage( tr( "Cannot start editing" ), "QField", Qgis::Warning );
     return QgsFeature();
+  }
+
+  // When duplicating a feature, insure the source primary ID is correctly set to null (i.e. new feature within the source dataset)
+  QString sourcePrimaryKeys = layer->customProperty( QStringLiteral( "QFieldSync/sourceDataPrimaryKeys" ) ).toString();
+  if ( layer->fields().lookupField( sourcePrimaryKeys ) >= 0 )
+  {
+    feature.setAttribute( layer->fields().lookupField( sourcePrimaryKeys ), QVariant() );
   }
 
   QgsFeature duplicatedFeature;
@@ -367,6 +374,16 @@ QgsFeature LayerUtils::duplicateFeature( QgsVectorLayer *layer, const QgsFeature
             chl->changeAttributeValue( fid, chl->fields().indexOf( fieldPair.referencingField() ), duplicatedFeature.attribute( fieldPair.referencedField() ) );
           }
         }
+      }
+    }
+
+    // Insure the source primary ID of a duplicated child feature is correctly set to null (i.e. new feature within the source dataset)
+    sourcePrimaryKeys = chl->customProperty( QStringLiteral( "QFieldSync/sourceDataPrimaryKeys" ) ).toString();
+    for ( auto fid : fids )
+    {
+      if ( chl->fields().lookupField( sourcePrimaryKeys ) >= 0 )
+      {
+        chl->changeAttributeValue( fid, chl->fields().lookupField( sourcePrimaryKeys ), QVariant() );
       }
     }
 

--- a/src/core/utils/layerutils.h
+++ b/src/core/utils/layerutils.h
@@ -131,7 +131,7 @@ class LayerUtils : public QObject
      * return the duplicated feature with attribute values saved updated to match what was saved
      * into the layer dataset.
      */
-    static QgsFeature duplicateFeature( QgsVectorLayer *layer, const QgsFeature &feature );
+    static QgsFeature duplicateFeature( QgsVectorLayer *layer, QgsFeature feature );
 
     /**
      * Adds a \a feature into the \a layer.

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -162,10 +162,8 @@ Popup {
                     return;
                   if (!connectionSettings.visible) {
                     connectionSettings.visible = true;
-                    projects.visible = false;
                   } else {
                     connectionSettings.visible = false;
-                    projects.visible = true;
                   }
                 }
               }

--- a/src/qml/geometryeditors/FillRing.qml
+++ b/src/qml/geometryeditors/FillRing.qml
@@ -49,8 +49,6 @@ QfVisibilityFadingRow {
     onConfirmed: {
       digitizingLogger.writeCoordinates();
       rubberbandModel.frozen = true;
-      if (!featureModel.currentLayer.editBuffer())
-        featureModel.currentLayer.startEditing();
       var result = GeometryUtils.addRingFromRubberband(featureModel.currentLayer, featureModel.feature.id, rubberbandModel);
       if (result !== GeometryUtils.Success) {
         if (result === GeometryUtils.AddRingNotClosed)
@@ -63,10 +61,9 @@ QfVisibilityFadingRow {
           displayToast(qsTr('The ring doesn\'t have any existing ring to fit into'), 'error');
         else
           displayToast(qsTr('Unknown error when creating the ring'), 'error');
-        featureModel.currentLayer.rollBack();
         drawPolygonToolbar.rubberbandModel.reset();
       } else {
-        addPolygonDialog.show();
+        addPolygonDialog.open();
       }
     }
 
@@ -92,11 +89,7 @@ QfVisibilityFadingRow {
     }
 
     onRejected: {
-      commitRing();
-    }
-
-    function show() {
-      this.open();
+      drawPolygonToolbar.rubberbandModel.reset();
     }
   }
 
@@ -113,12 +106,12 @@ QfVisibilityFadingRow {
     drawPolygonToolbar.cancel();
   }
 
-  function commitRing() {
+  function commitRingFeature() {
     featureModel.currentLayer.commitChanges();
     drawPolygonToolbar.rubberbandModel.reset();
   }
 
-  function cancelRing() {
+  function cancelRingFeature() {
     featureModel.currentLayer.rollBack();
     drawPolygonToolbar.rubberbandModel.reset();
   }
@@ -128,8 +121,8 @@ QfVisibilityFadingRow {
     var feature = FeatureUtils.createBlankFeature(featureModel.currentLayer.fields, polygonGeometry);
 
     // Show form
-    formPopupLoader.onFeatureSaved.connect(commitRing);
-    formPopupLoader.onFeatureCancelled.connect(cancelRing);
+    formPopupLoader.onFeatureSaved.connect(commitRingFeature);
+    formPopupLoader.onFeatureCancelled.connect(cancelRingFeature);
     formPopupLoader.feature = feature;
     formPopupLoader.open();
   }

--- a/src/qml/geometryeditors/SplitFeature.qml
+++ b/src/qml/geometryeditors/SplitFeature.qml
@@ -41,24 +41,13 @@ QfVisibilityFadingRow {
     onConfirmed: {
       digitizingLogger.writeCoordinates();
       rubberbandModel.frozen = true;
-      // TODO: featureModel.currentLayer.selectByIds([featureModel.feature.id], VectorLayerStatic.SetSelection)
-      LayerUtils.selectFeaturesInLayer(featureModel.currentLayer, [featureModel.feature.id], VectorLayerStatic.SetSelection);
-      if (!featureModel.currentLayer.editBuffer())
-        featureModel.currentLayer.startEditing();
-      var result = GeometryUtils.splitFeatureFromRubberband(featureModel.currentLayer, drawLineToolbar.rubberbandModel);
+      const result = GeometryUtils.splitFeatureFromRubberband(featureModel.currentLayer, featureModel.feature.id, drawLineToolbar.rubberbandModel);
       if (result !== GeometryUtils.Success) {
         displayToast(qsTr('Feature could not be split'), 'error');
-        featureModel.currentLayer.rollBack();
-        rubberbandModel.reset();
-        cancel();
-        finished();
-      } else {
-        featureModel.currentLayer.commitChanges();
-        rubberbandModel.reset();
-        cancel();
-        finished();
       }
-      featureModel.currentLayer.removeSelection();
+      rubberbandModel.reset();
+      cancel();
+      finished();
     }
 
     onCancel: {

--- a/test/test_geometryutils.cpp
+++ b/test/test_geometryutils.cpp
@@ -71,13 +71,13 @@ TEST_CASE( "GeometryUtils" )
   SECTION( "SplitFeatureFromRubberband" )
   {
     REQUIRE( mLayer->startEditing() );
-    REQUIRE( GeometryUtils::splitFeatureFromRubberband( mLayer.get(), model.get() ) == GeometryUtils::GeometryOperationResult::NothingHappened );
+    REQUIRE( GeometryUtils::splitFeatureFromRubberband( mLayer.get(), 1, model.get() ) == GeometryUtils::GeometryOperationResult::NothingHappened );
 
     model->addVertexFromPoint( QgsPoint( 7.5, 8.5 ) );
     model->addVertexFromPoint( QgsPoint( 9.5, 8.5 ) );
     mLayer->select( 1 );
 
-    REQUIRE( GeometryUtils::splitFeatureFromRubberband( mLayer.get(), model.get() ) == GeometryUtils::GeometryOperationResult::Success );
+    REQUIRE( GeometryUtils::splitFeatureFromRubberband( mLayer.get(), 1, model.get() ) == GeometryUtils::GeometryOperationResult::Success );
     REQUIRE( mLayer->rollBack() );
   }
 }


### PR DESCRIPTION
This should fix delta collisions. 