### PR TITLE
[Backport release-3_7] fix: shared datasets files were not fetched from the shared datasets project

### DIFF
--- a/src/core/qfieldcloud/qfieldcloudproject.cpp
+++ b/src/core/qfieldcloud/qfieldcloudproject.cpp
@@ -949,9 +949,11 @@ void QFieldCloudProject::download()
               }
 
               if ( cloudEtag == localEtag )
+              {
                 continue;
+              }
 
-              prepareDownloadTransfer( mId, fileName, fileSize, cloudEtag );
+              prepareDownloadTransfer( mSharedDatasetsProjectId, fileName, fileSize, cloudEtag );
             }
           }
           emit downloadBytesTotalChanged();


### PR DESCRIPTION
Backport #6636
 **Authored by:** @suricactus