### PR TITLE
Remove debug crumbs impacting large projects

### DIFF
--- a/src/core/qfieldcloud/layerobserver.cpp
+++ b/src/core/qfieldcloud/layerobserver.cpp
@@ -116,8 +116,6 @@ void LayerObserver::onBeforeCommitChanges()
   while ( featuresIt.nextFeature( f ) )
     changedFeatures.insert( f.id(), f );
 
-  qInfo() << "LayerObserver::onBeforeCommitChanges: vl->id()=" << vl->id() << "sourcePkAttrPair=" << changedFids;
-
   // NOTE no need to keep track of added features, as they are always present in the layer after commit
   mChangedFeatures.insert( vl->id(), changedFeatures );
   mPatchedFids.insert( vl->id(), QgsFeatureIds() );
@@ -134,12 +132,8 @@ void LayerObserver::onCommittedFeaturesAdded( const QString &localLayerId, const
   const QPair<int, QString> localPkAttrPair = DeltaFileWrapper::getLocalPkAttribute( vl );
   const QPair<int, QString> sourcePkAttrPair = DeltaFileWrapper::getSourcePkAttribute( vl );
 
-  qInfo() << "LayerObserver::onCommittedFeaturesAdded: sourcePkAttrPair=" << sourcePkAttrPair << " sourceLayerId=" << sourceLayerId;
-
   for ( const QgsFeature &newFeature : addedFeatures )
   {
-    qInfo() << "  LayerObserver::onCommittedFeaturesAdded: adding create delta... FID=" << newFeature.id();
-
     mDeltaFileWrapper->addCreate( localLayerId, sourceLayerId, localPkAttrPair.second, sourcePkAttrPair.second, newFeature );
   }
 }
@@ -156,15 +150,11 @@ void LayerObserver::onCommittedFeaturesRemoved( const QString &localLayerId, con
   const QPair<int, QString> localPkAttrPair = DeltaFileWrapper::getLocalPkAttribute( vl );
   const QPair<int, QString> sourcePkAttrPair = DeltaFileWrapper::getSourcePkAttribute( vl );
 
-  qInfo() << "LayerObserver::onCommittedFeaturesRemoved: sourcePkAttrPair=" << sourcePkAttrPair << " sourceLayerId=" << sourceLayerId << " deletedFeatureIds=" << deletedFeatureIds;
-
   for ( const QgsFeatureId &fid : deletedFeatureIds )
   {
     Q_ASSERT( changedFeatures.contains( fid ) );
 
     QgsFeature oldFeature = changedFeatures.take( fid );
-
-    qInfo() << "  LayerObserver::onCommittedFeaturesRemoved: adding delete delta... FID=" << fid;
 
     mDeltaFileWrapper->addDelete( localLayerId, sourceLayerId, localPkAttrPair.second, sourcePkAttrPair.second, oldFeature );
   }
@@ -186,8 +176,6 @@ void LayerObserver::onCommittedAttributeValuesChanges( const QString &localLayer
   const QPair<int, QString> localPkAttrPair = DeltaFileWrapper::getLocalPkAttribute( vl );
   const QPair<int, QString> sourcePkAttrPair = DeltaFileWrapper::getSourcePkAttribute( vl );
 
-  qInfo() << "LayerObserver::onCommittedAttributeValuesChanges: sourcePkAttrPair=" << sourcePkAttrPair << " sourceLayerId=" << sourceLayerId << " changedAttributesValuesFids=" << changedAttributesValuesFids;
-
   for ( const QgsFeatureId fid : changedAttributesValuesFids )
   {
     if ( patchedFids.contains( fid ) )
@@ -199,8 +187,6 @@ void LayerObserver::onCommittedAttributeValuesChanges( const QString &localLayer
 
     QgsFeature oldFeature = changedFeatures.take( fid );
     QgsFeature newFeature = vl->getFeature( fid );
-
-    qInfo() << "LayerObserver::onCommittedAttributeValuesChanges: adding patch delta... FID=" << fid;
 
     if ( vl->fields().indexOf( "fid_1" ) != -1 && localPkAttrPair.second == sourcePkAttrPair.second && newFeature.attribute( "fid" ) != newFeature.attribute( "fid_1" ) )
     {
@@ -227,8 +213,6 @@ void LayerObserver::onCommittedGeometriesChanges( const QString &localLayerId, c
   const QPair<int, QString> localPkAttrPair = DeltaFileWrapper::getLocalPkAttribute( vl );
   const QPair<int, QString> sourcePkAttrPair = DeltaFileWrapper::getSourcePkAttribute( vl );
 
-  qInfo() << "LayerObserver::onCommittedGeometriesChanges: sourcePkAttrPair=" << sourcePkAttrPair << " sourceLayerId=" << sourceLayerId << " changedGeometriesFids=" << changedGeometriesFids;
-
   for ( const QgsFeatureId &fid : changedGeometriesFids )
   {
     if ( patchedFids.contains( fid ) )
@@ -240,8 +224,6 @@ void LayerObserver::onCommittedGeometriesChanges( const QString &localLayerId, c
 
     QgsFeature oldFeature = changedFeatures.take( fid );
     QgsFeature newFeature = vl->getFeature( fid );
-
-    qInfo() << "  LayerObserver::onCommittedGeometriesChanges: adding patch delta... FID=" << fid;
 
     if ( vl->fields().indexOf( "fid_1" ) != -1 && localPkAttrPair.second == sourcePkAttrPair.second && newFeature.attribute( "fid" ) != newFeature.attribute( "fid_1" ) )
     {
@@ -310,10 +292,6 @@ void LayerObserver::addLayerListeners()
           QgsMessageLog::logMessage( tr( "Failed to find a source primary key column in layer \"%1\"" ).arg( layer->name() ) );
           continue;
         }
-
-        qInfo() << "LayerObserver::addLayerListeners: vl->getLocalPkAttribute()=" << DeltaFileWrapper::getLocalPkAttribute( vl );
-        qInfo() << "LayerObserver::addLayerListeners: vl->getSourcePkAttribute()=" << DeltaFileWrapper::getSourcePkAttribute( vl );
-        qInfo() << "LayerObserver::addLayerListeners: vl->customProperties()=" << vl->customProperties().keys();
 
         disconnect( vl, &QgsVectorLayer::beforeCommitChanges, this, &LayerObserver::onBeforeCommitChanges );
         disconnect( vl, &QgsVectorLayer::committedFeaturesAdded, this, &LayerObserver::onCommittedFeaturesAdded );


### PR DESCRIPTION
We shouldn't need these anymore. And if we do, they shouldn't be qInfo flooding the logs buffer / sentry etc.