### PR TITLE
Insure project position from GNSS receiver is updated when projection transform properties change

### DIFF
--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -605,7 +605,25 @@ void Positioning::setCoordinateTransformer( QgsQuickCoordinateTransformer *coord
   if ( mCoordinateTransformer == coordinateTransformer )
     return;
 
+  if ( mCoordinateTransformer )
+  {
+    disconnect( mCoordinateTransformer, &QgsQuickCoordinateTransformer::destinationCrsChanged, this, &Positioning::processProjectedPosition );
+    disconnect( mCoordinateTransformer, &QgsQuickCoordinateTransformer::transformContextChanged, this, &Positioning::processProjectedPosition );
+    disconnect( mCoordinateTransformer, &QgsQuickCoordinateTransformer::deltaZChanged, this, &Positioning::processProjectedPosition );
+    disconnect( mCoordinateTransformer, &QgsQuickCoordinateTransformer::skipAltitudeTransformationChanged, this, &Positioning::processProjectedPosition );
+    disconnect( mCoordinateTransformer, &QgsQuickCoordinateTransformer::verticalGridChanged, this, &Positioning::processProjectedPosition );
+  }
+
   mCoordinateTransformer = coordinateTransformer;
+
+  if ( mCoordinateTransformer )
+  {
+    connect( mCoordinateTransformer, &QgsQuickCoordinateTransformer::destinationCrsChanged, this, &Positioning::processProjectedPosition );
+    connect( mCoordinateTransformer, &QgsQuickCoordinateTransformer::transformContextChanged, this, &Positioning::processProjectedPosition );
+    connect( mCoordinateTransformer, &QgsQuickCoordinateTransformer::deltaZChanged, this, &Positioning::processProjectedPosition );
+    connect( mCoordinateTransformer, &QgsQuickCoordinateTransformer::skipAltitudeTransformationChanged, this, &Positioning::processProjectedPosition );
+    connect( mCoordinateTransformer, &QgsQuickCoordinateTransformer::verticalGridChanged, this, &Positioning::processProjectedPosition );
+  }
 
   emit coordinateTransformerChanged();
 }

--- a/src/core/qgsquick/qgsquickcoordinatetransformer.cpp
+++ b/src/core/qgsquick/qgsquickcoordinatetransformer.cpp
@@ -98,6 +98,9 @@ void QgsQuickCoordinateTransformer::setSourceCrs( const QgsCoordinateReferenceSy
 
 void QgsQuickCoordinateTransformer::setTransformContext( const QgsCoordinateTransformContext &context )
 {
+  if ( mCoordinateTransform.context() == context )
+    return;
+
   mCoordinateTransform.setContext( context );
   emit transformContextChanged();
 }


### PR DESCRIPTION
Stumbled on a bad issue when testing QField in really bad reception area. Basically, the phone's internal GNSS device would receive sporadic updates every 10-20 seconds, which meant that QField would launch, get a position and hold that position in memory without being reprojected (no project loaded yet).

Opening a project would then show the GNSS location as valid in the positioning information, but reprojected to 0,0 (since the reprojection didn't have the destination CRS provided by the project at the time is picked it on project launch).

I had seen this before, but never able to reproduce the circumstances.

Hourray for poor GNSS reception today!