### PR TITLE
Memory layer creation and vector/raster layer loading APIs

### DIFF
--- a/src/core/layertreemapcanvasbridge.cpp
+++ b/src/core/layertreemapcanvasbridge.cpp
@@ -39,7 +39,8 @@ LayerTreeMapCanvasBridge::LayerTreeMapCanvasBridge( FlatLayerTreeModel *model, Q
 {
   connect( mRoot, &QgsLayerTreeGroup::visibilityChanged, this, &LayerTreeMapCanvasBridge::nodeVisibilityChanged );
   connect( model, &FlatLayerTreeModel::mapThemeChanged, this, &LayerTreeMapCanvasBridge::mapThemeChanged );
-  connect( model, &FlatLayerTreeModel::layersAdded, this, &LayerTreeMapCanvasBridge::layersAdded );
+  connect( model, &FlatLayerTreeModel::layersAdded, this, &LayerTreeMapCanvasBridge::layersChanged );
+  connect( model, &FlatLayerTreeModel::layersRemoved, this, &LayerTreeMapCanvasBridge::layersChanged );
 
   connect( mTrackingModel, &TrackingModel::layerInTrackingChanged, this, &LayerTreeMapCanvasBridge::layerInTrackingChanged );
 
@@ -157,7 +158,7 @@ void LayerTreeMapCanvasBridge::mapThemeChanged()
     QgsProject::instance()->mapThemeCollection()->applyTheme( mModel->mapTheme(), mRoot, mModel->layerTreeModel() );
 }
 
-void LayerTreeMapCanvasBridge::layersAdded()
+void LayerTreeMapCanvasBridge::layersChanged()
 {
   deferredSetCanvasLayers();
 }

--- a/src/core/layertreemapcanvasbridge.cpp
+++ b/src/core/layertreemapcanvasbridge.cpp
@@ -39,6 +39,7 @@ LayerTreeMapCanvasBridge::LayerTreeMapCanvasBridge( FlatLayerTreeModel *model, Q
 {
   connect( mRoot, &QgsLayerTreeGroup::visibilityChanged, this, &LayerTreeMapCanvasBridge::nodeVisibilityChanged );
   connect( model, &FlatLayerTreeModel::mapThemeChanged, this, &LayerTreeMapCanvasBridge::mapThemeChanged );
+  connect( model, &FlatLayerTreeModel::layersAdded, this, &LayerTreeMapCanvasBridge::layersAdded );
 
   connect( mTrackingModel, &TrackingModel::layerInTrackingChanged, this, &LayerTreeMapCanvasBridge::layerInTrackingChanged );
 
@@ -154,6 +155,11 @@ void LayerTreeMapCanvasBridge::mapThemeChanged()
 {
   if ( !mModel->mapTheme().isEmpty() )
     QgsProject::instance()->mapThemeCollection()->applyTheme( mModel->mapTheme(), mRoot, mModel->layerTreeModel() );
+}
+
+void LayerTreeMapCanvasBridge::layersAdded()
+{
+  deferredSetCanvasLayers();
 }
 
 void LayerTreeMapCanvasBridge::layerInTrackingChanged( QgsVectorLayer *layer, bool tracking )

--- a/src/core/layertreemapcanvasbridge.h
+++ b/src/core/layertreemapcanvasbridge.h
@@ -79,6 +79,7 @@ class LayerTreeMapCanvasBridge : public QObject
     void extentChanged();
     void nodeVisibilityChanged();
     void mapThemeChanged();
+    void layersAdded();
     void layerInTrackingChanged( QgsVectorLayer *layer, bool tracking );
 
   private:

--- a/src/core/layertreemapcanvasbridge.h
+++ b/src/core/layertreemapcanvasbridge.h
@@ -79,7 +79,7 @@ class LayerTreeMapCanvasBridge : public QObject
     void extentChanged();
     void nodeVisibilityChanged();
     void mapThemeChanged();
-    void layersAdded();
+    void layersChanged();
     void layerInTrackingChanged( QgsVectorLayer *layer, bool tracking );
 
   private:

--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -36,6 +36,7 @@ FlatLayerTreeModel::FlatLayerTreeModel( QgsLayerTree *layerTree, QgsProject *pro
 {
   setSourceModel( mSourceModel );
   connect( mSourceModel, &FlatLayerTreeModelBase::layersAdded, this, &FlatLayerTreeModel::layersAdded );
+  connect( mSourceModel, &FlatLayerTreeModelBase::layersRemoved, this, &FlatLayerTreeModel::layersRemoved );
   connect( mSourceModel, &FlatLayerTreeModelBase::mapThemeChanged, this, &FlatLayerTreeModel::mapThemeChanged );
   connect( mSourceModel, &FlatLayerTreeModelBase::isTemporalChanged, this, &FlatLayerTreeModel::isTemporalChanged );
   connect( mSourceModel, &FlatLayerTreeModelBase::isFrozenChanged, this, &FlatLayerTreeModel::isFrozenChanged );

--- a/src/core/layertreemodel.h
+++ b/src/core/layertreemodel.h
@@ -88,6 +88,7 @@ class FlatLayerTreeModelBase : public QAbstractProxyModel
 
   signals:
     void layersAdded();
+    void layersRemoved();
     void mapThemeChanged();
     void isTemporalChanged();
     void isFrozenChanged();
@@ -204,6 +205,7 @@ class FlatLayerTreeModel : public QSortFilterProxyModel
 
   signals:
     void layersAdded();
+    void layersRemoved();
     void mapThemeChanged();
     void isTemporalChanged();
     void isFrozenChanged();

--- a/src/core/layertreemodel.h
+++ b/src/core/layertreemodel.h
@@ -87,6 +87,7 @@ class FlatLayerTreeModelBase : public QAbstractProxyModel
     Q_INVOKABLE QgsRectangle nodeExtent( const QModelIndex &index, QgsQuickMapSettings *mapSettings, const float buffer );
 
   signals:
+    void layersAdded();
     void mapThemeChanged();
     void isTemporalChanged();
     void isFrozenChanged();
@@ -202,6 +203,7 @@ class FlatLayerTreeModel : public QSortFilterProxyModel
     Q_INVOKABLE QgsRectangle nodeExtent( const QModelIndex &index, QgsQuickMapSettings *mapSettings, const float buffer = 0.02 );
 
   signals:
+    void layersAdded();
     void mapThemeChanged();
     void isTemporalChanged();
     void isFrozenChanged();

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -423,6 +423,7 @@ void QgisMobileapp::initDeclarative( QQmlEngine *engine )
   qmlRegisterUncreatableType<QgsRelationManager>( "org.qgis", 1, 0, "RelationManager", "The relation manager is available from the QgsProject. Try `qgisProject.relationManager`" );
   qmlRegisterUncreatableType<QgsWkbTypes>( "org.qgis", 1, 0, "QgsWkbTypes", "" );
   qmlRegisterUncreatableType<QgsMapLayer>( "org.qgis", 1, 0, "MapLayer", "" );
+  qmlRegisterUncreatableType<QgsRasterLayer>( "org.qgis", 1, 0, "RasterLayer", "" );
   qmlRegisterUncreatableType<QgsVectorLayer>( "org.qgis", 1, 0, "VectorLayerStatic", "" );
 
   // Register QgsQuick QML types

--- a/src/core/utils/layerutils.h
+++ b/src/core/utils/layerutils.h
@@ -174,6 +174,43 @@ class LayerUtils : public QObject
     Q_INVOKABLE static bool hasMValue( QgsVectorLayer *layer );
 
     /**
+     * Loads a vector layer.
+     * \param uri the data source uri
+     * \param name the layer name
+     * \param provider the data provider name
+     */
+    Q_INVOKABLE static QgsVectorLayer *loadVectorLayer( const QString &uri, const QString &name = QString(), const QString &provider = QStringLiteral( "ogr" ) );
+
+    /**
+     * Loads a raster layer.
+     * \param uri the data source uri
+     * \param name the layer name
+     * \param provider the data provider name
+     */
+    Q_INVOKABLE static QgsRasterLayer *loadRasterLayer( const QString &uri, const QString &name = QString(), const QString &provider = QStringLiteral( "gdal" ) );
+
+    /**
+     * Attempts to parse a GeoJSON string to a memory vector layer containing the collection of
+     * features. The geometry type will be taken from the first parsed feature.
+     * \param name layer name
+     * \param string the GeoJSON string
+     * \param crs optional layer CRS for layers with geometry
+     */
+    Q_INVOKABLE static QgsVectorLayer *memoryLayerFromJsonString( const QString &name, const QString &string, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() );
+
+    /**
+     * Creates a new memory layer using the specified parameters.
+     * \param name layer name
+     * \param fields fields for layer
+     * \param geometryType optional layer geometry type
+     * \param crs optional layer CRS for layers with geometry
+     */
+    Q_INVOKABLE static QgsVectorLayer *createMemoryLayer( const QString &name,
+                                                          const QgsFields &fields = QgsFields(),
+                                                          Qgis::WkbType geometryType = Qgis::WkbType::NoGeometry,
+                                                          const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() );
+
+    /**
      * Returns a feature iterator to get features matching a given \a expression within the provided \a layer.
      */
     Q_INVOKABLE static FeatureIterator createFeatureIteratorFromExpression( QgsVectorLayer *layer, const QString &expression );

--- a/src/core/utils/projectutils.cpp
+++ b/src/core/utils/projectutils.cpp
@@ -46,6 +46,14 @@ QVariantMap ProjectUtils::mapLayers( QgsProject *project )
   return mapLayers;
 }
 
+void ProjectUtils::addMapLayer( QgsProject *project, QgsMapLayer *layer )
+{
+  if ( !project )
+    return;
+
+  project->addMapLayer( layer );
+}
+
 Qgis::TransactionMode ProjectUtils::transactionMode( QgsProject *project )
 {
   if ( !project )

--- a/src/core/utils/projectutils.cpp
+++ b/src/core/utils/projectutils.cpp
@@ -46,12 +46,28 @@ QVariantMap ProjectUtils::mapLayers( QgsProject *project )
   return mapLayers;
 }
 
-void ProjectUtils::addMapLayer( QgsProject *project, QgsMapLayer *layer )
+bool ProjectUtils::addMapLayer( QgsProject *project, QgsMapLayer *layer )
 {
   if ( !project )
+    return false;
+
+  return ( project->addMapLayer( layer ) );
+}
+
+void ProjectUtils::removeMapLayer( QgsProject *project, QgsMapLayer *layer )
+{
+  if ( !project || !layer )
     return;
 
-  project->addMapLayer( layer );
+  project->removeMapLayer( layer );
+}
+
+void ProjectUtils::removeMapLayer( QgsProject *project, const QString &layerId )
+{
+  if ( !project || layerId.isEmpty() )
+    return;
+
+  project->removeMapLayer( layerId );
 }
 
 Qgis::TransactionMode ProjectUtils::transactionMode( QgsProject *project )

--- a/src/core/utils/projectutils.h
+++ b/src/core/utils/projectutils.h
@@ -37,6 +37,8 @@ class ProjectUtils : public QObject
      */
     Q_INVOKABLE static QVariantMap mapLayers( QgsProject *project = nullptr );
 
+    Q_INVOKABLE static void addMapLayer( QgsProject *project = nullptr, QgsMapLayer *layer = nullptr );
+
     /**
      * Returns the transaction mode for a given \a project.
      * \note To be removed when QField updates to QGIS 3.38.

--- a/src/core/utils/projectutils.h
+++ b/src/core/utils/projectutils.h
@@ -35,9 +35,24 @@ class ProjectUtils : public QObject
      * \note This function mimics QgsProject::mapLayers with a return type
      * that is QML compatible.
      */
-    Q_INVOKABLE static QVariantMap mapLayers( QgsProject *project = nullptr );
+    Q_INVOKABLE static QVariantMap mapLayers( QgsProject *project );
 
-    Q_INVOKABLE static void addMapLayer( QgsProject *project = nullptr, QgsMapLayer *layer = nullptr );
+    /**
+     * Adds a map \a layer to a \a project layers registry.
+     */
+    Q_INVOKABLE static bool addMapLayer( QgsProject *project, QgsMapLayer *layer );
+
+    /**
+     * Removes a map \a layer from a \a project layers registry.
+     */
+    Q_INVOKABLE static void removeMapLayer( QgsProject *project, QgsMapLayer *layer );
+
+    /**
+     * Removes a map layer from a project layers registry matching a given layer ID.
+     * \param project the project
+     * \param layerId the layer ID
+     */
+    Q_INVOKABLE static void removeMapLayer( QgsProject *project, const QString &layerId );
 
     /**
      * Returns the transaction mode for a given \a project.


### PR DESCRIPTION
These new APIs provide plugin authors with additional powers to inject layers within the currently opened project (for the duration of the project session).

The new APIs are documented within the .h[eaders].

Should be super interesting to see what people do with this. 

Here's a simple example that'd load a new memory layer showing the content of a GeoJSON string:

```
let layer = LayerUtils.memoryLayerFromJsonString("my_results", fetched_json_string, CoordinareReferenceSystemUtils.wgs84Crs())
ProjectUtils.addMapLayer(qgisProject, layer)
```

To subsequently remove the layer:

```
let layer = qgisProject.getMapLayersByName("my_results")[0];
ProjectUtils.removeMapLayer(layer);
```

Hint: the layers loading functions can lead to really cool stuff when paired with gdal's vsicurl prefix. This would add a remotely stored raster to a project:

```
let layer = LayerUtils.loadRasterLayer("/vsicurl/https://opengis.ch/cool_raster.tif", "cool_raster")
ProjectUtils.addMapLayer(qgisProject, layer)
```
