### PR TITLE
Ensures correct project ID extraction

### DIFF
--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -80,15 +80,14 @@ const QString QFieldCloudUtils::getProjectId( const QString &fileName )
   if ( path.isEmpty() )
     return QString();
 
-  const QString cloudPath = QFieldCloudUtils::localCloudDirectory();
+  const QString cloudPath = QFileInfo( QFieldCloudUtils::localCloudDirectory() ).canonicalFilePath();
   if ( cloudPath.isEmpty() || !path.startsWith( cloudPath ) )
     return QString();
 
   const QRegularExpression re(
     QStringLiteral( "^%1[/\\\\][^/\\\\]+[/\\\\]([^/\\\\]+)" )
       .arg( QRegularExpression::escape( cloudPath ) ) );
-  const QRegularExpressionMatch match = re.match( path, 0,
-                                                  QRegularExpression::NormalMatch, QRegularExpression::AnchorAtOffsetMatchOption );
+  const QRegularExpressionMatch match = re.match( path );
 
   if ( match.hasMatch() )
   {


### PR DESCRIPTION
### 🚀 Description

Ensures that the project ID is correctly extracted from the file path by using the canonical file path for the cloud directory. This resolves potential issues caused by symbolic links or relative paths, ensuring accurate project identification.

### Issue

Previously, project ID detection could fail on Android devices because the same directory could be referenced via different paths (e.g., `/data/user/0/...` vs `/data/data/...`) due to symbolic links. By canonicalizing both the input file path and the cloud directory, we ensure consistent matching and reliable extraction of the project ID.

### ✨ Key Changes

-   Uses `QFileInfo::canonicalFilePath()` to obtain the absolute path of the cloud directory, ensuring consistent and correct path comparison.