### PR TITLE
Add a new element from the relation form.

### DIFF
--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -40,26 +40,7 @@ Item {
   height: childrenRect.height
 
   property var currentKeyValue: value
-  property EmbeddedFeatureForm embeddedFeatureForm: embeddedPopup
-
-  EmbeddedFeatureForm {
-    id: addFeaturePopup
-
-    embeddedLevel: form.embeddedLevel + 1
-    digitizingToolbar: form.digitizingToolbar
-    codeReader: form.codeReader
-
-    onFeatureSaved: {
-      const referencedValue = addFeaturePopup.attributeFormModel.attribute(relationCombobox.relation.resolveReferencedField(field.name));
-      const index = featureListModel.findKey(referencedValue);
-      if (index < 0) {
-        // model not yet reloaded - keep the value and set it onModelReset
-        comboBox._cachedCurrentValue = referencedValue;
-      } else {
-        comboBox.currentIndex = index;
-      }
-    }
-  }
+  property EmbeddedFeatureForm embeddedFeatureForm: embeddedPopupLoader.item
 
   Popup {
     id: searchFeaturePopup
@@ -635,21 +616,26 @@ Item {
     }
   }
 
-  EmbeddedFeatureForm {
-    id: embeddedPopup
+  Loader {
+    id: embeddedPopupLoader
+    active: false
 
-    embeddedLevel: form.embeddedLevel + 1
-    digitizingToolbar: form.digitizingToolbar
-    codeReader: form.codeReader
+    sourceComponent: EmbeddedFeatureForm {
+      id: embeddedPopup
 
-    onFeatureSaved: {
-      const referencedValue = embeddedPopup.attributeFormModel.attribute(relationCombobox.relation.resolveReferencedField(field.name));
-      const index = featureListModel.findKey(referencedValue);
-      if ((featureListModel.addNull && index < 1) || index < 0) {
-        // model not yet reloaded - keep the value and set it onModelReset
-        comboBox._cachedCurrentValue = referencedValue;
-      } else {
-        comboBox.currentIndex = index;
+      embeddedLevel: form.embeddedLevel + 1
+      digitizingToolbar: form.digitizingToolbar
+      codeReader: form.codeReader
+
+      onFeatureSaved: {
+        const referencedValue = embeddedPopup.attributeFormModel.attribute(relationCombobox.relation.resolveReferencedField(field.name));
+        const index = featureListModel.findKey(referencedValue);
+        if ((featureListModel.addNull && index < 1) || index < 0) {
+          // model not yet reloaded - keep the value and set it onModelReset
+          comboBox._cachedCurrentValue = referencedValue;
+        } else {
+          comboBox.currentIndex = index;
+        }
       }
     }
   }
@@ -658,17 +644,24 @@ Item {
     showAddFeaturePopup(geometry);
   }
 
+  function ensureEmbeddedFormLoaded() {
+    if (!embeddedPopupLoader.active) {
+      embeddedPopupLoader.active = true;
+    }
+  }
+
   function showAddFeaturePopup(geometry) {
-    embeddedPopup.state = 'Add';
-    embeddedPopup.currentLayer = null;
+    ensureEmbeddedFormLoaded();
+    embeddedFeatureForm.state = 'Add';
+    embeddedFeatureForm.currentLayer = null;
     if (relationCombobox.relation !== undefined) {
-      embeddedPopup.currentLayer = relationCombobox.relation.referencedLayer;
+      embeddedFeatureForm.currentLayer = relationCombobox.relation.referencedLayer;
     } else if (relationCombobox.layerResolver !== undefined) {
-      embeddedPopup.currentLayer = relationCombobox.layerResolver.currentLayer;
+      embeddedFeatureForm.currentLayer = relationCombobox.layerResolver.currentLayer;
     }
     if (geometry !== undefined) {
-      embeddedPopup.applyGeometry(geometry);
+      embeddedFeatureForm.applyGeometry(geometry);
     }
-    embeddedPopup.open();
+    embeddedFeatureForm.open();
   }
 }

--- a/src/qml/editorwidgets/RelationEditorBase.qml
+++ b/src/qml/editorwidgets/RelationEditorBase.qml
@@ -211,24 +211,37 @@ EditorWidgetBase {
     }
   }
 
-  property EmbeddedFeatureForm embeddedPopup: EmbeddedFeatureForm {
-    embeddedLevel: form.embeddedLevel + 1
-    digitizingToolbar: form.digitizingToolbar
-    codeReader: form.codeReader
+  property EmbeddedFeatureForm embeddedPopup: embeddedPopupLoader.item
 
-    onFeatureCancelled: {
-      if (autoSave) {
+  function ensureEmbeddedFormLoaded() {
+    if (!embeddedPopupLoader.active) {
+      embeddedPopupLoader.active = true;
+    }
+  }
+
+  Loader {
+    id: embeddedPopupLoader
+    active: false
+
+    sourceComponent: EmbeddedFeatureForm {
+      embeddedLevel: form.embeddedLevel + 1
+      digitizingToolbar: form.digitizingToolbar
+      codeReader: form.codeReader
+
+      onFeatureCancelled: {
+        if (autoSave) {
+          relationEditorModel.reload();
+        }
+      }
+
+      onFeatureSaved: id => {
+        relationEditorModel.featureFocus = id;
         relationEditorModel.reload();
       }
-    }
 
-    onFeatureSaved: id => {
-      relationEditorModel.featureFocus = id;
-      relationEditorModel.reload();
-    }
-
-    onOpened: {
-      addingIndicator.running = false;
+      onOpened: {
+        addingIndicator.running = false;
+      }
     }
   }
 
@@ -409,6 +422,7 @@ EditorWidgetBase {
   }
 
   function showAddFeaturePopup(geometry) {
+    ensureEmbeddedFormLoaded();
     embeddedPopup.state = 'Add';
     embeddedPopup.currentLayer = relationEditorModel.relation.referencingLayer;
     embeddedPopup.linkedParentFeature = relationEditorModel.feature;

--- a/src/qml/editorwidgets/RelationReference.qml
+++ b/src/qml/editorwidgets/RelationReference.qml
@@ -98,6 +98,7 @@ EditorWidgetBase {
 
     onClicked: {
       if (relationReference.currentKeyValue !== undefined && relationReference.currentKeyValue !== '') {
+        relationReference.ensureEmbeddedFormLoaded();
         relationReference.embeddedFeatureForm.state = isEnabled ? 'Edit' : 'ReadOnly';
         relationReference.embeddedFeatureForm.currentLayer = listModel.currentLayer;
         relationReference.embeddedFeatureForm.feature = listModel.getFeatureFromKeyValue(relationReference.currentKeyValue);

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -57,6 +57,8 @@ EditorWidgetBase {
     enabled: isEnabled
     visible: !listModel.allowMulti
     relation: undefined
+    layerResolver: layerResolver
+    allowAddFeature: currentLayer && currentLayer.customProperty('QFieldSync/allow_value_relation_feature_addition') !== undefined ? currentLayer.customProperty('QFieldSync/allow_value_relation_feature_addition') : false
   }
 
   Column {

--- a/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
@@ -165,6 +165,7 @@ RelationEditorBase {
             bgcolor: 'transparent'
 
             onClicked: {
+              ensureEmbeddedFormLoaded();
               embeddedPopup.state = isEnabled ? 'Edit' : 'ReadOnly';
               embeddedPopup.currentLayer = orderedRelationModel.relation.referencingLayer;
               embeddedPopup.linkedRelation = orderedRelationModel.relation;

--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -110,6 +110,7 @@ RelationEditorBase {
           bgcolor: 'transparent'
 
           onClicked: {
+            ensureEmbeddedFormLoaded();
             embeddedPopup.state = isEnabled ? 'Edit' : 'ReadOnly';
             embeddedPopup.currentLayer = nmRelationId ? referencingFeatureListModel.nmRelation.referencedLayer : referencingFeatureListModel.relation.referencingLayer;
             embeddedPopup.linkedRelation = referencingFeatureListModel.relation;


### PR DESCRIPTION
## 🚀 Description
This PR enables adding new items directly from the relation form in QField.  
When a choice list (e.g., from a CSV) is incomplete, users can now type a new value and click **Add** to insert it on-the-fly, extending the list for future selections.  
This improves fieldwork efficiency by removing the need to manually edit the source layer.

### ✨ Key Changes
- Added `layerResolver` support in `RelationCombobox` to determine the target layer dynamically.
- Updated `RelationCombobox` to show an **Add** button.
- Lazy-load embedded forms in relation editors.
  - Wrapped embedded relation editor forms in QML Loaders to load them only when needed. This (hopefully) reduces initial UI load times for relation comboboxes and editors while preserving functionality when editing or adding related features.

### :link: Linked PRs
- https://github.com/opengisch/qfieldsync/pull/710
- https://github.com/opengisch/libqfieldsync/pull/122

### QFieldSync Demo
<img width="1297" height="790" alt="image" src="https://github.com/user-attachments/assets/0ffcf368-96ee-44ab-b426-9b27d4600eb9" />

### QField Demo
[Screencast From 2025-08-15 02-15-16.webm](https://github.com/user-attachments/assets/0aa0a565-6e32-41bd-abda-57e9324cf2f7)
