### PR TITLE
Reduce the number of column for the value relation editor widget when space missing

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -411,7 +411,7 @@ Page {
     id: fieldItem
 
     Item {
-      width: parent && parent.width > 0 ? parent.width / ColumnCount > 200 ? parent.width / ColumnCount : parent.width : form.width
+      width: parent && parent.width > 0 ? parent.width / ColumnCount > 190 ? parent.width / ColumnCount : parent.width : form.width
       height: fieldGroupTitle.height + fieldContent.childrenRect.height
 
       Rectangle {

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -106,7 +106,7 @@ EditorWidgetBase {
           anchors.left: parent.left
           anchors.right: parent.right
           anchors.top: parent.top
-          columns: config['NofColumns'] ? config['NofColumns'] : 1
+          columns: config['NofColumns'] ? Math.min(config['NofColumns'], parent.width / 100) : 1
           columnSpacing: 1
           rowSpacing: 0
 
@@ -196,6 +196,7 @@ EditorWidgetBase {
                   anchors.right: parent.right
                   anchors.left: checkBox.right
                   anchors.leftMargin: 4
+                  anchors.rightMargin: 4
                   width: parent.width - checkBox.width
                   topPadding: 4
                   bottomPadding: 4


### PR DESCRIPTION
Addresses UX issue raised in https://github.com/opengisch/QField/issues/6564

While we now respect the nb of columns configured for value relation editor widgets, due to the nature of the devices running QField it might not be a realistic proposition :) the PR improves things by adopting a flexible nb. of column (maxed out to the user configured nb) based on available space. This matches the behavior we adopted for tab / group's column count.

