### PR TITLE
Properly handle the absence of support for multipart geometry editing

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3771,13 +3771,13 @@ ApplicationWindow {
       geometryEditingFeature.vertexModel.crs = featureForm.selection.focusedLayer.crs;
       geometryEditingFeature.currentLayer = featureForm.selection.focusedLayer;
       geometryEditingFeature.feature = featureForm.selection.focusedFeature;
-      if (!geometryEditingVertexModel.editingAllowed) {
-        displayToast(qsTr("Editing of multi geometry layer is not supported yet."));
-        geometryEditingVertexModel.clear();
-      } else {
+      if (geometryEditingVertexModel.editingAllowed) {
         featureForm.state = "Hidden";
+        geometryEditorsToolbar.init();
+      } else {
+        displayToast(qsTr("Editing of multipart geometry is not supported yet."), 'warning');
+        geometryEditingVertexModel.clear();
       }
-      geometryEditorsToolbar.init();
     }
 
     Component.onCompleted: focusstack.addFocusTaker(this)


### PR DESCRIPTION
The code was prior to now blocking editing but still initializing the tool, leading to confusing toaster message. The PR also tweaks the warning to properly warn people we can't edit multipart geometry feature but _can_ edit multipart geometry layer provided a given feature geometry has a single part.

This does _not_ fix https://github.com/opengisch/QField/issues/1508 but at least lets the users know the split tool won't work with multipart geometries :)