### PR TITLE
Deactivate tracking by default for project creation

### DIFF
--- a/src/qml/ProjectCreationScreen.qml
+++ b/src/qml/ProjectCreationScreen.qml
@@ -213,7 +213,7 @@ Page {
         id: trackPositionGroupBox
         title: qsTr("Track your position?")
         width: parent.width
-        checked: true
+        checked: false
         icon: Theme.getThemeVectorIcon("directions_walk_24dp")
         iconColor: Theme.mainTextColor
 


### PR DESCRIPTION
I think it's a better default, esp. since when enabled, we do auto tracking on project load which in turn means it turns the positioning on automatically and triggers on Android some permission requests (once, but still).