### PR TITLE
Implement WMS/AMS legend graphics as well as legend placeholder images

### DIFF
--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -592,7 +592,7 @@ QVariant FlatLayerTreeModelBase::data( const QModelIndex &index, int role ) cons
           std::reverse( legendParts.begin(), legendParts.end() );
           id += '/' + legendParts.join( QStringLiteral( "~__~" ) );
         }
-        if ( QgsWmsLegendNode *wmsNode = qobject_cast<QgsWmsLegendNode *>( legendNode ) )
+        else if ( QgsWmsLegendNode *wmsNode = qobject_cast<QgsWmsLegendNode *>( legendNode ) )
         {
           QgsLayerTreeNode *node = mLayerTreeModel->index2node( sourceIndex.parent() );
           if ( QgsLayerTree::isLayer( node ) )
@@ -602,6 +602,20 @@ QVariant FlatLayerTreeModelBase::data( const QModelIndex &index, int role ) cons
             if ( rasterLayer && rasterLayer->dataProvider() && rasterLayer->dataProvider()->supportsLegendGraphic() )
             {
               id += QStringLiteral( "image://asynclegend/layer" );
+              id += '/' + nodeLayer->layerId();
+            }
+          }
+        }
+        else if ( QgsImageLegendNode *imageNode = qobject_cast<QgsImageLegendNode *>( legendNode ) )
+        {
+          QgsLayerTreeNode *node = mLayerTreeModel->index2node( sourceIndex.parent() );
+          if ( QgsLayerTree::isLayer( node ) )
+          {
+            QgsLayerTreeLayer *nodeLayer = QgsLayerTree::toLayer( node );
+            QgsMapLayer *layer = qobject_cast<QgsMapLayer *>( nodeLayer->layer() );
+            if ( layer && !layer->legendPlaceholderImage().isEmpty() )
+            {
+              id += QStringLiteral( "image://legend/image" );
               id += '/' + nodeLayer->layerId();
             }
           }
@@ -641,6 +655,10 @@ QVariant FlatLayerTreeModelBase::data( const QModelIndex &index, int role ) cons
       else if ( QgsLayerTreeModelLegendNode *legendNode = mLayerTreeModel->index2legendNode( sourceIndex ) )
       {
         if ( QgsWmsLegendNode *wmsNode = qobject_cast<QgsWmsLegendNode *>( legendNode ) )
+        {
+          return FlatLayerTreeModel::Image;
+        }
+        else if ( QgsImageLegendNode *imageNode = qobject_cast<QgsImageLegendNode *>( legendNode ) )
         {
           return FlatLayerTreeModel::Image;
         }

--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -577,22 +577,7 @@ QVariant FlatLayerTreeModelBase::data( const QModelIndex &index, int role ) cons
       QString id;
       if ( QgsLayerTreeModelLegendNode *legendNode = mLayerTreeModel->index2legendNode( sourceIndex ) )
       {
-        if ( QgsSymbolLegendNode *symbolNode = qobject_cast<QgsSymbolLegendNode *>( legendNode ) )
-        {
-          id += QStringLiteral( "image://legend/legend" );
-          id += '/' + symbolNode->layerNode()->layerId();
-          QStringList legendParts;
-          QModelIndex currentIndex = sourceIndex;
-          while ( symbolNode )
-          {
-            legendParts << QString::number( currentIndex.internalId() );
-            currentIndex = currentIndex.parent();
-            symbolNode = qobject_cast<QgsSymbolLegendNode *>( mLayerTreeModel->index2legendNode( currentIndex ) );
-          }
-          std::reverse( legendParts.begin(), legendParts.end() );
-          id += '/' + legendParts.join( QStringLiteral( "~__~" ) );
-        }
-        else if ( QgsWmsLegendNode *wmsNode = qobject_cast<QgsWmsLegendNode *>( legendNode ) )
+        if ( QgsWmsLegendNode *wmsNode = qobject_cast<QgsWmsLegendNode *>( legendNode ) )
         {
           QgsLayerTreeNode *node = mLayerTreeModel->index2node( sourceIndex.parent() );
           if ( QgsLayerTree::isLayer( node ) )
@@ -619,6 +604,21 @@ QVariant FlatLayerTreeModelBase::data( const QModelIndex &index, int role ) cons
               id += '/' + nodeLayer->layerId();
             }
           }
+        }
+        else
+        {
+          id += QStringLiteral( "image://legend/legend" );
+          id += '/' + legendNode->layerNode()->layerId();
+          QStringList legendParts;
+          QModelIndex currentIndex = sourceIndex;
+          while ( legendNode )
+          {
+            legendParts << QString::number( currentIndex.internalId() );
+            currentIndex = currentIndex.parent();
+            legendNode = qobject_cast<QgsSymbolLegendNode *>( mLayerTreeModel->index2legendNode( currentIndex ) );
+          }
+          std::reverse( legendParts.begin(), legendParts.end() );
+          id += '/' + legendParts.join( QStringLiteral( "~__~" ) );
         }
       }
       else

--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -731,9 +731,9 @@ QVariant FlatLayerTreeModelBase::data( const QModelIndex &index, int role ) cons
           name += QStringLiteral( " [%1]" ).arg( count );
         }
       }
-      else if ( QgsLayerTreeModelLegendNode *sym = mLayerTreeModel->index2legendNode( sourceIndex ) )
+      else if ( QgsLayerTreeModelLegendNode *symbol = mLayerTreeModel->index2legendNode( sourceIndex ) )
       {
-        name = sym->data( Qt::DisplayRole ).toString();
+        name = symbol->data( Qt::DisplayRole ).toString();
       }
 
       return name;
@@ -1119,6 +1119,17 @@ QVariant FlatLayerTreeModelBase::data( const QModelIndex &index, int role ) cons
       return QString();
     }
 
+    case FlatLayerTreeModel::Checkable:
+    {
+      QgsLayerTreeModelLegendNode *legendNode = mLayerTreeModel->index2legendNode( sourceIndex );
+      if ( legendNode )
+      {
+        return ( legendNode->flags() & Qt::ItemIsUserCheckable ) ? true : false;
+      }
+
+      return true;
+    }
+
     default:
       return QAbstractProxyModel::data( index, role );
   }
@@ -1304,6 +1315,7 @@ QHash<int, QByteArray> FlatLayerTreeModelBase::roleNames() const
   roleNames[FlatLayerTreeModel::SnappingEnabled] = "SnappingEnabled";
   roleNames[FlatLayerTreeModel::HasNotes] = "HasNotes";
   roleNames[FlatLayerTreeModel::Notes] = "Notes";
+  roleNames[FlatLayerTreeModel::Checkable] = "Checkable";
   return roleNames;
 }
 

--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -16,6 +16,7 @@
 
 #include "layertreemodel.h"
 
+#include <qgscolorramplegendnode.h>
 #include <qgslayernotesutils.h>
 #include <qgslayertree.h>
 #include <qgslayertreemodel.h>
@@ -395,6 +396,13 @@ int FlatLayerTreeModelBase::buildMap( QgsLayerTreeModel *model, const QModelInde
         QgsMapLayer *layer = nodeLayer->layer();
         if ( layer && layer->flags().testFlag( QgsMapLayer::Private ) )
           continue;
+      }
+
+      QgsLayerTreeModelLegendNode *legendNode = mLayerTreeModel->index2legendNode( index );
+      if ( qobject_cast<QgsColorRampLegendNode *>( legendNode ) || qobject_cast<QgsDataDefinedSizeLegendNode *>( legendNode ) )
+      {
+        // Skip unsupported legend types
+        continue;
       }
 
       if ( node && !node->isExpanded() )

--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -662,11 +662,7 @@ QVariant FlatLayerTreeModelBase::data( const QModelIndex &index, int role ) cons
       }
       else if ( QgsLayerTreeModelLegendNode *legendNode = mLayerTreeModel->index2legendNode( sourceIndex ) )
       {
-        if ( QgsWmsLegendNode *wmsNode = qobject_cast<QgsWmsLegendNode *>( legendNode ) )
-        {
-          return FlatLayerTreeModel::Image;
-        }
-        else if ( QgsImageLegendNode *imageNode = qobject_cast<QgsImageLegendNode *>( legendNode ) )
+        if ( qobject_cast<QgsWmsLegendNode *>( legendNode ) || qobject_cast<QgsImageLegendNode *>( legendNode ) )
         {
           return FlatLayerTreeModel::Image;
         }

--- a/src/core/layertreemodel.h
+++ b/src/core/layertreemodel.h
@@ -155,6 +155,7 @@ class FlatLayerTreeModel : public QSortFilterProxyModel
       SnappingEnabled,
       HasNotes,
       Notes,
+      Checkable,
     };
     Q_ENUM( Roles )
 

--- a/src/core/layertreemodel.h
+++ b/src/core/layertreemodel.h
@@ -158,6 +158,15 @@ class FlatLayerTreeModel : public QSortFilterProxyModel
     };
     Q_ENUM( Roles )
 
+    enum Types
+    {
+      Layer,
+      Group,
+      Image,
+      Legend,
+    };
+    Q_ENUM( Types )
+
     explicit FlatLayerTreeModel( QgsLayerTree *layerTree, QgsProject *project, QObject *parent = nullptr );
 
     Q_INVOKABLE QVariant data( const QModelIndex &index, int role ) const override;

--- a/src/core/legendimageprovider.cpp
+++ b/src/core/legendimageprovider.cpp
@@ -14,6 +14,8 @@
  *                                                                         *
  ***************************************************************************/
 #include "legendimageprovider.h"
+#include "qgsapplication.h"
+#include "qgsimagecache.h"
 
 #include <QQuickTextureFactory>
 #include <qgslayertree.h>
@@ -86,8 +88,7 @@ QPixmap LegendImageProvider::requestPixmap( const QString &id, QSize *, const QS
       }
     }
   }
-
-  if ( idParts.value( 0 ) == QStringLiteral( "layer" ) )
+  else if ( idParts.value( 0 ) == QStringLiteral( "layer" ) )
   {
     QgsLayerTreeLayer *layerNode = mRootNode->findLayer( idParts.value( 1 ) );
     if ( layerNode )
@@ -114,6 +115,20 @@ QPixmap LegendImageProvider::requestPixmap( const QString &id, QSize *, const QS
         QPixmap pixmap( iconSize, iconSize );
         pixmap.fill( QColor( 255, 255, 255 ) );
         return pixmap;
+      }
+    }
+  }
+  else if ( idParts.value( 0 ) == QStringLiteral( "image" ) )
+  {
+    QgsLayerTreeLayer *layerNode = mRootNode->findLayer( idParts.value( 1 ) );
+    if ( layerNode )
+    {
+      QgsMapLayer *mapLayer = layerNode->layer();
+      if ( mapLayer && !mapLayer->legendPlaceholderImage().isEmpty() )
+      {
+        bool fitsInCache = false;
+        const QImage image = QgsApplication::imageCache()->pathAsImage( mapLayer->legendPlaceholderImage(), QSize(), false, 1.0, fitsInCache );
+        return QPixmap::fromImage( image );
       }
     }
   }

--- a/src/core/legendimageprovider.h
+++ b/src/core/legendimageprovider.h
@@ -26,6 +26,10 @@
 class QgsLayerTreeModel;
 class QgsLayerTree;
 
+/**
+ * \brief This class provides legend images for the layer tree model.
+ * \ingroup core
+ */
 class LegendImageProvider : public QQuickImageProvider
 {
   public:
@@ -39,6 +43,11 @@ class LegendImageProvider : public QQuickImageProvider
 };
 
 
+/**
+ * \brief This class provides responses of asynchronously requested legend images for the layer
+ * tree model . Used for online WMS and AMS layers.
+ * \ingroup core
+ */
 class AsyncLegendImageResponse : public QQuickImageResponse
 {
   public:
@@ -58,6 +67,11 @@ class AsyncLegendImageResponse : public QQuickImageResponse
 };
 
 
+/**
+ * \brief This class prepares asynchrnous legend images requests. Used
+ * for online WMS and AMS layers.
+ * \ingroup core
+ */
 class AsyncLegendImageProvider : public QQuickAsyncImageProvider
 {
   public:

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -288,6 +288,7 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   mClipboardManager = std::make_unique<ClipboardManager>( this );
   mFlatLayerTree = new FlatLayerTreeModel( mProject->layerTreeRoot(), mProject, this );
   mLegendImageProvider = new LegendImageProvider( mFlatLayerTree->layerTreeModel() );
+  mAsyncLegendImageProvider = new AsyncLegendImageProvider( mFlatLayerTree->layerTreeModel() );
   mLocalFilesImageProvider = new LocalFilesImageProvider();
   mProjectsImageProvider = new ProjectsImageProvider();
   mBarcodeImageProvider = new BarcodeImageProvider();
@@ -327,6 +328,7 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   Q_ASSERT_X( mMapCanvas, "QML Init", "QgsQuickMapCanvasMap not found. It is likely that we failed to load the QML files. Check debug output for related messages." );
   mMapCanvas->mapSettings()->setProject( mProject );
   mBookmarkModel->setMapSettings( mMapCanvas->mapSettings() );
+  mAsyncLegendImageProvider->setMapSettings( mMapCanvas->mapSettings() );
 
   mFlatLayerTree->layerTreeModel()->setLegendMapViewData( mMapCanvas->mapSettings()->mapSettings().mapUnitsPerPixel(),
                                                           static_cast<int>( std::round( mMapCanvas->mapSettings()->outputDpi() ) ), mMapCanvas->mapSettings()->mapSettings().scale() );
@@ -606,6 +608,7 @@ void QgisMobileapp::registerGlobalVariables()
   rootContext()->setContextProperty( "qfieldAuthRequestHandler", mAuthRequestHandler );
   rootContext()->setContextProperty( "trackingModel", mTrackingModel );
   addImageProvider( QLatin1String( "legend" ), mLegendImageProvider );
+  addImageProvider( QLatin1String( "asynclegend" ), mAsyncLegendImageProvider );
   addImageProvider( QLatin1String( "localfiles" ), mLocalFilesImageProvider );
   addImageProvider( QLatin1String( "projects" ), mProjectsImageProvider );
   addImageProvider( QLatin1String( "barcode" ), mBarcodeImageProvider );

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -50,6 +50,7 @@ class LayerTreeMapCanvasBridge;
 class FlatLayerTreeModel;
 class LayerTreeModel;
 class LegendImageProvider;
+class AsyncLegendImageProvider;
 class LocalFilesImageProvider;
 class ProjectsImageProvider;
 class TrackingModel;
@@ -227,6 +228,7 @@ class QFIELD_CORE_EXPORT QgisMobileapp : public QQmlApplicationEngine
     QPointer<QgsQuickMapCanvasMap> mMapCanvas;
     bool mFirstRenderingFlag;
     LegendImageProvider *mLegendImageProvider = nullptr;
+    AsyncLegendImageProvider *mAsyncLegendImageProvider = nullptr;
     LocalFilesImageProvider *mLocalFilesImageProvider = nullptr;
     ProjectsImageProvider *mProjectsImageProvider = nullptr;
     BarcodeImageProvider *mBarcodeImageProvider = nullptr;

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -390,7 +390,7 @@ Drawer {
     height: 48 + mainWindow.sceneBottomMargin
     width: parent.width
     anchors.bottom: parent.bottom
-    color: Theme.darkTheme ? Theme.mainBackgroundColorSemiOpaque : Theme.lightestGray
+    color: Theme.darkTheme ? Theme.mainBackgroundColorSemiOpaque : Theme.lightestGraySemiOpaque
 
     Item {
       height: 48

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -153,7 +153,7 @@ Popup {
           text: qsTr('Show on map')
           font: Theme.defaultFont
           // visible for all layer tree items but nonspatial layers
-          visible: index && layerTree.data(index, FlatLayerTreeModel.HasSpatialExtent) ? true : false
+          visible: index && layerTree.data(index, FlatLayerTreeModel.Checkable) && layerTree.data(index, FlatLayerTreeModel.HasSpatialExtent) ? true : false
           indicator.height: 16
           indicator.width: 16
           indicator.implicitHeight: 24
@@ -243,7 +243,7 @@ Popup {
           id: zoomToButton
           Layout.fillWidth: true
           Layout.topMargin: 5
-          text: index ? layerTree.data(index, FlatLayerTreeModel.Type) === FlatLayerTreeModel.Group ? qsTr('Zoom to group') : layerTree.data(index, FlatLayerTreeModel.Type) === FlatLayerTreeModel.Legend ? qsTr('Zoom to parent layer') : qsTr('Zoom to layer') : ''
+          text: index ? layerTree.data(index, FlatLayerTreeModel.Type) === FlatLayerTreeModel.Group ? qsTr('Zoom to group') : layerTree.data(index, FlatLayerTreeModel.Type) === FlatLayerTreeModel.Legend && layerTree.data(index, FlatLayerTreeModel.LayerType) === "vectorlayer" ? qsTr('Zoom to parent layer') : qsTr('Zoom to layer') : ''
           visible: zoomToButtonVisible
           icon.source: Theme.getThemeVectorIcon('zoom_out_map_24dp')
 

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -45,7 +45,7 @@ Popup {
     updateCredits();
     itemVisibleCheckBox.checked = layerTree.data(index, FlatLayerTreeModel.Visible);
     itemLabelsVisibleCheckBox.checked = layerTree.data(index, FlatLayerTreeModel.LabelsVisible);
-    expandCheckBox.text = layerTree.data(index, FlatLayerTreeModel.Type) === 'group' ? qsTr('Expand group') : qsTr('Expand legend item');
+    expandCheckBox.text = layerTree.data(index, FlatLayerTreeModel.Type) === FlatLayerTreeModel.Group ? qsTr('Expand group') : qsTr('Expand legend item');
     expandCheckBox.checked = !layerTree.data(index, FlatLayerTreeModel.IsCollapsed);
     reloadDataButtonVisible = layerTree.data(index, FlatLayerTreeModel.CanReloadData);
     zoomToButtonVisible = layerTree.data(index, FlatLayerTreeModel.HasSpatialExtent);
@@ -243,7 +243,7 @@ Popup {
           id: zoomToButton
           Layout.fillWidth: true
           Layout.topMargin: 5
-          text: index ? layerTree.data(index, FlatLayerTreeModel.Type) === 'group' ? qsTr('Zoom to group') : layerTree.data(index, FlatLayerTreeModel.Type) === 'legend' ? qsTr('Zoom to parent layer') : qsTr('Zoom to layer') : ''
+          text: index ? layerTree.data(index, FlatLayerTreeModel.Type) === FlatLayerTreeModel.Group ? qsTr('Zoom to group') : layerTree.data(index, FlatLayerTreeModel.Type) === FlatLayerTreeModel.Legend ? qsTr('Zoom to parent layer') : qsTr('Zoom to layer') : ''
           visible: zoomToButtonVisible
           icon.source: Theme.getThemeVectorIcon('zoom_out_map_24dp')
 
@@ -420,13 +420,13 @@ Popup {
   function updateTitle() {
     if (index === undefined)
       return;
-    var title = layerTree.data(index, Qt.Name);
-    var type = layerTree.data(index, FlatLayerTreeModel.Type);
-    var vl = layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer);
+    const type = layerTree.data(index, FlatLayerTreeModel.Type);
+    const vl = layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer);
+    let title = layerTree.data(index, Qt.Name);
     if (vl) {
-      if (type === 'legend') {
+      if (type === FlatLayerTreeModel.Legend) {
         title += ' (' + vl.name + ')';
-      } else if (type === 'layer' && layerTree.data(index, FlatLayerTreeModel.IsValid)) {
+      } else if (type === FlatLayerTreeModel.Layer && layerTree.data(index, FlatLayerTreeModel.IsValid)) {
         var count = layerTree.data(index, FlatLayerTreeModel.FeatureCount);
         if (count !== undefined && count >= 0) {
           var countSuffix = ' [' + count + ']';
@@ -435,7 +435,7 @@ Popup {
         }
       }
     }
-    titleLabel.text = title;
+    titleLabel.text = title !== undefined ? title : "";
   }
 
   function updateCredits() {
@@ -452,7 +452,7 @@ Popup {
   function isTrackingButtonVisible() {
     if (!index)
       return false;
-    return layerTree.data(index, FlatLayerTreeModel.Type) === 'layer' && !layerTree.data(index, FlatLayerTreeModel.ReadOnly) && layerTree.data(index, FlatLayerTreeModel.Trackable);
+    return layerTree.data(index, FlatLayerTreeModel.Type) === FlatLayerTreeModel.Layer && !layerTree.data(index, FlatLayerTreeModel.ReadOnly) && layerTree.data(index, FlatLayerTreeModel.Trackable);
   }
 
   function isShowFeaturesListButtonVisible() {

--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -31,7 +31,7 @@ ListView {
   delegate: Rectangle {
     id: rectangle
     property int itemPadding: 30 * TreeLevel
-    property bool isSelectedLayer: Type === "layer" && VectorLayerPointer && VectorLayerPointer == activeLayer
+    property bool isSelectedLayer: Type === FlatLayerTreeModel.Layer && VectorLayerPointer && VectorLayerPointer == activeLayer
     width: parent ? parent.width : undefined
     height: line.height + 7
     color: isSelectedLayer ? Theme.mainColor : "transparent"
@@ -130,9 +130,40 @@ ListView {
         anchors.verticalCenter: parent.verticalCenter
         spacing: 5
 
+        Rectangle {
+          visible: Type == FlatLayerTreeModel.Image
+          width: rectangle.width - itemPadding - 36
+          height: legendImage.height + 8
+          color: "#f2f2f2" // hard-coded color as most legends are intented to be displayed against white backgrounds
+          radius: 4
+
+          Flickable {
+            anchors.fill: parent
+            anchors.margins: 4
+            contentWidth: legendImage.width
+            contentHeight: legendImage.height
+            clip: true
+            ScrollBar.horizontal: QfScrollBar {
+            }
+
+            Image {
+              id: legendImage
+              fillMode: Image.PreserveAspectFit
+              cache: false
+              smooth: true
+              mipmap: true
+              source: {
+                if (!legend.isVisible || Type != FlatLayerTreeModel.Image)
+                  return '';
+                return LegendImage;
+              }
+            }
+          }
+        }
+
         Item {
           id: layerVisibility
-          property bool isVisible: HasSpatialExtent
+          property bool isVisible: Type != FlatLayerTreeModel.Image && HasSpatialExtent
           height: 24
           width: visible ? parent.height : 0
           anchors.verticalCenter: parent.verticalCenter
@@ -146,7 +177,6 @@ ListView {
             iconSource: !Visible ? Theme.getThemeVectorIcon('ic_hide_green_48dp') : Theme.getThemeVectorIcon('ic_show_green_48dp')
             iconColor: isSelectedLayer ? Theme.mainOverlayColor : Theme.mainTextColor
             bgcolor: "transparent"
-            visible: HasSpatialExtent
             enabled: (allowActiveLayerChange || (projectInfo.activeLayer != VectorLayerPointer))
             onClicked: {
               layerTree.setData(legend.model.index(index, 0), !Visible, FlatLayerTreeModel.Visible);
@@ -161,55 +191,55 @@ ListView {
           height: 24
           width: 24
           anchors.verticalCenter: parent.verticalCenter
+          visible: Type != FlatLayerTreeModel.Image
 
           Image {
             anchors.fill: parent
             anchors.margins: 4
+            fillMode: Image.PreserveAspectFit
             cache: false
             smooth: true
             mipmap: true
             source: {
-              if (!legend.isVisible)
+              if (!legend.isVisible || Type == FlatLayerTreeModel.Image)
                 return '';
               if (LegendImage != '') {
-                return "image://legend/" + LegendImage;
-              } else if (LayerType == "vectorlayer") {
-                switch (VectorLayerPointer.geometryType()) {
-                case Qgis.GeometryType.Point:
-                  return Theme.getThemeVectorIcon('ic_vectorlayer_point_18dp');
-                case Qgis.GeometryType.Line:
-                  return Theme.getThemeVectorIcon('ic_vectorlayer_line_18dp');
-                case Qgis.GeometryType.Polygon:
-                  return Theme.getThemeVectorIcon('ic_vectorlayer_polygon_18dp');
-                case Qgis.GeometryType.Null:
-                case Qgis.GeometryType.Unknown:
-                  return Theme.getThemeVectorIcon('ic_vectorlayer_table_18dp');
+                return LegendImage;
+              } else if (Type == FlatLayerTreeModel.Layer) {
+                if (LayerType == "vectorlayer") {
+                  switch (VectorLayerPointer.geometryType()) {
+                  case Qgis.GeometryType.Point:
+                    return Theme.getThemeVectorIcon('ic_vectorlayer_point_18dp');
+                  case Qgis.GeometryType.Line:
+                    return Theme.getThemeVectorIcon('ic_vectorlayer_line_18dp');
+                  case Qgis.GeometryType.Polygon:
+                    return Theme.getThemeVectorIcon('ic_vectorlayer_polygon_18dp');
+                  case Qgis.GeometryType.Null:
+                  case Qgis.GeometryType.Unknown:
+                    return Theme.getThemeVectorIcon('ic_vectorlayer_table_18dp');
+                  }
+                } else if (LayerType == "rasterlayer") {
+                  return Theme.getThemeVectorIcon('ic_rasterlayer_18dp');
+                } else if (LayerType == "meshlayer") {
+                  return Theme.getThemeVectorIcon('ic_meshlayer_18dp');
+                } else if (LayerType == "vectortilelayer") {
+                  return Theme.getThemeVectorIcon('ic_vectortilelayer_18dp');
+                } else if (LayerType == "annotationlayer") {
+                  return Theme.getThemeVectorIcon('ic_annotationlayer_18dp');
                 }
-              } else if (LayerType == "rasterlayer") {
-                return Theme.getThemeVectorIcon('ic_rasterlayer_18dp');
-              } else if (LayerType == "meshlayer") {
-                return Theme.getThemeVectorIcon('ic_meshlayer_18dp');
-              } else if (LayerType == "vectortilelayer") {
-                return Theme.getThemeVectorIcon('ic_vectortilelayer_18dp');
-              } else if (LayerType == "annotationlayer") {
-                return Theme.getThemeVectorIcon('ic_annotationlayer_18dp');
-              } else if (Type == "group") {
+              } else if (Type == FlatLayerTreeModel.Group) {
                 return Theme.getThemeVectorIcon('ic_group_18dp');
               } else {
                 return '';
               }
             }
-            width: 16
-            height: 16
-            sourceSize.width: 16 * screen.devicePixelRatio
-            sourceSize.height: 16 * screen.devicePixelRatio
-            fillMode: Image.PreserveAspectFit
             opacity: Visible ? 1 : 0.25
           }
         }
 
         Text {
           id: layerName
+          visible: Type != FlatLayerTreeModel.Image
           width: rectangle.width - itemPadding - 46 // legend icon + right padding
           - collapsedState.width - (layerVisibility.isVisible ? layerVisibility.width : -5) - badges.width
           padding: 3
@@ -217,7 +247,7 @@ ListView {
           text: Name
           horizontalAlignment: Text.AlignLeft
           font.pointSize: Theme.tipFont.pointSize
-          font.bold: Type === "group" || (Type === "layer" && VectorLayerPointer && VectorLayerPointer == activeLayer) ? true : false
+          font.bold: Type == FlatLayerTreeModel.Group || (Type == FlatLayerTreeModel.Layer && VectorLayerPointer && VectorLayerPointer == activeLayer) ? true : false
           elide: Text.ElideRight
           opacity: Visible ? 1 : 0.25
           color: {
@@ -232,6 +262,7 @@ ListView {
 
         RowLayout {
           id: badges
+          visible: Type != FlatLayerTreeModel.Image
           anchors.verticalCenter: parent.verticalCenter
           spacing: 4
 
@@ -277,7 +308,7 @@ ListView {
 
           QfToolButton {
             id: invalidBadge
-            property bool isVisible: Type === 'layer' && !IsValid
+            property bool isVisible: Type == FlatLayerTreeModel.Layer && !IsValid
             visible: isVisible
             height: 24
             width: 24
@@ -339,7 +370,7 @@ ListView {
 
           QfToolButton {
             id: snappingBadge
-            property bool isVisible: stateMachine.state === "digitize" && qgisProject.snappingConfig.mode === Qgis.SnappingMode.AdvancedConfiguration && Type === "layer" && LayerType === "vectorlayer" && VectorLayerPointer.geometryType() !== Qgis.GeometryType.Null && VectorLayerPointer.geometryType() !== Qgis.GeometryType.Unknown
+            property bool isVisible: stateMachine.state === "digitize" && qgisProject.snappingConfig.mode === Qgis.SnappingMode.AdvancedConfiguration && Type === FlatLayerTreeModel.Layer && LayerType === "vectorlayer" && VectorLayerPointer.geometryType() !== Qgis.GeometryType.Null && VectorLayerPointer.geometryType() !== Qgis.GeometryType.Unknown
             visible: isVisible
             height: 24
             width: 24

--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -149,7 +149,7 @@ ListView {
             Image {
               id: legendImage
               fillMode: Image.PreserveAspectFit
-              cache: false
+              cache: true
               smooth: true
               mipmap: true
               source: {

--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -163,7 +163,7 @@ ListView {
 
         Item {
           id: layerVisibility
-          property bool isVisible: Type != FlatLayerTreeModel.Image && HasSpatialExtent
+          property bool isVisible: Checkable && HasSpatialExtent
           height: 24
           width: visible ? parent.height : 0
           anchors.verticalCenter: parent.verticalCenter

--- a/src/qml/imports/Theme/Theme.qml
+++ b/src/qml/imports/Theme/Theme.qml
@@ -76,10 +76,11 @@ QtObject {
 
   property color darkRed: "#c0392b"
   property color darkGray: "#212121"
-  property color darkGraySemiOpaque: "#4D212121"
+  property color darkGraySemiOpaque: "#4d212121"
   property color gray: "#888888"
   property color lightGray: "#dddddd"
   property color lightestGray: "#eeeeee"
+  property color lightestGraySemiOpaque: "#e0eeeeee"
   property color light: "#ffffff"
 
   property color errorColor: darkTheme ? "#df3422" : "#c0392b"


### PR DESCRIPTION
This PR implements legend graphic fetching for WMS and ArcMapService layers (as well as any QGIS provider in the future that'll implement the required functions over there).

Screenshot time:

<img width="991" height="763" alt="image" src="https://github.com/user-attachments/assets/2ecddf35-d256-4cb8-96c4-40aea5736560" />

This can provide crucial information to users consuming WMS layers, where the symbology can often be complex and without a legend simply undecipherable. 

While in this part of the code, it was easy to add support for the little-known legend placeholder image option in QGIS. Here's how it looks in QField:

<img width="503" height="350" alt="image" src="https://github.com/user-attachments/assets/b262b073-874f-4406-96b4-025ad3d2826d" />

Here's where users set this up in QGIS:

<img width="845" height="283" alt="image" src="https://github.com/user-attachments/assets/f34e2430-e1be-42bc-8c99-b10510519ef4" />
