### PR TITLE
Fix tracking configuraton window not popping up when the layer suppresses the feature form

### DIFF
--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -293,7 +293,7 @@ Popup {
 
           onClicked: {
             var layer = layerTree.data(index, FlatLayerTreeModel.VectorLayerPointer);
-            close();
+            popup.close();
             if (trackingModel.layerInTracking(layer)) {
               trackingModel.stopTracker(layer);
               displayToast(qsTr('Track on layer %1 stopped').arg(layer.name));

--- a/src/qml/TrackerSettings.qml
+++ b/src/qml/TrackerSettings.qml
@@ -37,16 +37,28 @@ Popup {
         if (embeddedAttributeFormModel.rowCount() > 0 && !featureModel.suppressFeatureForm()) {
           embeddedFeatureForm.active = true;
         } else {
-          trackingModel.startTracker(tracker.vectorLayer, positionSource.positionInformation, positionSource.projectedPosition);
-          displayToast(qsTr('Track on layer %1 started').arg(tracker.vectorLayer.name));
-          if (featureModel.currentLayer.geometryType === Qgis.GeometryType.Point) {
-            projectInfo.saveTracker(featureModel.currentLayer);
-          }
-          tracker = undefined;
-          trackingModel.trackingSetupDone();
+          startTracking();
         }
       }
     }
+  }
+
+  function startTracking() {
+    trackingModel.startTracker(tracker.vectorLayer, positionSource.positionInformation, positionSource.projectedPosition);
+    displayToast(qsTr('Track on layer %1 started').arg(tracker.vectorLayer.name));
+    if (featureModel.currentLayer.geometryType === Qgis.GeometryType.Point) {
+      projectInfo.saveTracker(featureModel.currentLayer);
+    }
+    tracker = undefined;
+    trackingModel.trackingSetupDone();
+  }
+
+  function resumeTracking() {
+    trackingModel.startTracker(tracker.vectorLayer, positionSource.positionInformation, positionSource.projectedPosition);
+    displayToast(qsTr('Track on layer %1 started').arg(tracker.vectorLayer.name));
+    projectInfo.saveTracker(featureModel.currentLayer);
+    tracker = undefined;
+    trackingModel.trackingSetupDone();
   }
 
   onTrackerChanged: {
@@ -485,12 +497,7 @@ Popup {
           if (embeddedAttributeFormModel.rowCount() > 0 && !featureModel.suppressFeatureForm()) {
             embeddedFeatureForm.active = true;
           } else {
-            trackingModel.startTracker(tracker.vectorLayer, positionSource.positionInformation, positionSource.projectedPosition);
-            displayToast(qsTr('Track on layer %1 started').arg(tracker.vectorLayer.name));
-            if (featureModel.currentLayer.geometryType === Qgis.GeometryType.Point) {
-              projectInfo.saveTracker(featureModel.currentLayer);
-            }
-            tracker = undefined;
+            startTracking();
             trackerSettings.close();
           }
         }
@@ -510,9 +517,7 @@ Popup {
 
         onClicked: {
           applySettings();
-          trackingModel.startTracker(tracker.vectorLayer, positionSource.positionInformation, positionSource.projectedPosition);
-          displayToast(qsTr('Track on layer %1 started').arg(tracker.vectorLayer.name));
-          projectInfo.saveTracker(featureModel.currentLayer);
+          resumeTracking();
           trackerSettings.close();
         }
       }
@@ -581,14 +586,8 @@ Popup {
           tracker.feature = featureModel.feature;
           embeddedFeatureFormPopup.close();
           embeddedFeatureForm.active = false;
-          trackingModel.startTracker(tracker.vectorLayer, positionSource.positionInformation, positionSource.projectedPosition);
-          displayToast(qsTr('Track on layer %1 started').arg(tracker.vectorLayer.name));
-          if (featureModel.currentLayer.geometryType === Qgis.GeometryType.Point) {
-            projectInfo.saveTracker(featureModel.currentLayer);
-          }
-          tracker = undefined;
+          startTracking();
           trackerSettings.close();
-          trackingModel.trackingSetupDone();
         }
 
         onCancelled: {


### PR DESCRIPTION
This fixes a tracking issue affecting vector layers set to suppress the feature addition form. I stumbled on this while testing the project creation code, but I think it also addresses this report (https://github.com/opengisch/QField/issues/6486#issuecomment-3254225852) by @bladnor.