### PR TITLE
Pass on application style hints and proper enum value for Material theme's dark / light values

### DIFF
--- a/src/qml/imports/Theme/Theme.qml
+++ b/src/qml/imports/Theme/Theme.qml
@@ -228,7 +228,8 @@ QtObject {
     } else {
       darkTheme = appearance === 'dark';
     }
-    Material.theme = darkTheme ? "Dark" : "Light";
+    Application.styleHints.colorScheme = Theme.darkTheme ? Qt.ColorScheme.Dark : Qt.ColorScheme.Light;
+    Material.theme = Theme.darkTheme ? Material.Dark : Material.Light;
     applyColors(darkTheme ? Theme.darkThemeColors : Theme.lightThemeColors);
     mainBackgroundColor = Material.backgroundColor;
     mainTextColor = Material.foreground;

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -48,7 +48,7 @@ ApplicationWindow {
   leftPadding: 0
   rightPadding: 0
 
-  Material.theme: Theme.darkTheme ? "Dark" : "Light"
+  Material.theme: Theme.darkTheme ? Material.Dark : Material.Light
   Material.accent: Theme.mainColor
 
   property bool sceneLoaded: false


### PR DESCRIPTION
With Qt 6.9.2, that'll give us some nicer colors for the notification bar icons / time and navigation bar.