### PR TITLE
Project creation core functionality

### DIFF
--- a/src/core/platforms/platformutilities.cpp
+++ b/src/core/platforms/platformutilities.cpp
@@ -108,6 +108,7 @@ void PlatformUtilities::afterUpdate()
   }
 
   QDir applicationDir( applicationDirectory() );
+  applicationDir.mkpath( QStringLiteral( "Created Projects" ) );
   applicationDir.mkpath( QStringLiteral( "Imported Projects" ) );
   applicationDir.mkpath( QStringLiteral( "Imported Datasets" ) );
 }

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -1036,8 +1036,7 @@ void QgisMobileapp::readProjectFile()
           mProject->clear();
 
           // Add a default basemap
-          QgsRasterLayer *layer = new QgsRasterLayer( QStringLiteral( "type=xyz&tilePixelRatio=1&url=https://tile.openstreetmap.org/%7Bz%7D/%7Bx%7D/%7By%7D.png&zmax=19&zmin=0&crs=EPSG3857" ), QStringLiteral( "OpenStreetMap" ), QLatin1String( "wms" ) );
-          mProject->addMapLayers( QList<QgsMapLayer *>() << layer );
+          mProject->addMapLayers( QList<QgsMapLayer *>() << LayerUtils::createBasemap() );
         }
       }
 
@@ -1080,46 +1079,12 @@ void QgisMobileapp::readProjectFile()
       vlayer->loadDefaultStyle( ok );
       if ( !ok )
       {
-        bool hasSymbol = true;
-        Qgis::SymbolType symbolType;
-        switch ( vlayer->geometryType() )
-        {
-          case Qgis::GeometryType::Point:
-            symbolType = Qgis::SymbolType::Marker;
-            break;
-          case Qgis::GeometryType::Line:
-            symbolType = Qgis::SymbolType::Line;
-            break;
-          case Qgis::GeometryType::Polygon:
-            symbolType = Qgis::SymbolType::Fill;
-            break;
-          case Qgis::GeometryType::Unknown:
-            hasSymbol = false;
-            break;
-          case Qgis::GeometryType::Null:
-            hasSymbol = false;
-            break;
-        }
-
-        if ( hasSymbol )
-        {
-          QgsSymbol *symbol = mProject->styleSettings()->defaultSymbol( symbolType );
-          if ( !symbol )
-            symbol = LayerUtils::defaultSymbol( vlayer );
-          QgsSingleSymbolRenderer *renderer = new QgsSingleSymbolRenderer( symbol );
-          vlayer->setRenderer( renderer );
-        }
+        LayerUtils::setDefaultRenderer( vlayer, mProject );
       }
 
       if ( !vlayer->labeling() )
       {
-        QgsTextFormat textFormat = mProject->styleSettings()->defaultTextFormat();
-        QgsAbstractVectorLayerLabeling *labeling = LayerUtils::defaultLabeling( vlayer, textFormat );
-        if ( labeling )
-        {
-          vlayer->setLabeling( labeling );
-          vlayer->setLabelsEnabled( vlayer->geometryType() == Qgis::GeometryType::Point );
-        }
+        LayerUtils::setDefaultLabeling( vlayer, mProject );
       }
 
       const QgsFields fields = vlayer->fields();

--- a/src/core/utils/layerutils.h
+++ b/src/core/utils/layerutils.h
@@ -27,6 +27,8 @@ class QgsVectorLayer;
 class QgsRasterLayer;
 class QgsSymbol;
 
+#define OPENSTREETMAP_URL QStringLiteral( "type=xyz&tilePixelRatio=1&url=https://tile.openstreetmap.org/%7Bz%7D/%7Bx%7D/%7By%7D.png&zmax=19&zmin=0&crs=EPSG3857" )
+
 /**
  * A class providing a feature iterator interface to be used within QML/javascript environment.
  *
@@ -99,9 +101,15 @@ class LayerUtils : public QObject
     */
     static QgsSymbol *defaultSymbol( QgsVectorLayer *layer );
 
+    static void setDefaultRenderer( QgsVectorLayer *layer, QgsProject *project = nullptr );
+
     static QgsAbstractVectorLayerLabeling *defaultLabeling( QgsVectorLayer *layer, QgsTextFormat textFormat = QgsTextFormat() );
 
+    static void setDefaultLabeling( QgsVectorLayer *layer, QgsProject *project = nullptr );
+
     static QgsRasterLayer *createOnlineElevationLayer();
+
+    static QgsMapLayer *createBasemap( const QString &style = QString() );
 
     /**
     * Returns TRUE if the vector layer is used as an atlas coverage layer in

--- a/src/core/utils/layerutils.h
+++ b/src/core/utils/layerutils.h
@@ -101,14 +101,29 @@ class LayerUtils : public QObject
     */
     static QgsSymbol *defaultSymbol( QgsVectorLayer *layer );
 
+    /**
+     * Sets the default symbology render for a given \a layer.
+     */
     static void setDefaultRenderer( QgsVectorLayer *layer, QgsProject *project = nullptr );
 
+    /**
+     * Returns the default vector layer labeling for a given \a layer and \a textFormat.
+     */
     static QgsAbstractVectorLayerLabeling *defaultLabeling( QgsVectorLayer *layer, QgsTextFormat textFormat = QgsTextFormat() );
 
+    /**
+     * Sets the default labeling for a given \a layer.
+     */
     static void setDefaultLabeling( QgsVectorLayer *layer, QgsProject *project = nullptr );
 
+    /**
+     * Creats an online raster elevation layer.
+     */
     static QgsRasterLayer *createOnlineElevationLayer();
 
+    /**
+     * Creates an online basemap layer.
+     */
     static QgsMapLayer *createBasemap( const QString &style = QString() );
 
     /**

--- a/src/core/utils/projectutils.cpp
+++ b/src/core/utils/projectutils.cpp
@@ -14,9 +14,17 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "layerutils.h"
+#include "platformutilities.h"
 #include "projectutils.h"
 
 #include <qgsmaplayer.h>
+#include <qgsprojectdisplaysettings.h>
+#include <qgsrasterlayer.h>
+#include <qgsvectorfilewriter.h>
+#include <qgsvectorlayer.h>
+#include <qgsvectortilelayer.h>
+#include <qgsvectortileutils.h>
 
 ProjectUtils::ProjectUtils( QObject *parent )
   : QObject( parent )
@@ -52,4 +60,259 @@ QString ProjectUtils::title( QgsProject *project )
     return QString();
 
   return project->title();
+}
+
+QString ProjectUtils::createProject( const QVariantMap &options )
+{
+  QString projectTitle = options.value( QStringLiteral( "title" ), tr( "Created Project" ) ).toString();
+  QString projectFilename = projectTitle;
+  projectFilename.replace( QRegularExpression( "[^A-Za-z0-9_]" ), QStringLiteral( "_" ) );
+
+  QDir createdProjectsDir( QStringLiteral( "%1/Created Projects/" ).arg( PlatformUtilities::instance()->applicationDirectory() ) );
+  QString createdProjectDir = createdProjectsDir.filePath( projectFilename );
+  int uniqueSuffix = 2;
+  while ( QFileInfo::exists( createdProjectDir ) )
+  {
+    createdProjectDir = QStringLiteral( "%1_%2" ).arg( createdProjectsDir.filePath( projectFilename ), QString::number( uniqueSuffix++ ) );
+  }
+  createdProjectsDir.mkpath( createdProjectDir );
+  const QString projectFilepath = QStringLiteral( "%1/%2.qgz" ).arg( createdProjectDir, projectFilename );
+
+  QList<QgsMapLayer *> createdProjectLayers;
+  QgsProject *createdProject = new QgsProject();
+
+  // Basic project settings
+  createdProject->setCrs( QgsCoordinateReferenceSystem( "EPSG:3857" ) );
+  createdProject->displaySettings()->setCoordinateType( Qgis::CoordinateDisplayType::CustomCrs );
+  createdProject->displaySettings()->setCoordinateCustomCrs( QgsCoordinateReferenceSystem( "EPSG:4326" ) );
+
+  // Notes layer
+  QgsVectorLayer *notesLayer = nullptr;
+  if ( options.value( QStringLiteral( "notes" ) ).toBool() )
+  {
+    const QString notesFilepath = QStringLiteral( "%1/notes.gpkg" ).arg( createdProjectDir );
+
+    QgsFields fields;
+    fields.append( QgsField( QStringLiteral( "time" ), QMetaType::QDateTime ) );
+    fields.append( QgsField( QStringLiteral( "note" ), QMetaType::QString ) );
+    if ( options.value( QStringLiteral( "camera_capture" ) ).toBool() )
+    {
+      fields.append( QgsField( QStringLiteral( "camera" ), QMetaType::QString ) );
+    }
+    QgsVectorFileWriter::SaveVectorOptions writerOptions;
+    QgsVectorFileWriter *writer = QgsVectorFileWriter::create( notesFilepath, fields, Qgis::WkbType::PointZ, QgsCoordinateReferenceSystem( "EPSG:4326" ), createdProject->transformContext(), writerOptions );
+    delete writer;
+
+    notesLayer = new QgsVectorLayer( notesFilepath, tr( "Notes" ) );
+    fields = notesLayer->fields();
+    LayerUtils::setDefaultRenderer( notesLayer );
+
+    QVariantMap widgetOptions;
+    QgsEditorWidgetSetup widgetSetup;
+
+    // Configure fid field
+    widgetSetup = QgsEditorWidgetSetup( QStringLiteral( "Hidden" ), widgetOptions );
+    notesLayer->setEditorWidgetSetup( fields.indexOf( QStringLiteral( "fid" ) ), widgetSetup );
+
+    // Configure time field
+    widgetOptions.clear();
+    widgetOptions[QStringLiteral( "display_format" )] = QStringLiteral( "yyyy-MM-dd HH:mm" );
+    widgetOptions[QStringLiteral( "field_format" )] = QStringLiteral( "yyyy-MM-dd HH:mm" );
+    widgetOptions[QStringLiteral( "field_format_overwrite" )] = true;
+    widgetOptions[QStringLiteral( "allow_null" )] = true;
+    widgetOptions[QStringLiteral( "calendar_popup" )] = true;
+    widgetSetup = QgsEditorWidgetSetup( QStringLiteral( "DateTime" ), widgetOptions );
+    notesLayer->setEditorWidgetSetup( fields.indexOf( QStringLiteral( "time" ) ), widgetSetup );
+    notesLayer->setDefaultValueDefinition( fields.indexOf( QStringLiteral( "time" ) ), QgsDefaultValue( QStringLiteral( "now()" ), false ) );
+
+    // Configure note field
+    widgetOptions.clear();
+    widgetOptions[QStringLiteral( "IsMultiline" )] = true;
+    widgetSetup = QgsEditorWidgetSetup( QStringLiteral( "TextEdit" ), widgetOptions );
+    notesLayer->setEditorWidgetSetup( fields.indexOf( QStringLiteral( "note" ) ), widgetSetup );
+
+    if ( options.value( QStringLiteral( "camera_capture" ) ).toBool() )
+    {
+      // Configure camera field
+      widgetOptions.clear();
+      widgetOptions[QStringLiteral( "DocumentViewer" )] = 1;
+      widgetOptions[QStringLiteral( "RelativeStorage" )] = 1;
+      widgetOptions[QStringLiteral( "FileWidget" )] = true;
+      widgetOptions[QStringLiteral( "FileWidgetButton" )] = true;
+      widgetSetup = QgsEditorWidgetSetup( QStringLiteral( "ExternalResource" ), widgetOptions );
+      notesLayer->setEditorWidgetSetup( fields.indexOf( QStringLiteral( "camera" ) ), widgetSetup );
+    }
+
+    // Insure the layer is ready cloud-friendly
+    notesLayer->setCustomProperty( QStringLiteral( "QFieldSync/cloud_action" ), QStringLiteral( "offline" ) );
+    notesLayer->setCustomProperty( QStringLiteral( "QFieldSync/action" ), QStringLiteral( "offline" ) );
+
+    createdProjectLayers << notesLayer;
+  }
+
+  // Tracks layer
+  QgsVectorLayer *tracksLayer = nullptr;
+  if ( options.value( QStringLiteral( "tracks" ) ).toBool() )
+  {
+    const QString tracksFilepath = QStringLiteral( "%1/tracks.gpkg" ).arg( createdProjectDir );
+
+    QgsFields fields;
+    fields.append( QgsField( QStringLiteral( "time" ), QMetaType::QDateTime ) );
+    QgsVectorFileWriter::SaveVectorOptions writerOptions;
+    QgsVectorFileWriter *writer = QgsVectorFileWriter::create( tracksFilepath, fields, Qgis::WkbType::LineStringZM, QgsCoordinateReferenceSystem( "EPSG:4326" ), createdProject->transformContext(), writerOptions );
+    delete writer;
+
+    tracksLayer = new QgsVectorLayer( tracksFilepath, tr( "Tracks" ) );
+    fields = tracksLayer->fields();
+    LayerUtils::setDefaultRenderer( tracksLayer );
+
+    QVariantMap widgetOptions;
+    QgsEditorWidgetSetup widgetSetup;
+
+    // Configure fid field
+    widgetSetup = QgsEditorWidgetSetup( QStringLiteral( "Hidden" ), widgetOptions );
+    tracksLayer->setEditorWidgetSetup( fields.indexOf( QStringLiteral( "fid" ) ), widgetSetup );
+
+    // Configure time field
+    widgetOptions.clear();
+    widgetOptions[QStringLiteral( "display_format" )] = QStringLiteral( "yyyy-MM-dd HH:mm" );
+    widgetOptions[QStringLiteral( "field_format" )] = QStringLiteral( "yyyy-MM-dd HH:mm" );
+    widgetOptions[QStringLiteral( "field_format_overwrite" )] = true;
+    widgetOptions[QStringLiteral( "allow_null" )] = true;
+    widgetOptions[QStringLiteral( "calendar_popup" )] = true;
+    widgetSetup = QgsEditorWidgetSetup( QStringLiteral( "DateTime" ), widgetOptions );
+    tracksLayer->setEditorWidgetSetup( fields.indexOf( QStringLiteral( "time" ) ), widgetSetup );
+    tracksLayer->setDefaultValueDefinition( fields.indexOf( QStringLiteral( "time" ) ), QgsDefaultValue( QStringLiteral( "now()" ), false ) );
+
+    // Skip feature form when launching tracks
+    QgsEditFormConfig formConfig = tracksLayer->editFormConfig();
+    formConfig.setSuppress( Qgis::AttributeFormSuppression::On );
+    tracksLayer->setEditFormConfig( formConfig );
+
+    if ( options.value( QStringLiteral( "track_on_launch" ) ).toBool() )
+    {
+      // Launch tracks on project opening
+      tracksLayer->setCustomProperty( QStringLiteral( "QFieldSync/tracking_session_active" ), true );
+      tracksLayer->setCustomProperty( QStringLiteral( "QFieldSync/tracking_time_requirement_active" ), true );
+      tracksLayer->setCustomProperty( QStringLiteral( "QFieldSync/tracking_time_requirement_interval_seconds" ), 2 );
+      tracksLayer->setCustomProperty( QStringLiteral( "QFieldSync/tracking_erroneous_distance_safeguard_active" ), true );
+      tracksLayer->setCustomProperty( QStringLiteral( "QFieldSync/tracking_erroneous_distance_safeguard_maximum_meters" ), 50 );
+      tracksLayer->setCustomProperty( QStringLiteral( "QFieldSync/tracking_measurement_type" ), 1 ); // Attach epoch value to the M value
+    }
+
+    // Insure the layer is ready cloud-friendly
+    tracksLayer->setCustomProperty( QStringLiteral( "QFieldSync/cloud_action" ), QStringLiteral( "offline" ) );
+    tracksLayer->setCustomProperty( QStringLiteral( "QFieldSync/action" ), QStringLiteral( "offline" ) );
+
+    createdProjectLayers << tracksLayer;
+  }
+
+  // Basemap
+  QgsMapLayer *basemapLayer = nullptr;
+  const QString basemap = options.value( QStringLiteral( "basemap" ), QStringLiteral( "color" ) ).toString();
+  if ( basemap.compare( QStringLiteral( "custom" ) ) == 0 )
+  {
+    QString basemapUrl = options.value( QStringLiteral( "basemap_url" ) ).toString();
+    if ( !basemapUrl.isEmpty() )
+    {
+      if ( basemapUrl.endsWith( QStringLiteral( ".json" ), Qt::CaseInsensitive ) )
+      {
+        // Vector tile layer style URL
+        QgsDataSourceUri uri;
+        uri.setParam( QStringLiteral( "type" ), QStringLiteral( "xyz" ) );
+        uri.setParam( QStringLiteral( "styleUrl" ), basemapUrl );
+        uri.setParam( QStringLiteral( "zmin" ), QString::number( 0 ) );
+        uri.setParam( QStringLiteral( "zmax" ), QString::number( 14 ) );
+        basemapUrl = uri.encodedUri();
+
+        QgsVectorTileUtils::updateUriSources( basemapUrl );
+        QgsVectorTileLayer *layer = new QgsVectorTileLayer( basemapUrl, tr( "Basemap" ) );
+        QString error;
+        QStringList warnings;
+        QList<QgsMapLayer *> subLayers;
+        layer->loadDefaultStyleAndSubLayers( error, warnings, subLayers );
+        basemapLayer = layer;
+      }
+      else if ( basemapUrl.contains( QStringLiteral( "{z}" ), Qt::CaseInsensitive ) || basemapUrl.contains( QStringLiteral( "{q}" ), Qt::CaseInsensitive ) )
+      {
+        // XYZ raster layer URL
+        QgsDataSourceUri uri;
+        uri.setParam( QStringLiteral( "type" ), QStringLiteral( "xyz" ) );
+        uri.setParam( QStringLiteral( "url" ), basemapUrl );
+        uri.setParam( QStringLiteral( "zmin" ), QString::number( 0 ) );
+        uri.setParam( QStringLiteral( "zmax" ), QString::number( 19 ) );
+        basemapUrl = uri.encodedUri();
+
+        basemapLayer = new QgsRasterLayer( basemapUrl, tr( "Basemap" ), QStringLiteral( "wms" ) );
+      }
+    }
+  }
+  else if ( basemap.compare( QStringLiteral( "blank" ) ) != 0 )
+  {
+    basemapLayer = LayerUtils::createBasemap( basemap );
+    if ( basemap.compare( QStringLiteral( "darkgray" ) ) == 0 )
+    {
+      createdProject->setBackgroundColor( QColor( 15, 15, 15 ) );
+    }
+    else if ( basemap.compare( QStringLiteral( "lightgray" ) ) == 0 )
+    {
+      createdProject->setBackgroundColor( QColor( 240, 240, 240 ) );
+    }
+    else
+    {
+      createdProject->setBackgroundColor( QColor( 242, 239, 233 ) );
+    }
+  }
+
+  if ( basemapLayer && basemapLayer->isValid() )
+  {
+    createdProjectLayers << basemapLayer;
+    createdProject->setCrs( basemapLayer->crs() );
+  }
+
+  createdProject->addMapLayers( createdProjectLayers );
+
+  connect( createdProject, &QgsProject::writeProject, [createdProject, basemapLayer]( QDomDocument &document ) {
+    QDomNodeList nodes = document.elementsByTagName( "qgis" );
+    if ( !nodes.isEmpty() )
+    {
+      QDomNode node = nodes.item( 0 );
+      QDomElement element = node.toElement();
+
+      QDomElement canvasElement = document.createElement( QStringLiteral( "mapcanvas" ) );
+      canvasElement.setAttribute( QStringLiteral( "name" ), QStringLiteral( "theMapCanvas" ) );
+
+      node.appendChild( canvasElement );
+
+      if ( basemapLayer && basemapLayer->isValid() )
+      {
+        QgsRectangle extent = basemapLayer->extent();
+
+        try
+        {
+          QgsCoordinateTransform transform( basemapLayer->crs(), createdProject->crs(), createdProject->transformContext() );
+          extent = transform.transform( extent );
+        }
+        catch ( const QgsException &e )
+        {
+          extent = QgsRectangle();
+        }
+
+        if ( !extent.isEmpty() )
+        {
+          QgsMapSettings mapSettings;
+          mapSettings.setDestinationCrs( createdProject->crs() );
+          mapSettings.setOutputSize( QSize( 500, 500 ) );
+          mapSettings.setExtent( extent );
+          mapSettings.writeXml( canvasElement, document );
+        }
+      }
+    }
+  } );
+
+  const bool written = createdProject->write( projectFilepath );
+  createdProject->clear();
+  createdProject->deleteLater();
+
+  return written ? projectFilepath : QString();
 }

--- a/src/core/utils/projectutils.h
+++ b/src/core/utils/projectutils.h
@@ -50,6 +50,15 @@ class ProjectUtils : public QObject
 
     /**
      * Creates a new project and return the local path of the project file.
+     *
+     * The available \a options are:
+     * - title: the project title
+     * - basemap: the basemap type (color, lightgray, darkgray, custom, blank)
+     * - basemap_url: a custom basemap URL (XYZ raster layer or vector tile layer style JSON)
+     * - notes: set to TRUE to add a notes layer
+     * - camera_capture: set to TRUE to add an image/video capture field to the notes layer
+     * - tracks: set to TRUE to add a tracks layer
+     * - track_on_launch: set to TRUE to start tracking position on project launch
      */
     Q_INVOKABLE static QString createProject( const QVariantMap &options );
 };

--- a/src/core/utils/projectutils.h
+++ b/src/core/utils/projectutils.h
@@ -47,6 +47,11 @@ class ProjectUtils : public QObject
      * Returns the \a project title.
      */
     Q_INVOKABLE static QString title( QgsProject *project = nullptr );
+
+    /**
+     * Creates a new project and return the local path of the project file.
+     */
+    Q_INVOKABLE static QString createProject( const QVariantMap &options );
 };
 
 #endif // PROJECTUTILS_H

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -969,6 +969,15 @@ Page {
   }
 
   Component.onCompleted: {
+    console.log(ProjectUtils.createProject({
+          "title": "blah blah blah",
+          "basemap": "custom",
+          "basemap_url": "https://vector.openstreetmap.org/demo/shortbread/colorful.json",
+          "notes": true,
+          "camera_capture": true,
+          "tracks": true,
+          "track_on_launch": true
+        }));
     adjustWelcomeScreen();
     var runCount = settings.value("/QField/RunCount", 0) * 1;
     var feedbackFormShown = settings.value("/QField/FeedbackFormShown", false);

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -969,15 +969,6 @@ Page {
   }
 
   Component.onCompleted: {
-    console.log(ProjectUtils.createProject({
-          "title": "blah blah blah",
-          "basemap": "custom",
-          "basemap_url": "https://vector.openstreetmap.org/demo/shortbread/colorful.json",
-          "notes": true,
-          "camera_capture": true,
-          "tracks": true,
-          "track_on_launch": true
-        }));
     adjustWelcomeScreen();
     var runCount = settings.value("/QField/RunCount", 0) * 1;
     var feedbackFormShown = settings.value("/QField/FeedbackFormShown", false);


### PR DESCRIPTION
This PR adds a utility function accessible within our QML environment to create a project from a map of keys/values. E.g: this would create a simple project with notes and tracks:

```
ProjectUtils.createProject({
          "title": "My project",
          "basemap": "lightgray",
          "notes": true,
          "camera_capture": true,
          "tracks": true,
          "track_on_launch": true
}));
```

The project returns the project file path (i.e. /path/to/project.qgs). This core functionality will be plugged into GUI work done by @mohsenD98 .

A separate PR will deal with upgrading a local project to a cloud project upon project creation or for a preexisting local project.