### PR TITLE
Provide some visual feedback that a picture was taken

### DIFF
--- a/src/qml/QFieldCamera.qml
+++ b/src/qml/QFieldCamera.qml
@@ -189,8 +189,11 @@ Popup {
 
         onImageSaved: (requestId, path) => {
           currentPath = path;
-          photoPreview.source = UrlUtils.fromString(path);
+        }
+
+        onPreviewChanged: {
           cameraItem.state = "PhotoPreview";
+          photoPreview.source = imageCapture.preview;
         }
       }
       recorder: MediaRecorder {


### PR DESCRIPTION
A screen turning white animation will help users on  slower devices to know something happened instead of hitting the button repeatedly until the captured image is saved.