### PR TITLE
Fix tracking not creating tracks after first track stopped

### DIFF
--- a/src/core/rubberbandmodel.cpp
+++ b/src/core/rubberbandmodel.cpp
@@ -140,9 +140,9 @@ void RubberbandModel::insertVertices( int index, int count )
   emit vertexCountChanged();
 }
 
-void RubberbandModel::removeVertices( int index, int count )
+void RubberbandModel::removeVertices( int index, int count, bool keepLast )
 {
-  if ( mPointList.size() <= 1 )
+  if ( mPointList.size() <= ( keepLast ? 1 : 0 ) )
     return;
 
   mPointList.remove( index, count );
@@ -239,10 +239,10 @@ QgsPoint RubberbandModel::penultimateCoordinate() const
 
 void RubberbandModel::setCurrentCoordinate( const QgsPoint &currentCoordinate )
 {
-  // play safe, but try to find out
-  // Q_ASSERT( mPointList.count() != 0 );
   if ( mPointList.count() == 0 )
-    return;
+  {
+    mPointList << QgsPoint();
+  }
 
   if ( mPointList.at( mCurrentCoordinateIndex ) == currentCoordinate )
     return;
@@ -333,7 +333,7 @@ void RubberbandModel::removeVertex()
 
 void RubberbandModel::reset( bool keepLast )
 {
-  removeVertices( 0, mPointList.size() - ( keepLast ? 1 : 0 ) );
+  removeVertices( 0, mPointList.size() - ( keepLast ? 1 : 0 ), keepLast );
 
   mFrozen = false;
   emit frozenChanged();

--- a/src/core/rubberbandmodel.h
+++ b/src/core/rubberbandmodel.h
@@ -173,7 +173,7 @@ class QFIELD_CORE_EXPORT RubberbandModel : public QObject
     void insertVertices( int index, int count );
 
     //! Remove \a count vertices starting at \a index
-    void removeVertices( int index, int count );
+    void removeVertices( int index, int count, bool keepLast = true );
 
     //! Returns the current vertex point transformed to the given \a crs
     QgsPoint currentPoint( const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem(), Qgis::WkbType wkbType = Qgis::WkbType::PointZ ) const;


### PR DESCRIPTION
Fixes tracker unable to create new tracks _once a track was previously created_, as raised here (https://github.com/opengisch/QField/issues/6486#issuecomment-3168787924).

Test cases coming to insure we cover this during our development cycles.