### PR TITLE
Fix visiblity of the orthometric vertical adjustment combobox item visibility

### DIFF
--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -950,11 +950,18 @@ Page {
                     onClicked: positioningDeviceComboBox.popup.open()
                   }
 
+                  Connections {
+                    target: positionSource
+
+                    function onDeviceIdChanged() {
+                      verticalGridShiftComboBox.reload();
+                    }
+                  }
+
                   onCurrentIndexChanged: {
                     var modelIndex = positioningDeviceModel.index(currentIndex, 0);
                     positioningSettings.positioningDevice = positioningDeviceModel.data(modelIndex, PositioningDeviceModel.DeviceId);
                     positioningSettings.positioningDeviceName = positioningDeviceModel.data(modelIndex, PositioningDeviceModel.DeviceName);
-                    verticalGridShiftComboBox.reload();
                   }
 
                   Component.onCompleted: {
@@ -1546,11 +1553,12 @@ Page {
                       "text": qsTr("None"),
                       "value": Positioning.ElevationCorrectionMode.None
                     });
-                  if (positionSource.deviceCapabilities & AbstractGnssReceiver.OrthometricAltitude)
+                  if ((positionSource.deviceCapabilities & AbstractGnssReceiver.OrthometricAltitude) != 0) {
                     verticalGridShiftComboBox.model.append({
                         "text": qsTr("Orthometric from device"),
                         "value": Positioning.ElevationCorrectionMode.OrthometricFromDevice
                       });
+                  }
 
                   // Add geoid files to combobox
                   var geoidFiles = platformUtilities.availableGrids();
@@ -1563,7 +1571,7 @@ Page {
                     verticalGridShiftComboBox.currentIndex = indexOfValue(positioningSettings.elevationCorrectionMode);
                     positioningSettings.verticalGrid = "";
                   } else if (positioningSettings.elevationCorrectionMode === Positioning.ElevationCorrectionMode.OrthometricFromDevice) {
-                    if (positionSource.deviceCapabilities & AbstractGnssReceiver.OrthometricAltitude)
+                    if ((positionSource.deviceCapabilities & AbstractGnssReceiver.OrthometricAltitude) != 0)
                       verticalGridShiftComboBox.currentIndex = verticalGridShiftComboBox.indexOfValue(positioningSettings.elevationCorrectionMode);
                     else
                       // Orthometric not available -> fallback to None


### PR DESCRIPTION
Fixes https://github.com/opengisch/QField/issues/6471 

Two issues in there, including a wrong flags check as well as an assumption device capacities updates immediately after the device combobox index changes, which it does not these days.