### PR TITLE
Implement feature form spacer widget support

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -24,6 +24,7 @@
 #include <qgsattributeeditorhtmlelement.h>
 #include <qgsattributeeditorqmlelement.h>
 #include <qgsattributeeditorrelation.h>
+#include <qgsattributeeditorspacerelement.h>
 #include <qgsattributeeditortextelement.h>
 #include <qgsdatetimefieldformatter.h>
 #include <qgseditorwidgetsetup.h>
@@ -674,7 +675,18 @@ void AttributeFormModelBase::buildForm( QgsAttributeEditorContainer *container, 
       }
 
       case Qgis::AttributeEditorType::SpacerElement:
+      {
+        QgsAttributeEditorSpacerElement *spacerElement = static_cast<QgsAttributeEditorSpacerElement *>( element );
+
+        item->setData( "spacer", AttributeFormModel::ElementType );
+        item->setData( spacerElement->drawLine() ? QStringLiteral( "-" ) : QString(), AttributeFormModel::Name );
+        item->setData( true, AttributeFormModel::CurrentlyVisible );
+        item->setData( false, AttributeFormModel::AttributeEditable );
+        item->setData( false, AttributeFormModel::AttributeAllowEdit );
+
+        parent->appendRow( item );
         break;
+      }
 
       case Qgis::AttributeEditorType::Action:
       case Qgis::AttributeEditorType::Invalid:

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -204,6 +204,34 @@ Page {
   }
 
   Component {
+    id: spacerContainer
+
+    Item {
+      height: childrenRect.height
+      anchors {
+        left: parent.left
+        right: parent.right
+        leftMargin: 12
+        rightMargin: 12
+      }
+
+      Item {
+        width: parent.width
+        height: 36
+
+        Rectangle {
+          anchors.centerIn: parent
+          width: parent.width * 0.66
+          height: 3
+          radius: 1
+          color: Theme.controlBackgroundAlternateColor
+          visible: containerName !== ""
+        }
+      }
+    }
+  }
+
+  Component {
     id: textContainer
 
     Item {
@@ -468,14 +496,29 @@ Page {
           property var labelColor: LabelColor
           property string itemType: Type
 
-          active: (Type === 'container' && GroupIndex !== undefined && GroupIndex.valid) || ((Type === 'text' || Type === 'html' || Type === 'qml') && form.model.featureModel.modelMode != FeatureModel.MultiFeatureModel)
+          active: (Type === 'container' && GroupIndex !== undefined && GroupIndex.valid) || ((Type === 'text' || Type === 'html' || Type === 'qml' || Type === 'spacer') && form.model.featureModel.modelMode != FeatureModel.MultiFeatureModel)
           height: status == Loader.Ready ? item.childrenRect.height : 0
           anchors {
             left: parent.left
             right: parent.right
           }
 
-          sourceComponent: Type === 'container' && GroupIndex !== undefined && GroupIndex.valid ? innerContainer : Type === 'qml' ? qmlContainer : Type === 'html' ? htmlContainer : Type === 'text' ? textContainer : dummyContainer
+          sourceComponent: {
+            if (Type === 'container') {
+              if (GroupIndex !== undefined && GroupIndex.valid) {
+                return innerContainer;
+              }
+            } else if (Type === 'qml') {
+              return qmlContainer;
+            } else if (Type === 'html') {
+              return htmlContainer;
+            } else if (Type === 'text') {
+              return textContainer;
+            } else if (Type === 'spacer') {
+              return spacerContainer;
+            }
+            return dummyContainer;
+          }
         }
 
         Item {


### PR DESCRIPTION
Implements an enhancement request posted on our ideas platform here (https://ideas.qfield.org/app-feature-requests/p/support-for-spacer-widget) and discussed in our community platform here (https://community.qfield.org/t/text-and-spacer-widget/426).

See the spacer (with line drawing enabled) in action just above PA_STATUS:

<img width="891" height="403" alt="image" src="https://github.com/user-attachments/assets/c0bfe58c-e96e-4091-acb1-7eea6cfbf627" />
