### PR TITLE
Fix interference between the value relation completer text field and the search popup

### DIFF
--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -59,6 +59,10 @@ Item {
       if (searchableText.typedFilter != '') {
         searchBar.setSearchTerm(searchableText.typedFilter);
       }
+      if (searchableText.focus) {
+        searchableText.text = '';
+        searchableText.focus = false;
+      }
       if (resultsList.contentHeight > resultsList.height) {
         searchBar.focusOnTextField();
       }


### PR DESCRIPTION
This PR fixes https://github.com/opengisch/QField/issues/6631 , whereas the value relation editor completer text field can interfere with the search popup.