### PR TITLE
Fix active feature locator filter breaking the search bar layout when matching against multiline string fields

### DIFF
--- a/src/core/locator/activelayerfeatureslocatorfilter.cpp
+++ b/src/core/locator/activelayerfeatureslocatorfilter.cpp
@@ -276,20 +276,21 @@ void ActiveLayerFeaturesLocatorFilter::fetchResults( const QString &string, cons
       {
         if ( idx < mAttributeAliases.count() )
         {
-          result.displayString = QStringLiteral( "%1 (%2)" ).arg( attrString, mAttributeAliases[idx] );
+          result.description = QStringLiteral( "%1 (%2)" ).arg( attrString, mAttributeAliases[idx] );
         }
         else
         {
-          result.displayString = attrString;
+          result.description = attrString;
         }
         break;
       }
       idx++;
     }
-    if ( result.displayString.isEmpty() )
+    if ( result.description.isEmpty() )
       continue; //not sure how this result slipped through...
+
+    result.displayString = mDispExpression.evaluate( &mContext ).toString();
     result.group = mLayerName;
-    result.description = mDispExpression.evaluate( &mContext ).toString();
 #if _QGIS_VERSION_INT >= 33300
     result.setUserData( QVariantList() << f.id() << mLayerId );
 #else


### PR DESCRIPTION
Fixes this issue, spotted while polishing the FOSS4G 2025 conference app:

<img width="720" height="1057" alt="image" src="https://github.com/user-attachments/assets/55ec1f58-0ab0-4b46-85bd-0b42cab519f6" />

