### PR TITLE
Avoid falling into an outdated state when up-to-date and pushing changes onto the sever

### DIFF
--- a/src/core/qfieldcloud/qfieldcloudproject.cpp
+++ b/src/core/qfieldcloud/qfieldcloudproject.cpp
@@ -1648,6 +1648,13 @@ void QFieldCloudProject::push( bool shouldDownloadUpdates )
       setStatus( ProjectStatus::Idle );
       setLastLocalPushDeltas( QDateTime::currentDateTimeUtc().toString( Qt::ISODate ) );
 
+      if ( !isOutdated() )
+      {
+        // If we are not in an outdated state, avoid falling into outdated state due to our own data change
+        setLastLocalDataLastUpdatedAt( QDateTime::currentDateTimeUtc().addSecs( 60 * 2 ) );
+        QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastLocalDataLastUpdatedAt" ), mLastLocalDataLastUpdatedAt );
+      }
+
       QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastLocalPushDeltas" ), mLastLocalPushDeltas );
 
       mDeltaFileWrapper->reset();


### PR DESCRIPTION
For the "hey, there are changes on the server, synchronize!" indicator to be useful for most use cases, we should *not* fall into an outdated state when we were up-to-date and have just pushed _our own changes_ onto the server.