### PR TITLE
Add project mode preference (browsed vs. digitized)

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -4059,6 +4059,11 @@ ApplicationWindow {
       geofencer.applyProjectSettings(qgisProject);
       positioningSettings.geofencingPreventDigitizingDuringAlert = iface.readProjectBoolEntry("qfieldsync", "/geofencingShouldPreventDigitizing", false);
       mapCanvasTour.startOnFreshRun();
+      const initialFocusedLayer = iface.readProjectEntry("qfieldsync", "/initialFocusedLayer", "");
+      const initialMapMode = iface.readProjectEntry("qfieldsync", "/initialMapMode", "");
+      if (initialMapMode === "digitizing") {
+        stateMachine.state = "digitize";
+      }
     }
 
     function onSetMapExtent(extent) {


### PR DESCRIPTION
### 🚀 Description
Allow for users to define projects as mostly browsed vs. digitized, impact default mode when opening

### ✨ Key Changes
* **Changes in qfieldsync**:  
  *  https://github.com/opengisch/qfieldsync/pull/729
* **Changes in libqfieldsync**: 
  * https://github.com/opengisch/libqfieldsync/pull/130

### New QFieldSync view

<img width="979" height="1476" alt="image" src="https://github.com/user-attachments/assets/05b3cb45-9d55-43ab-a050-8d7e124a2e8d" />
