### PR TITLE
Fix crash when trying to modify a null string in a QFieldUtils java function

### DIFF
--- a/platform/android/src/ch/opengis/qfield/QFieldUtils.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldUtils.java
@@ -56,8 +56,14 @@ public class QFieldUtils {
             extension = filename.substring(dotIndex + 1);
         }
 
-        return string.replace("{filename}", filename)
-            .replace("{extension}", extension);
+        if (string != null) {
+            string = string.replace("{filename}", filename)
+                         .replace("{extension}", extension);
+        } else {
+            string = filename;
+        }
+
+        return string;
     }
 
     /**


### PR DESCRIPTION
Spotted on sentry (https://opengisch.sentry.io/issues/6145345122/?project=6119013&query=is%3Aunresolved&referrer=issue-stream).