### PR TITLE
Redesign dropdown arrow with scalable ShapePath

### DIFF
--- a/src/qml/imports/Theme/QfButton.qml
+++ b/src/qml/imports/Theme/QfButton.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls
 import QtQuick.Controls.impl
 import QtQuick.Controls.Material
 import QtQuick.Controls.Material.impl
+import QtQuick.Shapes
 
 Button {
   id: button
@@ -68,40 +69,35 @@ Button {
     anchors.verticalCenter: parent.verticalCenter
     visible: button.dropdown
 
-    width: 36
     height: parent.height
+    width: height
 
     color: "transparent"
 
-    Rectangle {
-      anchors.left: parent.left
-      anchors.verticalCenter: parent.verticalCenter
-
-      width: 1.5
-      height: parent.height - 16
-      opacity: button.enabled ? 1 : 0.25
-
-      color: button.color
-    }
-
-    Canvas {
+    Shape {
       id: dropdownArrow
       anchors.centerIn: parent
-      implicitWidth: 40
-      implicitHeight: 40
+      width: 20
+      height: 20
       visible: true
       opacity: button.enabled ? 1 : 0.25
 
-      onPaint: {
-        var ctx = getContext("2d");
-        ctx.fillStyle = button.color;
-        ctx.strokeStyle = button.color;
-        ctx.lineWidth = 1;
-        ctx.moveTo(14, 15);
-        ctx.lineTo(width - 16, 15);
-        ctx.lineTo((width / 2) - 1, height - 15);
-        ctx.stroke();
-        ctx.fill();
+      ShapePath {
+        strokeWidth: 2
+        strokeColor: button.color
+        fillColor: "transparent"
+
+        startX: dropdownArrow.width * 0.25
+        startY: dropdownArrow.height * 0.35
+
+        PathLine {
+          x: dropdownArrow.width * 0.5
+          y: dropdownArrow.height * 0.55
+        }
+        PathLine {
+          x: dropdownArrow.width * 0.75
+          y: dropdownArrow.height * 0.35
+        }
       }
     }
 

--- a/src/qml/imports/Theme/QfProgrerssRing.qml
+++ b/src/qml/imports/Theme/QfProgrerssRing.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Shapes
 
 ProgressBar {
   id: control
@@ -9,39 +10,42 @@ ProgressBar {
   property color color: Theme.mainColor
   property color backgroundColor: Theme.lightGray
 
-  background: Rectangle {
-    implicitWidth: control.size
-    implicitHeight: control.size
-    radius: control.width / 2
-    color: "transparent"
-    border.color: control.backgroundColor
-    border.width: control.strokeWidth
+  implicitWidth: control.size
+  implicitHeight: control.size
+
+  background: Shape {
+    anchors.fill: parent
+    ShapePath {
+      strokeWidth: control.strokeWidth
+      strokeColor: control.backgroundColor
+      fillColor: "transparent"
+
+      PathAngleArc {
+        centerX: control.width / 2
+        centerY: control.height / 2
+        radiusX: control.width / 2 - control.strokeWidth / 2
+        radiusY: radiusX
+        startAngle: 0
+        sweepAngle: 360
+      }
+    }
   }
 
-  onVisualPositionChanged: {
-    canvas.requestPaint();
-  }
+  contentItem: Shape {
+    anchors.fill: parent
+    ShapePath {
+      strokeWidth: control.strokeWidth
+      strokeColor: control.color
+      fillColor: "transparent"
+      capStyle: ShapePath.RoundCap
 
-  contentItem: Item {
-    Canvas {
-      id: canvas
-      anchors.fill: parent
-      antialiasing: true
-      renderTarget: Canvas.Image
-      property real radius: control.width / 2 - control.strokeWidth / 2
-
-      onPaint: {
-        var ctx = canvas.getContext("2d");
-        ctx.clearRect(0, 0, canvas.width, canvas.height);
-        ctx.save();
-        ctx.lineWidth = control.strokeWidth;
-        ctx.strokeStyle = control.color;
-        ctx.lineCap = "round";
-        ctx.beginPath();
-        ctx.arc(width / 2, height / 2, radius, -0.5 * Math.PI, -0.5 * Math.PI + control.visualPosition * 2 * Math.PI);
-        ctx.stroke();
-        ctx.closePath();
-        ctx.restore();
+      PathAngleArc {
+        centerX: control.width / 2
+        centerY: control.height / 2
+        radiusX: control.width / 2 - control.strokeWidth / 2
+        radiusY: radiusX
+        startAngle: -90
+        sweepAngle: control.visualPosition * 360
       }
     }
   }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2783,20 +2783,32 @@ ApplicationWindow {
       leftPadding: Theme.menuItemLeftPadding
       rightPadding: 40
 
-      arrow: Canvas {
-        x: parent.width - width
-        y: (parent.height - height) / 2
-        implicitWidth: 40
-        implicitHeight: 40
+      arrow: Shape {
+        id: sensorItemArrowShape
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.rightMargin: width / 2
+        width: 20
+        height: 20
+        visible: true
         opacity: sensorListInstantiator.count > 0 ? 1 : 0
-        onPaint: {
-          var ctx = getContext("2d");
-          ctx.strokeStyle = Theme.mainColor;
-          ctx.lineWidth = 1;
-          ctx.moveTo(15, 15);
-          ctx.lineTo(width - 15, height / 2);
-          ctx.lineTo(15, height - 15);
-          ctx.stroke();
+
+        ShapePath {
+          strokeWidth: 2
+          strokeColor: Theme.mainColor
+          fillColor: "transparent"
+
+          startX: sensorItemArrowShape.width * 0.35
+          startY: sensorItemArrowShape.height * 0.25
+
+          PathLine {
+            x: sensorItemArrowShape.width * 0.65
+            y: sensorItemArrowShape.height * 0.5
+          }
+          PathLine {
+            x: sensorItemArrowShape.width * 0.35
+            y: sensorItemArrowShape.height * 0.75
+          }
         }
       }
 
@@ -3376,20 +3388,31 @@ ApplicationWindow {
       leftPadding: Theme.menuItemLeftPadding
       rightPadding: 40
 
-      arrow: Canvas {
-        x: parent.width - width
-        y: (parent.height - height) / 2
-        implicitWidth: 40
-        implicitHeight: 40
+      arrow: Shape {
+        id: preciseViewArrowShape
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.rightMargin: width / 2
+        width: 20
+        height: 20
         visible: true
-        onPaint: {
-          var ctx = getContext("2d");
-          ctx.strokeStyle = Theme.mainColor;
-          ctx.lineWidth = 1;
-          ctx.moveTo(15, 15);
-          ctx.lineTo(width - 15, height / 2);
-          ctx.lineTo(15, height - 15);
-          ctx.stroke();
+
+        ShapePath {
+          strokeWidth: 2
+          strokeColor: Theme.mainColor
+          fillColor: "transparent"
+
+          startX: preciseViewArrowShape.width * 0.35
+          startY: preciseViewArrowShape.height * 0.25
+
+          PathLine {
+            x: preciseViewArrowShape.width * 0.65
+            y: preciseViewArrowShape.height * 0.5
+          }
+          PathLine {
+            x: preciseViewArrowShape.width * 0.35
+            y: preciseViewArrowShape.height * 0.75
+          }
         }
       }
 


### PR DESCRIPTION
## 🚀 Description
This PR refactors the dropdown arrow in the QfButton component. The previous Canvas-based implementation was replaced with a vector ShapePath, making the arrow scalable, responsive to theme color changes, and visually cleaner.

### ✨ Key Changes
- Replaced `Canvas` with `Shape` for the arrow.
- Arrow automatically adapts to theme changes (color).
- Scales correctly with different button sizes.
- Visual appearance is cleaner and more consistent with Material/modern UI patterns.

### Previous:  

<img width="1065" height="209" alt="image" src="https://github.com/user-attachments/assets/99ef6017-6ee4-463b-8149-271e2b440ef5" />

### New:  

<img width="1067" height="207" alt="image" src="https://github.com/user-attachments/assets/4173e49d-3721-4bd9-8aa8-829ff7f84ba0" />


---

### Previous:    

<img width="477" height="178" alt="Screenshot From 2025-09-06 17-10-29" src="https://github.com/user-attachments/assets/787af9ce-53eb-4e25-b523-756653ed14dc" />

### New:  

<img width="477" height="178" alt="Screenshot From 2025-09-06 17-13-42" src="https://github.com/user-attachments/assets/f20f9cba-9110-4333-952f-83915f5f7a21" />

---

### Previous:    

<img width="477" height="178" alt="Screenshot From 2025-09-06 17-19-34" src="https://github.com/user-attachments/assets/c8ca1239-c77a-4d9e-843d-9f47ffa9a24d" />

### New:  

<img width="477" height="178" alt="Screenshot From 2025-09-06 17-21-01" src="https://github.com/user-attachments/assets/2257e765-4edb-4825-bcbe-89930fee2aca" />
