### PR TITLE
Fix delta file wrapper typo leading to failure to merge geometry-only patches

### DIFF
--- a/src/core/qfieldcloud/deltafilewrapper.cpp
+++ b/src/core/qfieldcloud/deltafilewrapper.cpp
@@ -1589,7 +1589,7 @@ bool DeltaFileWrapper::deltaContainsActualChange( const QJsonObject &delta ) con
   }
 
   // when the "geometry" value differs, then it means the delta makes sense
-  if ( newData.value( QStringLiteral( "geometry" ) ) != newData.value( QStringLiteral( "geometry" ) ) )
+  if ( newData.value( QStringLiteral( "geometry" ) ) != oldData.value( QStringLiteral( "geometry" ) ) )
   {
     return true;
   }


### PR DESCRIPTION
@suricactus , spotted a typo that caused consecutive geometry-only delta patches to kill the merged patch. 

Context: https://github.com/opengisch/QField/issues/6583#issuecomment-3364517069