### PR TITLE
Implement a mechanism to toggle between service and non-service positioning

### DIFF
--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -315,14 +315,13 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
      */
     Q_INVOKABLE virtual void vibrate( int milliseconds ) const { Q_UNUSED( milliseconds ) }
 
-
     /**
      * Starts a positioning service on supported platforms.
      */
     virtual void startPositioningService() const {}
 
     /**
-     * Starts a positioning service on supported platforms.
+     * Stops a positioning service on supported platforms.
      */
     virtual void stopPositioningService() const {}
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -331,6 +331,7 @@ ApplicationWindow {
     id: positionSource
     objectName: "positionSource"
 
+    serviceMode: trackings.count > 0
     deviceId: positioningSettings.positioningDevice
     badAccuracyThreshold: positioningSettings.accuracyBad
     excellentAccuracyThreshold: positioningSettings.accuracyExcellent


### PR DESCRIPTION
This PR gives us the ability to turn positioning-through-service mode on or off on supported platforms. Practically speaking, this means that we are now going to activate positioning service on Android _only_ then one or more tracking sessions are ongoing. 

While I initially thought running the positioning service all the time was good (it gave us nice notification area position details for e.g.), it turns out I had underestimated the impact on the battery usage front.

So, at the cost of adding a bit of complexity in the code, we can now avoid positioning service on Android when not needed, saving battery power.