### PR TITLE
Add display expression so features appear nicer in the feature list 

### DIFF
--- a/src/core/utils/projectutils.cpp
+++ b/src/core/utils/projectutils.cpp
@@ -139,6 +139,9 @@ QString ProjectUtils::createProject( const QVariantMap &options )
     LayerUtils::setDefaultRenderer( notesLayer, nullptr, options.value( QStringLiteral( "camera_capture" ) ).toBool() ? QStringLiteral( "camera" ) : QString(), QStringLiteral( "color" ) );
     LayerUtils::setDefaultLabeling( notesLayer );
 
+    // Set a nice display expression for the feature list
+    notesLayer->setDisplayExpression( "COALESCE( title , 'Note #' || fid || ' from ' || format_date( timestamp, 'yyyy-MM-dd HH:mm' ) )" );
+
     int fieldIndex;
     QVariantMap widgetOptions;
     QgsEditorWidgetSetup widgetSetup;
@@ -240,6 +243,9 @@ QString ProjectUtils::createProject( const QVariantMap &options )
     tracksLayer = new QgsVectorLayer( tracksFilepath, tr( "Tracks" ) );
     fields = tracksLayer->fields();
     LayerUtils::setDefaultRenderer( tracksLayer );
+
+    // Set a nice display expression for the feature list
+    tracksLayer->setDisplayExpression( "'Track #' || fid || ' from ' || format_date( timestamp, 'yyyy-MM-dd HH:mm' )" );
 
     int fieldIndex;
     QVariantMap widgetOptions;


### PR DESCRIPTION
| before | after |
|-|-|
| <img width="635" height="732" alt="image" src="https://github.com/user-attachments/assets/fcef957c-24ad-4ce4-96d6-2009cd361735" /> | <img width="635" height="732" alt="image" src="https://github.com/user-attachments/assets/a9207af1-57ad-4864-baac-a6e98a0c065f" /> |


Ah, the screenshot for the tracks is lying, the datetime is formatted as nicely as for the notes. You see my experiments there :)