### PR TITLE
Implement GNSS accuracy quality classification requirement for averaged positioning and tracker sessions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,8 @@ repos:
       exclude: |
         (?x)^(
           i18n/|
-          vcpkg/
+          vcpkg/|
+          platform/android/res/
         )
     - id: check-yaml
     - id: check-added-large-files

--- a/src/core/positioning/gnsspositioninformation.h
+++ b/src/core/positioning/gnsspositioninformation.h
@@ -70,6 +70,7 @@ class GnssPositionInformation
     Q_PROPERTY( double vacc READ vacc )
     Q_PROPERTY( bool vaccValid READ vaccValid )
     Q_PROPERTY( double hvacc READ hvacc )
+    Q_PROPERTY( AccuracyQuality accuracyQuality READ accuracyQuality WRITE setAccuracyQuality )
     Q_PROPERTY( double hvaccValid READ hvaccValid )
     Q_PROPERTY( QDateTime utcDateTime READ utcDateTime )
     Q_PROPERTY( QChar fixMode READ fixMode )
@@ -108,6 +109,15 @@ class GnssPositionInformation
     };
 
     Q_ENUM( FixStatus )
+
+    enum AccuracyQuality
+    {
+      AccuracyBad,
+      AccuracyOk,
+      AccuracyExcellent
+    };
+
+    Q_ENUM( AccuracyQuality )
 
     GnssPositionInformation( double latitude = std::numeric_limits<double>::quiet_NaN(), double longitude = std::numeric_limits<double>::quiet_NaN(), double elevation = std::numeric_limits<double>::quiet_NaN(),
                              double speed = std::numeric_limits<double>::quiet_NaN(), double direction = std::numeric_limits<double>::quiet_NaN(), const QList<QgsSatelliteInfo> &satellitesInView = QList<QgsSatelliteInfo>(),
@@ -226,6 +236,13 @@ class GnssPositionInformation
     void setHVacc( double hvacc ) { mHvacc = hvacc; }
     double hvacc() const { return mHvacc; }
     bool hvaccValid() const { return !std::isnan( mHvacc ); }
+
+    /**
+     * Sets the accuracy quality classification.
+     * Indicates if the position accuracy is bad, okay, or excellent.
+     */
+    void setAccuracyQuality( AccuracyQuality quality ) { mAccuracyQuality = quality; }
+    AccuracyQuality accuracyQuality() const { return mAccuracyQuality; }
 
     /**
      * The date and time at which this position was reported, in UTC time.
@@ -354,6 +371,7 @@ class GnssPositionInformation
     double mHacc = std::numeric_limits<double>::quiet_NaN();
     double mVacc = std::numeric_limits<double>::quiet_NaN();
     double mHvacc = std::numeric_limits<double>::quiet_NaN();
+    AccuracyQuality mAccuracyQuality = AccuracyBad;
     QDateTime mUtcDateTime;
     QChar mFixMode;
     int mFixType = 0;

--- a/src/core/positioning/gnsspositioninformation.h
+++ b/src/core/positioning/gnsspositioninformation.h
@@ -112,6 +112,7 @@ class GnssPositionInformation
 
     enum AccuracyQuality
     {
+      AccuracyUndetermined,
       AccuracyBad,
       AccuracyOk,
       AccuracyExcellent
@@ -238,8 +239,8 @@ class GnssPositionInformation
     bool hvaccValid() const { return !std::isnan( mHvacc ); }
 
     /**
-     * Sets the accuracy quality classification.
-     * Indicates if the position accuracy is bad, okay, or excellent.
+     * Accuracy quality classification.
+     * Indicates if the position accuracy is bad, ok, or excellent, based on user-provided thresholds.
      */
     void setAccuracyQuality( AccuracyQuality quality ) { mAccuracyQuality = quality; }
     AccuracyQuality accuracyQuality() const { return mAccuracyQuality; }
@@ -371,7 +372,7 @@ class GnssPositionInformation
     double mHacc = std::numeric_limits<double>::quiet_NaN();
     double mVacc = std::numeric_limits<double>::quiet_NaN();
     double mHvacc = std::numeric_limits<double>::quiet_NaN();
-    AccuracyQuality mAccuracyQuality = AccuracyBad;
+    AccuracyQuality mAccuracyQuality = AccuracyUndetermined;
     QDateTime mUtcDateTime;
     QChar mFixMode;
     int mFixType = 0;
@@ -396,6 +397,7 @@ class GnssPositionInformation
 };
 
 Q_DECLARE_METATYPE( GnssPositionInformation )
+Q_DECLARE_METATYPE( GnssPositionInformation::AccuracyQuality )
 
 class GnssPositionDetails
 {

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -558,7 +558,7 @@ void Positioning::processGnssPositionInformation()
     {
       quality = GnssPositionInformation::AccuracyExcellent;
     }
-    else if ( isBadThresholdDefined && hacc <= badAccuracyThreshold() )
+    else if ( isBadThresholdDefined && hacc >= badAccuracyThreshold() )
     {
       quality = GnssPositionInformation::AccuracyOk;
     }

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -557,13 +557,9 @@ void Positioning::processGnssPositionInformation()
       {
         quality = GnssPositionInformation::AccuracyOk;
       }
-      else if ( isExcellentThresholdDefined || isBadThresholdDefined )
-      {
-        quality = GnssPositionInformation::AccuracyBad;
-      }
       else
       {
-        quality = GnssPositionInformation::AccuracyOk;
+        quality = GnssPositionInformation::AccuracyBad;
       }
     }
     else
@@ -581,8 +577,11 @@ void Positioning::processGnssPositionInformation()
 
   if ( mAveragedPosition )
   {
-    mCollectedPositionInformations << mPositionInformation;
-    mPositionInformation = PositioningUtils::averagedPositionInformation( mCollectedPositionInformations, mAveragedPositionFilterAccuracy );
+    if ( !mAveragedPositionFilterAccuracy || mPositionInformation.accuracyQuality() != GnssPositionInformation::AccuracyBad )
+    {
+      mCollectedPositionInformations << mPositionInformation;
+    }
+    mPositionInformation = PositioningUtils::averagedPositionInformation( mCollectedPositionInformations );
     emit averagedPositionCountChanged();
   }
 

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -536,20 +536,33 @@ void Positioning::processGnssPositionInformation()
 
   GnssPositionInformation::AccuracyQuality quality = GnssPositionInformation::AccuracyBad;
   const double hacc = mPositionInformation.hacc();
+  const bool isExcellentThresholdDefined = !std::isnan( excellentAccuracyThreshold() );
+  const bool isBadThresholdDefined = !std::isnan( badAccuracyThreshold() );
 
   if ( !std::isnan( hacc ) )
   {
-    if ( hacc <= excellentAccuracyThreshold() )
+    if ( isExcellentThresholdDefined && hacc <= excellentAccuracyThreshold() )
+    {
       quality = GnssPositionInformation::AccuracyExcellent;
-    else if ( hacc <= badAccuracyThreshold() )
+    }
+    else if ( isBadThresholdDefined && hacc <= badAccuracyThreshold() )
+    {
       quality = GnssPositionInformation::AccuracyOk;
-    else
+    }
+    else if ( isExcellentThresholdDefined || isBadThresholdDefined )
+    {
       quality = GnssPositionInformation::AccuracyBad;
+    }
+    else
+    {
+      quality = GnssPositionInformation::AccuracyOk;
+    }
   }
   else
   {
     quality = GnssPositionInformation::AccuracyBad;
   }
+
   mPositionInformation.setAccuracyQuality( quality );
 
   if ( mPositionInformation.isValid() )
@@ -606,6 +619,7 @@ void Positioning::setBadAccuracyThreshold( double threshold )
 {
   if ( mBadAccuracyThreshold == threshold )
     return;
+
   mBadAccuracyThreshold = threshold;
   emit badAccuracyThresholdChanged();
 }
@@ -614,6 +628,7 @@ void Positioning::setExcellentAccuracyThreshold( double threshold )
 {
   if ( mExcellentAccuracyThreshold == threshold )
     return;
+
   mExcellentAccuracyThreshold = threshold;
   emit excellentAccuracyThresholdChanged();
 }

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -534,6 +534,24 @@ void Positioning::processGnssPositionInformation()
 {
   mPositionInformation = mPositioningSourceReplica->property( "positionInformation" ).value<GnssPositionInformation>();
 
+  GnssPositionInformation::AccuracyQuality quality = GnssPositionInformation::AccuracyBad;
+  const double hacc = mPositionInformation.hacc();
+
+  if ( !std::isnan( hacc ) )
+  {
+    if ( hacc <= excellentAccuracyThreshold() )
+      quality = GnssPositionInformation::AccuracyExcellent;
+    else if ( hacc <= badAccuracyThreshold() )
+      quality = GnssPositionInformation::AccuracyOk;
+    else
+      quality = GnssPositionInformation::AccuracyBad;
+  }
+  else
+  {
+    quality = GnssPositionInformation::AccuracyBad;
+  }
+  mPositionInformation.setAccuracyQuality( quality );
+
   if ( mPositionInformation.isValid() )
   {
     mSourcePosition = QgsPoint( mPositionInformation.longitude(), mPositionInformation.latitude(), mPositionInformation.elevation() );
@@ -581,4 +599,21 @@ void Positioning::processProjectedPosition()
   }
 
   emit positionInformationChanged();
+}
+
+
+void Positioning::setBadAccuracyThreshold( double threshold )
+{
+  if ( mBadAccuracyThreshold == threshold )
+    return;
+  mBadAccuracyThreshold = threshold;
+  emit badAccuracyThresholdChanged();
+}
+
+void Positioning::setExcellentAccuracyThreshold( double threshold )
+{
+  if ( mExcellentAccuracyThreshold == threshold )
+    return;
+  mExcellentAccuracyThreshold = threshold;
+  emit excellentAccuracyThresholdChanged();
 }

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -582,7 +582,7 @@ void Positioning::processGnssPositionInformation()
   if ( mAveragedPosition )
   {
     mCollectedPositionInformations << mPositionInformation;
-    mPositionInformation = PositioningUtils::averagedPositionInformation( mCollectedPositionInformations, mAveragePositionFilterAccuracy );
+    mPositionInformation = PositioningUtils::averagedPositionInformation( mCollectedPositionInformations, mAveragedPositionFilterAccuracy );
     emit averagedPositionCountChanged();
   }
 
@@ -654,16 +654,16 @@ void Positioning::setExcellentAccuracyThreshold( double threshold )
   emit excellentAccuracyThresholdChanged();
 }
 
-bool Positioning::averagePositionFilterAccuracy() const
+bool Positioning::averagedPositionFilterAccuracy() const
 {
-  return mAveragePositionFilterAccuracy;
+  return mAveragedPositionFilterAccuracy;
 }
 
-void Positioning::setAveragePositionFilterAccuracy( bool enabled )
+void Positioning::setAveragedPositionFilterAccuracy( bool enabled )
 {
-  if ( mAveragePositionFilterAccuracy == enabled )
+  if ( mAveragedPositionFilterAccuracy == enabled )
     return;
 
-  mAveragePositionFilterAccuracy = enabled;
-  emit averagePositionFilterAccuracyChanged();
+  mAveragedPositionFilterAccuracy = enabled;
+  emit averagedPositionFilterAccuracyChanged();
 }

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -79,8 +79,6 @@ void Positioning::setupSource()
   connect( mPositioningSourceReplica.data(), SIGNAL( deviceLastErrorChanged() ), this, SIGNAL( deviceLastErrorChanged() ) );
   connect( mPositioningSourceReplica.data(), SIGNAL( deviceSocketStateChanged() ), this, SIGNAL( deviceSocketStateChanged() ) );
   connect( mPositioningSourceReplica.data(), SIGNAL( deviceSocketStateStringChanged() ), this, SIGNAL( deviceSocketStateStringChanged() ) );
-  connect( mPositioningSourceReplica.data(), SIGNAL( averagedPositionChanged() ), this, SIGNAL( averagedPositionChanged() ) );
-  connect( mPositioningSourceReplica.data(), SIGNAL( averagedPositionCountChanged() ), this, SIGNAL( averagedPositionCountChanged() ) );
   connect( mPositioningSourceReplica.data(), SIGNAL( elevationCorrectionModeChanged() ), this, SIGNAL( elevationCorrectionModeChanged() ) );
   connect( mPositioningSourceReplica.data(), SIGNAL( antennaHeightChanged() ), this, SIGNAL( antennaHeightChanged() ) );
   connect( mPositioningSourceReplica.data(), SIGNAL( orientationChanged() ), this, SIGNAL( orientationChanged() ) );

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -67,6 +67,7 @@ class Positioning : public QObject
 
     Q_PROPERTY( bool backgroundMode READ backgroundMode WRITE setBackgroundMode NOTIFY backgroundModeChanged )
 
+    Q_PROPERTY( bool averagePositionFilterAccuracy READ averagePositionFilterAccuracy WRITE setAveragePositionFilterAccuracy NOTIFY averagePositionFilterAccuracyChanged )
     Q_PROPERTY( double badAccuracyThreshold READ badAccuracyThreshold WRITE setBadAccuracyThreshold NOTIFY badAccuracyThresholdChanged )
     Q_PROPERTY( double excellentAccuracyThreshold READ excellentAccuracyThreshold WRITE setExcellentAccuracyThreshold NOTIFY excellentAccuracyThresholdChanged )
 
@@ -274,6 +275,16 @@ class Positioning : public QObject
      */
     void setExcellentAccuracyThreshold( double threshold );
 
+    /**
+     * Returns whether the average position filter accuracy is enabled.
+     */
+    bool averagePositionFilterAccuracy() const;
+
+    /**
+     * Enables or disables the average position filter accuracy.
+     */
+    void setAveragePositionFilterAccuracy( bool enabled );
+
   signals:
     void activeChanged();
     void validChanged();
@@ -296,6 +307,7 @@ class Positioning : public QObject
     void triggerConnectDevice();
     void triggerDisconnectDevice();
 
+    void averagePositionFilterAccuracyChanged();
     void badAccuracyThresholdChanged();
     void excellentAccuracyThresholdChanged();
 
@@ -335,6 +347,7 @@ class Positioning : public QObject
     bool mAveragedPosition = false;
     QList<GnssPositionInformation> mCollectedPositionInformations;
 
+    bool mAveragePositionFilterAccuracy;
     double mBadAccuracyThreshold = std::numeric_limits<double>::quiet_NaN();
     double mExcellentAccuracyThreshold = std::numeric_limits<double>::quiet_NaN();
 };

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -347,7 +347,7 @@ class Positioning : public QObject
     bool mAveragedPosition = false;
     QList<GnssPositionInformation> mCollectedPositionInformations;
 
-    bool mAveragedPositionFilterAccuracy;
+    bool mAveragedPositionFilterAccuracy = false;
     double mBadAccuracyThreshold = std::numeric_limits<double>::quiet_NaN();
     double mExcellentAccuracyThreshold = std::numeric_limits<double>::quiet_NaN();
 };

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -332,6 +332,9 @@ class Positioning : public QObject
 
     QVariantMap mPropertiesToSync;
 
+    bool mAveragedPosition = false;
+    QList<GnssPositionInformation> mCollectedPositionInformations;
+
     double mBadAccuracyThreshold = std::numeric_limits<double>::quiet_NaN();
     double mExcellentAccuracyThreshold = std::numeric_limits<double>::quiet_NaN();
 };

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -67,6 +67,9 @@ class Positioning : public QObject
 
     Q_PROPERTY( bool backgroundMode READ backgroundMode WRITE setBackgroundMode NOTIFY backgroundModeChanged )
 
+    Q_PROPERTY( double badAccuracyThreshold READ badAccuracyThreshold WRITE setBadAccuracyThreshold NOTIFY badAccuracyThresholdChanged )
+    Q_PROPERTY( double excellentAccuracyThreshold READ excellentAccuracyThreshold WRITE setExcellentAccuracyThreshold NOTIFY excellentAccuracyThresholdChanged )
+
   public:
     explicit Positioning( QObject *parent = nullptr );
     virtual ~Positioning() = default;
@@ -251,6 +254,26 @@ class Positioning : public QObject
      */
     Q_INVOKABLE QList<GnssPositionInformation> getBackgroundPositionInformation() const;
 
+    /**
+     * Returns the threshold above which accuracy is considered bad.
+     */
+    double badAccuracyThreshold() const { return mBadAccuracyThreshold; }
+
+    /**
+     * Sets the threshold above which accuracy is considered bad.
+     */
+    void setBadAccuracyThreshold( double threshold );
+
+    /**
+     * Returns the threshold below which accuracy is considered excellent.
+     */
+    double excellentAccuracyThreshold() const { return mExcellentAccuracyThreshold; }
+
+    /**
+     * Sets the threshold below which accuracy is considered excellent.
+     */
+    void setExcellentAccuracyThreshold( double threshold );
+
   signals:
     void activeChanged();
     void validChanged();
@@ -272,6 +295,9 @@ class Positioning : public QObject
 
     void triggerConnectDevice();
     void triggerDisconnectDevice();
+
+    void badAccuracyThresholdChanged();
+    void excellentAccuracyThresholdChanged();
 
   private slots:
     void onApplicationStateChanged( Qt::ApplicationState state );
@@ -305,6 +331,9 @@ class Positioning : public QObject
     bool mBackgroundMode = false;
 
     QVariantMap mPropertiesToSync;
+
+    double mBadAccuracyThreshold = std::numeric_limits<double>::quiet_NaN();
+    double mExcellentAccuracyThreshold = std::numeric_limits<double>::quiet_NaN();
 };
 
 #endif // POSITIONING_H

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -54,6 +54,7 @@ class Positioning : public QObject
     Q_PROPERTY( QgsPoint projectedPosition READ projectedPosition NOTIFY positionInformationChanged )
     Q_PROPERTY( double projectedHorizontalAccuracy READ projectedHorizontalAccuracy NOTIFY positionInformationChanged )
 
+    Q_PROPERTY( bool averagedPositionFilterAccuracy READ averagedPositionFilterAccuracy WRITE setAveragedPositionFilterAccuracy NOTIFY averagedPositionFilterAccuracyChanged )
     Q_PROPERTY( bool averagedPosition READ averagedPosition WRITE setAveragedPosition NOTIFY averagedPositionChanged )
     Q_PROPERTY( int averagedPositionCount READ averagedPositionCount NOTIFY averagedPositionCountChanged )
 
@@ -67,7 +68,6 @@ class Positioning : public QObject
 
     Q_PROPERTY( bool backgroundMode READ backgroundMode WRITE setBackgroundMode NOTIFY backgroundModeChanged )
 
-    Q_PROPERTY( bool averagePositionFilterAccuracy READ averagePositionFilterAccuracy WRITE setAveragePositionFilterAccuracy NOTIFY averagePositionFilterAccuracyChanged )
     Q_PROPERTY( double badAccuracyThreshold READ badAccuracyThreshold WRITE setBadAccuracyThreshold NOTIFY badAccuracyThresholdChanged )
     Q_PROPERTY( double excellentAccuracyThreshold READ excellentAccuracyThreshold WRITE setExcellentAccuracyThreshold NOTIFY excellentAccuracyThresholdChanged )
 
@@ -164,6 +164,16 @@ class Positioning : public QObject
      * Returns the position horizontal accuracy in the destination CRS' map units.
      */
     double projectedHorizontalAccuracy() const;
+
+    /**
+     * Returns whether the average position filter accuracy is enabled.
+     */
+    bool averagedPositionFilterAccuracy() const;
+
+    /**
+     * Enables or disables the average position filter accuracy.
+     */
+    void setAveragedPositionFilterAccuracy( bool enabled );
 
     /**
      * Returns whether the position information is averaged from an ongoing stream of incoming positions from the device.
@@ -275,16 +285,6 @@ class Positioning : public QObject
      */
     void setExcellentAccuracyThreshold( double threshold );
 
-    /**
-     * Returns whether the average position filter accuracy is enabled.
-     */
-    bool averagePositionFilterAccuracy() const;
-
-    /**
-     * Enables or disables the average position filter accuracy.
-     */
-    void setAveragePositionFilterAccuracy( bool enabled );
-
   signals:
     void activeChanged();
     void validChanged();
@@ -307,7 +307,7 @@ class Positioning : public QObject
     void triggerConnectDevice();
     void triggerDisconnectDevice();
 
-    void averagePositionFilterAccuracyChanged();
+    void averagedPositionFilterAccuracyChanged();
     void badAccuracyThresholdChanged();
     void excellentAccuracyThresholdChanged();
 
@@ -347,7 +347,7 @@ class Positioning : public QObject
     bool mAveragedPosition = false;
     QList<GnssPositionInformation> mCollectedPositionInformations;
 
-    bool mAveragePositionFilterAccuracy;
+    bool mAveragedPositionFilterAccuracy;
     double mBadAccuracyThreshold = std::numeric_limits<double>::quiet_NaN();
     double mExcellentAccuracyThreshold = std::numeric_limits<double>::quiet_NaN();
 };

--- a/src/core/positioning/positioningsource.cpp
+++ b/src/core/positioning/positioningsource.cpp
@@ -347,7 +347,8 @@ void PositioningSource::lastGnssPositionInformationChanged( const GnssPositionIn
 
   if ( mAveragedPosition )
   {
-    mCollectedPositionInformations << positionInformation;
+    if ( positionInformation.accuracyQuality() != GnssPositionInformation::AccuracyBad )
+      mCollectedPositionInformations << positionInformation;
     mPositionInformation = PositioningUtils::averagedPositionInformation( mCollectedPositionInformations );
   }
   else

--- a/src/core/positioning/positioningsource.cpp
+++ b/src/core/positioning/positioningsource.cpp
@@ -344,24 +344,11 @@ void PositioningSource::lastGnssPositionInformationChanged( const GnssPositionIn
                                                      lastGnssPositionInformation.imuHeading(),
                                                      lastGnssPositionInformation.imuSteering(),
                                                      mOrientation );
-
-  if ( mAveragedPosition )
-  {
-    mCollectedPositionInformations << positionInformation;
-    mPositionInformation = PositioningUtils::averagedPositionInformation( mCollectedPositionInformations );
-  }
-  else
-  {
-    mPositionInformation = positionInformation;
-  }
+  mPositionInformation = positionInformation;
 
   if ( !mBackgroundMode )
   {
     emit positionInformationChanged();
-    if ( mAveragedPosition )
-    {
-      emit averagedPositionCountChanged();
-    }
   }
   else
   {

--- a/src/core/positioning/positioningsource.cpp
+++ b/src/core/positioning/positioningsource.cpp
@@ -347,8 +347,7 @@ void PositioningSource::lastGnssPositionInformationChanged( const GnssPositionIn
 
   if ( mAveragedPosition )
   {
-    if ( positionInformation.accuracyQuality() != GnssPositionInformation::AccuracyBad )
-      mCollectedPositionInformations << positionInformation;
+    mCollectedPositionInformations << positionInformation;
     mPositionInformation = PositioningUtils::averagedPositionInformation( mCollectedPositionInformations );
   }
   else

--- a/src/core/positioning/positioningsource.cpp
+++ b/src/core/positioning/positioningsource.cpp
@@ -103,25 +103,6 @@ void PositioningSource::setValid( bool valid )
   emit validChanged();
 }
 
-void PositioningSource::setAveragedPosition( bool averaged )
-{
-  if ( mAveragedPosition == averaged )
-    return;
-
-  mAveragedPosition = averaged;
-  if ( mAveragedPosition )
-  {
-    mCollectedPositionInformations << mPositionInformation;
-  }
-  else
-  {
-    mCollectedPositionInformations.clear();
-  }
-
-  emit averagedPositionCountChanged();
-  emit averagedPositionChanged();
-}
-
 void PositioningSource::setLogging( bool logging )
 {
   if ( mLogging == logging )

--- a/src/core/positioning/positioningsource.h
+++ b/src/core/positioning/positioningsource.h
@@ -44,9 +44,6 @@ class PositioningSource : public QObject
 
     Q_PROPERTY( GnssPositionInformation positionInformation READ positionInformation NOTIFY positionInformationChanged )
 
-    Q_PROPERTY( bool averagedPosition READ averagedPosition WRITE setAveragedPosition NOTIFY averagedPositionChanged )
-    Q_PROPERTY( int averagedPositionCount READ averagedPositionCount NOTIFY averagedPositionCountChanged )
-
     Q_PROPERTY( ElevationCorrectionMode elevationCorrectionMode READ elevationCorrectionMode WRITE setElevationCorrectionMode NOTIFY elevationCorrectionModeChanged )
     Q_PROPERTY( double antennaHeight READ antennaHeight WRITE setAntennaHeight NOTIFY antennaHeightChanged )
 
@@ -141,22 +138,6 @@ class PositioningSource : public QObject
     GnssPositionInformation positionInformation() const { return mPositionInformation; };
 
     /**
-     * Returns whether the position information is averaged from an ongoing stream of incoming positions from the device.
-     */
-    bool averagedPosition() const { return mAveragedPosition; }
-
-    /**
-     * Sets whether the position information is \a averaged from an ongoing stream of incoming positions from the device.
-     */
-    void setAveragedPosition( bool averaged );
-
-    /**
-     * Returns the current number of collected position informations from which the averaged position is calculated.
-     * \note When averaged position is off, the value is zero.
-     */
-    int averagedPositionCount() const { return static_cast<int>( mCollectedPositionInformations.size() ); }
-
-    /**
      * Returns the current elevation correction mode.
      * \note Some modes depends on device capabilities.
      */
@@ -241,8 +222,6 @@ class PositioningSource : public QObject
     void deviceSocketStateChanged();
     void deviceSocketStateStringChanged();
     void positionInformationChanged();
-    void averagedPositionChanged();
-    void averagedPositionCountChanged();
     void elevationCorrectionModeChanged();
     void antennaHeightChanged();
     void orientationChanged();
@@ -269,9 +248,6 @@ class PositioningSource : public QObject
     bool mValid = false;
 
     GnssPositionInformation mPositionInformation;
-    QList<GnssPositionInformation> mCollectedPositionInformations;
-
-    bool mAveragedPosition = false;
 
     ElevationCorrectionMode mElevationCorrectionMode = ElevationCorrectionMode::None;
     double mAntennaHeight = 0.0;

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -524,7 +524,8 @@ void QgisMobileapp::initDeclarative( QQmlEngine *engine )
   qmlRegisterUncreatableType<QAbstractSocket>( "org.qfield", 1, 0, "QAbstractSocket", "" );
   qmlRegisterUncreatableType<AbstractGnssReceiver>( "org.qfield", 1, 0, "AbstractGnssReceiver", "" );
   qmlRegisterUncreatableType<Tracker>( "org.qfield", 1, 0, "Tracker", "" );
-  qRegisterMetaType<GnssPositionInformation>( "GnssPositionInformation" );
+  qmlRegisterUncreatableType<GnssPositionInformation>( "org.qfield", 1, 0, "GnssPositionInformation", "Access to enums and properties only; cannot instantiate in QML." );
+
   qRegisterMetaType<GnssPositionDetails>( "GnssPositionDetails" );
   qRegisterMetaType<PluginInformation>( "PluginInformation" );
 

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -191,6 +191,13 @@ void Tracker::positionReceived()
     return;
   }
 
+  if ( mSkipBadPositionReceived )
+  {
+    // Occurs when filterAccuracy property is true and the received position accuracy quality was determined to be bad
+    mSkipBadPositionReceived = false;
+    return;
+  }
+
   if ( !qgsDoubleNear( mTimeInterval, 0.0 ) )
   {
     mTimeIntervalFulfilled = mRubberbandModel->vertexCount() == 1 || ( ( mLastDevicePositionTimestampMSecsSinceEpoch - mLastVertexPositionTimestampMSecsSinceEpoch ) >= mTimeInterval * 1000 );
@@ -307,7 +314,9 @@ void Tracker::processPositionInformation( const GnssPositionInformation &positio
     return;
 
   if ( mFilterAccuracy && positionInformation.accuracyQuality() == GnssPositionInformation::AccuracyBad )
-    return;
+  {
+    mSkipBadPositionReceived = true;
+  }
 
   mLastDevicePositionTimestampMSecsSinceEpoch = positionInformation.utcDateTime().toMSecsSinceEpoch();
 

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -306,7 +306,7 @@ void Tracker::processPositionInformation( const GnssPositionInformation &positio
   if ( !mIsActive && !mIsReplaying )
     return;
 
-  if ( positionInformation.accuracyQuality() == GnssPositionInformation::AccuracyBad )
+  if ( mFilterAccuracy && positionInformation.accuracyQuality() == GnssPositionInformation::AccuracyBad )
     return;
 
   mLastDevicePositionTimestampMSecsSinceEpoch = positionInformation.utcDateTime().toMSecsSinceEpoch();
@@ -446,4 +446,18 @@ void Tracker::rubberbandModelVertexCountChanged()
       }
     }
   }
+}
+
+bool Tracker::filterAccuracy() const
+{
+  return mFilterAccuracy;
+}
+
+void Tracker::setFilterAccuracy( bool enabled )
+{
+  if ( mFilterAccuracy == enabled )
+    return;
+
+  mFilterAccuracy = enabled;
+  emit filterAccuracyChanged();
 }

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -361,6 +361,9 @@ void Tracker::replayPositionInformationList( const QList<GnssPositionInformation
   connect( mRubberbandModel, &RubberbandModel::currentCoordinateChanged, this, &Tracker::positionReceived );
   for ( const GnssPositionInformation &positionInformation : positionInformationList )
   {
+    if ( mFilterAccuracy && positionInformation.accuracyQuality() == GnssPositionInformation::AccuracyBad )
+      continue;
+
     if ( isPointGeometry && mFeatureModel->appExpressionContextScopesGenerator() )
     {
       mFeatureModel->appExpressionContextScopesGenerator()->setPositionInformation( positionInformation );

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -306,6 +306,9 @@ void Tracker::processPositionInformation( const GnssPositionInformation &positio
   if ( !mIsActive && !mIsReplaying )
     return;
 
+  if ( positionInformation.accuracyQuality() == GnssPositionInformation::AccuracyBad )
+    return;
+
   mLastDevicePositionTimestampMSecsSinceEpoch = positionInformation.utcDateTime().toMSecsSinceEpoch();
 
   double measureValue = 0.0;

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -212,6 +212,7 @@ class Tracker : public QObject
     bool mMinimumDistanceFulfilled = false;
     bool mSensorCaptureFulfilled = false;
     bool mSkipPositionReceived = false;
+    bool mSkipBadPositionReceived = false;
 
     QPointer<QgsVectorLayer> mVectorLayer;
     QgsFeature mFeature;

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -217,6 +217,7 @@ class Tracker : public QObject
     QgsFeature mFeature;
 
     bool mVisible = true;
+    bool mFilterAccuracy = false;
 
     QDateTime mStartPositionTimestamp;
     qint64 mLastDevicePositionTimestampMSecsSinceEpoch = 0;
@@ -225,8 +226,6 @@ class Tracker : public QObject
     MeasureType mMeasureType = Tracker::SecondsSinceStart;
 
     QgsDistanceArea mDa;
-
-    bool mFilterAccuracy;
 };
 
 #endif // TRACKER_H

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -56,6 +56,8 @@ class Tracker : public QObject
 
     Q_PROPERTY( QDateTime startPositionTimestamp READ startPositionTimestamp WRITE setStartPositionTimestamp NOTIFY startPositionTimestampChanged )
 
+    Q_PROPERTY( bool filterAccuracy READ filterAccuracy WRITE setFilterAccuracy NOTIFY filterAccuracyChanged )
+
   public:
     enum MeasureType
     {
@@ -155,6 +157,12 @@ class Tracker : public QObject
 
     void suspendUntilReplay();
 
+    //! Returns TRUE if GNSS accuracy filtering is enabled
+    bool filterAccuracy() const;
+
+    //! Sets whether GNSS accuracy filtering is enabled
+    void setFilterAccuracy( bool enabled );
+
   signals:
     void isActiveChanged();
     void isSuspendedChanged();
@@ -175,6 +183,8 @@ class Tracker : public QObject
     void featureChanged();
 
     void startPositionTimestampChanged();
+
+    void filterAccuracyChanged();
 
   private slots:
     void positionReceived();
@@ -215,6 +225,8 @@ class Tracker : public QObject
     MeasureType mMeasureType = Tracker::SecondsSinceStart;
 
     QgsDistanceArea mDa;
+
+    bool mFilterAccuracy;
 };
 
 #endif // TRACKER_H

--- a/src/core/utils/positioningutils.cpp
+++ b/src/core/utils/positioningutils.cpp
@@ -53,7 +53,7 @@ GnssPositionInformation PositioningUtils::averagedPositionInformation( const QLi
   return averagedPositionInformation( convertedList );
 }
 
-GnssPositionInformation PositioningUtils::averagedPositionInformation( const QList<GnssPositionInformation> &positionsInformation )
+GnssPositionInformation PositioningUtils::averagedPositionInformation( const QList<GnssPositionInformation> &positionsInformation, bool filterAccuracy )
 {
   if ( positionsInformation.isEmpty() )
     return GnssPositionInformation();
@@ -88,7 +88,7 @@ GnssPositionInformation PositioningUtils::averagedPositionInformation( const QLi
 
   for ( const GnssPositionInformation &pi : positionsInformation )
   {
-    if ( pi.accuracyQuality() == GnssPositionInformation::AccuracyBad )
+    if ( filterAccuracy && pi.accuracyQuality() == GnssPositionInformation::AccuracyBad )
       continue;
 
     ++validPositionsCount;

--- a/src/core/utils/positioningutils.cpp
+++ b/src/core/utils/positioningutils.cpp
@@ -88,6 +88,9 @@ GnssPositionInformation PositioningUtils::averagedPositionInformation( const QLi
 
   for ( const GnssPositionInformation &pi : positionsInformation )
   {
+    if ( pi.accuracyQuality() == GnssPositionInformation::AccuracyBad )
+      continue;
+
     if ( !std::isnan( pi.latitude() ) )
       latitude = !std::isnan( latitude ) ? latitude + pi.latitude() : pi.latitude();
     if ( !std::isnan( pi.longitude() ) )

--- a/src/core/utils/positioningutils.cpp
+++ b/src/core/utils/positioningutils.cpp
@@ -53,7 +53,7 @@ GnssPositionInformation PositioningUtils::averagedPositionInformation( const QLi
   return averagedPositionInformation( convertedList );
 }
 
-GnssPositionInformation PositioningUtils::averagedPositionInformation( const QList<GnssPositionInformation> &positionsInformation, bool filterAccuracy )
+GnssPositionInformation PositioningUtils::averagedPositionInformation( const QList<GnssPositionInformation> &positionsInformation )
 {
   if ( positionsInformation.isEmpty() )
     return GnssPositionInformation();
@@ -85,14 +85,8 @@ GnssPositionInformation PositioningUtils::averagedPositionInformation( const QLi
   QString sourceName = QStringLiteral( "%1 (%2)" ).arg( positionsInformation.at( 0 ).sourceName(), QObject::tr( "averaged" ) );
 
   int validPositionsCount = 0;
-
   for ( const GnssPositionInformation &pi : positionsInformation )
   {
-    if ( filterAccuracy && pi.accuracyQuality() == GnssPositionInformation::AccuracyBad )
-      continue;
-
-    ++validPositionsCount;
-
     if ( !std::isnan( pi.latitude() ) )
       latitude = !std::isnan( latitude ) ? latitude + pi.latitude() : pi.latitude();
     if ( !std::isnan( pi.longitude() ) )
@@ -116,6 +110,8 @@ GnssPositionInformation PositioningUtils::averagedPositionInformation( const QLi
       verticalSpeed = !std::isnan( verticalSpeed ) ? verticalSpeed + pi.verticalSpeed() : pi.verticalSpeed();
     if ( !std::isnan( pi.magneticVariation() ) )
       magneticVariation = !std::isnan( magneticVariation ) ? magneticVariation + pi.magneticVariation() : pi.magneticVariation();
+
+    ++validPositionsCount;
   }
 
   if ( validPositionsCount == 0 )

--- a/src/core/utils/positioningutils.cpp
+++ b/src/core/utils/positioningutils.cpp
@@ -58,8 +58,6 @@ GnssPositionInformation PositioningUtils::averagedPositionInformation( const QLi
   if ( positionsInformation.isEmpty() )
     return GnssPositionInformation();
 
-  const int positionsInformationCount = positionsInformation.size();
-
   double latitude = std::numeric_limits<double>::quiet_NaN();
   double longitude = std::numeric_limits<double>::quiet_NaN();
   double elevation = std::numeric_limits<double>::quiet_NaN();
@@ -86,10 +84,14 @@ GnssPositionInformation PositioningUtils::averagedPositionInformation( const QLi
   int quality = positionsInformation.at( 0 ).quality();
   QString sourceName = QStringLiteral( "%1 (%2)" ).arg( positionsInformation.at( 0 ).sourceName(), QObject::tr( "averaged" ) );
 
+  int validPositionsCount = 0;
+
   for ( const GnssPositionInformation &pi : positionsInformation )
   {
     if ( pi.accuracyQuality() == GnssPositionInformation::AccuracyBad )
       continue;
+
+    ++validPositionsCount;
 
     if ( !std::isnan( pi.latitude() ) )
       latitude = !std::isnan( latitude ) ? latitude + pi.latitude() : pi.latitude();
@@ -116,12 +118,15 @@ GnssPositionInformation PositioningUtils::averagedPositionInformation( const QLi
       magneticVariation = !std::isnan( magneticVariation ) ? magneticVariation + pi.magneticVariation() : pi.magneticVariation();
   }
 
-  return GnssPositionInformation( latitude / positionsInformationCount, longitude / positionsInformationCount, elevation / positionsInformationCount,
-                                  speed / positionsInformationCount, direction / positionsInformationCount, satellitesInView,
-                                  pdop / positionsInformationCount, hdop / positionsInformationCount, vdop / positionsInformationCount,
-                                  hacc / positionsInformationCount, vacc / positionsInformationCount, utcDateTime,
+  if ( validPositionsCount == 0 )
+    return GnssPositionInformation(); // No valid data to average
+
+  return GnssPositionInformation( latitude / validPositionsCount, longitude / validPositionsCount, elevation / validPositionsCount,
+                                  speed / validPositionsCount, direction / validPositionsCount, satellitesInView,
+                                  pdop / validPositionsCount, hdop / validPositionsCount, vdop / validPositionsCount,
+                                  hacc / validPositionsCount, vacc / validPositionsCount, utcDateTime,
                                   fixMode, fixType, quality, satellitesUsed, status, satPrn, satInfoComplete,
-                                  verticalSpeed / positionsInformationCount, magneticVariation / positionsInformationCount, positionsInformationCount, sourceName );
+                                  verticalSpeed / validPositionsCount, magneticVariation / validPositionsCount, validPositionsCount, sourceName );
 }
 
 double PositioningUtils::bearingTrueNorth( const QgsPoint &position, const QgsCoordinateReferenceSystem &crs )

--- a/src/core/utils/positioningutils.h
+++ b/src/core/utils/positioningutils.h
@@ -47,9 +47,8 @@ class QFIELD_CORE_EXPORT PositioningUtils : public QObject
 
     /**
      * Returns an average GnssPositionInformation from a list of position information.
-     * If filterAccuracy is true, positions with AccuracyBad are excluded from averaging.
      */
-    static GnssPositionInformation averagedPositionInformation( const QList<GnssPositionInformation> &positionsInformation, bool filterAccuracy = false );
+    static GnssPositionInformation averagedPositionInformation( const QList<GnssPositionInformation> &positionsInformation );
 
     /**
      * Returns an average GnssPositionInformation from a list of position information

--- a/src/core/utils/positioningutils.h
+++ b/src/core/utils/positioningutils.h
@@ -46,9 +46,10 @@ class QFIELD_CORE_EXPORT PositioningUtils : public QObject
     static Q_INVOKABLE GnssPositionInformation createEmptyGnssPositionInformation();
 
     /**
-     * Returns an average GnssPositionInformation from a list of position information
+     * Returns an average GnssPositionInformation from a list of position information.
+     * If filterAccuracy is true, positions with AccuracyBad are excluded from averaging.
      */
-    static GnssPositionInformation averagedPositionInformation( const QList<GnssPositionInformation> &positionsInformation );
+    static GnssPositionInformation averagedPositionInformation( const QList<GnssPositionInformation> &positionsInformation, bool filterAccuracy = false );
 
     /**
      * Returns an average GnssPositionInformation from a list of position information

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -1187,7 +1187,6 @@ Page {
                     positioningSettings.accuracyBad = NaN;
                   } else {
                     positioningSettings.accuracyBad = parseFloat(text);
-                    positionSource.badAccuracyThreshold = positioningSettings.accuracyBad;
                   }
                 }
               }
@@ -1227,7 +1226,6 @@ Page {
                     positioningSettings.accuracyExcellent = NaN;
                   } else {
                     positioningSettings.accuracyExcellent = parseFloat(text);
-                    positionSource.excellentAccuracyThreshold = positioningSettings.accuracyExcellent;
                   }
                 }
               }

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -1187,6 +1187,7 @@ Page {
                     positioningSettings.accuracyBad = NaN;
                   } else {
                     positioningSettings.accuracyBad = parseFloat(text);
+                    positionSource.badAccuracyThreshold = positioningSettings.accuracyBad;
                   }
                 }
               }
@@ -1226,6 +1227,7 @@ Page {
                     positioningSettings.accuracyExcellent = NaN;
                   } else {
                     positioningSettings.accuracyExcellent = parseFloat(text);
+                    positionSource.excellentAccuracyThreshold = positioningSettings.accuracyExcellent;
                   }
                 }
               }

--- a/src/qml/TrackingSession.qml
+++ b/src/qml/TrackingSession.qml
@@ -16,6 +16,7 @@ Item {
   Component.onCompleted: {
     tracker.rubberbandModel = rubberbandModel;
     tracker.featureModel = featureModel;
+    tracker.filterAccuracy = positioningSettings.accuracyRequirement;
   }
 
   Connections {

--- a/src/qml/TrackingSession.qml
+++ b/src/qml/TrackingSession.qml
@@ -20,6 +20,14 @@ Item {
   }
 
   Connections {
+    target: positioningSettings
+
+    function onAccuracyRequirementChanged() {
+      tracker.filterAccuracy = positioningSettings.accuracyRequirement;
+    }
+  }
+
+  Connections {
     target: positionSource
     enabled: tracker.isActive
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -334,7 +334,7 @@ ApplicationWindow {
     deviceId: positioningSettings.positioningDevice
     badAccuracyThreshold: positioningSettings.accuracyBad
     excellentAccuracyThreshold: positioningSettings.accuracyExcellent
-    averagePositionFilterAccuracy: positioningSettings.accuracyRequirement
+    averagedPositionFilterAccuracy: positioningSettings.accuracyRequirement
 
     property bool jumpToPosition: false
     property bool currentness: false

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -332,8 +332,9 @@ ApplicationWindow {
     objectName: "positionSource"
 
     deviceId: positioningSettings.positioningDevice
-    badAccuracyThreshold: positioningSettings.accuracyRequirement ? positioningSettings.accuracyBad : NaN
-    excellentAccuracyThreshold: positioningSettings.accuracyRequirement ? positioningSettings.accuracyExcellent : NaN
+    badAccuracyThreshold: positioningSettings.accuracyBad
+    excellentAccuracyThreshold: positioningSettings.accuracyExcellent
+    averagePositionFilterAccuracy: positioningSettings.accuracyRequirement
 
     property bool jumpToPosition: false
     property bool currentness: false
@@ -2277,8 +2278,21 @@ ApplicationWindow {
 
         QfBadge {
           alignment: QfBadge.Alignment.TopRight
-          visible: positioningSettings.accuracyIndicator && gnssButton.state === "On"
-          color: !positionSource.positionInformation || !positionSource.positionInformation.haccValid || positionSource.positionInformation.hacc > positioningSettings.accuracyBad ? Theme.accuracyBad : positionSource.positionInformation.hacc > positioningSettings.accuracyExcellent ? Theme.accuracyTolerated : Theme.accuracyExcellent
+          visible: positioningSettings.accuracyIndicator && gnssButton.state === "On" && positionSource.positionInformation.accuracyQuality != GnssPositionInformation.AccuracyUndetermined
+          color: {
+            if (!positionSource.positionInformation || !positionSource.positionInformation.haccValid)
+              return Theme.accuracyBad;
+            switch (positionSource.positionInformation.accuracyQuality) {
+            case GnssPositionInformation.AccuracyExcellent:
+              return Theme.accuracyExcellent;
+            case GnssPositionInformation.AccuracyOk:
+              return Theme.accuracyTolerated;
+            case GnssPositionInformation.AccuracyBad:
+            case GnssPositionInformation.AccuracyUndetermined:
+            default:
+              return Theme.accuracyBad;
+            }
+          }
         }
       }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -332,6 +332,8 @@ ApplicationWindow {
     objectName: "positionSource"
 
     deviceId: positioningSettings.positioningDevice
+    badAccuracyThreshold: positioningSettings.accuracyRequirement ? positioningSettings.accuracyBad : NaN
+    excellentAccuracyThreshold: positioningSettings.accuracyRequirement ? positioningSettings.accuracyExcellent : NaN
 
     property bool jumpToPosition: false
     property bool currentness: false


### PR DESCRIPTION
## 🚀 Description

This PR introduces a new `AccuracyQuality` classification to enhance filtering of GNSS position data

### ✨ Key Changes:

* **`GnssPositionInformation`:**
  * Added `AccuracyQuality` enum (`AccuracyBad`, `AccuracyOk`, `AccuracyExcellent`) with `Q_PROPERTY` support.
  * New member `mAccuracyQuality` and corresponding getter/setter.

* **`Positioning`:**
  * Added `badAccuracyThreshold` and `excellentAccuracyThreshold` as configurable properties with signals.
  * `processGnssPositionInformation()` now evaluates and assigns an appropriate `AccuracyQuality`.

* **`PositioningSource`:**
  * Averaging now only includes positions with `AccuracyOk` or better.

* **`PositioningUtils`:**
  * Low-quality positions are excluded from averaging logic.

* **`Tracker`:**
  * Ignores positions marked as `AccuracyBad`.
