### PR TITLE
Cursor lock on soft/hard canvas lock to position revealed enabling/disabling hover handler is problematic when mixed with dragging

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -505,7 +505,7 @@ ApplicationWindow {
 
     HoverHandler {
       id: hoverHandler
-      enabled: !(positionSource.active && coordinateLocator.positionLocked) && (!digitizingToolbar.rubberbandModel || !digitizingToolbar.rubberbandModel.frozen)
+      enabled: !digitizingToolbar.rubberbandModel || !digitizingToolbar.rubberbandModel.frozen
       acceptedDevices: !qfieldSettings.mouseAsTouchScreen ? PointerDevice.Stylus | PointerDevice.Mouse : PointerDevice.Stylus
       grabPermissions: PointerHandler.TakeOverForbidden
 


### PR DESCRIPTION
Master only. Without this fix in, panning around when the map canvas is following (i.e. soft locked to) location breaks after a small movement.