### PR TITLE
fix(qfc): potential problem where a deleted delta scrambles the delta ids

### DIFF
--- a/src/core/deltafilewrapper.cpp
+++ b/src/core/deltafilewrapper.cpp
@@ -1400,8 +1400,10 @@ int DeltaFileWrapper::getDeltaIndexByUuid( const QString &uuid ) const
 {
   int idx = 0;
 
-  for ( const QJsonValue &deltaJson : std::as_const( mDeltas ) )
+  for ( const QJsonValueConstRef &deltaJson : std::as_const( mDeltas ) )
   {
+    Q_ASSERT( deltaJson.isObject() );
+
     const QVariantMap delta = deltaJson.toObject().toVariantMap();
 
     if ( delta.value( QStringLiteral( "uuid" ) ) == uuid )

--- a/src/core/deltafilewrapper.h
+++ b/src/core/deltafilewrapper.h
@@ -341,6 +341,15 @@ class DeltaFileWrapper : public QObject
      */
     void setIsPushing( bool isPushing );
 
+
+    /**
+     * Retuns the index position of a delta with given \a uuid in the deltas list or -1 if missing.
+     *
+     * @param uuid the uuid we are looking for
+     */
+    int getDeltaIndexByUuid( const QString &uuid ) const;
+
+
   signals:
     /**
      * Emitted when the `deltas` list has changed.
@@ -437,9 +446,9 @@ class DeltaFileWrapper : public QObject
     const QgsProject *mProject = nullptr;
 
     /**
-     * A mapping between the local primary key and it's index in the delta file.
+     * A mapping between the local primary key and the uuid of the delta.
      */
-    QMap<QString, QMap<QString, int>> mLocalPkDeltaIdx;
+    QMap<QString, QMap<QString, QString>> mLocalPkToDeltaUuid;
 
     /**
      * The list of JSON deltas.


### PR DESCRIPTION
Prior to this commit the data was stored as:

    // { localLayerId: { localPk: indexInTheDeltafile } }
    QMap<QString, QMap<QString, int>> mLocalPkDeltaIdx;

However, in `DeltaFileWrapper::mergeDeleteDelta` we have `mDeltas.removeAt`, which can potentially change all delta indices in the deltafile, but never update them in `mLocalPkDeltaIdx`.

This change removes the dependency of the positions in the deltafile and adds replaces it with the uuids of the deltas:

    // { localLayerId: { localPk: deltaUuid } }
    QMap<QString, QMap<QString, QString>> mLocalPkToDeltaUuid;

As the UUIDs does not have a direct mapping, a new method is also added:

    /**
     * Retuns the index position of a delta with given \a uuid in the deltas list or -1 if missing. *
     * @param uuid the uuid we are looking for */ int getDeltaIndexByUuid( const QString &uuid ) const;

Since the function must always return a value >=0, we added an assert and no other special handling.

Paving the path to fix in the future #6583 .