### PR TITLE
Postioning's logs file receiver to replay NMEA logs and tracking test cases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "iOS")
   message(STATUS "QT_HOST_PATH: ${QT_HOST_PATH}")
 endif()
 
+set (TEST_DATA_DIR "${CMAKE_CURRENT_SOURCE_DIR}/test/testdata")
 set(ENABLE_TESTS CACHE BOOL "Build unit tests")
 
 if(MSVC)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -32,6 +32,7 @@ set(QFIELD_CORE_SRCS
     positioning/internalgnssreceiver.cpp
     positioning/nmeagnssreceiver.cpp
     positioning/egenioussreceiver.cpp
+    positioning/filereceiver.cpp
     positioning/tcpreceiver.cpp
     positioning/udpreceiver.cpp
     positioning/positioning.cpp
@@ -164,6 +165,7 @@ set(QFIELD_CORE_HDRS
     positioning/internalgnssreceiver.h
     positioning/nmeagnssreceiver.h
     positioning/egenioussreceiver.h
+    positioning/filereceiver.h
     positioning/tcpreceiver.h
     positioning/udpreceiver.h
     positioning/geofencer.h

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -242,6 +242,20 @@ void FeatureModel::setAppExpressionContextScopesGenerator( AppExpressionContextS
   emit appExpressionContextScopesGeneratorChanged();
 }
 
+Geometry *FeatureModel::geometry()
+{
+  return mGeometry;
+}
+
+void FeatureModel::setGeometry( Geometry *geometry )
+{
+  if ( mGeometry == geometry )
+    return;
+
+  mGeometry = geometry;
+  emit geometryChanged();
+}
+
 VertexModel *FeatureModel::vertexModel()
 {
   return mVertexModel;

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -27,8 +27,6 @@
 #include <qgsfeature.h>
 #include <qgsrelationmanager.h>
 
-#include <memory>
-
 /**
  * \ingroup core
  */
@@ -41,9 +39,8 @@ class FeatureModel : public QAbstractListModel
     Q_PROPERTY( QgsFeature linkedParentFeature READ linkedParentFeature WRITE setLinkedParentFeature NOTIFY linkedParentFeatureChanged )
     Q_PROPERTY( QgsRelation linkedRelation READ linkedRelation WRITE setLinkedRelation NOTIFY linkedRelationChanged )
     Q_PROPERTY( QString linkedRelationOrderingField READ linkedRelationOrderingField WRITE setLinkedRelationOrderingField NOTIFY linkedRelationOrderingFieldChanged )
-    //! the vertex model is used to highlight vertices on the map
     Q_PROPERTY( VertexModel *vertexModel READ vertexModel WRITE setVertexModel NOTIFY vertexModelChanged )
-    Q_PROPERTY( Geometry *geometry MEMBER mGeometry NOTIFY geometryChanged )
+    Q_PROPERTY( Geometry *geometry READ geometry WRITE setGeometry NOTIFY geometryChanged )
     Q_PROPERTY( bool featureAdditionLocked READ featureAdditionLocked NOTIFY featureAdditionLockedChanged )
     Q_PROPERTY( bool attributeEditingLocked READ attributeEditingLocked NOTIFY attributeEditingLockedChanged )
     Q_PROPERTY( bool geometryEditingLocked READ geometryEditingLocked NOTIFY geometryEditingLockedChanged )
@@ -144,9 +141,14 @@ class FeatureModel : public QAbstractListModel
     void setCurrentLayer( QgsVectorLayer *layer );
     QgsVectorLayer *layer() const;
 
-    //! \copydoc vertexModel
+    //! Returns the geometry object that will drive the feature geometry.
+    Geometry *geometry();
+    //! Sets the geometry object that will drive the feature geometry.
+    void setGeometry( Geometry *geometry );
+
+    //! Returns the vertex model is used to highlight vertices on the map.
     VertexModel *vertexModel();
-    //! \copydoc vertexModel
+    //! Sets the vertex \a model is used to highlight vertices on the map.
     void setVertexModel( VertexModel *model );
 
     bool featureAdditionLocked() const { return mFeatureAdditionLocked; }

--- a/src/core/positioning/filereceiver.cpp
+++ b/src/core/positioning/filereceiver.cpp
@@ -1,0 +1,90 @@
+/***************************************************************************
+ tcpreceiver.cpp - TcpReceiver
+
+ ---------------------
+ begin                : September 2022
+ copyright            : (C) 2022 by Matthias Kuhn
+ email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "filereceiver.h"
+
+#include <QFileInfo>
+
+QLatin1String FileReceiver::identifier = QLatin1String( "file" );
+
+FileReceiver::FileReceiver( const QString &filePath, const int interval, QObject *parent )
+  : NmeaGnssReceiver( parent )
+  , mBuffer( new QBuffer() )
+{
+  QFileInfo fi( filePath );
+  if ( fi.exists() && fi.size() > 0 )
+  {
+    mLogs.setFileName( filePath );
+    setValid( true );
+  }
+  else
+  {
+    setValid( false );
+  }
+
+  mTimer.setSingleShot( false );
+  mTimer.setInterval( std::max( 50, interval ) );
+  connect( &mTimer, &QTimer::timeout, this, &FileReceiver::readLogsLine );
+
+  initNmeaConnection( mBuffer );
+}
+
+FileReceiver::~FileReceiver()
+{
+  mBuffer->deleteLater();
+  mBuffer = nullptr;
+}
+
+void FileReceiver::handleConnectDevice()
+{
+  if ( !valid() )
+  {
+    return;
+  }
+
+  qInfo() << QStringLiteral( "FileReceiver: Initiating replay of logs %1" ).arg( mLogs.fileName() );
+  mLogs.open( QIODevice::ReadOnly );
+  mBuffer->open( QIODevice::ReadWrite );
+
+  setSocketState( QAbstractSocket::ConnectedState );
+
+  mTimer.start();
+}
+
+void FileReceiver::handleDisconnectDevice()
+{
+  mTimer.stop();
+
+  setSocketState( QAbstractSocket::UnconnectedState );
+
+  mLogs.close();
+  mBuffer->close();
+}
+
+void FileReceiver::readLogsLine()
+{
+  if ( mLogs.atEnd() )
+  {
+    mLogs.seek( 0 );
+  }
+
+  const QByteArray line = mLogs.readLine().trimmed();
+
+  mBuffer->buffer().clear();
+  mBuffer->seek( 0 );
+  mBuffer->write( line + QByteArray( "\r\n" ) );
+  mBuffer->seek( 0 );
+}

--- a/src/core/positioning/filereceiver.h
+++ b/src/core/positioning/filereceiver.h
@@ -1,0 +1,51 @@
+/***************************************************************************
+ filereceiver.h - FileReceiver
+
+ ---------------------
+ begin                : August 2025
+ copyright            : (C) 2025 by Mathieu Pellerin
+ email                : mathieu@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef FILERECEIVER_H
+#define FILERECEIVER_H
+
+#include "nmeagnssreceiver.h"
+
+#include <QBuffer>
+#include <QObject>
+#include <QTimer>
+
+/**
+ * The FileReceiver replays a provided NMEA log file in a loop. Useful to
+ * debug external GNSS devices.
+ * \ingroup core
+ */
+class FileReceiver : public NmeaGnssReceiver
+{
+    Q_OBJECT
+
+  public:
+    explicit FileReceiver( const QString &filePath = QString(), const int interval = 0, QObject *parent = nullptr );
+    ~FileReceiver() override;
+
+    static QLatin1String identifier;
+
+  private:
+    void handleConnectDevice() override;
+    void handleDisconnectDevice() override;
+
+    void readLogsLine();
+
+    QFile mLogs;
+    QTimer mTimer;
+    QBuffer *mBuffer = nullptr;
+};
+
+#endif // FILERECEIVER_H

--- a/src/core/positioning/positioningdevicemodel.cpp
+++ b/src/core/positioning/positioningdevicemodel.cpp
@@ -15,6 +15,7 @@
  ***************************************************************************/
 
 #include "egenioussreceiver.h"
+#include "filereceiver.h"
 #include "positioningdevicemodel.h"
 #include "tcpreceiver.h"
 #include "udpreceiver.h"
@@ -174,6 +175,9 @@ const QString PositioningDeviceModel::deviceId( const Device &device ) const
 
     case UdpDevice:
       return QStringLiteral( "%1:%2:%3" ).arg( UdpReceiver::identifier, device.settings.value( QStringLiteral( "address" ) ).toString(), QString::number( device.settings.value( QStringLiteral( "port" ) ).toInt() ) );
+
+    case FileDevice:
+      return QStringLiteral( "%1:%2:%3" ).arg( FileReceiver::identifier, device.settings.value( QStringLiteral( "filePath" ) ).toString(), QString::number( device.settings.value( QStringLiteral( "interval" ) ).toInt() ) );
 
 #ifdef WITH_SERIALPORT
     case SerialPortDevice:

--- a/src/core/positioning/positioningdevicemodel.h
+++ b/src/core/positioning/positioningdevicemodel.h
@@ -34,6 +34,7 @@ class PositioningDeviceModel : public QAbstractListModel
       UdpDevice,
       EgenioussDevice,
       SerialPortDevice,
+      FileDevice,
     };
     Q_ENUM( Type )
 

--- a/src/core/positioning/positioningsource.cpp
+++ b/src/core/positioning/positioningsource.cpp
@@ -21,6 +21,7 @@
 #include "serialportreceiver.h"
 #endif
 #include "egenioussreceiver.h"
+#include "filereceiver.h"
 #include "internalgnssreceiver.h"
 #include "positioningsource.h"
 #include "positioningutils.h"
@@ -238,31 +239,43 @@ void PositioningSource::setupDevice()
   }
   else
   {
-    if ( mDeviceId.startsWith( TcpReceiver::identifier + ":" ) )
+    if ( mDeviceId.startsWith( FileReceiver::identifier + ":" ) )
     {
+      const int prefixLength = FileReceiver::identifier.length() + 1;
+      const int intervalSeparator = mDeviceId.lastIndexOf( ':' );
+      const QString filePath = mDeviceId.mid( prefixLength, intervalSeparator - prefixLength );
+      const int interval = mDeviceId.mid( intervalSeparator + 1 ).toInt();
+      mReceiver = new FileReceiver( filePath, interval, this );
+    }
+    else if ( mDeviceId.startsWith( TcpReceiver::identifier + ":" ) )
+    {
+      const int prefixLength = TcpReceiver::identifier.length() + 1;
       const qsizetype portSeparator = mDeviceId.lastIndexOf( ':' );
-      const QString address = mDeviceId.mid( 4, portSeparator - 4 );
+      const QString address = mDeviceId.mid( prefixLength, portSeparator - prefixLength );
       const int port = mDeviceId.mid( portSeparator + 1 ).toInt();
       mReceiver = new TcpReceiver( address, port, this );
     }
     else if ( mDeviceId.startsWith( UdpReceiver::identifier + ":" ) )
     {
+      const int prefixLength = UdpReceiver::identifier.length() + 1;
       const qsizetype portSeparator = mDeviceId.lastIndexOf( ':' );
-      const QString address = mDeviceId.mid( 4, portSeparator - 4 );
+      const QString address = mDeviceId.mid( prefixLength, portSeparator - prefixLength );
       const int port = mDeviceId.mid( portSeparator + 1 ).toInt();
       mReceiver = new UdpReceiver( address, port, this );
     }
     else if ( mDeviceId.startsWith( EgenioussReceiver::identifier + ":" ) )
     {
+      const int prefixLength = EgenioussReceiver::identifier.length() + 1;
       const qsizetype portSeparator = mDeviceId.lastIndexOf( ':' );
-      const QString address = mDeviceId.mid( 10, portSeparator - 10 );
+      const QString address = mDeviceId.mid( prefixLength, portSeparator - prefixLength );
       const int port = mDeviceId.mid( portSeparator + 1 ).toInt();
       mReceiver = new EgenioussReceiver( address, port, this );
     }
 #ifdef WITH_SERIALPORT
     else if ( mDeviceId.startsWith( SerialPortReceiver::identifier + ":" ) )
     {
-      const QString address = mDeviceId.mid( 7 );
+      const int prefixLength = SerialPortReceiver::identifier.length() + 1;
+      const QString address = mDeviceId.mid( prefixLength );
       mReceiver = new SerialPortReceiver( address, this );
     }
 #endif

--- a/src/core/rubberbandmodel.cpp
+++ b/src/core/rubberbandmodel.cpp
@@ -140,9 +140,9 @@ void RubberbandModel::insertVertices( int index, int count )
   emit vertexCountChanged();
 }
 
-void RubberbandModel::removeVertices( int index, int count )
+void RubberbandModel::removeVertices( int index, int count, bool keepLast )
 {
-  if ( mPointList.size() <= 1 )
+  if ( mPointList.size() <= ( keepLast ? 1 : 0 ) )
     return;
 
   mPointList.remove( index, count );
@@ -239,10 +239,10 @@ QgsPoint RubberbandModel::penultimateCoordinate() const
 
 void RubberbandModel::setCurrentCoordinate( const QgsPoint &currentCoordinate )
 {
-  // play safe, but try to find out
-  // Q_ASSERT( mPointList.count() != 0 );
   if ( mPointList.count() == 0 )
-    return;
+  {
+    mPointList << QgsPoint();
+  }
 
   if ( mPointList.at( mCurrentCoordinateIndex ) == currentCoordinate )
     return;
@@ -333,7 +333,7 @@ void RubberbandModel::removeVertex()
 
 void RubberbandModel::reset( bool keepLast )
 {
-  removeVertices( 0, mPointList.size() - ( keepLast ? 1 : 0 ) );
+  removeVertices( 0, mPointList.size() - ( keepLast ? 1 : 0 ), keepLast );
 
   mFrozen = false;
   emit frozenChanged();

--- a/src/core/rubberbandmodel.h
+++ b/src/core/rubberbandmodel.h
@@ -173,7 +173,7 @@ class QFIELD_CORE_EXPORT RubberbandModel : public QObject
     void insertVertices( int index, int count );
 
     //! Remove \a count vertices starting at \a index
-    void removeVertices( int index, int count );
+    void removeVertices( int index, int count, bool keepLast = true );
 
     //! Returns the current vertex point transformed to the given \a crs
     QgsPoint currentPoint( const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem(), Qgis::WkbType wkbType = Qgis::WkbType::PointZ ) const;

--- a/src/qml/FileDeviceChooser.qml
+++ b/src/qml/FileDeviceChooser.qml
@@ -1,0 +1,56 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import org.qfield
+import Theme
+
+/**
+ * \ingroup qml
+ */
+Item {
+  width: parent.width
+
+  property alias deviceFilePath: filePath.text
+  property alias deviceInterval: interval.text
+
+  function generateName() {
+    return deviceFilePath + ' (' + deviceInterval + ' ms)';
+  }
+
+  function setSettings(settings) {
+    deviceFilePath = settings['filePath'];
+    deviceInterval = settings['interval'];
+  }
+
+  function getSettings() {
+    return {
+      "filePath": deviceFilePath.trim(),
+      "interval": parseInt(deviceInterval)
+    };
+  }
+
+  GridLayout {
+    width: parent.width
+    columns: 1
+    columnSpacing: 10
+    rowSpacing: 10
+
+    TextField {
+      id: filePath
+      Layout.fillWidth: true
+      font: Theme.defaultFont
+      placeholderText: qsTr("File path")
+      text: ''
+      inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhPreferLowercase
+    }
+
+    TextField {
+      id: interval
+      Layout.fillWidth: true
+      font: Theme.defaultFont
+      placeholderText: qsTr("Interval (in milliseconds)")
+      text: '100'
+      inputMethodHints: Qt.ImhFormattedNumbersOnly
+    }
+  }
+}

--- a/src/qml/FileDeviceChooser.qml
+++ b/src/qml/FileDeviceChooser.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Dialogs
 import QtQuick.Layouts
 import org.qfield
 import Theme
@@ -35,13 +36,29 @@ Item {
     columnSpacing: 10
     rowSpacing: 10
 
-    TextField {
-      id: filePath
+    RowLayout {
       Layout.fillWidth: true
-      font: Theme.defaultFont
-      placeholderText: qsTr("File path")
-      text: ''
-      inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhPreferLowercase
+
+      TextField {
+        id: filePath
+        Layout.fillWidth: true
+        font: Theme.defaultFont
+        placeholderText: qsTr("File path")
+        text: ''
+        inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhPreferLowercase
+      }
+      QfToolButton {
+        width: 48
+        height: 48
+
+        iconSource: Theme.getThemeVectorIcon("ic_folder_open_black_24dp")
+        iconColor: Theme.mainTextColor
+        bgcolor: "transparent"
+
+        onClicked: {
+          fileDialog.open();
+        }
+      }
     }
 
     TextField {
@@ -52,5 +69,10 @@ Item {
       text: '100'
       inputMethodHints: Qt.ImhFormattedNumbersOnly
     }
+  }
+
+  FileDialog {
+    id: fileDialog
+    onAccepted: filePath.text = selectedFile
   }
 }

--- a/src/qml/PositioningDeviceSettings.qml
+++ b/src/qml/PositioningDeviceSettings.qml
@@ -75,6 +75,12 @@ Popup {
           "value": PositioningDeviceModel.SerialPortDevice
         });
     }
+    if (Qt.platform.os !== "android" && Qt.platform.os !== "ios") {
+      positioningDeviceTypeModel.insert(positioningDeviceTypeModel.count, {
+          "name": qsTr('Logs file (NMEA)'),
+          "value": PositioningDeviceModel.FileDevice
+        });
+    }
     if (positioningSettings.egenioussEnabled) {
       positioningDeviceTypeModel.insert(0, {
           "name": qsTr('Egeniouss'),
@@ -157,6 +163,8 @@ Popup {
           height: 36
           icon.source: {
             switch (value) {
+            case PositioningDeviceModel.FileDevice:
+              return Theme.getThemeVectorIcon("ic_file_black_24dp");
             case PositioningDeviceModel.BluetoothDevice:
               return Theme.getThemeVectorIcon('ic_bluetooth_receiver_black_24dp');
             case PositioningDeviceModel.TcpDevice:
@@ -183,6 +191,8 @@ Popup {
 
           icon.source: {
             switch (positioningDeviceType.currentValue) {
+            case PositioningDeviceModel.FileDevice:
+              return Theme.getThemeVectorIcon("ic_file_black_24dp");
             case PositioningDeviceModel.BluetoothDevice:
               return Theme.getThemeVectorIcon('ic_bluetooth_receiver_black_24dp');
             case PositioningDeviceModel.TcpDevice:
@@ -249,6 +259,8 @@ Popup {
         Layout.fillHeight: true
         source: {
           switch (positioningDeviceType.currentValue) {
+          case PositioningDeviceModel.FileDevice:
+            return "qrc:/qml/FileDeviceChooser.qml";
           case PositioningDeviceModel.BluetoothDevice:
             return "qrc:/qml/BluetoothDeviceChooser.qml";
           case PositioningDeviceModel.TcpDevice:

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -896,6 +896,8 @@ Page {
                       switch (DeviceType) {
                       case PositioningDeviceModel.InternalDevice:
                         return Theme.getThemeVectorIcon('ic_internal_receiver_black_24dp');
+                      case PositioningDeviceModel.FileDevice:
+                        return Theme.getThemeVectorIcon("ic_file_black_24dp");
                       case PositioningDeviceModel.BluetoothDevice:
                         return Theme.getThemeVectorIcon('ic_bluetooth_receiver_black_24dp');
                       case PositioningDeviceModel.TcpDevice:
@@ -924,6 +926,8 @@ Page {
                       switch (positioningDeviceComboBox.currentValue) {
                       case PositioningDeviceModel.InternalDevice:
                         return Theme.getThemeVectorIcon('ic_internal_receiver_black_24dp');
+                      case PositioningDeviceModel.FileDevice:
+                        return Theme.getThemeVectorIcon("ic_file_black_24dp");
                       case PositioningDeviceModel.BluetoothDevice:
                         return Theme.getThemeVectorIcon('ic_bluetooth_receiver_black_24dp');
                       case PositioningDeviceModel.TcpDevice:

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -17,6 +17,7 @@
         <file>ElevationProfile.qml</file>
         <file>FeatureForm.qml</file>
         <file>FeatureListForm.qml</file>
+        <file>FileDeviceChooser.qml</file>
         <file>GridRenderer.qml</file>
         <file>LinePolygon.qml</file>
         <file>LocationMarker.qml</file>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -82,6 +82,8 @@ if (WITH_SPIX)
   add_subdirectory(spix)
 endif ()
 
+add_definitions(-DTEST_DATA_DIR="${TEST_DATA_DIR}")
+
 ADD_CATCH2_TEST(layerobservertest test_layerobserver.cpp FALSE)
 ADD_CATCH2_TEST(featureutilstest test_featureutils.cpp TRUE)
 ADD_CATCH2_TEST(featuremodeltest test_featuremodel.cpp TRUE)
@@ -98,5 +100,6 @@ ADD_CATCH2_TEST(orderedrelationmodeltest test_orderedrelationmodel.cpp FALSE)
 ADD_CATCH2_TEST(referencingfeaturelistmodeltest test_referencingfeaturelistmodel.cpp FALSE)
 ADD_CATCH2_TEST(expressionevaluatortest test_expressionevaluator.cpp TRUE)
 ADD_CATCH2_TEST(appinterfacetest test_appinterface.cpp TRUE)
+ADD_CATCH2_TEST(trackingtest test_tracking.cpp FALSE)
 
 ADD_QFIELD_QML_TEST(qmltest test_qml.cpp)

--- a/test/test_tracking.cpp
+++ b/test/test_tracking.cpp
@@ -1,0 +1,156 @@
+/***************************************************************************
+                        test_featurehistory.h
+                        ---------------------
+  begin                : Aug 2025
+  copyright            : (C) 2025 by Mathieu Pellerin
+  email                : mathieu@opengis.ch
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#define QFIELDTEST_MAIN
+#include "catch2.h"
+#include "featuremodel.h"
+#include "geometry.h"
+#include "positioning.h"
+#include "qgsquick/qgsquickcoordinatetransformer.h"
+#include "rubberbandmodel.h"
+#include "tracker.h"
+#include "trackingmodel.h"
+#include "utils/featureutils.h"
+
+#include <QEventLoop>
+#include <QTimer>
+#include <qgsproject.h>
+#include <qgsvectorlayer.h>
+#include <qgsvectorlayerjoininfo.h>
+
+
+TEST_CASE( "Tracking" )
+{
+  // Setup dummy project with one empty line vector layer
+  std::unique_ptr<QgsProject> project = std::make_unique<QgsProject>();
+  std::unique_ptr<QgsVectorLayer> vl = std::make_unique<QgsVectorLayer>( QStringLiteral( "LineString?crs=epsg:3946" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) );
+  project->setCrs( vl->crs() );
+  project->addMapLayer( vl.get() );
+
+  // Setup the coordinate transformer to be used to reproject incoming WGS84 positions
+  std::unique_ptr<QgsQuickCoordinateTransformer> coordinateTransformer = std::make_unique<QgsQuickCoordinateTransformer>();
+  coordinateTransformer->setDestinationCrs( project->crs() );
+  coordinateTransformer->setTransformContext( project->transformContext() );
+
+  // Setup positioning
+  Positioning *positioning = new Positioning();
+  positioning->setDeviceId( QStringLiteral( "file:%1/../nmea_server/TrimbleR1.txt:100" ).arg( TEST_DATA_DIR ) );
+  positioning->setCoordinateTransformer( coordinateTransformer.get() );
+
+  // Setup the rubberband model to be used by the tracker
+  std::unique_ptr<RubberbandModel> rubberbandModel = std::make_unique<RubberbandModel>();
+  rubberbandModel->setCrs( project->crs() );
+  rubberbandModel->setVectorLayer( vl.get() );
+  rubberbandModel->setGeometryType( Qgis::GeometryType::Line );
+
+  // Setup the geometry object that ties the rubberband model and the feature model together
+  std::unique_ptr<Geometry> geometry = std::make_unique<Geometry>();
+  geometry->setRubberbandModel( rubberbandModel.get() );
+  geometry->setVectorLayer( vl.get() );
+
+  // Setup the feature model to be used by the tracker
+  std::unique_ptr<FeatureModel> featureModel = std::make_unique<FeatureModel>();
+  featureModel->setCurrentLayer( vl.get() );
+  featureModel->setGeometry( geometry.get() );
+
+  // Setup the tracking model and create a tracker on the line layer
+  std::unique_ptr<TrackingModel> trackingModel = std::make_unique<TrackingModel>();
+  QModelIndex idx = trackingModel->createTracker( vl.get() );
+  Tracker *tracker = trackingModel->data( idx, TrackingModel::TrackerPointer ).value<Tracker *>();
+  REQUIRE( tracker );
+  tracker->setFeatureModel( featureModel.get() );
+  tracker->setRubberbandModel( rubberbandModel.get() );
+
+
+  QObject::connect( positioning, &Positioning::positionInformationChanged, [=]() {
+    tracker->processPositionInformation( positioning->positionInformation(), positioning->projectedPosition() );
+  } );
+
+  QEventLoop loop;
+  QTimer timer;
+  timer.setSingleShot( true );
+  timer.setInterval( 10000 );
+  QObject::connect( &timer, &QTimer::timeout, &loop, &QEventLoop::quit );
+  positioning->setActive( true );
+
+  // Reset the feature model and its geometry via updateRubberband()
+  featureModel->resetFeature();
+  featureModel->resetAttributes();
+  featureModel->updateRubberband();
+
+  // Track against no constraints
+  tracker->start();
+  timer.start();
+  loop.exec();
+  tracker->stop();
+
+  // Insure the tracked feature has been added
+  REQUIRE( vl->featureCount() == 1 );
+
+  // Reset the feature model and its geometry via updateRubberband()
+  featureModel->resetFeature();
+  featureModel->resetAttributes();
+  featureModel->updateRubberband();
+
+  // Track against minimum distance constraints
+  tracker->setMinimumDistance( 0.2 );
+  tracker->setTimeInterval( 0.0 );
+  tracker->start();
+  timer.start();
+  loop.exec();
+  tracker->stop();
+
+  // Insure the tracked feature has been added
+  REQUIRE( vl->featureCount() == 2 );
+
+  // Reset the feature model and its geometry via updateRubberband()
+  featureModel->resetFeature();
+  featureModel->resetAttributes();
+  featureModel->updateRubberband();
+
+  // Track against time interval constraints
+  tracker->setMinimumDistance( 0.0 );
+  tracker->setTimeInterval( 2.0 );
+  tracker->start();
+  timer.start();
+  loop.exec();
+  tracker->stop();
+
+  // Insure the tracked feature has been added
+  REQUIRE( vl->featureCount() == 3 );
+
+  // Reset the feature model and its geometry via updateRubberband()
+  featureModel->resetFeature();
+  featureModel->resetAttributes();
+  featureModel->updateRubberband();
+
+  // Track against time interval constraints
+  tracker->setMinimumDistance( 0.2 );
+  tracker->setTimeInterval( 2.0 );
+  tracker->start();
+  timer.start();
+  loop.exec();
+  tracker->stop();
+
+  // Insure the tracked feature has been added
+  REQUIRE( vl->featureCount() == 4 );
+
+  // Cleanup
+  positioning->setActive( false );
+  positioning->deleteLater();
+  delete positioning;
+}


### PR DESCRIPTION
This PR adds a new positioning receiver type that allows for the replay of NMEA logs (without the need for a faux nmeaserver). It simplifies testing positioning-related functionalities among other things.

<img width="645" height="597" alt="image" src="https://github.com/user-attachments/assets/a3a77c0c-b4e8-4d3b-883b-67463b2171cd" />

It also allows us to build a bunch of C++ test cases covering positioning functionalities. This PR adds basic tracking test cases, which tests a bunch of classes that drives tracking. This was motivated by a regression that went unreported for a few versions, and we just can't afford that kind of breakage. 