### PR TITLE
When exiting QField, insure all background tasks are cancelled

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -1479,6 +1479,7 @@ QgisMobileapp::~QgisMobileapp()
   delete mProject;
   delete mAppMissingGridHandler;
 
+  QgsApplication::taskManager()->cancelAll();
   mApp->exitQgis();
   QMetaObject::invokeMethod( mApp, &QgsApplication::quit, Qt::QueuedConnection );
 }


### PR DESCRIPTION
Slow background tasks are possibly lingering such as font downloads. Cancelling them prior to calling mApp->exitQgis() is wise. 