### PR TITLE
Increase connection pool maximum concurrent connection to workaround issues with large nb. of layers packed into data.gpkg

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -214,6 +214,9 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   // Set QGIS-specific core settings
   QgsSettingsRegistryCore::settingsEnableWMSTilePrefetching->setValue( true );
 
+  // Increase maximum concurrent connections allowed
+  QgsApplication::settingsConnectionPoolMaximumConcurrentConnections->setValue( 10 );
+
   // Set a nicer default hyperlink color to be used in QML Text items
   QPalette palette = app->palette();
   palette.setColor( QPalette::Link, QColor( 128, 204, 40 ) );


### PR DESCRIPTION
This can prevent rendering freeze when complex symbology / labeling / etc expressions max. out the pool and end up in an forever loop waiting for the pool to free itself.