### PR TITLE
Updates qca to version 2.3.10

### DIFF
--- a/vcpkg/ports/qca/portfile.cmake
+++ b/vcpkg/ports/qca/portfile.cmake
@@ -12,7 +12,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KDE/qca
     REF "v${VERSION}"
-    SHA512 956d36058db61498c492fc9b5345b45ca75a5e8214fcbf358273dfacdd5980c1394394652536d9332df05f29fc912d0781338bcca403d98de1285bb8b1216402
+    SHA512 21bbc483f78d8c6b99bf2a4375db6a1bcc8a1a16df01e2295dc6a5b43fa27ccbef39114ee33d456071f712a00aca0ab3bc1bf767df82333c2f98ea35f7d35b45
     PATCHES
         0001-fix-path-for-vcpkg.patch
         0002-fix-build-error.patch

--- a/vcpkg/ports/qca/vcpkg.json
+++ b/vcpkg/ports/qca/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "qca",
-  "version": "2.3.9",
+  "version": "2.3.10",
   "description": "Qt Cryptographic Architecture (QCA).",
   "homepage": "https://userbase.kde.org/QCA",
   "dependencies": [


### PR DESCRIPTION
Updates the qca port to version 2.3.10. (Fix build in macOS 26)