### PR TITLE
Only wipe value of source primary key attribute when not driven by a client-side default value expression

### DIFF
--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -951,7 +951,11 @@ void FeatureModel::applyGeometry( bool fromVertexModel )
                       const QString sourcePrimaryKeys = mLayer->customProperty( QStringLiteral( "QFieldSync/sourceDataPrimaryKeys" ) ).toString();
                       if ( !sourcePrimaryKeys.isEmpty() && mLayer->fields().lookupField( sourcePrimaryKeys ) >= 0 )
                       {
-                        newFeature.setAttribute( mLayer->fields().lookupField( sourcePrimaryKeys ), QVariant() );
+                        const int sourcePrimaryKeysIndex = mLayer->fields().lookupField( sourcePrimaryKeys );
+                        if ( !mLayer->fields().at( sourcePrimaryKeysIndex ).defaultValueDefinition().isValid() )
+                        {
+                          newFeature.setAttribute( mLayer->fields().lookupField( sourcePrimaryKeys ), QVariant() );
+                        }
                       }
                       mLayer->addFeature( newFeature );
                     }

--- a/src/core/utils/geometryutils.cpp
+++ b/src/core/utils/geometryutils.cpp
@@ -270,9 +270,12 @@ GeometryUtils::GeometryOperationResult GeometryUtils::splitFeatureFromRubberband
     if ( !sourcePrimaryKeys.isEmpty() && layer->fields().lookupField( sourcePrimaryKeys ) >= 0 )
     {
       const int sourcePrimaryKeysIndex = layer->fields().lookupField( sourcePrimaryKeys );
-      for ( const QgsFeatureId &createdFeatureId : createdFeatureIds )
+      if ( !layer->fields().at( sourcePrimaryKeysIndex ).defaultValueDefinition().isValid() )
       {
-        layer->changeAttributeValue( createdFeatureId, sourcePrimaryKeysIndex, QVariant() );
+        for ( const QgsFeatureId &createdFeatureId : createdFeatureIds )
+        {
+          layer->changeAttributeValue( createdFeatureId, sourcePrimaryKeysIndex, QVariant() );
+        }
       }
     }
     layer->commitChanges( !wasEditing );

--- a/src/core/utils/layerutils.cpp
+++ b/src/core/utils/layerutils.cpp
@@ -462,7 +462,11 @@ QgsFeature LayerUtils::duplicateFeature( QgsVectorLayer *layer, QgsFeature featu
   QString sourcePrimaryKeys = layer->customProperty( QStringLiteral( "QFieldSync/sourceDataPrimaryKeys" ) ).toString();
   if ( layer->fields().lookupField( sourcePrimaryKeys ) >= 0 )
   {
-    feature.setAttribute( layer->fields().lookupField( sourcePrimaryKeys ), QVariant() );
+    const int sourcePrimaryKeysIndex = layer->fields().lookupField( sourcePrimaryKeys );
+    if ( !layer->fields().at( sourcePrimaryKeysIndex ).defaultValueDefinition().isValid() )
+    {
+      feature.setAttribute( sourcePrimaryKeysIndex, QVariant() );
+    }
   }
 
   QgsFeature duplicatedFeature;
@@ -515,9 +519,12 @@ QgsFeature LayerUtils::duplicateFeature( QgsVectorLayer *layer, QgsFeature featu
     if ( !sourcePrimaryKeys.isEmpty() && chl->fields().lookupField( sourcePrimaryKeys ) >= 0 )
     {
       const int sourcePrimaryKeysIndex = chl->fields().lookupField( sourcePrimaryKeys );
-      for ( auto fid : fids )
+      if ( !chl->fields().at( sourcePrimaryKeysIndex ).defaultValueDefinition().isValid() )
       {
-        chl->changeAttributeValue( fid, sourcePrimaryKeysIndex, QVariant() );
+        for ( auto fid : fids )
+        {
+          chl->changeAttributeValue( fid, sourcePrimaryKeysIndex, QVariant() );
+        }
       }
     }
 


### PR DESCRIPTION
TIL: a primary key attribute from a postgis layer can have its value driven by a client-side default value expression.  We need to take that into account when duplicating features and guarding ourselves from bogus source primary key duplication.

Master-only as 3.7 did _not_ have that protection in place.