### PR TITLE
fix: shared datasets files were not fetched from the shared datasets project

### DIFF
--- a/src/core/qfieldcloud/qfieldcloudproject.cpp
+++ b/src/core/qfieldcloud/qfieldcloudproject.cpp
@@ -949,9 +949,11 @@ void QFieldCloudProject::download()
               }
 
               if ( cloudEtag == localEtag )
+              {
                 continue;
+              }
 
-              prepareDownloadTransfer( mId, fileName, fileSize, cloudEtag );
+              prepareDownloadTransfer( mSharedDatasetsProjectId, fileName, fileSize, cloudEtag );
             }
           }
           emit downloadBytesTotalChanged();


### PR DESCRIPTION
Basically the ID that it was requested was incorrect. This broke in this commit https://github.com/opengisch/QField/commit/ad6b64c9a3f94a1e5c2f85b73071be3056c7a333 and therefore shared datasets did not work throughout the whole 3.7.0 onwards.

Before:
<img width="770" height="1189" alt="image" src="https://github.com/user-attachments/assets/1381ea41-525f-45c4-8054-f9fb511e9f04" />
