### PR TITLE
Avoid needless rebuilding of the layer tree when the map theme changes to an empty string

### DIFF
--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -1380,7 +1380,11 @@ void FlatLayerTreeModelBase::setMapTheme( const QString &mapTheme )
   mMapTheme = mapTheme;
   emit mapThemeChanged();
 
-  buildMap( mLayerTreeModel );
+  if ( !mapTheme.isEmpty() )
+  {
+    // Setting a map theme likely changes the layer tree structure, rebuild
+    buildMap( mLayerTreeModel );
+  }
 }
 
 void FlatLayerTreeModelBase::updateCurrentMapTheme()


### PR DESCRIPTION
On slow/old devices with a large layer tree, it avoids a freeze that can be felt by users.