### PR TITLE
Fix long constraints error descriptions going beyond screen edge

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -559,9 +559,10 @@ Page {
               left: parent.left
               right: parent.right
               top: fieldLabel.bottom
+              rightMargin: 10
             }
 
-            font.pointSize: fieldLabel.font.pointSize / 3 * 2
+            font.pointSize: fieldLabel.font.pointSize * 0.8
             text: {
               if (ConstraintHardValid && ConstraintSoftValid)
                 return '';
@@ -571,6 +572,7 @@ Page {
             visible: !ConstraintHardValid || !ConstraintSoftValid
             opacity: fieldLabel.opacity
             color: !ConstraintHardValid ? Theme.errorColor : Theme.warningColor
+            wrapMode: Text.WordWrap
           }
 
           Item {


### PR DESCRIPTION
This PR fixes long constraints error descriptions rendered beyond screen edge by adding a proper right margin and word wrap. I've taken the opportunity to slightly increase the font size too to help readability.

@ZsanettMed , that should fix the issue you spotted. 