### PR TITLE
[Backport release-3_7] Fix clipboard holds feature property not emitting signal when going from true to false

### DIFF
--- a/src/core/clipboardmanager.cpp
+++ b/src/core/clipboardmanager.cpp
@@ -46,7 +46,6 @@ void ClipboardManager::dataChanged()
     return;
   }
 
-  mHoldsFeature = false;
   mHasNativeFeature = false;
   mNativeFeature = QgsFeature();
   mHtmlFeature.clear();


### PR DESCRIPTION
Backport #6525
 **Authored by:** @nirvn