### PR TITLE
Allow for locator filters to define theme-driven icon colors

### DIFF
--- a/src/core/locator/activelayerfeatureslocatorfilter.cpp
+++ b/src/core/locator/activelayerfeatureslocatorfilter.cpp
@@ -238,7 +238,7 @@ void ActiveLayerFeaturesLocatorFilter::fetchResults( const QString &string, cons
       result.userData = QVariantList() << f.id() << mLayerId;
 #endif
       result.score = static_cast<double>( searchString.length() ) / result.displayString.size();
-      result.actions << QgsLocatorResult::ResultAction( OpenForm, tr( "Open form" ), QStringLiteral( "qrc:/themes/qfield/nodpi/ic_baseline-list_white_24dp.svg" ) );
+      result.actions << QgsLocatorResult::ResultAction( OpenForm, tr( "Open form" ), QStringLiteral( "qrc:/themes/qfield/nodpi/ic_baseline-list_white_24dp.svg?color=mainColor" ) );
       if ( mLayerIsSpatial )
       {
         result.actions << QgsLocatorResult::ResultAction( Navigation, tr( "Set feature as destination" ), QStringLiteral( "qrc:/themes/qfield/nodpi/ic_navigation_flag_purple_24dp.svg" ) );
@@ -297,7 +297,7 @@ void ActiveLayerFeaturesLocatorFilter::fetchResults( const QString &string, cons
     result.userData = QVariantList() << f.id() << mLayerId;
 #endif
     result.score = static_cast<double>( searchString.length() ) / result.displayString.size();
-    result.actions << QgsLocatorResult::ResultAction( OpenForm, tr( "Open form" ), QStringLiteral( "qrc:/themes/qfield/nodpi/ic_baseline-list_white_24dp.svg" ) );
+    result.actions << QgsLocatorResult::ResultAction( OpenForm, tr( "Open form" ), QStringLiteral( "qrc:/themes/qfield/nodpi/ic_baseline-list_white_24dp.svg?color=mainColor" ) );
     if ( mLayerIsSpatial )
     {
       result.actions << QgsLocatorResult::ResultAction( Navigation, tr( "Set feature as destination" ), QStringLiteral( "qrc:/themes/qfield/nodpi/ic_navigation_flag_purple_24dp.svg" ) );

--- a/src/core/locator/featureslocatorfilter.cpp
+++ b/src/core/locator/featureslocatorfilter.cpp
@@ -119,7 +119,7 @@ void FeaturesLocatorFilter::fetchResults( const QString &string, const QgsLocato
 #endif
       result.icon = preparedLayer->layerIcon;
       result.score = static_cast<double>( string.length() ) / result.displayString.size();
-      result.actions << QgsLocatorResult::ResultAction( OpenForm, tr( "Open form" ), QStringLiteral( "qrc:/themes/qfield/nodpi/ic_baseline-list_white_24dp.svg" ) );
+      result.actions << QgsLocatorResult::ResultAction( OpenForm, tr( "Open form" ), QStringLiteral( "qrc:/themes/qfield/nodpi/ic_baseline-list_white_24dp.svg?color=mainColor" ) );
       if ( preparedLayer->layerGeometryType != Qgis::GeometryType::Null && preparedLayer->layerGeometryType != Qgis::GeometryType::Unknown )
       {
         result.actions << QgsLocatorResult::ResultAction( Navigation, tr( "Set feature as destination" ), QStringLiteral( "qrc:/themes/qfield/nodpi/ic_navigation_flag_purple_24dp.svg" ) );

--- a/src/qml/LocatorItem.qml
+++ b/src/qml/LocatorItem.qml
@@ -523,6 +523,10 @@ Item {
               bgcolor: "transparent"
 
               iconSource: IconPath
+              iconColor: {
+                const colorMatch = IconPath.match(/(?:\?|&)color=([^\s&]+)(?:&|$)/);
+                return colorMatch !== null ? Theme[colorMatch[1]] : "transparent";
+              }
 
               onClicked: {
                 locatorItem.state = "off";


### PR DESCRIPTION
This PR improves custom theme integration into the search bar by allowing locator filters to rely on theme colors to colorize the action buttons. An improvement derived from polishing the FOSS4G 2025 conference project.

Before:

<img width="490" height="491" alt="Screenshot From 2025-10-13 09-23-12" src="https://github.com/user-attachments/assets/17a2e3c0-7037-46f0-89a0-114ea7e88d0f" />

Patched:

<img width="490" height="491" alt="Screenshot From 2025-10-13 09-22-12" src="https://github.com/user-attachments/assets/0c57fba3-bb37-47d8-809b-372079cb5c3a" />
