### PR TITLE
[Backport release-3_7] Fix relation editor widget not respecting the show label setting

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -570,7 +570,7 @@ void AttributeFormModelBase::buildForm( QgsAttributeEditorContainer *container, 
         QgsAttributeEditorRelation *editorRelation = static_cast<QgsAttributeEditorRelation *>( element );
         const QgsRelation relation = editorRelation->relation();
 
-        item->setData( !editorRelation->label().isEmpty() ? editorRelation->label() : relation.name(), AttributeFormModel::Name );
+        item->setData( element->showLabel() ? !editorRelation->label().isEmpty() ? editorRelation->label() : relation.name() : QString(), AttributeFormModel::Name );
         item->setData( true, AttributeFormModel::AttributeEditable );
         item->setData( true, AttributeFormModel::CurrentlyVisible );
         item->setData( "relation", AttributeFormModel::ElementType );


### PR DESCRIPTION
Backport #6745
 **Authored by:** @nirvn