### PR TITLE
Fix misrepresenting a cloud project as locally available when download was not completed

### DIFF
--- a/src/core/qfieldcloud/qfieldcloudproject.cpp
+++ b/src/core/qfieldcloud/qfieldcloudproject.cpp
@@ -2116,8 +2116,8 @@ QFieldCloudProject *QFieldCloudProject::fromDetails( const QVariantHash &details
     QDir localPath( QStringLiteral( "%1/%2/%3" ).arg( QFieldCloudUtils::localCloudDirectory(), username, project->id() ) );
     if ( localPath.exists() )
     {
-      project->mCheckout = LocalAndRemoteCheckout;
       restoreLocalSettings( project, localPath );
+      project->mCheckout = !project->mLocalPath.isEmpty() ? LocalAndRemoteCheckout : RemoteCheckout;
     }
   }
 
@@ -2193,11 +2193,10 @@ void QFieldCloudProject::restoreLocalSettings( QFieldCloudProject *project, cons
   project->mAutoPushIntervalMins = QFieldCloudUtils::projectSetting( project->id(), QStringLiteral( "autoPushIntervalMins" ), 30 ).toInt();
 
   // generate local export id if not present. Possible reasons for missing localExportId are:
-  // - just upgraded QField that introduced the field
-  // - the local settings were somehow deleted, but not the project itself
+  // - the cloud project download aborted halfway
+  // - the local settings were somehow deleted, but not the project itself (unlikely)
   if ( project->lastLocalExportId().isEmpty() )
   {
-    project->mLastLocalExportId = QUuid::createUuid().toString( QUuid::WithoutBraces );
-    QFieldCloudUtils::setProjectSetting( project->id(), QStringLiteral( "lastLocalExportId" ), project->lastLocalExportId() );
+    project->mLocalPath.clear();
   }
 };

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -748,7 +748,9 @@ void QFieldCloudProjectsModel::loadProjects( const QJsonArray &remoteProjects, b
           continue;
         }
 
-        if ( cloudProject->isSharedDatasetsProject() )
+        // If the cloud project is a special shared dataset project or if the cloud project
+        // had a folder but was not downloaded properly, do not add to the model
+        if ( cloudProject->isSharedDatasetsProject() || cloudProject->localPath().isEmpty() )
         {
           delete cloudProject;
         }

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -700,7 +700,7 @@ Popup {
 
   function revertLocalChangesFromCurrentProject() {
     if (cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.status === QFieldCloudProject.Idle) {
-      if (cloudProjectsModel.revertLocalChangesFromCurrentProject(cloudProjectsModel.currentProjectId)) {
+      if (cloudProjectsModel.revertLocalChangesFromCurrentProject()) {
         displayToast(qsTr('Local changes reverted'));
       } else {
         displayToast(qsTr('Failed to revert changes'), 'error');


### PR DESCRIPTION
This should reduce user confusion whereas we were previously advertising a cloud project as being locally available yet would lead to a [ download project ] button.