### PR TITLE
Allow QFieldCloud to access Project folder view without opening Project

### DIFF
--- a/src/core/qfieldcloud/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloud/qfieldcloudconnection.cpp
@@ -862,10 +862,6 @@ void QFieldCloudConnection::processPendingAttachments()
           return;
         }
       }
-      if ( httpCode == 201 )
-      {
-        qInfo() << QStringLiteral( "Upload succeeded for %1" ).arg( fileName );
-      }
 
       if ( httpCode != 201 && httpCode != 404 )
       {

--- a/src/core/qfieldcloud/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloud/qfieldcloudconnection.cpp
@@ -862,6 +862,10 @@ void QFieldCloudConnection::processPendingAttachments()
           return;
         }
       }
+      if ( httpCode == 201 )
+      {
+        qInfo() << QStringLiteral( "Upload succeeded for %1" ).arg( fileName );
+      }
 
       if ( httpCode != 201 && httpCode != 404 )
       {

--- a/src/core/qfieldcloud/qfieldcloudconnection.h
+++ b/src/core/qfieldcloud/qfieldcloudconnection.h
@@ -231,6 +231,7 @@ class QFieldCloudConnection : public QObject
     void providerConfigurationChanged();
     void userInformationChanged();
     void pendingAttachmentsUploadFinished();
+    void allAttachmentsWritten();
     void error();
 
     void loginFailed( const QString &reason );

--- a/src/core/qfieldcloud/qfieldcloudconnection.h
+++ b/src/core/qfieldcloud/qfieldcloudconnection.h
@@ -231,7 +231,7 @@ class QFieldCloudConnection : public QObject
     void providerConfigurationChanged();
     void userInformationChanged();
     void pendingAttachmentsUploadFinished();
-    void allAttachmentsWritten();
+    void pendingAttachmentsAdded();
     void error();
 
     void loginFailed( const QString &reason );

--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -68,13 +68,30 @@ bool QFieldCloudUtils::isCloudAction( const QgsMapLayer *layer )
 
 const QString QFieldCloudUtils::getProjectId( const QString &fileName )
 {
-  QFileInfo fi( fileName );
-  QDir baseDir = fi.isDir() ? fi.canonicalFilePath() : fi.canonicalPath();
-  QString basePath = QFileInfo( baseDir.path() ).canonicalFilePath();
-  QString cloudPath = QFileInfo( localCloudDirectory() ).canonicalFilePath();
+  if ( fileName.isEmpty() )
+    return QString();
 
-  if ( !cloudPath.isEmpty() && basePath.startsWith( cloudPath ) )
-    return baseDir.dirName();
+  const QString path = QFileInfo( fileName ).canonicalFilePath();
+  if ( path.isEmpty() )
+    return QString();
+
+  const QString cloudPath = QFieldCloudUtils::localCloudDirectory();
+  if ( cloudPath.isEmpty() || !path.startsWith( cloudPath ) )
+    return QString();
+
+  const QRegularExpression re(
+    QStringLiteral( "^%1[/\\\\]([^/\\\\]+)[/\\\\]([^/\\\\]+)" )
+      .arg( QRegularExpression::escape( cloudPath ) ) );
+  const QRegularExpressionMatch match = re.match( path, 0,
+                                                  QRegularExpression::NormalMatch, QRegularExpression::AnchoredMatchOption );
+
+  if ( match.hasMatch() )
+  {
+    const QString username = match.captured( 1 );
+    const QString projectId = match.captured( 2 );
+    Q_UNUSED( username );
+    return projectId;
+  }
 
   return QString();
 }

--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -83,7 +83,7 @@ const QString QFieldCloudUtils::getProjectId( const QString &fileName )
     QStringLiteral( "^%1[/\\\\]([^/\\\\]+)[/\\\\]([^/\\\\]+)" )
       .arg( QRegularExpression::escape( cloudPath ) ) );
   const QRegularExpressionMatch match = re.match( path, 0,
-                                                  QRegularExpression::NormalMatch, QRegularExpression::AnchoredMatchOption );
+                                                  QRegularExpression::NormalMatch, QRegularExpression::AnchorAtOffsetMatchOption );
 
   if ( match.hasMatch() )
   {

--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -87,9 +87,7 @@ const QString QFieldCloudUtils::getProjectId( const QString &fileName )
 
   if ( match.hasMatch() )
   {
-    const QString username = match.captured( 1 );
     const QString projectId = match.captured( 2 );
-    Q_UNUSED( username );
     return projectId;
   }
 

--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -40,6 +40,11 @@ const QString QFieldCloudUtils::localCloudDirectory()
   QString cloudDirectoryPath = sLocalCloudDirectory.isNull()
                                  ? PlatformUtilities::instance()->systemLocalDataLocation( QStringLiteral( "cloud_projects" ) )
                                  : sLocalCloudDirectory;
+  // Remove trailing '/' or '\' if present
+  while ( !cloudDirectoryPath.isEmpty() && ( cloudDirectoryPath.endsWith( '/' ) || cloudDirectoryPath.endsWith( '\\' ) ) )
+  {
+    cloudDirectoryPath.chop( 1 );
+  }
   return cloudDirectoryPath;
 }
 

--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -85,15 +85,14 @@ const QString QFieldCloudUtils::getProjectId( const QString &fileName )
     return QString();
 
   const QRegularExpression re(
-    QStringLiteral( "^%1[/\\\\]([^/\\\\]+)[/\\\\]([^/\\\\]+)" )
+    QStringLiteral( "^%1[/\\\\][^/\\\\]+[/\\\\]([^/\\\\]+)" )
       .arg( QRegularExpression::escape( cloudPath ) ) );
   const QRegularExpressionMatch match = re.match( path, 0,
                                                   QRegularExpression::NormalMatch, QRegularExpression::AnchorAtOffsetMatchOption );
 
   if ( match.hasMatch() )
   {
-    const QString projectId = match.captured( 2 );
-    return projectId;
+    return match.captured( 1 );
   }
 
   return QString();

--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -288,7 +288,7 @@ void QFieldCloudUtils::writeToAttachmentsFile( const QString &username, const QS
     attachmentsFile.close();
 
     if ( cloudConnection )
-      emit cloudConnection->allAttachmentsWritten();
+      emit cloudConnection->pendingAttachmentsAdded();
   }
 }
 

--- a/src/core/utils/qfieldcloudutils.h
+++ b/src/core/utils/qfieldcloudutils.h
@@ -159,7 +159,7 @@ class QFieldCloudUtils : public QObject
   private:
     static inline const QString errorCodeOverQuota { QStringLiteral( "over_quota" ) };
 
-    static void writeToAttachmentsFile( const QString &username, const QString &projectId, const QStringList &fileNames, const QHash<QString, QString> *fileChecksumMap, const bool &checkSumCheck );
+    static void writeToAttachmentsFile( const QString &username, const QString &projectId, const QStringList &fileNames, const QHash<QString, QString> *fileChecksumMap, const bool &checkSumCheck, QFieldCloudConnection *cloudConnection = nullptr );
 
     static void writeFilesFromDirectory( const QString &dirPath, const QString &projectId, const QHash<QString, QString> *fileChecksumMap, const bool &checkSumCheck, QTextStream &attachmentsStream );
 

--- a/src/core/utils/qfieldcloudutils.h
+++ b/src/core/utils/qfieldcloudutils.h
@@ -90,7 +90,7 @@ class QFieldCloudUtils : public QObject
     /**
      * Returns the path to the local cloud directory.
      * By default inside the user profile unless overwritten with setLocalCloudDirectory
-     * Ensures the returned path does NOT have a trailing '/' or '\' to avoid issues with regex operations.
+     * \note The returned path will never have have a trailing '/' or '\' .
      */
     static const QString localCloudDirectory();
 

--- a/src/core/utils/qfieldcloudutils.h
+++ b/src/core/utils/qfieldcloudutils.h
@@ -107,10 +107,14 @@ class QFieldCloudUtils : public QObject
     static bool isCloudAction( const QgsMapLayer *layer );
 
     /**
-     * Returns the cloud project id.
+     * Returns the cloud project ID for a given file path.
      *
-     * @param fileName file name of the project to be checked
-     * @return const QString either UUID-like string or a null string in case of failure
+     * This function checks if the given file path is under the QField local cloud
+     * directory. If it is, it extracts and returns the project ID (UUID-like string)
+     * from the path. Otherwise, it returns a null QString.
+     *
+     * @param fileName Full path to a file or directory inside a cloud project
+     * @return QString Project ID if found; otherwise, an empty string
      */
     Q_INVOKABLE static const QString getProjectId( const QString &fileName );
 

--- a/src/core/utils/qfieldcloudutils.h
+++ b/src/core/utils/qfieldcloudutils.h
@@ -90,6 +90,7 @@ class QFieldCloudUtils : public QObject
     /**
      * Returns the path to the local cloud directory.
      * By default inside the user profile unless overwritten with setLocalCloudDirectory
+     * Ensures the returned path does NOT have a trailing '/' or '\' to avoid issues with regex operations.
      */
     static const QString localCloudDirectory();
 

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -12,6 +12,7 @@ Page {
   id: qfieldCloudScreen
 
   signal finished
+  signal openProjectFolder(string projectPath)
 
   property LayerObserver layerObserver
   property string requestedProjectDetails: ""
@@ -471,6 +472,7 @@ Page {
                     projectActions.projectLocalPath = LocalPath;
                     downloadProject.visible = LocalPath === '' && Status !== QFieldCloudProject.ProjectStatus.Downloading;
                     openProject.visible = LocalPath !== '';
+                    openProjectFolder.visible = LocalPath !== '';
                     removeProject.visible = LocalPath !== '';
                     cancelDownloadProject.visible = Status === QFieldCloudProject.ProjectStatus.Downloading;
                     projectActions.popup(gc.x + width - projectActions.width, gc.y - height);
@@ -939,6 +941,20 @@ Page {
           qfieldCloudScreen.visible = false;
           iface.loadFile(projectActions.projectLocalPath);
         }
+      }
+    }
+
+    MenuItem {
+      id: openProjectFolder
+
+      font: Theme.defaultFont
+      width: parent.width
+      height: visible ? 48 : 0
+      leftPadding: Theme.menuItemLeftPadding
+
+      text: qsTr("Open Project Folder")
+      onTriggered: {
+        qfieldCloudScreen.openProjectFolder(projectActions.projectLocalPath);
       }
     }
 

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -954,6 +954,7 @@ Page {
 
       text: qsTr("View Project Folder")
       onTriggered: {
+        cloudProjectsModel.currentProjectId = QFieldCloudUtils.getProjectId(projectActions.projectLocalPath);
         qfieldCloudScreen.viewProjectFolder(projectActions.projectLocalPath);
       }
     }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -968,12 +968,7 @@ Page {
 
       text: qsTr("Remove Stored Project")
       onTriggered: {
-        cloudProjectsModel.removeLocalProject(projectActions.projectId);
-        iface.removeRecentProject(projectActions.projectLocalPath);
-        welcomeScreen.model.reloadModel();
-        if (projectActions.projectLocalPath === qgisProject.fileName) {
-          iface.clearProject();
-        }
+        confirmRemoveDialog.open();
       }
     }
 
@@ -987,6 +982,28 @@ Page {
       onTriggered: {
         cloudProjectsModel.projectCancelDownload(projectActions.projectId);
       }
+    }
+  }
+
+  QfDialog {
+    id: confirmRemoveDialog
+    parent: mainWindow.contentItem
+    title: removeProject.text
+    Label {
+      width: parent.width
+      wrapMode: Text.WordWrap
+      text: qsTr("Are you sure you want to remove `%1`?").arg(projectActions.projectName)
+    }
+    onAccepted: {
+      cloudProjectsModel.removeLocalProject(projectActions.projectId);
+      iface.removeRecentProject(projectActions.projectLocalPath);
+      welcomeScreen.model.reloadModel();
+      if (projectActions.projectLocalPath === qgisProject.fileName) {
+        iface.clearProject();
+      }
+    }
+    onRejected: {
+      visible = false;
     }
   }
 

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -12,7 +12,7 @@ Page {
   id: qfieldCloudScreen
 
   signal finished
-  signal openProjectFolder(string projectPath)
+  signal viewProjectFolder(string projectPath)
 
   property LayerObserver layerObserver
   property string requestedProjectDetails: ""
@@ -472,7 +472,7 @@ Page {
                     projectActions.projectLocalPath = LocalPath;
                     downloadProject.visible = LocalPath === '' && Status !== QFieldCloudProject.ProjectStatus.Downloading;
                     openProject.visible = LocalPath !== '';
-                    openProjectFolder.visible = LocalPath !== '';
+                    viewProjectFolder.visible = LocalPath !== '';
                     removeProject.visible = LocalPath !== '';
                     cancelDownloadProject.visible = Status === QFieldCloudProject.ProjectStatus.Downloading;
                     projectActions.popup(gc.x + width - projectActions.width, gc.y - height);
@@ -945,16 +945,16 @@ Page {
     }
 
     MenuItem {
-      id: openProjectFolder
+      id: viewProjectFolder
 
       font: Theme.defaultFont
       width: parent.width
       height: visible ? 48 : 0
       leftPadding: Theme.menuItemLeftPadding
 
-      text: qsTr("Open Project Folder")
+      text: qsTr("View Project Folder")
       onTriggered: {
-        qfieldCloudScreen.openProjectFolder(projectActions.projectLocalPath);
+        qfieldCloudScreen.viewProjectFolder(projectActions.projectLocalPath);
       }
     }
 

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -954,7 +954,6 @@ Page {
 
       text: qsTr("View Project Folder")
       onTriggered: {
-        cloudProjectsModel.currentProjectId = QFieldCloudUtils.getProjectId(projectActions.projectLocalPath);
         qfieldCloudScreen.viewProjectFolder(projectActions.projectLocalPath);
       }
     }

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -491,12 +491,9 @@ Page {
 
         text: qsTr("Push to QFieldCloud")
         onTriggered: {
+          pushFilesToQFieldCloudConnection.enabled = true;
+          pushFilesToQFieldCloudConnection.sendingItem = true;
           QFieldCloudUtils.addPendingAttachments(cloudConnection.userInformation.username, cloudProjectsModel.currentProjectId, [itemMenu.itemPath], cloudConnection, true);
-          cloudConnection.onPendingAttachmentsAdded.connect(function handler() {
-              platformUtilities.uploadPendingAttachments(cloudConnection);
-              displayToast(qsTr("‘%1’ is being uploaded to QFieldCloud").arg(FileUtils.fileName(itemMenu.itemPath)));
-              cloudConnection.onPendingAttachmentsAdded.disconnect(handler);
-            });
         }
       }
 
@@ -882,17 +879,32 @@ Page {
             }
           }
           if (fileNames.length > 0) {
+            pushFilesToQFieldCloudConnection.enabled = true;
             QFieldCloudUtils.addPendingAttachments(cloudConnection.userInformation.username, cloudProjectsModel.currentProjectId, fileNames, cloudConnection, true);
-            cloudConnection.onPendingAttachmentsAdded.connect(function handler() {
-                platformUtilities.uploadPendingAttachments(cloudConnection);
-                localFilesModel.clearSelection();
-                cloudConnection.onPendingAttachmentsAdded.disconnect(handler);
-              });
           } else {
             displayToast(qsTr("Please select one or more files to push to QFieldCloud."));
           }
         }
       }
+    }
+  }
+
+  Connections {
+    id: pushFilesToQFieldCloudConnection
+    enabled: false
+    target: cloudConnection
+
+    property bool sendingItem: false
+
+    function onPendingAttachmentsAdded() {
+      platformUtilities.uploadPendingAttachments(cloudConnection);
+      if (pushFilesToQFieldCloudConnection.sendingItem) {
+        displayToast(qsTr("‘%1’ is being uploaded to QFieldCloud").arg(FileUtils.fileName(itemMenu.itemPath)));
+        pushFilesToQFieldCloudConnection.sendingItem = false;
+      } else {
+        localFilesModel.clearSelection();
+      }
+      pushFilesToQFieldCloudConnection.enabled = false;
     }
   }
 

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -493,7 +493,7 @@ Page {
         onTriggered: {
           pushFilesToQFieldCloudConnection.enabled = true;
           pushFilesToQFieldCloudConnection.sendingItem = true;
-          QFieldCloudUtils.addPendingAttachments(cloudConnection.userInformation.username, cloudProjectsModel.currentProjectId, [itemMenu.itemPath], cloudConnection, true);
+          QFieldCloudUtils.addPendingAttachments(cloudConnection.userInformation.username, QFieldCloudUtils.getProjectId(table.model.currentPath), [itemMenu.itemPath], cloudConnection, true);
         }
       }
 
@@ -880,7 +880,7 @@ Page {
           }
           if (fileNames.length > 0) {
             pushFilesToQFieldCloudConnection.enabled = true;
-            QFieldCloudUtils.addPendingAttachments(cloudConnection.userInformation.username, cloudProjectsModel.currentProjectId, fileNames, cloudConnection, true);
+            QFieldCloudUtils.addPendingAttachments(cloudConnection.userInformation.username, QFieldCloudUtils.getProjectId(table.model.currentPath), fileNames, cloudConnection, true);
           } else {
             displayToast(qsTr("Please select one or more files to push to QFieldCloud."));
           }

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -882,9 +882,12 @@ Page {
             }
           }
           if (fileNames.length > 0) {
-            QFieldCloudUtils.addPendingAttachments(projectInfo.cloudUserInformation.username, cloudProjectsModel.currentProjectId, fileNames, cloudConnection, true);
-            platformUtilities.uploadPendingAttachments(cloudConnection);
-            localFilesModel.clearSelection();
+            QFieldCloudUtils.addPendingAttachments(cloudConnection.userInformation.username, cloudProjectsModel.currentProjectId, fileNames, cloudConnection, true);
+            cloudConnection.onAllAttachmentsWritten.connect(function handler() {
+                platformUtilities.uploadPendingAttachments(cloudConnection);
+                localFilesModel.clearSelection();
+                cloudConnection.onAllAttachmentsWritten.disconnect(handler);
+              });
           } else {
             displayToast(qsTr("Please select one or more files to push to QFieldCloud."));
           }

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -481,7 +481,7 @@ Page {
 
       MenuItem {
         id: pushDatasetToCloud
-        enabled: (itemMenu.itemMetaType == LocalFilesModel.Dataset && itemMenu.itemType == LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId) || (itemMenu.itemMetaType == LocalFilesModel.Folder && itemMenu.itemWithinQFieldCloudProjectFolder)
+        enabled: (itemMenu.itemMetaType == LocalFilesModel.File) || (itemMenu.itemMetaType == LocalFilesModel.Dataset && itemMenu.itemType == LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId) || (itemMenu.itemMetaType == LocalFilesModel.Folder && itemMenu.itemWithinQFieldCloudProjectFolder)
         visible: enabled
 
         font: Theme.defaultFont
@@ -491,9 +491,12 @@ Page {
 
         text: qsTr("Push to QFieldCloud")
         onTriggered: {
-          QFieldCloudUtils.addPendingAttachments(projectInfo.cloudUserInformation.username, cloudProjectsModel.currentProjectId, [itemMenu.itemPath], cloudConnection, true);
-          platformUtilities.uploadPendingAttachments(cloudConnection);
-          displayToast(qsTr("‘%1’ is being uploaded to QFieldCloud").arg(FileUtils.fileName(itemMenu.itemPath)));
+          QFieldCloudUtils.addPendingAttachments(cloudConnection.userInformation.username, cloudProjectsModel.currentProjectId, [itemMenu.itemPath], cloudConnection, true);
+          cloudConnection.onAllAttachmentsWritten.connect(function handler() {
+              platformUtilities.uploadPendingAttachments(cloudConnection);
+              displayToast(qsTr("‘%1’ is being uploaded to QFieldCloud").arg(FileUtils.fileName(itemMenu.itemPath)));
+              cloudConnection.onAllAttachmentsWritten.disconnect(handler);
+            });
         }
       }
 

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -492,7 +492,7 @@ Page {
         text: qsTr("Push to QFieldCloud")
         onTriggered: {
           pushFilesToQFieldCloudConnection.enabled = true;
-          pushFilesToQFieldCloudConnection.sendingItem = true;
+          pushFilesToQFieldCloudConnection.sendingMultiple = true;
           QFieldCloudUtils.addPendingAttachments(cloudConnection.userInformation.username, QFieldCloudUtils.getProjectId(table.model.currentPath), [itemMenu.itemPath], cloudConnection, true);
         }
       }
@@ -894,15 +894,16 @@ Page {
     enabled: false
     target: cloudConnection
 
-    property bool sendingItem: false
+    property bool sendingMultiple: false
 
     function onPendingAttachmentsAdded() {
       platformUtilities.uploadPendingAttachments(cloudConnection);
-      if (pushFilesToQFieldCloudConnection.sendingItem) {
+      if (pushFilesToQFieldCloudConnection.sendingMultiple) {
         displayToast(qsTr("‘%1’ is being uploaded to QFieldCloud").arg(FileUtils.fileName(itemMenu.itemPath)));
-        pushFilesToQFieldCloudConnection.sendingItem = false;
+        pushFilesToQFieldCloudConnection.sendingMultiple = false;
       } else {
         localFilesModel.clearSelection();
+        displayToast(qsTr("Items being uploaded to QFieldCloud"));
       }
       pushFilesToQFieldCloudConnection.enabled = false;
     }

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -448,7 +448,7 @@ Page {
       MenuItem {
         id: viewFile
 
-        enabled: true
+        enabled: itemMenu.itemMetaType != LocalFilesModel.Folder
         visible: enabled
 
         font: Theme.defaultFont
@@ -456,7 +456,7 @@ Page {
         height: enabled ? 48 : 0
         leftPadding: Theme.menuItemLeftPadding
 
-        text: qsTr("View")
+        text: qsTr("View file")
         onTriggered: {
           platformUtilities.open(itemMenu.itemPath);
         }

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -492,10 +492,10 @@ Page {
         text: qsTr("Push to QFieldCloud")
         onTriggered: {
           QFieldCloudUtils.addPendingAttachments(cloudConnection.userInformation.username, cloudProjectsModel.currentProjectId, [itemMenu.itemPath], cloudConnection, true);
-          cloudConnection.onAllAttachmentsWritten.connect(function handler() {
+          cloudConnection.onPendingAttachmentsAdded.connect(function handler() {
               platformUtilities.uploadPendingAttachments(cloudConnection);
               displayToast(qsTr("‘%1’ is being uploaded to QFieldCloud").arg(FileUtils.fileName(itemMenu.itemPath)));
-              cloudConnection.onAllAttachmentsWritten.disconnect(handler);
+              cloudConnection.onPendingAttachmentsAdded.disconnect(handler);
             });
         }
       }
@@ -883,10 +883,10 @@ Page {
           }
           if (fileNames.length > 0) {
             QFieldCloudUtils.addPendingAttachments(cloudConnection.userInformation.username, cloudProjectsModel.currentProjectId, fileNames, cloudConnection, true);
-            cloudConnection.onAllAttachmentsWritten.connect(function handler() {
+            cloudConnection.onPendingAttachmentsAdded.connect(function handler() {
                 platformUtilities.uploadPendingAttachments(cloudConnection);
                 localFilesModel.clearSelection();
-                cloudConnection.onAllAttachmentsWritten.disconnect(handler);
+                cloudConnection.onPendingAttachmentsAdded.disconnect(handler);
               });
           } else {
             displayToast(qsTr("Please select one or more files to push to QFieldCloud."));

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -445,6 +445,23 @@ Page {
       bottomMargin: sceneBottomMargin
       paddingMultiplier: 2
 
+      MenuItem {
+        id: viewFile
+
+        enabled: true
+        visible: enabled
+
+        font: Theme.defaultFont
+        width: parent.width
+        height: enabled ? 48 : 0
+        leftPadding: Theme.menuItemLeftPadding
+
+        text: qsTr("View")
+        onTriggered: {
+          platformUtilities.open(itemMenu.itemPath);
+        }
+      }
+
       // File items
       MenuItem {
         id: sendDatasetTo

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -4359,6 +4359,12 @@ ApplicationWindow {
     }
 
     Component.onCompleted: focusstack.addFocusTaker(this)
+
+    onOpenProjectFolder: projectPath => {
+      qfieldLocalDataPickerScreen.projectFolderView = true;
+      qfieldLocalDataPickerScreen.model.resetToPath(projectPath);
+      qfieldLocalDataPickerScreen.visible = true;
+    }
   }
 
   QFieldCloudPopup {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -4360,7 +4360,7 @@ ApplicationWindow {
 
     Component.onCompleted: focusstack.addFocusTaker(this)
 
-    onOpenProjectFolder: projectPath => {
+    onViewProjectFolder: projectPath => {
       qfieldLocalDataPickerScreen.projectFolderView = true;
       qfieldLocalDataPickerScreen.model.resetToPath(projectPath);
       qfieldLocalDataPickerScreen.visible = true;


### PR DESCRIPTION
### 🚀 Description

This pull request enhances **QFieldCloud** by enabling access to the Project folder view without opening the project. It also adds **confirmation** when deleting projects and introduces **file viewing** directly from the folder view.

### ✨ Key Changes

* **Folder view:** Added support for accessing the folder view independently of the project's open state.
* **Confirmation:** Implemented a delete confirmation dialog to prevent accidental deletions.
* **File viewing:** Introduced a "View file" option for directly previewing files.

### Demo
[Screencast From 2025-09-13 16-46-47.webm](https://github.com/user-attachments/assets/6484a58f-ab1a-400c-8df7-67d56d1399de)
