### PR TITLE
Whenever a HTTP 416 is received when partially downloading a file, restart the download from scratch.

### DIFF
--- a/src/core/qfieldcloud/qfieldcloudproject.cpp
+++ b/src/core/qfieldcloud/qfieldcloudproject.cpp
@@ -1232,9 +1232,10 @@ void QFieldCloudProject::downloadFileConnections( const QString &fileKey )
     if ( rawReply->error() != QNetworkReply::NoError )
     {
       const int httpStatus = rawReply->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
-      if ( httpStatus == 416 )
+      if ( httpStatus == 416 && mDownloadFileTransfers[fileKey].retryCount < 3 )
       {
         mDownloadFileTransfers[fileKey].resumableDownload = false;
+        mDownloadFileTransfers[fileKey].retryCount++;
 
         NetworkReply *newReply = downloadFile(
           mDownloadFileTransfers[fileKey].projectId,

--- a/src/core/qfieldcloud/qfieldcloudproject.cpp
+++ b/src/core/qfieldcloud/qfieldcloudproject.cpp
@@ -1231,6 +1231,28 @@ void QFieldCloudProject::downloadFileConnections( const QString &fileKey )
 
     if ( rawReply->error() != QNetworkReply::NoError )
     {
+      const int httpStatus = rawReply->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
+      if ( httpStatus == 416 )
+      {
+        mDownloadFileTransfers[fileKey].resumableDownload = false;
+
+        NetworkReply *newReply = downloadFile(
+          mDownloadFileTransfers[fileKey].projectId,
+          mDownloadFileTransfers[fileKey].fileName,
+          true,
+          true );
+
+        if ( newReply )
+        {
+          mDownloadFileTransfers[fileKey].networkReply = newReply;
+          newReply->setParent( reply );
+          downloadFileConnections( fileKey );
+        }
+
+        reply->abort();
+        return;
+      }
+
       hasError = true;
       errorMessageDetail = QFieldCloudConnection::errorString( rawReply );
       errorMessage = tr( "Network error. Failed to download file `%1`." ).arg( fileKey );
@@ -1375,7 +1397,7 @@ NetworkReply *QFieldCloudProject::downloadFile( const QString &projectId, const 
   if ( partialFile.exists() )
   {
     qint64 partialSize = partialFile.size();
-    if ( partialSize < QFIELDCLOUD_MINIMUM_RANGE_HEADER_LENGTH || partialSize > fileTransfer.bytesTotal || ( partialSize == fileTransfer.bytesTotal ) && fileTransfer.etag != FileUtils::fileEtag( fileTransfer.partialFilePath ) )
+    if ( !fileTransfer.resumableDownload || partialSize < QFIELDCLOUD_MINIMUM_RANGE_HEADER_LENGTH || partialSize > fileTransfer.bytesTotal || ( partialSize == fileTransfer.bytesTotal ) && fileTransfer.etag != FileUtils::fileEtag( fileTransfer.partialFilePath ) )
     {
       // Invalid or dirty file; delete and re-download
       partialFile.remove();

--- a/src/core/qfieldcloud/qfieldcloudproject.h
+++ b/src/core/qfieldcloud/qfieldcloudproject.h
@@ -454,6 +454,7 @@ class QFieldCloudProject : public QObject
         QNetworkReply::NetworkError error = QNetworkReply::NoError;
         int redirectsCount = 0;
         QUrl lastRedirectUrl;
+        bool resumableDownload = true;
     };
 
     //! Tracks the job status (status, error etc) for a particular project. For now 1 project can have only 1 job of a type.

--- a/src/core/qfieldcloud/qfieldcloudproject.h
+++ b/src/core/qfieldcloud/qfieldcloudproject.h
@@ -455,6 +455,7 @@ class QFieldCloudProject : public QObject
         int redirectsCount = 0;
         QUrl lastRedirectUrl;
         bool resumableDownload = true;
+        int retryCount = 0;
     };
 
     //! Tracks the job status (status, error etc) for a particular project. For now 1 project can have only 1 job of a type.

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -764,37 +764,27 @@ Page {
               ColumnLayout {
                 Layout.topMargin: 20
                 Layout.bottomMargin: 20
-                Layout.preferredWidth: projectDetailsCodeContainer.desiredWidth
+                Layout.preferredWidth: projectDetailsCode.desiredWidth
                 Layout.alignment: Qt.AlignHCenter
                 spacing: 5
 
-                Rectangle {
-                  id: projectDetailsCodeContainer
-
-                  property int desiredWidth: Math.min(mainWindow.width - 40, 250)
+                Image {
+                  id: projectDetailsCode
                   Layout.preferredWidth: desiredWidth
                   Layout.preferredHeight: desiredWidth
+                  fillMode: Image.PreserveAspectFit
 
-                  color: "transparent"
-                  radius: 4
-                  border.width: 1
-                  border.color: Theme.mainTextColor
-
-                  Image {
-                    anchors.fill: parent
-                    fillMode: Image.PreserveAspectFit
-
-                    sourceSize.width: projectDetailsCodeContainer.desiredWidth * Screen.devicePixelRatio
-                    sourceSize.height: projectDetailsCodeContainer.desiredWidth * Screen.devicePixelRatio
-                    source: projectDetails.cloudProject != undefined ? "image://barcode/?text=" + encodeURIComponent(UrlUtils.createActionUrl("qfield", "cloud", {
-                          "project": projectDetails.cloudProject.id
-                        })) + "&color=%2380cc28" : ""
-                  }
+                  sourceSize.width: desiredWidth * Screen.devicePixelRatio
+                  sourceSize.height: desiredWidth * Screen.devicePixelRatio
+                  source: projectDetails.cloudProject != undefined ? "image://barcode/?text=" + encodeURIComponent(UrlUtils.createActionUrl("qfield", "cloud", {
+                        "project": projectDetails.cloudProject.id
+                      })) + "&color=%2380cc28" : ""
+                  property int desiredWidth: Math.min(mainWindow.width - 40, 250)
                 }
 
                 Text {
                   id: projectDetailsCodeLabel
-                  Layout.preferredWidth: projectDetailsCodeContainer.desiredWidth - 20
+                  Layout.preferredWidth: projectDetailsCode.desiredWidth - 20
                   font: Theme.tinyFont
                   color: Theme.secondaryTextColor
                   wrapMode: Text.WordWrap
@@ -810,6 +800,7 @@ Page {
         QfButton {
           id: downloadProjectBtn
           Layout.fillWidth: true
+          progressValue: projectDetails.cloudProject ? projectDetails.cloudProject.downloadProgress : 0
           text: {
             if (projectDetails.cloudProject != undefined && projectDetails.cloudProject.status === QFieldCloudProject.ProjectStatus.Downloading) {
               if (projectDetails.cloudProject.packagingStatus === QFieldCloudProject.PackagingBusyStatus) {

--- a/src/qml/imports/Theme/QfButton.qml
+++ b/src/qml/imports/Theme/QfButton.qml
@@ -12,6 +12,7 @@ Button {
   property alias radius: backgroundRectangle.radius
   property alias borderColor: backgroundRectangle.border.color
   property bool dropdown: false
+  property real progressValue: 0.0
 
   signal dropdownClicked
 
@@ -34,6 +35,7 @@ Button {
     radius: 12
     border.width: 1
     border.color: !parent.enabled ? Theme.controlBackgroundDisabledColor : button.bgcolor != "#00000000" ? button.bgcolor : button.color
+    clip: true
 
     Ripple {
       clip: true
@@ -43,6 +45,35 @@ Button {
       anchor: parent
       active: button.down
       color: Theme.darkTheme ? "#22000000" : button.bgcolor == "#ffffff" || button.bgcolor == "#00000000" ? "#10000000" : "#22ffffff"
+    }
+
+    Loader {
+      active: progressValue != 0.0 && progressValue != 1.0
+      sourceComponent: progressComponent
+    }
+
+    Component {
+      id: progressComponent
+      Rectangle {
+        width: backgroundRectangle.width * progressValue
+        height: backgroundRectangle.height
+        radius: backgroundRectangle.radius
+        color: Theme.mainColor
+        clip: true
+
+        Rectangle {
+          width: Math.min(10, parent.width / 2)
+          height: parent.height
+          anchors.right: parent.right
+          color: parent.color
+        }
+
+        Behavior on width  {
+          NumberAnimation {
+            duration: 200
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## 🚀 Description

Improves the robustness of partial file downloads by handling HTTP 416 (Range Not Satisfiable) responses.  
When a server returns HTTP 416, the client now restarts the download from scratch.

### ✨ Key Changes

- Detects HTTP 416 response during partial downloads.
- Removes any invalid or outdated partial files.
- Initiates a full download without the Range header to ensure data integrity.

### NEW Downloading animation


[Screencast From 2025-09-07 19-48-52.webm](https://github.com/user-attachments/assets/55e021c3-bdae-46c2-894f-41108f03044a)
