### PR TITLE
Fix value relation crash when searching for values and returning no matches

### DIFF
--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -247,6 +247,8 @@ Item {
       valueRole: 'keyFieldValue'
 
       onCurrentIndexChanged: {
+        if (searchFeaturePopup.opened)
+          return;
         const newValue = featureListModel.dataFromRowIndex(currentIndex, FeatureListModel.KeyFieldRole);
         if (newValue !== currentKeyValue) {
           valueChangeRequested(newValue, false);


### PR DESCRIPTION
This pull request fixes a crash with the value relation editor widget whereas searching for a value in the popup which leads to an absence of matching value would kill QField.

@AROUX-GIS , can you confirm that this build fixes your crash, thanks.