### PR TITLE
Insure that the feature lists form (auto) zooming respects the fixed scale navigation mode

### DIFF
--- a/src/core/featurelistextentcontroller.h
+++ b/src/core/featurelistextentcontroller.h
@@ -33,6 +33,7 @@ class FeatureListExtentController : public QObject
     Q_PROPERTY( MultiFeatureListModel *model MEMBER mModel NOTIFY modelChanged )
     Q_PROPERTY( FeatureListModelSelection *selection MEMBER mSelection NOTIFY selectionChanged )
     Q_PROPERTY( bool autoZoom MEMBER mAutoZoom NOTIFY autoZoomChanged )
+    Q_PROPERTY( bool keepScale MEMBER mKeepScale NOTIFY keepScaleChanged )
     Q_PROPERTY( QgsQuickMapSettings *mapSettings MEMBER mMapSettings NOTIFY mapSettingsChanged )
 
   public:
@@ -56,6 +57,7 @@ class FeatureListExtentController : public QObject
 
   signals:
     void autoZoomChanged();
+    void keepScaleChanged();
     void selectionChanged();
     void modelChanged();
     void mapSettingsChanged();
@@ -70,6 +72,7 @@ class FeatureListExtentController : public QObject
     FeatureListModelSelection *mSelection = nullptr;
     QgsQuickMapSettings *mMapSettings = nullptr;
     bool mAutoZoom = false;
+    bool mKeepScale = false;
 };
 
 #endif // FEATURELISTEXTENTCONTROLLER_H

--- a/src/core/utils/featureutils.cpp
+++ b/src/core/utils/featureutils.cpp
@@ -78,12 +78,11 @@ QgsRectangle FeatureUtils::extent( QgsQuickMapSettings *mapSettings, QgsVectorLa
 {
   if ( mapSettings && layer && layer->geometryType() != Qgis::GeometryType::Unknown && layer->geometryType() != Qgis::GeometryType::Null )
   {
-    QgsCoordinateTransform transf( layer->crs(), mapSettings->destinationCrs(), mapSettings->mapSettings().transformContext() );
+    QgsCoordinateTransform ct( layer->crs(), mapSettings->destinationCrs(), mapSettings->mapSettings().transformContext() );
     QgsGeometry geom( feature.geometry() );
     if ( !geom.isNull() )
     {
-      geom.transform( transf );
-
+      geom.transform( ct );
       QgsRectangle extent;
       if ( geom.type() == Qgis::GeometryType::Point && geom.constGet()->partCount() == 1 )
       {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3754,6 +3754,8 @@ ApplicationWindow {
       model: featureForm.model
     }
 
+    extentController.keepScale: qfieldSettings.locatorKeepScale
+
     selectionColor: "#ff7777"
 
     onShowMessage: displayToast(message)


### PR DESCRIPTION
Fixes https://github.com/opengisch/QField/issues/5995 as well as an unreported issue with zooming onto features when layer CRS doesn't match with the project CRS.