### PR TITLE
Fixes plugin refresh on tab switch

### DIFF
--- a/src/qml/PluginManagerSettings.qml
+++ b/src/qml/PluginManagerSettings.qml
@@ -58,7 +58,7 @@ QfPopup {
         currentIndex: 0
 
         onClicked: {
-          if (index == 1 && !popup.availablePluginsFetched) {
+          if (currentIndex == 1 && !popup.availablePluginsFetched) {
             pluginManager.pluginModel.refresh(true);
           }
         }


### PR DESCRIPTION
Fixes an issue where the available plugins are not refreshed when switching to the "Available" tab in the plugin manager. It ensures the plugin list is refreshed only when the "Available" tab is selected and the plugins haven't been fetched yet.

[Screencast From 2025-10-03 19-08-33.webm](https://github.com/user-attachments/assets/cb18b78b-205c-43ff-9cf1-9b9719cef37c)

