### PR TITLE
Insure feature form attribute default values relying on relation_aggregate can update when children are added/removed

### DIFF
--- a/src/core/attributeformmodel.cpp
+++ b/src/core/attributeformmodel.cpp
@@ -90,6 +90,11 @@ void AttributeFormModel::applyParentDefaultValues()
   return mSourceModel->applyParentDefaultValues();
 }
 
+void AttributeFormModel::applyRelationshipDefaultValues()
+{
+  return mSourceModel->applyRelationshipDefaultValues();
+}
+
 bool AttributeFormModel::filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const
 {
   return mSourceModel->data( mSourceModel->index( source_row, 0, source_parent ), CurrentlyVisible ).toBool();

--- a/src/core/attributeformmodel.h
+++ b/src/core/attributeformmodel.h
@@ -109,6 +109,9 @@ class AttributeFormModel : public QSortFilterProxyModel
     //! Applies default values linked to a parent feature
     Q_INVOKABLE void applyParentDefaultValues();
 
+    //! Applies default values linked to relationships
+    Q_INVOKABLE void applyRelationshipDefaultValues();
+
   signals:
     void featureModelChanged();
     void hasTabsChanged();

--- a/src/core/attributeformmodelbase.h
+++ b/src/core/attributeformmodelbase.h
@@ -66,6 +66,9 @@ class AttributeFormModelBase : public QStandardItemModel
     //! \copydoc AttributeFormModel::applyParentDefaultValues
     void applyParentDefaultValues();
 
+    //! \copydoc AttributeFormModel::applyRelationshipDefaultValues
+    void applyRelationshipDefaultValues();
+
   signals:
     void featureModelChanged();
     void hasTabsChanged();

--- a/src/qml/editorwidgets/RelationEditorBase.qml
+++ b/src/qml/editorwidgets/RelationEditorBase.qml
@@ -196,6 +196,7 @@ EditorWidgetBase {
         displayToast(qsTr("Failed to delete referencing feature"), 'error');
       }
       visible = false;
+      form.model.applyRelationshipDefaultValues();
     }
     onRejected: {
       visible = false;
@@ -228,6 +229,7 @@ EditorWidgetBase {
       onFeatureSaved: id => {
         relationEditorModel.featureFocus = id;
         relationEditorModel.reload();
+        form.model.applyRelationshipDefaultValues();
       }
 
       onOpened: {


### PR DESCRIPTION
Fixes https://github.com/opengisch/QField/issues/6625 , which in turn serves as a nice relationship functionality.