### PR TITLE
Prefix the id with the layer name when we don't have a display expression

### DIFF
--- a/src/core/utils/featureutils.cpp
+++ b/src/core/utils/featureutils.cpp
@@ -68,8 +68,14 @@ QString FeatureUtils::displayName( QgsVectorLayer *layer, const QgsFeature &feat
   context.setFeature( feature );
 
   QString name = QgsExpression( layer->displayExpression() ).evaluate( &context ).toString();
-  if ( name.isEmpty() )
-    name = QString::number( feature.id() );
+  QList<int> pkAttrIdxs = layer->primaryKeyAttributes() << -1;
+  QString pkAttrName = layer->fields().at( pkAttrIdxs[0] ).name();
+
+  // if the suggested feature name or the displayExpression evaluates to just the primary key, then prefix the layer name in front
+  if ( name.isEmpty() || layer->displayExpression() == QStringLiteral( "\"%1\"" ).arg( pkAttrName ) )
+  {
+    name = QStringLiteral( "%1 #%2" ).arg( layer->name(), QString::number( feature.id() ) );
+  }
 
   return name;
 }

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -115,7 +115,7 @@ Rectangle {
 
       text: {
         if (model && selection && selection.focusedItem > -1 && (toolBar.state === 'Navigation' || toolBar.state === 'Edit')) {
-          var featurePosition = model.count > 1 ? ((selection.focusedItem + 1) + '/' + model.count + ': ') : '';
+          const featurePosition = model.count > 1 ? ((selection.focusedItem + 1) + '/' + model.count + ': ') : '';
           return featurePosition + FeatureUtils.displayName(selection.focusedLayer, selection.focusedFeature);
         } else {
           return toolBar.title;


### PR DESCRIPTION
Instead of raw PK value, prefix with the layer name. Otherwise we get in funny situation in the navbar with `1/2: 3`.

Before:

https://github.com/user-attachments/assets/fbd6b32c-0408-484b-9311-b9bb7d04ac45


After:

https://github.com/user-attachments/assets/11f3b17b-8059-435e-ab36-953f1b5f3d78

