### PR TITLE
Show corrected altitude when stamping details onto an image

### DIFF
--- a/src/core/expressionevaluator.cpp
+++ b/src/core/expressionevaluator.cpp
@@ -92,6 +92,15 @@ void ExpressionEvaluator::setAppExpressionContextScopesGenerator( AppExpressionC
   emit appExpressionContextScopesGeneratorChanged();
 }
 
+void ExpressionEvaluator::setVariables( const QVariantMap &variables )
+{
+  if ( mVariables == variables )
+    return;
+
+  mVariables = variables;
+  emit variablesChanged();
+}
+
 QVariant ExpressionEvaluator::evaluate()
 {
   if ( mExpressionText.isEmpty() )
@@ -123,6 +132,15 @@ QVariant ExpressionEvaluator::evaluate()
   if ( mFeature.isValid() )
   {
     expressionContext.setFeature( mFeature );
+  }
+  if ( !mVariables.isEmpty() )
+  {
+    QgsExpressionContextScope *scope = new QgsExpressionContextScope();
+    for ( auto it = mVariables.constKeyValueBegin(); it != mVariables.constKeyValueEnd(); ++it )
+    {
+      scope->addVariable( QgsExpressionContextScope::StaticVariable( it->first, it->second, true, true ) );
+    }
+    expressionContext << scope;
   }
 
   QVariant value;

--- a/src/core/expressionevaluator.h
+++ b/src/core/expressionevaluator.h
@@ -46,6 +46,7 @@ class ExpressionEvaluator : public QObject
     Q_PROPERTY( QgsProject *project READ project WRITE setProject NOTIFY projectChanged )
     Q_PROPERTY( QgsQuickMapSettings *mapSettings READ mapSettings WRITE setMapSettings NOTIFY mapSettingsChanged )
     Q_PROPERTY( AppExpressionContextScopesGenerator *appExpressionContextScopesGenerator READ appExpressionContextScopesGenerator WRITE setAppExpressionContextScopesGenerator NOTIFY appExpressionContextScopesGeneratorChanged )
+    Q_PROPERTY( QVariantMap variables READ variables WRITE setVariables NOTIFY variablesChanged )
 
   public:
     //! Expression evaluator modes
@@ -100,6 +101,12 @@ class ExpressionEvaluator : public QObject
     //! Sets the application expression context scopes \a generator object
     void setAppExpressionContextScopesGenerator( AppExpressionContextScopesGenerator *generator );
 
+    //! Returns the map of variables injected into the expression context when evaluating
+    QVariantMap variables() const { return mVariables; }
+
+    //! Sets the map of variables injected into the expression context when evaluating
+    void setVariables( const QVariantMap &variables );
+
     //! Returns the evaluated expression text value
     Q_INVOKABLE QVariant evaluate();
 
@@ -111,6 +118,7 @@ class ExpressionEvaluator : public QObject
     void projectChanged();
     void mapSettingsChanged();
     void appExpressionContextScopesGeneratorChanged();
+    void variablesChanged();
 
   private:
     Mode mMode = ExpressionMode;
@@ -122,5 +130,6 @@ class ExpressionEvaluator : public QObject
     QgsProject *mProject = nullptr;
     QgsQuickMapSettings *mMapSettings = nullptr;
     QPointer<AppExpressionContextScopesGenerator> mAppExpressionContextScopesGenerator;
+    QVariantMap mVariables;
 };
 #endif // EXPRESSIONEVALUATOR_H


### PR DESCRIPTION
Fixes https://github.com/opengisch/QField/issues/6541 whereas the altitude stamped onto photos were not taking grid corrections into account.

I tried a few approaches, but settled on injecting a pair of variables for now. The underlying addition of a variables property to our expression evaluator object should come in handy in the future too, as well as for plugins.