### PR TITLE
[Backport release-3_7] Fix data-defined feature form properties (such as editable) not initializing properly

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -275,6 +275,8 @@ void AttributeFormModelBase::resetModel()
 void AttributeFormModelBase::applyFeatureModel()
 {
   mExpressionContext = mFeatureModel->createExpressionContext();
+  mExpressionContext.setFields( mFeatureModel->feature().fields() );
+  mExpressionContext.setFeature( mFeatureModel->feature() );
   mExpressionContext << QgsExpressionContextUtils::formScope( mFeatureModel->feature() );
 
   for ( int i = 0; i < invisibleRootItem()->rowCount(); ++i )


### PR DESCRIPTION
Backport #6529
 **Authored by:** @nirvn