### PR TITLE
Add key-based fallback sorting to `FeatureCheckListModel`.

### DIFF
--- a/src/core/featurechecklistmodel.cpp
+++ b/src/core/featurechecklistmodel.cpp
@@ -581,7 +581,20 @@ bool FeatureCheckListModel::lessThan( const QModelIndex &left, const QModelIndex
     }
   }
 
-  return false;
+  // Order By Key (as a fallback)
+  const QString leftKey = sourceModel()->data( left, FeatureListModel::KeyFieldRole ).toString().toLower();
+  const QString rightKey = sourceModel()->data( right, FeatureListModel::KeyFieldRole ).toString().toLower();
+
+  if ( leftKey.isEmpty() && !rightKey.isEmpty() )
+  {
+    return true;
+  }
+  else if ( !leftKey.isEmpty() && rightKey.isEmpty() )
+  {
+    return false;
+  }
+
+  return leftKey < rightKey;
 }
 
 double FeatureCheckListModel::calcFuzzyScore( const QString &displayString, const QString &searchTerm ) const


### PR DESCRIPTION
## 🚀 Description
This PR completes the sorting logic in `FeatureCheckListModel::lessThan()` by adding a final fallback to sort by the feature key when no other criteria (group, checked-first, search term, or value ordering) apply.


### ✨ Key Changes
- Added key-based sorting as the last comparison step


### 🔄 Preserved existing logic for:
- Group ordering
- Checked-first sorting
- Search relevance and fuzzy score
- Value-based ordering when enabled

### Demo

<img width="1702" height="940" alt="image" src="https://github.com/user-attachments/assets/73028938-3ef3-4b18-9566-5d410e86882b" />
