### PR TITLE
Rework handling of back button to minimize instead of double-tapping-to-exit

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -130,6 +130,9 @@ ApplicationWindow {
           } else if (stateMachine.state === 'measure') {
             mainWindow.closeMeasureTool();
             event.accepted = true;
+          } else if (Qt.platform.os === "android" || Qt.platform.os === "ios") {
+            mainWindow.visibility = Window.Minimized;
+            event.accepted = true;
           }
         }
       }


### PR DESCRIPTION
Instead of making the back button end with a frustrating "tap twice to exit", let's just suspend the app, a slightly more expected behavior on mobile platform.

~~Let's return the back button handling to the OS, it's long overdue.~~

~~For people in need of a proper hard exit, we have an exit button on the welcome screen on mobile platforms, and the good old windows close button on desktop platforms :)~~