### PR TITLE
Rounded popup for nice visual improvement and harmony

### DIFF
--- a/src/qml/BookmarkProperties.qml
+++ b/src/qml/BookmarkProperties.qml
@@ -35,7 +35,7 @@ Popup {
 
   Page {
     width: parent.width
-    padding: 10
+    padding: 5
     header: QfPageHeader {
       id: pageHeader
       title: qsTr("Bookmark Properties")

--- a/src/qml/BookmarkProperties.qml
+++ b/src/qml/BookmarkProperties.qml
@@ -19,7 +19,7 @@ Popup {
   width: Math.min(350, mainWindow.width - Theme.popupScreenEdgeMargin)
   x: (parent.width - width) / 2
   y: (parent.height - height) / 2
-  padding: 0
+  padding: 5
   modal: true
   closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
   focus: visible

--- a/src/qml/BookmarkProperties.qml
+++ b/src/qml/BookmarkProperties.qml
@@ -8,7 +8,7 @@ import Theme
 /**
  * \ingroup qml
  */
-Popup {
+QfPopup {
   id: bookmarkProperties
 
   property string bookmarkId: ''
@@ -19,8 +19,6 @@ Popup {
   width: Math.min(350, mainWindow.width - Theme.popupScreenEdgeHorizontalMargin)
   x: (parent.width - width) / 2
   y: (parent.height - height) / 2
-  padding: 5
-  modal: true
   closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
   focus: visible
 

--- a/src/qml/BookmarkProperties.qml
+++ b/src/qml/BookmarkProperties.qml
@@ -16,7 +16,7 @@ Popup {
   property string bookmarkGroup: ''
 
   parent: mainWindow.contentItem
-  width: Math.min(350, mainWindow.width - Theme.popupScreenEdgeMargin)
+  width: Math.min(350, mainWindow.width - Theme.popupScreenEdgeHorizontalMargin)
   x: (parent.width - width) / 2
   y: (parent.height - height) / 2
   padding: 5

--- a/src/qml/BrowserPanel.qml
+++ b/src/qml/BrowserPanel.qml
@@ -24,7 +24,7 @@ Popup {
   height: mainWindow.height - (browserPanel.fullscreen ? 0 : Theme.popupScreenEdgeMargin * 2)
   x: browserPanel.fullscreen ? 0 : Theme.popupScreenEdgeMargin
   y: browserPanel.fullscreen ? 0 : Theme.popupScreenEdgeMargin
-  padding: 0
+  padding: fullscreen ? 0 : 5
   modal: true
   closePolicy: Popup.CloseOnEscape
   focus: visible

--- a/src/qml/BrowserPanel.qml
+++ b/src/qml/BrowserPanel.qml
@@ -20,10 +20,10 @@ Popup {
   property bool fullscreen: false
   property bool clearCookiesOnOpen: false
 
-  width: mainWindow.width - (browserPanel.fullscreen ? 0 : Theme.popupScreenEdgeMargin * 2)
-  height: mainWindow.height - (browserPanel.fullscreen ? 0 : Theme.popupScreenEdgeMargin * 2)
-  x: browserPanel.fullscreen ? 0 : Theme.popupScreenEdgeMargin
-  y: browserPanel.fullscreen ? 0 : Theme.popupScreenEdgeMargin
+  width: mainWindow.width - (browserPanel.fullscreen ? 0 : Theme.popupScreenEdgeHorizontalMargin * 2)
+  height: mainWindow.height - (browserPanel.fullscreen ? 0 : Theme.popupScreenEdgeVerticalMargin * 2)
+  x: browserPanel.fullscreen ? 0 : Theme.popupScreenEdgeVerticalMargin
+  y: browserPanel.fullscreen ? 0 : Theme.popupScreenEdgeVerticalMargin
   padding: fullscreen ? 0 : 5
   modal: true
   closePolicy: Popup.CloseOnEscape

--- a/src/qml/BrowserPanel.qml
+++ b/src/qml/BrowserPanel.qml
@@ -8,7 +8,7 @@ import Theme
 /**
  * \ingroup qml
  */
-Popup {
+QfPopup {
   id: browserPanel
 
   signal cancel
@@ -25,7 +25,6 @@ Popup {
   x: browserPanel.fullscreen ? 0 : Theme.popupScreenEdgeVerticalMargin
   y: browserPanel.fullscreen ? 0 : Theme.popupScreenEdgeVerticalMargin
   padding: fullscreen ? 0 : 5
-  modal: true
   closePolicy: Popup.CloseOnEscape
   focus: visible
 

--- a/src/qml/Changelog.qml
+++ b/src/qml/Changelog.qml
@@ -7,7 +7,7 @@ import Theme
 /**
  * \ingroup qml
  */
-Popup {
+QfPopup {
   id: changelogPopup
 
   parent: mainWindow.contentItem
@@ -15,8 +15,6 @@ Popup {
   height: mainWindow.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
   x: Theme.popupScreenEdgeHorizontalMargin
   y: (mainWindow.height - height) / 2
-  padding: 5
-  modal: true
   closePolicy: Popup.CloseOnEscape
   focus: visible
 

--- a/src/qml/Changelog.qml
+++ b/src/qml/Changelog.qml
@@ -15,7 +15,7 @@ Popup {
   height: mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
   x: Theme.popupScreenEdgeMargin
   y: (mainWindow.height - height) / 2
-  padding: 0
+  padding: 5
   modal: true
   closePolicy: Popup.CloseOnEscape
   focus: visible

--- a/src/qml/Changelog.qml
+++ b/src/qml/Changelog.qml
@@ -23,6 +23,7 @@ Popup {
   Page {
     focus: true
     anchors.fill: parent
+    padding: 5
 
     header: QfPageHeader {
       title: qsTr("What's new in QField")

--- a/src/qml/Changelog.qml
+++ b/src/qml/Changelog.qml
@@ -11,9 +11,9 @@ Popup {
   id: changelogPopup
 
   parent: mainWindow.contentItem
-  width: mainWindow.width - Theme.popupScreenEdgeMargin * 2
-  height: mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
-  x: Theme.popupScreenEdgeMargin
+  width: mainWindow.width - Theme.popupScreenEdgeHorizontalMargin * 2
+  height: mainWindow.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
+  x: Theme.popupScreenEdgeHorizontalMargin
   y: (mainWindow.height - height) / 2
   padding: 5
   modal: true

--- a/src/qml/CodeReader.qml
+++ b/src/qml/CodeReader.qml
@@ -106,7 +106,7 @@ Popup {
   Page {
     width: parent.width
     height: parent.height
-    padding: 10
+    padding: 5
     header: ToolBar {
       id: toolBar
 

--- a/src/qml/CodeReader.qml
+++ b/src/qml/CodeReader.qml
@@ -10,7 +10,7 @@ import Theme
 /**
  * \ingroup qml
  */
-Popup {
+QfPopup {
   id: codeReader
 
   //! Emitted when a QR code or NFC tag has been decoded/received
@@ -28,7 +28,6 @@ Popup {
   x: (parent.width - width) / 2
   y: (parent.height - height) / 2
   z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes
-  padding: 5
 
   closePolicy: Popup.CloseOnEscape
   dim: true

--- a/src/qml/CodeReader.qml
+++ b/src/qml/CodeReader.qml
@@ -20,11 +20,11 @@ Popup {
 
   property string decodedString: ''
   property var barcodeRequestedItem: undefined //<! when a feature form is requesting a bardcode, this will be set to attribute editor widget which triggered the request
-  property int popupWidth: mainWindow.width <= mainWindow.height ? mainWindow.width - Theme.popupScreenEdgeMargin : mainWindow.height - Theme.popupScreenEdgeMargin
+  property int popupWidth: mainWindow.width <= mainWindow.height ? mainWindow.width - Theme.popupScreenEdgeHorizontalMargin : mainWindow.height - Theme.popupScreenEdgeVerticalMargin
   property bool openedOnce: false
 
   width: popupWidth
-  height: Math.min(mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4), popupWidth + toolBar.height + acceptButton.height)
+  height: Math.min(mainWindow.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4), popupWidth + toolBar.height + acceptButton.height)
   x: (parent.width - width) / 2
   y: (parent.height - height) / 2
   z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes

--- a/src/qml/CodeReader.qml
+++ b/src/qml/CodeReader.qml
@@ -28,7 +28,7 @@ Popup {
   x: (parent.width - width) / 2
   y: (parent.height - height) / 2
   z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes
-  padding: 0
+  padding: 5
 
   closePolicy: Popup.CloseOnEscape
   dim: true

--- a/src/qml/EmbeddedFeatureForm.qml
+++ b/src/qml/EmbeddedFeatureForm.qml
@@ -6,7 +6,7 @@ import Theme
 /**
  * \ingroup qml
  */
-Popup {
+QfPopup {
   id: formPopup
 
   property alias state: form.state
@@ -48,13 +48,11 @@ Popup {
   parent: mainWindow.contentItem
   closePolicy: form.state === "ReadOnly" ? Popup.CloseOnEscape : Popup.NoAutoClose // prevent accidental feature addition and editing
 
-  padding: 5
   width: mainWindow.width - Theme.popupScreenEdgeHorizontalMargin * 2
   height: mainWindow.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
-  x: Theme.popupScreenEdgeVerticalMargin
+  x: Theme.popupScreenEdgeVerticalMargin / 2
   y: (mainWindow.height - height) / 2
   z: 1000 + embeddedLevel
-  modal: true
   focus: visible
 
   FeatureForm {

--- a/src/qml/EmbeddedFeatureForm.qml
+++ b/src/qml/EmbeddedFeatureForm.qml
@@ -48,7 +48,7 @@ Popup {
   parent: mainWindow.contentItem
   closePolicy: form.state === "ReadOnly" ? Popup.CloseOnEscape : Popup.NoAutoClose // prevent accidental feature addition and editing
 
-  padding: 0
+  padding: 5
   width: mainWindow.width - Theme.popupScreenEdgeMargin
   height: mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
   x: Theme.popupScreenEdgeMargin / 2

--- a/src/qml/EmbeddedFeatureForm.qml
+++ b/src/qml/EmbeddedFeatureForm.qml
@@ -49,9 +49,9 @@ Popup {
   closePolicy: form.state === "ReadOnly" ? Popup.CloseOnEscape : Popup.NoAutoClose // prevent accidental feature addition and editing
 
   padding: 5
-  width: mainWindow.width - Theme.popupScreenEdgeMargin
-  height: mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
-  x: Theme.popupScreenEdgeMargin / 2
+  width: mainWindow.width - Theme.popupScreenEdgeHorizontalMargin * 2
+  height: mainWindow.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
+  x: Theme.popupScreenEdgeVerticalMargin
   y: (mainWindow.height - height) / 2
   z: 1000 + embeddedLevel
   modal: true

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -811,6 +811,7 @@ Page {
         iconColor: model.featureModel.featureAdditionLocked || !model.constraintsHardValid ? Theme.mainOverlayColor : Theme.mainTextColor
         bgcolor: model.featureModel.featureAdditionLocked || !model.constraintsHardValid ? Theme.errorColor : !model.constraintsSoftValid ? Theme.warningColor : "transparent"
         borderColor: Theme.mainBackgroundColor
+        roundborder: true
         round: true
 
         onClicked: {

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -784,14 +784,11 @@ Page {
   header: ToolBar {
     id: toolbar
 
-    property color elementColor: toolbar.background.visible ? Theme.mainOverlayColor : Theme.mainTextColor
-
     height: visible ? form.topMargin + 48 : 0
     visible: form.state === 'Add'
     objectName: "toolbar"
     background: Rectangle {
-      visible: model.featureModel.featureAdditionLocked || !model.constraintsHardValid || !model.constraintsSoftValid
-      color: model.featureModel.featureAdditionLocked || !model.constraintsHardValid ? Theme.errorColor : !model.constraintsSoftValid ? Theme.warningColor : "transparent"
+      color: "transparent"
     }
 
     RowLayout {
@@ -799,7 +796,6 @@ Page {
       anchors.topMargin: form.topMargin
       anchors.leftMargin: form.leftMargin
       anchors.rightMargin: form.rightMargin
-      Layout.margins: 0
 
       QfToolButton {
         id: saveButton
@@ -812,8 +808,10 @@ Page {
         clip: true
 
         iconSource: Theme.getThemeVectorIcon("ic_check_white_24dp")
-        iconColor: toolbar.elementColor
-        opacity: model.constraintsHardValid ? 1.0 : 0.3
+        iconColor: model.featureModel.featureAdditionLocked || !model.constraintsHardValid ? Theme.mainOverlayColor : Theme.mainTextColor
+        bgcolor: model.featureModel.featureAdditionLocked || !model.constraintsHardValid ? Theme.errorColor : !model.constraintsSoftValid ? Theme.warningColor : "transparent"
+        borderColor: Theme.mainBackgroundColor
+        round: true
 
         onClicked: {
           if (model.constraintsHardValid) {
@@ -835,7 +833,7 @@ Page {
         objectName: "titleLabel"
 
         font: Theme.strongFont
-        color: toolbar.elementColor
+        color: Theme.mainTextColor
 
         text: {
           const featureModel = model.featureModel;
@@ -918,7 +916,7 @@ Page {
         visible: !setupOnly
 
         iconSource: form.state === 'Add' ? Theme.getThemeVectorIcon('ic_delete_forever_white_24dp') : Theme.getThemeVectorIcon('ic_close_white_24dp')
-        iconColor: toolbar.elementColor
+        iconColor: Theme.mainTextColor
 
         onClicked: {
           Qt.inputMethod.hide();

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -800,9 +800,10 @@ Page {
       QfToolButton {
         id: saveButton
 
-        Layout.alignment: Qt.AlignTop | Qt.AlignLeft
+        property bool isVisible: form.state === 'Add' || form.state === 'Edit'
 
-        visible: (form.state === 'Add' || form.state === 'Edit')
+        Layout.alignment: Qt.AlignTop | Qt.AlignLeft
+        visible: isVisible
         width: 48
         height: 48
         clip: true
@@ -830,7 +831,8 @@ Page {
         id: titleLabel
         Layout.fillWidth: true
         Layout.preferredHeight: parent.height
-        Layout.rightMargin: setupOnly ? 48 : 0
+        Layout.leftMargin: !saveButton.isVisible ? 48 : 0
+        Layout.rightMargin: !closeButton.isVisible ? 48 : 0
         objectName: "titleLabel"
 
         font: Theme.strongFont
@@ -909,12 +911,13 @@ Page {
       QfToolButton {
         id: closeButton
 
-        Layout.alignment: Qt.AlignTop | Qt.AlignRight
+        property bool isVisible: !setupOnly
 
+        Layout.alignment: Qt.AlignTop | Qt.AlignRight
         width: 48
         height: 48
         clip: true
-        visible: !setupOnly
+        visible: isVisible
 
         iconSource: form.state === 'Add' ? Theme.getThemeVectorIcon('ic_delete_forever_white_24dp') : Theme.getThemeVectorIcon('ic_close_white_24dp')
         iconColor: Theme.mainTextColor

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -25,8 +25,8 @@ Popup {
   property bool opacitySliderVisible: false
 
   parent: mainWindow.contentItem
-  width: Math.min(childrenRect.width, mainWindow.width - Theme.popupScreenEdgeMargin)
-  height: Math.min(popupLayout.childrenRect.height + headerLayout.childrenRect.height + 30, mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4))
+  width: Math.min(childrenRect.width, mainWindow.width - Theme.popupScreenEdgeHorizontalMargin)
+  height: Math.min(popupLayout.childrenRect.height + headerLayout.childrenRect.height + 30, mainWindow.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4))
   x: (mainWindow.width - width) / 2
   y: (mainWindow.height - height) / 2
   padding: 5

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -8,7 +8,7 @@ import Theme
 /**
  * \ingroup qml
  */
-Popup {
+QfPopup {
   id: popup
 
   property var layerTree
@@ -29,8 +29,6 @@ Popup {
   height: Math.min(popupLayout.childrenRect.height + headerLayout.childrenRect.height + 30, mainWindow.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4))
   x: (mainWindow.width - width) / 2
   y: (mainWindow.height - height) / 2
-  padding: 5
-  modal: true
   closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
   focus: visible
 

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -62,19 +62,19 @@ Popup {
     id: popupContent
     width: parent.width
     height: parent.height
-    padding: 10
+    padding: 5
     header: RowLayout {
       id: headerLayout
       spacing: 2
       Label {
         id: titleLabel
         Layout.fillWidth: true
-        Layout.leftMargin: 10
+        Layout.leftMargin: reloadDataButtonVisible ? zoomInButton.width + headerLayout.spacing : 0
         topPadding: 10
         bottomPadding: 10
         text: ''
         font: Theme.strongFont
-        horizontalAlignment: Text.AlignLeft
+        horizontalAlignment: Text.AlignHCenter
         wrapMode: Text.WordWrap
       }
       QfToolButton {
@@ -110,7 +110,7 @@ Popup {
 
       ColumnLayout {
         id: popupLayout
-        width: popupContent.width - 20
+        width: popupContent.width - 10
         spacing: 4
 
         FontMetrics {

--- a/src/qml/LayerTreeItemProperties.qml
+++ b/src/qml/LayerTreeItemProperties.qml
@@ -26,10 +26,10 @@ Popup {
 
   parent: mainWindow.contentItem
   width: Math.min(childrenRect.width, mainWindow.width - Theme.popupScreenEdgeMargin)
-  height: Math.min(popupLayout.childrenRect.height + headerLayout.childrenRect.height + 20, mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4))
+  height: Math.min(popupLayout.childrenRect.height + headerLayout.childrenRect.height + 30, mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4))
   x: (mainWindow.width - width) / 2
   y: (mainWindow.height - height) / 2
-  padding: 0
+  padding: 5
   modal: true
   closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
   focus: visible
@@ -104,6 +104,7 @@ Popup {
       }
       contentWidth: popupLayout.childrenRect.width
       contentHeight: popupLayout.childrenRect.height
+      width: parent.width
       height: parent.height
       clip: true
 

--- a/src/qml/LocatorSettings.qml
+++ b/src/qml/LocatorSettings.qml
@@ -13,7 +13,7 @@ Popup {
 
   property alias locatorFiltersModel: locatorfiltersList.model
 
-  width: Math.min(400, mainWindow.width - Theme.popupScreenEdgeMargin)
+  width: Math.min(400, mainWindow.width - Theme.popupScreenEdgeHorizontalMargin)
   x: (parent.width - width) / 2
   y: (parent.height - height) / 2
   padding: 5

--- a/src/qml/LocatorSettings.qml
+++ b/src/qml/LocatorSettings.qml
@@ -8,7 +8,7 @@ import Theme
 /**
  * \ingroup qml
  */
-Popup {
+QfPopup {
   id: popup
 
   property alias locatorFiltersModel: locatorfiltersList.model
@@ -16,8 +16,6 @@ Popup {
   width: Math.min(400, mainWindow.width - Theme.popupScreenEdgeHorizontalMargin)
   x: (parent.width - width) / 2
   y: (parent.height - height) / 2
-  padding: 5
-  modal: true
   closePolicy: Popup.CloseOnEscape
   parent: Overlay.overlay
   focus: visible

--- a/src/qml/LocatorSettings.qml
+++ b/src/qml/LocatorSettings.qml
@@ -16,7 +16,7 @@ Popup {
   width: Math.min(400, mainWindow.width - Theme.popupScreenEdgeMargin)
   x: (parent.width - width) / 2
   y: (parent.height - height) / 2
-  padding: 0
+  padding: 5
   modal: true
   closePolicy: Popup.CloseOnEscape
   parent: Overlay.overlay

--- a/src/qml/LocatorSettings.qml
+++ b/src/qml/LocatorSettings.qml
@@ -26,7 +26,7 @@ Popup {
     id: page
     width: parent.width
     height: locatorfiltersList.height + 60
-    padding: 10
+    padding: 5
     header: QfPageHeader {
       id: pageHeader
       title: qsTr("Search Bar Settings")

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -39,8 +39,6 @@ Rectangle {
   property double leftMargin: 0.0
   property double rightMargin: 0.0
 
-  property color elementColor: navigationStatusIndicator.visible ? Theme.mainOverlayColor : Theme.mainTextColor
-
   signal backClicked
   signal statusIndicatorClicked
   signal statusIndicatorSwiped(var direction)
@@ -92,8 +90,7 @@ Rectangle {
     id: navigationStatusIndicator
     anchors.fill: parent
     height: toolBar.topMargin + 48
-    visible: toolBar.state === "Edit" && (!featureForm.model.constraintsHardValid || !featureForm.model.constraintsSoftValid)
-    color: !featureForm.model.constraintsHardValid ? Theme.errorColor : !featureForm.model.constraintsSoftValid ? Theme.warningColor : "transparent"
+    color: "transparent"
     clip: true
   }
 
@@ -107,7 +104,7 @@ Rectangle {
       // Insure that the text is always visually centered by using the same left and right margi
       property double balancedMargin: Math.max((saveButton.visible ? saveButton.width : 0) + (previousButton.visible ? previousButton.width : 0) + (nextButton.visible ? nextButton.width : 0) + (multiClearButton.visible ? multiClearButton.width : 0), (cancelButton.visible ? cancelButton.width : 0) + (editButton.visible ? editButton.width : 0) + (editGeomButton.visible ? editGeomButton.width : 0) + (multiEditButton.visible ? multiEditButton.width : 0) + (menuButton.visible ? menuButton.width : 0))
       font: Theme.strongFont
-      color: toolBar.elementColor
+      color: Theme.mainTextColor
       anchors.left: parent.left
       anchors.right: parent.right
       anchors.top: parent.top
@@ -194,7 +191,7 @@ Rectangle {
     clip: true
 
     iconSource: Theme.getThemeVectorIcon("ic_chevron_right_white_24dp")
-    iconColor: toolBar.elementColor
+    iconColor: Theme.mainTextColor
 
     enabled: toolBar.state === "Navigation"
 
@@ -228,7 +225,7 @@ Rectangle {
     clip: true
 
     iconSource: toolBar.state === "Navigation" ? Theme.getThemeVectorIcon("ic_chevron_left_white_24dp") : Theme.getThemeVectorIcon("ic_arrow_left_white_24dp")
-    iconColor: toolBar.elementColor
+    iconColor: Theme.mainTextColor
 
     enabled: toolBar.state !== "Edit" && !toolBar.multiSelection
 
@@ -262,9 +259,11 @@ Rectangle {
     clip: true
 
     iconSource: Theme.getThemeVectorIcon("ic_check_white_24dp")
-    iconColor: toolBar.elementColor
+    iconColor: !featureForm.model.constraintsHardValid ? Theme.mainOverlayColor : Theme.mainTextColor
+    bgcolor: !featureForm.model.constraintsHardValid ? Theme.errorColor : !featureForm.model.constraintsSoftValid ? Theme.warningColor : "transparent"
+    borderColor: Theme.mainBackgroundColor
+    round: true
 
-    opacity: featureForm.model.constraintsHardValid ? 1.0 : 0.3
     onClicked: {
       if (toolBar.state === "ProcessingLaunch") {
         processingRunClicked();
@@ -297,7 +296,7 @@ Rectangle {
     clip: true
 
     iconSource: Theme.getThemeVectorIcon("ic_clear_white_24dp")
-    iconColor: toolBar.elementColor
+    iconColor: Theme.mainTextColor
 
     onClicked: {
       toolBar.cancel();
@@ -322,7 +321,7 @@ Rectangle {
     anchors.topMargin: toolBar.topMargin
 
     iconSource: Theme.getThemeVectorIcon("ic_edit_geometry_white_24dp")
-    iconColor: toolBar.elementColor
+    iconColor: Theme.mainTextColor
 
     width: visible ? 48 : 0
     height: 48
@@ -364,7 +363,7 @@ Rectangle {
     clip: true
 
     iconSource: Theme.getThemeVectorIcon("ic_edit_attributes_white_24dp")
-    iconColor: toolBar.elementColor
+    iconColor: Theme.mainTextColor
 
     onClicked: {
       toolBar.editAttributesButtonClicked();
@@ -406,7 +405,7 @@ Rectangle {
     clip: true
 
     iconSource: Theme.getThemeVectorIcon("ic_dot_menu_black_24dp")
-    iconColor: toolBar.elementColor
+    iconColor: Theme.mainTextColor
 
     onClicked: {
       if (toolBar.state === "Indication") {
@@ -436,7 +435,7 @@ Rectangle {
     clip: true
 
     iconSource: Theme.getThemeVectorIcon("ic_clear_white_24dp")
-    iconColor: toolBar.elementColor
+    iconColor: Theme.mainTextColor
 
     enabled: (toolBar.multiSelection && toolBar.model)
 
@@ -461,7 +460,7 @@ Rectangle {
     height: 48
     verticalAlignment: Text.AlignVCenter
     font: Theme.strongFont
-    color: toolBar.elementColor
+    color: Theme.mainTextColor
 
     text: model.selectedFeatures.length < 100 ? model.selectedFeatures.length : '99+'
 
@@ -481,7 +480,7 @@ Rectangle {
     clip: true
 
     iconSource: Theme.getThemeVectorIcon("ic_edit_attributes_white_24dp")
-    iconColor: toolBar.elementColor
+    iconColor: Theme.mainTextColor
 
     enabled: toolBar.model && toolBar.model.canEditAttributesSelection && toolBar.model.selectedCount > 1 && projectInfo.editRights
 

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -262,6 +262,7 @@ Rectangle {
     iconColor: !featureForm.model.constraintsHardValid ? Theme.mainOverlayColor : Theme.mainTextColor
     bgcolor: !featureForm.model.constraintsHardValid ? Theme.errorColor : !featureForm.model.constraintsSoftValid ? Theme.warningColor : "transparent"
     borderColor: Theme.mainBackgroundColor
+    roundborder: true
     round: true
 
     onClicked: {

--- a/src/qml/NotesItem.qml
+++ b/src/qml/NotesItem.qml
@@ -28,7 +28,7 @@ Popup {
     id: popupContent
     width: parent.width
     height: parent.height
-    padding: 10
+    padding: 5
 
     header: RowLayout {
       id: headerLayout

--- a/src/qml/NotesItem.qml
+++ b/src/qml/NotesItem.qml
@@ -15,8 +15,8 @@ Popup {
   property alias notes: notesText.text
 
   parent: mainWindow.contentItem
-  width: Math.min(childrenRect.width, mainWindow.width - Theme.popupScreenEdgeMargin)
-  height: Math.min(popupLayout.childrenRect.height + headerLayout.childrenRect.height + 20, mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4))
+  width: Math.min(childrenRect.width, mainWindow.width - Theme.popupScreenEdgeHorizontalMargin)
+  height: Math.min(popupLayout.childrenRect.height + headerLayout.childrenRect.height + 20, mainWindow.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4))
   x: (mainWindow.width - width) / 2
   y: (mainWindow.height - height) / 2
   padding: 5

--- a/src/qml/NotesItem.qml
+++ b/src/qml/NotesItem.qml
@@ -19,7 +19,7 @@ Popup {
   height: Math.min(popupLayout.childrenRect.height + headerLayout.childrenRect.height + 20, mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4))
   x: (mainWindow.width - width) / 2
   y: (mainWindow.height - height) / 2
-  padding: 0
+  padding: 5
   modal: true
   closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
   focus: visible

--- a/src/qml/NotesItem.qml
+++ b/src/qml/NotesItem.qml
@@ -8,7 +8,7 @@ import Theme
 /**
  * \ingroup qml
  */
-Popup {
+QfPopup {
   id: popup
 
   property alias title: titleLabel.text
@@ -19,8 +19,6 @@ Popup {
   height: Math.min(popupLayout.childrenRect.height + headerLayout.childrenRect.height + 20, mainWindow.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4))
   x: (mainWindow.width - width) / 2
   y: (mainWindow.height - height) / 2
-  padding: 5
-  modal: true
   closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
   focus: visible
 

--- a/src/qml/PluginManagerSettings.qml
+++ b/src/qml/PluginManagerSettings.qml
@@ -13,11 +13,11 @@ Popup {
 
   property bool availablePluginsFetched: false
 
-  width: Math.min(400, mainWindow.width - Theme.popupScreenEdgeMargin)
+  width: Math.min(500, mainWindow.width - Theme.popupScreenEdgeMargin)
   height: mainWindow.height - 160
   x: (parent.width - width) / 2
   y: (parent.height - height) / 2
-  padding: 0
+  padding: 5
   modal: true
   closePolicy: Popup.CloseOnEscape
   parent: Overlay.overlay

--- a/src/qml/PluginManagerSettings.qml
+++ b/src/qml/PluginManagerSettings.qml
@@ -8,7 +8,7 @@ import Theme
 /**
  * \ingroup qml
  */
-Popup {
+QfPopup {
   id: popup
 
   property bool availablePluginsFetched: false
@@ -17,8 +17,6 @@ Popup {
   height: mainWindow.height - 120
   x: (parent.width - width) / 2
   y: (parent.height - height) / 2
-  padding: 5
-  modal: true
   closePolicy: Popup.CloseOnEscape
   parent: Overlay.overlay
   focus: visible

--- a/src/qml/PluginManagerSettings.qml
+++ b/src/qml/PluginManagerSettings.qml
@@ -14,7 +14,7 @@ Popup {
   property bool availablePluginsFetched: false
 
   width: Math.min(500, mainWindow.width - Theme.popupScreenEdgeHorizontalMargin)
-  height: mainWindow.height - 160
+  height: mainWindow.height - 120
   x: (parent.width - width) / 2
   y: (parent.height - height) / 2
   padding: 5
@@ -31,7 +31,7 @@ Popup {
     id: page
     width: parent.width
     height: parent.height
-    padding: 10
+    padding: 5
     header: QfPageHeader {
       id: pageHeader
       title: qsTr("Plugins")

--- a/src/qml/PluginManagerSettings.qml
+++ b/src/qml/PluginManagerSettings.qml
@@ -13,7 +13,7 @@ Popup {
 
   property bool availablePluginsFetched: false
 
-  width: Math.min(500, mainWindow.width - Theme.popupScreenEdgeMargin)
+  width: Math.min(500, mainWindow.width - Theme.popupScreenEdgeHorizontalMargin)
   height: mainWindow.height - 160
   x: (parent.width - width) / 2
   y: (parent.height - height) / 2

--- a/src/qml/PluginManagerSettings.qml
+++ b/src/qml/PluginManagerSettings.qml
@@ -56,16 +56,10 @@ QfPopup {
         Layout.preferredHeight: defaultHeight
         model: [qsTr("Local Plugins"), qsTr("Available Plugins")]
         currentIndex: 0
-        delegate: TabButton {
-          text: modelData
-          height: filterBar.defaultHeight
-          width: pluginsLayout.width / filterBar.count
-          font: Theme.defaultFont
-          onClicked: {
-            filterBar.currentIndex = index;
-            if (index == 1 && !popup.availablePluginsFetched) {
-              pluginManager.pluginModel.refresh(true);
-            }
+
+        onClicked: {
+          if (index == 1 && !popup.availablePluginsFetched) {
+            pluginManager.pluginModel.refresh(true);
           }
         }
       }

--- a/src/qml/PositioningDeviceSettings.qml
+++ b/src/qml/PositioningDeviceSettings.qml
@@ -16,7 +16,7 @@ Popup {
 
   width: mainWindow.width - Theme.popupScreenEdgeHorizontalMargin * 2
   height: mainWindow.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
-  x: Theme.popupScreenEdgeHorizontalMargin
+  x: (mainWindow.width - width) / 2
   y: (mainWindow.height - height) / 2
   padding: 5
   modal: true
@@ -101,7 +101,7 @@ Popup {
     id: page
     width: parent.width
     height: parent.height
-    padding: 10
+    padding: 5
     header: QfPageHeader {
       id: pageHeader
       title: qsTr("Positioning Device Settings")
@@ -132,7 +132,7 @@ Popup {
       Label {
         text: qsTr("Connection type")
         font: Theme.strongFont
-        color: Theme.mainColor
+        color: Theme.mainTextColor
         wrapMode: Text.WordWrap
         Layout.fillWidth: true
         Layout.topMargin: 5
@@ -143,7 +143,7 @@ Popup {
         Layout.fillWidth: true
         Layout.columnSpan: 2
         height: 1
-        color: Theme.mainColor
+        color: Theme.mainTextColor
       }
 
       ComboBox {
@@ -226,7 +226,7 @@ Popup {
       Label {
         text: qsTr("Connection details")
         font: Theme.strongFont
-        color: Theme.mainColor
+        color: Theme.mainTextColor
         wrapMode: Text.WordWrap
         Layout.fillWidth: true
         Layout.topMargin: 5
@@ -237,7 +237,7 @@ Popup {
         Layout.fillWidth: true
         Layout.columnSpan: 2
         height: 1
-        color: Theme.mainColor
+        color: Theme.mainTextColor
       }
 
       ListModel {

--- a/src/qml/PositioningDeviceSettings.qml
+++ b/src/qml/PositioningDeviceSettings.qml
@@ -8,7 +8,7 @@ import Theme
 /**
  * \ingroup qml
  */
-Popup {
+QfPopup {
   id: popup
   parent: mainWindow.contentItem
 
@@ -18,8 +18,6 @@ Popup {
   height: mainWindow.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
   x: (mainWindow.width - width) / 2
   y: (mainWindow.height - height) / 2
-  padding: 5
-  modal: true
   focus: visible
 
   property alias name: positioningDeviceName.text

--- a/src/qml/PositioningDeviceSettings.qml
+++ b/src/qml/PositioningDeviceSettings.qml
@@ -137,13 +137,6 @@ QfPopup {
         Layout.columnSpan: 2
       }
 
-      Rectangle {
-        Layout.fillWidth: true
-        Layout.columnSpan: 2
-        height: 1
-        color: Theme.mainTextColor
-      }
-
       ComboBox {
         id: positioningDeviceType
         Layout.fillWidth: true
@@ -229,13 +222,6 @@ QfPopup {
         Layout.fillWidth: true
         Layout.topMargin: 5
         Layout.columnSpan: 2
-      }
-
-      Rectangle {
-        Layout.fillWidth: true
-        Layout.columnSpan: 2
-        height: 1
-        color: Theme.mainTextColor
       }
 
       ListModel {

--- a/src/qml/PositioningDeviceSettings.qml
+++ b/src/qml/PositioningDeviceSettings.qml
@@ -14,9 +14,9 @@ Popup {
 
   signal apply
 
-  width: mainWindow.width - Theme.popupScreenEdgeMargin * 2
-  height: mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
-  x: Theme.popupScreenEdgeMargin
+  width: mainWindow.width - Theme.popupScreenEdgeHorizontalMargin * 2
+  height: mainWindow.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
+  x: Theme.popupScreenEdgeHorizontalMargin
   y: (mainWindow.height - height) / 2
   padding: 5
   modal: true

--- a/src/qml/PositioningDeviceSettings.qml
+++ b/src/qml/PositioningDeviceSettings.qml
@@ -18,7 +18,7 @@ Popup {
   height: mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
   x: Theme.popupScreenEdgeMargin
   y: (mainWindow.height - height) / 2
-  padding: 0
+  padding: 5
   modal: true
   focus: visible
 

--- a/src/qml/QFieldAudioRecorder.qml
+++ b/src/qml/QFieldAudioRecorder.qml
@@ -10,7 +10,7 @@ import Theme
 /**
  * \ingroup qml
  */
-Popup {
+QfPopup {
   id: audioRecorder
 
   signal finished(string path)
@@ -25,7 +25,6 @@ Popup {
   x: (parent.width - width) / 2
   y: (parent.height - height) / 2
   z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes
-  padding: 5
   parent: mainWindow.contentItem
 
   closePolicy: Popup.CloseOnEscape

--- a/src/qml/QFieldAudioRecorder.qml
+++ b/src/qml/QFieldAudioRecorder.qml
@@ -25,7 +25,7 @@ Popup {
   x: (parent.width - width) / 2
   y: (parent.height - height) / 2
   z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes
-  padding: 0
+  padding: 5
   parent: mainWindow.contentItem
 
   closePolicy: Popup.CloseOnEscape

--- a/src/qml/QFieldAudioRecorder.qml
+++ b/src/qml/QFieldAudioRecorder.qml
@@ -18,10 +18,10 @@ Popup {
 
   property bool preRecording: true
   property bool hasRecordedClip: player.duration > 0
-  property int popupWidth: Math.min(400, mainWindow.width <= mainWindow.height ? mainWindow.width - Theme.popupScreenEdgeMargin : mainWindow.height - Theme.popupScreenEdgeMargin)
+  property int popupWidth: Math.min(400, mainWindow.width <= mainWindow.height ? mainWindow.width - Theme.popupScreenEdgeVerticalMargin : mainWindow.height - Theme.popupScreenEdgeVerticalMargin)
 
   width: popupWidth
-  height: Math.min(mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4), popupWidth + toolBar.height + recordButton.height)
+  height: Math.min(mainWindow.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4), popupWidth + toolBar.height + recordButton.height)
   x: (parent.width - width) / 2
   y: (parent.height - height) / 2
   z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes

--- a/src/qml/QFieldCloudDeltaHistory.qml
+++ b/src/qml/QFieldCloudDeltaHistory.qml
@@ -33,7 +33,7 @@ Popup {
     id: page
     width: parent.width
     height: Math.min(deltaList.contentHeight + toolBar.childrenRect.height + 20, mainWindow.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4))
-    padding: 10
+    padding: 5
     header: ToolBar {
       id: toolBar
       height: 48

--- a/src/qml/QFieldCloudDeltaHistory.qml
+++ b/src/qml/QFieldCloudDeltaHistory.qml
@@ -13,7 +13,7 @@ Popup {
 
   property alias model: deltaList.model
 
-  width: Math.min(400, mainWindow.width - Theme.popupScreenEdgeMargin * 2)
+  width: Math.min(400, mainWindow.width - Theme.popupScreenEdgeHorizontalMargin * 2)
   height: page.height
   x: (mainWindow.width - width) / 2
   y: (mainWindow.height - height) / 2
@@ -32,7 +32,7 @@ Popup {
   Page {
     id: page
     width: parent.width
-    height: Math.min(deltaList.contentHeight + toolBar.childrenRect.height + 20, mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4))
+    height: Math.min(deltaList.contentHeight + toolBar.childrenRect.height + 20, mainWindow.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4))
     padding: 10
     header: ToolBar {
       id: toolBar

--- a/src/qml/QFieldCloudDeltaHistory.qml
+++ b/src/qml/QFieldCloudDeltaHistory.qml
@@ -8,7 +8,7 @@ import Theme
 /**
  * \ingroup qml
  */
-Popup {
+QfPopup {
   id: popup
 
   property alias model: deltaList.model
@@ -17,7 +17,6 @@ Popup {
   height: page.height
   x: (mainWindow.width - width) / 2
   y: (mainWindow.height - height) / 2
-  padding: 5
 
   onOpened: function () {
     if (cloudProjectsModel.currentProjectId) {

--- a/src/qml/QFieldCloudDeltaHistory.qml
+++ b/src/qml/QFieldCloudDeltaHistory.qml
@@ -17,7 +17,7 @@ Popup {
   height: page.height
   x: (mainWindow.width - width) / 2
   y: (mainWindow.height - height) / 2
-  padding: 0
+  padding: 5
 
   onOpened: function () {
     if (cloudProjectsModel.currentProjectId) {

--- a/src/qml/QFieldCloudPackageLayersFeedback.qml
+++ b/src/qml/QFieldCloudPackageLayersFeedback.qml
@@ -13,8 +13,8 @@ QfDialog {
   property alias packagedLayersListViewModel: packagedLayersListView.model
 
   parent: mainWindow.contentItem
-  width: mainWindow.width - Theme.popupScreenEdgeMargin * 2
-  height: Math.min(300 + packagedLayersListView.contentHeight, mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4))
+  width: mainWindow.width - Theme.popupScreenEdgeVerticalMargin * 2
+  height: Math.min(300 + packagedLayersListView.contentHeight, mainWindow.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4))
 
   title: qsTr("QFieldCloud had troubles packaging your project")
 

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -328,13 +328,6 @@ Page {
                 Layout.topMargin: 5
                 Layout.columnSpan: 2
               }
-
-              Rectangle {
-                Layout.fillWidth: true
-                Layout.columnSpan: 2
-                height: 1
-                color: Theme.mainTextColor
-              }
             }
 
             ListView {
@@ -433,13 +426,6 @@ Page {
                 Layout.topMargin: 10
                 Layout.columnSpan: 2
               }
-
-              Rectangle {
-                Layout.fillWidth: true
-                Layout.columnSpan: 2
-                height: 1
-                color: Theme.mainTextColor
-              }
             }
 
             ListView {
@@ -470,13 +456,6 @@ Page {
                 Layout.fillWidth: true
                 Layout.topMargin: 5
                 Layout.columnSpan: 2
-              }
-
-              Rectangle {
-                Layout.fillWidth: true
-                Layout.columnSpan: 2
-                height: 1
-                color: Theme.mainTextColor
               }
 
               Label {
@@ -806,13 +785,6 @@ Page {
                 Layout.fillWidth: true
                 Layout.topMargin: 5
                 Layout.columnSpan: 2
-              }
-
-              Rectangle {
-                Layout.fillWidth: true
-                Layout.columnSpan: 2
-                height: 1
-                color: Theme.mainTextColor
               }
             }
 

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -42,7 +42,7 @@ Item {
   }
   height: childrenRect.height
 
-  Popup {
+  QfPopup {
     id: searchFeaturePopup
 
     readonly property int minimumHeight: mainWindow.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
@@ -53,8 +53,6 @@ Item {
     x: Theme.popupScreenEdgeHorizontalMargin
     y: (mainWindow.height - height) / 2
     z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes
-    padding: 5
-    modal: true
     closePolicy: Popup.CloseOnEscape
     focus: visible
 

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -53,7 +53,7 @@ Item {
     x: Theme.popupScreenEdgeMargin
     y: (mainWindow.height - height) / 2
     z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes
-    padding: 0
+    padding: 5
     modal: true
     closePolicy: Popup.CloseOnEscape
     focus: visible

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -79,6 +79,7 @@ Item {
 
     Page {
       anchors.fill: parent
+      padding: 5
 
       header: QfPageHeader {
         title: fieldLabel

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -45,12 +45,12 @@ Item {
   Popup {
     id: searchFeaturePopup
 
-    readonly property int minimumHeight: mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
+    readonly property int minimumHeight: mainWindow.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
 
     parent: mainWindow.contentItem
-    width: mainWindow.width - Theme.popupScreenEdgeMargin * 2
+    width: mainWindow.width - Theme.popupScreenEdgeHorizontalMargin * 2
     height: minimumHeight > 0 ? minimumHeight : 200
-    x: Theme.popupScreenEdgeMargin
+    x: Theme.popupScreenEdgeHorizontalMargin
     y: (mainWindow.height - height) / 2
     z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes
     padding: 5

--- a/src/qml/TemporalProperties.qml
+++ b/src/qml/TemporalProperties.qml
@@ -14,7 +14,7 @@ Popup {
   property MapSettings mapSettings
 
   parent: mainWindow.contentItem
-  width: Math.min(350, mainWindow.width - Theme.popupScreenEdgeMargin)
+  width: Math.min(350, mainWindow.width - Theme.popupScreenEdgeHorizontalMargin)
   x: (parent.width - width) / 2
   y: (parent.height - height) / 2
   padding: 5

--- a/src/qml/TemporalProperties.qml
+++ b/src/qml/TemporalProperties.qml
@@ -8,7 +8,7 @@ import Theme
 /**
  * \ingroup qml
  */
-Popup {
+QfPopup {
   id: temporalProperties
 
   property MapSettings mapSettings
@@ -17,8 +17,6 @@ Popup {
   width: Math.min(350, mainWindow.width - Theme.popupScreenEdgeHorizontalMargin)
   x: (parent.width - width) / 2
   y: (parent.height - height) / 2
-  padding: 5
-  modal: true
   closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
   focus: visible
 

--- a/src/qml/TemporalProperties.qml
+++ b/src/qml/TemporalProperties.qml
@@ -17,7 +17,7 @@ Popup {
   width: Math.min(350, mainWindow.width - Theme.popupScreenEdgeMargin)
   x: (parent.width - width) / 2
   y: (parent.height - height) / 2
-  padding: 0
+  padding: 5
   modal: true
   closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
   focus: visible

--- a/src/qml/TemporalProperties.qml
+++ b/src/qml/TemporalProperties.qml
@@ -24,7 +24,7 @@ Popup {
 
   Page {
     width: parent.width
-    padding: 10
+    padding: 5
     header: QfPageHeader {
       id: pageHeader
       title: qsTr("Temporal Properties")

--- a/src/qml/TrackerSettings.qml
+++ b/src/qml/TrackerSettings.qml
@@ -13,9 +13,9 @@ Popup {
 
   parent: mainWindow.contentItem
   padding: 5
-  width: mainWindow.width - Theme.popupScreenEdgeMargin
-  height: mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
-  x: Theme.popupScreenEdgeMargin / 2
+  width: mainWindow.width - Theme.popupScreenEdgeHorizontalMargin * 2
+  height: mainWindow.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
+  x: Theme.popupScreenEdgeHorizontalMargin
   y: (mainWindow.height - height) / 2
   modal: true
   closePolicy: Popup.NoAutoClose
@@ -561,11 +561,11 @@ Popup {
       id: embeddedFeatureFormPopup
       parent: mainWindow.contentItem
 
-      x: Theme.popupScreenEdgeMargin / 2
-      y: Theme.popupScreenEdgeMargin
+      x: Theme.popupScreenEdgeHorizontalMargin
+      y: Theme.popupScreenEdgeVerticalMargin
       padding: 5
-      width: parent.width - Theme.popupScreenEdgeMargin
-      height: parent.height - Theme.popupScreenEdgeMargin * 2
+      width: parent.width - Theme.popupScreenEdgeHorizontalMargin * 2
+      height: parent.height - Theme.popupScreenEdgeVerticalMargin * 2
       modal: true
       closePolicy: Popup.NoAutoClose
 

--- a/src/qml/TrackerSettings.qml
+++ b/src/qml/TrackerSettings.qml
@@ -12,7 +12,7 @@ Popup {
   id: trackInformationPopup
 
   parent: mainWindow.contentItem
-  padding: 0
+  padding: 5
   width: mainWindow.width - Theme.popupScreenEdgeMargin
   height: mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
   x: Theme.popupScreenEdgeMargin / 2
@@ -563,7 +563,7 @@ Popup {
 
       x: Theme.popupScreenEdgeMargin / 2
       y: Theme.popupScreenEdgeMargin
-      padding: 0
+      padding: 5
       width: parent.width - Theme.popupScreenEdgeMargin
       height: parent.height - Theme.popupScreenEdgeMargin * 2
       modal: true

--- a/src/qml/TrackerSettings.qml
+++ b/src/qml/TrackerSettings.qml
@@ -139,13 +139,6 @@ QfPopup {
             Layout.columnSpan: 2
           }
 
-          Rectangle {
-            Layout.fillWidth: true
-            Layout.columnSpan: 2
-            height: 1
-            color: Theme.mainTextColor
-          }
-
           Label {
             text: qsTr("Time requirement")
             font: Theme.defaultFont
@@ -358,13 +351,6 @@ QfPopup {
             Layout.fillWidth: true
             Layout.columnSpan: 2
             Layout.topMargin: 4
-          }
-
-          Rectangle {
-            Layout.fillWidth: true
-            Layout.columnSpan: 2
-            height: 1
-            color: Theme.mainTextColor
           }
 
           Label {

--- a/src/qml/TrackerSettings.qml
+++ b/src/qml/TrackerSettings.qml
@@ -8,16 +8,14 @@ import Theme
 /**
  * \ingroup qml
  */
-Popup {
+QfPopup {
   id: trackInformationPopup
 
   parent: mainWindow.contentItem
-  padding: 5
   width: mainWindow.width - Theme.popupScreenEdgeHorizontalMargin * 2
   height: mainWindow.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
   x: Theme.popupScreenEdgeHorizontalMargin
   y: (mainWindow.height - height) / 2
-  modal: true
   closePolicy: Popup.NoAutoClose
 
   property var tracker: undefined
@@ -558,16 +556,14 @@ Popup {
   Component {
     id: embeddedFeatureFormComponent
 
-    Popup {
+    QfPopup {
       id: embeddedFeatureFormPopup
       parent: mainWindow.contentItem
 
       x: Theme.popupScreenEdgeHorizontalMargin
       y: Theme.popupScreenEdgeVerticalMargin
-      padding: 5
       width: parent.width - Theme.popupScreenEdgeHorizontalMargin * 2
       height: parent.height - Theme.popupScreenEdgeVerticalMargin * 2
-      modal: true
       closePolicy: Popup.NoAutoClose
 
       FeatureForm {

--- a/src/qml/TrackerSettings.qml
+++ b/src/qml/TrackerSettings.qml
@@ -89,6 +89,7 @@ Popup {
   Page {
     focus: true
     anchors.fill: parent
+    padding: 5
 
     header: QfPageHeader {
       title: tracker !== undefined && tracker.vectorLayer ? qsTr("Tracking: %1").arg(tracker.vectorLayer.name) : qsTr("Tracking")

--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -249,7 +249,7 @@ EditorWidgetBase {
       x: Theme.popupScreenEdgeMargin
       y: (mainWindow.height - height) / 2
       z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes
-      padding: 0
+      padding: 5
       modal: true
       closePolicy: Popup.CloseOnEscape
       focus: visible

--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -244,9 +244,9 @@ EditorWidgetBase {
       id: searchFeaturePopup
 
       parent: mainWindow.contentItem
-      width: mainWindow.width - Theme.popupScreenEdgeMargin * 2
-      height: mainWindow.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
-      x: Theme.popupScreenEdgeMargin
+      width: mainWindow.width - Theme.popupScreenEdgeHorizontalMargin * 2
+      height: mainWindow.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
+      x: Theme.popupScreenEdgeHorizontalMargin
       y: (mainWindow.height - height) / 2
       z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes
       padding: 5

--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -266,6 +266,7 @@ EditorWidgetBase {
 
       Page {
         anchors.fill: parent
+        padding: 5
 
         header: QfPageHeader {
           title: fieldLabel

--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -240,7 +240,7 @@ EditorWidgetBase {
       }
     }
 
-    Popup {
+    QfPopup {
       id: searchFeaturePopup
 
       parent: mainWindow.contentItem
@@ -249,8 +249,6 @@ EditorWidgetBase {
       x: Theme.popupScreenEdgeHorizontalMargin
       y: (mainWindow.height - height) / 2
       z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature formes
-      padding: 5
-      modal: true
       closePolicy: Popup.CloseOnEscape
       focus: visible
 

--- a/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
@@ -79,7 +79,7 @@ RelationEditorBase {
             geometryHighlighter.geometryWrapper.crs = orderedRelationModel.relation.referencingLayer.crs;
             mapCanvas.mapSettings.extent = FeatureUtils.extent(mapCanvas.mapSettings, orderedRelationModel.relation.referencingLayer, nmRelationId ? model.nmReferencingFeature : model.referencingFeature);
           } else {
-            viewButton.onClicked();
+            viewButton.click();
           }
         }
       }

--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -72,7 +72,7 @@ RelationEditorBase {
               geometryHighlighter.geometryWrapper.crs = referencingFeatureListModel.relation.referencingLayer.crs;
               mapCanvas.mapSettings.setExtent(FeatureUtils.extent(mapCanvas.mapSettings, referencingFeatureListModel.relation.referencingLayer, nmRelationId ? model.nmReferencingFeature : model.referencingFeature), true);
             } else {
-              viewButton.onClicked();
+              viewButton.click();
             }
           }
         }

--- a/src/qml/imports/Theme/QfPopup.qml
+++ b/src/qml/imports/Theme/QfPopup.qml
@@ -1,0 +1,21 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Controls.Material
+import QtQuick.Controls.Material.impl
+
+Popup {
+  id: control
+  padding: 5
+  modal: true
+
+  background: Rectangle {
+    radius: control.Material.roundedScale
+    color: Theme.mainBackgroundColor
+
+    layer.enabled: control.Material.elevation > 0
+    layer.effect: RoundedElevationEffect {
+      elevation: control.Material.elevation
+      roundedScale: control.Material.roundedScale
+    }
+  }
+}

--- a/src/qml/imports/Theme/Theme.qml
+++ b/src/qml/imports/Theme/Theme.qml
@@ -166,7 +166,8 @@ QtObject {
       "weight": Font.Bold
     })
 
-  readonly property int popupScreenEdgeMargin: 40
+  readonly property int popupScreenEdgeVerticalMargin: 40
+  readonly property int popupScreenEdgeHorizontalMargin: 20
 
   readonly property int menuItemIconlessLeftPadding: 52
   readonly property int menuItemLeftPadding: 12

--- a/src/qml/imports/Theme/qmldir
+++ b/src/qml/imports/Theme/qmldir
@@ -25,3 +25,4 @@ QfDialog 1.0 QfDialog.qml
 QfMenu 1.0 QfMenu.qml
 QfExpandableGroupBox 1.0 QfExpandableGroupBox.qml
 QfProjectThumbnail 1.0 QfProjectThumbnail.qml
+QfPopup 1.0 QfPopup.qml

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -4207,15 +4207,13 @@ ApplicationWindow {
       parent: Overlay.overlay
     }
 
-    Popup {
+    QfPopup {
       id: loginDialogPopup
       parent: Overlay.overlay
       width: parent.width - Theme.popupScreenEdgeHorizontalMargin * 2
       height: parent.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
       x: Theme.popupScreenEdgeHorizontalMargin
       y: (mainWindow.height - height) / 2
-      padding: 5
-      modal: true
       closePolicy: Popup.CloseOnEscape
 
       LayerLoginDialog {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1419,7 +1419,7 @@ ApplicationWindow {
 
       onClicked: {
         if (gnssButton.followActive && gnssButton.followOrientationActive) {
-          gnssButton.onClicked();
+          gnssButton.click();
         }
         mapCanvas.mapSettings.rotation = 0;
       }
@@ -4214,7 +4214,7 @@ ApplicationWindow {
       height: parent.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
       x: Theme.popupScreenEdgeMargin
       y: (mainWindow.height - height) / 2
-      padding: 0
+      padding: 5
       modal: true
       closePolicy: Popup.CloseOnEscape
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -4210,9 +4210,9 @@ ApplicationWindow {
     Popup {
       id: loginDialogPopup
       parent: Overlay.overlay
-      width: parent.width - Theme.popupScreenEdgeMargin * 2
-      height: parent.height - Math.max(Theme.popupScreenEdgeMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
-      x: Theme.popupScreenEdgeMargin
+      width: parent.width - Theme.popupScreenEdgeHorizontalMargin * 2
+      height: parent.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4)
+      x: Theme.popupScreenEdgeHorizontalMargin
       y: (mainWindow.height - height) / 2
       padding: 5
       modal: true
@@ -4591,7 +4591,7 @@ ApplicationWindow {
     parent: mainWindow.contentItem
     z: 10000 // 1000s are embedded feature forms, user a higher value to insure the dialog will always show above embedded feature forms
 
-    width: Math.min(mainWindow.width - Theme.popupScreenEdgeMargin * 2, 400)
+    width: Math.min(mainWindow.width - Theme.popupScreenEdgeVerticalMargin * 2, 400)
 
     property string url: ""
     property string serverName: ""
@@ -4629,7 +4629,7 @@ ApplicationWindow {
     parent: mainWindow.contentItem
     z: 10000 // 1000s are embedded feature forms, user a higher value to insure the dialog will always show above embedded feature forms
 
-    width: Math.min(mainWindow.width - Theme.popupScreenEdgeMargin * 2, 400)
+    width: Math.min(mainWindow.width - Theme.popupScreenEdgeVerticalMargin * 2, 400)
 
     property string pluginName: ""
     property bool isProjectPlugin: false

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -118,6 +118,7 @@
         <file>imports/Theme/QfSearchBar.qml</file>
         <file>imports/Theme/QfDialog.qml</file>
         <file>imports/Theme/QfMenu.qml</file>
+        <file>imports/Theme/QfPopup.qml</file>
         <file>imports/Theme/QfTimeItem.qml</file>
         <file>imports/Theme/QfCalendarItem.qml</file>
         <file>imports/Theme/QfBadge.qml</file>


### PR DESCRIPTION
The days of 90 degree angled corners are gone. Adding a bit of roundness to our popups makes us look a lot better in circa 2025 OSes.

The PR also reworks horizontal margins for popups to get us a bit of extra content space, and makes the feature form constraints feedback look a lot nicer.