### PR TITLE
Implement the area parameter to recover delete holes algorithm into the processing toolbox

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -7,6 +7,7 @@ set(QFIELD_CORE_SRCS
     utils/geometryutils.cpp
     utils/layerutils.cpp
     utils/positioningutils.cpp
+    utils/processingutils.cpp
     utils/projectutils.cpp
     utils/qfieldcloudutils.cpp
     utils/relationutils.cpp
@@ -137,6 +138,7 @@ set(QFIELD_CORE_HDRS
     utils/geometryutils.h
     utils/layerutils.h
     utils/positioningutils.h
+    utils/processingutils.h
     utils/projectutils.h
     utils/qfieldcloudutils.h
     utils/relationutils.h

--- a/src/core/processing/processingalgorithmparametersmodel.cpp
+++ b/src/core/processing/processingalgorithmparametersmodel.cpp
@@ -22,7 +22,7 @@
 #include <qgsprocessingalgorithm.h>
 #include <qgsprocessingparameters.h>
 #include <qgsprocessingregistry.h>
-
+#include <qgsunittypes.h>
 
 ProcessingAlgorithmParametersModel::ProcessingAlgorithmParametersModel( QObject *parent )
   : QSortFilterProxyModel( parent )
@@ -140,7 +140,7 @@ void ProcessingAlgorithmParametersModelBase::rebuild()
 
   if ( mAlgorithm )
   {
-    const static QStringList sSupportedParameters = { QStringLiteral( "number" ), QStringLiteral( "distance" ), QStringLiteral( "enum" ), QStringLiteral( "boolean" ), QStringLiteral( "source" ) };
+    const static QStringList sSupportedParameters = { QStringLiteral( "number" ), QStringLiteral( "area" ), QStringLiteral( "distance" ), QStringLiteral( "enum" ), QStringLiteral( "boolean" ), QStringLiteral( "source" ) };
     const QgsProcessingAlgorithm *algorithm = QgsApplication::instance()->processingRegistry()->algorithmById( mAlgorithmId );
     for ( const QgsProcessingParameterDefinition *definition : algorithm->parameterDefinitions() )
     {
@@ -267,7 +267,14 @@ QVariant ProcessingAlgorithmParametersModelBase::data( const QModelIndex &index,
       return mValues.at( index.row() );
     case ParameterConfigurationRole:
       QVariantMap configuration;
-      if ( mParameters.at( index.row() )->type() == QStringLiteral( "distance" ) )
+      if ( mParameters.at( index.row() )->type() == QStringLiteral( "area" ) )
+      {
+        const QgsProcessingParameterArea *parameterArea = dynamic_cast<const QgsProcessingParameterArea *>( mParameters.at( index.row() ) );
+        configuration["minimum"] = parameterArea->minimum();
+        configuration["maximum"] = parameterArea->maximum();
+        configuration["areaUnit"] = static_cast<int>( ( mInPlaceLayer ? QgsUnitTypes::distanceToAreaUnit( mInPlaceLayer->crs().mapUnits() ) : Qgis::AreaUnit::Unknown ) );
+      }
+      else if ( mParameters.at( index.row() )->type() == QStringLiteral( "distance" ) )
       {
         const QgsProcessingParameterDistance *parameterDistance = dynamic_cast<const QgsProcessingParameterDistance *>( mParameters.at( index.row() ) );
         configuration["minimum"] = parameterDistance->minimum();

--- a/src/core/processing/processingalgorithmsmodel.cpp
+++ b/src/core/processing/processingalgorithmsmodel.cpp
@@ -158,7 +158,7 @@ void ProcessingAlgorithmsModelBase::addProvider( QgsProcessingProvider *provider
   const QList<const QgsProcessingAlgorithm *> algorithms = provider->algorithms();
   for ( const QgsProcessingAlgorithm *algorithm : algorithms )
   {
-    const static QStringList sSupportedParameters = { QStringLiteral( "number" ), QStringLiteral( "distance" ), QStringLiteral( "enum" ), QStringLiteral( "boolean" ), QStringLiteral( "sink" ), QStringLiteral( "source" ) };
+    const static QStringList sSupportedParameters = { QStringLiteral( "number" ), QStringLiteral( "area" ), QStringLiteral( "distance" ), QStringLiteral( "enum" ), QStringLiteral( "boolean" ), QStringLiteral( "sink" ), QStringLiteral( "source" ) };
     const QgsProcessingFeatureBasedAlgorithm *featureBasedAlgorithm = dynamic_cast<const QgsProcessingFeatureBasedAlgorithm *>( algorithm );
     if ( algorithm->flags() & Qgis::ProcessingAlgorithmFlag::SupportsInPlaceEdits )
     {

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -99,6 +99,7 @@
 #include "processingalgorithm.h"
 #include "processingalgorithmparametersmodel.h"
 #include "processingalgorithmsmodel.h"
+#include "processingutils.h"
 #include "projectinfo.h"
 #include "projectsimageprovider.h"
 #include "projectsource.h"
@@ -550,6 +551,7 @@ void QgisMobileapp::initDeclarative( QQmlEngine *engine )
   REGISTER_SINGLETON( "org.qfield", UrlUtils, "UrlUtils" );
   REGISTER_SINGLETON( "org.qfield", QFieldCloudUtils, "QFieldCloudUtils" );
   REGISTER_SINGLETON( "org.qfield", PositioningUtils, "PositioningUtils" );
+  REGISTER_SINGLETON( "org.qfield", ProcessingUtils, "ProcessingUtils" );
   REGISTER_SINGLETON( "org.qfield", ProjectUtils, "ProjectUtils" );
   REGISTER_SINGLETON( "org.qfield", CoordinateReferenceSystemUtils, "CoordinateReferenceSystemUtils" );
 

--- a/src/core/utils/processingutils.cpp
+++ b/src/core/utils/processingutils.cpp
@@ -1,0 +1,29 @@
+/***************************************************************************
+  processingutils.cpp - ProcessingUtils
+
+ ---------------------
+ begin                : 20.08.2025
+ copyright            : (C) 2025 by Mathieu Pellerin
+ email                : mathieu at opengis dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "processingutils.h"
+
+#include <qgsunittypes.h>
+
+ProcessingUtils::ProcessingUtils( QObject *parent )
+  : QObject( parent )
+{
+}
+
+double ProcessingUtils::fromAreaUnitToAreaUnitFactor( Qgis::AreaUnit fromUnit, Qgis::AreaUnit toUnit )
+{
+  return QgsUnitTypes::fromUnitToUnitFactor( fromUnit, toUnit );
+}

--- a/src/core/utils/processingutils.h
+++ b/src/core/utils/processingutils.h
@@ -1,0 +1,44 @@
+/***************************************************************************
+  processingutils.h - ProcessingUtils
+
+ ---------------------
+ begin                : 20.08.2025
+ copyright            : (C) 2025 by Mathieu Pellerin
+ email                : mathieu at opengis dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef PROCESSINGUTILS_H
+#define PROCESSINGUTILS_H
+
+#include "qfield_core_export.h"
+
+#include <QObject>
+#include <qgis.h>
+
+
+/**
+ * \ingroup core
+ */
+class QFIELD_CORE_EXPORT ProcessingUtils : public QObject
+{
+    Q_OBJECT
+
+  public:
+    explicit ProcessingUtils( QObject *parent = nullptr );
+
+    /**
+     * Returns the conversion factor between the specified areal units.
+     * \param fromUnit area unit to convert from
+     * \param toUnit area unit to convert to
+     * \returns multiplication factor to convert between units
+     */
+    static Q_INVOKABLE double fromAreaUnitToAreaUnitFactor( Qgis::AreaUnit fromUnit, Qgis::AreaUnit toUnit );
+};
+
+#endif // PROCESSINGUTILS_H

--- a/src/qml/processingparameterwidgets/area.qml
+++ b/src/qml/processingparameterwidgets/area.qml
@@ -1,0 +1,253 @@
+import QtQuick
+import QtQuick.Controls
+import Theme
+import org.qfield
+import org.qgis
+
+ProcessingParameterWidgetBase {
+  id: areaItem
+
+  property real step: 1
+  property real min: configuration['minimum']
+  property real max: configuration['maximum']
+  property int areaUnit: configuration['areaUnit']
+  property bool areaConvertible: areaUnit !== Qgis.AreaUnit.SquareDegrees && areaUnit !== Qgis.AreaUnit.Unknown
+
+  height: childrenRect.height
+
+  property double currentValue: areaConvertible ? value * ProcessingUtils.fromAreaUnitToAreaUnitFactor(areaUnit, unitTypesComboBox.currentValue) : value
+
+  Row {
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.top: parent.top
+    spacing: 5
+
+    QfTextField {
+      id: textField
+      height: fontMetrics.height + 20
+      width: parent.width - decreaseButton.width - increaseButton.width - (areaConvertible ? unitTypesComboBox.width : unitTypeLabel.width) - parent.spacing * 3
+
+      font: Theme.defaultFont
+      color: value === undefined || !enabled ? Theme.mainTextDisabledColor : Theme.mainTextColor
+
+      text: currentValue !== undefined ? currentValue : ''
+
+      validator: doubleValidator
+
+      inputMethodHints: Qt.ImhFormattedNumbersOnly
+
+      onTextChanged: {
+        if (parseFloat(text) !== currentValue) {
+          if (!isNaN(parseFloat(text))) {
+            let numberValue = Math.max(areaItem.min, Math.min(areaItem.max, text));
+            prepareValueChangeRequest(numberValue);
+          }
+        }
+      }
+    }
+
+    Label {
+      id: unitTypeLabel
+      visible: !areaConvertible
+      width: areaConvertible ? contentWidth : 0
+      font: Theme.defaultFont
+      color: Theme.mainTextColor
+
+      text: areaUnit === Qgis.AreaUnit.SquareDegrees ? qsTr('square degrees') : qsTr('<unknown>')
+    }
+
+    QfComboBox {
+      id: unitTypesComboBox
+
+      visible: areaConvertible
+      implicitContentWidthPolicy: ComboBox.WidestTextWhenCompleted
+
+      textRole: "display"
+      valueRole: "value"
+      model: ListModel {
+        ListElement {
+          display: qsTr("sqr. meters")
+          value: Qgis.AreaUnit.SquareMeters
+        }
+        ListElement {
+          display: qsTr("sqr. kilometers")
+          value: Qgis.AreaUnit.SquareKilometers
+        }
+        ListElement {
+          display: qsTr("sqr. feet")
+          value: Qgis.AreaUnit.SquareFeet
+        }
+        ListElement {
+          display: qsTr("sqr. yards")
+          value: Qgis.AreaUnit.SquareYards
+        }
+        ListElement {
+          display: qsTr("sqr. miles")
+          value: Qgis.AreaUnit.SquareMiles
+        }
+        ListElement {
+          display: qsTr("hectares")
+          value: Qgis.AreaUnit.Hectares
+        }
+        ListElement {
+          display: qsTr("acres")
+          value: Qgis.AreaUnit.Acres
+        }
+        ListElement {
+          display: qsTr("sqr. nautical miles")
+          value: Qgis.AreaUnit.SquareNauticalMiles
+        }
+        ListElement {
+          display: qsTr("sqr. centimeters")
+          value: Qgis.AreaUnit.SquareCentimeters
+        }
+        ListElement {
+          display: qsTr("sqr. millimeters")
+          value: Qgis.AreaUnit.SquareMillimeters
+        }
+        ListElement {
+          display: qsTr("sqr. inches")
+          value: Qgis.AreaUnit.SquareInches
+        }
+      }
+
+      onCurrentIndexChanged: {
+        if (!isNaN(parseFloat(textField.text))) {
+          let numberValue = Math.max(areaItem.min, Math.min(areaItem.max, textField.text));
+          prepareValueChangeRequest(numberValue);
+        }
+      }
+
+      Component.onCompleted: {
+        if (areaConvertible) {
+          for (let i = 0; i < model.count; i++) {
+            if (model.get(i).value === areaUnit) {
+              currentIndex = areaUnit;
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    QfToolButton {
+      id: decreaseButton
+      width: enabled ? 48 : 0
+      height: 48
+
+      anchors.verticalCenter: textField.verticalCenter
+
+      iconSource: Theme.getThemeVectorIcon("ic_remove_white_24dp")
+      iconColor: Theme.mainTextColor
+      bgcolor: "transparent"
+      visible: enabled
+
+      onClicked: {
+        adjustValue(-1);
+      }
+      onDoubleClicked: {
+        adjustValue(-1);
+      }
+      onPressAndHold: {
+        changeValueTimer.increase = false;
+        changeValueTimer.interval = 700;
+        changeValueTimer.restart();
+      }
+      onReleased: {
+        changeValueTimer.stop();
+      }
+      onCanceled: {
+        changeValueTimer.stop();
+      }
+    }
+
+    QfToolButton {
+      id: increaseButton
+      width: enabled ? 48 : 0
+      height: 48
+
+      anchors.verticalCenter: textField.verticalCenter
+
+      iconSource: Theme.getThemeVectorIcon("ic_add_white_24dp")
+      iconColor: Theme.mainTextColor
+      bgcolor: "transparent"
+      visible: enabled
+
+      onClicked: {
+        adjustValue(1);
+      }
+      onDoubleClicked: {
+        adjustValue(1);
+      }
+      onPressAndHold: {
+        changeValueTimer.increase = true;
+        changeValueTimer.interval = 700;
+        changeValueTimer.restart();
+      }
+      onReleased: {
+        changeValueTimer.stop();
+      }
+      onCanceled: {
+        changeValueTimer.stop();
+      }
+    }
+  }
+
+  Timer {
+    id: changeValueTimer
+    interval: 700
+    repeat: true
+
+    property bool increase: true
+
+    onTriggered: {
+      var hitBoundary = false;
+      if (increase) {
+        adjustValue(1);
+        hitBoundary = parseFloat(textField.text) === areaItem.max;
+      } else {
+        adjustValue(-1);
+        hitBoundary = parseFloat(textField.text) === areaItem.min;
+      }
+      if (!hitBoundary) {
+        if (interval > 50)
+          interval = interval * 0.7;
+      } else {
+        stop();
+      }
+    }
+  }
+
+  function adjustValue(direction) {
+    var currentValue = parseFloat(textField.text);
+    var newValue;
+    if (!isNaN(currentValue)) {
+      newValue = currentValue + (areaItem.step * direction);
+      prepareValueChangeRequest(Math.min(areaItem.max, Math.max(areaItem.min, newValue)));
+    } else {
+      newValue = 0;
+      prepareValueChangeRequest(newValue, false);
+    }
+  }
+
+  FontMetrics {
+    id: fontMetrics
+    font: textField.font
+  }
+
+  DoubleValidator {
+    id: doubleValidator
+    locale: 'C'
+    bottom: areaItem.min
+    top: areaItem.max
+  }
+
+  function prepareValueChangeRequest(newValue) {
+    if (areaConvertible) {
+      valueChangeRequested(newValue * ProcessingUtils.fromAreaUnitToAreaUnitFactor(unitTypesComboBox.currentValue, areaUnit));
+    } else {
+      valueChangeRequested(newValue);
+    }
+  }
+}

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -38,6 +38,7 @@
         <file>ProcessingAlgorithmForm.qml</file>
         <file>ProcessingAlgorithmPreview.qml</file>
         <file>processingparameterwidgets/ProcessingParameterWidgetBase.qml</file>
+        <file>processingparameterwidgets/area.qml</file>
         <file>processingparameterwidgets/boolean.qml</file>
         <file>processingparameterwidgets/enum.qml</file>
         <file>processingparameterwidgets/distance.qml</file>


### PR DESCRIPTION
While we shipped with the super useful delete holes algorithm when we first released our processing toolbox support in QField, we since then lost support as the algorithm moved away from (ab)using the distance parameter to represent an area. 

By implementing support for the area parameter in QField, we regain the algorithm out of the box. 

Proof of life:

<img width="1035" height="687" alt="image" src="https://github.com/user-attachments/assets/176cd8ff-ef39-4cc8-b3e8-4c9d678dce1a" />
