### PR TITLE
Location marker bubble

### DIFF
--- a/src/qml/LocationMarker.qml
+++ b/src/qml/LocationMarker.qml
@@ -12,7 +12,6 @@ Item {
 
   property variant location // QgsPoint
 
-  // props
   property point screenLocation
   property real screenAccuracy
   readonly property bool isOnMapCanvas: screenLocation.x > 0 && screenLocation.x < mapCanvas.width && screenLocation.y > 0 && screenLocation.y < mapCanvas.height


### PR DESCRIPTION
### 🚀 Description

Adds a tappable info bubble anchored to the location marker. guiding user: "Tap on your location marker to show actions"

### ✨ Key Changes

* Introduces a configurable info bubble for the location marker (text, color, visibility, and action).
* Makes the bubble tappable to open the pie menu and hides the bubble after the pie menu is opened; persists that state in settings.

### Demo   
   
<img width="498" height="723" alt="image" src="https://github.com/user-attachments/assets/2f84ad2e-744f-4be5-a668-77faf0dfee8d" />
