### PR TITLE
Project localization/translation support

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -209,9 +209,13 @@ int main( int argc, char **argv )
   QgsApplication app( argc, argv, true, profilePath, QStringLiteral( "mobile" ) );
 
   if ( !qfieldTranslatorLoaded || qfieldTranslator.isEmpty() )
+  {
     ( void ) qfieldTranslator.load( QStringLiteral( "qfield_%1" ).arg( QLocale().name() ), QStringLiteral( ":/i18n/" ), "_" );
+  }
   if ( !qtTranslatorLoaded || qtTranslator.isEmpty() )
+  {
     ( void ) qtTranslator.load( QStringLiteral( "qt_%1" ).arg( QLocale().name() ), QStringLiteral( ":/i18n/" ), "_" );
+  }
 
   if ( !customLanguage.isEmpty() )
   {
@@ -221,6 +225,11 @@ int main( int argc, char **argv )
     // Set locale to emit QgsApplication's localeChanged signal
     QgsApplication::setLocale( QLocale() );
   }
+
+  QLocale locale;
+  const QString localeName = locale.name();
+  const int localeTagSeparator = localeName.indexOf( QStringLiteral( "_" ) );
+  QgsApplication::settingsLocaleUserLocale->setValue( localeName.mid( 0, localeTagSeparator ) );
 
   const QString qfieldFontName( qgetenv( "QFIELD_FONT_NAME" ) );
   if ( !qfieldFontName.isEmpty() )

--- a/src/core/localfilesmodel.cpp
+++ b/src/core/localfilesmodel.cpp
@@ -277,6 +277,19 @@ void LocalFilesModel::reloadModel()
             // Skip project preview images
             continue;
           }
+          else if ( suffix == QStringLiteral( "qgs" ) || suffix == QStringLiteral( "qgz" ) )
+          {
+            QRegularExpression re( QStringLiteral( "(.*)_[A-Za-z]{2}" ) );
+            QRegularExpressionMatch match = re.match( fi.completeBaseName() );
+            if ( match.hasMatch() )
+            {
+              if ( items.contains( QStringLiteral( "%1.qgs" ).arg( match.captured( 1 ) ), Qt::CaseInsensitive ) || items.contains( QStringLiteral( "%1.qgz" ).arg( match.captured( 1 ) ), Qt::CaseInsensitive ) )
+              {
+                // Skip translated project, users should always use the original project
+                continue;
+              }
+            }
+          }
           else if ( item == QStringLiteral( "qfield_webdav_configuration.json" ) )
           {
             // Skip QField WebDAV configuration file

--- a/src/core/localfilesmodel.cpp
+++ b/src/core/localfilesmodel.cpp
@@ -290,6 +290,18 @@ void LocalFilesModel::reloadModel()
               }
             }
           }
+          else if ( suffix == QStringLiteral( "zip" ) )
+          {
+            if ( item.endsWith( QStringLiteral( "_attachments.zip" ), Qt::CaseInsensitive ) )
+            {
+              const QString reducedItemName = item.mid( 0, item.size() - 16 );
+              if ( items.contains( QStringLiteral( "%1.qgs" ).arg( reducedItemName ), Qt::CaseInsensitive ) || items.contains( QStringLiteral( "%1.qgz" ).arg( reducedItemName ), Qt::CaseInsensitive ) )
+              {
+                // Skip project attachments sidecar file
+                continue;
+              }
+            }
+          }
           else if ( item == QStringLiteral( "qfield_webdav_configuration.json" ) )
           {
             // Skip QField WebDAV configuration file

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -351,6 +351,7 @@ Page {
               Layout.fillWidth: true
               Layout.leftMargin: 20
               Layout.rightMargin: 20
+              Layout.bottomMargin: 0
 
               columns: 2
               columnSpacing: 0
@@ -429,7 +430,7 @@ Page {
                 color: Theme.mainColor
                 wrapMode: Text.WordWrap
                 Layout.fillWidth: true
-                Layout.topMargin: 5
+                Layout.topMargin: 10
                 Layout.columnSpan: 2
               }
 
@@ -455,10 +456,11 @@ Page {
               Layout.fillWidth: true
               Layout.leftMargin: 20
               Layout.rightMargin: 20
+              Layout.bottomMargin: 0
 
               columns: 2
               columnSpacing: 0
-              rowSpacing: 5
+              rowSpacing: 0
 
               Label {
                 text: qsTr('User Interface')
@@ -552,12 +554,12 @@ Page {
               Layout.fillWidth: true
               Layout.leftMargin: 20
               Layout.rightMargin: 20
-              Layout.topMargin: 5
               Layout.bottomMargin: 5
+              Layout.topMargin: 5
 
               columns: 1
               columnSpacing: 0
-              rowSpacing: 0
+              rowSpacing: 5
 
               visible: platformUtilities.capabilities & PlatformUtilities.AdjustBrightness
 
@@ -600,12 +602,12 @@ Page {
               Layout.fillWidth: true
               Layout.leftMargin: 20
               Layout.rightMargin: 20
+              Layout.bottomMargin: 10
               Layout.topMargin: 5
-              Layout.bottomMargin: 40
 
               columns: 1
               columnSpacing: 0
-              rowSpacing: 5
+              rowSpacing: 10
 
               Label {
                 Layout.fillWidth: true


### PR DESCRIPTION
This PR implements support for localized / translated project files so that QField can speak a lot of languages too (background reading: https://www.opengis.ch/2018/09/11/qgis-speaks-a-lot-of-languages/). This also works with cloud projects, which is reallly nice. 

Contrary to QGIS, we will always display a localized project if the _XX.qm file is present (i.e., we don't require users to overwrite / specify a locale). It will respect the phone / device's OS locale, or the one specified in QField settings panel.

Implements / fixes https://github.com/opengisch/QField/issues/5670